### PR TITLE
fix: rename_tab persistence, registry cleanup, sidebar purge

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -74,6 +74,7 @@ interface AgentEngineClient {
     key: string,
     opts?: { workspace?: string },
   ): Promise<void>;
+  clearStatus(key: string, opts?: { workspace?: string }): Promise<void>;
   setProgress(
     value: number,
     opts?: { label?: string; workspace?: string; surface?: string },
@@ -276,6 +277,19 @@ export class AgentEngine {
       }
     }
 
+    // Clean up sidebar entries for agents that were purged from the registry
+    const currentAgentIds = new Set(agents.map((a) => a.agent_id));
+    for (const [agentId] of this.sidebarSnapshot) {
+      if (!currentAgentIds.has(agentId)) {
+        try {
+          await this.client.clearStatus(agentId);
+        } catch {
+          // Best-effort sidebar cleanup
+        }
+        this.sidebarSnapshot.delete(agentId);
+      }
+    }
+
     // Progress bar
     if (total > 0) {
       await this.client.setProgress(done / total, {
@@ -285,10 +299,11 @@ export class AgentEngine {
   }
 
   /**
-   * Public sweep: reconcile registry then sync sidebar.
+   * Public sweep: reconcile registry, purge dead entries, then sync sidebar.
    */
   async runSweep(): Promise<void> {
     await this.registry.reconcile();
+    await this.registry.purgeTerminal();
     await this.syncSidebar();
   }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -124,6 +124,30 @@ export class AgentRegistry {
   }
 
   /**
+   * Purge terminal-state agents (done/error) whose surface no longer exists.
+   * Clears sidebar clutter from dead agents, failed spawns, and orphaned entries.
+   * Agents whose surface is still alive are kept (user may want to inspect output).
+   */
+  async purgeTerminal(): Promise<number> {
+    const surfaces = await this.surfaceProvider();
+    const liveSurfaceRefs = new Set(surfaces.map((s) => s.ref));
+    let purged = 0;
+
+    for (const [id, agent] of this.agents) {
+      if (
+        TERMINAL_STATES.has(agent.state) &&
+        !liveSurfaceRefs.has(agent.surface_id)
+      ) {
+        this.agents.delete(id);
+        this.stateMgr.removeState(id);
+        purged++;
+      }
+    }
+
+    return purged;
+  }
+
+  /**
    * Get direct children of parentId.
    */
   getChildren(parentId: string): AgentRecord[] {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -455,7 +455,9 @@ export class CmuxSocketClient {
     if (opts?.workspace) {
       args.push(this.rawV1Arg("--workspace"), opts.workspace);
     }
-    args.push(this.rawV1Arg("--title"), title);
+    // Title is a positional arg (matching CLI: cmux rename-tab --surface X "title")
+    // NOT a --title flag — the V1 protocol ignores unknown flags silently.
+    args.push(title);
     await this.sendV1Args("rename_tab", args);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -901,6 +901,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       log: (message, eventOpts) => client.log(message, eventOpts),
       setStatus: (key, value, statusOpts) =>
         client.setStatus(key, value, statusOpts),
+      clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
       readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
       send: (surface, text, sendOpts) => client.send(surface, text, sendOpts),
       sendKey: (surface, key, keyOpts) => client.sendKey(surface, key, keyOpts),

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -358,26 +358,25 @@ describe("CmuxSocketClient", () => {
     );
   });
 
-  it("sends --title flag for renameTab V1 command", async () => {
+  it("sends title as positional arg for renameTab V1 command", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 
     await client.renameTab("surface:1", "build logs", {
       workspace: "workspace:1",
     });
 
+    // Title is positional (matching CLI format), NOT a --title flag
     expect(lastV1Command).toBe(
-      `rename_tab --surface surface:1 --workspace workspace:1 --title "build logs"`,
+      `rename_tab --surface surface:1 --workspace workspace:1 "build logs"`,
     );
   });
 
-  it("sends --title flag for renameTab without workspace", async () => {
+  it("sends title as positional arg for renameTab without workspace", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 
     await client.renameTab("surface:1", "agent run");
 
-    expect(lastV1Command).toBe(
-      `rename_tab --surface surface:1 --title "agent run"`,
-    );
+    expect(lastV1Command).toBe(`rename_tab --surface surface:1 "agent run"`);
   });
 });
 

--- a/tests/mcp-quality.test.ts
+++ b/tests/mcp-quality.test.ts
@@ -1,0 +1,307 @@
+/**
+ * MCP Quality Tests — rename_tab persistence, registry cleanup, stale surface refs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import type { CmuxSurface } from "../src/types.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-mcp-quality-test");
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "test-agent-1",
+    surface_id: "surface:42",
+    state: "working",
+    repo: "testrepo",
+    model: "opus",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "test task",
+    pid: 12345,
+    version: 1,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:01:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    ...overrides,
+  };
+}
+
+function makeSurface(ref: string): CmuxSurface {
+  return {
+    ref,
+    title: `Surface ${ref}`,
+    type: "terminal",
+    index: 0,
+    selected: false,
+  };
+}
+
+// ── Issue 1: rename_tab sends title as positional arg, not --title flag ──
+
+describe("rename_tab persistence — socket V1 command format", () => {
+  it("sends title as positional arg matching CLI format", async () => {
+    // The CLI sends: cmux --json rename-tab --surface surface:1 "My Title"
+    // The socket V1 must send: rename_tab --surface surface:1 "My Title"
+    // NOT: rename_tab --surface surface:1 --title "My Title"
+
+    const mockExec: ExecFn = vi
+      .fn()
+      .mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["rename_tab"];
+
+    await tool.handler(
+      { surface: "surface:1", title: "Agent Build" },
+      {} as any,
+    );
+
+    // CLI path: the exec mock captures the args
+    expect(mockExec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "rename-tab",
+      "--surface",
+      "surface:1",
+      "Agent Build",
+    ]);
+
+    // The title should NOT appear as a --title flag
+    const callArgs = (mockExec as any).mock.calls[0][1];
+    expect(callArgs).not.toContain("--title");
+  });
+});
+
+// ── Issue 2: close_surface should clean up agent registry ──
+
+describe("close_surface cleans up agent registry", () => {
+  let stateMgr: StateManager;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    stateMgr = new StateManager(TEST_DIR);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("marks agent as error when its surface is closed", async () => {
+    // Set up agent on surface:42
+    const record = makeRecord({
+      agent_id: "agent-on-closed-surface",
+      surface_id: "surface:42",
+      state: "working",
+    });
+    stateMgr.writeState(record);
+
+    // Surface provider initially returns the surface
+    let liveSurfaces = [makeSurface("surface:42")];
+    const surfaceProvider = async () => liveSurfaces;
+    const registry = new AgentRegistry(stateMgr, surfaceProvider);
+    await registry.reconstitute();
+
+    // Verify agent is working
+    const before = registry.get("agent-on-closed-surface");
+    expect(before?.state).toBe("working");
+
+    // Simulate surface being closed — remove from live surfaces
+    liveSurfaces = [];
+
+    // After reconcile, agent should be marked error
+    await registry.reconcile();
+
+    const after = registry.get("agent-on-closed-surface");
+    expect(after?.state).toBe("error");
+    expect(after?.error).toContain("surface:42");
+  });
+
+  it("purges terminal-state agents from registry after grace period", async () => {
+    // Terminal-state agents (done/error) should not linger forever
+    const doneRecord = makeRecord({
+      agent_id: "done-agent",
+      surface_id: "surface:99",
+      state: "done",
+    });
+    const errorRecord = makeRecord({
+      agent_id: "errored-agent",
+      surface_id: "surface:100",
+      state: "error",
+      error: "surface disappeared",
+    });
+    stateMgr.writeState(doneRecord);
+    stateMgr.writeState(errorRecord);
+
+    const surfaceProvider = async () => [] as CmuxSurface[];
+    const registry = new AgentRegistry(stateMgr, surfaceProvider);
+    await registry.reconstitute();
+
+    // Both should exist initially
+    expect(registry.list()).toHaveLength(2);
+
+    // After purge, terminal-state agents with no live surface should be removed
+    const purged = await registry.purgeTerminal();
+
+    expect(purged).toBe(2);
+    expect(registry.list()).toHaveLength(0);
+    expect(registry.get("done-agent")).toBeNull();
+    expect(registry.get("errored-agent")).toBeNull();
+  });
+
+  it("does NOT purge terminal agents whose surface is still alive", async () => {
+    const doneRecord = makeRecord({
+      agent_id: "done-but-surface-alive",
+      surface_id: "surface:42",
+      state: "done",
+    });
+    stateMgr.writeState(doneRecord);
+
+    const surfaceProvider = async () => [makeSurface("surface:42")];
+    const registry = new AgentRegistry(stateMgr, surfaceProvider);
+    await registry.reconstitute();
+
+    const purged = await registry.purgeTerminal();
+
+    expect(purged).toBe(0);
+    // Should NOT be purged — surface is still alive (user might want to inspect)
+    expect(registry.get("done-but-surface-alive")).not.toBeNull();
+  });
+});
+
+// ── Issue 3: Stale surface refs return clear errors ──
+
+describe("stale surface refs return clear errors", () => {
+  it("returns surface_not_found error for operations on closed surfaces", async () => {
+    // Mock exec that simulates a surface not existing
+    const mockExec: ExecFn = vi.fn().mockImplementation((_cmd, args) => {
+      // list-workspaces returns a workspace
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                id: "ws-1",
+                ref: "workspace:1",
+                title: "WS",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      // list-panes returns empty
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      // list-pane-surfaces returns no surfaces
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [],
+          }),
+          stderr: "",
+        };
+      }
+      // Any operation on a stale surface should fail
+      if (args.includes("read-screen")) {
+        throw Object.assign(new Error("surface not found"), {
+          code: 1,
+          stderr: "surface not found: surface:dead",
+        });
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["read_screen"];
+
+    const result = await tool.handler(
+      { surface: "surface:dead", lines: 50 },
+      {} as any,
+    );
+
+    // Should return an error, not crash
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.ok).toBe(false);
+    // Error message should mention the surface ref clearly
+    expect(parsed.error).toMatch(/surface/i);
+  });
+
+  it("send_input returns clear error for stale surface", async () => {
+    const mockExec: ExecFn = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                id: "ws-1",
+                ref: "workspace:1",
+                title: "WS",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            surfaces: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        throw Object.assign(new Error("surface not found"), {
+          code: 1,
+          stderr: "surface not found: surface:gone",
+        });
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:gone", text: "hello" },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/surface/i);
+  });
+});


### PR DESCRIPTION
## Summary
- **rename_tab persistence**: Socket V1 client was sending title as `--title` flag (silently ignored by cmux daemon). Now sends as positional arg matching CLI format: `rename_tab --surface X "title"`
- **Registry cleanup**: New `purgeTerminal()` on `AgentRegistry` removes done/error agents whose surface no longer exists. Wired into the sweep cycle automatically.
- **Sidebar purge**: Sweep now detects agents removed by purge and calls `clearStatus()` to clean up their sidebar entries. No more dead-agent clutter.

## Test plan
- [x] 332/332 tests passing (6 new in `mcp-quality.test.ts`)
- [x] `bun run typecheck` clean
- [x] Socket rename_tab test updated: title is positional, not `--title` flag
- [x] Registry purge tests: terminal agents purged when surface gone, kept when surface alive
- [x] Stale surface ref tests: operations on dead surfaces return clear error

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `rename_tab` title argument and purge stale agents from registry and sidebar
> - Fixes `CmuxSocketClient.renameTab` to send the tab title as a positional argument instead of a `--title` flag, matching the CLI contract.
> - Adds `AgentRegistry.purgeTerminal` which removes done/error agents whose surfaces no longer exist from both the in-memory registry and on-disk state.
> - Updates `AgentEngine.runSweep` to call `registry.purgeTerminal()` each sweep, and updates `AgentEngine.syncSidebar` to issue `clearStatus` calls for agents no longer in the registry, keeping the sidebar in sync.
> - Behavioral Change: stale terminal-state agents are now automatically removed from registry and sidebar on each sweep rather than accumulating indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57c479e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->