### PR TITLE
feat: formatted MCP output for all tool responses

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -21,7 +21,7 @@ function pad(text: string, width: number): string {
   return s.padEnd(width);
 }
 
-function padRight(text: string, width: number): string {
+function alignRight(text: string, width: number): string {
   const s = String(text ?? "");
   if (s.length >= width) return s.slice(0, width - 1) + "\u2026";
   return s.padStart(width);
@@ -30,7 +30,7 @@ function padRight(text: string, width: number): string {
 // Context bar: visual fill indicator
 function contextBar(pct: number | null): string {
   if (pct === null) return "   \u2500";
-  const filled = Math.round(pct / 10);
+  const filled = Math.max(0, Math.min(10, Math.round(pct / 10)));
   const bar = "\u2588".repeat(filled) + "\u2591".repeat(10 - filled);
   return `${bar} ${pct}%`;
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,208 @@
+/**
+ * Beautiful terminal output formatting for cmux MCP tool responses.
+ *
+ * Uses Unicode box-drawing characters for clean, professional display.
+ * No ANSI color codes (MCP tool output doesn't support them in Claude Code).
+ */
+
+import type { AgentRecord } from "./agent-types.js";
+import type { CmuxSurface, ParsedScreenResult } from "./types.js";
+
+function truncate(text: string, maxLen: number = 60): string {
+  if (!text) return "";
+  text = text.replace(/\n/g, " ").trim();
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + "\u2026";
+}
+
+function pad(text: string, width: number): string {
+  const s = String(text ?? "");
+  if (s.length >= width) return s.slice(0, width - 1) + "\u2026";
+  return s.padEnd(width);
+}
+
+function padRight(text: string, width: number): string {
+  const s = String(text ?? "");
+  if (s.length >= width) return s.slice(0, width - 1) + "\u2026";
+  return s.padStart(width);
+}
+
+// Context bar: visual fill indicator
+function contextBar(pct: number | null): string {
+  if (pct === null) return "   \u2500";
+  const filled = Math.round(pct / 10);
+  const bar = "\u2588".repeat(filled) + "\u2591".repeat(10 - filled);
+  return `${bar} ${pct}%`;
+}
+
+interface SurfaceEntry {
+  ref?: string;
+  title?: string;
+  type?: string;
+  workspace_ref?: string;
+  pane_ref?: string;
+  screen_preview?: string;
+}
+
+export function formatListSurfaces(
+  surfaces: SurfaceEntry[],
+  workspaces: Array<{ ref: string; title?: string }>,
+): string {
+  if (!surfaces || surfaces.length === 0) {
+    return "\u250c\u2500 cmux surfaces\n\u2502 No surfaces found.\n\u2514\u2500";
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `\u250c\u2500 cmux surfaces \u2500 ${surfaces.length} surface${surfaces.length !== 1 ? "s" : ""} in ${workspaces.length} workspace${workspaces.length !== 1 ? "s" : ""}`,
+  );
+  lines.push(
+    `\u2502 ${pad("Ref", 14)} ${pad("Type", 10)} ${pad("Title", 30)} ${pad("Workspace", 14)}`,
+  );
+  lines.push(
+    `\u251c${"─".repeat(14)}${"─".repeat(11)}${"─".repeat(31)}${"─".repeat(14)}`,
+  );
+
+  for (const s of surfaces) {
+    const ref = pad(s.ref ?? "", 14);
+    const type = pad(s.type ?? "terminal", 10);
+    const title = pad(truncate(s.title ?? "", 28), 30);
+    const ws = pad(s.workspace_ref ?? "", 14);
+    lines.push(`\u2502 ${ref} ${type} ${title} ${ws}`);
+    if (s.screen_preview) {
+      const previewLine = truncate(s.screen_preview, 60);
+      lines.push(`\u2502   \u2514 ${previewLine}`);
+    }
+  }
+
+  lines.push("\u2514\u2500");
+  return lines.join("\n");
+}
+
+export function formatReadScreen(
+  surfaceRef: string,
+  title: string | null,
+  content: string | null,
+  parsed: ParsedScreenResult,
+  scrollbackUsed: boolean,
+  lines: number,
+): string {
+  const result: string[] = [];
+
+  // Header with surface info
+  const titleStr = title ? ` "${truncate(title, 30)}"` : "";
+  result.push(`\u250c\u2500 ${surfaceRef}${titleStr}`);
+
+  // Parsed agent status line
+  const statusParts: string[] = [];
+  if (parsed.agent_type) statusParts.push(`agent: ${parsed.agent_type}`);
+  if (parsed.status) statusParts.push(`status: ${parsed.status}`);
+  if (parsed.model) statusParts.push(`model: ${truncate(parsed.model, 20)}`);
+  if (parsed.context_pct !== null)
+    statusParts.push(`ctx: ${contextBar(parsed.context_pct)}`);
+  else if (parsed.token_count !== null)
+    statusParts.push(`tokens: ${parsed.token_count.toLocaleString()}`);
+  if (parsed.cost !== null)
+    statusParts.push(`cost: $${parsed.cost.toFixed(2)}`);
+  if (parsed.done_signal) statusParts.push("DONE");
+
+  if (statusParts.length > 0) {
+    result.push(`\u2502 ${statusParts.join("  \u2502  ")}`);
+  }
+
+  if (parsed.errors && parsed.errors.length > 0) {
+    result.push(
+      `\u2502 errors: ${parsed.errors.map((e) => truncate(e, 40)).join(", ")}`,
+    );
+  }
+
+  if (parsed.response) {
+    result.push(`\u251c\u2500 Response`);
+    result.push(`\u2502 ${truncate(parsed.response, 70)}`);
+  }
+
+  // Content (if not parsed_only)
+  if (content) {
+    result.push(
+      `\u251c\u2500 Screen (${lines} line${lines !== 1 ? "s" : ""}${scrollbackUsed ? " + scrollback" : ""})`,
+    );
+    const contentLines = content.split("\n").slice(0, 25);
+    for (const line of contentLines) {
+      result.push(`\u2502 ${line}`);
+    }
+    if (content.split("\n").length > 25) {
+      result.push(`\u2502 ... (${content.split("\n").length - 25} more lines)`);
+    }
+  }
+
+  result.push("\u2514\u2500");
+  return result.join("\n");
+}
+
+export function formatListAgents(agents: AgentRecord[], count: number): string {
+  if (count === 0) {
+    return "\u250c\u2500 cmux agents\n\u2502 No agents running.\n\u2514\u2500";
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `\u250c\u2500 cmux agents \u2500 ${count} agent${count !== 1 ? "s" : ""}`,
+  );
+  lines.push(
+    `\u2502 ${pad("ID", 20)} ${pad("Repo", 16)} ${pad("State", 8)} ${pad("Model", 18)} ${pad("Surface", 12)}`,
+  );
+  lines.push(
+    `\u251c${"─".repeat(20)}${"─".repeat(17)}${"─".repeat(9)}${"─".repeat(19)}${"─".repeat(12)}`,
+  );
+
+  for (const a of agents) {
+    const id = pad(truncate(a.agent_id, 18), 20);
+    const repo = pad(truncate(a.repo, 14), 16);
+    const state = pad(a.state, 8);
+    const model = pad(truncate(a.model, 16), 18);
+    const surface = pad(a.surface_id, 12);
+    lines.push(`\u2502 ${id} ${repo} ${state} ${model} ${surface}`);
+    if (a.error) {
+      lines.push(`\u2502   err: ${truncate(a.error, 60)}`);
+    }
+  }
+
+  lines.push("\u2514\u2500");
+  return lines.join("\n");
+}
+
+export function formatAgentState(agent: AgentRecord): string {
+  const lines: string[] = [];
+  lines.push(`\u250c\u2500 Agent: ${agent.agent_id}`);
+  lines.push(
+    `\u2502 repo: ${agent.repo}  state: ${agent.state}  model: ${agent.model}`,
+  );
+  lines.push(`\u2502 surface: ${agent.surface_id}  cli: ${agent.cli}`);
+  if (agent.cli_session_id) {
+    lines.push(`\u2502 session: ${agent.cli_session_id}`);
+  }
+  if (agent.parent_agent_id) {
+    lines.push(`\u2502 parent: ${agent.parent_agent_id}`);
+  }
+  if (agent.error) {
+    lines.push(`\u2502 error: ${truncate(agent.error, 60)}`);
+  }
+  lines.push(
+    `\u2502 created: ${agent.created_at}  depth: ${agent.spawn_depth}`,
+  );
+  lines.push("\u2514\u2500");
+  return lines.join("\n");
+}
+
+export function formatOk(
+  action: string,
+  details: Record<string, unknown>,
+): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(details)) {
+    if (v !== undefined && v !== null && k !== "ok" && k !== "applied") {
+      parts.push(`${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`);
+    }
+  }
+  return `\u2714 ${action}${parts.length > 0 ? " \u2500 " + parts.join("  ") : ""}`;
+}

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -190,7 +190,12 @@ function parseTokenCount(text: string): number | null {
     return Number.parseInt(usageMatch[1].replaceAll(",", ""), 10);
   }
 
-  const tokensMatch = text.match(TOKENS_RE);
+  // AIDEV-NOTE: TOKENS_RE is a loose fallback ("N tokens") that can false-positive on prose.
+  // Restrict it to the last 5 non-empty lines of the screen buffer where footer/status lines live.
+  const lines = text.split("\n");
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  const tail = nonEmpty.slice(-5).join("\n");
+  const tokensMatch = tail.match(TOKENS_RE);
   if (tokensMatch) {
     return Number.parseInt(tokensMatch[1].replaceAll(",", ""), 10);
   }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -190,12 +190,7 @@ function parseTokenCount(text: string): number | null {
     return Number.parseInt(usageMatch[1].replaceAll(",", ""), 10);
   }
 
-  // AIDEV-NOTE: TOKENS_RE is a loose fallback ("N tokens") that can false-positive on prose.
-  // Restrict it to the last 5 non-empty lines of the screen buffer where footer/status lines live.
-  const lines = text.split("\n");
-  const nonEmpty = lines.filter((l) => l.trim() !== "");
-  const tail = nonEmpty.slice(-5).join("\n");
-  const tokensMatch = tail.match(TOKENS_RE);
+  const tokensMatch = text.match(TOKENS_RE);
   if (tokensMatch) {
     return Number.parseInt(tokensMatch[1].replaceAll(",", ""), 10);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,13 @@ import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { AgentEngine, type AgentLifecycleEvent } from "./agent-engine.js";
 import type { AgentRecord } from "./agent-types.js";
+import {
+  formatListSurfaces,
+  formatReadScreen,
+  formatListAgents,
+  formatAgentState,
+  formatOk,
+} from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
@@ -33,6 +40,18 @@ function ok(data: Record<string, unknown>): ToolReturn {
   const payload = { ok: true, ...data };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
+    structuredContent: payload,
+  };
+}
+
+/** ok() variant with formatted human-readable text content */
+function okFormatted(
+  formattedText: string,
+  data: Record<string, unknown>,
+): ToolReturn {
+  const payload = { ok: true, ...data };
+  return {
+    content: [{ type: "text", text: formattedText }],
     structuredContent: payload,
   };
 }
@@ -290,11 +309,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }),
           ),
         );
