### PR TITLE
fix: update test count 298 → 306 in landing page

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -987,7 +987,7 @@
         <span class="stat-label">agent CLIs</span>
       </div>
       <div class="stat-item">
-        <span class="stat-value">298</span>
+        <span class="stat-value">306</span>
         <span class="stat-label">tests passing</span>
       </div>
     </div>
@@ -1626,7 +1626,7 @@
         appendOrc(grn('\u2713') + ' ' + sec('brainlayer#91: ') + amb('perf: optimize FTS5 hybrid search (4.3x)'));
         await sleep(600);
         appendOrc('');
-        appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 298 tests passing') + grn(' \u2501\u2501\u2501'));
+        appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 306 tests passing') + grn(' \u2501\u2501\u2501'));
         setStat(4, 0, '\u2713 complete');
 
         await sleep(3000);


### PR DESCRIPTION
## Summary
Update stale test count in two places: stat strip and animated demo finale.
298 → 306 after spawn_agent buildLaunchCommand tests were added in PR #41.

## Test plan
- [x] 306/306 tests pass
- [x] Verified: 21 tools (correct), 5 CLIs (correct), 306 tests (now correct)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update test count from 298 to 306 on landing page
> Updates the 'tests passing' stat and terminal demo output in [index.html](https://github.com/EtanHey/cmuxlayer/pull/42/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3) to reflect the current count of 306.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cf4655.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->