### PR TITLE
fix: site audit — stale stats, missing tool, SEO

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -22,6 +22,8 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://cmuxlayer.etanheyman.com"),
+  alternates: { canonical: "/" },
   title: "cmuxLayer — Terminal MCP for AI Agents",
   description:
     "MCP server that gives AI agents programmatic control over terminal panes. 22 tools. Split, read, send, automate. One Unix socket.",

--- a/site/components/animated-demo.tsx
+++ b/site/components/animated-demo.tsx
@@ -623,7 +623,7 @@ export function AnimatedDemo() {
     appendOrc("");
     appendOrc(
       grn("\u2501\u2501\u2501 ") +
-        wht("2 agents \u00B7 2 PRs \u00B7 310 tests passing") +
+        wht("2 agents \u00B7 2 PRs \u00B7 326 tests passing") +
         grn(" \u2501\u2501\u2501"),
     );
     setStat(4, 0, "\u2713 complete");

--- a/site/components/stat-strip.tsx
+++ b/site/components/stat-strip.tsx
@@ -2,7 +2,7 @@ const stats = [
   { value: "0.2ms", label: "socket latency" },
   { value: "22", label: "MCP tools" },
   { value: "5", label: "agent CLIs" },
-  { value: "310", label: "tests passing" },
+  { value: "326", label: "tests passing" },
 ];
 
 export function StatStrip() {

--- a/site/components/tools.tsx
+++ b/site/components/tools.tsx
@@ -41,7 +41,7 @@ const coreTools: Tool[] = [
 const agentTools: Tool[] = [
   {
     name: "spawn_agent",
-    desc: "Launch a Claude, Codex, Gemini, or Cursor agent in a new pane",
+    desc: "Launch a Claude, Codex, Gemini, Cursor, or Kiro agent in a new pane",
   },
   {
     name: "send_to_agent",
@@ -74,6 +74,10 @@ const agentTools: Tool[] = [
   {
     name: "kill",
     desc: "Force-kill an unresponsive agent process",
+  },
+  {
+    name: "my_agents",
+    desc: "Get all children of a parent agent with live screen status",
   },
   {
     name: "interact",


### PR DESCRIPTION
## Summary
- Update test count 310 → 326 in stat-strip and animated demo
- Add missing `my_agents` tool to agent lifecycle list (21 → 22 tools shown)
- Add Kiro to `spawn_agent` description (was missing from CLI list)
- Add `metadataBase` + canonical URL for proper SEO meta tag resolution

## Test plan
- [x] `npm run build` passes in `site/`
- [x] Tool count now shows 22 (11 core + 11 agent lifecycle)
- [x] All 5 CLIs mentioned: Claude, Codex, Gemini, Cursor, Kiro

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale test stats, add `my_agents` tool, and set canonical URL on site
> - Updates the displayed test count from 310 to 326 in both [stat-strip.tsx](https://github.com/EtanHey/cmuxlayer/pull/51/files#diff-94b461f79285fd681cb40123c3c4a4eddbda705bcd96a17202d26ffe9d5e1612) and [animated-demo.tsx](https://github.com/EtanHey/cmuxlayer/pull/51/files#diff-ff083799a9ac869a3af228cc044811e1ee2d87966c6b2de41f7a58933d2ff72c).
> - Adds a new `my_agents` tool entry to [tools.tsx](https://github.com/EtanHey/cmuxlayer/pull/51/files#diff-4387c41d322db40a25caeafc0a83a5ac60eaba5ea7d531de2a6ec9d1305b821b) that returns all children of a parent agent with live screen status; also updates the `spawn_agent` description to mention Kiro.
> - Sets `metadataBase` and a canonical URL of `/` in [layout.tsx](https://github.com/EtanHey/cmuxlayer/pull/51/files#diff-b5f0a9f3ed9cd07c1505f2bd1cb33a6b469602b6c7b2ec55a60a365db442c587) to fix SEO metadata resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ae14ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->