-        return ok({
+        const data = {
           workspaces: workspaces.workspaces,
           surfaces,
           workspace_ref: args.workspace,
-        });
+        };
+        const formatted = formatListSurfaces(
+          surfaces as Array<{
+            ref?: string;
+            title?: string;
+            type?: string;
+            workspace_ref?: string;
+            pane_ref?: string;
+            screen_preview?: string;
+          }>,
+          workspaces.workspaces as Array<{ ref: string; title?: string }>,
+        );
+        return okFormatted(formatted, data);
       } catch (e) {
         return err(e);
       }
@@ -342,7 +373,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
           result.title = args.title;
         }
-        return ok({ ...result });
+        const data = { ...result };
+        return okFormatted(
+          formatOk("new_split", {
+            surface: result.surface,
+            direction: args.direction,
+            type: args.type,
+            title: result.title,
+          }),
+          data,
+        );
       } catch (e) {
         return err(e);
       }
@@ -395,7 +435,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: args.workspace,
           });
         }
-        return ok({ surface: args.surface, applied: "send_input" });
+        const data = { surface: args.surface };
+        return okFormatted(formatOk("send_input", data), data);
       } catch (e) {
         return err(e);
       }
@@ -416,7 +457,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         await client.sendKey(args.surface, args.key, {
           workspace: args.workspace,
         });
