### PR TITLE
fix: log registry reconstitution errors instead of silently swallowing

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
 
 // The 11 low-level tools from the design doc
 const EXPECTED_TOOLS = [
@@ -1077,5 +1078,37 @@ describe("tool handler integration", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/selector.*required/i);
     expect(mockExec).not.toHaveBeenCalled();
+  });
+});
+
+describe("registry reconstitution error logging", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("logs errors instead of silently swallowing them", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(AgentRegistry.prototype, "reconstitute").mockRejectedValueOnce(
+      new Error("disk corrupted"),
+    );
+
+    const mockExec: ExecFn = vi
+      .fn()
+      .mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    createServer({ exec: mockExec });
+
+    // Allow the async .catch() handler to run
+    await vi.waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(
+        "[cmux-mcp] registry reconstitution failed:",
+        expect.any(Error),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Replace empty `.catch(() => {})` on `registry.reconstitute()` with `console.error` logging using the `[cmux-mcp]` prefix
- Add test verifying errors are logged, not swallowed (uses fake timers to prevent `startSweep` leak, `restoreAllMocks` in `afterEach` for safe cleanup)

## Motivation
When agent state on disk is corrupted or unreadable, the silent catch made it impossible to debug why agents disappeared after restart. Now the error shows up in stderr.

## Test plan
- [x] New test: `registry reconstitution error logging > logs errors instead of silently swallowing them`
- [x] Full suite passes (279 tests, 17 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling during registry recovery scenarios, ensuring proper error logging and system resilience.

---

**Note:** This release contains internal test improvements with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log registry reconstitution errors instead of silently swallowing them
> Previously, errors thrown by `AgentRegistry.prototype.reconstitute` were silently swallowed. This change logs them to `console.error` with the prefix `[cmux-mcp] registry reconstitution failed:`. A new test suite in [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/21/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d) verifies the error is surfaced correctly using a spy and a mock rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf974a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->