### PR TITLE
feat: agent env vars — MCP_CONNECTION_NONBLOCKING + NO_FLICKER

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -125,6 +125,11 @@ const LIFECYCLE_LOGS = {
  * For other CLIs: uses `cd ~/Gits/<repo> && <cli>` since they
  * don't have launcher functions yet.
  */
+// Env vars for headless/spawned agent sessions:
+// - MCP_CONNECTION_NONBLOCKING: skip MCP connection wait (Claude Code 2.1.90+)
+// - CLAUDE_CODE_NO_FLICKER: stable alt-screen rendering for terminal parsing
+const AGENT_ENV = "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
+
 export function buildLaunchCommand(cli: CliType, repo: string): string {
   const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
   if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {
@@ -134,15 +139,16 @@ export function buildLaunchCommand(cli: CliType, repo: string): string {
   }
   switch (cli) {
     case "claude":
+      // repoGolem launcher handles env vars via ralph-registry
       return `${safeRepo}Claude -s`;
     case "codex":
-      return `cd ~/Gits/${safeRepo} && codex`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} codex`;
     case "gemini":
-      return `cd ~/Gits/${safeRepo} && gemini`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini`;
     case "kiro":
-      return `cd ~/Gits/${safeRepo} && kiro-cli`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli`;
     case "cursor":
-      return `cd ~/Gits/${safeRepo} && cursor agent`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} cursor agent`;
   }
 }
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -475,27 +475,27 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("claude", "golems")).toBe("golemsClaude -s");
   });
 
-  it("uses cd + raw command for codex", () => {
+  it("uses cd + env vars + raw command for codex", () => {
     expect(buildLaunchCommand("codex", "brainlayer")).toBe(
-      "cd ~/Gits/brainlayer && codex",
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex",
     );
   });
 
-  it("uses cd + raw command for gemini", () => {
+  it("uses cd + env vars + raw command for gemini", () => {
     expect(buildLaunchCommand("gemini", "voicelayer")).toBe(
-      "cd ~/Gits/voicelayer && gemini",
+      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini",
     );
   });
 
-  it("uses cd + kiro-cli for kiro", () => {
+  it("uses cd + env vars + kiro-cli for kiro", () => {
     expect(buildLaunchCommand("kiro", "golems")).toBe(
-      "cd ~/Gits/golems && kiro-cli",
+      "cd ~/Gits/golems && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli",
     );
   });
 
-  it("uses cd + cursor agent for cursor", () => {
+  it("uses cd + env vars + cursor agent for cursor", () => {
     expect(buildLaunchCommand("cursor", "cmuxlayer")).toBe(
-      "cd ~/Gits/cmuxlayer && cursor agent",
+      "cd ~/Gits/cmuxlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 cursor agent",
     );
   });
 
@@ -529,5 +529,21 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("claude", "my.project")).toBe(
       "my.projectClaude -s",
     );
+  });
+
+  it("includes CLAUDE_CODE_NO_FLICKER=1 for non-Claude CLIs", () => {
+    const cmd = buildLaunchCommand("codex", "brainlayer");
+    expect(cmd).toContain("CLAUDE_CODE_NO_FLICKER=1");
+  });
+
+  it("includes MCP_CONNECTION_NONBLOCKING=1 for non-Claude CLIs", () => {
+    const cmd = buildLaunchCommand("gemini", "voicelayer");
+    expect(cmd).toContain("MCP_CONNECTION_NONBLOCKING=1");
+  });
+
+  it("does NOT include env vars for claude (launcher handles them)", () => {
+    const cmd = buildLaunchCommand("claude", "brainlayer");
+    expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
+    expect(cmd).not.toContain("CLAUDE_CODE_NO_FLICKER");
   });
 });


### PR DESCRIPTION
## Summary
- Non-Claude CLI agents (codex, gemini, kiro, cursor) now launch with `MCP_CONNECTION_NONBLOCKING=1` and `CLAUDE_CODE_NO_FLICKER=1`
- Claude agents use repoGolem launchers which handle env vars via ralph-registry (also updated locally)
- `MCP_CONNECTION_NONBLOCKING`: skips MCP connection wait in headless mode (Claude Code 2.1.90+)
- `CLAUDE_CODE_NO_FLICKER`: stable alt-screen rendering, improves `read_screen` parsing reliability

## Test plan
- [x] 335/335 tests passing (3 new env var assertions)
- [x] `bun run typecheck` clean
- [x] Claude launcher does NOT include env vars (repoGolem handles them)
- [x] All 4 non-Claude CLIs include both env vars
- [x] Ralph launcher updated locally (`~/.config/ralphtools/lib/ralph-registry.zsh`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inject `MCP_CONNECTION_NONBLOCKING` and `CLAUDE_CODE_NO_FLICKER` env vars for non-claude CLIs
> Adds an `AGENT_ENV` constant in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/53/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) and prepends it to the shell command built by `buildLaunchCommand` for codex, gemini, kiro, and cursor. The claude branch is unchanged, as its launcher handles env vars separately. Tests are updated to assert the env vars are present for non-claude commands and absent for claude.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e704624.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable configuration for non-Claude agent engines (codex, gemini, kiro, cursor).
  * Expanded test coverage to verify environment configuration is correctly applied across agent engine types, with explicit verification that Claude engine behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->