### PR TITLE
fix: fall back to CLI for new_split and close_surface

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -58,11 +58,14 @@ export async function createCmuxClient(
 
   const socketAvailable = await probeSocket(socketPath, opts?.timeoutMs);
 
+  const cliFallback = new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+
   if (socketAvailable) {
     const client = new CmuxSocketClient({
       socketPath,
       timeoutMs: opts?.timeoutMs,
       password: opts?.password,
+      cliFallback,
     });
     // Verify socket actually works (catches auth failures)
     try {
@@ -74,5 +77,5 @@ export async function createCmuxClient(
     }
   }
 
-  return new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  return cliFallback;
 }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -18,6 +18,7 @@ import type {
   CmuxReadScreenResult,
   CmuxStatusEntry,
 } from "./types.js";
+import type { CmuxClient } from "./cmux-client.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
 
@@ -36,6 +37,8 @@ export interface CmuxSocketClientOptions {
   timeoutMs?: number;
   /** Password for socket access mode "password" */
   password?: string;
+  /** CLI client fallback for V2 methods not supported by the daemon */
+  cliFallback?: CmuxClient;
 }
 
 // ── Socket-level errors ────────────────────────────────────────────────
@@ -71,12 +74,14 @@ export class CmuxSocketClient {
   private socketPath: string;
   private timeoutMs: number;
   private password?: string;
+  private cliFallback?: CmuxClient;
 
   constructor(opts?: CmuxSocketClientOptions) {
     this.socketPath =
       opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
     this.password = opts?.password;
+    this.cliFallback = opts?.cliFallback;
   }
 
   // ── Low-level: send a V2 request, get a V2 response ────────────────
@@ -347,11 +352,18 @@ export class CmuxSocketClient {
       if (opts.workspace) params.workspace_id = opts.workspace;
       if (opts.url) params.url = opts.url;
 
-      const result = await this.call<Record<string, unknown>>(
-        "pane.create",
-        params,
-      );
-      return this.mapSplitResult(result, "browser");
+      try {
+        const result = await this.call<Record<string, unknown>>(
+          "pane.create",
+          params,
+        );
+        return this.mapSplitResult(result, "browser");
+      } catch (e) {
+        if (this.isMethodNotFound(e) && this.cliFallback) {
+          return this.cliFallback.newSplit(direction, opts);
+        }
+        throw e;
+      }
     }
 
     if (opts?.url) {
@@ -363,11 +375,18 @@ export class CmuxSocketClient {
     if (opts?.surface) params.surface_id = opts.surface;
     if (opts?.pane) params.pane_id = opts.pane;
 
-    const result = await this.call<Record<string, unknown>>(
-      "pane.split",
-      params,
-    );
-    return this.mapSplitResult(result, "terminal");
+    try {
+      const result = await this.call<Record<string, unknown>>(
+        "pane.split",
+        params,
+      );
+      return this.mapSplitResult(result, "terminal");
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallback.newSplit(direction, opts);
+      }
+      throw e;
+    }
   }
 
   async send(
@@ -546,7 +565,14 @@ export class CmuxSocketClient {
       surface_id: surface,
       workspace_id: workspace,
     };
-    await this.call("surface.close", params);
+    try {
+      await this.call("surface.close", params);
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallback.closeSurface(surface, opts);
+      }
+      throw e;
+    }
   }
 
   async listStatus(opts?: { workspace?: string }): Promise<CmuxStatusEntry[]> {
@@ -677,6 +703,10 @@ export class CmuxSocketClient {
   }
 
   // ── Helpers ────────────────────────────────────────────────────────
+
+  private isMethodNotFound(e: unknown): boolean {
+    return e instanceof CmuxSocketError && e.code === "method_not_found";
+  }
 
   private mapSplitResult(
     parsed: Record<string, unknown>,

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import * as net from "node:net";
 import * as fs from "node:fs";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
+import { CmuxClient } from "../src/cmux-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
 
 // ── Mock V2 Socket Server ──────────────────────────────────────────────
@@ -355,6 +356,118 @@ describe("CmuxSocketClient", () => {
     expect(lastV1Command).toBe(
       `set_status agent active --tab=${MOCK_WORKSPACE_ID}`,
     );
+  });
+});
+
+describe("CmuxSocketClient V2→CLI fallback", () => {
+  let cliCalls: { method: string; args: unknown[] }[];
+
+  function createMockCli(): CmuxClient {
+    cliCalls = [];
+    return {
+      newSplit: async (direction: string, opts?: unknown) => {
+        cliCalls.push({ method: "newSplit", args: [direction, opts] });
+        return {
+          workspace: "workspace:1",
+          surface: "surface:cli",
+          pane: "pane:cli",
+          title: "",
+          type: "terminal" as const,
+        };
+      },
+      closeSurface: async (surface: string, opts?: unknown) => {
+        cliCalls.push({ method: "closeSurface", args: [surface, opts] });
+      },
+    } as unknown as CmuxClient;
+  }
+
+  it("newSplit falls back to CLI when pane.split returns method_not_found", async () => {
+    const saved = MOCK_RESPONSES["pane.split"];
+    delete MOCK_RESPONSES["pane.split"];
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: createMockCli(),
+      });
+      const result = await client.newSplit("right", {
+        workspace: "workspace:1",
+      });
+      expect(cliCalls).toHaveLength(1);
+      expect(cliCalls[0].method).toBe("newSplit");
+      expect(result.surface).toBe("surface:cli");
+    } finally {
+      MOCK_RESPONSES["pane.split"] = saved;
+    }
+  });
+
+  it("newSplit browser falls back to CLI when pane.create returns method_not_found", async () => {
+    // pane.create is already NOT in MOCK_RESPONSES
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+    const result = await client.newSplit("right", {
+      workspace: "workspace:1",
+      type: "browser",
+      url: "https://example.com",
+    });
+    expect(cliCalls).toHaveLength(1);
+    expect(cliCalls[0].method).toBe("newSplit");
+    expect(cliCalls[0].args[1]).toMatchObject({ type: "browser" });
+  });
+
+  it("closeSurface falls back to CLI when surface.close returns method_not_found", async () => {
+    const saved = MOCK_RESPONSES["surface.close"];
+    delete MOCK_RESPONSES["surface.close"];
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: createMockCli(),
+      });
+      await client.closeSurface("surface:1", { workspace: "workspace:1" });
+      expect(cliCalls).toHaveLength(1);
+      expect(cliCalls[0].method).toBe("closeSurface");
+      expect(cliCalls[0].args[0]).toBe("surface:1");
+    } finally {
+      MOCK_RESPONSES["surface.close"] = saved;
+    }
+  });
+
+  it("newSplit throws when no CLI fallback and method_not_found", async () => {
+    const saved = MOCK_RESPONSES["pane.split"];
+    delete MOCK_RESPONSES["pane.split"];
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+      await expect(
+        client.newSplit("right", { workspace: "workspace:1" }),
+      ).rejects.toThrow("method_not_found");
+    } finally {
+      MOCK_RESPONSES["pane.split"] = saved;
+    }
+  });
+
+  it("closeSurface throws when no CLI fallback and method_not_found", async () => {
+    const saved = MOCK_RESPONSES["surface.close"];
+    delete MOCK_RESPONSES["surface.close"];
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+      await expect(
+        client.closeSurface("surface:1", { workspace: "workspace:1" }),
+      ).rejects.toThrow("method_not_found");
+    } finally {
+      MOCK_RESPONSES["surface.close"] = saved;
+    }
+  });
+
+  it("uses V2 when method is available (no fallback triggered)", async () => {
+    // pane.split IS in MOCK_RESPONSES — V2 should work directly
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+    const result = await client.newSplit("right", { workspace: "workspace:1" });
+    expect(cliCalls).toHaveLength(0);
+    expect(result.surface).toBe("surface:2"); // from MOCK_RESPONSES
   });
 });
 


