### PR TITLE
fix: smart context window inference + model extraction fallbacks

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,7 @@
 export {
   parseScreen,
   resolveModelMax,
+  inferContextWindow,
   MODEL_MAX_TOKENS,
 } from "./screen-parser.js";
 export type {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -4,13 +4,12 @@ import type {
   ParsedScreenStatus,
 } from "./types.js";
 
-// AIDEV-NOTE: Model context window sizes in tokens. Used to compute context_pct from raw token_count.
-// Keep this table updated as new models launch.
-// ORDER MATTERS: resolveModelMax uses substring matching, so more-specific keys (e.g. "gpt-5")
-// must come before less-specific ones (e.g. "gpt-4") if they share a common prefix.
+// AIDEV-NOTE: DEFAULT context window sizes per model family. All Claude models default to 200K.
+// The 1M tier is detected via "(1M" suffix in the status line or inferred from token_count > 200K.
+// ORDER MATTERS: resolveModelMax uses substring matching — longer keys must come first.
 export const MODEL_MAX_TOKENS: Record<string, number> = {
-  // Claude models
-  opus: 1_000_000,
+  // Claude models — ALL default to 200K (1M is the Max-plan tier, detected separately)
+  opus: 200_000,
   sonnet: 200_000,
   haiku: 200_000,
   // GPT / Codex models
@@ -22,28 +21,49 @@ export const MODEL_MAX_TOKENS: Record<string, number> = {
   "gemini-1": 1_000_000,
 };
 
-/**
- * Resolve the max context window size for a model string.
- * Matches by prefix/keyword — e.g. "Sonnet 4.6" matches "sonnet", "gpt-5.4 high" matches "gpt-5".
- * Returns null if model is unknown.
- */
-// Pre-sorted by key length descending so longer (more specific) keys match first.
-// This makes matching deterministic regardless of Object.entries() iteration order.
+// Pre-sorted by key length descending for deterministic longest-match-first.
 const SORTED_MODEL_ENTRIES = Object.entries(MODEL_MAX_TOKENS).sort(
   ([a], [b]) => b.length - a.length,
 );
 
+/**
+ * Resolve the DEFAULT context window for a model string.
+ * Returns the base tier (e.g. 200K for Claude). Use inferContextWindow() for
+ * smart inference that detects the 1M tier from "(1M" suffix or token count.
+ */
 export function resolveModelMax(model: string | null): number | null {
   if (!model) return null;
   const lower = model.toLowerCase().trim();
 
-  // Match by substring — also try space-separated variants (e.g., "gpt 4" matches "gpt-4")
   for (const [key, max] of SORTED_MODEL_ENTRIES) {
     if (lower.includes(key) || lower.includes(key.replace("-", " ")))
       return max;
   }
 
   return null;
+}
+
+/**
+ * Smart context window inference. Uses three signals:
+ * 1. Explicit "(1M" in screen text → 1M (Max plan confirmed)
+ * 2. token_count > default window → must be 1M (can't exceed 200K on 200K tier)
+ * 3. Fall back to resolveModelMax() default
+ */
+export function inferContextWindow(
+  model: string | null,
+  tokenCount: number | null,
+  rawText: string,
+): number | null {
+  const defaultMax = resolveModelMax(model);
+  if (defaultMax === null) return null;
+
+  // Signal 1: explicit "(1M" in the status line
+  if (/\(1M\b/i.test(rawText)) return 1_000_000;
+
+  // Signal 2: token count exceeds default → must be a larger tier
+  if (tokenCount !== null && tokenCount > defaultMax) return 1_000_000;
+
+  return defaultMax;
 }
 
 const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
@@ -54,6 +74,11 @@ const TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/i;
 const MODEL_COST_RE = /🤖\s*([^|\n]+?)\s*\|\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)/i;
 const HEADER_MODEL_RE =
   /^\s*[▝▜▛▘▐].*?\b((?:Opus|Sonnet|Haiku|GPT|Claude)\s+[0-9][^(\n·|]*)/m;
+// Fallback: 🤖 + model name + version, without requiring cost or pipe
+const MODEL_EMOJI_RE =
+  /🤖\s*((?:Opus|Sonnet|Haiku|GPT|Claude)\s+[0-9][0-9.]*)/i;
+// Last resort: 🤖 + bare model family name (for narrow panes where version is cut off)
+const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CODEX_MODEL_RE =
   /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*[·•]\s*(\d+)%\s+left/m;
@@ -191,7 +216,12 @@ function parseModelAndCost(
     };
   }
 
-  const model = text.match(HEADER_MODEL_RE)?.[1]?.trim() ?? null;
+  // Fallback chain: header spinner → 🤖+version → 🤖+keyword (narrow panes)
+  const model =
+    text.match(HEADER_MODEL_RE)?.[1]?.trim() ??
+    text.match(MODEL_EMOJI_RE)?.[1]?.trim() ??
+    text.match(MODEL_KEYWORD_RE)?.[1]?.trim() ??
+    null;
   const costMatch = text.match(/💰\s*\$([0-9]+(?:\.[0-9]+)?)/);
 
   return {
@@ -285,7 +315,7 @@ export function parseScreen(text: string): ParsedScreenResult {
   const errors = parseErrors(normalized);
   const { model, cost } = parseModelAndCost(normalized, agentType);
   const tokenCount = parseTokenCount(normalized);
-  const contextWindow = resolveModelMax(model);
+  const contextWindow = inferContextWindow(model, tokenCount, normalized);
 
   // Compute context_pct: percentage of context window USED (0=fresh, 100=full)
   // Clamped to [0, 100] — token_count can exceed context_window in practice

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -3,6 +3,7 @@ import {
   parseScreen,
   MODEL_MAX_TOKENS,
   resolveModelMax,
+  inferContextWindow,
 } from "../src/screen-parser.js";
 
 describe("parseScreen", () => {
@@ -49,6 +50,50 @@ Token usage: total=12,345 input=10,000 output=2,345
 
     expect(parsed.agent_type).toBe("claude");
     expect(parsed.status).toBe("working");
+  });
+
+  it("extracts model from no-cost status line (production format)", () => {
+    const parsed = parseScreen(`
+✻ Working…
+  Reading files
+Token usage: total=356,835
+🤖 Opus 4.6 (1M context)
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Opus 4.6");
+    expect(parsed.token_count).toBe(356835);
+    // "(1M" detected in text → 1M window
+    expect(parsed.context_window).toBe(1_000_000);
+    expect(parsed.context_pct).toBe(36); // 356835/1000000
+  });
+
+  it("extracts model from narrow pane (keyword only)", () => {
+    const parsed = parseScreen(`
+✻ Working…
+Token usage: total=356,835
+🤖 Opus
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Opus");
+    // token_count > 200K default → must be 1M tier
+    expect(parsed.context_window).toBe(1_000_000);
+    expect(parsed.context_pct).toBe(36);
+  });
+
+  it("extracts model from timer-only status line (no cost)", () => {
+    const parsed = parseScreen(`
+⏺ Completed successfully
+Token usage: total=50,000
+🤖 Sonnet 4.6 | ⏱️  2m 11s
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.model).toBe("Sonnet 4.6");
+    expect(parsed.cost).toBeNull();
+    expect(parsed.context_window).toBe(200_000);
+    expect(parsed.context_pct).toBe(25); // 50000/200000
   });
 
   it("parses Codex-style output with model, context left, and actions", () => {
@@ -109,7 +154,8 @@ Token usage: total=40,000 input=35,000 output=5,000
       expect(parsed.context_pct).toBe(20); // 40000/200000 = 20%
     });
 
-    it("computes context_pct for Claude Opus from token_count (1M window)", () => {
+    it("infers 1M window for Opus when token_count > 200K", () => {
+      // No "(1M" marker, but 250K tokens can't fit in 200K → must be 1M tier
       const parsed = parseScreen(`
 ⏺ Completed successfully
 Token usage: total=250,000 input=200,000 output=50,000
@@ -119,8 +165,31 @@ Token usage: total=250,000 input=200,000 output=50,000
       expect(parsed.agent_type).toBe("claude");
       expect(parsed.token_count).toBe(250000);
       expect(parsed.model).toBe("Opus 4.6");
-      expect(parsed.context_window).toBe(1_000_000);
+      expect(parsed.context_window).toBe(1_000_000); // inferred from token_count > 200K
       expect(parsed.context_pct).toBe(25); // 250000/1000000 = 25%
+    });
+
+    it("defaults Opus to 200K when token_count is low and no 1M signal", () => {
+      const parsed = parseScreen(`
+✻ Working…
+Token usage: total=50,000
+🤖 Opus 4.6 | 💰 $2.00
+`);
+
+      expect(parsed.model).toBe("Opus 4.6");
+      expect(parsed.context_window).toBe(200_000); // default tier
+      expect(parsed.context_pct).toBe(25); // 50000/200000
+    });
+
+    it("detects 1M tier from explicit (1M marker in status line", () => {
+      const parsed = parseScreen(`
+✻ Working…
+Token usage: total=50,000
+🤖 Opus 4.6 (1M context)
+`);
+
+      expect(parsed.context_window).toBe(1_000_000); // "(1M" detected
+      expect(parsed.context_pct).toBe(5); // 50000/1000000
     });
 
     it("computes context_pct for Claude Haiku from token_count (200K window)", () => {
@@ -178,7 +247,21 @@ etanheyman ~ [master] $
       expect(parsed).toHaveProperty("context_window");
     });
 
-    it("clamps context_pct to 100 when token_count exceeds context_window", () => {
+    it("clamps context_pct to 100 when near context limit", () => {
+      // Sonnet 200K tier with exactly 200K tokens
+      const parsed = parseScreen(`
+⏺ Completed successfully
+Token usage: total=200,000
+🤖 Sonnet 4.6 | 💰 $8.00
+`);
+
+      expect(parsed.token_count).toBe(200000);
+      expect(parsed.context_window).toBe(200_000);
+      expect(parsed.context_pct).toBe(100);
+    });
+
+    it("infers 1M when Sonnet token_count exceeds 200K default", () => {
+      // 300K tokens can't fit in 200K → must be Max plan (1M)
       const parsed = parseScreen(`
 ⏺ Completed successfully
 Token usage: total=300,000 input=250,000 output=50,000
@@ -186,8 +269,8 @@ Token usage: total=300,000 input=250,000 output=50,000
 `);
 
       expect(parsed.token_count).toBe(300000);
-      expect(parsed.context_window).toBe(200_000);
-      expect(parsed.context_pct).toBe(100); // clamped, not 150
+      expect(parsed.context_window).toBe(1_000_000); // inferred upgrade
+      expect(parsed.context_pct).toBe(30); // 300000/1000000
     });
 
     it("computes context_pct for Gemini from token_count", () => {
@@ -205,20 +288,13 @@ Model: gemini-2.5-pro
     });
   });
 
-  describe("resolveModelMax", () => {
-    it("resolves Sonnet variants to 200K", () => {
+  describe("resolveModelMax (default tiers)", () => {
+    it("resolves ALL Claude models to 200K default", () => {
       expect(resolveModelMax("Sonnet 4.6")).toBe(200_000);
-      expect(resolveModelMax("Sonnet 4")).toBe(200_000);
-      expect(resolveModelMax("sonnet")).toBe(200_000);
-    });
-
-    it("resolves Opus variants to 1M", () => {
-      expect(resolveModelMax("Opus 4.6")).toBe(1_000_000);
-      expect(resolveModelMax("opus")).toBe(1_000_000);
-    });
-
-    it("resolves Haiku variants to 200K", () => {
+      expect(resolveModelMax("Opus 4.6")).toBe(200_000);
       expect(resolveModelMax("Haiku 3.5")).toBe(200_000);
+      expect(resolveModelMax("sonnet")).toBe(200_000);
+      expect(resolveModelMax("opus")).toBe(200_000);
       expect(resolveModelMax("haiku")).toBe(200_000);
     });
 
@@ -230,7 +306,6 @@ Model: gemini-2.5-pro
     it("resolves GPT-5/Codex models to 1M (hyphenated and space-separated)", () => {
       expect(resolveModelMax("gpt-5.4 high")).toBe(1_000_000);
       expect(resolveModelMax("gpt-5.4")).toBe(1_000_000);
-      // Space-separated format from Claude's HEADER_MODEL_RE
       expect(resolveModelMax("GPT 5")).toBe(1_000_000);
     });
 
@@ -244,6 +319,43 @@ Model: gemini-2.5-pro
     it("returns null for unknown models", () => {
       expect(resolveModelMax(null)).toBeNull();
       expect(resolveModelMax("mystery-model")).toBeNull();
+    });
+  });
+
+  describe("inferContextWindow (smart tier detection)", () => {
+    it("returns default 200K for Opus with low token count", () => {
+      expect(inferContextWindow("Opus 4.6", 50_000, "🤖 Opus 4.6")).toBe(
+        200_000,
+      );
+    });
+
+    it("upgrades to 1M when (1M marker present", () => {
+      expect(
+        inferContextWindow("Opus 4.6", 50_000, "🤖 Opus 4.6 (1M context)"),
+      ).toBe(1_000_000);
+    });
+
+    it("upgrades to 1M when token_count exceeds default", () => {
+      expect(inferContextWindow("Opus 4.6", 250_000, "🤖 Opus 4.6")).toBe(
+        1_000_000,
+      );
+      expect(inferContextWindow("Sonnet 4.6", 300_000, "🤖 Sonnet 4.6")).toBe(
+        1_000_000,
+      );
+    });
+
+    it("keeps 1M for models that default to 1M (GPT, Gemini)", () => {
+      expect(inferContextWindow("gpt-5.4 high", 50_000, "gpt-5.4")).toBe(
+        1_000_000,
+      );
+      expect(
+        inferContextWindow("gemini-2.5-pro", 50_000, "gemini-2.5-pro"),
+      ).toBe(1_000_000);
+    });
+
+    it("returns null for unknown models", () => {
+      expect(inferContextWindow(null, 50_000, "")).toBeNull();
+      expect(inferContextWindow("mystery", 50_000, "")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes context_pct returning null in production. Two root causes:

**1. Model extraction failed on real Claude status lines:**
- `MODEL_COST_RE` requires `💰 $cost` — fails on `🤖 Opus 4.6 (1M context)` 
- `HEADER_MODEL_RE` requires box-drawing chars — fails on `🤖` prefix
- **Fix:** 3-level fallback: header → `MODEL_EMOJI_RE` (🤖+version) → `MODEL_KEYWORD_RE` (🤖+family name for narrow panes)

**2. Context window defaults were wrong:**
- Opus was hardcoded to 1M but default tier is 200K (1M = Max plan only)
- **Fix:** `inferContextWindow()` with 3 signals:
  - `(1M` in status text → 1M confirmed
  - `token_count > 200K` → must be 1M tier (can't exceed window)
  - Fall back to 200K default for all Claude models

## Test plan
- [x] 265 tests pass (31 screen-parser, 9 new)
- [x] TypeScript compiles clean
- [x] Verified 6 production scenarios from dist/:
  - `🤖 Opus 4.6 (1M context)` → model=Opus 4.6, win=1M, pct=36
  - `🤖 Opus` (narrow pane) → model=Opus, win=1M (inferred from tokens), pct=36
  - `🤖 Opus 4.6` (low tokens) → model=Opus 4.6, win=200K (default), pct=25
  - `🤖 Sonnet 4.6` (200K tier) → win=200K, pct=20
  - `🤖 Sonnet 4.6` (300K tokens) → win=1M (inferred), pct=30
  - `🤖 Haiku 3.5` → win=200K, pct=5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix smart context window inference and model extraction fallbacks in screen-parser
> - Adds `inferContextWindow` to [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/14/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50), which detects a 1,000,000-token context window when `(1M` appears in the raw text or `tokenCount` exceeds the 200K default, falling back to `resolveModelMax`.
> - Extends `parseModelAndCost` with two new regexes (`MODEL_EMOJI_RE`, `MODEL_KEYWORD_RE`) to extract Claude model names from status lines that omit cost, use only a version number, or show only a family keyword (e.g. `🤖 Opus`).
> - Reduces the default context window for Claude Opus from 1,000,000 to 200,000 in `MODEL_MAX_TOKENS`; the 1M tier is now detected dynamically by `inferContextWindow`.
> - Behavioral Change: `resolveModelMax` now returns 200K for Opus (previously 1M), and `context_window`/`context_pct` in parsed screens can dynamically shift to 1M only when the `(1M` marker or a high token count is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d10830.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude model detection with fallback pattern matching for cases where model names are truncated.
  * Fixed context window calculation to intelligently detect 1M capacity based on token count thresholds and explicit markers.

* **Refactor**
  * Updated Claude Opus base context window from 1M to 200K tokens for consistency across model families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->