### PR TITLE
fix: log silent catches — registry reconstitute + sweep errors

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -297,8 +297,8 @@ export class AgentEngine {
   startSweep(intervalMs: number = 5000): void {
     if (this.sweepTimer) return;
     this.sweepTimer = setInterval(() => {
-      this.runSweep().catch(() => {
-        // Sweep errors are non-fatal — next sweep will retry
+      this.runSweep().catch((e) => {
+        console.error("[cmux-mcp] sweep failed (will retry):", e);
       });
     }, intervalMs);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -867,7 +867,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
 
     // Reconstitute registry from disk on startup (async, best-effort)
-    registry.reconstitute().catch(() => {});
+    registry
+      .reconstitute()
+      .catch((e) =>
+        console.error("[cmux-mcp] registry reconstitution failed:", e),
+      );
     engine.startSweep(5000);
 
     // 11. spawn_agent


### PR DESCRIPTION
## Security Audit: cmuxLayer

| # | Severity | File:Line | Pattern | Finding | Fix |
|---|----------|-----------|---------|---------|-----|
| 1 | CRITICAL | server.ts:870 | silent-catch | `.catch(() => {})` on registry reconstitute — startup errors invisible | Log with `[cmux-mcp]` prefix |
| 2 | CRITICAL | agent-engine.ts:300 | silent-catch | `.catch(() => {})` on sweep — recurring errors invisible | Log with retry context |
| 3 | MEDIUM | server.ts (all tools) | missing-annotations | 0/22 tools have ToolAnnotations | Separate PR |
| 4 | OK | cmux-client.ts | exec-pattern | Uses `execFile` (not `exec`) — no shell injection | No fix needed |
| 5 | OK | agent-engine.ts:127 | path-traversal | buildLaunchCommand rejects "." and ".." | Already fixed in PR #41 |
| 6 | OK | server.ts | send_input | Text goes to terminal by design — not injection | No fix needed |
| 7 | OK | server.ts | process.env | All access has `??` fallbacks | No fix needed |

### Summary
- Critical: 2 (both fixed) | High: 0 | Medium: 1 (ToolAnnotations, separate PR) | Low: 0
- ToolAnnotations coverage: 0/22 tools annotated
- Verdict: **PASS WITH NOTES** (ToolAnnotations need follow-up)

### Audited patterns
- Silent `.catch(() => {})` — 2 found, 2 fixed
- Empty `catch {}` blocks — 14 found, all intentional with comments
- `exec`/`spawn` calls — uses `execFile` (safe)
- `process.env` access — all have fallbacks
- Path traversal — already mitigated in PR #41
- Hardcoded secrets — none found

## Test plan
- [x] 310/310 tests pass
- [x] Typecheck clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log previously silent errors in registry reconstitution and sweep failures
> Silent `.catch()` handlers in [`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/46/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/46/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now log errors to stderr via `console.error` instead of discarding them. Failures in `registry.reconstitute()` log `[cmux-mcp] registry reconstitution failed:` and sweep run failures log `[cmux-mcp] sweep failed (will retry):`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d95d39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - System maintenance operations now log error details when failures occur
  - Sweep operation failures now report error information to stderr
  - Registry reconstitution failures now report detailed error messages
  - Previously silent errors are now visible for improved system observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->