### PR TITLE
feat: cmuxLayer landing page

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,1127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cmuxLayer — Terminal MCP for AI Agents</title>
+  <meta name="description" content="MCP server that gives AI agents programmatic control over terminal panes. 21 tools. Split, read, send, automate. One Unix socket.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;0,6..72,700;1,6..72,400;1,6..72,700&family=Outfit:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #09090b;
+      --bg-elevated: #111114;
+      --bg-card: #151519;
+      --border: #222228;
+      --border-hover: #38383f;
+      --text: #fafaf9;
+      --text-secondary: #a8a29e;
+      --text-dim: #6b6660;
+      --accent: #22d3ee;
+      --accent-bright: #67e8f9;
+      --accent-subtle: rgba(34, 211, 238, 0.08);
+      --accent-glow: rgba(34, 211, 238, 0.12);
+      --teal: #5eead4;
+      --red: #cf6060;
+      --green: #4ade80;
+      --display: 'Newsreader', Georgia, serif;
+      --sans: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      --mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--sans);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      overflow-x: hidden;
+    }
+
+    /* Grain */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");
+      pointer-events: none;
+      z-index: 9999;
+    }
+
+    .wrap {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    .wrap-wide {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    /* ─── Nav ─── */
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      padding: 16px 0;
+      background: rgba(9, 9, 11, 0.8);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.3s;
+    }
+
+    nav.scrolled { border-bottom-color: var(--border); }
+
+    nav .wrap {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: var(--text);
+      font-family: var(--mono);
+      font-weight: 500;
+      font-size: 15px;
+      letter-spacing: -0.02em;
+      opacity: 0.9;
+      transition: opacity 0.2s;
+    }
+
+    .logo:hover { opacity: 1; }
+
+    .logo .accent { color: var(--accent); }
+
+    .logo-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      background: var(--accent-subtle);
+      border: 1px solid rgba(34, 211, 238, 0.15);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+    }
+
+    .nav-right {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .nav-right a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 400;
+      transition: color 0.2s;
+    }
+
+    .nav-right a:hover { color: var(--text); }
+
+    .nav-gh {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .nav-gh .arrow {
+      display: inline-block;
+      transition: transform 0.2s;
+    }
+
+    .nav-gh:hover .arrow { transform: translateX(2px); }
+
+    /* ─── Hero ─── */
+    .hero {
+      padding: 180px 0 80px;
+      text-align: center;
+    }
+
+    h1 {
+      font-family: var(--display);
+      font-size: clamp(40px, 6vw, 68px);
+      font-weight: 700;
+      letter-spacing: -0.035em;
+      line-height: 1.08;
+      margin-bottom: 24px;
+      max-width: 700px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    h1 em {
+      font-style: italic;
+      color: var(--accent);
+    }
+
+    .hero-sub {
+      font-size: 17px;
+      color: var(--text-secondary);
+      max-width: 500px;
+      margin: 0 auto 40px;
+      line-height: 1.65;
+      font-weight: 300;
+    }
+
+    .hero-actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin-bottom: 48px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      text-decoration: none;
+      cursor: pointer;
+      border: none;
+      font-family: var(--sans);
+      transition: transform 0.15s, box-shadow 0.2s, background 0.2s;
+    }
+
+    .btn:hover { transform: scale(1.03); }
+    .btn:active { transform: scale(0.98); }
+
+    .btn-primary {
+      background: var(--text);
+      color: var(--bg);
+    }
+
+    .btn-primary:hover {
+      box-shadow: 0 0 24px rgba(250, 250, 249, 0.15);
+    }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+    }
+
+    .btn-ghost:hover {
+      color: var(--text);
+      border-color: var(--border-hover);
+    }
+
+    /* Install */
+    .install-block {
+      max-width: 420px;
+      margin: 0 auto;
+    }
+
+    .install-cmd {
+      display: flex;
+      align-items: center;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 12px 18px;
+      font-family: var(--mono);
+      font-size: 14px;
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: border-color 0.25s;
+      position: relative;
+    }
+
+    .install-cmd:hover {
+      border-color: var(--accent);
+    }
+
+    .install-cmd code { color: var(--text); flex: 1; }
+    .install-cmd .dim { color: var(--text-dim); }
+
+    .copy-btn {
+      background: none;
+      border: none;
+      color: var(--text-dim);
+      cursor: pointer;
+      padding: 4px;
+      transition: color 0.2s;
+    }
+
+    .copy-btn:hover { color: var(--accent); }
+
+    /* ─── Terminal ─── */
+    .terminal-section {
+      padding: 0 0 100px;
+    }
+
+    .terminal {
+      background: #0c0c0e;
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 16px;
+      overflow: hidden;
+      max-width: 820px;
+      margin: 0 auto;
+      position: relative;
+    }
+
+    .terminal::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 60px;
+      background: linear-gradient(transparent, var(--bg));
+      pointer-events: none;
+    }
+
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 14px 18px;
+      background: rgba(255,255,255,0.03);
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+    }
+
+    .dot { width: 11px; height: 11px; border-radius: 50%; }
+    .dot-r { background: #ff5f57; }
+    .dot-y { background: #febc2e; }
+    .dot-g { background: #28c840; }
+
+    .terminal-title {
+      font-size: 12px;
+      color: var(--text-dim);
+      margin-left: 10px;
+      font-family: var(--mono);
+    }
+
+    .terminal-body {
+      padding: 20px 22px 48px;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.85;
+    }
+
+    .t { display: block; }
+    .t-gap { margin-top: 12px; }
+
+    .t-prompt { color: #6ec1e4; }
+    .t-user { color: var(--text); }
+    .t-dim { color: #4a4a52; }
+    .t-sys { color: #78787f; font-style: italic; }
+    .t-tool { color: var(--accent); font-weight: 500; }
+    .t-arg { color: #a8d8a8; }
+    .t-str { color: var(--accent-bright); }
+    .t-num { color: var(--teal); }
+    .t-border { color: #333338; }
+    .t-body { color: var(--text-secondary); }
+
+    /* ─── Sections ─── */
+    .section {
+      padding: 100px 0;
+    }
+
+    .section-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--accent);
+      margin-bottom: 12px;
+      text-align: center;
+      font-weight: 500;
+    }
+
+    .section-heading {
+      font-family: var(--display);
+      font-size: clamp(26px, 3.5vw, 36px);
+      font-weight: 600;
+      letter-spacing: -0.025em;
+      text-align: center;
+      margin-bottom: 56px;
+      line-height: 1.15;
+    }
+
+    .divider {
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--border), transparent);
+    }
+
+    /* ─── Problem / Solution ─── */
+    .ps-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+
+    .ps-card {
+      padding: 32px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      display: flex;
+      flex-direction: column;
+      transition: border-color 0.3s;
+    }
+
+    .ps-card:hover {
+      border-color: var(--border-hover);
+    }
+
+    .ps-card.problem { border-top: 2px solid var(--red); }
+    .ps-card.solution { border-top: 2px solid var(--teal); }
+
+    .ps-tag {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 14px;
+      font-weight: 500;
+    }
+
+    .problem .ps-tag { color: var(--red); }
+    .solution .ps-tag { color: var(--teal); }
+
+    .ps-title {
+      font-family: var(--sans);
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin-bottom: 14px;
+    }
+
+    .ps-body {
+      color: var(--text-secondary);
+      font-size: 15px;
+      line-height: 1.7;
+      font-weight: 300;
+      flex: 1;
+    }
+
+    .ps-body strong { color: var(--text); font-weight: 500; }
+
+    /* ─── Tools ─── */
+    .tools-section {
+      padding: 100px 0;
+    }
+
+    .tools-group {
+      max-width: 640px;
+      margin: 0 auto 48px;
+    }
+
+    .tools-group:last-child { margin-bottom: 0; }
+
+    .tools-group-label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      margin-bottom: 16px;
+      padding-left: 2px;
+      font-weight: 500;
+    }
+
+    .tool-item {
+      display: flex;
+      align-items: baseline;
+      gap: 20px;
+      padding: 12px 16px;
+      border-radius: 8px;
+      transition: background 0.2s;
+    }
+
+    .tool-item:hover {
+      background: var(--bg-elevated);
+    }
+
+    .tool-item .name {
+      font-family: var(--mono);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--accent);
+      min-width: 160px;
+      flex-shrink: 0;
+    }
+
+    .tool-item .desc {
+      font-size: 14px;
+      color: var(--text-secondary);
+      font-weight: 300;
+    }
+
+    .tool-divider {
+      height: 1px;
+      background: var(--border);
+      margin: 8px 0;
+      max-width: 640px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    /* ─── Integrations ─── */
+    .integrations-section {
+      padding: 80px 0 100px;
+      text-align: center;
+    }
+
+    .logo-row {
+      display: flex;
+      justify-content: center;
+      gap: 40px;
+      flex-wrap: wrap;
+      margin-bottom: 64px;
+    }
+
+    .logo-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      transition: transform 0.2s;
+    }
+
+    .logo-item:hover { transform: translateY(-3px); }
+
+    .logo-box {
+      width: 52px;
+      height: 52px;
+      border-radius: 12px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 11px;
+      transition: border-color 0.25s;
+    }
+
+    .logo-box svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    .logo-item:hover .logo-box {
+      border-color: var(--border-hover);
+    }
+
+    .logo-name {
+      font-size: 12px;
+      color: var(--text-dim);
+      transition: color 0.2s;
+    }
+
+    .logo-item:hover .logo-name { color: var(--text-secondary); }
+
+    /* ─── Setup ─── */
+    .setup-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+      max-width: 780px;
+      margin: 0 auto;
+    }
+
+    .setup-card {
+      text-align: left;
+    }
+
+    .setup-num {
+      font-family: var(--mono);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--accent);
+      margin-bottom: 10px;
+    }
+
+    .setup-text {
+      font-size: 14px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      font-weight: 300;
+      margin-bottom: 10px;
+    }
+
+    .setup-code {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 8px 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text);
+      cursor: pointer;
+      transition: border-color 0.2s;
+    }
+
+    .setup-code:hover { border-color: var(--accent); }
+
+    .setup-code span { flex: 1; }
+
+    .setup-code .copy-icon {
+      color: var(--text-dim);
+      transition: color 0.2s;
+      flex-shrink: 0;
+    }
+
+    .setup-code:hover .copy-icon { color: var(--accent); }
+
+    /* ─── Speed ─── */
+    .speed-section {
+      padding: 80px 0;
+    }
+
+    .speed-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    .speed-card {
+      padding: 28px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      text-align: center;
+      transition: border-color 0.3s;
+    }
+
+    .speed-card:hover { border-color: var(--border-hover); }
+
+    .speed-val {
+      font-family: var(--mono);
+      font-size: 36px;
+      font-weight: 500;
+      color: var(--accent);
+      letter-spacing: -0.03em;
+      margin-bottom: 4px;
+    }
+
+    .speed-label {
+      font-size: 13px;
+      color: var(--text-dim);
+      font-weight: 300;
+    }
+
+    .speed-note {
+      font-size: 13px;
+      color: var(--text-dim);
+      text-align: center;
+      margin-top: 16px;
+      font-weight: 300;
+    }
+
+    /* ─── CTA ─── */
+    .cta-section {
+      padding: 100px 0 80px;
+      text-align: center;
+    }
+
+    .cta-heading {
+      font-family: var(--display);
+      font-size: clamp(26px, 4vw, 42px);
+      font-weight: 600;
+      letter-spacing: -0.03em;
+      margin-bottom: 12px;
+    }
+
+    .cta-sub {
+      color: var(--text-secondary);
+      font-size: 15px;
+      margin-bottom: 36px;
+      font-weight: 300;
+    }
+
+    /* ─── Footer ─── */
+    footer {
+      padding: 32px 0;
+      border-top: 1px solid var(--border);
+    }
+
+    footer .wrap {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .footer-left {
+      font-size: 13px;
+      color: var(--text-dim);
+      font-weight: 300;
+    }
+
+    .footer-left a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .footer-left a:hover { color: var(--accent); }
+
+    .footer-right {
+      display: flex;
+      gap: 20px;
+    }
+
+    .footer-right a {
+      font-size: 13px;
+      color: var(--text-dim);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .footer-right a:hover { color: var(--text-secondary); }
+
+    /* ─── Responsive ─── */
+    @media (max-width: 768px) {
+      .nav-right a:not(.nav-gh) { display: none; }
+      .hero { padding: 140px 0 60px; }
+      .ps-grid { grid-template-columns: 1fr; }
+      .setup-grid { grid-template-columns: 1fr; }
+      .speed-grid { grid-template-columns: 1fr; }
+      .logo-row { gap: 24px; }
+      footer .wrap { flex-direction: column; gap: 12px; }
+    }
+
+    @media (max-width: 480px) {
+      .hero-actions { flex-direction: column; }
+      .btn { width: 100%; justify-content: center; }
+    }
+
+    /* ─── Animations ─── */
+    .reveal {
+      opacity: 0;
+      transform: translateY(16px);
+      transition: opacity 0.8s ease, transform 0.8s ease;
+    }
+
+    .reveal.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .reveal-d1 { transition-delay: 0.1s; }
+    .reveal-d2 { transition-delay: 0.2s; }
+    .reveal-d3 { transition-delay: 0.3s; }
+  </style>
+</head>
+<body>
+
+  <nav id="nav">
+    <div class="wrap">
+      <a href="#" class="logo">
+        <div class="logo-icon">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <rect x="1" y="1" width="5" height="12" rx="1" stroke="#22d3ee" stroke-width="1.5" fill="none"/>
+            <rect x="8" y="1" width="5" height="5" rx="1" stroke="#22d3ee" stroke-width="1.5" fill="none"/>
+            <rect x="8" y="8" width="5" height="5" rx="1" stroke="#22d3ee" stroke-width="1.5" fill="none"/>
+          </svg>
+        </div>
+        <span class="accent">cmux</span>Layer
+      </a>
+      <div class="nav-right">
+        <a href="#tools">Tools</a>
+        <a href="#setup">Setup</a>
+        <a href="https://github.com/EtanHey/cmuxlayer" class="nav-gh">GitHub <span class="arrow">&nearr;</span></a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="wrap">
+      <h1 class="reveal">Your agents can't touch the terminal. <em>Fix that.</em></h1>
+      <p class="hero-sub reveal reveal-d1">
+        MCP server that gives AI agents programmatic control over terminal panes.
+        Split, read, send, automate &mdash; through one Unix socket.
+      </p>
+      <div class="hero-actions reveal reveal-d2">
+        <a href="#setup" class="btn btn-primary">Get started</a>
+        <a href="https://github.com/EtanHey/cmuxlayer" class="btn btn-ghost">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          View source
+        </a>
+      </div>
+      <div class="install-block reveal reveal-d3">
+        <div class="install-cmd" onclick="copyText(this, 'npm install cmuxlayer')">
+          <code><span class="dim">$</span> npm install cmuxlayer</code>
+          <button class="copy-btn" aria-label="Copy">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M5 11H3.5A1.5 1.5 0 012 9.5v-6A1.5 1.5 0 013.5 2h6A1.5 1.5 0 0111 3.5V5"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Terminal -->
+  <section class="terminal-section">
+    <div class="wrap-wide">
+      <div class="terminal reveal">
+        <div class="terminal-bar">
+          <div class="dot dot-r"></div>
+          <div class="dot dot-y"></div>
+          <div class="dot dot-g"></div>
+          <span class="terminal-title">claude ~ my-project</span>
+        </div>
+        <div class="terminal-body">
+          <span class="t"><span class="t-prompt">&#10095;</span> <span class="t-user">Split a new pane and run tests there</span></span>
+          <span class="t t-gap"><span class="t-body">I'll create a split and start the test runner.</span></span>
+          <span class="t t-gap"><span class="t-border">&#9484;&#9472;</span> <span class="t-tool">new_split</span>(<span class="t-arg">direction</span>=<span class="t-str">"right"</span>)</span>
+          <span class="t"><span class="t-border">&#9474;</span></span>
+          <span class="t"><span class="t-border">&#9474;</span>  <span class="t-dim">workspace:</span> <span class="t-str">"workspace:1"</span>  <span class="t-dim">surface:</span> <span class="t-str">"surface:2"</span></span>
+          <span class="t"><span class="t-border">&#9474;</span></span>
+          <span class="t"><span class="t-border">&#9492;&#9472;</span> <span class="t-dim">type: terminal</span></span>
+          <span class="t t-gap"><span class="t-border">&#9484;&#9472;</span> <span class="t-tool">send_input</span>(<span class="t-arg">surface</span>=<span class="t-str">"surface:2"</span>, <span class="t-arg">text</span>=<span class="t-str">"bun test\n"</span>)</span>
+          <span class="t"><span class="t-border">&#9492;&#9472;</span> <span class="t-dim">ok</span></span>
+          <span class="t t-gap"><span class="t-border">&#9484;&#9472;</span> <span class="t-tool">read_screen</span>(<span class="t-arg">surface</span>=<span class="t-str">"surface:2"</span>, <span class="t-arg">lines</span>=<span class="t-num">5</span>)</span>
+          <span class="t"><span class="t-border">&#9474;</span></span>
+          <span class="t"><span class="t-border">&#9474;</span>  <span class="t-num">290</span> <span class="t-dim">pass</span>  <span class="t-num">0</span> <span class="t-dim">fail</span>  <span class="t-dim">Ran</span> <span class="t-num">296</span> <span class="t-dim">tests</span> <span class="t-dim">[2.37s]</span></span>
+          <span class="t"><span class="t-border">&#9474;</span></span>
+          <span class="t"><span class="t-border">&#9492;&#9472;</span> <span class="t-dim">lines: 5 &middot; scrollback: false</span></span>
+          <span class="t t-gap"><span class="t-body">All 296 tests pass. The test runner is in the right split.</span></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap"><div class="divider"></div></div>
+
+  <!-- Problem / Solution -->
+  <section class="section">
+    <div class="wrap">
+      <div class="ps-grid">
+        <div class="ps-card problem reveal">
+          <div class="ps-tag">The problem</div>
+          <h2 class="ps-title">Agents are blind</h2>
+          <p class="ps-body">
+            AI agents can write code but can't see the terminal they run in.
+            They can't split panes, read output from other processes, or
+            orchestrate parallel work.<br><br>
+            You end up being the <strong>human clipboard</strong> &mdash;
+            copying test output, switching tabs, relaying errors.
+          </p>
+        </div>
+        <div class="ps-card solution reveal reveal-d1">
+          <div class="ps-tag">The fix</div>
+          <h2 class="ps-title">21 tools. One socket.</h2>
+          <p class="ps-body">
+            cmuxLayer connects to cmux via a <strong>persistent Unix socket</strong> and
+            exposes every terminal operation as an MCP tool. Split panes, read screens,
+            send keystrokes, open browsers, spawn agents.<br><br>
+            Socket-first architecture: <strong>0.2ms per operation</strong>.
+            CLI fallback when the socket isn't available.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap"><div class="divider"></div></div>
+
+  <!-- Speed -->
+  <section class="speed-section">
+    <div class="wrap">
+      <div class="section-label reveal">Performance</div>
+      <h2 class="section-heading reveal">Socket, not subprocess</h2>
+      <div class="speed-grid">
+        <div class="speed-card reveal">
+          <div class="speed-val">0.2ms</div>
+          <div class="speed-label">Unix socket (default)</div>
+        </div>
+        <div class="speed-card reveal reveal-d1">
+          <div class="speed-val">287ms</div>
+          <div class="speed-label">CLI subprocess (fallback)</div>
+        </div>
+      </div>
+      <p class="speed-note reveal reveal-d2">1,423x faster. Auto-reconnects. Falls back gracefully.</p>
+    </div>
+  </section>
+
+  <div class="wrap"><div class="divider"></div></div>
+
+  <!-- Tools -->
+  <section class="tools-section" id="tools">
+    <div class="wrap">
+      <div class="section-label">MCP tools</div>
+      <h2 class="section-heading">21 tools. Two groups.</h2>
+
+      <div class="tools-group">
+        <div class="tools-group-label">Core &mdash; terminal operations</div>
+        <div class="tool-item reveal">
+          <span class="name">list_surfaces</span>
+          <span class="desc">Enumerate all surfaces across workspaces</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">new_split</span>
+          <span class="desc">Create terminal or browser splits in any direction</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">send_input</span>
+          <span class="desc">Type text into a surface as if from the keyboard</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">send_key</span>
+          <span class="desc">Send key combos &mdash; Enter, Ctrl-C, Escape, arrows</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">read_screen</span>
+          <span class="desc">Capture visible terminal output with optional scrollback</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">rename_tab</span>
+          <span class="desc">Set the workspace tab title</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">notify</span>
+          <span class="desc">Push macOS notifications from any surface</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">set_status</span>
+          <span class="desc">Update sidebar status entries with icons and colors</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">set_progress</span>
+          <span class="desc">Show a progress bar with label in the sidebar</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">close_surface</span>
+          <span class="desc">Close a terminal or browser surface</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">browser_surface</span>
+          <span class="desc">Open a scriptable browser alongside terminal panes</span>
+        </div>
+      </div>
+
+      <div class="tool-divider"></div>
+
+      <div class="tools-group">
+        <div class="tools-group-label">Agent lifecycle &mdash; spawn and monitor</div>
+        <div class="tool-item reveal">
+          <span class="name">spawn_agent</span>
+          <span class="desc">Launch a Claude, Codex, Gemini, or Cursor agent in a new pane</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">send_to_agent</span>
+          <span class="desc">Deliver a message to a running agent</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">read_agent_output</span>
+          <span class="desc">Capture an agent's latest terminal output</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">get_agent_state</span>
+          <span class="desc">Check agent status: running, idle, waiting, done, error</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">list_agents</span>
+          <span class="desc">Enumerate all active agents across workspaces</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">wait_for</span>
+          <span class="desc">Block until an agent reaches a target state</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">wait_for_all</span>
+          <span class="desc">Block until multiple agents finish in parallel</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">stop_agent</span>
+          <span class="desc">Gracefully stop a running agent</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">kill</span>
+          <span class="desc">Force-kill an unresponsive agent process</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">interact</span>
+          <span class="desc">Send interactive input to an agent waiting for a response</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap"><div class="divider"></div></div>
+
+  <!-- Integrations + Setup -->
+  <section class="integrations-section" id="setup">
+    <div class="wrap">
+      <div class="section-label">Works with</div>
+      <h2 class="section-heading">Any MCP client. Any agent.</h2>
+
+      <div class="logo-row reveal">
+        <!-- Claude -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M16.604 2.985c-.48-.227-1.043-.01-1.27.474L9.263 16.16c-.226.483-.01 1.056.47 1.283.48.228 1.044.01 1.27-.474l6.07-12.7c.228-.484.012-1.057-.469-1.284zM7.652 7.335c-.386-.35-.98-.32-1.327.067L2.103 12.36a.976.976 0 000 1.28l4.222 4.957c.347.387.94.418 1.327.067a.967.967 0 00.066-1.34L3.95 13l3.768-4.325a.967.967 0 00-.066-1.34zM16.348 7.335c.386-.35.98-.32 1.327.067l4.222 4.958a.976.976 0 010 1.28l-4.222 4.957a.942.942 0 01-1.327.067.967.967 0 01-.066-1.34L20.05 13l-3.768-4.325a.967.967 0 01.066-1.34z" fill="#D97757"/>
+            </svg>
+          </div>
+          <span class="logo-name">Claude Code</span>
+        </div>
+        <!-- Cursor -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="#fafaf9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+          <span class="logo-name">Cursor</span>
+        </div>
+        <!-- VS Code -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M16.5 1.5l-9 8.5L3 6.5l-1.5 1 5 4.5-5 4.5 1.5 1 4.5-3.5 9 8.5 4-2V3.5l-4-2zm0 4v13l-6.5-6.5 6.5-6.5z" fill="#007ACC"/>
+            </svg>
+          </div>
+          <span class="logo-name">VS Code</span>
+        </div>
+        <!-- Zed -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 5h16L4 19h16" stroke="#fafaf9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+          <span class="logo-name">Zed</span>
+        </div>
+        <!-- Codex -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="12" cy="12" r="9" stroke="#10a37f" stroke-width="1.5"/>
+              <path d="M12 7v10M7 12h10" stroke="#10a37f" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <span class="logo-name">Codex</span>
+        </div>
+        <!-- Gemini -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10c1.85 0 3.58-.51 5.06-1.39C14.24 19.14 12 16.32 12 13c0-3.32 2.24-6.14 5.06-7.61A9.93 9.93 0 0012 2z" fill="#4285f4"/>
+              <path d="M22 12c0 5.52-4.48 10-10 10-1.85 0-3.58-.51-5.06-1.39C9.76 19.14 12 16.32 12 13c0-3.32-2.24-6.14-5.06-7.61A9.93 9.93 0 0112 2c5.52 0 10 4.48 10 10z" fill="#34a853"/>
+            </svg>
+          </div>
+          <span class="logo-name">Gemini</span>
+        </div>
+        <!-- Kiro -->
+        <div class="logo-item">
+          <div class="logo-box">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 3l9 5v8l-9 5-9-5V8l9-5z" stroke="#ff9900" stroke-width="1.5" stroke-linejoin="round"/>
+              <path d="M12 8v8" stroke="#ff9900" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <span class="logo-name">Kiro</span>
+        </div>
+      </div>
+
+      <div class="section-label">Get started</div>
+      <h2 class="section-heading">Three steps. Under a minute.</h2>
+
+      <div class="setup-grid">
+        <div class="setup-card reveal">
+          <div class="setup-num">01</div>
+          <div class="setup-text">Install cmuxLayer from npm</div>
+          <div class="setup-code" onclick="copyText(this, 'npm install -g cmuxlayer')">
+            <span>npm install -g cmuxlayer</span>
+            <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M5 11H3.5A1.5 1.5 0 012 9.5v-6A1.5 1.5 0 013.5 2h6A1.5 1.5 0 0111 3.5V5"/></svg>
+          </div>
+        </div>
+        <div class="setup-card reveal reveal-d1">
+          <div class="setup-num">02</div>
+          <div class="setup-text">Add to your MCP config</div>
+          <div class="setup-code" onclick="copyText(this, '&quot;cmuxlayer&quot;: { &quot;command&quot;: &quot;cmuxlayer&quot; }')">
+            <span>"cmuxlayer": { "command": "cmuxlayer" }</span>
+            <svg class="copy-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M5 11H3.5A1.5 1.5 0 012 9.5v-6A1.5 1.5 0 013.5 2h6A1.5 1.5 0 0111 3.5V5"/></svg>
+          </div>
+        </div>
+        <div class="setup-card reveal reveal-d2">
+          <div class="setup-num">03</div>
+          <div class="setup-text">Ask your agent to split a pane</div>
+          <div class="setup-code" style="cursor: default; border-color: var(--border);">
+            <span style="color: var(--accent);">It just works.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap"><div class="divider"></div></div>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <div class="wrap">
+      <h2 class="cta-heading reveal">Give your agents<br>hands in the terminal.</h2>
+      <p class="cta-sub reveal reveal-d1">Open source. TypeScript. 296 tests. Built for cmux.</p>
+      <div class="hero-actions reveal reveal-d2">
+        <a href="#setup" class="btn btn-primary">Get started</a>
+        <a href="https://github.com/EtanHey/cmuxlayer" class="btn btn-ghost">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          Star on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer>
+    <div class="wrap">
+      <div class="footer-left">cmuxLayer &mdash; by <a href="https://etanheyman.com">Etan Heyman</a></div>
+      <div class="footer-right">
+        <a href="https://github.com/EtanHey/cmuxlayer">GitHub</a>
+        <a href="https://github.com/manaflow-ai/cmux">cmux</a>
+        <a href="https://github.com/EtanHey/brainlayer">BrainLayer</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Nav scroll
+    const nav = document.getElementById('nav');
+    window.addEventListener('scroll', () => {
+      nav.classList.toggle('scrolled', window.scrollY > 20);
+    });
+
+    // Reveal observer
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('visible');
+      });
+    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+    document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+    // Copy helper
+    function copyText(el, text) {
+      navigator.clipboard.writeText(text).then(() => {
+        el.style.borderColor = 'var(--green)';
+        setTimeout(() => { el.style.borderColor = ''; }, 1500);
+      });
+    }
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Static HTML landing page for cmuxLayer following the BrainLayer design system
- Newsreader + Outfit + JetBrains Mono typography, electric cyan accent on dark
- SVG grain overlay, gradient dividers, staggered reveal animations
- Terminal demo showing real MCP tool calls (`new_split`, `send_input`, `read_screen`)
- All 21 MCP tools listed in grouped layout (Core + Agent Lifecycle)
- Integration logos, 3-step setup with click-to-copy, performance stats
- Responsive with hover states on all interactive elements

## Test plan
- [ ] Open `landing/index.html` in browser — verify layout, animations, typography
- [ ] Test click-to-copy on install commands
- [ ] Test mobile responsive breakpoints (768px, 480px)
- [ ] Verify hover states on all buttons, tools, logos, code blocks
- [ ] Check scroll-triggered reveal animations fire correctly
- [ ] Validate nav blur + border on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cmuxLayer marketing landing page with animated reveals and copy-to-clipboard
> - Adds [landing/index.html](https://github.com/EtanHey/cmuxlayer/pull/27/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3), a static marketing page with sections for hero, terminal demo, problem/solution, performance, tools, integrations, setup steps, and a call-to-action footer.
> - Includes inlined CSS for layout, theming, and responsive design, plus SVG icons.
> - Scroll listener toggles a border style on the navbar after 20px of scroll; an `IntersectionObserver` triggers CSS reveal animations on `.reveal` elements as they enter the viewport.
> - `copyText` helper writes install/config commands to the clipboard and briefly changes the clicked element's border to green as visual confirmation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ab9fb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->