### PR TITLE
feat: animated terminal demo — looping orchestration movie

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -711,192 +711,123 @@
       font-weight: 300;
     }
 
-    /* ─── Interactive Pane Demo ─── */
-    .demo-section {
-      padding: 100px 0;
-    }
+    /* ─── Animated Terminal Demo ─── */
+    .demo-section { padding: 100px 0; }
 
     .demo-frame {
-      max-width: 900px;
+      max-width: 920px;
       margin: 0 auto;
       border-radius: 12px;
-      border: 1px solid rgba(34, 197, 94, 0.15);
+      border: 1px solid rgba(34,197,94,0.15);
       background: #0a0a0c;
       overflow: hidden;
-      box-shadow:
-        0 0 60px rgba(34, 197, 94, 0.04),
-        0 20px 60px rgba(0, 0, 0, 0.4);
+      box-shadow: 0 0 80px rgba(34,197,94,0.05), 0 24px 64px rgba(0,0,0,0.5);
     }
 
+    /* Title bar */
     .demo-titlebar {
-      display: flex;
-      align-items: center;
-      gap: 7px;
+      display: flex; align-items: center; gap: 7px;
       padding: 10px 14px;
       background: rgba(255,255,255,0.025);
       border-bottom: 1px solid rgba(255,255,255,0.05);
     }
-
     .demo-titlebar .dot { width: 10px; height: 10px; }
+    .demo-titlebar-text { font-family: var(--mono); font-size: 11px; color: var(--text-dim); margin-left: 8px; }
 
