### PR TITLE
feat: push cmux agent lifecycle updates over Claude channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 </p>
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-228%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-233%20passing-brightgreen.svg)](#testing)
 [![MCP](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
 
 ---
 
-**230 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
+**233 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
 
 cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
 
@@ -41,6 +41,12 @@ Add to your editor's MCP config:
 ```
 
 Requires [cmux](https://github.com/manaflow-ai/cmux) to be installed and running.
+
+## Claude Channels Preview
+
+Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` in the server environment and launch Claude Code with `--channels <server-name>` plus `--dangerously-load-development-channels <server-name>` during preview. With that enabled, cmuxlayer advertises `experimental["claude/channel"]` and emits one-way `notifications/claude/channel` updates when tracked agents are spawned, finish, or error.
+
+See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the notification format, OpenClaw pairing patterns worth stealing, and the remaining gaps for a real cmux mobile client.
 
 ## MCP Tools (10)
 

--- a/docs/claude-channels-mobile.md
+++ b/docs/claude-channels-mobile.md
@@ -1,0 +1,53 @@
+# Claude Channels And Mobile Notes
+
+## Status
+
+cmuxlayer can now expose a Claude Code `--channels` compatible push surface for agent lifecycle updates. When `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` is set, the stdio MCP server:
+
+- advertises `capabilities.experimental["claude/channel"] = {}`
+- sets server instructions describing the one-way channel behavior
+- emits `notifications/claude/channel` for agent `spawned`, `done`, and `errored` lifecycle events
+
+The implementation reuses the existing `AgentEngine.syncSidebar()` lifecycle dedupe, so sidebar logs and Claude channel pushes stay aligned.
+
+## What The Channel Prototype Is Good For
+
+Claude channels are a useful notification plane for orchestrator sessions. The current payloads carry identifier-safe metadata for `event`, `agent_id`, `repo`, `state`, `surface_id`, `model`, `cli`, and optional parent/session IDs, which is enough for:
+
+- orchestrator awareness that a worker has started, completed, or crashed
+- low-frequency status fan-out into an already-running Claude session
+- eventually bridging BrainBar pub/sub events into Claude-visible `<channel>` updates
+
+This is intentionally one-way. cmuxlayer does not register a reply tool or accept inbound channel messages.
+
+## OpenClaw Patterns Worth Stealing
+
+OpenClaw's mobile node pairing is the best reference point for a real cmux mobile bridge. The patterns that transfer cleanly are:
+
+- Keep the first hop local. OpenClaw's gateway is loopback-first and only exposed remotely through an explicit transport like Tailscale Serve, Funnel, or SSH tunneling.
+- Require explicit owner approval. Unknown devices do not start sending commands immediately; they enter a pending approval flow.
+- Use trust on first use for the gateway itself. The iOS client stores the server fingerprint and forces a user-visible trust decision on first connect.
+- Store pairing state explicitly. Pending requests, paired devices, scopes, and rotated tokens live in durable structures rather than an ad hoc boolean trust flag.
+- Bound approvals by scope. Approval is not global; the granted role/scope is checked and stale approvals are invalidated when superseded.
+- Make reconnect and catch-up explicit. OpenClaw treats reconnect as a stateful resume problem, not an excuse to flood replay blindly.
+
+## What cmux Mobile Still Needs
+
+Claude channels do not make cmux mobile "done". They help with notifications, but not with terminal transport. A serious mobile design still needs:
+
+- A Mac-side bridge process. iOS cannot connect to cmux's local Unix socket directly, so a local bridge must translate cmuxlayer and BrainBar events into a mobile-friendly transport such as authenticated WebSocket.
+- Real device pairing and approval. OpenClaw's pending-request, approval, TOFU fingerprint, scoped token, and stale-request invalidation model should be copied almost directly.
+- A terminal data plane separate from channels. `notifications/claude/channel` is appropriate for coarse lifecycle events, not for high-frequency terminal output.
+- Incremental terminal syncing. cmux still lacks a native pushed output subscription, so mobile terminal rendering needs either polling plus diffing or a new stream API for PTY output.
+- Viewport and resize contracts. Mobile needs a clear protocol for rows, columns, scrollback windows, and reconnect snapshots.
+- Multi-client control rules. If desktop and mobile can both type, the bridge needs explicit control leases or another arbitration mechanism.
+- Background delivery strategy. iOS background WebSockets are unreliable; notification-only background behavior needs APNs or a similar out-of-band wake path.
+
+## Recommended Architecture Split
+
+Use two planes:
+
+1. Notification plane: BrainBar pub/sub plus Claude `--channels` for low-frequency agent and orchestrator events.
+2. Terminal plane: a dedicated mobile bridge that streams terminal deltas and forwards user input to cmuxlayer or cmux directly.
+
+That split keeps Claude sessions useful as orchestrators while avoiding the mistake of treating channel notifications as a terminal streaming protocol.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -33,6 +33,8 @@ export interface SpawnAgentResult {
   state: AgentState;
 }
 
+export type AgentLifecycleEvent = "spawned" | "done" | "errored";
+
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
@@ -87,6 +89,10 @@ interface AgentEngineClient {
       focus?: boolean;
     },
   ): Promise<CmuxNewSplitResult>;
+  notifyLifecycleEvent(
+    event: AgentLifecycleEvent,
+    agent: AgentRecord,
+  ): Promise<void>;
 }
 
 /** State → sidebar icon/color mapping */
@@ -99,6 +105,12 @@ const STATE_SIDEBAR: Record<AgentState, { icon: string; color: string }> = {
   done: { icon: "checkmark.square.fill", color: "#6B7280" },
   error: { icon: "xmark.circle.fill", color: "#EF4444" },
 };
+
+const LIFECYCLE_LOGS = {
+  spawned: { message: "spawned", level: "info" },
+  done: { message: "done", level: "success" },
+  errored: { message: "errored", level: "error" },
+} as const;
 
 /**
  * Build the shell command that launches a CLI agent.
@@ -152,6 +164,31 @@ export class AgentEngine {
     return this.registry;
   }
 
+  private async emitLifecycleEvent(
+    agent: AgentRecord,
+    event: AgentLifecycleEvent,
+  ): Promise<void> {
+    const eventKey = `${agent.agent_id}:${event}`;
+    if (this.loggedEvents.has(eventKey)) {
+      return;
+    }
+
+    const spec = LIFECYCLE_LOGS[event];
+    await this.client.log(`${spec.message}: ${agent.repo}`, {
+      level: spec.level,
+      source: "cmux-mcp",
+    });
+
+    try {
+      // Channel delivery is best-effort and must not break the sweep loop.
+      await this.client.notifyLifecycleEvent(event, agent);
+    } catch {
+      // Ignore Claude channel push failures; logs and sidebar state remain canonical.
+    }
+
+    this.loggedEvents.add(eventKey);
+  }
+
   /**
    * Sync sidebar: diff agents against snapshot, push only changes.
    * Logs lifecycle events (spawned, done, error) once each.
@@ -168,31 +205,17 @@ export class AgentEngine {
 
       // Lifecycle log: spawned (first encounter)
       if (!this.sidebarSnapshot.has(agentId)) {
-        if (!this.loggedEvents.has(`${agentId}:spawned`)) {
-          await this.client.log(`spawned: ${repo}`, {
-            level: "info",
-            source: "cmux-mcp",
-          });
-          this.loggedEvents.add(`${agentId}:spawned`);
-        }
+        await this.emitLifecycleEvent(agent, "spawned");
       }
 
       // Lifecycle log: done
-      if (state === "done" && !this.loggedEvents.has(`${agentId}:done`)) {
-        await this.client.log(`done: ${repo}`, {
-          level: "success",
-          source: "cmux-mcp",
-        });
-        this.loggedEvents.add(`${agentId}:done`);
+      if (state === "done") {
+        await this.emitLifecycleEvent(agent, "done");
       }
 
       // Lifecycle log: error
-      if (state === "error" && !this.loggedEvents.has(`${agentId}:error`)) {
-        await this.client.log(`errored: ${repo}`, {
-          level: "error",
-          source: "cmux-mcp",
-        });
-        this.loggedEvents.add(`${agentId}:error`);
+      if (state === "error") {
+        await this.emitLifecycleEvent(agent, "errored");
       }
 
       // Status diff — only push if changed

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,11 @@ import { parseReservedModeKey } from "./mode-policy.js";
 import { replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
-import { AgentEngine } from "./agent-engine.js";
+import {
+  AgentEngine,
+  type AgentLifecycleEvent,
+} from "./agent-engine.js";
+import type { AgentRecord } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
 
 type TextContent = { type: "text"; text: string };
@@ -21,6 +25,11 @@ type ToolReturn = {
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
+
+const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
+const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
+const CLAUDE_CHANNEL_INSTRUCTIONS =
+  "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmux agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 
 function ok(data: Record<string, unknown>): ToolReturn {
   const payload = { ok: true, ...data };
@@ -58,16 +67,76 @@ export interface CreateServerOptions {
   stateDir?: string;
   /** Skip agent lifecycle initialization (for testing low-level tools only) */
   skipAgentLifecycle?: boolean;
+  /** Opt into Claude Code channel notifications for lifecycle events */
+  enableClaudeChannels?: boolean;
+}
+
+function formatLifecycleChannelContent(
+  event: AgentLifecycleEvent,
+  agent: AgentRecord,
+): string {
+  switch (event) {
+    case "spawned":
+      return `cmux agent spawned: ${agent.repo} (${agent.agent_id}) is ${agent.state}`;
+    case "done":
+      return `cmux agent done: ${agent.repo} (${agent.agent_id}) finished`;
+    case "errored":
+      return agent.error
+        ? `cmux agent errored: ${agent.repo} (${agent.agent_id}) - ${agent.error}`
+        : `cmux agent errored: ${agent.repo} (${agent.agent_id})`;
+  }
+}
+
+function buildLifecycleChannelMeta(
+  event: AgentLifecycleEvent,
+  agent: AgentRecord,
+): Record<string, string> {
+  const meta: Record<string, string> = {
+    source: "cmux-agent-status",
+    event,
+    agent_id: agent.agent_id,
+    repo: agent.repo,
+    state: agent.state,
+    surface_id: agent.surface_id,
+    model: agent.model,
+    cli: agent.cli,
+    spawn_depth: String(agent.spawn_depth),
+  };
+
+  if (agent.parent_agent_id) {
+    meta.parent_agent_id = agent.parent_agent_id;
+  }
+  if (agent.cli_session_id) {
+    meta.cli_session_id = agent.cli_session_id;
+  }
+
+  return meta;
 }
 
 export function createServer(opts?: CreateServerOptions): McpServer {
   const client =
     opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  const enableClaudeChannels =
+    opts?.enableClaudeChannels ??
+    process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1";
 
-  const server = new McpServer({
-    name: "@golems/cmux-mcp",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      name: "@golems/cmux-mcp",
+      version: "0.1.0",
+    },
+    enableClaudeChannels
+      ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }
+      : undefined,
+  );
+
+  if (enableClaudeChannels) {
+    server.server.registerCapabilities({
+      experimental: {
+        [CLAUDE_CHANNEL_CAPABILITY]: {},
+      },
+    });
+  }
 
   // 1. list_surfaces
   server.tool(
@@ -576,7 +645,36 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
     };
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    const engine = new AgentEngine(stateMgr, registry, client);
+    const notifyLifecycleEvent = async (
+      event: AgentLifecycleEvent,
+      agent: AgentRecord,
+    ): Promise<void> => {
+      if (!enableClaudeChannels || !server.server.transport) {
+        return;
+      }
+
+      // Claude turns meta keys into <channel ...> attributes, so keep keys simple.
+      await server.server.notification({
+        method: CLAUDE_CHANNEL_NOTIFICATION,
+        params: {
+          content: formatLifecycleChannelContent(event, agent),
+          meta: buildLifecycleChannelMeta(event, agent),
+        },
+      });
+    };
+    const engine = new AgentEngine(stateMgr, registry, {
+      log: (message, eventOpts) => client.log(message, eventOpts),
+      setStatus: (key, value, statusOpts) =>
+        client.setStatus(key, value, statusOpts),
+      readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
+      send: (surface, text, sendOpts) => client.send(surface, text, sendOpts),
+      sendKey: (surface, key, keyOpts) =>
+        client.sendKey(surface, key, keyOpts),
+      setProgress: (value, progressOpts) =>
+        client.setProgress(value, progressOpts),
+      newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),
+      notifyLifecycleEvent,
+    });
 
     // Reconstitute registry from disk on startup (async, best-effort)
     registry.reconstitute().catch(() => {});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
