### PR TITLE
fix: restore claude auth and sidebar quoting

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -126,7 +126,15 @@ function buildLaunchCommand(cli: CliType, repo: string): string {
   const cdCmd = `cd ~/Gits/${safeRepo}`;
   switch (cli) {
     case "claude":
-      return `${cdCmd} && claude --dangerously-skip-permissions`;
+      return [
+        "source ~/.zshrc >/dev/null 2>&1 || true",
+        "unset ANTHROPIC_API_KEY",
+        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then`,
+        `${safeRepo}Claude -s`,
+        "else",
+        `${cdCmd} && claude --dangerously-skip-permissions`,
+        "fi",
+      ].join("; ");
     case "codex":
       return `${cdCmd} && codex`;
     case "gemini":

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -129,11 +129,7 @@ function buildLaunchCommand(cli: CliType, repo: string): string {
       return [
         "source ~/.zshrc >/dev/null 2>&1 || true",
         "unset ANTHROPIC_API_KEY",
-        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then`,
-        `${safeRepo}Claude -s`,
-        "else",
-        `${cdCmd} && claude --dangerously-skip-permissions`,
-        "fi",
+        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then ${safeRepo}Claude -s; else ${cdCmd} && claude --dangerously-skip-permissions; fi`,
       ].join("; ");
     case "codex":
       return `${cdCmd} && codex`;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -129,7 +129,7 @@ function buildLaunchCommand(cli: CliType, repo: string): string {
       return [
         "source ~/.zshrc >/dev/null 2>&1 || true",
         "unset ANTHROPIC_API_KEY",
-        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then ${safeRepo}Claude -s; else ${cdCmd} && claude --dangerously-skip-permissions; fi`,
+        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then ${cdCmd} && ${safeRepo}Claude -s; else ${cdCmd} && claude --dangerously-skip-permissions; fi`,
       ].join("; ");
     case "codex":
       return `${cdCmd} && codex`;

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -23,6 +23,7 @@ import type {
 
 const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const REQUEST_TIMEOUT_MS = 10_000;
+const V1_SAFE_ARG_RE = /^[A-Za-z0-9_./:@%+=#,-]+$/;
 
 export interface CmuxSocketClientOptions {
   socketPath?: string;
@@ -238,6 +239,19 @@ export class CmuxSocketClient {
     });
   }
 
+  private quoteV1Arg(arg: string): string {
+    if (!arg) return '""';
+    if (V1_SAFE_ARG_RE.test(arg)) return arg;
+    return JSON.stringify(arg);
+  }
+
+  private sendV1Args(args: string[]): Promise<string> {
+    const [command, ...rest] = args;
+    return this.sendV1(
+      [command, ...rest.map((arg) => this.quoteV1Arg(arg))].join(" "),
+    );
+  }
+
   /**
    * Execute a V2 method and return the result. Throws on error.
    */
@@ -407,7 +421,7 @@ export class CmuxSocketClient {
     const args = ["rename_tab", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
     args.push(title);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async setStatus(
@@ -429,13 +443,13 @@ export class CmuxSocketClient {
         ? (await this.identify(opts.surface)).caller?.workspace_ref
         : undefined);
     if (workspace) args.push("--workspace", workspace);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {
     const args = ["clear_status", key];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async setProgress(
@@ -454,13 +468,13 @@ export class CmuxSocketClient {
         ? (await this.identify(opts.surface)).caller?.workspace_ref
         : undefined);
     if (workspace) args.push("--workspace", workspace);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async clearProgress(opts?: { workspace?: string }): Promise<void> {
     const args = ["clear_progress"];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async log(
@@ -481,7 +495,7 @@ export class CmuxSocketClient {
         ? (await this.identify(opts.surface)).caller?.workspace_ref
         : undefined);
     if (workspace) args.push("--workspace", workspace);
-    await this.sendV1(args.join(" "));
+    await this.sendV1Args(args);
   }
 
   async closeSurface(
@@ -499,7 +513,7 @@ export class CmuxSocketClient {
   async listStatus(opts?: { workspace?: string }): Promise<CmuxStatusEntry[]> {
     const args = ["list_status"];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
-    const raw = await this.sendV1(args.join(" "));
+    const raw = await this.sendV1Args(args);
     if (!raw || raw === "OK") return [];
     try {
       return JSON.parse(raw) as CmuxStatusEntry[];

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -486,7 +486,7 @@ export class CmuxSocketClient {
       surface?: string;
     },
   ): Promise<void> {
-    const args = ["log", JSON.stringify(message)];
+    const args = ["log", message];
     if (opts?.level) args.push("--level", opts.level);
     if (opts?.source) args.push("--source", opts.source);
     const workspace =

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -437,18 +437,16 @@ export class CmuxSocketClient {
     const args = ["set_status", key, value];
     if (opts?.icon) args.push("--icon", opts.icon);
     if (opts?.color) args.push("--color", opts.color);
-    const workspace =
-      opts?.workspace ??
-      (opts?.surface
-        ? (await this.identify(opts.surface)).caller?.workspace_ref
-        : undefined);
-    if (workspace) args.push("--workspace", workspace);
+    const tabId = await this.resolveSidebarTabId(opts);
+    if (tabId) args.push(`--tab=${tabId}`);
     await this.sendV1Args(args);
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {
     const args = ["clear_status", key];
-    if (opts?.workspace) args.push("--workspace", opts.workspace);
+    if (opts?.workspace) {
+      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+    }
     await this.sendV1Args(args);
   }
 
@@ -462,18 +460,16 @@ export class CmuxSocketClient {
   ): Promise<void> {
     const args = ["set_progress", String(value)];
     if (opts?.label) args.push("--label", opts.label);
-    const workspace =
-      opts?.workspace ??
-      (opts?.surface
-        ? (await this.identify(opts.surface)).caller?.workspace_ref
-        : undefined);
-    if (workspace) args.push("--workspace", workspace);
+    const tabId = await this.resolveSidebarTabId(opts);
+    if (tabId) args.push(`--tab=${tabId}`);
     await this.sendV1Args(args);
   }
 
   async clearProgress(opts?: { workspace?: string }): Promise<void> {
     const args = ["clear_progress"];
-    if (opts?.workspace) args.push("--workspace", opts.workspace);
+    if (opts?.workspace) {
+      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+    }
     await this.sendV1Args(args);
   }
 
@@ -486,15 +482,12 @@ export class CmuxSocketClient {
       surface?: string;
     },
   ): Promise<void> {
-    const args = ["log", message];
+    const args = ["log"];
     if (opts?.level) args.push("--level", opts.level);
     if (opts?.source) args.push("--source", opts.source);
-    const workspace =
-      opts?.workspace ??
-      (opts?.surface
-        ? (await this.identify(opts.surface)).caller?.workspace_ref
-        : undefined);
-    if (workspace) args.push("--workspace", workspace);
+    const tabId = await this.resolveSidebarTabId(opts);
+    if (tabId) args.push(`--tab=${tabId}`);
+    args.push("--", message);
     await this.sendV1Args(args);
   }
 
@@ -512,7 +505,9 @@ export class CmuxSocketClient {
 
   async listStatus(opts?: { workspace?: string }): Promise<CmuxStatusEntry[]> {
     const args = ["list_status"];
-    if (opts?.workspace) args.push("--workspace", opts.workspace);
+    if (opts?.workspace) {
+      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+    }
     const raw = await this.sendV1Args(args);
     if (!raw || raw === "OK") return [];
     try {
@@ -594,6 +589,40 @@ export class CmuxSocketClient {
     throw new CmuxSocketError(
       `Unable to resolve workspace for surface ${surface}`,
       "not_found",
+    );
+  }
+
+  private async resolveSidebarTabId(opts?: {
+    workspace?: string;
+    surface?: string;
+  }): Promise<string | undefined> {
+    const workspace =
+      opts?.workspace ??
+      (opts?.surface
+        ? (await this.identify(opts.surface)).caller?.workspace_ref
+        : undefined);
+    if (!workspace) return undefined;
+    return this.resolveWorkspaceTabId(workspace);
+  }
+
+  private async resolveWorkspaceTabId(workspace: string): Promise<string> {
+    const { workspaces } = await this.listWorkspaces();
+    const match = workspaces.find(
+      (candidate) => candidate.ref === workspace || candidate.id === workspace,
+    );
+
+    if (match?.id) return match.id;
+    if (this.looksLikeUuid(workspace)) return workspace;
+
+    throw new CmuxSocketError(
+      `Unable to resolve tab id for workspace ${workspace}`,
+      "not_found",
+    );
+  }
+
+  private looksLikeUuid(value: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
     );
   }
 

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -23,7 +23,13 @@ import type {
 
 const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const REQUEST_TIMEOUT_MS = 10_000;
-const V1_SAFE_ARG_RE = /^[A-Za-z0-9_./:@%+=#,-]+$/;
+const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
+
+interface V1RawArg {
+  raw: string;
+}
+
+type V1Arg = string | V1RawArg;
 
 export interface CmuxSocketClientOptions {
   socketPath?: string;
@@ -241,14 +247,22 @@ export class CmuxSocketClient {
 
   private quoteV1Arg(arg: string): string {
     if (!arg) return '""';
-    if (V1_SAFE_ARG_RE.test(arg)) return arg;
+    if (V1_SAFE_VALUE_RE.test(arg)) return arg;
     return JSON.stringify(arg);
   }
 
-  private sendV1Args(args: string[]): Promise<string> {
-    const [command, ...rest] = args;
+  private rawV1Arg(arg: string): V1RawArg {
+    return { raw: arg };
+  }
+
+  private sendV1Args(command: string, args: V1Arg[] = []): Promise<string> {
     return this.sendV1(
-      [command, ...rest.map((arg) => this.quoteV1Arg(arg))].join(" "),
+      [
+        command,
+        ...args.map((arg) =>
+          typeof arg === "string" ? this.quoteV1Arg(arg) : arg.raw,
+        ),
+      ].join(" "),
     );
   }
 
@@ -418,10 +432,12 @@ export class CmuxSocketClient {
     title: string,
     opts?: { workspace?: string },
   ): Promise<void> {
-    const args = ["rename_tab", "--surface", surface];
-    if (opts?.workspace) args.push("--workspace", opts.workspace);
+    const args: V1Arg[] = [this.rawV1Arg("--surface"), surface];
+    if (opts?.workspace) {
+      args.push(this.rawV1Arg("--workspace"), opts.workspace);
+    }
     args.push(title);
-    await this.sendV1Args(args);
+    await this.sendV1Args("rename_tab", args);
   }
 
   async setStatus(
@@ -434,20 +450,22 @@ export class CmuxSocketClient {
       surface?: string;
     },
   ): Promise<void> {
-    const args = ["set_status", key, value];
-    if (opts?.icon) args.push("--icon", opts.icon);
-    if (opts?.color) args.push("--color", opts.color);
+    const args: V1Arg[] = [key, value];
+    if (opts?.icon) args.push(this.rawV1Arg("--icon"), opts.icon);
+    if (opts?.color) args.push(this.rawV1Arg("--color"), opts.color);
     const tabId = await this.resolveSidebarTabId(opts);
-    if (tabId) args.push(`--tab=${tabId}`);
-    await this.sendV1Args(args);
+    if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
+    await this.sendV1Args("set_status", args);
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {
-    const args = ["clear_status", key];
+    const args: V1Arg[] = [key];
     if (opts?.workspace) {
-      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+      args.push(
+        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+      );
     }
-    await this.sendV1Args(args);
+    await this.sendV1Args("clear_status", args);
   }
 
   async setProgress(
@@ -458,19 +476,21 @@ export class CmuxSocketClient {
       surface?: string;
     },
   ): Promise<void> {
-    const args = ["set_progress", String(value)];
-    if (opts?.label) args.push("--label", opts.label);
+    const args: V1Arg[] = [String(value)];
+    if (opts?.label) args.push(this.rawV1Arg("--label"), opts.label);
     const tabId = await this.resolveSidebarTabId(opts);
-    if (tabId) args.push(`--tab=${tabId}`);
-    await this.sendV1Args(args);
+    if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
+    await this.sendV1Args("set_progress", args);
   }
 
   async clearProgress(opts?: { workspace?: string }): Promise<void> {
-    const args = ["clear_progress"];
+    const args: V1Arg[] = [];
     if (opts?.workspace) {
-      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+      args.push(
+        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+      );
     }
-    await this.sendV1Args(args);
+    await this.sendV1Args("clear_progress", args);
   }
 
   async log(
@@ -482,13 +502,13 @@ export class CmuxSocketClient {
       surface?: string;
     },
   ): Promise<void> {
-    const args = ["log"];
-    if (opts?.level) args.push("--level", opts.level);
-    if (opts?.source) args.push("--source", opts.source);
+    const args: V1Arg[] = [];
+    if (opts?.level) args.push(this.rawV1Arg("--level"), opts.level);
+    if (opts?.source) args.push(this.rawV1Arg("--source"), opts.source);
     const tabId = await this.resolveSidebarTabId(opts);
-    if (tabId) args.push(`--tab=${tabId}`);
-    args.push("--", message);
-    await this.sendV1Args(args);
+    if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
+    args.push(this.rawV1Arg("--"), message);
+    await this.sendV1Args("log", args);
   }
 
   async closeSurface(
@@ -504,11 +524,13 @@ export class CmuxSocketClient {
   }
 
   async listStatus(opts?: { workspace?: string }): Promise<CmuxStatusEntry[]> {
-    const args = ["list_status"];
+    const args: V1Arg[] = [];
     if (opts?.workspace) {
-      args.push(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`);
+      args.push(
+        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+      );
     }
-    const raw = await this.sendV1Args(args);
+    const raw = await this.sendV1Args("list_status", args);
     if (!raw || raw === "OK") return [];
     try {
       return JSON.parse(raw) as CmuxStatusEntry[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface SurfaceMode {
 }
 
 export interface CmuxWorkspace {
+  id?: string;
   ref: string;
   title: string;
   index: number;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -134,7 +134,9 @@ describe("AgentEngine", () => {
       expect(surface).toBe("surface:new");
       expect(opts).toEqual({ workspace: "ws:1" });
       expect(launchCmd).toContain("unset ANTHROPIC_API_KEY");
-      expect(launchCmd).toContain("brainlayerClaude -s");
+      expect(launchCmd).toContain(
+        "if command -v brainlayerClaude >/dev/null 2>&1; then brainlayerClaude -s; else cd ~/Gits/brainlayer && claude --dangerously-skip-permissions; fi",
+      );
       expect(launchCmd).toContain("claude --dangerously-skip-permissions");
     });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -135,7 +135,7 @@ describe("AgentEngine", () => {
       expect(opts).toEqual({ workspace: "ws:1" });
       expect(launchCmd).toContain("unset ANTHROPIC_API_KEY");
       expect(launchCmd).toContain(
-        "if command -v brainlayerClaude >/dev/null 2>&1; then brainlayerClaude -s; else cd ~/Gits/brainlayer && claude --dangerously-skip-permissions; fi",
+        "if command -v brainlayerClaude >/dev/null 2>&1; then cd ~/Gits/brainlayer && brainlayerClaude -s; else cd ~/Gits/brainlayer && claude --dangerously-skip-permissions; fi",
       );
       expect(launchCmd).toContain("claude --dangerously-skip-permissions");
     });

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -120,6 +120,24 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).toHaveBeenCalled();
     });
 
+    it("launches Claude with repo setup and API-key auth disabled", async () => {
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Fix gap F",
+      });
+
+      const [surface, launchCmd, opts] = (
+        mockClient.send as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      expect(surface).toBe("surface:new");
+      expect(opts).toEqual({ workspace: "ws:1" });
+      expect(launchCmd).toContain("unset ANTHROPIC_API_KEY");
+      expect(launchCmd).toContain("brainlayerClaude -s");
+      expect(launchCmd).toContain("claude --dangerously-skip-permissions");
+    });
+
     it("writes initial state file", async () => {
       const result = await engine.spawnAgent({
         repo: "brainlayer",

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -16,12 +16,14 @@ import { createCmuxClient } from "../src/cmux-client-factory.js";
 // ── Mock V2 Socket Server ──────────────────────────────────────────────
 
 const MOCK_SOCKET_PATH = "/tmp/cmux-test-mock.sock";
+const MOCK_WORKSPACE_ID = "8481D6A0-CE17-4B7C-8695-7A722D30FEE2";
 
 const MOCK_RESPONSES: Record<string, unknown> = {
   "system.ping": { pong: true },
   "workspace.list": {
     workspaces: [
       {
+        id: MOCK_WORKSPACE_ID,
         ref: "workspace:1",
         title: "Test WS",
         index: 0,
@@ -290,7 +292,7 @@ describe("CmuxSocketClient", () => {
     });
 
     expect(lastV1Command).toBe(
-      'set_status agent "brainlayerCodex: building" --workspace workspace:1',
+      `set_status agent "brainlayerCodex: building" --tab=${MOCK_WORKSPACE_ID}`,
     );
   });
 
@@ -303,7 +305,7 @@ describe("CmuxSocketClient", () => {
     });
 
     expect(lastV1Command).toBe(
-      'set_progress 0.95 --label "enrichment 95%" --workspace workspace:1',
+      `set_progress 0.95 --label "enrichment 95%" --tab=${MOCK_WORKSPACE_ID}`,
     );
   });
 
@@ -315,7 +317,31 @@ describe("CmuxSocketClient", () => {
     });
 
     expect(lastV1Command).toBe(
-      'log "agent finished cleanly" --workspace workspace:1',
+      `log --tab=${MOCK_WORKSPACE_ID} -- "agent finished cleanly"`,
+    );
+  });
+
+  it("preserves flag-shaped log messages as message payloads", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.log("--workspace", {
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      `log --tab=${MOCK_WORKSPACE_ID} -- --workspace`,
+    );
+  });
+
+  it("resolves surface-derived workspaces to tab ids for V1 sidebar commands", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.setStatus("agent", "active", {
+      surface: "surface:1",
+    });
+
+    expect(lastV1Command).toBe(
+      `set_status agent active --tab=${MOCK_WORKSPACE_ID}`,
     );
   });
 });

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -306,6 +306,18 @@ describe("CmuxSocketClient", () => {
       'set_progress 0.95 --label "enrichment 95%" --workspace workspace:1',
     );
   });