-    .demo-titlebar-text {
-      font-family: var(--mono);
-      font-size: 11px;
-      color: var(--text-dim);
-      margin-left: 8px;
-    }
-
-    .demo-layout {
-      display: flex;
-      min-height: 360px;
-    }
-
-    /* Left pane — orchestrator */
-    .demo-left {
-      flex: 0 0 45%;
-      border-right: 2px solid rgba(34, 197, 94, 0.12);
-      display: flex;
-      flex-direction: column;
-    }
-
-    .demo-pane-bar {
-      display: flex;
-      align-items: center;
-      padding: 6px 12px;
-      background: rgba(255,255,255,0.02);
+    /* Workspace tabs */
+    .demo-ws-tabs {
+      display: flex; gap: 0;
+      background: rgba(255,255,255,0.015);
       border-bottom: 1px solid rgba(255,255,255,0.04);
-      font-family: var(--mono);
-      font-size: 11px;
     }
-
-    .demo-pane-title {
-      color: var(--accent);
-      font-weight: 500;
-    }
-
-    .demo-pane-meta {
+    .demo-ws-tab {
+      padding: 5px 14px;
+      font-family: var(--mono); font-size: 10px;
       color: var(--text-dim);
-      margin-left: auto;
+      border-bottom: 2px solid transparent;
+      transition: all 0.2s;
     }
+    .demo-ws-tab.active { color: var(--accent); border-bottom-color: var(--accent); background: rgba(34,197,94,0.03); }
 
-    .demo-pane-content {
-      flex: 1;
-      padding: 12px 14px;
-      font-family: var(--mono);
-      font-size: 12px;
-      line-height: 1.75;
-      overflow: hidden;
+    /* Split layout */
+    .demo-layout { display: flex; min-height: 380px; }
+
+    .demo-left {
+      flex: 0 0 44%;
+      border-right: 2px solid rgba(34,197,94,0.12);
+      display: flex; flex-direction: column;
     }
-
-    .demo-line { display: block; }
-    .demo-line-gap { margin-top: 8px; }
-    .d-green { color: var(--accent); }
-    .d-bright { color: var(--accent-bright); }
-    .d-amber { color: var(--amber); }
-    .d-cyan { color: var(--cyan); }
-    .d-dim { color: #3a3a40; }
-    .d-body { color: var(--text-secondary); }
-    .d-teal { color: var(--teal); }
-    .d-white { color: var(--text); }
-
-    /* Right pane — tabbed agents */
     .demo-right {
       flex: 1;
-      display: flex;
-      flex-direction: column;
+      display: flex; flex-direction: column;
+      position: relative;
     }
 
+    /* Pane bar */
+    .demo-pane-bar {
+      display: flex; align-items: center;
+      padding: 5px 12px;
+      background: rgba(255,255,255,0.02);
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      font-family: var(--mono); font-size: 10px;
+    }
+    .demo-pane-title { color: var(--accent); font-weight: 500; }
+    .demo-pane-meta { color: var(--text-dim); margin-left: auto; font-size: 10px; }
+
+    /* Agent tabs */
     .demo-tabs {
       display: flex;
       background: rgba(255,255,255,0.02);
       border-bottom: 1px solid rgba(255,255,255,0.04);
     }
-
     .demo-tab {
-      padding: 6px 16px;
-      font-family: var(--mono);
-      font-size: 11px;
+      padding: 5px 14px;
+      font-family: var(--mono); font-size: 10px;
       color: var(--text-dim);
-      cursor: pointer;
       border-bottom: 2px solid transparent;
-      transition: color 0.2s, border-color 0.2s, background 0.2s;
-      user-select: none;
+      transition: all 0.2s;
     }
+    .demo-tab.active { color: var(--accent); border-bottom-color: var(--accent); background: rgba(34,197,94,0.04); }
 
-    .demo-tab:hover {
-      color: var(--text-secondary);
-      background: rgba(255,255,255,0.02);
+    /* Pane content */
+    .demo-pane-body {
+      flex: 1; padding: 10px 12px;
+      font-family: var(--mono); font-size: 11.5px; line-height: 1.7;
+      overflow: hidden; white-space: pre-wrap; color: var(--text-secondary);
     }
-
-    .demo-tab.active {
-      color: var(--accent);
-      border-bottom-color: var(--accent);
-      background: rgba(34, 197, 94, 0.04);
-    }
-
-    .demo-tab-panel {
-      display: none;
-      flex: 1;
-      padding: 12px 14px;
-      font-family: var(--mono);
-      font-size: 12px;
-      line-height: 1.75;
-      overflow: hidden;
-    }
-
-    .demo-tab-panel.active { display: block; }
 
     /* Status bar */
     .demo-statusbar {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 5px 14px;
-      background: rgba(34, 197, 94, 0.04);
-      border-top: 1px solid rgba(34, 197, 94, 0.1);
-      font-family: var(--mono);
-      font-size: 10px;
-      color: var(--text-dim);
+      display: flex; align-items: center; gap: 14px;
+      padding: 4px 12px;
+      background: rgba(34,197,94,0.04);
+      border-top: 1px solid rgba(34,197,94,0.1);
+      font-family: var(--mono); font-size: 10px; color: var(--text-dim);
     }
-
-    .demo-status-dot {
-      display: inline-block;
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      margin-right: 4px;
-    }
-
-    .demo-status-dot.green { background: var(--accent); }
-    .demo-status-dot.amber { background: var(--amber); }
+    .s-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-right: 4px; }
+    .s-green { background: var(--accent); }
 
     /* Typing cursor */
-    .typing-cursor {
-      display: inline-block;
-      width: 7px;
-      height: 14px;
-      background: var(--accent);
-      vertical-align: text-bottom;
+    .demo-cursor {
+      display: inline-block; width: 7px; height: 13px;
+      background: var(--accent); vertical-align: text-bottom;
       animation: blink 1s step-end infinite;
     }
 
-    /* Context bar in demo */
-    .ctx-filled {
-      color: var(--accent);
-      letter-spacing: -2px;
-      font-size: 11px;
-    }
-
-    .ctx-empty {
-      color: #1e1e22;
-      letter-spacing: -2px;
-      font-size: 11px;
-    }
+    /* Color helpers */
+    .c-g { color: var(--accent); }
+    .c-gb { color: var(--accent-bright); }
+    .c-a { color: var(--amber); }
+    .c-c { color: var(--cyan); }
+    .c-t { color: var(--teal); }
+    .c-d { color: #3a3a40; }
+    .c-w { color: var(--text); }
+    .c-s { color: var(--text-secondary); }
 
     @media (max-width: 768px) {
       .demo-layout { flex-direction: column; min-height: auto; }
-      .demo-left { flex: none; border-right: none; border-bottom: 2px solid rgba(34, 197, 94, 0.12); }
-      .demo-pane-content, .demo-tab-panel { font-size: 11px; }
+      .demo-left { flex: none; border-right: none; border-bottom: 2px solid rgba(34,197,94,0.12); min-height: 200px; }
+      .demo-pane-body { font-size: 10px; }
     }
 
     /* ─── Footer ─── */
@@ -1284,101 +1215,41 @@
 
   <div class="wrap"><div class="divider"></div></div>
 
-  <!-- Interactive Demo -->
+  <!-- Animated Terminal Demo -->
   <section class="demo-section">
     <div class="wrap-wide">
-      <div class="section-label reveal">Live preview</div>
+      <div class="section-label reveal">See it work</div>
       <h2 class="section-heading reveal">Two agents. One orchestrator. Zero tab-switching.</h2>
 
-      <div class="demo-frame reveal">
+      <div class="demo-frame reveal" id="demo">
         <div class="demo-titlebar">
-          <div class="dot dot-r"></div>
-          <div class="dot dot-y"></div>
-          <div class="dot dot-g"></div>
-          <span class="demo-titlebar-text">cmux &mdash; workspace:1 &mdash; 4 surfaces</span>
+          <div class="dot dot-r"></div><div class="dot dot-y"></div><div class="dot dot-g"></div>
+          <span class="demo-titlebar-text">cmux &mdash; workspace:1</span>
         </div>
-
+        <div class="demo-ws-tabs">
+          <div class="demo-ws-tab active">orcClaude</div>
+          <div class="demo-ws-tab">coachClaude</div>
+          <div class="demo-ws-tab">shellClaude</div>
+        </div>
         <div class="demo-layout">
-          <!-- Left: Orchestrator pane -->
           <div class="demo-left">
             <div class="demo-pane-bar">
               <span class="demo-pane-title">orchestrator</span>
-              <span class="demo-pane-meta">surface:1</span>
+              <span class="demo-pane-meta" id="d-orc-meta">surface:1</span>
             </div>
-            <div class="demo-pane-content">
-              <span class="demo-line"><span class="d-green">&#10095;</span> <span class="d-white">Run the full deploy pipeline</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-body" id="demo-typing"></span><span class="typing-cursor" id="demo-cursor"></span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">&#9484;&#9472;</span> <span class="d-bright">spawn_agent</span>(<span class="d-cyan">repo</span>=<span class="d-amber">"api"</span>)</span>
-              <span class="demo-line"><span class="d-dim">&#9492;&#9472;</span> <span class="d-green">&#10003;</span> <span class="d-dim">agent:</span> <span class="d-amber">sonnet-api-a3f7</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">&#9484;&#9472;</span> <span class="d-bright">spawn_agent</span>(<span class="d-cyan">repo</span>=<span class="d-amber">"web"</span>)</span>
-              <span class="demo-line"><span class="d-dim">&#9492;&#9472;</span> <span class="d-green">&#10003;</span> <span class="d-dim">agent:</span> <span class="d-amber">opus-web-c1d4</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">&#9484;&#9472;</span> <span class="d-bright">wait_for_all</span>(<span class="d-cyan">agents</span>=<span class="d-amber">["sonnet-api-a3f7", "opus-web-c1d4"]</span>)</span>
-              <span class="demo-line"><span class="d-dim">&#9474;</span>  <span class="d-body">waiting for 2 agents...</span></span>
-              <span class="demo-line"><span class="d-dim">&#9474;</span>  <span class="d-green">&#10003;</span> <span class="d-dim">sonnet-api-a3f7:</span> <span class="d-green">done</span> <span class="d-dim">(47s)</span></span>
-              <span class="demo-line"><span class="d-dim">&#9474;</span>  <span class="d-green">&#10003;</span> <span class="d-dim">opus-web-c1d4:</span>  <span class="d-green">done</span> <span class="d-dim">(1m12s)</span></span>
-              <span class="demo-line"><span class="d-dim">&#9492;&#9472;</span> <span class="d-green">all done</span></span>
-            </div>
+            <div class="demo-pane-body" id="d-orc"></div>
           </div>
-
-          <!-- Right: Tabbed agent views -->
           <div class="demo-right">
-            <div class="demo-tabs">
-              <div class="demo-tab active" data-tab="api">api-agent</div>
-              <div class="demo-tab" data-tab="web">web-agent</div>
-              <div class="demo-tab" data-tab="tests">test-runner</div>
-            </div>
-
-            <!-- Tab: API agent -->
-            <div class="demo-tab-panel active" data-panel="api">
-              <span class="demo-line"><span class="d-dim">agent:</span> <span class="d-amber">sonnet-api-a3f7</span>  <span class="d-dim">cli:</span> <span class="d-body">claude</span></span>
-              <span class="demo-line"><span class="d-dim">model:</span> <span class="d-body">claude-sonnet-4-6</span>  <span class="d-dim">state:</span> <span class="d-green">done</span></span>
-              <span class="demo-line"><span class="d-dim">ctx:</span> <span class="ctx-filled">&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;</span><span class="ctx-empty">&#9608;&#9608;&#9608;&#9608;&#9608;</span> <span class="d-teal">72%</span>  <span class="d-dim">cost:</span> <span class="d-teal">$0.84</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">&#9472;&#9472;&#9472; output &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span></span>
-              <span class="demo-line"><span class="d-body">Fixed rate limiter: sliding window now resets</span></span>
-              <span class="demo-line"><span class="d-body">per-user instead of globally. Added 3 tests.</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">files:</span> <span class="d-body">src/middleware/rate-limit.ts (+47 -12)</span></span>
-              <span class="demo-line"><span class="d-dim">       </span> <span class="d-body">tests/rate-limit.test.ts (+89)</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-green">&#10003;</span> <span class="d-body">Committed:</span> <span class="d-amber">fix: per-user sliding window rate limiter</span></span>
-            </div>
-
-            <!-- Tab: Web agent -->
-            <div class="demo-tab-panel" data-panel="web">
-              <span class="demo-line"><span class="d-dim">agent:</span> <span class="d-amber">opus-web-c1d4</span>  <span class="d-dim">cli:</span> <span class="d-body">claude</span></span>
-              <span class="demo-line"><span class="d-dim">model:</span> <span class="d-body">claude-opus-4-6</span>  <span class="d-dim">state:</span> <span class="d-green">done</span></span>
-              <span class="demo-line"><span class="d-dim">ctx:</span> <span class="ctx-filled">&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;</span><span class="ctx-empty">&#9608;&#9608;</span> <span class="d-teal">89%</span>  <span class="d-dim">cost:</span> <span class="d-teal">$2.31</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">&#9472;&#9472;&#9472; output &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span></span>
-              <span class="demo-line"><span class="d-body">Added metrics dashboard page with charts for</span></span>
-              <span class="demo-line"><span class="d-body">request latency, error rate, and throughput.</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-dim">files:</span> <span class="d-body">src/pages/metrics.tsx (+234)</span></span>
-              <span class="demo-line"><span class="d-dim">       </span> <span class="d-body">src/components/Chart.tsx (+87)</span></span>
-              <span class="demo-line"><span class="d-dim">       </span> <span class="d-body">src/api/metrics.ts (+41)</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-green">&#10003;</span> <span class="d-body">Committed:</span> <span class="d-amber">feat: add metrics dashboard with latency charts</span></span>
-            </div>
-
-            <!-- Tab: Test runner -->
-            <div class="demo-tab-panel" data-panel="tests">
-              <span class="demo-line"><span class="d-dim">surface:4</span>  <span class="d-dim">type:</span> <span class="d-body">terminal</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-green">$</span> <span class="d-white">bun test</span></span>
-              <span class="demo-line demo-line-gap"><span class="d-body">bun test v1.2.4</span></span>
-              <span class="demo-line"><span class="d-body">src/middleware/rate-limit.test.ts:</span></span>
-              <span class="demo-line">  <span class="d-green">&#10003;</span> <span class="d-body">resets per user, not global</span></span>
-              <span class="demo-line">  <span class="d-green">&#10003;</span> <span class="d-body">allows burst then throttles</span></span>
-              <span class="demo-line">  <span class="d-green">&#10003;</span> <span class="d-body">sliding window expires correctly</span></span>
-              <span class="demo-line"><span class="d-body">src/pages/metrics.test.tsx:</span></span>
-              <span class="demo-line">  <span class="d-green">&#10003;</span> <span class="d-body">renders latency chart</span></span>
-              <span class="demo-line">  <span class="d-green">&#10003;</span> <span class="d-body">fetches metrics on mount</span></span>
-              <span class="demo-line demo-line-gap"> <span class="d-teal">47</span> <span class="d-dim">pass</span>  <span class="d-teal">0</span> <span class="d-dim">fail</span>  <span class="d-dim">Ran</span> <span class="d-teal">47</span> <span class="d-dim">tests [1.84s]</span></span>
-            </div>
+            <div class="demo-tabs" id="d-tabs"></div>
+            <div class="demo-pane-body" id="d-agent" style="position:relative;"></div>
           </div>
         </div>
-
-        <!-- Status bar -->
         <div class="demo-statusbar">
-          <span><span class="demo-status-dot green"></span>socket connected</span>
-          <span>4 surfaces</span>
-          <span>2 agents</span>
-          <span id="demo-latency">latency: 0.2ms</span>
-          <span style="margin-left: auto;">workspace:1</span>
+          <span><span class="s-dot s-green"></span>socket</span>
+          <span id="d-surfaces">2 surfaces</span>
+          <span id="d-agents">0 agents</span>
+          <span id="d-latency">0.2ms</span>
+          <span style="margin-left:auto;" id="d-status">ready</span>
         </div>
       </div>
     </div>
@@ -1430,70 +1301,208 @@
 
     document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 
-    // Demo tabs
-    let tabCycleId = null;
-    document.querySelectorAll('.demo-tab').forEach(tab => {
-      tab.addEventListener('click', () => {
-        // Stop auto-cycle on manual click
-        if (tabCycleId) { clearInterval(tabCycleId); tabCycleId = null; }
-        const target = tab.dataset.tab;
-        tab.closest('.demo-right').querySelectorAll('.demo-tab').forEach(t => t.classList.remove('active'));
-        tab.closest('.demo-right').querySelectorAll('.demo-tab-panel').forEach(p => p.classList.remove('active'));
-        tab.classList.add('active');
-        tab.closest('.demo-right').querySelector(`[data-panel="${target}"]`).classList.add('active');
-      });
-    });
-
-    // Typing animation in orchestrator
+    // ── Animated Terminal Demo ──
     (function() {
-      const el = document.getElementById('demo-typing');
-      const cursor = document.getElementById('demo-cursor');
-      if (!el) return;
-      const text = 'Both agents done. Tests green. Pushing to main.';
-      let i = 0;
-      function type() {
-        if (i <= text.length) {
-          el.textContent = text.slice(0, i);
-          i++;
-          setTimeout(type, 45 + Math.random() * 35);
-        } else {
-          if (cursor) cursor.style.display = 'none';
-          // Auto-cycle tabs after typing finishes
-          setTimeout(startTabCycle, 2000);
-        }
+      const orc = document.getElementById('d-orc');
+      const agent = document.getElementById('d-agent');
+      const tabs = document.getElementById('d-tabs');
+      const dSurfaces = document.getElementById('d-surfaces');
+      const dAgents = document.getElementById('d-agents');
+      const dLatency = document.getElementById('d-latency');
+      const dStatus = document.getElementById('d-status');
+      if (!orc) return;
+
+      // Helpers
+      const c = (cls, text) => `<span class="${cls}">${text}</span>`;
+      const dim = t => c('c-d', t);
+      const grn = t => c('c-g', t);
+      const brg = t => c('c-gb', t);
+      const amb = t => c('c-a', t);
+      const cyn = t => c('c-c', t);
+      const tea = t => c('c-t', t);
+      const wht = t => c('c-w', t);
+      const sec = t => c('c-s', t);
+      const bdr = t => dim(t);
+
+      function ctxBar(pct) {
+        const f = Math.round(pct / 5.5);
+        const e = 18 - f;
+        return grn('\u2588'.repeat(f)) + dim('\u2588'.repeat(e)) + ' ' + tea(pct + '%');
       }
-      // Start typing when demo scrolls into view
-      const demoObs = new IntersectionObserver((entries) => {
-        entries.forEach(e => {
-          if (e.isIntersecting) { type(); demoObs.disconnect(); }
-        });
-      }, { threshold: 0.3 });
-      demoObs.observe(el.closest('.demo-frame'));
-    })();
 
-    // Auto-cycle demo tabs
-    function startTabCycle() {
-      const tabs = document.querySelectorAll('.demo-tab');
-      const panels = document.querySelectorAll('.demo-tab-panel');
-      if (!tabs.length) return;
-      const order = ['web', 'tests', 'api'];
-      let idx = 0;
-      tabCycleId = setInterval(() => {
-        const target = order[idx % order.length];
-        tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === target));
-        panels.forEach(p => p.classList.toggle('active', p.dataset.panel === target));
-        idx++;
-      }, 3000);
-    }
+      let typing = false;
+      async function typeIn(el, text, speed) {
+        typing = true;
+        const cursor = '<span class="demo-cursor"></span>';
+        for (let i = 0; i <= text.length; i++) {
+          const before = el.innerHTML.replace(/<span class="demo-cursor"><\/span>/g, '');
+          el.innerHTML = before + esc(text.slice(0, i)) + cursor;
+          await sleep(speed + Math.random() * speed * 0.6);
+        }
+        // Remove cursor after a beat
+        await sleep(300);
+        el.innerHTML = el.innerHTML.replace(/<span class="demo-cursor"><\/span>/g, '');
+        typing = false;
+      }
 
-    // Latency flicker in status bar
-    (function() {
-      const el = document.getElementById('demo-latency');
-      if (!el) return;
+      function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+      function appendOrc(html) { orc.innerHTML += html + '\n'; orc.scrollTop = orc.scrollHeight; }
+      function setAgent(html) { agent.innerHTML = html; }
+      function setTabs(arr, active) {
+        tabs.innerHTML = arr.map(t =>
+          `<div class="demo-tab${t === active ? ' active' : ''}">${esc(t)}</div>`
+        ).join('');
+      }
+      function setStat(s, a, st) {
+        dSurfaces.textContent = s + ' surfaces';
+        dAgents.textContent = a + ' agents';
+        dStatus.textContent = st;
+      }
+
+      // Latency flicker
       setInterval(() => {
-        const v = (0.15 + Math.random() * 0.15).toFixed(1);
-        el.textContent = 'latency: ' + v + 'ms';
-      }, 2000);
+        dLatency.textContent = (0.1 + Math.random() * 0.2).toFixed(1) + 'ms';
+      }, 1800);
+
+      // ── The Movie Script ──
+      async function runCycle() {
+        // Reset
+        orc.innerHTML = ''; agent.innerHTML = ''; tabs.innerHTML = '';
+        setStat(2, 0, 'ready');
+
+        // Phase 1 — Prompt
+        appendOrc(grn('\u276F') + ' ' + wht('Deploy the voice fix and optimize brain search'));
+        await sleep(800);
+        appendOrc('');
+        await typeIn(orc, 'Spawning two agents in parallel.', 35);
+        await sleep(400);
+
+        // Phase 2 — Spawn agent 1
+        appendOrc('');
+        appendOrc(bdr('\u250C\u2500') + ' ' + brg('spawn_agent') + '(' + cyn('repo') + '=' + amb('"voicelayer"') + ', ' + cyn('model') + '=' + amb('"opus"') + ')');
+        await sleep(600);
+        appendOrc(bdr('\u2502') + '  ' + dim('agent_id:') + ' ' + amb('opus-voice-a3f7'));
+        appendOrc(bdr('\u2502') + '  ' + dim('surface:') + '  ' + amb('surface:3') + '  ' + dim('state:') + ' ' + grn('creating'));
+        appendOrc(bdr('\u2514\u2500') + ' ' + dim('cli: claude'));
+        setStat(3, 1, 'spawning');
+        setTabs(['voiceFix'], 'voiceFix');
+        setAgent(
+          dim('agent: ') + amb('opus-voice-a3f7') + '  ' + dim('cli: claude\n') +
+          dim('model: ') + sec('claude-opus-4-6') + '  ' + dim('state: ') + grn('booting') + '\n\n' +
+          sec('> Claude Code v1.0.23\n') +
+          sec('> Model: claude-opus-4-6 (1M context)\n') +
+          sec('> Loading repo: voicelayer\n') +
+          dim('tokens: ') + tea('0') + '  ' + dim('cost: ') + tea('$0.00')
+        );
+        await sleep(1200);
+
+        // Phase 3 — Spawn agent 2
+        appendOrc('');
+        appendOrc(bdr('\u250C\u2500') + ' ' + brg('spawn_agent') + '(' + cyn('repo') + '=' + amb('"brainlayer"') + ', ' + cyn('model') + '=' + amb('"sonnet"') + ')');
+        await sleep(500);
+        appendOrc(bdr('\u2502') + '  ' + dim('agent_id:') + ' ' + amb('sonnet-brain-c1d4'));
+        appendOrc(bdr('\u2502') + '  ' + dim('surface:') + '  ' + amb('surface:4') + '  ' + dim('state:') + ' ' + grn('creating'));
+        appendOrc(bdr('\u2514\u2500') + ' ' + dim('cli: claude'));
+        setStat(4, 2, 'spawning');
+        setTabs(['voiceFix', 'brainOpt'], 'voiceFix');
+        await sleep(800);
+
+        // Phase 4 — Agents working (show voiceFix activity)
+        setStat(4, 2, 'agents working');
+        const workSteps = [
+          { tok: '42K', pct: 21, cost: '$0.23', state: 'working', out: 'Reading src/tts/edge-tts.ts...\nFound fallback issue at line 147' },
+          { tok: '87K', pct: 43, cost: '$0.61', state: 'working', out: 'Reading src/tts/edge-tts.ts...\nFound fallback issue at line 147\n\nEditing src/tts/edge-tts.ts\n  + if (!stream) return fallbackToGoogleTTS(text)' },
+          { tok: '134K', pct: 67, cost: '$1.12', state: 'working', out: 'Reading src/tts/edge-tts.ts...\nFound fallback issue at line 147\n\nEditing src/tts/edge-tts.ts\n  + if (!stream) return fallbackToGoogleTTS(text)\n\nRunning: bun test src/tts/\n  ' + grn('\u2713') + ' edge-tts falls back on timeout\n  ' + grn('\u2713') + ' google-tts returns audio buffer' },
+        ];
+        for (const step of workSteps) {
+          setAgent(
+            dim('agent: ') + amb('opus-voice-a3f7') + '  ' + dim('state: ') + grn(step.state) + '\n' +
+            dim('model: ') + sec('claude-opus-4-6') + '  ' + dim('tokens: ') + tea(step.tok) + '\n' +
+            dim('ctx: ') + ctxBar(step.pct) + '  ' + dim('cost: ') + tea(step.cost) + '\n\n' +
+            sec(step.out)
+          );
+          await sleep(2000);
+        }
+
+        // Phase 5 — Switch to brainOpt tab
+        setTabs(['voiceFix', 'brainOpt'], 'brainOpt');
+        setAgent(
+          dim('agent: ') + amb('sonnet-brain-c1d4') + '  ' + dim('state: ') + grn('working') + '\n' +
+          dim('model: ') + sec('claude-sonnet-4-6') + '  ' + dim('tokens: ') + tea('96K') + '\n' +
+          dim('ctx: ') + ctxBar(48) + '  ' + dim('cost: ') + tea('$0.34') + '\n\n' +
+          sec('Optimizing FTS5 query in brain_search.\n') +
+          sec('Rewrote hybrid_search() to use pre-filtered\n') +
+          sec('candidate set before semantic ranking.\n\n') +
+          sec('Benchmark: 48ms \u2192 11ms (4.3x faster)')
+        );
+        await sleep(3000);
+
+        // Phase 6 — Monitor from orchestrator
+        setTabs(['voiceFix', 'brainOpt'], 'voiceFix');
+        appendOrc('');
+        appendOrc(bdr('\u250C\u2500') + ' ' + brg('read_screen') + '(' + cyn('surface') + '=' + amb('"surface:3"') + ', ' + cyn('parsed_only') + '=' + tea('true') + ')');
+        await sleep(600);
+        appendOrc(bdr('\u2502') + '  ' + dim('agent:') + ' ' + sec('claude') + '  ' + dim('status:') + ' ' + grn('idle') + '  ' + dim('model:') + ' ' + sec('opus-4-6'));
+        appendOrc(bdr('\u2502') + '  ' + dim('tokens:') + ' ' + tea('142K') + '  ' + dim('ctx:') + ' ' + tea('71%') + '  ' + dim('cost:') + ' ' + tea('$1.12'));
+        appendOrc(bdr('\u2514\u2500') + ' ' + grn('done_signal: "CLAUDE_COUNTER: 7"'));
+        await sleep(1000);
+
+        // Phase 7 — wait_for_all
+        appendOrc('');
+        appendOrc(bdr('\u250C\u2500') + ' ' + brg('wait_for_all') + '(' + cyn('target') + '=' + amb('"done"') + ')');
+        await sleep(800);
+        appendOrc(bdr('\u2502') + '  ' + grn('\u2713') + ' ' + dim('opus-voice-a3f7:') + '  ' + grn('done') + ' ' + dim('(34s)'));
+        await sleep(500);
+        appendOrc(bdr('\u2502') + '  ' + grn('\u2713') + ' ' + dim('sonnet-brain-c1d4:') + ' ' + grn('done') + ' ' + dim('(51s)'));
+        appendOrc(bdr('\u2514\u2500') + ' ' + grn('all agents finished'));
+        setStat(4, 2, 'all done');
+        await sleep(1000);
+
+        // Phase 8 — Results
+        setAgent(
+          dim('agent: ') + amb('opus-voice-a3f7') + '  ' + dim('state: ') + grn('\u2713 done') + '\n' +
+          dim('tokens: ') + tea('142K') + '  ' + dim('cost: ') + tea('$1.12') + '\n\n' +
+          dim('files:\n') +
+          sec('  src/tts/edge-tts.ts (+23 -4)\n') +
+          sec('  tests/tts.test.ts (+47)\n\n') +
+          grn('\u2713') + ' ' + sec('Committed: ') + amb('fix: edge-tts fallback to google-tts')
+        );
+        await sleep(1200);
+
+        appendOrc('');
+        await typeIn(orc, 'Both done. Creating PRs.', 30);
+        await sleep(500);
+        appendOrc('');
+        appendOrc(grn('\u2713') + ' ' + sec('PR #142: ') + amb('fix: edge-tts fallback to google-tts'));
+        await sleep(400);
+        appendOrc(grn('\u2713') + ' ' + sec('PR #87: ') + amb('perf: optimize FTS5 hybrid search (4.3x)'));
+        await sleep(600);
+        appendOrc('');
+        appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 298 tests passing') + grn(' \u2501\u2501\u2501'));
+        setStat(4, 0, '\u2713 complete');
+
+        await sleep(4000);
+
+        // Fade and restart
+        orc.style.opacity = '0'; agent.style.opacity = '0';
+        await sleep(600);
+        orc.style.opacity = '1'; agent.style.opacity = '1';
+      }
+
+      // Start on scroll
+      const demoObs = new IntersectionObserver((entries) => {
+        entries.forEach(async e => {
+          if (e.isIntersecting) {
+            demoObs.disconnect();
+            orc.style.transition = 'opacity 0.5s';
+            agent.style.transition = 'opacity 0.5s';
+            while (true) { await runCycle(); }
+          }
+        });
+      }, { threshold: 0.2 });
+      demoObs.observe(document.getElementById('demo'));
     })();
 
     // Copy to clipboard

--- a/landing/index.html
+++ b/landing/index.html
@@ -1369,14 +1369,15 @@
       // ── The Movie Script ──
       async function runCycle() {
         // Reset
-        orc.innerHTML = ''; agent.innerHTML = ''; tabs.innerHTML = '';
+        orc.innerHTML = ''; tabs.innerHTML = '';
+        agent.innerHTML = dim('no active agents');
         setStat(2, 0, 'ready');
 
         // Phase 1 — Prompt
         appendOrc(grn('\u276F') + ' ' + wht('Deploy the voice fix and optimize brain search'));
         await sleep(800);
         appendOrc('');
-        await typeIn(orc, 'Spawning two agents in parallel.', 35);
+        await typeIn(orc, 'On it. Two parallel agents for this.', 35);
         await sleep(400);
 
         // Phase 2 — Spawn agent 1
@@ -1472,23 +1473,18 @@
         await sleep(1200);
 
         appendOrc('');
-        await typeIn(orc, 'Both done. Creating PRs.', 30);
+        await typeIn(orc, 'Both done. Pushing PRs now.', 30);
         await sleep(500);
         appendOrc('');
-        appendOrc(grn('\u2713') + ' ' + sec('PR #142: ') + amb('fix: edge-tts fallback to google-tts'));
+        appendOrc(grn('\u2713') + ' ' + sec('voicelayer#34: ') + amb('fix: edge-tts fallback to google-tts'));
         await sleep(400);
-        appendOrc(grn('\u2713') + ' ' + sec('PR #87: ') + amb('perf: optimize FTS5 hybrid search (4.3x)'));
+        appendOrc(grn('\u2713') + ' ' + sec('brainlayer#91: ') + amb('perf: optimize FTS5 hybrid search (4.3x)'));
         await sleep(600);
         appendOrc('');
         appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 298 tests passing') + grn(' \u2501\u2501\u2501'));
         setStat(4, 0, '\u2713 complete');
 
         await sleep(4000);
-
-        // Fade and restart
-        orc.style.opacity = '0'; agent.style.opacity = '0';
-        await sleep(600);
-        orc.style.opacity = '1'; agent.style.opacity = '1';
       }
 
       // Start on scroll
@@ -1496,9 +1492,15 @@
         entries.forEach(async e => {
           if (e.isIntersecting) {
             demoObs.disconnect();
-            orc.style.transition = 'opacity 0.5s';
-            agent.style.transition = 'opacity 0.5s';
-            while (true) { await runCycle(); }
+            const frame = document.getElementById('demo');
+            const layout = frame.querySelector('.demo-layout');
+            layout.style.transition = 'opacity 0.6s ease';
+            while (true) {
+              layout.style.opacity = '1';
+              await runCycle();
+              layout.style.opacity = '0.15';
+              await sleep(800);
+            }
           }
         });
       }, { threshold: 0.2 });

--- a/landing/index.html
+++ b/landing/index.html
@@ -1221,7 +1221,7 @@
       <div class="section-label reveal">See it work</div>
       <h2 class="section-heading reveal">Two agents. One orchestrator. Zero tab-switching.</h2>
 
-      <div class="demo-frame reveal" id="demo">
+      <div class="demo-frame reveal" id="demo" aria-hidden="true">
         <div class="demo-titlebar">
           <div class="dot dot-r"></div><div class="dot dot-y"></div><div class="dot dot-g"></div>
           <span class="demo-titlebar-text">cmux &mdash; workspace:1</span>
@@ -1330,9 +1330,7 @@
         return grn('\u2588'.repeat(f)) + dim('\u2588'.repeat(e)) + ' ' + tea(pct + '%');
       }
 