+import { StateManager } from "../src/state-manager.js";
 
 // The 10 tools from the design doc
 const EXPECTED_TOOLS = [
@@ -16,11 +21,34 @@ const EXPECTED_TOOLS = [
   "browser_surface",
 ] as const;
 
+const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
+
 describe("createServer", () => {
   it("returns an McpServer with a connect method", async () => {
     const server = createServer({ skipAgentLifecycle: true });
     expect(server).toBeDefined();
     expect(typeof server.connect).toBe("function");
+  });
+
+  it("registers Claude channel capability when enabled", () => {
+    const server = createServer({
+      skipAgentLifecycle: true,
+      enableClaudeChannels: true,
+    });
+    const rawServer = (server as any).server;
+
+    expect(rawServer._capabilities.experimental).toEqual({
+      "claude/channel": {},
+    });
+    expect(rawServer._instructions).toContain("notifications/claude/channel");
+  });
+
+  it("does not register Claude channel capability by default", () => {
+    const server = createServer({ skipAgentLifecycle: true });
+    const rawServer = (server as any).server;
+
+    expect(rawServer._capabilities.experimental).toBeUndefined();
+    expect(rawServer._instructions).toBeUndefined();
   });
 });
 
@@ -36,6 +64,126 @@ describe("tool registration", () => {
       expect(toolNames).toContain(expected);
     }
     expect(toolNames).toHaveLength(EXPECTED_TOOLS.length);
+  });
+});
+
+describe("Claude channels", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+    rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("emits lifecycle notifications over the MCP transport when enabled", async () => {
+    vi.useFakeTimers();
+    rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+
+    const stateMgr = new StateManager(CHANNEL_TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "a1",
+      surface_id: "surface:42",
+      state: "done",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "Ship channel prototype",
+      pid: null,
+      version: 1,
+      created_at: "2026-03-21T00:00:00Z",
+      updated_at: "2026-03-21T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            ref: "surface:42",
+            title: "agent",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+      log: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue(undefined),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:42",
+        text: "$ ",
+        lines: 5,
+        scrollback_used: false,
+      }),
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      setProgress: vi.fn().mockResolvedValue(undefined),
+      newSplit: vi.fn(),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir: CHANNEL_TEST_DIR,
+      enableClaudeChannels: true,
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const messages: any[] = [];
+    clientTransport.onmessage = (message) => {
+      messages.push(message);
+    };
+
+    await server.connect(serverTransport);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const notifications = messages.filter(
+      (message) =>
+        "method" in message &&
+        message.method === "notifications/claude/channel",
+    );
+    expect(notifications).toHaveLength(2);
+    expect(notifications).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            meta: expect.objectContaining({
+              event: "spawned",
+              agent_id: "a1",
+              repo: "brainlayer",
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            meta: expect.objectContaining({
+              event: "done",
+              agent_id: "a1",
+              repo: "brainlayer",
+            }),
+          }),
+        }),
+      ]),
+    );
+
+    await server.close();
+    await clientTransport.close();
   });
 });
 

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -44,6 +44,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
     identify: vi.fn().mockResolvedValue({}),
     browser: vi.fn().mockResolvedValue({}),
     log: vi.fn().mockResolvedValue(undefined),