### PR DESCRIPTION
## Summary
- `new_split` and `close_surface` MCP tools returned `method_not_found` because the cmux daemon's V2 socket protocol doesn't support `pane.create`, `pane.split`, or `surface.close` methods
- Added CLI fallback: when V2 methods fail with `method_not_found`, the socket client delegates to the CLI client (`cmux new-split`, `cmux close-surface`) which work correctly
- Factory auto-wires the CLI fallback when creating socket clients — transparent to all MCP handlers

## Test plan
- [x] 6 new tests covering: terminal split fallback, browser split fallback, close_surface fallback, throws-without-fallback (×2), V2-preferred-when-available
- [x] All 290 tests pass (6 pre-existing failures in unrelated Claude channels tests)
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to CLI for `newSplit` and `closeSurface` when socket daemon lacks V2 methods
> - `CmuxSocketClient` now accepts an optional `cliFallback` in its constructor options, stored as a private field.
> - `newSplit` and `closeSurface` catch `CmuxSocketError` with code `method_not_found` and delegate to the CLI fallback if one is provided; otherwise they rethrow.
> - `createCmuxClient` in [cmux-client-factory.ts](https://github.com/EtanHey/cmuxlayer/pull/26/files#diff-37e2c062823d882ca9c154692047152501d1bd813787b69cf13d4a1dbbcd1342) creates a single `CmuxClient` up front and passes it as `cliFallback` when constructing `CmuxSocketClient`, reusing it as the direct return value if the socket is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc82944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->