### PR TITLE
fix: simplify spawn_agent launch command and fix rename_tab persistence

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -115,28 +115,34 @@ const LIFECYCLE_LOGS = {
 /**
  * Build the shell command that launches a CLI agent.
  * Repo name is sanitized to prevent command injection.
+ *
+ * For claude: uses repoGolem launchers (e.g. `voicelayerClaude -s`)
+ * which handle cd, model, iTerm profile, MCP config, and contexts.
+ * No `cd` prefix needed — the launcher does it.
+ *
+ * For other CLIs: uses `cd ~/Gits/<repo> && <cli>` since they
+ * don't have launcher functions yet.
  */
-function buildLaunchCommand(cli: CliType, repo: string): string {
+export function buildLaunchCommand(cli: CliType, repo: string): string {
   const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
   if (!safeRepo || safeRepo !== repo) {
     throw new Error(
       `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed.`,
     );
   }
-  const cdCmd = `cd ~/Gits/${safeRepo}`;
   switch (cli) {
     case "claude":
-      return `${cdCmd} && ${safeRepo}Claude -s`;
+      return `${safeRepo}Claude -s`;
     case "codex":
-      return `${cdCmd} && codex`;
+      return `cd ~/Gits/${safeRepo} && codex`;
     case "gemini":
-      return `${cdCmd} && gemini`;
+      return `cd ~/Gits/${safeRepo} && gemini`;
     case "kiro":
-      return `${cdCmd} && kiro-cli`;
+      return `cd ~/Gits/${safeRepo} && kiro-cli`;
     case "cursor":
-      return `${cdCmd} && cursor agent`;
+      return `cd ~/Gits/${safeRepo} && cursor agent`;
     default:
-      return `${cdCmd} && ${cli}`;
+      return `cd ~/Gits/${safeRepo} && ${cli}`;
   }
 }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -125,9 +125,9 @@ const LIFECYCLE_LOGS = {
  */
 export function buildLaunchCommand(cli: CliType, repo: string): string {
   const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
-  if (!safeRepo || safeRepo !== repo) {
+  if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {
     throw new Error(
-      `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed.`,
+      `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed. "." and ".." are not permitted.`,
     );
   }
   switch (cli) {
@@ -141,8 +141,6 @@ export function buildLaunchCommand(cli: CliType, repo: string): string {
       return `cd ~/Gits/${safeRepo} && kiro-cli`;
     case "cursor":
       return `cd ~/Gits/${safeRepo} && cursor agent`;
-    default:
-      return `cd ~/Gits/${safeRepo} && ${cli}`;
   }
 }
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -509,6 +509,16 @@ describe("buildLaunchCommand", () => {
     expect(() => buildLaunchCommand("claude", "")).toThrow(/Invalid repo name/);
   });
 
+  it("rejects path-traversal names . and ..", () => {
+    expect(() => buildLaunchCommand("codex", ".")).toThrow(/Invalid repo name/);
+    expect(() => buildLaunchCommand("codex", "..")).toThrow(
+      /Invalid repo name/,
+    );
+    expect(() => buildLaunchCommand("claude", ".")).toThrow(
+      /Invalid repo name/,
+    );
+  });
+
   it("allows dots, hyphens, underscores in repo names", () => {
     expect(buildLaunchCommand("claude", "my-project")).toBe(
       "my-projectClaude -s",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { AgentEngine } from "../src/agent-engine.js";
+import { AgentEngine, buildLaunchCommand } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
@@ -133,7 +133,7 @@ describe("AgentEngine", () => {
       ).mock.calls[0];
       expect(surface).toBe("surface:new");
       expect(opts).toEqual({ workspace: "ws:1" });
-      expect(launchCmd).toBe("cd ~/Gits/brainlayer && brainlayerClaude -s");
+      expect(launchCmd).toBe("brainlayerClaude -s");
     });
 
     it("writes initial state file", async () => {
@@ -461,5 +461,63 @@ describe("AgentEngine", () => {
         /not in an interactive state/,
       );
     });
+  });
+});
+
+describe("buildLaunchCommand", () => {
+  it("uses repoGolem launcher for claude (no cd prefix)", () => {
+    expect(buildLaunchCommand("claude", "brainlayer")).toBe(
+      "brainlayerClaude -s",
+    );
+    expect(buildLaunchCommand("claude", "voicelayer")).toBe(
+      "voicelayerClaude -s",
+    );
+    expect(buildLaunchCommand("claude", "golems")).toBe("golemsClaude -s");
+  });
+
+  it("uses cd + raw command for codex", () => {
+    expect(buildLaunchCommand("codex", "brainlayer")).toBe(
+      "cd ~/Gits/brainlayer && codex",
+    );
+  });
+
+  it("uses cd + raw command for gemini", () => {
+    expect(buildLaunchCommand("gemini", "voicelayer")).toBe(
+      "cd ~/Gits/voicelayer && gemini",
+    );
+  });
+
+  it("uses cd + kiro-cli for kiro", () => {
+    expect(buildLaunchCommand("kiro", "golems")).toBe(
+      "cd ~/Gits/golems && kiro-cli",
+    );
+  });
+
+  it("uses cd + cursor agent for cursor", () => {
+    expect(buildLaunchCommand("cursor", "cmuxlayer")).toBe(
+      "cd ~/Gits/cmuxlayer && cursor agent",
+    );
+  });
+
+  it("rejects invalid repo names", () => {
+    expect(() => buildLaunchCommand("claude", "foo bar")).toThrow(
+      /Invalid repo name/,
+    );
+    expect(() => buildLaunchCommand("claude", "foo;rm -rf")).toThrow(
+      /Invalid repo name/,
+    );
+    expect(() => buildLaunchCommand("claude", "")).toThrow(/Invalid repo name/);
+  });
+
+  it("allows dots, hyphens, underscores in repo names", () => {
+    expect(buildLaunchCommand("claude", "my-project")).toBe(
+      "my-projectClaude -s",
+    );
+    expect(buildLaunchCommand("claude", "my_project")).toBe(
+      "my_projectClaude -s",
+    );
+    expect(buildLaunchCommand("claude", "my.project")).toBe(
+      "my.projectClaude -s",
+    );
   });
 });


### PR DESCRIPTION
## Summary
spawn_agent for claude CLI now uses repoGolem launchers directly instead of a redundant shell chain.

**Before:** `cd ~/Gits/brainlayer && brainlayerClaude -s`
**After:** `brainlayerClaude -s`

The launcher already handles: cd to repo, model selection, iTerm profile, MCP config, system prompts from contexts, and secrets. The `cd` was redundant and could cause issues if the launcher's cd path differed.

Non-claude CLIs (codex, gemini, kiro, cursor) keep the `cd` prefix since they don't have launcher functions yet.

Also exported `buildLaunchCommand` for direct testing.

## Test plan
- [x] 305/305 tests pass (was 298, +7 new)
- [x] Typecheck clean
- New tests cover:
  - claude uses repoGolem launcher for 3 different repos
  - codex, gemini, kiro, cursor use cd + raw command
  - Invalid repo names rejected (command injection prevention)
  - Dots, hyphens, underscores allowed in repo names

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildLaunchCommand` to return bare launcher for claude and reject path traversal repo names
> - `buildLaunchCommand` for `claude` now returns `<repo>Claude -s` without a `cd` prefix; other CLIs continue to use `cd ~/Gits/<repo> && ...` form.
> - Repo name validation now also rejects `.` and `..` to prevent path traversal.
> - `buildLaunchCommand` is exported and covered by new dedicated unit tests in [agent-engine.test.ts](https://github.com/EtanHey/cmuxlayer/pull/41/files#diff-23c096d87b5f141db61c3014b45beb25da33800c0513e4ca132c5c9b5a6aac46).
> - Behavioral Change: the spawn command for `claude` agents no longer includes a leading `cd` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe41149.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified Claude launcher command handling to remove working directory prefix.
  * Updated other model launchers' command construction (codex, gemini, kiro, cursor).

* **Tests**
  * Expanded launcher command generation test coverage with validation for CLI types and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->