-        return ok({ surface: args.surface, applied: "send_key" });
+        const data = { surface: args.surface, key: args.key };
+        return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
         return err(e);
       }
@@ -466,21 +508,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
 
         if (args.parsed_only) {
-          return ok({
+          const data = {
             surface: result.surface,
             title: surface?.title ?? null,
             parsed,
-          });
+          };
+          const formatted = formatReadScreen(
+            result.surface,
+            surface?.title ?? null,
+            null,
+            parsed,
+            false,
+            0,
+          );
+          return okFormatted(formatted, data);
         }
 
-        return ok({
+        const data = {
           surface: result.surface,
           title: surface?.title ?? null,
           lines: result.lines,
           content: result.text,
           scrollback_used: result.scrollback_used,
           parsed,
-        });
+        };
+        const formatted = formatReadScreen(
+          result.surface,
+          surface?.title ?? null,
+          result.text,
+          parsed,
+          result.scrollback_used,
+          result.lines,
+        );
+        return okFormatted(formatted, data);
       } catch (e) {
         return err(e);
       }
@@ -515,11 +575,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         await client.renameTab(args.surface, finalTitle, {
           workspace: args.workspace,
         });
-        return ok({
-          surface: args.surface,
-          title: finalTitle,
-          applied: "rename_tab",
-        });
+        const data = { surface: args.surface, title: finalTitle };
+        return okFormatted(formatOk("rename_tab", data), data);
       } catch (e) {
         return err(e);
       }
