### PR TITLE
fix: recover read_screen parser fallbacks

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -68,6 +68,7 @@ export function inferContextWindow(
 
 const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const DONE_SIGNAL_RE = /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)\b/;
+const CLAUDE_COUNTER_RE = /^\s*CLAUDE_COUNTER:\s*(\d+)\s*$/m;
 const RESPONSE_BLOCK_RE = /---RESPONSE_START---\s*(.*?)\s*---RESPONSE_END---/s;
 const TOKEN_USAGE_RE = /Token usage:\s*total=([0-9][0-9,]*)/i;
 const TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/i;
@@ -152,12 +153,72 @@ function parseTokenCount(text: string): number | null {
 }
 
 function parseDoneSignal(text: string): string | null {
-  return text.match(DONE_SIGNAL_RE)?.[1] ?? null;
+  const explicitDoneSignal = text.match(DONE_SIGNAL_RE)?.[1];
+  if (explicitDoneSignal) {
+    return explicitDoneSignal;
+  }
+
+  const claudeCounter = text.match(CLAUDE_COUNTER_RE)?.[1];
+  return claudeCounter ? `CLAUDE_COUNTER:${claudeCounter}` : null;
+}
+
+function trimBlankEdges(lines: string[]): string[] {
+  let start = 0;
+  let end = lines.length;
+
+  while (start < end && lines[start].trim() === "") start++;
+  while (end > start && lines[end - 1].trim() === "") end--;
+
+  return lines.slice(start, end);
+}
+
+function extractClaudeResponseTail(text: string): string | null {
+  if (!CLAUDE_COUNTER_RE.test(text)) {
+    return null;
+  }
+
+  const lines = text.split("\n");
+  const counterIndex = lines.findIndex((line) => CLAUDE_COUNTER_RE.test(line));
+  if (counterIndex === -1) {
+    return null;
+  }
+
+  let startIndex = 0;
+  for (let i = counterIndex - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (CLAUDE_WORKING_LINE_RE.test(line) || CLAUDE_DONE_LINE_RE.test(line)) {
+      startIndex = i + 1;
+      break;
+    }
+  }
+
+  const candidateLines = trimBlankEdges(
+    lines
+      .slice(startIndex, counterIndex)
+      .filter(
+        (line) =>
+          !/^\s*(?:Token usage:|🤖\s|CLAUDE_COUNTER:)/.test(line) &&
+          !/^\s*(?:[⏺●✻✢✳✶]\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing))\b/.test(
+            line,
+          ) &&
+          !/^\s{2,}(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/.test(
+            line,
+          ) &&
+          !/^\s*(?:Bash|Read|Edit|Write|Glob|Grep|LS)\(/.test(line) &&
+          !/^\s*\/Users\//.test(line),
+      ),
+  );
+
+  if (candidateLines.length === 0) {
+    return null;
+  }
+
+  return candidateLines.join("\n");
 }
 
 function parseResponse(text: string): string | null {
   const response = text.match(RESPONSE_BLOCK_RE)?.[1]?.trim();
-  return response || null;
+  return response || extractClaudeResponseTail(text);
 }
 
 function parseErrors(text: string): string[] {
@@ -252,6 +313,9 @@ function inferStatus(
   const joined = lines.join("\n");
 
   if (doneSignal) {
+    if (doneSignal.startsWith("CLAUDE_COUNTER:")) {
+      return "idle";
+    }
     return "done";
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,8 @@ import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { AgentEngine, type AgentLifecycleEvent } from "./agent-engine.js";
 import type { AgentRecord } from "./agent-types.js";
-import { parseScreen } from "./screen-parser.js";
+import { inferContextWindow, parseScreen } from "./screen-parser.js";
+import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -53,6 +54,58 @@ function requireValue(
   if (value === undefined || value === "") {
     throw new Error(message);
   }
+}
+
+function pickLatestSurfaceModel(
+  stateMgr: StateManager,
+  surfaceRef: string,
+): string | null {
+  const matches = stateMgr
+    .listStates()
+    .filter((record) => record.surface_id === surfaceRef && record.model);
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  matches.sort((a, b) => {
+    if (b.version !== a.version) return b.version - a.version;
+    return (
+      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+    );
+  });
+
+  return matches[0]?.model ?? null;
+}
+
+function enrichParsedScreen(
+  parsed: ParsedScreenResult,
+  rawText: string,
+  fallbackModel: string | null,
+): ParsedScreenResult {
+  const model = parsed.model ?? fallbackModel;
+  const contextWindow =
+    parsed.context_window ?? inferContextWindow(model, parsed.token_count, rawText);
+
+  let contextPct = parsed.context_pct;
+  if (
+    contextPct === null &&
+    parsed.agent_type !== "codex" &&
+    parsed.token_count !== null &&
+    contextWindow !== null
+  ) {
+    contextPct = Math.min(
+      100,
+      Math.round((parsed.token_count / contextWindow) * 100),
+    );
+  }
+
+  return {
+    ...parsed,
+    model,
+    context_window: contextWindow,
+    context_pct: contextPct,
+  };
 }
 
 export interface CreateServerOptions {
@@ -113,6 +166,9 @@ function buildLifecycleChannelMeta(
 export function createServer(opts?: CreateServerOptions): McpServer {
   const client =
     opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  const stateDir =
+    opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
+  const stateMgr = new StateManager(stateDir);
   const enableClaudeChannels =
     opts?.enableClaudeChannels ??
     process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1";
@@ -134,6 +190,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
     });
   }
+
+  const findSurfaceByRef = async (
+    surfaceRef: string,
+    workspace?: string,
+  ): Promise<CmuxSurface | null> => {
+    try {
+      const workspaceRefs = workspace
+        ? [workspace]
+        : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+
+      for (const workspaceRef of workspaceRefs) {
+        const panes = await client.listPanes({ workspace: workspaceRef });
+        for (const pane of panes.panes) {
+          const group = await client.listPaneSurfaces({
+            workspace: workspaceRef,
+            pane: pane.ref,
+          });
+          const surface = group.surfaces.find((entry) => entry.ref === surfaceRef);
+          if (surface) {
+            return surface;
+          }
+        }
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  };
 
   // 1. list_surfaces
   server.tool(
@@ -372,17 +457,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           lines: args.lines,
           scrollback: args.scrollback,
         });
-        const parsed = parseScreen(result.text);
+        const surface = await findSurfaceByRef(result.surface, args.workspace);
+        const parsed = enrichParsedScreen(
+          parseScreen(result.text),
+          result.text,
+          pickLatestSurfaceModel(stateMgr, result.surface),
+        );
 
         if (args.parsed_only) {
           return ok({
             surface: result.surface,
+            title: surface?.title ?? null,
             parsed,
           });
         }
 
         return ok({
           surface: result.surface,
+          title: surface?.title ?? null,
           lines: result.lines,
           content: result.text,
           scrollback_used: result.scrollback_used,
@@ -633,9 +725,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // --- Agent Lifecycle Tools (Phase 5) ---
 
   if (!opts?.skipAgentLifecycle) {
-    const stateDir =
-      opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
-    const stateMgr = new StateManager(stateDir);
     const surfaceProvider = async () => {
       try {
         const workspaces = await client.listWorkspaces();

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -82,6 +82,34 @@ Token usage: total=356,835
     expect(parsed.context_pct).toBe(36);
   });
 
+  it("treats CLAUDE_COUNTER as an idle done signal and extracts fallback response text", () => {
+    const parsed = parseScreen(`
+✻ Working…
+  Reading src/server.ts
+
+Codex is working well — searching through real session files for patterns to parse, writing tests first (TDD). 90% context left.
+
+No idle agents to reassign right now. Everything is either done or Codex is handling the last task.
+
+Token usage: total=356,835
+🤖 Opus
+CLAUDE_COUNTER: 92
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.done_signal).toBe("CLAUDE_COUNTER:92");
+    expect(parsed.response).toBe(
+      [
+        "Codex is working well — searching through real session files for patterns to parse, writing tests first (TDD). 90% context left.",
+        "",
+        "No idle agents to reassign right now. Everything is either done or Codex is handling the last task.",
+      ].join("\n"),
+    );
+    expect(parsed.context_window).toBe(1_000_000);
+    expect(parsed.context_pct).toBe(36);
+  });
+
   it("extracts model from timer-only status line (no cost)", () => {
     const parsed = parseScreen(`
 ⏺ Completed successfully

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -458,6 +458,96 @@ describe("tool handler integration", () => {
     });
   });
 
+  it("read_screen parsed_only includes the tab title and recovers model context from agent state", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-read-screen-parser-fallback");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "sonnet-orchestrator-123",
+      surface_id: "surface:1",
+      state: "idle",
+      repo: "orchestrator",
+      model: "Sonnet 4.6",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "Monitor parser output",
+      pid: null,
+      version: 1,
+      created_at: "2026-03-23T00:00:00Z",
+      updated_at: "2026-03-23T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:1",
+        text: [
+          "Parser fallback is running in the narrow pane.",
+          "Token usage: total=40,000",
+          "CLAUDE_COUNTER: 7",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [{ ref: "workspace:1" }],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            ref: "surface:1",
+            title: "orchestratorClaude",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+    } as any;
+
+    const server = createServer({
+      client: mockClient,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["read_screen"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", parsed_only: true },
+      {} as any,
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.title).toBe("orchestratorClaude");
+    expect(parsed.parsed).toMatchObject({
+      agent_type: "claude",
+      status: "idle",
+      model: "Sonnet 4.6",
+      context_window: 200000,
+      context_pct: 20,
+      done_signal: "CLAUDE_COUNTER:7",
+      response: "Parser fallback is running in the narrow pane.",
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("send_input handler calls cmux send", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 


### PR DESCRIPTION
## Summary
- treat `CLAUDE_COUNTER` as a Claude done-signal fallback and map it to `idle`
- extract fallback Claude response text when structured response markers are missing
- recover missing model/context data from agent state and include the surface title in `read_screen` output

## Test plan
- [x] npx vitest run
- [x] npx tsc --noEmit
- [x] npx biome check src/ tests/
- [x] npx tsc


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `read_screen` parser to recover response text and status when explicit DONE tokens are absent
> - When an explicit `*_DONE` token is missing but a `CLAUDE_COUNTER: N` line is present, `parseDoneSignal` now returns `'CLAUDE_COUNTER:N'` and `inferStatus` treats this as `idle` rather than `done`.
> - Adds `extractClaudeResponseTail` in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/15/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to extract a best-effort response from the lines preceding the `CLAUDE_COUNTER` marker, filtering out status/noise lines when no explicit `---RESPONSE_START/END---` block exists.
> - The `read_screen` handler in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/15/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now returns a `title` field for the target surface and enriches parsed results with inferred `model`, `context_window`, and `context_pct` using prior agent state when those fields are absent from the raw parse.
> - Behavioral Change: screens ending with `CLAUDE_COUNTER` are now reported as `idle` instead of `done`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f576d91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screen parsing with improved fallback signal detection to handle additional session formats.
  * Screen reads now enrich results with inferred model information and context window usage metrics.
  * Added persistent state recovery mechanism for improved session handling and status reporting.

* **Tests**
  * New test coverage for fallback parsing scenarios and state-based screen recovery integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->