-      let typing = false;
       async function typeIn(el, text, speed) {
-        typing = true;
         const cursor = '<span class="demo-cursor"></span>';
         for (let i = 0; i <= text.length; i++) {
           const before = el.innerHTML.replace(/<span class="demo-cursor"><\/span>/g, '');
@@ -1342,7 +1340,6 @@
         // Remove cursor after a beat
         await sleep(300);
         el.innerHTML = el.innerHTML.replace(/<span class="demo-cursor"><\/span>/g, '');
-        typing = false;
       }
 
       function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
@@ -1495,11 +1492,18 @@
             const frame = document.getElementById('demo');
             const layout = frame.querySelector('.demo-layout');
             layout.style.transition = 'opacity 0.6s ease';
+            // Respect reduced motion preference
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+              await runCycle(); // Run once, don't loop
+              return;
+            }
             while (true) {
-              layout.style.opacity = '1';
-              await runCycle();
-              layout.style.opacity = '0.15';
-              await sleep(800);
+              try {
+                layout.style.opacity = '1';
+                await runCycle();
+                layout.style.opacity = '0.15';
+                await sleep(800);
+              } catch(e) { await sleep(3000); }
             }
           }
         });


### PR DESCRIPTION
## Summary
Replace the static interactive demo with a continuously looping animated movie showing cmux orchestrating AI agents across repos.

