### PR TITLE
docs: fix stale counts, document all 21 MCP tools, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# cmuxlayer — Terminal Multiplexer MCP
+
+> MCP server for multi-agent workspace orchestration via [cmux](https://github.com/manaflow-ai/cmux).
+
+## Stack
+- TypeScript + Zod, built with `tsc`, runs on Node 20+
+- MCP SDK (`@modelcontextprotocol/sdk`)
+- Persistent Unix socket connection to cmux (1,423x faster than CLI subprocess fallback)
+- Vitest for testing (278 tests across 17 test files)
+
+## Development
+```bash
+bun install
+bun run dev          # Run with tsx (hot reload)
+bun run build        # Compile TypeScript to dist/
+bun run test         # 278 tests via vitest
+bun run typecheck    # Type checking only
+```
+
+## Architecture
+
+### MCP Tools (21 total)
+- **11 core tools**: list_surfaces, new_split, send_input, send_key, read_screen, rename_tab, notify, set_status, set_progress, close_surface, browser_surface
+- **10 agent lifecycle tools**: spawn_agent, send_to_agent, read_agent_output, get_agent_state, list_agents, wait_for, wait_for_all, stop_agent, kill, interact
+
+### Key Source Files
+| File | Role |
+|------|------|
+| `server.ts` | MCP tool registration and handlers (all 21 tools) |
+| `cmux-socket-client.ts` | Persistent Unix socket to cmux |
+| `cmux-client.ts` | CLI wrapper fallback |
+| `agent-engine.ts` | Agent lifecycle — spawn, monitor, quality tracking |
+| `agent-registry.ts` | Registry of active agents across surfaces |
+| `screen-parser.ts` | Parse terminal output for agent type, model, tokens, context % |
+| `mode-policy.ts` | Mode enforcement (autonomous vs manual) |
+| `state-manager.ts` | Sidebar state synchronization |
+| `naming.ts` | Surface naming rules (launcher prefix preservation) |
+| `event-log.ts` | Audit trail for agent actions |
+| `pattern-registry.ts` | Reusable workflow patterns |
+
+### Connection Model
+Socket client connects to cmux via Unix socket at the path provided by `cmux socket-path`.
+Auto-reconnects on disconnect. Falls back to CLI subprocess if socket unavailable.
+
+### Mode Policy
+Two axes per surface:
+- **control**: `autonomous` (full access) or `manual` (read-only for mutating tools)
+- **intent**: `chat` or `audit`
+
+### Claude Channels (Preview)
+Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` to enable one-way lifecycle notifications via `notifications/claude/channel`.
+
+## Testing Conventions
+- Test files mirror source: `src/foo.ts` -> `tests/foo.test.ts`
+- Agent engine tests use 1-second timeouts for state change detection
+- Server tests mock the cmux client via `createServer({ exec, skipAgentLifecycle })` pattern
+- No integration tests requiring a running cmux instance — all mocked
+
+## Key Patterns
+- `ok(data)` / `err(error)` helpers for consistent MCP tool responses
+- All tool handlers return `{ content: TextContent[], structuredContent?, isError? }`
+- Screen parser recognizes Claude, Codex, Gemini, and Cursor agent output formats
+- Agent lifecycle tools are registered conditionally (skipped when `skipAgentLifecycle: true`)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 </p>
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-272%20passing-brightgreen.svg)](#testing)
-[![MCP](https://img.shields.io/badge/MCP-11%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-278%20passing-brightgreen.svg)](#testing)
+[![MCP](https://img.shields.io/badge/MCP-21%20tools-green.svg)](https://modelcontextprotocol.io)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
 
 ---
 
-**272 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **11 MCP tools** · **Agent lifecycle engine**
+**278 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **21 MCP tools** · **Agent lifecycle engine**
 
 cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
 
@@ -48,7 +48,9 @@ Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` in the server environment and launch Cl
 
 See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the notification format, OpenClaw pairing patterns worth stealing, and the remaining gaps for a real cmux mobile client.
 
-## MCP Tools (11)
+## MCP Tools (21)
+
+### Core (11)
 
 | Tool | Description |
 |------|-------------|
@@ -63,6 +65,21 @@ See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the not
 | `set_progress` | Set sidebar progress indicator (0.0-1.0) |
 | `close_surface` | Close a surface |
 | `browser_surface` | Interact with browser surfaces |
+
+### Agent Lifecycle (10)
+
+| Tool | Description |
+|------|-------------|
+| `spawn_agent` | Spawn a CLI agent in a new or existing surface |
+| `send_to_agent` | Send a prompt or message to a running agent |
+| `read_agent_output` | Read recent output from an agent's surface |
+| `get_agent_state` | Get current state of a tracked agent |
+| `list_agents` | List all tracked agents and their states |
+| `wait_for` | Wait for an agent to reach a target state (with timeout) |
+| `wait_for_all` | Wait for multiple agents to reach target states |
+| `stop_agent` | Gracefully stop a running agent |
+| `kill` | Force-kill an agent process |
+| `interact` | Send interactive input (confirm, cancel, etc.) to an agent |
 
 ## Architecture
 
@@ -87,6 +104,7 @@ AI Agent  ─── MCP ───>  cmuxlayer
 | `naming.ts` | Surface naming rules (launcher prefix preservation) |
 | `mode-policy.ts` | Mode enforcement (autonomous = full access, manual = read-only) |
 | `state-manager.ts` | Sidebar state synchronization |
+| `screen-parser.ts` | Parse terminal output to extract agent type, model, token count, context % |
 | `event-log.ts` | Audit trail for all agent actions |
 | `pattern-registry.ts` | Reusable patterns for common workflows |
 
@@ -122,7 +140,7 @@ cmuxlayer development has contributed back to cmux:
 ## Testing
 
 ```bash
-bun run test        # 230 tests via vitest
+bun run test        # 278 tests via vitest
 bun run typecheck   # Type checking
 ```
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 11 low-level tools + 7 agent lifecycle tools.
+ * cmux MCP server — registers 11 core tools + 10 agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";


### PR DESCRIPTION
## Summary
- **README.md**: Update test count from 272 to 278. Update MCP tool count from 11 to 21 -- the README was missing all 10 agent lifecycle tools (spawn_agent, send_to_agent, read_agent_output, get_agent_state, list_agents, wait_for, wait_for_all, stop_agent, kill, interact). Split tool table into Core (11) and Agent Lifecycle (10) sections. Add screen-parser.ts to key components.
- **CLAUDE.md** (new): Project-specific instructions for AI agents working on this codebase -- stack, architecture, all 21 tools, key source files, testing conventions.
- **src/server.ts**: Fix header comment from "7 agent lifecycle" to "10 agent lifecycle".

## Test plan
- [ ] Verify test count: `bun run test` should show 278 passing
- [ ] Verify tool count: `grep -c 'server\.tool(' src/server.ts` should show 21
- [ ] Verify badges render correctly on GitHub
- [ ] No private paths in any file: `grep -r 'orchestrator\|golems/' CLAUDE.md README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document all 21 MCP tools and add CLAUDE.md engineering reference
> - Adds [CLAUDE.md](https://github.com/EtanHey/cmuxlayer/pull/20/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) as a top-level engineering reference covering project stack, dev commands, architecture, all 21 MCP tools, connection model, mode policy, and testing conventions.
> - Updates [README.md](https://github.com/EtanHey/cmuxlayer/pull/20/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect current counts (278 tests, 21 MCP tools) and splits the MCP Tools section into Core (11) and Agent Lifecycle (10) subsections with a new table for lifecycle tools.
> - Updates the [server.ts](https://github.com/EtanHey/cmuxlayer/pull/20/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) file header comment to accurately reflect 11 core + 10 agent lifecycle tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4846c3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->