### PR TITLE
fix: add Docs nav link, fix npm footer link

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -17,6 +17,10 @@ export default function Home() {
         links={[
           { label: "Tools", href: "#tools" },
           { label: "Setup", href: "#setup" },
+          {
+            label: "Docs",
+            href: "https://github.com/EtanHey/cmuxlayer#readme",
+          },
         ]}
       />
       <Hero />

--- a/site/components/shared/footer.tsx
+++ b/site/components/shared/footer.tsx
@@ -3,7 +3,7 @@ type Product = "brainlayer" | "voicelayer" | "cmuxlayer";
 const SIBLING_LINKS: Record<Product, { label: string; href: string }[]> = {
   cmuxlayer: [
     { label: "GitHub", href: "https://github.com/EtanHey/cmuxlayer" },
-    { label: "npm", href: "https://www.npmjs.com/package/cmuxlayer" },
+    { label: "npm", href: "https://github.com/EtanHey/cmuxlayer#install" },
     { label: "VoiceLayer", href: "https://voicelayer.etanheyman.com" },
     { label: "BrainLayer", href: "https://brainlayer.etanheyman.com" },
   ],


### PR DESCRIPTION
## Summary
- Add **Docs** link to nav bar → GitHub README (consistent with VoiceLayer's Docs pattern)
- Fix **npm** footer link from `npmjs.com/package/cmuxlayer` (404, not published yet) → GitHub install section

## Test plan
- [x] `npm run build` passes in `site/`
- [x] Docs link resolves to `github.com/EtanHey/cmuxlayer#readme`
- [x] npm footer link resolves to `github.com/EtanHey/cmuxlayer#install`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Docs nav link and fix npm footer link for cmuxlayer
> - Adds a "Docs" link to the Nav component in [page.tsx](https://github.com/EtanHey/cmuxlayer/pull/50/files#diff-afe7ea2226e7ebccca4193c76f7733c88010cbc883d4d86826b6c8cc22342113), pointing to the GitHub README.
> - Changes the npm footer link for the `cmuxlayer` product in [footer.tsx](https://github.com/EtanHey/cmuxlayer/pull/50/files#diff-4b0dd0baaff7f433685c1b0780f168716996a10b221cb119da289b64ade52b26) to point to the GitHub install section instead of the npm package page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75fc030.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->