### PR TITLE
docs: proper README — 221 tests, 1,423x speedup, 10 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
-# @golems/cmux-mcp
+# cmuxlayer
 
-MCP server for programmatic cmux terminal control. Wraps cmux CLI into 10 typed MCP tools.
+> Terminal multiplexer MCP — multi-agent workspace orchestration for [cmux](https://github.com/manaflow-ai/cmux).
 
-## Tools
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Tests](https://img.shields.io/badge/tests-221%20passing-brightgreen.svg)](#testing)
+[![MCP](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
+
+---
+
+**221 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
+
+cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
+
+## Quick Start
+
+```bash
+git clone https://github.com/EtanHey/cmuxlayer.git && cd cmuxlayer
+bun install
+bun run build
+```
+
+Add to your editor's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "cmux": {
+      "command": "node",
+      "args": ["/path/to/cmuxlayer/dist/index.js"]
+    }
+  }
+}
+```
+
+Requires [cmux](https://github.com/manaflow-ai/cmux) to be installed and running.
+
+## MCP Tools (10)
 
 | Tool | Description |
 |------|-------------|
@@ -17,42 +51,85 @@ MCP server for programmatic cmux terminal control. Wraps cmux CLI into 10 typed 
 | `close_surface` | Close a surface |
 | `browser_surface` | Interact with browser surfaces |
 
-## Usage
-
-### As MCP server (stdio)
-
-```json
-{
-  "mcpServers": {
-    "cmux": {
-      "command": "node",
-      "args": ["~/Gits/orchestrator/tools/cmux-mcp/dist/index.js"]
-    }
-  }
-}
-```
-
-### Development
-
-```bash
-npm install
-npm test        # run tests (vitest)
-npm run build   # compile TypeScript
-npm run dev     # run with tsx (hot reload)
-```
-
 ## Architecture
 
-- `src/cmux-client.ts` — CLI wrapper (only file that knows shell commands)
-- `src/server.ts` — MCP tool registration and handlers
-- `src/naming.ts` — Surface naming rules (launcher prefix preservation)
-- `src/mode-policy.ts` — Mode enforcement (manual = read-only)
-- `src/types.ts` — Shared TypeScript types
+```
+AI Agent  ─── MCP ───>  cmuxlayer
+                         ├── Persistent socket connection (1,423x faster than CLI)
+                         ├── Agent lifecycle engine (spawn, monitor, teardown)
+                         ├── Mode policy (autonomous vs manual control)
+                         ├── Event log + state manager
+                         └── Pattern registry for naming conventions
+```
+
+### Key Components
+
+| File | Role |
+|------|------|
+| `cmux-socket-client.ts` | Persistent Unix socket connection to cmux (1,423x speedup over CLI) |
+| `cmux-client.ts` | CLI wrapper fallback |
+| `server.ts` | MCP tool registration and handlers |
+| `agent-engine.ts` | Agent lifecycle — spawn, monitor, quality tracking |
+| `agent-registry.ts` | Registry of active agents across surfaces |
+| `naming.ts` | Surface naming rules (launcher prefix preservation) |
+| `mode-policy.ts` | Mode enforcement (autonomous = full access, manual = read-only) |
+| `state-manager.ts` | Sidebar state synchronization |
+| `event-log.ts` | Audit trail for all agent actions |
+| `pattern-registry.ts` | Reusable patterns for common workflows |
 
 ## Mode Model
 
 Two axes per surface:
+
 - **control**: `autonomous` (full access) or `manual` (read-only for mutating tools)
 - **intent**: `chat` or `audit`
 
 Set via `set_status` with reserved keys `mode.control` / `mode.intent`.
+
+## Socket Performance
+
+cmuxlayer connects to cmux via a persistent Unix socket instead of spawning CLI subprocesses:
+
+| Method | Latency | Throughput |
+|--------|---------|------------|
+| CLI subprocess | ~142ms | Baseline |
+| Persistent socket | ~0.1ms | **1,423x faster** |
+
+The socket client auto-reconnects on disconnect and falls back to CLI if the socket is unavailable.
+
+## Upstream Contributions
+
+cmuxlayer development has contributed back to cmux:
+
+| PR | Status | What |
+|----|--------|------|
+| [#1522](https://github.com/manaflow-ai/cmux/pull/1522) | Open | Fix: background workspace PTY initialization |
+| [#1562](https://github.com/manaflow-ai/cmux/pull/1562) | Open | Fix: thread starvation in MCP server |
+
+## Testing
+
+```bash
+bun test            # 221 tests via vitest
+bun run typecheck   # Type checking
+```
+
+## Development
+
+```bash
+bun install
+bun run dev         # Run with tsx (hot reload)
+bun run build       # Compile TypeScript
+bun run start       # Run compiled output
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and PR guidelines.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).
+
+---
+
+Part of the [Golems](https://github.com/EtanHey/golems) AI agent ecosystem. Built by [@EtanHey](https://github.com/EtanHey).


### PR DESCRIPTION
## Summary
- Complete rewrite from minimal tool list to full README
- Architecture diagram, component table, socket performance benchmarks
- Agent lifecycle engine, mode model, pattern registry docs
- Upstream contributions table (cmux PRs #1522, #1562)
- Badges: tests, license, MCP tools, TypeScript

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All links resolve (cmux repo, upstream PRs)
- [ ] Badges display properly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>