**The animation cycle (~35s, loops forever):**
1. orcClaude types a task prompt
2. Spawns opus agent for voicelayer (edge-tts fix)
3. Spawns sonnet agent for brainlayer (FTS5 optimization)
4. Agents work — code edits scroll, tokens climb, context bar fills
5. Tab switches to show second agent's work
6. `read_screen parsed_only=true` shows parsed agent state
7. `wait_for_all` completes with timing
8. PRs created with real repo#N format
9. Summary line → fade → restart

**cmux features showcased:**
- spawn_agent (repo, model, cli params)
- read_screen with parsed output (agent_type, status, tokens, ctx%, cost)
- wait_for_all (blocking wait with per-agent status)
- Workspace tabs (orcClaude, coachClaude, shellClaude)
- Agent tabs (voiceFix, brainOpt) with live switching
- Status bar (socket, surfaces, agents, latency flicker)
- Context bar visualization (filled/empty blocks with %)

**Visual:**
- Green brand #22c55e throughout
- Typing animation with cursor
- Smooth fade between cycles
- Realistic content: real repo names, tool signatures, file diffs

## Test plan
- [x] 298/298 tests pass
- [ ] Animation loops smoothly in browser
- [ ] Typing speed feels natural
- [ ] Tab switches are visible
- [ ] Mobile: stacks vertically

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add animated looping terminal demo to landing page
> - Replaces the static tabbed preview in [landing/index.html](https://github.com/EtanHey/cmuxlayer/pull/34/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3) with a fully script-driven animated demo that auto-plays a multi-step orchestrator narrative (spawning agents, switching tabs, displaying results).
> - The demo loops while the `#demo` section is in view; users with `prefers-reduced-motion` get a single run with no looping.
> - All previously static HTML content (hardcoded agent panels, tab panels, prewritten outputs) is removed — the pane content is now empty at load and populated entirely by the new IIFE.
> - New workspace tabs, consolidated color helpers, and an updated status bar (including a flickering numeric latency display) replace the old CSS and markup constructs.
> - Behavioral Change: manual tab click handling is removed; tabs are no longer user-interactive and are cycled automatically by the script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b89b3a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned landing page demo with an animated terminal interface replacing the previous interactive pane layout.
  * Implemented scroll-triggered animations with dynamic content updates and real-time status indicators.

* **Style**
  * Refreshed visual design, layout structure, and overall demo section presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->