### PR TITLE
fix: model extraction for narrow panes and no-cost status lines

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -54,6 +54,14 @@ const TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/i;
 const MODEL_COST_RE = /🤖\s*([^|\n]+?)\s*\|\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)/i;
 const HEADER_MODEL_RE =
   /^\s*[▝▜▛▘▐].*?\b((?:Opus|Sonnet|Haiku|GPT|Claude)\s+[0-9][^(\n·|]*)/m;
+// AIDEV-NOTE: Fallback for 🤖 lines without cost — e.g. "🤖 Opus 4.6 (1M context)"
+// or "🤖 Sonnet 4.6 | ⏱️ 2m". Captures model name up to first paren, pipe, or newline.
+const MODEL_EMOJI_RE =
+  /🤖\s*((?:Opus|Sonnet|Haiku|GPT|Claude)\s+[0-9][0-9.]*)/i;
+// AIDEV-NOTE: Last-resort fallback for narrow panes where model string is cut off.
+// If we see 🤖 followed by a known model family name, extract just the family name.
+// e.g. "🤖 Opus …" → "Opus", "🤖 Sonnet" → "Sonnet"
+const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CODEX_MODEL_RE =
   /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*[·•]\s*(\d+)%\s+left/m;
@@ -191,7 +199,12 @@ function parseModelAndCost(
     };
   }
 
-  const model = text.match(HEADER_MODEL_RE)?.[1]?.trim() ?? null;
+  // Fallback chain: full header → 🤖+version → 🤖+keyword (narrow panes)
+  const model =
+    text.match(HEADER_MODEL_RE)?.[1]?.trim() ??
+    text.match(MODEL_EMOJI_RE)?.[1]?.trim() ??
+    text.match(MODEL_KEYWORD_RE)?.[1]?.trim() ??
+    null;
   const costMatch = text.match(/💰\s*\$([0-9]+(?:\.[0-9]+)?)/);
 
   return {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -51,6 +51,60 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.status).toBe("working");
   });
 
+  it("extracts model from 🤖 line without cost (production format)", () => {
+    const parsed = parseScreen(`
+✻ Working…
+  Reading files
+Token usage: total=356,835
+🤖 Opus 4.6 (1M context)
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Opus 4.6");
+    expect(parsed.token_count).toBe(356835);
+    expect(parsed.context_window).toBe(1_000_000);
+    expect(parsed.context_pct).toBe(36); // 356835/1000000 ≈ 35.7 → rounds to 36
+  });
+
+  it("extracts model from narrow pane where version is cut off", () => {
+    const parsed = parseScreen(`
+✻ Working…
+Token usage: total=356,835
+🤖 Opus …
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Opus");
+    expect(parsed.context_window).toBe(1_000_000);
+    expect(parsed.context_pct).toBe(36); // 356835/1000000
+  });
+
+  it("extracts Sonnet from narrow pane without version number", () => {
+    const parsed = parseScreen(`
+✻ Working…
+Token usage: total=160,000
+🤖 Sonnet
+`);
+
+    expect(parsed.model).toBe("Sonnet");
+    expect(parsed.context_window).toBe(200_000);
+    expect(parsed.context_pct).toBe(80); // 160000/200000
+  });
+
+  it("extracts model from 🤖 line with only timer (no cost)", () => {
+    const parsed = parseScreen(`
+⏺ Completed successfully
+Token usage: total=50,000
+🤖 Sonnet 4.6 | ⏱️  2m 11s
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Sonnet 4.6");
+    expect(parsed.cost).toBeNull();
+    expect(parsed.context_window).toBe(200_000);
+    expect(parsed.context_pct).toBe(25); // 50000/200000
+  });
+
   it("parses Codex-style output with model, context left, and actions", () => {
     const parsed = parseScreen(`
 gpt-5.4 high · 87% left · ~/Gits/orchestrator


### PR DESCRIPTION
## Summary
Fixes context_pct returning null in production. Root cause: model extraction regexes required either `💰 $cost` or box-drawing spinner chars, but real Claude sessions show:
- `🤖 Opus 4.6 (1M context)` — no cost, no pipe
- `🤖 Opus …` — narrow pane cuts off the version number
- `🤖 Sonnet 4.6 | ⏱️ 2m` — timer but no cost

Added a 3-level fallback chain for model extraction:
1. `HEADER_MODEL_RE` — box-drawing header line (existing)
2. `MODEL_EMOJI_RE` — `🤖 ModelName Version` without cost (new)
3. `MODEL_KEYWORD_RE` — `🤖 Opus|Sonnet|Haiku` alone for narrow panes (new)

Once model is extracted, `resolveModelMax()` gives context_window, and context_pct computes from token_count/context_window.

## Test plan
- [x] 260 tests pass (4 new)
- [x] TypeScript compiles clean
- [x] Verified all 6 production formats from dist/ (full, no-cost, narrow, keyword-only, Sonnet, Haiku)
- [x] `🤖 Opus 4.6 (1M context)` → model=Opus 4.6, context_pct=36
- [x] `🤖 Opus …` → model=Opus, context_pct=36
- [x] `🤖 Sonnet` → model=Sonnet, context_window=200K

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model extraction from 🤖 status lines in narrow panes and no-cost banners
> Adds two new regex patterns in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/13/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to handle Claude banner formats where cost is absent or version text is truncated. `MODEL_EMOJI_RE` matches a model family plus version on a 🤖 line without a cost, while `MODEL_KEYWORD_RE` matches only the model family name when the version is cut off in narrow panes. `parseModelAndCost` now falls through to these patterns after the existing `HEADER_MODEL_RE` and `MODEL_COST_RE` checks fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff9d2ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model detection and parsing accuracy, including better support for narrow screen layouts and cases where cost information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->