### PR TITLE
fix: update landing stats — 22 tools, 310 tests

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>cmuxLayer — Terminal MCP for AI Agents</title>
-  <meta name="description" content="MCP server that gives AI agents programmatic control over terminal panes. 21 tools. Split, read, send, automate. One Unix socket.">
+  <meta name="description" content="MCP server that gives AI agents programmatic control over terminal panes. 22 tools. Split, read, send, automate. One Unix socket.">
   <meta property="og:title" content="cmuxLayer — Terminal MCP for AI Agents">
-  <meta property="og:description" content="21 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens. One Unix socket.">
+  <meta property="og:description" content="22 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens. One Unix socket.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://cmuxlayer.etanheyman.com">
   <meta name="twitter:card" content="summary">
@@ -979,7 +979,7 @@
         <span class="stat-label">socket latency</span>
       </div>
       <div class="stat-item">
-        <span class="stat-value">21</span>
+        <span class="stat-value">22</span>
         <span class="stat-label">MCP tools</span>
       </div>
       <div class="stat-item">
@@ -987,7 +987,7 @@
         <span class="stat-label">agent CLIs</span>
       </div>
       <div class="stat-item">
-        <span class="stat-value">306</span>
+        <span class="stat-value">310</span>
         <span class="stat-label">tests passing</span>
       </div>
     </div>
@@ -1626,7 +1626,7 @@
         appendOrc(grn('\u2713') + ' ' + sec('brainlayer#91: ') + amb('perf: optimize FTS5 hybrid search (4.3x)'));
         await sleep(600);
         appendOrc('');
-        appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 306 tests passing') + grn(' \u2501\u2501\u2501'));
+        appendOrc(grn('\u2501\u2501\u2501 ') + wht('2 agents \u00B7 2 PRs \u00B7 310 tests passing') + grn(' \u2501\u2501\u2501'));
         setStat(4, 0, '\u2713 complete');
 
         await sleep(3000);


### PR DESCRIPTION
Trivial stat update after my_agents tool. 21→22 tools, 306→310 tests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update landing page stats to 22 tools and 310 tests
> Updates numeric counts in [landing/index.html](https://github.com/EtanHey/cmuxlayer/pull/44/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3) to reflect current project state: the stat strip, meta description, Open Graph description, and animated terminal demo sequence all now show 22 MCP tools and 310 passing tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b509b9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->