@@ -551,14 +608,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: args.workspace,
           surface: args.surface,
         });
-        return ok({
+        const data = {
           title: args.title ?? null,
           subtitle: args.subtitle ?? null,
           body: args.body ?? null,
           workspace: args.workspace ?? null,
           surface: args.surface ?? null,
-          applied: "notify",
-        });
+        };
+        return okFormatted(formatOk("notify", data), data);
       } catch (e) {
         return err(e);
       }
@@ -590,11 +647,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: args.workspace,
           surface: args.surface,
         });
-        return ok({
-          key: args.key,
-          value: args.value,
-          applied: "set_status",
-        });
+        const data = { key: args.key, value: args.value };
+        return okFormatted(formatOk("set_status", data), data);
       } catch (e) {
         return err(e);
       }
@@ -622,11 +676,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: args.workspace,
           surface: args.surface,
         });
-        return ok({
-          value: args.value,
-          label: args.label,
-          applied: "set_progress",
-        });
+        const data = { value: args.value, label: args.label };
+        return okFormatted(formatOk("set_progress", data), data);
       } catch (e) {
         return err(e);
       }
@@ -646,7 +697,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         await client.closeSurface(args.surface, {
           workspace: args.workspace,
         });
-        return ok({ surface: args.surface, applied: "close_surface" });
+        const data = { surface: args.surface };
+        return okFormatted(formatOk("close_surface", data), data);
       } catch (e) {
         return err(e);
       }
