### PR TITLE
fix: demo polish — mobile heights, timing, OG domain

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="cmuxLayer — Terminal MCP for AI Agents">
   <meta property="og:description" content="21 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens. One Unix socket.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://etanhey.github.io/cmuxlayer/">
+  <meta property="og:url" content="https://cmuxlayer.etanheyman.com">
   <meta name="twitter:card" content="summary">
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%2309090b'/%3E%3Crect x='3' y='3' width='12' height='26' rx='2' stroke='%2322c55e' stroke-width='2' fill='none'/%3E%3Crect x='17' y='3' width='12' height='12' rx='2' stroke='%2322c55e' stroke-width='2' fill='none'/%3E%3Crect x='17' y='17' width='12' height='12' rx='2' stroke='%2322c55e' stroke-width='2' fill='none'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -829,7 +829,9 @@
 
     @media (max-width: 768px) {
       .demo-layout { flex-direction: column; min-height: auto; }
-      .demo-left { flex: none; border-right: none; border-bottom: 2px solid rgba(34,197,94,0.12); min-height: 200px; }
+      .demo-left { flex: none; border-right: none; border-bottom: 2px solid rgba(34,197,94,0.12); }
+      .demo-left .demo-pane-body { max-height: 220px; }
+      .demo-right .demo-pane-body { max-height: 220px; }
       .demo-pane-body { font-size: 10px; }
     }
 
@@ -1562,7 +1564,7 @@
         appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 298 tests passing') + grn(' \u2501\u2501\u2501'));
         setStat(4, 0, '\u2713 complete');
 
-        await sleep(4000);
+        await sleep(3000);
       }
 
       // Start on scroll


### PR DESCRIPTION
## Summary
Post-deploy polish pass on the animated terminal demo.

- **Mobile**: cap both orchestrator and agent panes at 220px max-height on narrow screens
- **Timing**: reduce end-of-cycle hold from 4s to 3s for tighter loop
- **OG URL**: update to cmuxlayer.etanheyman.com (was etanhey.github.io)
- Verified: zero remaining github.io references in the page

## Test plan
- [x] 298/298 tests pass
- [ ] Mobile: panes scroll within 220px bounds
- [ ] Animation loop feels natural (~30s cycle)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile layout, animation timing, and OG domain on landing demo
> - Removes the `min-height: 200px` constraint on the left demo pane for small screens and adds `max-height` caps to both pane bodies in [landing/index.html](https://github.com/EtanHey/cmuxlayer/pull/36/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3), fixing scroll/layout issues on mobile.
> - Reduces a delay in the demo animation sequence by 1 second so the next step advances faster.
> - Updates the Open Graph URL meta tag to the correct canonical domain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f86f78c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->