### PR TITLE
fix: add CNAME for cmuxlayer.etanheyman.com

### DIFF
--- a/landing/CNAME
+++ b/landing/CNAME
@@ -1,0 +1,1 @@
+cmuxlayer.etanheyman.com


### PR DESCRIPTION
Adds landing/CNAME so GitHub Pages serves on the custom domain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CNAME for cmuxlayer.etanheyman.com to landing directory
> Adds a [CNAME](https://github.com/EtanHey/cmuxlayer/pull/37/files#diff-68c4c283083a43175a7c7dd3f8764f29ae060ec07fb1c381515236089bb60972) file to the `landing` directory to configure the custom domain `cmuxlayer.etanheyman.com`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfb9f03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain routing configuration for the landing site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->