+
+  it("quotes log values with spaces for V1 sidebar commands", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.log("agent finished cleanly", {
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      'log "agent finished cleanly" --workspace workspace:1',
+    );
+  });
 });
 
 describe("createCmuxClient factory", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -329,7 +329,19 @@ describe("CmuxSocketClient", () => {
     });
 
     expect(lastV1Command).toBe(
-      `log --tab=${MOCK_WORKSPACE_ID} -- --workspace`,
+      `log --tab=${MOCK_WORKSPACE_ID} -- "--workspace"`,
+    );
+  });
+
+  it("quotes flag-shaped status values in the outgoing V1 command", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.setStatus("agent", "--workspace", {
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      `set_status agent "--workspace" --tab=${MOCK_WORKSPACE_ID}`,
     );
   });
 

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -89,6 +89,7 @@ const MOCK_RESPONSES: Record<string, unknown> = {
 };
 
 let mockServer: net.Server;
+let lastV1Command = "";
 
 function startMockServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -132,6 +133,7 @@ function startMockServer(): Promise<void> {
             }
           } catch {
             // Not JSON — handle as V1 plain-text command
+            lastV1Command = line;
             const cmd = line.split(" ")[0];
             if (
               cmd &&
@@ -183,6 +185,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await stopMockServer();
+});
+
+beforeEach(() => {
+  lastV1Command = "";
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -274,6 +280,31 @@ describe("CmuxSocketClient", () => {
     const result = await client.listStatus({ workspace: "workspace:1" });
     expect(result).toBeInstanceOf(Array);
     expect(result[0].key).toBe("agent");
+  });
+
+  it("quotes status values with spaces for V1 sidebar commands", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.setStatus("agent", "brainlayerCodex: building", {
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      'set_status agent "brainlayerCodex: building" --workspace workspace:1',
+    );
+  });
+
+  it("quotes progress labels with spaces for V1 sidebar commands", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.setProgress(0.95, {
+      label: "enrichment 95%",
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      'set_progress 0.95 --label "enrichment 95%" --workspace workspace:1',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- scrub `ANTHROPIC_API_KEY` before spawning Claude from cmuxlayer and prefer repo launchers after sourcing `~/.zshrc`
- quote V1 sidebar socket arguments so status values and progress labels with spaces survive socket transport
- add regression coverage for the Claude launch command and V1 sidebar quoting

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] manual auth check: bare `claude --print` failed with inherited `ANTHROPIC_API_KEY`, launch pattern with key scrub succeeded
- [x] manual sidebar check: `cmux sidebar-state` showed `agent1=brainlayerCodex: building` and `progress=0.95 enrichment: 95%` in an isolated workspace

## Notes
- local `cr review --plain` failed to start with `Review failed: Unknown error`, so GitHub-side review is requested below before merge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude auth and shell-quote sidebar V1 commands in `CmuxSocketClient`
> - The Claude agent launch command in [`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/9/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now unsets `ANTHROPIC_API_KEY`, sources `~/.zshrc`, and prefers a repo-scoped `${repo}Claude -s` executable before falling back to `claude --dangerously-skip-permissions`.
> - [`src/cmux-socket-client.ts`](https://github.com/EtanHey/cmuxlayer/pull/9/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) introduces `quoteV1Arg`/`rawV1Arg`/`sendV1Args` helpers to consistently shell-quote string arguments (spaces, unsafe chars) while passing flags verbatim.
> - Sidebar commands (`set_status`, `set_progress`, `log`, etc.) now resolve the target via `--tab=<id>` (from workspace or surface) rather than `--workspace`.
> - The `log` command inserts a `--` separator before the message to prevent flag-shaped strings from being misinterpreted.
> - Behavioral Change: any status/progress/log value containing spaces or special characters will now be quoted; tab targeting switches from workspace name to resolved tab UUID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c205dff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Claude agent launch to prefer repo-scoped binaries when present, with a safe fallback to the standard launcher.
  * Improved V1 command argument handling to correctly quote/escape arguments containing spaces.

* **Tests**
  * Added coverage for agent launch command construction and fallback behavior.
  * Added tests validating exact V1 argument quoting for status, progress, and log commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->