### PR TITLE
feat: parse read_screen output and add logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-**228 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
+**230 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
 
 cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
 
@@ -115,7 +115,7 @@ cmuxlayer development has contributed back to cmux:
 ## Testing
 
 ```bash
-bun test            # 221 tests via vitest
+bun run test        # 230 tests via vitest
 bun run typecheck   # Type checking
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,22 @@
 
 > Terminal multiplexer MCP — multi-agent workspace orchestration for [cmux](https://github.com/manaflow-ai/cmux).
 
+<p align="center">
+  <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxlayer Split Pane Grid logo" width="96" height="96" />
+</p>
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-221%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-228%20passing-brightgreen.svg)](#testing)
 [![MCP](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
 
 ---
 
-**221 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
+**228 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
 
 cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
+
+`read_screen` returns raw terminal text alongside structured parsed agent metadata for common CLI agents including Claude, Codex, and Gemini. That makes status checks, done-signal detection, token counting, and model extraction available directly through MCP without forcing each client to re-parse terminal output.
 
 ## Quick Start
 
@@ -44,7 +50,7 @@ Requires [cmux](https://github.com/manaflow-ai/cmux) to be installed and running
 | `new_split` | Create a new split pane (terminal or browser) |
 | `send_input` | Send text to a terminal surface (with optional enter/rename) |
 | `send_key` | Send a key press to a surface |
-| `read_screen` | Read screen content from a surface |
+| `read_screen` | Read raw screen text plus parsed agent state from a surface |
 | `rename_tab` | Rename a surface tab (with optional prefix preservation) |
 | `set_status` | Set sidebar status key-value pair |
 | `set_progress` | Set sidebar progress indicator (0.0-1.0) |

--- a/assets/cmuxlayer-logo-split-pane-grid.svg
+++ b/assets/cmuxlayer-logo-split-pane-grid.svg
@@ -1,0 +1,15 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="60" height="60" rx="6" fill="#0F172A"/>
+  <line x1="32" y1="6" x2="32" y2="58" stroke="#22C55E" stroke-width="1.5"/>
+  <line x1="6" y1="32" x2="58" y2="32" stroke="#22C55E" stroke-width="1.5"/>
+  <circle cx="32" cy="32" r="4" fill="#22C55E"/>
+  <circle cx="32" cy="32" r="2" fill="#0F172A"/>
+  <rect x="10" y="12" width="8" height="2" rx="1" fill="#22C55E" opacity="0.8"/>
+  <rect x="10" y="16" width="14" height="2" rx="1" fill="#22C55E" opacity="0.5"/>
+  <rect x="38" y="12" width="12" height="2" rx="1" fill="#A78BFA" opacity="0.8"/>
+  <rect x="38" y="16" width="6" height="2" rx="1" fill="#A78BFA" opacity="0.5"/>
+  <rect x="10" y="40" width="10" height="2" rx="1" fill="#F59E0B" opacity="0.8"/>
+  <rect x="10" y="44" width="16" height="2" rx="1" fill="#F59E0B" opacity="0.5"/>
+  <rect x="38" y="40" width="14" height="2" rx="1" fill="#EC4899" opacity="0.8"/>
+  <rect x="38" y="44" width="8" height="2" rx="1" fill="#EC4899" opacity="0.5"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "./dist/lib.js",
+  "module": "./dist/lib.js",
+  "types": "./dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
+    }
+  },
   "bin": {
     "cmux-mcp": "./dist/index.js"
   },

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5,7 +5,7 @@
 
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
-import type { CmuxClient } from "./cmux-client.js";
+import type { CmuxNewSplitResult, CmuxReadScreenResult } from "./types.js";
 import {
   generateAgentId,
   parseContextPercent,
@@ -36,6 +36,58 @@ export interface SpawnAgentResult {
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
+
+interface AgentEngineClient {
+  log(
+    message: string,
+    opts?: {
+      level?: "info" | "progress" | "success" | "warning" | "error";
+      source?: string;
+      workspace?: string;
+      surface?: string;
+    },
+  ): Promise<void>;
+  setStatus(
+    key: string,
+    value: string,
+    opts?: {
+      icon?: string;
+      color?: string;
+      workspace?: string;
+      surface?: string;
+    },
+  ): Promise<void>;
+  readScreen(
+    surface: string,
+    opts?: { workspace?: string; lines?: number; scrollback?: boolean },
+  ): Promise<CmuxReadScreenResult>;
+  send(
+    surface: string,
+    text: string,
+    opts?: { workspace?: string },
+  ): Promise<void>;
+  sendKey(
+    surface: string,
+    key: string,
+    opts?: { workspace?: string },
+  ): Promise<void>;
+  setProgress(
+    value: number,
+    opts?: { label?: string; workspace?: string; surface?: string },
+  ): Promise<void>;
+  newSplit(
+    direction: string,
+    opts?: {
+      workspace?: string;
+      surface?: string;
+      pane?: string;
+      type?: string;
+      url?: string;
+      title?: string;
+      focus?: boolean;
+    },
+  ): Promise<CmuxNewSplitResult>;
+}
 
 /** State → sidebar icon/color mapping */
 const STATE_SIDEBAR: Record<AgentState, { icon: string; color: string }> = {
@@ -79,7 +131,7 @@ function buildLaunchCommand(cli: CliType, repo: string): string {
 export class AgentEngine {
   private stateMgr: StateManager;
   private registry: AgentRegistry;
-  private client: CmuxClient;
+  private client: AgentEngineClient;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   /** agentId → last-pushed status string */
   private sidebarSnapshot = new Map<string, string>();
@@ -89,7 +141,7 @@ export class AgentEngine {
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
-    client: CmuxClient,
+    client: AgentEngineClient,
   ) {
     this.stateMgr = stateMgr;
     this.registry = registry;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,6 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createServer } from "./server.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
 
-export { parseScreen } from "./screen-parser.js";
-export type {
-  ParsedScreenAgentType,
-  ParsedScreenResult,
-  ParsedScreenStatus,
-} from "./types.js";
-
 async function main() {
   const client = await createCmuxClient();
   const server = createServer({ client });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createServer } from "./server.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
 
+export { parseScreen } from "./screen-parser.js";
+export type {
+  ParsedScreenAgentType,
+  ParsedScreenResult,
+  ParsedScreenStatus,
+} from "./types.js";
+
 async function main() {
   const client = await createCmuxClient();
   const server = createServer({ client });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,6 @@
+export { parseScreen } from "./screen-parser.js";
+export type {
+  ParsedScreenAgentType,
+  ParsedScreenResult,
+  ParsedScreenStatus,
+} from "./types.js";

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -19,6 +19,10 @@ const CODEX_ACTION_RE =
   /^\s*[•·]\s+(.+)$/gm;
 const GEMINI_MODEL_RE =
   /(?:^|\n)\s*(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
+const CLAUDE_DONE_LINE_RE =
+  /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
+const CLAUDE_WORKING_LINE_RE =
+  /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_RE, "");
@@ -38,7 +42,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (claudeMarkers.some((marker) => text.includes(marker))) {
     return "claude";
   }
-  if (HEADER_MODEL_RE.test(text)) {
+  if (HEADER_MODEL_RE.test(text) || MODEL_COST_RE.test(text) || CLAUDE_DONE_LINE_RE.test(text) || CLAUDE_WORKING_LINE_RE.test(text)) {
     return "claude";
   }
 
@@ -181,16 +185,19 @@ function inferStatus(
     return "done";
   }
 
+  if (agentType === "claude" && CLAUDE_DONE_LINE_RE.test(text)) {
+    return "done";
+  }
+
+  if (agentType === "claude" && CLAUDE_WORKING_LINE_RE.test(text)) {
+    return "working";
+  }
+
   const workingMarkers = [
-    "✻",
-    "⏺",
     "thinking",
-    "working",
-    "receiving ",
     " /loop",
     "bypass permissions on",
     "esc to interrupt",
-    "running",
   ];
   if (workingMarkers.some((marker) => joined.toLowerCase().includes(marker.toLowerCase()))) {
     return "working";

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1,0 +1,238 @@
+import type { ParsedScreenAgentType, ParsedScreenResult, ParsedScreenStatus } from "./types.js";
+
+const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const DONE_SIGNAL_RE = /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)\b/;
+const RESPONSE_BLOCK_RE =
+  /---RESPONSE_START---\s*(.*?)\s*---RESPONSE_END---/s;
+const TOKEN_USAGE_RE = /Token usage:\s*total=([0-9][0-9,]*)/i;
+const TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/i;
+const MODEL_COST_RE = /🤖\s*([^|\n]+?)\s*\|\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)/i;
+const HEADER_MODEL_RE =
+  /^\s*[▝▜▛▘▐].*?\b((?:Opus|Sonnet|Haiku|GPT|Claude)\s+[0-9][^(\n·|]*)/m;
+const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
+const CODEX_MODEL_RE =
+  /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*[·•]\s*(\d+)%\s+left/m;
+const CODEX_WORKING_RE =
+  /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
+const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
+const CODEX_ACTION_RE =
+  /^\s*[•·]\s+(.+)$/gm;
+const GEMINI_MODEL_RE =
+  /(?:^|\n)\s*(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function normalizeText(text: string): string {
+  return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function detectAgentType(text: string): ParsedScreenAgentType {
+  const claudeMarkers = [
+    "CLAUDE_COUNTER",
+    "bypass permissions on",
+    "---RESPONSE_START---",
+    "Claude Code",
+  ];
+  if (claudeMarkers.some((marker) => text.includes(marker))) {
+    return "claude";
+  }
+  if (HEADER_MODEL_RE.test(text)) {
+    return "claude";
+  }
+
+  if (CODEX_MODEL_RE.test(text) || CODEX_WORKING_RE.test(text) || CODEX_RESUME_RE.test(text)) {
+    return "codex";
+  }
+
+  if (/Gemini CLI/i.test(text)) {
+    return "gemini";
+  }
+  if (GEMINI_MODEL_RE.test(text) && !CODEX_MODEL_RE.test(text)) {
+    return "gemini";
+  }
+
+  return "unknown";
+}
+
+function parseTokenCount(text: string): number | null {
+  const usageMatch = text.match(TOKEN_USAGE_RE);
+  if (usageMatch) {
+    return Number.parseInt(usageMatch[1].replaceAll(",", ""), 10);
+  }
+
+  const tokensMatch = text.match(TOKENS_RE);
+  if (tokensMatch) {
+    return Number.parseInt(tokensMatch[1].replaceAll(",", ""), 10);
+  }
+
+  return null;
+}
+
+function parseDoneSignal(text: string): string | null {
+  return text.match(DONE_SIGNAL_RE)?.[1] ?? null;
+}
+
+function parseResponse(text: string): string | null {
+  const response = text.match(RESPONSE_BLOCK_RE)?.[1]?.trim();
+  return response || null;
+}
+
+function parseErrors(text: string): string[] {
+  const errors: string[] = [];
+  const lowered = text.toLowerCase();
+  const permissionPatterns = [
+    "approve command?",
+    "permission denied",
+    "permission prompt",
+    "do you want to allow",
+    "[y/n]",
+  ];
+
+  if (permissionPatterns.some((pattern) => lowered.includes(pattern))) {
+    errors.push("permission_prompt");
+  }
+
+  if (text.includes("SQLITE_BUSY")) {
+    errors.push("SQLITE_BUSY");
+  }
+
+  for (const match of text.matchAll(EXIT_CODE_RE)) {
+    const code = `exit_code:${match[1]}`;
+    if (!errors.includes(code)) {
+      errors.push(code);
+    }
+  }
+
+  return errors;
+}
+
+function parseModelAndCost(
+  text: string,
+  agentType: ParsedScreenAgentType,
+): { model: string | null; cost: number | null } {
+  if (agentType === "codex") {
+    const codexMatch = text.match(CODEX_MODEL_RE);
+    return {
+      model: codexMatch?.[1]?.trim() ?? null,
+      cost: null,
+    };
+  }
+
+  if (agentType === "gemini") {
+    return {
+      model: text.match(GEMINI_MODEL_RE)?.[1] ?? null,
+      cost: null,
+    };
+  }
+
+  const modelCostMatch = text.match(MODEL_COST_RE);
+  if (modelCostMatch) {
+    return {
+      model: modelCostMatch[1].trim(),
+      cost: Number.parseFloat(modelCostMatch[2]),
+    };
+  }
+
+  const model = text.match(HEADER_MODEL_RE)?.[1]?.trim() ?? null;
+  const costMatch = text.match(/💰\s*\$([0-9]+(?:\.[0-9]+)?)/);
+
+  return {
+    model,
+    cost: costMatch ? Number.parseFloat(costMatch[1]) : null,
+  };
+}
+
+function parseCodexContextPct(text: string): number | null {
+  const match = text.match(CODEX_MODEL_RE);
+  return match ? Number.parseInt(match[2], 10) : null;
+}
+
+function parseCodexActions(text: string): string[] {
+  return Array.from(text.matchAll(CODEX_ACTION_RE), (match) => match[1].trim());
+}
+
+function inferStatus(
+  text: string,
+  doneSignal: string | null,
+  errors: string[],
+  agentType: ParsedScreenAgentType,
+): ParsedScreenStatus {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const joined = lines.join("\n");
+
+  if (doneSignal) {
+    return "done";
+  }
+
+  if (errors.length > 0) {
+    return "frozen";
+  }
+
+  if (agentType === "codex" && CODEX_WORKING_RE.test(joined)) {
+    return "working";
+  }
+
+  if (agentType === "codex" && CODEX_RESUME_RE.test(text)) {
+    return "done";
+  }
+
+  const workingMarkers = [
+    "✻",
+    "⏺",
+    "thinking",
+    "working",
+    "receiving ",
+    " /loop",
+    "bypass permissions on",
+    "esc to interrupt",
+    "running",
+  ];
+  if (workingMarkers.some((marker) => joined.toLowerCase().includes(marker.toLowerCase()))) {
+    return "working";
+  }
+
+  if (agentType === "gemini" && /Gemini CLI/i.test(text) && /Thinking/i.test(text)) {
+    return "working";
+  }
+
+  if (agentType === "codex" && /(^|\n)\s*codex\s*>\s*$/m.test(text)) {
+    return "idle";
+  }
+
+  if (/(^|\n)\s*(❯|>>>|\$|>)\s*$/m.test(text)) {
+    return "idle";
+  }
+
+  return "idle";
+}
+
+export function parseScreen(text: string): ParsedScreenResult {
+  const normalized = normalizeText(text);
+  const agentType = detectAgentType(normalized);
+  const doneSignal = parseDoneSignal(normalized);
+  const errors = parseErrors(normalized);
+  const { model, cost } = parseModelAndCost(normalized, agentType);
+
+  const result: ParsedScreenResult = {
+    agent_type: agentType,
+    status: inferStatus(normalized, doneSignal, errors, agentType),
+    token_count: parseTokenCount(normalized),
+    done_signal: doneSignal,
+    response: parseResponse(normalized),
+    errors,
+    model,
+    cost,
+  };
+
+  if (agentType === "codex") {
+    result.context_pct = parseCodexContextPct(normalized);
+    result.actions = parseCodexActions(normalized);
+  }
+
+  return result;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { AgentEngine } from "./agent-engine.js";
+import { parseScreen } from "./screen-parser.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -303,6 +304,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           lines: result.lines,
           content: result.text,
           scrollback_used: result.scrollback_used,
+          parsed: parseScreen(result.text),
         });
       } catch (e) {
         return err(e);

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,22 @@ export interface CmuxReadScreenResult {
   scrollback_used: boolean;
 }
 
+export type ParsedScreenAgentType = "claude" | "codex" | "gemini" | "unknown";
+export type ParsedScreenStatus = "frozen" | "working" | "idle" | "done";
+
+export interface ParsedScreenResult {
+  agent_type: ParsedScreenAgentType;
+  status: ParsedScreenStatus;
+  token_count: number | null;
+  done_signal: string | null;
+  response: string | null;
+  errors: string[];
+  model: string | null;
+  cost: number | null;
+  context_pct?: number | null;
+  actions?: string[];
+}
+
 export interface CmuxStatusEntry {
   key: string;
   value: string;

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { parseScreen } from "../src/screen-parser.js";
+
+describe("parseScreen", () => {
+  it("parses Claude-style output with response block and done signal", () => {
+    const parsed = parseScreen(`
+\u001b[32m⏺ Completed successfully\u001b[0m
+---RESPONSE_START---
+Line one
+Line two
+---RESPONSE_END---
+ENRICHMENT_PROMPT_DONE
+Token usage: total=12,345 input=10,000 output=2,345
+🤖 Sonnet 4.6 | 💰 $7.73 | ⏱️  9hr 58m
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("done");
+    expect(parsed.token_count).toBe(12345);
+    expect(parsed.done_signal).toBe("ENRICHMENT_PROMPT_DONE");
+    expect(parsed.response).toBe("Line one\nLine two");
+    expect(parsed.model).toBe("Sonnet 4.6");
+    expect(parsed.cost).toBe(7.73);
+  });
+
+  it("parses Codex-style output with model, context left, and actions", () => {
+    const parsed = parseScreen(`
+gpt-5.4 high · 87% left · ~/Gits/orchestrator
+Working (2m 06s • esc to interrupt)
+• Ran rg -n "read_screen" src tests
+• Read src/server.ts
+• Edited src/screen-parser.ts
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.status).toBe("working");
+    expect(parsed.model).toBe("gpt-5.4 high");
+    expect(parsed.context_pct).toBe(87);
+    expect(parsed.actions).toContain('Ran rg -n "read_screen" src tests');
+  });
+
+  it("parses Gemini-style output from explicit Gemini CLI markers", () => {
+    const parsed = parseScreen(`
+Gemini CLI
+Model: gemini-3.1-pro
+Thinking...
+> Summarizing repository context
+`);
+
+    expect(parsed.agent_type).toBe("gemini");
+    expect(parsed.status).toBe("working");
+    expect(parsed.model).toBe("gemini-3.1-pro");
+  });
+
+  it("detects idle shell output and strips ANSI sequences", () => {
+    const parsed = parseScreen(`
+\u001b[36mLast login:\u001b[0m Fri Mar 13 18:10:54 on ttys016
+etanheyman ~ [master] $
+`);
+
+    expect(parsed.agent_type).toBe("unknown");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.errors).toEqual([]);
+  });
+});

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -23,6 +23,30 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.cost).toBe(7.73);
   });
 
+  it("treats completed Claude banners as done instead of working", () => {
+    const parsed = parseScreen(`
+\u001b[32m⏺ Completed successfully\u001b[0m
+  Added parser integration to read_screen
+🤖 Sonnet 4.6 | 💰 $1.25 | ⏱️  2m 11s
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("done");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.response).toBeNull();
+  });
+
+  it("treats active Claude status banners as working", () => {
+    const parsed = parseScreen(`
+✻ Working…
+  Reading src/server.ts
+🤖 Sonnet 4.6 | 💰 $0.50 | ⏱️  41s
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("working");
+  });
+
   it("parses Codex-style output with model, context left, and actions", () => {
     const parsed = parseScreen(`
 gpt-5.4 high · 87% left · ~/Gits/orchestrator

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -274,7 +274,14 @@ describe("tool handler integration", () => {
     mockExec = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({
         surface_ref: "surface:1",
-        text: "hello",
+        text: [
+          "---RESPONSE_START---",
+          "hello",
+          "---RESPONSE_END---",
+          "ENRICHMENT_PROMPT_DONE",
+          "Token usage: total=2,345",
+          "🤖 Sonnet 4.6 | 💰 $1.25",
+        ].join("\n"),
         lines: 20,
       }),
       stderr: "",
@@ -291,7 +298,16 @@ describe("tool handler integration", () => {
       expect.arrayContaining(["read-screen"]),
     );
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.content).toBe("hello");
+    expect(parsed.content).toContain("hello");
+    expect(parsed.parsed).toMatchObject({
+      agent_type: "claude",
+      status: "done",
+      token_count: 2345,
+      done_signal: "ENRICHMENT_PROMPT_DONE",
+      response: "hello",
+      model: "Sonnet 4.6",
+      cost: 1.25,
+    });
   });
 
   it("send_input handler calls cmux send", async () => {


### PR DESCRIPTION
## Summary
- add a TypeScript screen parser that detects Claude, Codex, and Gemini terminal output
- extend read_screen to return parsed structured output alongside raw text
- add the cmuxlayer Split Pane Grid logo asset and document the richer read_screen payload

## Test plan
- bun run typecheck
- bun run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `read_screen` tool now returns parsed agent metadata alongside raw terminal text, including status, token counts, model information, and error detection for improved CLI agent monitoring.

* **Documentation**
  * Updated `read_screen` tool documentation with details on returned parsed output.
  * Added visual branding to README.

* **Tests**
  * Increased test coverage to 228 tests, including comprehensive validation of screen parsing across multiple agent types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->