### PR TITLE
feat: Track B security — ToolAnnotations + send_input sanitization

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import { StateManager } from "./state-manager.js";
+import { sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import type { CmuxNewSplitResult, CmuxReadScreenResult } from "./types.js";
 import {
@@ -603,7 +604,7 @@ export class AgentEngine {
       );
     }
 
-    await this.client.send(agent.surface_id, text, {});
+    await this.client.send(agent.surface_id, sanitizeTerminalInput(text), {});
     if (pressEnter) {
       await this.client.sendKey(agent.surface_id, "return", {});
     }

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,18 @@
+/**
+ * Strip dangerous terminal control sequences from text before sending to panes.
+ * Preserves newline (\n), tab (\t), and carriage return (\r).
+ * Strips: ESC sequences, BEL, and other C0/C1 control characters.
+ */
+export function sanitizeTerminalInput(text: string): string {
+  // Strip ANSI escape sequences (ESC [ ... letter, ESC ] ... BEL/ST, ESC ( ..., etc.)
+  let result = text.replace(/\x1b[\[\]()#;?]*[0-9;]*[a-zA-Z@`]/g, "");
+  // Strip remaining ESC + any following char
+  result = result.replace(/\x1b./g, "");
+  // Strip standalone ESC
+  result = result.replace(/\x1b/g, "");
+  // Strip C0 control chars except HT(0x09), LF(0x0a), CR(0x0d)
+  result = result.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+  // Strip C1 control chars (0x80-0x9f)
+  result = result.replace(/[\x80-\x9f]/g, "");
+  return result;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
   formatOk,
 } from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
+import { sanitizeTerminalInput } from "./sanitize.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 type TextContent = { type: "text"; text: string };
@@ -59,24 +60,8 @@ const ANNOTATIONS = {
   } as const,
 };
 
-/**
- * Strip dangerous terminal control sequences from text before sending to panes.
- * Preserves newline (\n), tab (\t), and carriage return (\r).
- * Strips: ESC sequences, BEL, and other C0/C1 control characters.
- */
-export function sanitizeTerminalInput(text: string): string {
-  // Strip ANSI escape sequences (ESC [ ... letter, ESC ] ... BEL/ST, ESC ( ..., etc.)
-  let result = text.replace(/\x1b[\[\]()#;?]*[0-9;]*[a-zA-Z@`]/g, "");
-  // Strip remaining ESC + any following char
-  result = result.replace(/\x1b./g, "");
-  // Strip standalone ESC
-  result = result.replace(/\x1b/g, "");
-  // Strip C0 control chars except HT(0x09), LF(0x0a), CR(0x0d)
-  result = result.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
-  // Strip C1 control chars (0x80-0x9f)
-  result = result.replace(/[\x80-\x9f]/g, "");
-  return result;
-}
+// Re-export for test access
+export { sanitizeTerminalInput } from "./sanitize.js";
 
 const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,53 @@ type ToolReturn = {
   isError?: boolean;
 };
 
+/** ToolAnnotations for MCP spec compliance */
+const ANNOTATIONS = {
+  readOnly: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  } as const,
+  mutating: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  } as const,
+  destructive: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  } as const,
+  idempotentMutating: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  } as const,
+};
+
+/**
+ * Strip dangerous terminal control sequences from text before sending to panes.
+ * Preserves newline (\n), tab (\t), and carriage return (\r).
+ * Strips: ESC sequences, BEL, and other C0/C1 control characters.
+ */
+export function sanitizeTerminalInput(text: string): string {
+  // Strip ANSI escape sequences (ESC [ ... letter, ESC ] ... BEL/ST, ESC ( ..., etc.)
+  let result = text.replace(/\x1b[\[\]()#;?]*[0-9;]*[a-zA-Z@`]/g, "");
+  // Strip remaining ESC + any following char
+  result = result.replace(/\x1b./g, "");
+  // Strip standalone ESC
+  result = result.replace(/\x1b/g, "");
+  // Strip C0 control chars except HT(0x09), LF(0x0a), CR(0x0d)
+  result = result.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+  // Strip C1 control chars (0x80-0x9f)
+  result = result.replace(/[\x80-\x9f]/g, "");
+  return result;
+}
+
 const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
@@ -260,6 +307,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .default(8)
         .describe("Number of preview lines"),
     },
+    ANNOTATIONS.readOnly,
     async (args) => {
       try {
         const workspaces = await client.listWorkspaces();
@@ -356,6 +404,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .default(true)
         .describe("Focus the new pane"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         const result = await client.newSplit(args.direction, {
@@ -409,9 +458,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .describe("Rename tab suffix to this task name"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
-        await client.send(args.surface, args.text, {
+        const sanitizedText = sanitizeTerminalInput(args.text);
+        await client.send(args.surface, sanitizedText, {
           workspace: args.workspace,
         });
         if (args.press_enter) {
@@ -452,6 +503,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       key: z.string().describe("Key name (e.g. 'return', 'escape', 'tab')"),
       workspace: z.string().optional().describe("Target workspace ref"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         await client.sendKey(args.surface, args.key, {
@@ -493,6 +545,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "If true, return only parsed fields (omit raw content). Best for agent monitoring.",
         ),
     },
+    ANNOTATIONS.readOnly,
     async (args) => {
       try {
         const result = await client.readScreen(args.surface, {
@@ -561,6 +614,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .default(false)
         .describe("Only replace the task suffix, keeping launcher prefix"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         let finalTitle = args.title;
@@ -599,6 +653,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       workspace: z.string().optional().describe("Target workspace ref"),
       surface: z.string().optional().describe("Target surface ref"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         await client.notify({
@@ -638,6 +693,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .describe("Hex color"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         parseReservedModeKey(args.key, args.value);
@@ -669,6 +725,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       workspace: z.string().optional().describe("Target workspace ref"),
       surface: z.string().optional().describe("Target surface ref"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         await client.setProgress(args.value, {
@@ -692,6 +749,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface: z.string().describe("Target surface ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
     },
+    ANNOTATIONS.destructive,
     async (args) => {
       try {
         await client.closeSurface(args.surface, {
@@ -738,6 +796,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .describe("Timeout for wait action"),
     },
+    ANNOTATIONS.mutating,
     async (args) => {
       try {
         const browserArgs: string[] = [];
@@ -901,6 +960,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .describe("Maximum cost cap in USD for this agent"),
       },
+      ANNOTATIONS.mutating,
       async (args) => {
         try {
           const result = await engine.spawnAgent({
@@ -944,6 +1004,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(300000)
           .describe("Timeout in milliseconds (default: 5 minutes)"),
       },
+      ANNOTATIONS.mutating,
       async (args) => {
         try {
           const result = await engine.waitFor(
@@ -981,6 +1042,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(300000)
           .describe("Timeout in milliseconds (default: 5 minutes)"),
       },
+      ANNOTATIONS.mutating,
       async (args) => {
         try {
           const results = await engine.waitForAll(
@@ -1008,6 +1070,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       {
         agent_id: z.string().describe("Agent ID"),
       },
+      ANNOTATIONS.readOnly,
       async (args) => {
         try {
           const state = engine.getAgentState(args.agent_id);
@@ -1044,6 +1107,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         repo: z.string().optional().describe("Filter by repository"),
         model: z.string().optional().describe("Filter by model"),
       },
+      ANNOTATIONS.readOnly,
       async (args) => {
         try {
           const agents = engine.listAgents({
@@ -1075,6 +1139,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(false)
           .describe("Force kill instead of graceful Ctrl+C"),
       },
+      ANNOTATIONS.destructive,
       async (args) => {
         try {
           await engine.stopAgent(args.agent_id, args.force);
@@ -1103,6 +1168,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(true)
           .describe("Press enter after sending text"),
       },
+      ANNOTATIONS.mutating,
       async (args) => {
         try {
           await engine.sendToAgent(args.agent_id, args.text, args.press_enter);
@@ -1133,6 +1199,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("Number of screen lines to scan (default: 200)"),
         workspace: z.string().optional().describe("Target workspace ref"),
       },
+      ANNOTATIONS.readOnly,
       async (args) => {
         try {
           const opts: Record<string, unknown> = {
@@ -1212,6 +1279,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .describe("Slash command to run (required for action=skill)"),
       },
+      ANNOTATIONS.mutating,
       async (args) => {
         try {
           // Runtime validation per action (Decision 2)
@@ -1349,6 +1417,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(false)
           .describe("Force kill (SIGKILL) instead of graceful (Ctrl+C)"),
       },
+      ANNOTATIONS.destructive,
       async (args) => {
         try {
           const killed: string[] = [];
@@ -1415,6 +1484,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "Parent agent ID. If omitted, returns all root agents (no parent).",
           ),
       },
+      ANNOTATIONS.readOnly,
       async (args) => {
         try {
           let agents: AgentRecord[];

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Security hardening tests — ToolAnnotations + control sequence sanitization.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-security-hardening-test");
+
+function makeMockExec(): ExecFn {
+  return vi.fn().mockResolvedValue({
+    stdout: JSON.stringify({
+      workspaces: [{ ref: "ws:1", title: "main" }],
+      surfaces: [
+        {
+          ref: "surface:1",
+          title: "test",
+          type: "terminal",
+          index: 0,
+          selected: true,
+          workspace_ref: "ws:1",
+        },
+      ],
+    }),
+    stderr: "",
+  });
+}
+
+describe("B1: ToolAnnotations on all tools", () => {
+  const READONLY_TOOLS = [
+    "list_surfaces",
+    "read_screen",
+    "get_agent_state",
+    "list_agents",
+    "my_agents",
+    "read_agent_output",
+  ];
+
+  const DESTRUCTIVE_TOOLS = ["kill", "close_surface", "stop_agent"];
+
+  const MUTATING_TOOLS = [
+    "new_split",
+    "send_input",
+    "send_key",
+    "rename_tab",
+    "notify",
+    "set_status",
+    "set_progress",
+    "browser_surface",
+    "spawn_agent",
+    "send_to_agent",
+    "wait_for",
+    "wait_for_all",
+    "interact",
+  ];
+
+  let tools: Record<string, { annotations?: Record<string, unknown> }>;
+
+  beforeAll(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const server = createServer({
+      exec: makeMockExec(),
+      stateDir: TEST_DIR,
+    });
+    tools = (server as any)._registeredTools;
+  });
+
+  afterAll(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("all 22 tools have annotations", () => {
+    const toolNames = Object.keys(tools);
+    expect(toolNames.length).toBe(22);
+    for (const name of toolNames) {
+      expect(
+        tools[name].annotations,
+        `${name} missing annotations`,
+      ).toBeDefined();
+    }
+  });
+
+  it("read-only tools have readOnlyHint=true", () => {
+    for (const name of READONLY_TOOLS) {
+      const ann = tools[name]?.annotations;
+      expect(ann?.readOnlyHint, `${name} should be readOnly`).toBe(true);
+      expect(ann?.destructiveHint, `${name} should not be destructive`).toBe(
+        false,
+      );
+    }
+  });
+
+  it("destructive tools have destructiveHint=true", () => {
+    for (const name of DESTRUCTIVE_TOOLS) {
+      const ann = tools[name]?.annotations;
+      expect(ann?.readOnlyHint, `${name} should not be readOnly`).toBe(false);
+      expect(ann?.destructiveHint, `${name} should be destructive`).toBe(true);
+    }
+  });
+
+  it("mutating tools have readOnlyHint=false", () => {
+    for (const name of MUTATING_TOOLS) {
+      const ann = tools[name]?.annotations;
+      expect(ann?.readOnlyHint, `${name} should not be readOnly`).toBe(false);
+    }
+  });
+});
+
+describe("B3: sanitizeTerminalInput", () => {
+  // Import the sanitizer directly
+  let sanitizeTerminalInput: (text: string) => string;
+
+  beforeAll(async () => {
+    const mod = await import("../src/server.js");
+    sanitizeTerminalInput = mod.sanitizeTerminalInput;
+  });
+
+  it("strips ANSI color sequences", () => {
+    expect(sanitizeTerminalInput("hello\x1b[31mred\x1b[0m world")).toBe(
+      "hellored world",
+    );
+  });
+
+  it("strips cursor movement sequences", () => {
+    expect(sanitizeTerminalInput("test\x1b[2Amove")).toBe("testmove");
+  });
+
+  it("strips BEL character (0x07)", () => {
+    expect(sanitizeTerminalInput("test\x07bell")).toBe("testbell");
+  });
+
+  it("strips null bytes", () => {
+    expect(sanitizeTerminalInput("a\x00b")).toBe("ab");
+  });
+
+  it("strips C0 control chars except HT, LF, CR", () => {
+    // 0x01 (SOH), 0x02 (STX), 0x03 (ETX) should be stripped
+    expect(sanitizeTerminalInput("a\x01\x02\x03b")).toBe("ab");
+    // 0x0b (VT), 0x0c (FF) should be stripped
+    expect(sanitizeTerminalInput("a\x0b\x0cb")).toBe("ab");
+  });
+
+  it("preserves newline (0x0a)", () => {
+    expect(sanitizeTerminalInput("line1\nline2")).toBe("line1\nline2");
+  });
+
+  it("preserves tab (0x09)", () => {
+    expect(sanitizeTerminalInput("col1\tcol2")).toBe("col1\tcol2");
+  });
+
+  it("preserves carriage return (0x0d)", () => {
+    expect(sanitizeTerminalInput("line1\rline2")).toBe("line1\rline2");
+  });
+
+  it("strips OSC sequences (ESC ] ... BEL)", () => {
+    const result = sanitizeTerminalInput("pre\x1b]0;title\x07post");
+    expect(result).not.toContain("\x1b");
+    expect(result).not.toContain("\x07");
+    expect(result).toContain("pre");
+    expect(result).toContain("post");
+  });
+
+  it("strips DEL character (0x7f)", () => {
+    expect(sanitizeTerminalInput("ab\x7fc")).toBe("abc");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeTerminalInput("")).toBe("");
+  });
+
+  it("handles string with no control chars", () => {
+    expect(sanitizeTerminalInput("normal text 123!@#")).toBe(
+      "normal text 123!@#",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**B1: ToolAnnotations on all 22 MCP tools**
- 6 readOnly, 13 mutating, 3 destructive
- MCP spec compliance: readOnlyHint, destructiveHint, idempotentHint, openWorldHint

**B2: spawn_agent env allowlist** — N/A. spawn_agent has no env parameter.

**B3: send_input control sequence sanitization**
- sanitizeTerminalInput() strips ESC, BEL, C0 controls, DEL, C1 controls
- Preserves newline, tab, carriage return

Tests: 310 → 326 (+16 new)

## Test plan
- [x] 326/326 tests pass
- [x] Typecheck clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ToolAnnotations` to all MCP tools and sanitize `send_input` terminal text
> - Introduces a `sanitizeTerminalInput` function in [`src/sanitize.ts`](https://github.com/EtanHey/cmuxlayer/pull/48/files#diff-0591987dbf2bdf1de70e0160e13a41c8d4d8bc27b0ff0c877b1e274f54fc851c) that strips ANSI escape sequences, C0/C1 control characters (except HT, LF, CR), DEL, and standalone ESC from arbitrary text.
> - Applies `sanitizeTerminalInput` in both the `send_input` MCP tool handler ([`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/48/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595)) and `AgentEngine.sendToAgent` ([`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/48/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5)) before passing text to terminal surfaces.
> - Registers all 22 MCP tools with `ToolAnnotations` presets (`readOnly`, `mutating`, `destructive`, `idempotentMutating`) for MCP spec compliance.
> - Adds security hardening tests in [`tests/security-hardening.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/48/files#diff-d6ceee5b7be60bc20ad189731483ed03eeec1996adc2918ce1d867dec72ca0a6) covering annotation metadata and sanitization behavior.
> - Behavioral Change: `send_input` and `sendToAgent` now silently drop terminal control sequences from user-supplied text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5c9613.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->