+    notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as CmuxClient;
 }
@@ -205,6 +206,14 @@ describe("Sidebar Sync", () => {
       "spawned: brainlayer",
       expect.objectContaining({ level: "info", source: "cmux-mcp" }),
     );
+    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
+      "spawned",
+      expect.objectContaining({
+        agent_id: "a1",
+        repo: "brainlayer",
+        state: "working",
+      }),
+    );
   });
 
   it("logs done event when agent reaches done state", async () => {
@@ -231,6 +240,14 @@ describe("Sidebar Sync", () => {
       "done: brainlayer",
       expect.objectContaining({ level: "success", source: "cmux-mcp" }),
     );
+    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
+      "done",
+      expect.objectContaining({
+        agent_id: "a1",
+        repo: "brainlayer",
+        state: "done",
+      }),
+    );
   });
 
   it("logs error event when agent enters error state", async () => {
@@ -250,6 +267,14 @@ describe("Sidebar Sync", () => {
     expect(mockClient.log).toHaveBeenCalledWith(
       "errored: brainlayer",
       expect.objectContaining({ level: "error", source: "cmux-mcp" }),
+    );
+    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
+      "errored",
+      expect.objectContaining({
+        agent_id: "a1",
+        repo: "brainlayer",
+        state: "error",
+      }),
     );
   });
 
@@ -275,5 +300,13 @@ describe("Sidebar Sync", () => {
       (c) => typeof c[0] === "string" && c[0].startsWith("done:"),
     );
     expect(doneCalls).toHaveLength(1);
+
+    const channelCalls = (
+      (mockClient as any).notifyLifecycleEvent as ReturnType<typeof vi.fn>
+    ).mock.calls;
+    const spawnedChannelCalls = channelCalls.filter((c) => c[0] === "spawned");
+    expect(spawnedChannelCalls).toHaveLength(1);
+    const doneChannelCalls = channelCalls.filter((c) => c[0] === "done");
+    expect(doneChannelCalls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- add optional Claude Code --channels support behind CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1
- emit notifications/claude/channel for spawned, done, and errored agent lifecycle events using the existing sidebar dedupe path
- document OpenClaw pairing patterns and remaining cmux mobile gaps, and add transport-level regression coverage

## Test plan
- [x] npm test (17 files, 233 tests passing)
- [x] npm run typecheck
- [x] npm run build
- [x] in-memory MCP transport regression test for notifications/claude/channel
- [ ] authenticated live Claude Code session in cmux (claude in a fresh split is blocked locally by Invalid API key / Fix external API key)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push agent lifecycle events over Claude MCP channels
> - Adds a `notifyLifecycleEvent` method to `AgentEngineClient` in [src/agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/8/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) that fires once per agent per event (`spawned`, `done`, `errored`) with deduplication.
> - Adds Claude channel support to [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/8/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): when `enableClaudeChannels` is set (via option or `CMUXLAYER_ENABLE_CLAUDE_CHANNELS` env var), the MCP server registers an experimental `claude/channel` capability and emits `notifications/claude/channel` messages with content and structured meta for each lifecycle event.
> - Default behavior (channels disabled) is unchanged; notification failures are swallowed silently.
> - Adds documentation in [docs/claude-channels-mobile.md](https://github.com/EtanHey/cmuxlayer/pull/8/files#diff-afcfb511908f3d6a135752dda4fe9de223ecc3e3cba7bcc651a948a51b9669f7) covering the channel payload format and mobile client architecture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49f7f20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->