@@ -751,11 +803,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
         const result = await client.browser(browserArgs);
         // browser_surface actions map to cmux browser-surface subcommands
-        return ok({
-          action: args.action,
-          surface: args.surface,
-          result,
-        });
+        const data = { action: args.action, surface: args.surface, result };
+        return okFormatted(formatOk("browser_surface", data), data);
       } catch (e) {
         return err(e);
       }
@@ -859,7 +908,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             parent_agent_id: args.parent_agent_id,
             max_cost_per_agent: args.max_cost_per_agent,
           });
-          return ok({ ...result });
+          return okFormatted(
+            formatOk("spawn_agent", {
+              agent_id: result.agent_id,
+              repo: args.repo,
+              model: args.model,
+              surface: result.surface_id,
+            }),
+            { ...result },
+          );
         } catch (e) {
           return err(e);
         }
@@ -890,7 +947,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.target_state,
             args.timeout_ms,
           );
-          return ok({ ...result });
+          return okFormatted(
+            formatOk("wait_for", {
+              agent_id: args.agent_id,
+              state: result.state,
+            }),
+            { ...result },
+          );
         } catch (e) {
           return err(e);
         }
@@ -921,7 +984,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.target_state,
             args.timeout_ms,
           );
-          return ok({ results });
+          return okFormatted(
+            formatOk("wait_for_all", {
+              count: results.length,
+              target: args.target_state,
+            }),
+            { results },
+          );
         } catch (e) {
           return err(e);
         }
@@ -940,7 +1009,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const state = engine.getAgentState(args.agent_id);
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
-          return ok(state as unknown as Record<string, unknown>);
+          const formatted = formatAgentState(state);
+          return okFormatted(
+            formatted,
+            state as unknown as Record<string, unknown>,
+          );
         } catch (e) {
           return err(e);
         }
@@ -974,10 +1047,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             repo: args.repo,
             model: args.model,
           });
-          return ok({
+          const data = {
             agents: agents as unknown as Record<string, unknown>[],
             count: agents.length,
-          });
+          };
+          const formatted = formatListAgents(agents, agents.length);
+          return okFormatted(formatted, data);
         } catch (e) {
           return err(e);
         }
@@ -1000,11 +1075,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         try {
           await engine.stopAgent(args.agent_id, args.force);
           const state = engine.getAgentState(args.agent_id);
-          return ok({
+          const data = {
             agent_id: args.agent_id,
             state: state?.state ?? "done",
-            applied: "stop_agent",
-          });
+          };
+          return okFormatted(formatOk("stop_agent", data), data);
         } catch (e) {
           return err(e);
         }
@@ -1027,10 +1102,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           await engine.sendToAgent(args.agent_id, args.text, args.press_enter);
-          return ok({
-            agent_id: args.agent_id,
-            applied: "send_to_agent",
-          });
+          const data = { agent_id: args.agent_id };
+          return okFormatted(formatOk("send_to_agent", data), data);
         } catch (e) {
           return err(e);
         }
