### PR TITLE
fix: harden context_pct matching and clamping

### DIFF
--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -93,6 +93,8 @@ export function assertValidTransition(from: AgentState, to: AgentState): void {
 }
 
 /**
+ * @deprecated Use parseScreen().context_pct instead — it computes context usage from
+ * token_count/model_max and works for all agent types, not just Claude text patterns.
  * Parses context usage percentage from Claude Code status bar text.
  * Matches patterns like "80% context", "context 80%", "80% context remaining"
  */

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -27,13 +27,18 @@ export const MODEL_MAX_TOKENS: Record<string, number> = {
  * Matches by prefix/keyword — e.g. "Sonnet 4.6" matches "sonnet", "gpt-5.4 high" matches "gpt-5".
  * Returns null if model is unknown.
  */
+// Pre-sorted by key length descending so longer (more specific) keys match first.
+// This makes matching deterministic regardless of Object.entries() iteration order.
+const SORTED_MODEL_ENTRIES = Object.entries(MODEL_MAX_TOKENS).sort(
+  ([a], [b]) => b.length - a.length,
+);
+
 export function resolveModelMax(model: string | null): number | null {
   if (!model) return null;
   const lower = model.toLowerCase().trim();
 
-  // Try each key as a prefix/substring match
-  // Also match space-separated variants (e.g., "gpt 4" matches "gpt-4")
-  for (const [key, max] of Object.entries(MODEL_MAX_TOKENS)) {
+  // Match by substring — also try space-separated variants (e.g., "gpt 4" matches "gpt-4")
+  for (const [key, max] of SORTED_MODEL_ENTRIES) {
     if (lower.includes(key) || lower.includes(key.replace("-", " ")))
       return max;
   }
@@ -283,14 +288,16 @@ export function parseScreen(text: string): ParsedScreenResult {
   const contextWindow = resolveModelMax(model);
 
   // Compute context_pct: percentage of context window USED (0=fresh, 100=full)
-  // For Codex: invert the "% left" value (87% left → 13% used)
-  // For others: compute from token_count / context_window
+  // Clamped to [0, 100] — token_count can exceed context_window in practice
+  // but >100% is noise for monitoring. For Codex: invert "% left" → "% used".
+  // AIDEV-NOTE: For Codex, token_count may be null while context_pct is populated
+  // (Codex surfaces show "% left" directly rather than raw token counts).
   let contextPct: number | null = null;
   if (agentType === "codex") {
     const codexLeft = parseCodexContextPct(normalized);
     contextPct = codexLeft !== null ? 100 - codexLeft : null;
   } else if (tokenCount !== null && contextWindow !== null) {
-    contextPct = Math.round((tokenCount / contextWindow) * 100);
+    contextPct = Math.min(100, Math.round((tokenCount / contextWindow) * 100));
   }
 
   const result: ParsedScreenResult = {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -177,6 +177,32 @@ etanheyman ~ [master] $
       expect(parsed).toHaveProperty("context_pct");
       expect(parsed).toHaveProperty("context_window");
     });
+
+    it("clamps context_pct to 100 when token_count exceeds context_window", () => {
+      const parsed = parseScreen(`
+⏺ Completed successfully
+Token usage: total=300,000 input=250,000 output=50,000
+🤖 Sonnet 4.6 | 💰 $8.00
+`);
+
+      expect(parsed.token_count).toBe(300000);
+      expect(parsed.context_window).toBe(200_000);
+      expect(parsed.context_pct).toBe(100); // clamped, not 150
+    });
+
+    it("computes context_pct for Gemini from token_count", () => {
+      const parsed = parseScreen(`
+Gemini CLI
+Model: gemini-2.5-pro
+100,000 tokens
+`);
+
+      expect(parsed.agent_type).toBe("gemini");
+      expect(parsed.model).toBe("gemini-2.5-pro");
+      expect(parsed.token_count).toBe(100000);
+      expect(parsed.context_window).toBe(1_000_000);
+      expect(parsed.context_pct).toBe(10); // 100K/1M = 10%
+    });
   });
 
   describe("resolveModelMax", () => {
@@ -201,12 +227,18 @@ etanheyman ~ [master] $
       expect(resolveModelMax("gemini-2.5-pro")).toBe(1_000_000);
     });
 
-    it("resolves GPT/Codex models to 1M (hyphenated and space-separated)", () => {
+    it("resolves GPT-5/Codex models to 1M (hyphenated and space-separated)", () => {
       expect(resolveModelMax("gpt-5.4 high")).toBe(1_000_000);
       expect(resolveModelMax("gpt-5.4")).toBe(1_000_000);
       // Space-separated format from Claude's HEADER_MODEL_RE
       expect(resolveModelMax("GPT 5")).toBe(1_000_000);
+    });
+
+    it("resolves GPT-4 variants to 128K", () => {
       expect(resolveModelMax("GPT 4")).toBe(128_000);
+      expect(resolveModelMax("gpt-4-turbo")).toBe(128_000);
+      expect(resolveModelMax("gpt-4o")).toBe(128_000);
+      expect(resolveModelMax("gpt-4o-mini")).toBe(128_000);
     });
 
     it("returns null for unknown models", () => {


### PR DESCRIPTION
## Summary
Follow-up from CodeRabbit review of PR #11. Addresses:
- **HIGH**: Sort `MODEL_MAX_TOKENS` keys by length descending for deterministic substring matching (fixes `gpt-5` vs `gpt-4` iteration order fragility)
- **MEDIUM**: Clamp `context_pct` to `[0, 100]` — token_count can exceed context_window in practice
- **MEDIUM**: Deprecate `parseContextPercent()` in `agent-types.ts` (superseded by `parseScreen().context_pct`)
- **LOW**: Add Gemini context_pct test, GPT-4 variant tests, >100% clamping test

## Test plan
- [x] 256 tests pass (3 new)
- [x] TypeScript compiles clean
- [x] `resolveModelMax("gpt-4-turbo")` → 128K, `resolveModelMax("gpt-5.4")` → 1M
- [x] 300K tokens on 200K Sonnet → context_pct=100 (clamped, not 150)
- [x] Gemini with 100K tokens → context_pct=10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveModelMax` key matching order and clamp `context_pct` to 100
> - Sorts model entries by key length descending in `resolveModelMax` so longer, more specific keys (e.g. `gpt-4o`) match before shorter ones (e.g. `gpt-4`), making model resolution deterministic.
> - Clamps `context_pct` to a maximum of 100 using `Math.min(100, ...)` in `parseScreen` to handle cases where `token_count` exceeds the context window.
> - Deprecates the Claude-specific context percentage parser in [agent-types.ts](https://github.com/EtanHey/cmuxlayer/pull/12/files#diff-efd9180892738f786d25ac95f9c9adf7070aa3bc8d56cf1c7d726435f977c6d9) in favor of the generic `parseScreen().context_pct` computation.
> - Behavioral Change: `resolveModelMax` may now return different context windows than before for model identifiers that previously matched a shorter, less specific key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29b8e0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->