### PR TITLE
feat: model-aware context_pct in screen parser

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8,7 +8,6 @@ import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import type { CmuxNewSplitResult, CmuxReadScreenResult } from "./types.js";
 import {
   generateAgentId,
-  parseContextPercent,
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
   type AgentRecord,
@@ -16,6 +15,7 @@ import {
   type CliType,
   type WaitResult,
 } from "./agent-types.js";
+import { parseScreen } from "./screen-parser.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -235,10 +235,13 @@ export class AgentEngine {
       }
 
       // Quality tracking: check context usage for non-terminal agents
+      // AIDEV-NOTE: Uses parseScreen for model-aware context_pct (handles Claude, Codex, Gemini).
+      // Replaces legacy parseContextPercent which only matched "X% context" text patterns.
       if (!TERMINAL_STATES.has(state)) {
         try {
           const screen = await this.client.readScreen(surface_id, { lines: 5 });
-          const contextPct = parseContextPercent(screen.text);
+          const parsed = parseScreen(screen.text);
+          const contextPct = parsed.context_pct;
           if (
             contextPct !== null &&
             contextPct >= 80 &&

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,8 @@
-export { parseScreen } from "./screen-parser.js";
+export {
+  parseScreen,
+  resolveModelMax,
+  MODEL_MAX_TOKENS,
+} from "./screen-parser.js";
 export type {
   ParsedScreenAgentType,
   ParsedScreenResult,

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -6,6 +6,8 @@ import type {
 
 // AIDEV-NOTE: Model context window sizes in tokens. Used to compute context_pct from raw token_count.
 // Keep this table updated as new models launch.
+// ORDER MATTERS: resolveModelMax uses substring matching, so more-specific keys (e.g. "gpt-5")
+// must come before less-specific ones (e.g. "gpt-4") if they share a common prefix.
 export const MODEL_MAX_TOKENS: Record<string, number> = {
   // Claude models
   opus: 1_000_000,

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -30,8 +30,10 @@ export function resolveModelMax(model: string | null): number | null {
   const lower = model.toLowerCase().trim();
 
   // Try each key as a prefix/substring match
+  // Also match space-separated variants (e.g., "gpt 4" matches "gpt-4")
   for (const [key, max] of Object.entries(MODEL_MAX_TOKENS)) {
-    if (lower.includes(key)) return max;
+    if (lower.includes(key) || lower.includes(key.replace("-", " ")))
+      return max;
   }
 
   return null;

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1,9 +1,45 @@
-import type { ParsedScreenAgentType, ParsedScreenResult, ParsedScreenStatus } from "./types.js";
+import type {
+  ParsedScreenAgentType,
+  ParsedScreenResult,
+  ParsedScreenStatus,
+} from "./types.js";
+
+// AIDEV-NOTE: Model context window sizes in tokens. Used to compute context_pct from raw token_count.
+// Keep this table updated as new models launch.
+export const MODEL_MAX_TOKENS: Record<string, number> = {
+  // Claude models
+  opus: 1_000_000,
+  sonnet: 200_000,
+  haiku: 200_000,
+  // GPT / Codex models
+  "gpt-5": 1_000_000,
+  "gpt-4": 128_000,
+  // Gemini models
+  "gemini-3": 1_000_000,
+  "gemini-2": 1_000_000,
+  "gemini-1": 1_000_000,
+};
+
+/**
+ * Resolve the max context window size for a model string.
+ * Matches by prefix/keyword — e.g. "Sonnet 4.6" matches "sonnet", "gpt-5.4 high" matches "gpt-5".
+ * Returns null if model is unknown.
+ */
+export function resolveModelMax(model: string | null): number | null {
+  if (!model) return null;
+  const lower = model.toLowerCase().trim();
+
+  // Try each key as a prefix/substring match
+  for (const [key, max] of Object.entries(MODEL_MAX_TOKENS)) {
+    if (lower.includes(key)) return max;
+  }
+
+  return null;
+}
 
 const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DONE_SIGNAL_RE = /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)\b/;
-const RESPONSE_BLOCK_RE =
-  /---RESPONSE_START---\s*(.*?)\s*---RESPONSE_END---/s;
+const RESPONSE_BLOCK_RE = /---RESPONSE_START---\s*(.*?)\s*---RESPONSE_END---/s;
 const TOKEN_USAGE_RE = /Token usage:\s*total=([0-9][0-9,]*)/i;
 const TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/i;
 const MODEL_COST_RE = /🤖\s*([^|\n]+?)\s*\|\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)/i;
@@ -15,12 +51,10 @@ const CODEX_MODEL_RE =
 const CODEX_WORKING_RE =
   /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
 const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
-const CODEX_ACTION_RE =
-  /^\s*[•·]\s+(.+)$/gm;
+const CODEX_ACTION_RE = /^\s*[•·]\s+(.+)$/gm;
 const GEMINI_MODEL_RE =
   /(?:^|\n)\s*(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
-const CLAUDE_DONE_LINE_RE =
-  /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
+const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
@@ -42,11 +76,20 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (claudeMarkers.some((marker) => text.includes(marker))) {
     return "claude";
   }
-  if (HEADER_MODEL_RE.test(text) || MODEL_COST_RE.test(text) || CLAUDE_DONE_LINE_RE.test(text) || CLAUDE_WORKING_LINE_RE.test(text)) {
+  if (
+    HEADER_MODEL_RE.test(text) ||
+    MODEL_COST_RE.test(text) ||
+    CLAUDE_DONE_LINE_RE.test(text) ||
+    CLAUDE_WORKING_LINE_RE.test(text)
+  ) {
     return "claude";
   }
 
-  if (CODEX_MODEL_RE.test(text) || CODEX_WORKING_RE.test(text) || CODEX_RESUME_RE.test(text)) {
+  if (
+    CODEX_MODEL_RE.test(text) ||
+    CODEX_WORKING_RE.test(text) ||
+    CODEX_RESUME_RE.test(text)
+  ) {
     return "codex";
   }
 
@@ -199,11 +242,19 @@ function inferStatus(
     "bypass permissions on",
     "esc to interrupt",
   ];
-  if (workingMarkers.some((marker) => joined.toLowerCase().includes(marker.toLowerCase()))) {
+  if (
+    workingMarkers.some((marker) =>
+      joined.toLowerCase().includes(marker.toLowerCase()),
+    )
+  ) {
     return "working";
   }
 
-  if (agentType === "gemini" && /Gemini CLI/i.test(text) && /Thinking/i.test(text)) {
+  if (
+    agentType === "gemini" &&
+    /Gemini CLI/i.test(text) &&
+    /Thinking/i.test(text)
+  ) {
     return "working";
   }
 
@@ -224,11 +275,26 @@ export function parseScreen(text: string): ParsedScreenResult {
   const doneSignal = parseDoneSignal(normalized);
   const errors = parseErrors(normalized);
   const { model, cost } = parseModelAndCost(normalized, agentType);
+  const tokenCount = parseTokenCount(normalized);
+  const contextWindow = resolveModelMax(model);
+
+  // Compute context_pct: percentage of context window USED (0=fresh, 100=full)
+  // For Codex: invert the "% left" value (87% left → 13% used)
+  // For others: compute from token_count / context_window
+  let contextPct: number | null = null;
+  if (agentType === "codex") {
+    const codexLeft = parseCodexContextPct(normalized);
+    contextPct = codexLeft !== null ? 100 - codexLeft : null;
+  } else if (tokenCount !== null && contextWindow !== null) {
+    contextPct = Math.round((tokenCount / contextWindow) * 100);
+  }
 
   const result: ParsedScreenResult = {
     agent_type: agentType,
     status: inferStatus(normalized, doneSignal, errors, agentType),
-    token_count: parseTokenCount(normalized),
+    token_count: tokenCount,
+    context_pct: contextPct,
+    context_window: contextWindow,
     done_signal: doneSignal,
     response: parseResponse(normalized),
     errors,
@@ -237,7 +303,6 @@ export function parseScreen(text: string): ParsedScreenResult {
   };
 
   if (agentType === "codex") {
-    result.context_pct = parseCodexContextPct(normalized);
     result.actions = parseCodexActions(normalized);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,10 +12,7 @@ import { parseReservedModeKey } from "./mode-policy.js";
 import { replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
-import {
-  AgentEngine,
-  type AgentLifecycleEvent,
-} from "./agent-engine.js";
+import { AgentEngine, type AgentLifecycleEvent } from "./agent-engine.js";
 import type { AgentRecord } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
 
@@ -343,7 +340,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 5. read_screen
   server.tool(
     "read_screen",
-    "Read the current screen content of a terminal surface",
+    "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors. Use parsed_only=true for monitoring (omits raw terminal content).",
     {
       surface: z.string().describe("Target surface ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
@@ -360,6 +357,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .default(false)
         .describe("Include scrollback buffer"),
+      parsed_only: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, return only parsed fields (omit raw content). Best for agent monitoring.",
+        ),
     },
     async (args) => {
       try {
@@ -368,12 +372,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           lines: args.lines,
           scrollback: args.scrollback,
         });
+        const parsed = parseScreen(result.text);
+
+        if (args.parsed_only) {
+          return ok({
+            surface: result.surface,
+            parsed,
+          });
+        }
+
         return ok({
           surface: result.surface,
           lines: result.lines,
           content: result.text,
           scrollback_used: result.scrollback_used,
-          parsed: parseScreen(result.text),
+          parsed,
         });
       } catch (e) {
         return err(e);
@@ -668,8 +681,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         client.setStatus(key, value, statusOpts),
       readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
       send: (surface, text, sendOpts) => client.send(surface, text, sendOpts),
-      sendKey: (surface, key, keyOpts) =>
-        client.sendKey(surface, key, keyOpts),
+      sendKey: (surface, key, keyOpts) => client.sendKey(surface, key, keyOpts),
       setProgress: (value, progressOpts) =>
         client.setProgress(value, progressOpts),
       newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,12 +63,13 @@ export interface ParsedScreenResult {
   agent_type: ParsedScreenAgentType;
   status: ParsedScreenStatus;
   token_count: number | null;
+  context_pct: number | null;
+  context_window: number | null;
   done_signal: string | null;
   response: string | null;
   errors: string[];
   model: string | null;
   cost: number | null;
-  context_pct?: number | null;
   actions?: string[];
 }
 

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -153,10 +153,10 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [makeSurface("s:1")];
     await engine.getRegistry().reconstitute();
 
-    // Mock readScreen to return 80% context
+    // Mock readScreen: 160K tokens on Sonnet (200K window) = 80% used
     vi.mocked(mockClient.readScreen).mockResolvedValue({
       surface: "s:1",
-      text: "Claude Code  ● 80% context  Model: sonnet",
+      text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $3.50",
       lines: 5,
       scrollback_used: false,
     });
@@ -181,10 +181,10 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [makeSurface("s:2")];
     await engine.getRegistry().reconstitute();
 
-    // Mock readScreen to return 85% context
+    // Mock readScreen: 170K tokens on Haiku (200K window) = 85% used
     vi.mocked(mockClient.readScreen).mockResolvedValue({
       surface: "s:2",
-      text: "Claude Code  ● 85% context  Model: haiku",
+      text: "✻ Working…\nToken usage: total=170,000\n🤖 Haiku 3.5 | 💰 $0.10",
       lines: 5,
       scrollback_used: false,
     });
@@ -213,9 +213,10 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [makeSurface("s:1")];
     await engine.getRegistry().reconstitute();
 
+    // 160K tokens on Sonnet (200K window) = 80% used
     vi.mocked(mockClient.readScreen).mockResolvedValue({
       surface: "s:1",
-      text: "80% context remaining",
+      text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $2.00",
       lines: 5,
       scrollback_used: false,
     });
@@ -239,9 +240,10 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [makeSurface("s:1")];
     await engine.getRegistry().reconstitute();
 
+    // 100K tokens on Sonnet (200K window) = 50% used — below threshold
     vi.mocked(mockClient.readScreen).mockResolvedValue({
       surface: "s:1",
-      text: "Claude Code  ● 50% context  Model: sonnet",
+      text: "✻ Working…\nToken usage: total=100,000\n🤖 Sonnet 4.6 | 💰 $1.00",
       lines: 5,
       scrollback_used: false,
     });
@@ -275,9 +277,10 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [makeSurface("s:2")];
     await engine.getRegistry().reconstitute();
 
+    // 180K tokens on Haiku (200K window) = 90% used — above threshold
     vi.mocked(mockClient.readScreen).mockResolvedValue({
       surface: "s:2",
-      text: "Claude Code  ● 90% context  Model: haiku",
+      text: "✻ Working…\nToken usage: total=180,000\n🤖 Haiku 3.5 | 💰 $0.15",
       lines: 5,
       scrollback_used: false,
     });

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseScreen } from "../src/screen-parser.js";
+import {
+  parseScreen,
+  MODEL_MAX_TOKENS,
+  resolveModelMax,
+} from "../src/screen-parser.js";
 
 describe("parseScreen", () => {
   it("parses Claude-style output with response block and done signal", () => {
@@ -59,7 +63,7 @@ Working (2m 06s • esc to interrupt)
     expect(parsed.agent_type).toBe("codex");
     expect(parsed.status).toBe("working");
     expect(parsed.model).toBe("gpt-5.4 high");
-    expect(parsed.context_pct).toBe(87);
+    expect(parsed.context_pct).toBe(13); // 100 - 87% left = 13% used
     expect(parsed.actions).toContain('Ran rg -n "read_screen" src tests');
   });
 
@@ -85,5 +89,126 @@ etanheyman ~ [master] $
     expect(parsed.agent_type).toBe("unknown");
     expect(parsed.status).toBe("idle");
     expect(parsed.errors).toEqual([]);
+  });
+
+  // --- context_pct and context_window tests ---
+
+  describe("context_pct computation", () => {
+    it("computes context_pct for Claude Sonnet from token_count (200K window)", () => {
+      const parsed = parseScreen(`
+✻ Working…
+  Reading src/server.ts
+Token usage: total=40,000 input=35,000 output=5,000
+🤖 Sonnet 4.6 | 💰 $0.50 | ⏱️  41s
+`);
+
+      expect(parsed.agent_type).toBe("claude");
+      expect(parsed.token_count).toBe(40000);
+      expect(parsed.model).toBe("Sonnet 4.6");
+      expect(parsed.context_window).toBe(200_000);
+      expect(parsed.context_pct).toBe(20); // 40000/200000 = 20%
+    });
+
+    it("computes context_pct for Claude Opus from token_count (1M window)", () => {
+      const parsed = parseScreen(`
+⏺ Completed successfully
+Token usage: total=250,000 input=200,000 output=50,000
+🤖 Opus 4.6 | 💰 $12.50 | ⏱️  15m
+`);
+
+      expect(parsed.agent_type).toBe("claude");
+      expect(parsed.token_count).toBe(250000);
+      expect(parsed.model).toBe("Opus 4.6");
+      expect(parsed.context_window).toBe(1_000_000);
+      expect(parsed.context_pct).toBe(25); // 250000/1000000 = 25%
+    });
+
+    it("computes context_pct for Claude Haiku from token_count (200K window)", () => {
+      const parsed = parseScreen(`
+✻ Working…
+  Running tests
+Token usage: total=10,000
+🤖 Haiku 3.5 | 💰 $0.05
+`);
+
+      expect(parsed.agent_type).toBe("claude");
+      expect(parsed.token_count).toBe(10000);
+      expect(parsed.context_window).toBe(200_000);
+      expect(parsed.context_pct).toBe(5); // 10000/200000 = 5%
+    });
+
+    it("inverts Codex '% left' to '% used' for context_pct", () => {
+      const parsed = parseScreen(`
+gpt-5.4 high · 87% left · ~/Gits/orchestrator
+Working (2m 06s • esc to interrupt)
+• Ran rg -n "read_screen" src tests
+`);
+
+      expect(parsed.agent_type).toBe("codex");
+      expect(parsed.context_pct).toBe(13); // 100 - 87 = 13% used
+      expect(parsed.context_window).toBe(1_000_000); // gpt-5.4 resolves to 1M
+    });
+
+    it("returns null context_pct when model is unknown", () => {
+      const parsed = parseScreen(`
+etanheyman ~ [master] $
+`);
+
+      expect(parsed.agent_type).toBe("unknown");
+      expect(parsed.context_pct).toBeNull();
+      expect(parsed.context_window).toBeNull();
+    });
+
+    it("returns null context_pct when token_count unavailable for Claude", () => {
+      const parsed = parseScreen(`
+✻ Working…
+  Analyzing code
+🤖 Sonnet 4.6 | 💰 $0.10
+`);
+
+      expect(parsed.agent_type).toBe("claude");
+      expect(parsed.token_count).toBeNull();
+      expect(parsed.context_pct).toBeNull();
+      expect(parsed.context_window).toBe(200_000); // window known even without tokens
+    });
+
+    it("always includes context_pct and context_window fields (never undefined)", () => {
+      const parsed = parseScreen("etanheyman ~ $");
+      expect(parsed).toHaveProperty("context_pct");
+      expect(parsed).toHaveProperty("context_window");
+    });
+  });
+
+  describe("resolveModelMax", () => {
+    it("resolves Sonnet variants to 200K", () => {
+      expect(resolveModelMax("Sonnet 4.6")).toBe(200_000);
+      expect(resolveModelMax("Sonnet 4")).toBe(200_000);
+      expect(resolveModelMax("sonnet")).toBe(200_000);
+    });
+
+    it("resolves Opus variants to 1M", () => {
+      expect(resolveModelMax("Opus 4.6")).toBe(1_000_000);
+      expect(resolveModelMax("opus")).toBe(1_000_000);
+    });
+
+    it("resolves Haiku variants to 200K", () => {
+      expect(resolveModelMax("Haiku 3.5")).toBe(200_000);
+      expect(resolveModelMax("haiku")).toBe(200_000);
+    });
+
+    it("resolves Gemini models to 1M", () => {
+      expect(resolveModelMax("gemini-3.1-pro")).toBe(1_000_000);
+      expect(resolveModelMax("gemini-2.5-pro")).toBe(1_000_000);
+    });
+
+    it("resolves GPT/Codex models to 1M", () => {
+      expect(resolveModelMax("gpt-5.4 high")).toBe(1_000_000);
+      expect(resolveModelMax("gpt-5.4")).toBe(1_000_000);
+    });
+
+    it("returns null for unknown models", () => {
+      expect(resolveModelMax(null)).toBeNull();
+      expect(resolveModelMax("mystery-model")).toBeNull();
+    });
   });
 });

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -201,9 +201,12 @@ etanheyman ~ [master] $
       expect(resolveModelMax("gemini-2.5-pro")).toBe(1_000_000);
     });
 
-    it("resolves GPT/Codex models to 1M", () => {
+    it("resolves GPT/Codex models to 1M (hyphenated and space-separated)", () => {
       expect(resolveModelMax("gpt-5.4 high")).toBe(1_000_000);
       expect(resolveModelMax("gpt-5.4")).toBe(1_000_000);
+      // Space-separated format from Claude's HEADER_MODEL_RE
+      expect(resolveModelMax("GPT 5")).toBe(1_000_000);
+      expect(resolveModelMax("GPT 4")).toBe(128_000);
     });
 
     it("returns null for unknown models", () => {


### PR DESCRIPTION
## Summary
- Adds `context_pct` (% of context window used) and `context_window` (max tokens) to **every** `parseScreen()` result — not just Codex
- `MODEL_MAX_TOKENS` lookup table: Opus=1M, Sonnet/Haiku=200K, GPT-5=1M, GPT-4=128K, Gemini=1M
- Codex `context_pct` now inverted from "% left" → "% used" for consistency (87% left → 13% used)
- `read_screen` MCP tool gets `parsed_only` param — omits raw terminal noise for agent monitoring
- `agent-engine` quality tracking upgraded: uses `parseScreen()` instead of legacy `parseContextPercent()` text pattern
- Fixes the known bug where context percentage assumed 200K for all models (showed 120% for Opus at 24% actual)

## Test plan
- [x] 253 tests pass (13 new context_pct tests + all existing)
- [x] TypeScript compiles with `--noEmit` 
- [x] Claude Sonnet/Opus/Haiku context_pct computed correctly from token_count
- [x] Codex "% left" properly inverted to "% used"
- [x] Unknown models return null (no crash)
- [x] Quality tracking mocks updated for new parse approach
- [x] `resolveModelMax()` tested for all model families

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `parsed_only` parameter to terminal reading functionality, enabling retrieval of only parsed terminal state without raw content overhead.
  * Implemented model-aware context window resolution, automatically determining token limits based on model identifiers.

* **Improvements**
  * Enhanced context percentage and token usage tracking for consistent reporting across all agent types.
  * Refined quality degradation detection using unified context measurement methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add model-aware `context_pct` computation to `parseScreen` in screen parser
> - `parseScreen` in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/11/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) now computes `context_pct` and `context_window` for all agent types using token counts and a new `MODEL_MAX_TOKENS` map (covering Claude, GPT, Gemini models).
> - For Codex, `context_pct` is derived by inverting the '% left' value; for other agents, it is computed as `round(tokenCount / contextWindow * 100)` when both are available.
> - `AgentEngine.runSweep` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/11/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now uses `parseScreen` instead of the removed `parseContextPercent`, so degradation and kill decisions are based on token-aware context usage.
> - The `read_screen` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/11/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) gains an optional `parsed_only` flag that returns only `surface` and `parsed` fields, omitting raw content and line metadata.
> - Behavioral Change: `context_pct` values in the sweep loop may differ from previous regex-matched percentage strings, especially for non-Codex agents where the value is now token-derived.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19e3395.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->