@@ -1183,50 +1256,44 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           switch (args.action) {
             case "send": {
               await engine.sendToAgent(args.agent, args.text!, true);
-              return ok({
-                agent_id: args.agent,
-                action: "send",
-                applied: true,
-              });
+              const d = { agent_id: args.agent, action: "send" };
+              return okFormatted(formatOk("interact:send", d), d);
             }
             case "interrupt": {
               await client.sendKey(agent.surface_id, "c-c", {});
-              return ok({
-                agent_id: args.agent,
-                action: "interrupt",
-                applied: true,
-              });
+              const d = { agent_id: args.agent, action: "interrupt" };
+              return okFormatted(formatOk("interact:interrupt", d), d);
             }
             case "model": {
               const modelCmd = `/model ${args.model}`;
               await engine.sendToAgent(args.agent, modelCmd, true);
-              return ok({
+              const d = {
                 agent_id: args.agent,
                 action: "model",
                 model: args.model,
-                applied: true,
-              });
+              };
+              return okFormatted(formatOk("interact:model", d), d);
             }
             case "resume": {
               const resumeCmd = args.session_id
                 ? `/resume ${args.session_id}`
                 : "/resume";
               await engine.sendToAgent(args.agent, resumeCmd, true);
-              return ok({
+              const d = {
                 agent_id: args.agent,
                 action: "resume",
                 session_id: args.session_id,
-                applied: true,
-              });
+              };
+              return okFormatted(formatOk("interact:resume", d), d);
             }
             case "skill": {
               await engine.sendToAgent(args.agent, args.command!, true);
-              return ok({
+              const d = {
                 agent_id: args.agent,
                 action: "skill",
                 command: args.command,
-                applied: true,
-              });
+              };
+              return okFormatted(formatOk("interact:skill", d), d);
             }
             case "usage": {
               // Read screen to extract usage info
@@ -1297,7 +1364,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           if (targetIds.length === 0) {
-            return ok({ killed: [], message: "No agents to kill" });
+            return okFormatted(
+              formatOk("kill", { message: "No agents to kill" }),
+              { killed: [] },
+            );
           }
 
           // Kill each agent, collecting results
@@ -1318,11 +1388,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
 
-          return ok({
+          const data = {
             killed,
             errors: errors.length > 0 ? errors : undefined,
             force: args.force,
-          });
+          };
+          return okFormatted(formatOk("kill", { count: killed.length }), data);
         } catch (e) {
           return err(e);
         }

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -66,7 +66,8 @@ describe("read_agent_output uses CmuxReadScreenResult.text", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.found).toBe(true);
     expect(parsed.content).toBe("hello world");
@@ -106,7 +107,8 @@ describe("read_agent_output uses CmuxReadScreenResult.text", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.found).toBe(false);
   });
@@ -299,7 +301,9 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
       { repo: "test", model: "sonnet", cli: "claude", prompt: "parent task" },
       {} as any,
     );
-    const parentId = JSON.parse(parentResult.content[0].text).agent_id;
+    const parentId = (
+      parentResult.structuredContent ?? JSON.parse(parentResult.content[0].text)
+    ).agent_id;
 
     // Spawn child with parent_agent_id
     const childResult = await spawn.handler(
@@ -312,7 +316,8 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
       },
       {} as any,
     );
-    const childParsed = JSON.parse(childResult.content[0].text);
+    const childParsed =
+      childResult.structuredContent ?? JSON.parse(childResult.content[0].text);
     expect(childParsed.ok).toBe(true);
     expect(childParsed.agent_id).toBeDefined();
   });
@@ -334,7 +339,8 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
       },
       {} as any,
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
   });
 
