### PR TITLE
feat: Vercel deployment for cmuxlayer.etanheyman.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "outputDirectory": "landing",
+  "headers": [
+    {
+      "source": "/logos/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **vercel.json**: Serves `landing/` as static site — no build step (pure HTML + JS)
- **Security headers**: X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS, Permissions-Policy
- **Logo caching**: 1-year immutable for SVGs

## Setup steps (manual, after merge)
1. Vercel dashboard → Import `EtanHey/cmuxlayer`
2. Vercel auto-detects `vercel.json`
3. Add custom domain: `cmuxlayer.etanheyman.com`
4. Namecheap: CNAME record `cmuxlayer` → `cname.vercel-dns.com`

## Test plan
- [ ] `vercel.json` schema validates
- [ ] Site serves `landing/index.html` at root
- [ ] Security headers present
- [ ] Logo SVGs cached with immutable header

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Vercel deployment config for cmuxlayer.etanheyman.com with security and caching headers
> Adds [vercel.json](https://github.com/EtanHey/cmuxlayer/pull/40/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240) to configure static site deployment with `outputDirectory` set to `landing` and no framework.
>
> - Sets long-term immutable cache headers (`max-age=31536000`) for assets under `/logos/`
> - Adds security headers to all responses: `X-Content-Type-Options`, `X-Frame-Options: DENY`, strict referrer policy, HSTS (2-year, with subdomain and preload), and a restrictive Permissions-Policy disabling camera, microphone, and geolocation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51e926e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->