### PR TITLE
fix: press_enter reliability + tool description improvements

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -199,7 +199,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 3. send_input
   server.tool(
     "send_input",
-    "Send text input to a terminal surface",
+    "Send text input to a terminal surface. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",
     {
       surface: z.string().describe("Target surface ref"),
       text: z.string().describe("Text to send"),
@@ -208,7 +208,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .boolean()
         .optional()
         .default(false)
-        .describe("Press enter after sending text"),
+        .describe(
+          "Press enter after sending text. For reliability with interactive programs, send text first, then use a separate send_key 'return' call.",
+        ),
       rename_to_task: z
         .string()
         .optional()
@@ -220,6 +222,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: args.workspace,
         });
         if (args.press_enter) {
+          // Small delay to let the terminal process the text input before
+          // sending the return key. Without this, the enter keypress can
+          // arrive before the text is fully inserted into the terminal's
+          // input buffer, causing the enter to be swallowed.
+          await new Promise((resolve) => setTimeout(resolve, 50));
           await client.sendKey(args.surface, "return", {
             workspace: args.workspace,
           });
@@ -245,7 +252,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 4. send_key
   server.tool(
     "send_key",
-    "Send a key press to a terminal surface",
+    "Send a key press to a terminal surface. Use this after send_input to reliably submit commands — especially when targeting interactive programs like Claude sessions.",
     {
       surface: z.string().describe("Target surface ref"),
       key: z.string().describe("Key name (e.g. 'return', 'escape', 'tab')"),


### PR DESCRIPTION
## Summary

- Add 50ms delay between `send_text` and `send_key("return")` when `press_enter: true` — fixes race where enter arrives before text is fully inserted into the terminal input buffer
- Update `send_input` and `send_key` tool descriptions to guide AI agents toward the reliable two-step pattern (send text, then send_key separately)

## Root cause

cmux Swift dispatches `surface.send_text` and `surface.send_key` async on main thread. When fired back-to-back over the socket, the return keypress can arrive before the text insertion completes, causing enter to be swallowed. The socket returns `"ok": true` for both, masking the failure.

## Test plan

- [x] 224/224 tests pass
- [ ] Manual: send_input with press_enter to a Claude session, verify enter fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of input submission when using automatic execution, preventing command text loss.

* **Documentation**
  * Updated tool guidance to clarify recommended usage patterns for input operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->