### PR TITLE
fix: simplify spawn_agent launch and fix rename_tab persistence

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -126,11 +126,7 @@ function buildLaunchCommand(cli: CliType, repo: string): string {
   const cdCmd = `cd ~/Gits/${safeRepo}`;
   switch (cli) {
     case "claude":
-      return [
-        "source ~/.zshrc >/dev/null 2>&1 || true",
-        "unset ANTHROPIC_API_KEY",
-        `if command -v ${safeRepo}Claude >/dev/null 2>&1; then ${cdCmd} && ${safeRepo}Claude -s; else ${cdCmd} && claude --dangerously-skip-permissions; fi`,
-      ].join("; ");
+      return `${cdCmd} && ${safeRepo}Claude -s`;
     case "codex":
       return `${cdCmd} && codex`;
     case "gemini":

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -455,7 +455,7 @@ export class CmuxSocketClient {
     if (opts?.workspace) {
       args.push(this.rawV1Arg("--workspace"), opts.workspace);
     }
-    args.push(title);
+    args.push(this.rawV1Arg("--title"), title);
     await this.sendV1Args("rename_tab", args);
   }
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -120,7 +120,7 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).toHaveBeenCalled();
     });
 
-    it("launches Claude with repo setup and API-key auth disabled", async () => {
+    it("launches Claude via repoGolem launcher", async () => {
       await engine.spawnAgent({
         repo: "brainlayer",
         model: "sonnet",
@@ -133,11 +133,7 @@ describe("AgentEngine", () => {
       ).mock.calls[0];
       expect(surface).toBe("surface:new");
       expect(opts).toEqual({ workspace: "ws:1" });
-      expect(launchCmd).toContain("unset ANTHROPIC_API_KEY");
-      expect(launchCmd).toContain(
-        "if command -v brainlayerClaude >/dev/null 2>&1; then cd ~/Gits/brainlayer && brainlayerClaude -s; else cd ~/Gits/brainlayer && claude --dangerously-skip-permissions; fi",
-      );
-      expect(launchCmd).toContain("claude --dangerously-skip-permissions");
+      expect(launchCmd).toBe("cd ~/Gits/brainlayer && brainlayerClaude -s");
     });
 
     it("writes initial state file", async () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -357,6 +357,28 @@ describe("CmuxSocketClient", () => {
       `set_status agent active --tab=${MOCK_WORKSPACE_ID}`,
     );
   });
+
+  it("sends --title flag for renameTab V1 command", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.renameTab("surface:1", "build logs", {
+      workspace: "workspace:1",
+    });
+
+    expect(lastV1Command).toBe(
+      `rename_tab --surface surface:1 --workspace workspace:1 --title "build logs"`,
+    );
+  });
+
+  it("sends --title flag for renameTab without workspace", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.renameTab("surface:1", "agent run");
+
+    expect(lastV1Command).toBe(
+      `rename_tab --surface surface:1 --title "agent run"`,
+    );
+  });
 });
 
 describe("CmuxSocketClient V2→CLI fallback", () => {


### PR DESCRIPTION
## Summary
- **spawn_agent**: Removed the long shell chain (`source zshrc`, `unset ANTHROPIC_API_KEY`, `command -v` check, `--dangerously-skip-permissions` fallback). The repoGolem launcher (e.g. `brainlayerClaude -s`) handles all setup internally — just call it directly.
- **rename_tab**: Socket V1 protocol was passing the title as a trailing positional arg. cmux's V1 parser didn't apply it (returned OK but title didn't persist). Fixed by using explicit `--title` flag, matching how the CLI `cmux rename-tab --title` works.

## Test plan
- [x] All 298 tests pass
- [x] TypeScript typecheck clean
- [x] Added 2 new socket client tests verifying `--title` flag in V1 command (with and without workspace)
- [x] Updated agent engine test to verify simplified launch command
- [ ] Manual: spawn an agent and verify it boots via repoGolem launcher
- [ ] Manual: call `rename_tab` MCP tool and verify title persists in cmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `rename_tab` persistence and simplify `buildLaunchCommand` for claude CLI
> - `buildLaunchCommand` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/31/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now always runs `cd ~/Gits/<repo> && <repo>Claude -s`, dropping the shell rc sourcing, `ANTHROPIC_API_KEY` unset, and `claude --dangerously-skip-permissions` fallback.
> - `CmuxSocketClient.renameTab` in [cmux-socket-client.ts](https://github.com/EtanHey/cmuxlayer/pull/31/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) now passes the tab title as a `--title <title>` flag instead of a positional argument, fixing persistence of the rename.
> - Behavioral Change: the claude launch command no longer falls back to `claude --dangerously-skip-permissions` when no repo-specific launcher is found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1c508c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->