@@ -355,7 +361,8 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
       },
       {} as any,
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toMatch(/not found/i);
   });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -109,7 +109,8 @@ describe("agent lifecycle tool handlers", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toMatch(/^sonnet-brainlayer-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
@@ -135,7 +136,8 @@ describe("agent lifecycle tool handlers", () => {
     );
 
     const result = await list.handler({}, {} as any);
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.count).toBe(1);
     expect(parsed.agents[0].repo).toBe("brainlayer");
@@ -158,10 +160,13 @@ describe("agent lifecycle tool handlers", () => {
       },
       {} as any,
     );
-    const agentId = JSON.parse(spawnResult.content[0].text).agent_id;
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
 
     const result = await getState.handler({ agent_id: agentId }, {} as any);
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.cli).toBe("codex");
@@ -198,7 +203,9 @@ describe("agent lifecycle tool handlers", () => {
       },
       {} as any,
     );
-    const agentId = JSON.parse(spawnResult.content[0].text).agent_id;
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
 
     // Agent is in "booting" state — not interactive
     const result = await sendTo.handler(

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -330,7 +330,8 @@ describe("tool handler integration", () => {
       ]),
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.surfaces).toHaveLength(2);
     expect(parsed.surfaces[0]).toMatchObject({
       ref: "surface:1",
@@ -413,7 +414,8 @@ describe("tool handler integration", () => {
     );
 
     expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.surfaces[0].screen_preview_error).toMatch(
       /surface unavailable/,
     );
@@ -446,7 +448,8 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["read-screen"]),
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.content).toContain("hello");
     expect(parsed.parsed).toMatchObject({
       agent_type: "claude",
@@ -534,7 +537,8 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.title).toBe("orchestratorClaude");
     expect(parsed.parsed).toMatchObject({
       agent_type: "claude",
@@ -600,7 +604,8 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.title).toBe("orchestratorClaude");
     expect(parsed.parsed).toMatchObject({
       agent_type: "claude",
@@ -670,7 +675,8 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.title).toBe("qwanClaude (main)");
     expect(parsed.parsed).toMatchObject({
       agent_type: "claude",
@@ -701,7 +707,8 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["send"]),
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
   });
 
@@ -753,7 +760,8 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["new-split", "right"]),
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.surface).toBe("surface:2");
   });
 
@@ -806,7 +814,8 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["set-status", "task", "building"]),
     );
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
   });
 
@@ -932,10 +941,10 @@ describe("tool handler integration", () => {
       "surface:1",
     ]);
 
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed).toMatchObject({
       ok: true,
-      applied: "notify",
       title: null,
       subtitle: "Build",
       body: "Finished successfully",
@@ -1058,7 +1067,8 @@ describe("tool handler integration", () => {
       "surface:9",
       "url",
     ]);
-    const parsed = JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.result).toEqual({ url: "https://example.com" });
   });

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -25,7 +25,7 @@ function callTool(server: any, name: string, args: Record<string, unknown>) {
 }
 
 function parseResult(result: any): any {
-  return JSON.parse(result.content[0].text);
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
 describe("V2 tool registration", () => {


### PR DESCRIPTION
## Summary
- Convert all remaining `ok()` JSON responses to `okFormatted(formatOk(...))` for clean one-liner confirmations
- Add `format.ts` module with box-drawing formatters for surfaces, agents, screen reads, and generic actions
- 20 tools now return human-readable formatted output instead of raw JSON
- Usage/mcp data returns kept as `ok()` since they carry raw screen content

## What it looks like
```
✔ send_input ─ surface: surface:42
✔ spawn_agent ─ agent_id: claude-brainlayer-abc  repo: brainlayer  model: opus  surface: surface:78
✔ kill ─ count: 3

┌─ cmux agents ─ 2 agents
│ ID                   Repo             State    Model              Surface
├─────────────────────────────────────────────────────────────────────────────
│ claude-bl-abc        brainlayer       working  opus               surface:42
│ gemini-vl-def        voicelayer       idle     gemini-2.5-pro     surface:43
└─
```

## Test plan
- [x] 288 tests pass (0 failures)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Updated test assertions for new structured output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add formatted MCP tool responses with both human-readable text and structured content
> - Adds a new [format.ts](https://github.com/EtanHey/cmuxlayer/pull/23/files#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36b) module with Unicode box-drawn table renderers for surfaces, agents, screen reads, and a generic success line formatter.
> - Introduces `okFormatted()` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/23/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to return both a human-readable `content` field and a machine-readable `structuredContent` payload simultaneously.
> - Updates all tool handlers to use `okFormatted()` instead of plain `ok()`, so MCP clients see formatted text while programmatic callers use `structuredContent`.
> - Removes the `applied` key from structured payloads across most handlers.
> - Tests updated to read from `structuredContent` first, falling back to parsing `content[0].text` for compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1745669.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->