### PR TITLE
feat(screen-parser): recognize Cursor Agent CLI output

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -100,12 +100,47 @@ const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
+/** Cursor Agent CLI — mode bar, hex status, context strip, follow-up prompt */
+const CURSOR_MODE_BAR_RE =
+  /\/ commands · @ files · ! shell · ctrl\+r to review edits/i;
+const CURSOR_HEX_RUNNING_RE = /⬡\s+Running\.\.\./i;
+const CURSOR_HEX_IDLE_RE = /⬡\s+Idle\b/i;
+const CURSOR_TOKEN_LINE_RE =
+  /⬡\s+(?:Running\.\.\.|Idle)\s+([0-9][0-9,]*(?:\.[0-9]+)?)\s*([km])?\s*tokens\b/i;
+const CURSOR_STATUS_PCT_RE =
+  /(?:^|\n)\s*(?:Auto|Agent)\s*·\s*(\d+(?:\.\d+)?)\s*%\s*·/i;
+const CURSOR_FOLLOWUP_RE = /→\s*Add a follow-up/i;
+const CURSOR_STOP_RE = /ctrl\+c to stop/i;
+const CURSOR_SESSION_COMPLETE_RE =
+  /\b(?:Task completed|Generation complete|All edits applied|Session complete)\b/i;
+const CURSOR_CHECKMARK_DONE_RE =
+  /(?:^|\n)\s*[✓✔]\s*(?:Done|Complete|Completed)\b/i;
+const CURSOR_MODEL_LINE_RE = /^\s*Model:\s*(.+)$/im;
+const CURSOR_USING_LINE_RE = /^\s*Using\s*:?\s*(.+)$/im;
+const CURSOR_MODEL_INLINE_RE =
+  /\b(claude-[0-9][0-9a-z.-]*|gpt-[0-9][0-9a-z.-]*(?:\s+(?:high|low|mini))?|gemini-[0-9][0-9a-z.-]*)\b/i;
+
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_RE, "");
 }
 
 function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function isCursorAgentScreen(text: string): boolean {
+  if (CURSOR_MODE_BAR_RE.test(text)) return true;
+  if (CURSOR_FOLLOWUP_RE.test(text) && CURSOR_STOP_RE.test(text)) return true;
+  if (CURSOR_STATUS_PCT_RE.test(text) && /files edited/i.test(text)) {
+    return true;
+  }
+  if (
+    (CURSOR_HEX_RUNNING_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) &&
+    CURSOR_TOKEN_LINE_RE.test(text)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function detectAgentType(text: string): ParsedScreenAgentType {
@@ -140,6 +175,10 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   }
   if (GEMINI_MODEL_RE.test(text) && !CODEX_MODEL_RE.test(text)) {
     return "gemini";
+  }
+
+  if (isCursorAgentScreen(text)) {
+    return "cursor";
   }
 
   return "unknown";
@@ -269,6 +308,13 @@ function parseModelAndCost(
     };
   }
 
+  if (agentType === "cursor") {
+    return {
+      model: parseCursorModel(text),
+      cost: null,
+    };
+  }
+
   if (agentType === "gemini") {
     return {
       model: text.match(GEMINI_MODEL_RE)?.[1] ?? null,
@@ -307,6 +353,46 @@ function parseCodexActions(text: string): string[] {
   return Array.from(text.matchAll(CODEX_ACTION_RE), (match) => match[1].trim());
 }
 
+function parseCursorScaledTokenCount(raw: string, suffix?: string): number {
+  const n = Number.parseFloat(raw.replaceAll(",", ""));
+  if (!Number.isFinite(n)) return NaN;
+  const s = (suffix ?? "").toLowerCase();
+  if (s === "k") return Math.round(n * 1000);
+  if (s === "m") return Math.round(n * 1_000_000);
+  return Math.round(n);
+}
+
+function parseCursorTokenCount(text: string): number | null {
+  const m = text.match(CURSOR_TOKEN_LINE_RE);
+  if (!m) return null;
+  const value = parseCursorScaledTokenCount(m[1], m[2]);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Context % used from the "Auto · 22.5% · …" status strip */
+function parseCursorStatusContextPct(text: string): number | null {
+  const m = text.match(CURSOR_STATUS_PCT_RE);
+  if (!m) return null;
+  const pct = Number.parseFloat(m[1]);
+  if (!Number.isFinite(pct)) return null;
+  return Math.min(100, Math.round(pct));
+}
+
+function parseCursorModel(text: string): string | null {
+  const labeled =
+    text.match(CURSOR_MODEL_LINE_RE)?.[1]?.trim() ??
+    text.match(CURSOR_USING_LINE_RE)?.[1]?.trim();
+  if (labeled) return labeled;
+  const inline = text.match(CURSOR_MODEL_INLINE_RE)?.[0]?.trim();
+  return inline ?? null;
+}
+
+function parseCursorDoneSignal(text: string): string | null {
+  if (CURSOR_SESSION_COMPLETE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
+  if (CURSOR_CHECKMARK_DONE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
+  return null;
+}
+
 function inferStatus(
   text: string,
   doneSignal: string | null,
@@ -336,6 +422,16 @@ function inferStatus(
 
   if (agentType === "codex" && CODEX_RESUME_RE.test(text)) {
     return "done";
+  }
+
+  if (agentType === "cursor") {
+    if (CURSOR_HEX_RUNNING_RE.test(text)) {
+      return "working";
+    }
+    if (CURSOR_FOLLOWUP_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) {
+      return "idle";
+    }
+    return "idle";
   }
 
   if (agentType === "claude" && CLAUDE_DONE_LINE_RE.test(text)) {
@@ -382,10 +478,19 @@ function inferStatus(
 export function parseScreen(text: string): ParsedScreenResult {
   const normalized = normalizeText(text);
   const agentType = detectAgentType(normalized);
-  const doneSignal = parseDoneSignal(normalized);
+  let doneSignal = parseDoneSignal(normalized);
+  if (agentType === "cursor" && doneSignal === null) {
+    doneSignal = parseCursorDoneSignal(normalized);
+  }
   const errors = parseErrors(normalized);
   const { model, cost } = parseModelAndCost(normalized, agentType);
-  const tokenCount = parseTokenCount(normalized);
+  let tokenCount = parseTokenCount(normalized);
+  if (agentType === "cursor") {
+    const cursorTokens = parseCursorTokenCount(normalized);
+    if (cursorTokens !== null) {
+      tokenCount = cursorTokens;
+    }
+  }
   const contextWindow = inferContextWindow(model, tokenCount, normalized);
 
   // Compute context_pct: percentage of context window USED (0=fresh, 100=full)
@@ -393,10 +498,19 @@ export function parseScreen(text: string): ParsedScreenResult {
   // but >100% is noise for monitoring. For Codex: invert "% left" → "% used".
   // AIDEV-NOTE: For Codex, token_count may be null while context_pct is populated
   // (Codex surfaces show "% left" directly rather than raw token counts).
+  // Cursor: prefer the status strip "Auto · 22.5% · …" when present.
   let contextPct: number | null = null;
   if (agentType === "codex") {
     const codexLeft = parseCodexContextPct(normalized);
     contextPct = codexLeft !== null ? 100 - codexLeft : null;
+  } else if (agentType === "cursor") {
+    contextPct = parseCursorStatusContextPct(normalized);
+    if (contextPct === null && tokenCount !== null && contextWindow !== null) {
+      contextPct = Math.min(
+        100,
+        Math.round((tokenCount / contextWindow) * 100),
+      );
+    }
   } else if (tokenCount !== null && contextWindow !== null) {
     contextPct = Math.min(100, Math.round((tokenCount / contextWindow) * 100));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,12 @@ export interface CmuxReadScreenResult {
   scrollback_used: boolean;
 }
 
-export type ParsedScreenAgentType = "claude" | "codex" | "gemini" | "unknown";
+export type ParsedScreenAgentType =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "cursor"
+  | "unknown";
 export type ParsedScreenStatus = "frozen" | "working" | "idle" | "done";
 
 export interface ParsedScreenResult {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -166,6 +166,80 @@ Thinking...
     expect(parsed.model).toBe("gemini-3.1-pro");
   });
 
+  it("parses Cursor Agent working state with status strip, k tokens, and mode bar", () => {
+    const parsed = parseScreen(`
+Auto · 22.5% · 4 files edited
+
+⬡ Running...  3.3k tokens
+
+→ Add a follow-up
+ctrl+c to stop
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("working");
+    expect(parsed.token_count).toBe(3300);
+    expect(parsed.context_pct).toBe(23);
+  });
+
+  it("parses Cursor Agent idle with Idle line, comma tokens, and Model line", () => {
+    const parsed = parseScreen(`
+Auto · 10% · 1 file edited
+Model: gpt-5.2 high
+
+⬡ Idle  12,450 tokens
+
+→ Add a follow-up
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.token_count).toBe(12450);
+    expect(parsed.context_pct).toBe(10);
+    expect(parsed.model).toBe("gpt-5.2 high");
+  });
+
+  it("detects Cursor session completion as done_signal and status done", () => {
+    const parsed = parseScreen(`
+Auto · 90% · 2 files edited
+Task completed
+
+⬡ Idle  1.2k tokens
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.done_signal).toBe("CURSOR_SESSION_COMPLETE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("detects Cursor via follow-up prompt and ctrl+c without mode bar", () => {
+    const parsed = parseScreen(`
+→ Add a follow-up
+ctrl+c to stop
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+  });
+
+  it("detects Cursor via inline claude model id", () => {
+    const parsed = parseScreen(`
+Auto · 5% · 0 files edited
+Using claude-sonnet-4-20250514
+
+⬡ Idle  800 tokens
+4 files edited
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.model).toBe("claude-sonnet-4-20250514");
+  });
+
   it("detects idle shell output and strips ANSI sequences", () => {
     const parsed = parseScreen(`
 \u001b[36mLast login:\u001b[0m Fri Mar 13 18:10:54 on ttys016


### PR DESCRIPTION
Adds `agent_type: "cursor"` and parsing for Cursor Agent terminal UI: status strip context %, ⬡ Running/Idle token lines (k/m suffixes), mode bar, Model/Using lines, completion `done_signal`, and working/idle status. Branched from `main` so it is independent of the notify MCP PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Cursor as a new AI agent type.
  * Extended model detection to extract Cursor model information from screen output.
  * Added parsing of Cursor token counts and context usage metrics.
  * Added detection of Cursor session completion signals.

* **Tests**
  * Added comprehensive test coverage for Cursor screen parsing across multiple states (working, idle, completed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor Agent CLI output recognition to screen-parser
> - Adds `isCursorAgentScreen` to detect Cursor Agent screens via mode bar, follow-up/ctrl+c prompts, status strip, and hex Running/Idle lines in [src/screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/19/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50).
> - Extends `detectAgentType` to classify screens as `"cursor"` and adds a `"cursor"` branch to `parseModelAndCost` that extracts model names from labeled lines or inline tokens, with cost set to `null`.
> - Adds helpers `parseCursorTokenCount`, `parseCursorStatusContextPct`, `parseCursorDoneSignal`, and `parseCursorModel` to extract token counts (with k/m suffix support), context percentage, completion signals, and model names from Cursor-specific screen layouts.
> - Extends `inferStatus` so Cursor screens map to `"working"` when the hex Running line is present, and `"idle"` otherwise.
> - Adds `"cursor"` to the `ParsedScreenAgentType` union in [src/types.ts](https://github.com/EtanHey/cmuxlayer/pull/19/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) and covers all new paths with five test cases in [tests/screen-parser.test.ts](https://github.com/EtanHey/cmuxlayer/pull/19/files#diff-f9e39ca6ad69e6b5b1b6052b007496bda3425ccaf48a0f8699ec099e39b8e2e4).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c83a92b. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->