### PR TITLE
feat: notify MCP method + Cursor screen parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+bun.lock

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 </p>
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-233%20passing-brightgreen.svg)](#testing)
-[![MCP](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-272%20passing-brightgreen.svg)](#testing)
+[![MCP](https://img.shields.io/badge/MCP-11%20tools-green.svg)](https://modelcontextprotocol.io)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
 
 ---
 
-**233 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **10 MCP tools** · **Agent lifecycle engine**
+**272 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **11 MCP tools** · **Agent lifecycle engine**
 
 cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
 
@@ -48,7 +48,7 @@ Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` in the server environment and launch Cl
 
 See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the notification format, OpenClaw pairing patterns worth stealing, and the remaining gaps for a real cmux mobile client.
 
-## MCP Tools (10)
+## MCP Tools (11)
 
 | Tool | Description |
 |------|-------------|
@@ -58,6 +58,7 @@ See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the not
 | `send_key` | Send a key press to a surface |
 | `read_screen` | Read raw screen text plus parsed agent state from a surface |
 | `rename_tab` | Rename a surface tab (with optional prefix preservation) |
+| `notify` | Show a cmux notification banner |
 | `set_status` | Set sidebar status key-value pair |
 | `set_progress` | Set sidebar progress indicator (0.0-1.0) |
 | `close_surface` | Close a surface |

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -277,7 +277,8 @@ export class CmuxClient {
     workspace?: string;
     surface?: string;
   }): Promise<void> {
-    const args = ["notify", "--title", opts?.title ?? "Notification"];
+    const args = ["notify"];
+    if (opts?.title) args.push("--title", opts.title);
     if (opts?.subtitle) args.push("--subtitle", opts.subtitle);
     if (opts?.body) args.push("--body", opts.body);
     if (opts?.workspace) args.push("--workspace", opts.workspace);

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -270,6 +270,21 @@ export class CmuxClient {
     await this.run(args);
   }
 
+  async notify(opts?: {
+    title?: string;
+    subtitle?: string;
+    body?: string;
+    workspace?: string;
+    surface?: string;
+  }): Promise<void> {
+    const args = ["notify", "--title", opts?.title ?? "Notification"];
+    if (opts?.subtitle) args.push("--subtitle", opts.subtitle);
+    if (opts?.body) args.push("--body", opts.body);
+    if (opts?.workspace) args.push("--workspace", opts.workspace);
+    if (opts?.surface) args.push("--surface", opts.surface);
+    await this.run(args);
+  }
+
   async setStatus(
     key: string,
     value: string,

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -440,6 +440,28 @@ export class CmuxSocketClient {
     await this.sendV1Args("rename_tab", args);
   }
 
+  async notify(opts?: {
+    title?: string;
+    subtitle?: string;
+    body?: string;
+    workspace?: string;
+    surface?: string;
+  }): Promise<void> {
+    const args: V1Arg[] = [
+      this.rawV1Arg("--title"),
+      opts?.title ?? "Notification",
+    ];
+    if (opts?.subtitle) args.push(this.rawV1Arg("--subtitle"), opts.subtitle);
+    if (opts?.body) args.push(this.rawV1Arg("--body"), opts.body);
+    if (opts?.workspace) {
+      args.push(this.rawV1Arg("--workspace"), opts.workspace);
+    }
+    if (opts?.surface) {
+      args.push(this.rawV1Arg("--surface"), opts.surface);
+    }
+    await this.sendV1Args("notify", args);
+  }
+
   async setStatus(
     key: string,
     value: string,

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -447,10 +447,10 @@ export class CmuxSocketClient {
     workspace?: string;
     surface?: string;
   }): Promise<void> {
-    const args: V1Arg[] = [
-      this.rawV1Arg("--title"),
-      opts?.title ?? "Notification",
-    ];
+    const args: V1Arg[] = [];
+    if (opts?.title) {
+      args.push(this.rawV1Arg("--title"), opts.title);
+    }
     if (opts?.subtitle) args.push(this.rawV1Arg("--subtitle"), opts.subtitle);
     if (opts?.body) args.push(this.rawV1Arg("--body"), opts.body);
     if (opts?.workspace) {
@@ -484,7 +484,9 @@ export class CmuxSocketClient {
     const args: V1Arg[] = [key];
     if (opts?.workspace) {
       args.push(
-        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+        this.rawV1Arg(
+          `--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`,
+        ),
       );
     }
     await this.sendV1Args("clear_status", args);
@@ -509,7 +511,9 @@ export class CmuxSocketClient {
     const args: V1Arg[] = [];
     if (opts?.workspace) {
       args.push(
-        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+        this.rawV1Arg(
+          `--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`,
+        ),
       );
     }
     await this.sendV1Args("clear_progress", args);
@@ -549,7 +553,9 @@ export class CmuxSocketClient {
     const args: V1Arg[] = [];
     if (opts?.workspace) {
       args.push(
-        this.rawV1Arg(`--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`),
+        this.rawV1Arg(
+          `--tab=${await this.resolveWorkspaceTabId(opts.workspace)}`,
+        ),
       );
     }
     const raw = await this.sendV1Args("list_status", args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,10 @@
 /**
  * @golems/cmux-mcp — MCP server for programmatic cmux terminal control.
  *
- * Exposes 10 tools:
+ * Exposes 11 tools:
  *   list_surfaces, new_split, send_input, send_key, read_screen,
- *   rename_tab, set_status, set_progress, close_surface, browser_surface
+ *   rename_tab, notify, set_status, set_progress, close_surface,
+ *   browser_surface
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -100,12 +100,47 @@ const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
+/** Cursor Agent CLI — mode bar, hex status, context strip, follow-up prompt */
+const CURSOR_MODE_BAR_RE =
+  /\/ commands · @ files · ! shell · ctrl\+r to review edits/i;
+const CURSOR_HEX_RUNNING_RE = /⬡\s+Running\.\.\./i;
+const CURSOR_HEX_IDLE_RE = /⬡\s+Idle\b/i;
+const CURSOR_TOKEN_LINE_RE =
+  /⬡\s+(?:Running\.\.\.|Idle)\s+([0-9][0-9,]*(?:\.[0-9]+)?)\s*([km])?\s*tokens\b/i;
+const CURSOR_STATUS_PCT_RE =
+  /(?:^|\n)\s*(?:Auto|Agent)\s*·\s*(\d+(?:\.\d+)?)\s*%\s*·/i;
+const CURSOR_FOLLOWUP_RE = /→\s*Add a follow-up/i;
+const CURSOR_STOP_RE = /ctrl\+c to stop/i;
+const CURSOR_SESSION_COMPLETE_RE =
+  /\b(?:Task completed|Generation complete|All edits applied|Session complete)\b/i;
+const CURSOR_CHECKMARK_DONE_RE =
+  /(?:^|\n)\s*[✓✔]\s*(?:Done|Complete|Completed)\b/i;
+const CURSOR_MODEL_LINE_RE = /^\s*Model:\s*(.+)$/im;
+const CURSOR_USING_LINE_RE = /^\s*Using\s*:?\s*(.+)$/im;
+const CURSOR_MODEL_INLINE_RE =
+  /\b(claude-[0-9][0-9a-z.-]*|gpt-[0-9][0-9a-z.-]*(?:\s+(?:high|low|mini))?|gemini-[0-9][0-9a-z.-]*)\b/i;
+
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_RE, "");
 }
 
 function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function isCursorAgentScreen(text: string): boolean {
+  if (CURSOR_MODE_BAR_RE.test(text)) return true;
+  if (CURSOR_FOLLOWUP_RE.test(text) && CURSOR_STOP_RE.test(text)) return true;
+  if (CURSOR_STATUS_PCT_RE.test(text) && /files edited/i.test(text)) {
+    return true;
+  }
+  if (
+    (CURSOR_HEX_RUNNING_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) &&
+    CURSOR_TOKEN_LINE_RE.test(text)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function detectAgentType(text: string): ParsedScreenAgentType {
@@ -140,6 +175,10 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   }
   if (GEMINI_MODEL_RE.test(text) && !CODEX_MODEL_RE.test(text)) {
     return "gemini";
+  }
+
+  if (isCursorAgentScreen(text)) {
+    return "cursor";
   }
 
   return "unknown";
@@ -269,6 +308,13 @@ function parseModelAndCost(
     };
   }
 
+  if (agentType === "cursor") {
+    return {
+      model: parseCursorModel(text),
+      cost: null,
+    };
+  }
+
   if (agentType === "gemini") {
     return {
       model: text.match(GEMINI_MODEL_RE)?.[1] ?? null,
@@ -307,6 +353,46 @@ function parseCodexActions(text: string): string[] {
   return Array.from(text.matchAll(CODEX_ACTION_RE), (match) => match[1].trim());
 }
 
+function parseCursorScaledTokenCount(raw: string, suffix?: string): number {
+  const n = Number.parseFloat(raw.replaceAll(",", ""));
+  if (!Number.isFinite(n)) return NaN;
+  const s = (suffix ?? "").toLowerCase();
+  if (s === "k") return Math.round(n * 1000);
+  if (s === "m") return Math.round(n * 1_000_000);
+  return Math.round(n);
+}
+
+function parseCursorTokenCount(text: string): number | null {
+  const m = text.match(CURSOR_TOKEN_LINE_RE);
+  if (!m) return null;
+  const value = parseCursorScaledTokenCount(m[1], m[2]);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Context % used from the "Auto · 22.5% · …" status strip */
+function parseCursorStatusContextPct(text: string): number | null {
+  const m = text.match(CURSOR_STATUS_PCT_RE);
+  if (!m) return null;
+  const pct = Number.parseFloat(m[1]);
+  if (!Number.isFinite(pct)) return null;
+  return Math.min(100, Math.round(pct));
+}
+
+function parseCursorModel(text: string): string | null {
+  const labeled =
+    text.match(CURSOR_MODEL_LINE_RE)?.[1]?.trim() ??
+    text.match(CURSOR_USING_LINE_RE)?.[1]?.trim();
+  if (labeled) return labeled;
+  const inline = text.match(CURSOR_MODEL_INLINE_RE)?.[0]?.trim();
+  return inline ?? null;
+}
+
+function parseCursorDoneSignal(text: string): string | null {
+  if (CURSOR_SESSION_COMPLETE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
+  if (CURSOR_CHECKMARK_DONE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
+  return null;
+}
+
 function inferStatus(
   text: string,
   doneSignal: string | null,
@@ -336,6 +422,16 @@ function inferStatus(
 
   if (agentType === "codex" && CODEX_RESUME_RE.test(text)) {
     return "done";
+  }
+
+  if (agentType === "cursor") {
+    if (CURSOR_HEX_RUNNING_RE.test(text)) {
+      return "working";
+    }
+    if (CURSOR_FOLLOWUP_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) {
+      return "idle";
+    }
+    return "idle";
   }
 
   if (agentType === "claude" && CLAUDE_DONE_LINE_RE.test(text)) {
@@ -382,10 +478,19 @@ function inferStatus(
 export function parseScreen(text: string): ParsedScreenResult {
   const normalized = normalizeText(text);
   const agentType = detectAgentType(normalized);
-  const doneSignal = parseDoneSignal(normalized);
+  let doneSignal = parseDoneSignal(normalized);
+  if (agentType === "cursor" && doneSignal === null) {
+    doneSignal = parseCursorDoneSignal(normalized);
+  }
   const errors = parseErrors(normalized);
   const { model, cost } = parseModelAndCost(normalized, agentType);
-  const tokenCount = parseTokenCount(normalized);
+  let tokenCount = parseTokenCount(normalized);
+  if (agentType === "cursor") {
+    const cursorTokens = parseCursorTokenCount(normalized);
+    if (cursorTokens !== null) {
+      tokenCount = cursorTokens;
+    }
+  }
   const contextWindow = inferContextWindow(model, tokenCount, normalized);
 
   // Compute context_pct: percentage of context window USED (0=fresh, 100=full)
@@ -393,10 +498,19 @@ export function parseScreen(text: string): ParsedScreenResult {
   // but >100% is noise for monitoring. For Codex: invert "% left" → "% used".
   // AIDEV-NOTE: For Codex, token_count may be null while context_pct is populated
   // (Codex surfaces show "% left" directly rather than raw token counts).
+  // Cursor: prefer the status strip "Auto · 22.5% · …" when present.
   let contextPct: number | null = null;
   if (agentType === "codex") {
     const codexLeft = parseCodexContextPct(normalized);
     contextPct = codexLeft !== null ? 100 - codexLeft : null;
+  } else if (agentType === "cursor") {
+    contextPct = parseCursorStatusContextPct(normalized);
+    if (contextPct === null && tokenCount !== null && contextWindow !== null) {
+      contextPct = Math.min(
+        100,
+        Math.round((tokenCount / contextWindow) * 100),
+      );
+    }
   } else if (tokenCount !== null && contextWindow !== null) {
     contextPct = Math.min(100, Math.round((tokenCount / contextWindow) * 100));
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,9 +70,7 @@ function pickLatestSurfaceModel(
 
   matches.sort((a, b) => {
     if (b.version !== a.version) return b.version - a.version;
-    return (
-      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-    );
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
   });
 
   return matches[0]?.model ?? null;
@@ -85,7 +83,8 @@ function enrichParsedScreen(
 ): ParsedScreenResult {
   const model = parsed.model ?? fallbackModel;
   const contextWindow =
-    parsed.context_window ?? inferContextWindow(model, parsed.token_count, rawText);
+    parsed.context_window ??
+    inferContextWindow(model, parsed.token_count, rawText);
 
   let contextPct = parsed.context_pct;
   if (
@@ -207,7 +206,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: workspaceRef,
             pane: pane.ref,
           });
-          const surface = group.surfaces.find((entry) => entry.ref === surfaceRef);
+          const surface = group.surfaces.find(
+            (entry) => entry.ref === surfaceRef,
+          );
           if (surface) {
             return surface;
           }
@@ -533,8 +534,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       title: z
         .string()
         .optional()
-        .default("Notification")
-        .describe("Notification title"),
+        .describe(
+          'Notification title; omit to use cmux CLI default ("Notification")',
+        ),
       subtitle: z.string().optional().describe("Notification subtitle"),
       body: z.string().optional().describe("Notification body"),
       workspace: z.string().optional().describe("Target workspace ref"),
@@ -542,20 +544,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
     async (args) => {
       try {
-        const title = args.title ?? "Notification";
         await client.notify({
-          title,
+          title: args.title,
           subtitle: args.subtitle,
           body: args.body,
           workspace: args.workspace,
           surface: args.surface,
         });
         return ok({
-          title,
-          subtitle: args.subtitle,
-          body: args.body,
-          workspace: args.workspace,
-          surface: args.surface,
+          title: args.title ?? null,
+          subtitle: args.subtitle ?? null,
+          body: args.body ?? null,
+          workspace: args.workspace ?? null,
+          surface: args.surface ?? null,
           applied: "notify",
         });
       } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 10 low-level tools + 7 agent lifecycle tools.
+ * cmux MCP server — registers 11 low-level tools + 7 agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -525,7 +525,46 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 7. set_status
+  // 7. notify
+  server.tool(
+    "notify",
+    "Show a cmux notification banner for a workspace or specific surface.",
+    {
+      title: z
+        .string()
+        .optional()
+        .default("Notification")
+        .describe("Notification title"),
+      subtitle: z.string().optional().describe("Notification subtitle"),
+      body: z.string().optional().describe("Notification body"),
+      workspace: z.string().optional().describe("Target workspace ref"),
+      surface: z.string().optional().describe("Target surface ref"),
+    },
+    async (args) => {
+      try {
+        const title = args.title ?? "Notification";
+        await client.notify({
+          title,
+          subtitle: args.subtitle,
+          body: args.body,
+          workspace: args.workspace,
+          surface: args.surface,
+        });
+        return ok({
+          title,
+          subtitle: args.subtitle,
+          body: args.body,
+          workspace: args.workspace,
+          surface: args.surface,
+          applied: "notify",
+        });
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 8. set_status
   server.tool(
     "set_status",
     "Set a sidebar status key-value pair",
@@ -561,7 +600,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 8. set_progress
+  // 9. set_progress
   server.tool(
     "set_progress",
     "Set sidebar progress indicator (0.0 to 1.0)",
@@ -593,7 +632,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 9. close_surface
+  // 10. close_surface
   server.tool(
     "close_surface",
     "Close a surface (terminal or browser pane)",
@@ -613,7 +652,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 10. browser_surface
+  // 11. browser_surface
   server.tool(
     "browser_surface",
     "Interact with a browser surface (open, navigate, snapshot, click, type, eval, wait)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,12 @@ export interface CmuxReadScreenResult {
   scrollback_used: boolean;
 }
 
-export type ParsedScreenAgentType = "claude" | "codex" | "gemini" | "unknown";
+export type ParsedScreenAgentType =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "cursor"
+  | "unknown";
 export type ParsedScreenStatus = "frozen" | "working" | "idle" | "done";
 
 export interface ParsedScreenResult {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -166,6 +166,80 @@ Thinking...
     expect(parsed.model).toBe("gemini-3.1-pro");
   });
 
+  it("parses Cursor Agent working state with status strip, k tokens, and mode bar", () => {
+    const parsed = parseScreen(`
+Auto · 22.5% · 4 files edited
+
+⬡ Running...  3.3k tokens
+
+→ Add a follow-up
+ctrl+c to stop
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("working");
+    expect(parsed.token_count).toBe(3300);
+    expect(parsed.context_pct).toBe(23);
+  });
+
+  it("parses Cursor Agent idle with Idle line, comma tokens, and Model line", () => {
+    const parsed = parseScreen(`
+Auto · 10% · 1 file edited
+Model: gpt-5.2 high
+
+⬡ Idle  12,450 tokens
+
+→ Add a follow-up
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.token_count).toBe(12450);
+    expect(parsed.context_pct).toBe(10);
+    expect(parsed.model).toBe("gpt-5.2 high");
+  });
+
+  it("detects Cursor session completion as done_signal and status done", () => {
+    const parsed = parseScreen(`
+Auto · 90% · 2 files edited
+Task completed
+
+⬡ Idle  1.2k tokens
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.done_signal).toBe("CURSOR_SESSION_COMPLETE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("detects Cursor via follow-up prompt and ctrl+c without mode bar", () => {
+    const parsed = parseScreen(`
+→ Add a follow-up
+ctrl+c to stop
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+  });
+
+  it("detects Cursor via inline claude model id", () => {
+    const parsed = parseScreen(`
+Auto · 5% · 0 files edited
+Using claude-sonnet-4-20250514
+
+⬡ Idle  800 tokens
+4 files edited
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.model).toBe("claude-sonnet-4-20250514");
+  });
+
   it("detects idle shell output and strips ANSI sequences", () => {
     const parsed = parseScreen(`
 \u001b[36mLast login:\u001b[0m Fri Mar 13 18:10:54 on ttys016

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -56,7 +56,7 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 20 (10 low-level + 8 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 21 (11 low-level + 8 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -66,7 +66,7 @@ describe("agent lifecycle tool registration", () => {
       stateDir: TEST_DIR,
     });
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(20);
+    expect(Object.keys(registeredTools)).toHaveLength(21);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -620,7 +620,7 @@ describe("tool handler integration", () => {
       readScreen: vi.fn().mockResolvedValue({
         surface: "surface:1",
         text: [
-          '  Say "go" when you\'re ready and I\'ll start your timer.',
+          "  Say \"go\" when you're ready and I'll start your timer.",
           "",
           "  CLAUDE_COUNTER: 186",
           "",
@@ -902,7 +902,7 @@ describe("tool handler integration", () => {
     );
   });
 
-  it("notify handler calls cmux notify with defaults and optional args", async () => {
+  it("notify handler calls cmux notify without --title when title omitted", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
@@ -922,8 +922,6 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenCalledWith("cmux", [
       "--json",
       "notify",
-      "--title",
-      "Notification",
       "--subtitle",
       "Build",
       "--body",
@@ -938,12 +936,29 @@ describe("tool handler integration", () => {
     expect(parsed).toMatchObject({
       ok: true,
       applied: "notify",
-      title: "Notification",
+      title: null,
       subtitle: "Build",
       body: "Finished successfully",
       workspace: "workspace:1",
       surface: "surface:1",
     });
+  });
+
+  it("notify handler passes --title when title is provided", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["notify"];
+
+    await tool.handler({ title: "Done" }, {} as any);
+
+    expect(mockExec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "notify",
+      "--title",
+      "Done",
+    ]);
   });
 
   it("set_progress handler calls cmux set-progress", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,7 +7,7 @@ import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 
-// The 10 tools from the design doc
+// The 11 low-level tools from the design doc
 const EXPECTED_TOOLS = [
   "list_surfaces",
   "new_split",
@@ -15,6 +15,7 @@ const EXPECTED_TOOLS = [
   "send_key",
   "read_screen",
   "rename_tab",
+  "notify",
   "set_status",
   "set_progress",
   "close_surface",
@@ -53,7 +54,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 10 tools", () => {
+  it("registers all 11 tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;
@@ -899,6 +900,50 @@ describe("tool handler integration", () => {
         "New Title",
       ]),
     );
+  });
+
+  it("notify handler calls cmux notify with defaults and optional args", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["notify"];
+
+    const result = await tool.handler(
+      {
+        subtitle: "Build",
+        body: "Finished successfully",
+        workspace: "workspace:1",
+        surface: "surface:1",
+      },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "notify",
+      "--title",
+      "Notification",
+      "--subtitle",
+      "Build",
+      "--body",
+      "Finished successfully",
+      "--workspace",
+      "workspace:1",
+      "--surface",
+      "surface:1",
+    ]);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toMatchObject({
+      ok: true,
+      applied: "notify",
+      title: "Notification",
+      subtitle: "Build",
+      body: "Finished successfully",
+      workspace: "workspace:1",
+      surface: "surface:1",
+    });
   });
 
   it("set_progress handler calls cmux set-progress", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -40,14 +40,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 20 (10 low-level + 8 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 21 (11 low-level + 8 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(20);
+    expect(count).toBe(21);
   });
 });
 


### PR DESCRIPTION
Adds notify as MCP tool (was CLI-only) + Cursor agent screen parsing for read_screen. 7 files changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `notify` MCP tool and Cursor Agent screen parser support
> - Adds a `notify` tool to the MCP server (now 11 tools) that sends notification banners with optional title, subtitle, body, workspace, and surface via `CmuxClient.notify` and `CmuxSocketClient.notify`.
> - Extends [src/screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/18/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to detect and parse Cursor Agent CLI screens, adding `'cursor'` to `ParsedScreenAgentType` and implementing helpers for token counts, context percent, model extraction, done signals, and working/idle status inference.
> - Adds 5 new screen-parser tests for Cursor Agent states and integration tests for the `notify` handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94a1dc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->