### PR TITLE
fix: audit-critical — .text bug, socket backoff, spawn schema

### DIFF
--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -16,6 +16,19 @@ import {
 const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const REQUEST_TIMEOUT_MS = 10_000;
 
+export interface BackoffOptions {
+  /** Base delay in milliseconds (default: 100) */
+  baseMs?: number;
+  /** Maximum delay in milliseconds (default: 10_000) */
+  maxMs?: number;
+  /** Apply random jitter to prevent thundering herd (default: true) */
+  jitter?: boolean;
+}
+
+export interface CmuxPersistentSocketOptions extends CmuxSocketClientOptions {
+  backoff?: BackoffOptions;
+}
+
 interface V2Request {
   id: string;
   method: string;
@@ -46,10 +59,43 @@ export class CmuxPersistentSocket {
   /** Guards against concurrent connect() calls */
   private connectPromise: Promise<void> | null = null;
 
-  constructor(opts?: CmuxSocketClientOptions) {
+  // Backoff state
+  private backoffBaseMs: number;
+  private backoffMaxMs: number;
+  private backoffJitter: boolean;
+  private backoffAttempt = 0;
+  private _currentBackoffMs = 0;
+
+  constructor(opts?: CmuxPersistentSocketOptions) {
     this.socketPath =
       opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.backoffBaseMs = opts?.backoff?.baseMs ?? 100;
+    this.backoffMaxMs = opts?.backoff?.maxMs ?? 10_000;
+    this.backoffJitter = opts?.backoff?.jitter ?? true;
+  }
+
+  /** Current backoff delay in ms (0 when connected or no failures). */
+  currentBackoffMs(): number {
+    return this._currentBackoffMs;
+  }
+
+  /** Advance backoff to the next exponential step. */
+  incrementBackoff(): void {
+    this.backoffAttempt++;
+    const exponential = Math.min(
+      this.backoffBaseMs * Math.pow(2, this.backoffAttempt - 1),
+      this.backoffMaxMs,
+    );
+    this._currentBackoffMs = this.backoffJitter
+      ? Math.round(exponential * (0.5 + Math.random() * 0.5))
+      : exponential;
+  }
+
+  /** Reset backoff after a successful connection. */
+  resetBackoff(): void {
+    this.backoffAttempt = 0;
+    this._currentBackoffMs = 0;
   }
 
   async connect(): Promise<void> {
@@ -64,6 +110,7 @@ export class CmuxPersistentSocket {
         this.connected = true;
         settled = true;
         this.connectPromise = null;
+        this.resetBackoff();
         resolve();
       });
 
@@ -143,6 +190,10 @@ export class CmuxPersistentSocket {
     params: Record<string, unknown> = {},
   ): Promise<T> {
     if (!this.connected || !this.socket) {
+      if (this._currentBackoffMs > 0) {
+        await new Promise((r) => setTimeout(r, this._currentBackoffMs));
+      }
+      this.incrementBackoff();
       await this.connect();
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -837,6 +837,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("CLI tool to launch"),
         prompt: z.string().describe("Task prompt to send after agent is ready"),
         workspace: z.string().optional().describe("Target workspace ref"),
+        parent_agent_id: z
+          .string()
+          .optional()
+          .describe(
+            "ID of the parent agent for hierarchical spawning. Parent must exist.",
+          ),
+        max_cost_per_agent: z
+          .number()
+          .optional()
+          .describe("Maximum cost cap in USD for this agent"),
       },
       async (args) => {
         try {
@@ -846,6 +856,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             cli: args.cli,
             prompt: args.prompt,
             workspace: args.workspace,
+            parent_agent_id: args.parent_agent_id,
+            max_cost_per_agent: args.max_cost_per_agent,
           });
           return ok({ ...result });
         } catch (e) {
@@ -1053,10 +1065,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (args.workspace) opts.workspace = args.workspace;
 
           const raw = await client.readScreen(args.surface, opts);
-          const text =
-            typeof raw === "string"
-              ? raw
-              : ((raw as { content?: string }).content ?? "");
+          const text = typeof raw === "string" ? raw : (raw.text ?? "");
 
           const startMarker = `${args.tag}_START`;
           const endMarker = `${args.tag}_END`;

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for Phase 5 audit fixes:
+ * 1. CRITICAL: read_agent_output must use .text (not .content) from readScreen
+ * 2. HIGH: CmuxPersistentSocket reconnection with exponential backoff + jitter
+ * 3. MEDIUM: spawn_agent MCP schema exposes parent_agent_id and max_cost_per_agent
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as net from "node:net";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
+import { CmuxSocketError } from "../src/cmux-socket-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-audit-fixes-test");
+
+// ── 1. CRITICAL: read_agent_output uses .text ──────────────────────────
+
+describe("read_agent_output uses CmuxReadScreenResult.text", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("extracts delimited content from readScreen .text field", async () => {
+    const screenText =
+      "some preamble\nOUTPUT_START\nhello world\nOUTPUT_END\ntrailing";
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:1",
+        text: screenText,
+        lines: 5,
+        scrollback_used: true,
+      }),
+      // Stubs for other client methods used during server init
+      listSurfaces: vi.fn().mockResolvedValue([]),
+      send: vi.fn(),
+      sendKey: vi.fn(),
+      newSplit: vi.fn(),
+      renameTab: vi.fn(),
+      closeSurface: vi.fn(),
+      run: vi.fn(),
+    };
+
+    const mockExec: ExecFn = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      client: mockClient as any,
+      stateDir: TEST_DIR,
+    });
+    const tool = (server as any)._registeredTools["read_agent_output"];
+    expect(tool).toBeDefined();
+
+    const result = await tool.handler(
+      { surface: "surface:1", tag: "OUTPUT", lines: 200 },
+      {} as any,
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.found).toBe(true);
+    expect(parsed.content).toBe("hello world");
+  });
+
+  it("returns found:false when markers are absent", async () => {
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:1",
+        text: "no markers here",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      listSurfaces: vi.fn().mockResolvedValue([]),
+      send: vi.fn(),
+      sendKey: vi.fn(),
+      newSplit: vi.fn(),
+      renameTab: vi.fn(),
+      closeSurface: vi.fn(),
+      run: vi.fn(),
+    };
+
+    const mockExec: ExecFn = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      client: mockClient as any,
+      stateDir: TEST_DIR,
+    });
+    const tool = (server as any)._registeredTools["read_agent_output"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", tag: "OUTPUT", lines: 200 },
+      {} as any,
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.found).toBe(false);
+  });
+});
+
+// ── 2. HIGH: CmuxPersistentSocket exponential backoff + jitter ─────────
+
+describe("CmuxPersistentSocket exponential backoff with jitter", () => {
+  const MOCK_SOCKET_PATH = join(tmpdir(), "cmux-backoff-test.sock");
+  let mockServer: net.Server | null = null;
+
+  function startMockServer(): Promise<net.Server> {
+    return new Promise((resolve) => {
+      const srv = net.createServer((conn) => {
+        conn.on("data", (chunk) => {
+          const req = JSON.parse(chunk.toString().trim());
+          const resp = JSON.stringify({
+            id: req.id,
+            ok: true,
+            result: { pong: true },
+          });
+          conn.write(resp + "\n");
+        });
+      });
+      try {
+        require("node:fs").unlinkSync(MOCK_SOCKET_PATH);
+      } catch {}
+      srv.listen(MOCK_SOCKET_PATH, () => resolve(srv));
+    });
+  }
+
+  afterEach(() => {
+    if (mockServer) {
+      mockServer.close();
+      mockServer = null;
+    }
+    try {
+      require("node:fs").unlinkSync(MOCK_SOCKET_PATH);
+    } catch {}
+  });
+
+  it("exposes backoff configuration options", () => {
+    const socket = new CmuxPersistentSocket({
+      socketPath: MOCK_SOCKET_PATH,
+      backoff: {
+        baseMs: 100,
+        maxMs: 5000,
+        jitter: true,
+      },
+    });
+    // Should construct without error
+    expect(socket).toBeDefined();
+    socket.disconnect();
+  });
+
+  it("increases delay between reconnection attempts", () => {
+    const socket = new CmuxPersistentSocket({
+      socketPath: MOCK_SOCKET_PATH,
+      timeoutMs: 500,
+      backoff: {
+        baseMs: 50,
+        maxMs: 1000,
+        jitter: false, // disable jitter for deterministic test
+      },
+    });
+
+    expect(socket.currentBackoffMs()).toBe(0);
+
+    // First failure → baseMs * 2^0 = 50
+    socket.incrementBackoff();
+    const delay1 = socket.currentBackoffMs();
+    expect(delay1).toBe(50);
+
+    // Second failure → baseMs * 2^1 = 100
+    socket.incrementBackoff();
+    const delay2 = socket.currentBackoffMs();
+    expect(delay2).toBe(100);
+
+    // Third → 200
+    socket.incrementBackoff();
+    expect(socket.currentBackoffMs()).toBe(200);
+
+    socket.disconnect();
+  });
+
+  it("resets backoff after successful connection", async () => {
+    mockServer = await startMockServer();
+    const socket = new CmuxPersistentSocket({
+      socketPath: MOCK_SOCKET_PATH,
+      timeoutMs: 500,
+      backoff: {
+        baseMs: 50,
+        maxMs: 1000,
+        jitter: false,
+      },
+    });
+
+    // Simulate some failures
+    socket.incrementBackoff();
+    socket.incrementBackoff();
+    expect(socket.currentBackoffMs()).toBe(100);
+
+    // Successful connect should reset backoff
+    await socket.connect();
+    expect(socket.isConnected()).toBe(true);
+    expect(socket.currentBackoffMs()).toBe(0);
+
+    socket.disconnect();
+  });
+
+  it("caps backoff at maxMs", () => {
+    const socket = new CmuxPersistentSocket({
+      socketPath: MOCK_SOCKET_PATH,
+      backoff: {
+        baseMs: 100,
+        maxMs: 500,
+        jitter: false,
+      },
+    });
+
+    // Simulate many failures — backoff should never exceed maxMs
+    // (This tests the internal calculation, exposed via currentBackoffMs)
+    for (let i = 0; i < 20; i++) {
+      socket.incrementBackoff();
+    }
+    expect(socket.currentBackoffMs()).toBeLessThanOrEqual(500);
+
+    socket.disconnect();
+  });
+
+  it("applies jitter when enabled", () => {
+    const socket = new CmuxPersistentSocket({
+      socketPath: MOCK_SOCKET_PATH,
+      backoff: {
+        baseMs: 100,
+        maxMs: 5000,
+        jitter: true,
+      },
+    });
+
+    // With jitter, repeated calls should produce varying delays
+    const delays = new Set<number>();
+    for (let i = 0; i < 10; i++) {
+      socket.incrementBackoff();
+      delays.add(socket.currentBackoffMs());
+      socket.resetBackoff();
+      socket.incrementBackoff();
+    }
+    // With jitter there should be some variance (not all identical)
+    // At minimum it should not be exactly the same every time
+    expect(delays.size).toBeGreaterThan(1);
+
+    socket.disconnect();
+  });
+});
+
+// ── 3. MEDIUM: spawn_agent exposes parent_agent_id + max_cost_per_agent ─
+
+describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent", () => {
+  let mockExec: ExecFn;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("accepts parent_agent_id in spawn_agent", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+
+    // First spawn a parent
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parentResult = await spawn.handler(
+      { repo: "test", model: "sonnet", cli: "claude", prompt: "parent task" },
+      {} as any,
+    );
+    const parentId = JSON.parse(parentResult.content[0].text).agent_id;
+
+    // Spawn child with parent_agent_id
+    const childResult = await spawn.handler(
+      {
+        repo: "test",
+        model: "haiku",
+        cli: "claude",
+        prompt: "child task",
+        parent_agent_id: parentId,
+      },
+      {} as any,
+    );
+    const childParsed = JSON.parse(childResult.content[0].text);
+    expect(childParsed.ok).toBe(true);
+    expect(childParsed.agent_id).toBeDefined();
+  });
+
+  it("accepts max_cost_per_agent in spawn_agent", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "test",
+        model: "opus",
+        cli: "claude",
+        prompt: "expensive task",
+        max_cost_per_agent: 5.0,
+      },
+      {} as any,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("rejects invalid parent_agent_id", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "test",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "orphan",
+        parent_agent_id: "nonexistent-agent",
+      },
+      {} as any,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Summary
- **CRITICAL**: `read_agent_output` used `.content` instead of `.text` from `CmuxReadScreenResult`, causing delimiter extraction to silently return `found: false` even when markers were present — broke all orchestration output parsing.
- **HIGH**: `CmuxPersistentSocket` now implements exponential backoff with configurable jitter on reconnection, preventing thundering herd after cmux restart.
- **MEDIUM**: `spawn_agent` MCP schema now exposes `parent_agent_id` and `max_cost_per_agent`, closing the feature parity gap with the engine.

## Test plan
- [x] 10 new tests in `tests/audit-fixes.test.ts` (TDD: written before fixes)
- [x] Full suite: 288/288 passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `.text` bug in `read_agent_output`, add socket backoff, and extend `spawn_agent` schema
> - Fixes `read_agent_output` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/22/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to read from `.text` instead of `.content` when `readScreen` returns an object, preventing empty output.
> - Adds exponential backoff with optional jitter to `CmuxPersistentSocket` in [cmux-persistent-socket.ts](https://github.com/EtanHey/cmuxlayer/pull/22/files#diff-4241cd7c196a7c577e98f44bd5ac5ad678fbfa738d9a631f6422e7ff2135cd03); backoff resets on successful connection and accumulates across failed reconnect attempts.
> - Extends the `spawn_agent` tool schema with optional `parent_agent_id` and `max_cost_per_agent` fields, forwarding them to the engine.
> - Adds a Vitest suite in [audit-fixes.test.ts](https://github.com/EtanHey/cmuxlayer/pull/22/files#diff-604af3ca9408e075923fa584b707d50d12b66da76c118a9d3255990e63b8957b) covering all three fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ee2f2a4. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->