### PR TITLE
feat: hero rewrite + comparison section (R62 differentiation)

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,6 +1,7 @@
 import { Nav } from "@/components/shared/nav";
 import { Hero } from "@/components/hero";
 import { StatStrip } from "@/components/stat-strip";
+import { Comparison } from "@/components/comparison";
 import { Terminal } from "@/components/terminal";
 import { Pipeline } from "@/components/pipeline";
 import { Tools } from "@/components/tools";
@@ -25,6 +26,8 @@ export default function Home() {
       />
       <Hero />
       <StatStrip />
+      <Divider />
+      <Comparison />
       <Divider />
       <Terminal />
       <Divider />

--- a/site/components/comparison.tsx
+++ b/site/components/comparison.tsx
@@ -1,0 +1,125 @@
+const withoutItems = [
+  "Alt-tab between 5 terminal windows",
+  "Copy-paste output from one agent to another",
+  "Manually check if each agent finished",
+  "One agent at a time, sequential work",
+  "~142ms per CLI subprocess call",
+];
+
+const withItems = [
+  "All agents visible in one split workspace",
+  "One agent reads another's screen directly",
+  "Auto-monitor with parsed status and done signals",
+  "Parallel multi-agent orchestration",
+  "0.1ms persistent socket (1,423x faster)",
+];
+
+function XIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className="shrink-0 mt-[3px]"
+    >
+      <path d="M3 3l8 8M11 3l-8 8" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0 mt-[3px]"
+    >
+      <path d="M2.5 7.5l3 3 6-6" />
+    </svg>
+  );
+}
+
+export function Comparison() {
+  return (
+    <section className="py-[100px]">
+      <div className="max-w-[960px] mx-auto px-6">
+        <div className="text-[11px] uppercase tracking-[0.12em] text-accent mb-3 text-center font-medium">
+          The status quo
+        </div>
+        <h2 className="font-display text-[clamp(26px,3.5vw,36px)] font-semibold tracking-[-0.025em] text-center mb-4 leading-[1.15]">
+          You are the bottleneck
+        </h2>
+        <p className="text-[15px] text-text-secondary text-center max-w-[520px] mx-auto mb-14 font-light leading-[1.6]">
+          Four AI agents in four terminals. You&apos;re the message bus, the
+          clipboard, and the status checker. That&apos;s not orchestration
+          &mdash; that&apos;s overhead.
+        </p>
+
+        <div className="grid grid-cols-2 gap-4 max-w-[780px] mx-auto max-md:grid-cols-1">
+          {/* WITHOUT */}
+          <div className="rounded-xl border border-border bg-bg-card p-6">
+            <div className="flex items-center gap-2 mb-5">
+              <span className="text-xs font-mono uppercase tracking-[0.1em] text-red font-medium">
+                Without cmuxLayer
+              </span>
+            </div>
+            <div className="flex flex-col gap-3.5">
+              {withoutItems.map((item) => (
+                <div key={item} className="flex items-start gap-3">
+                  <span className="text-red">
+                    <XIcon />
+                  </span>
+                  <span className="text-[13.5px] text-text-secondary font-light leading-[1.5]">
+                    {item}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* WITH */}
+          <div
+            className="rounded-xl border border-accent/20 p-6"
+            style={{
+              background:
+                "linear-gradient(135deg, rgba(34,197,94,0.04) 0%, rgba(9,9,11,1) 100%)",
+            }}
+          >
+            <div className="flex items-center gap-2 mb-5">
+              <span className="text-xs font-mono uppercase tracking-[0.1em] text-accent font-medium">
+                With cmuxLayer
+              </span>
+            </div>
+            <div className="flex flex-col gap-3.5">
+              {withItems.map((item) => (
+                <div key={item} className="flex items-start gap-3">
+                  <span className="text-accent">
+                    <CheckIcon />
+                  </span>
+                  <span className="text-[13.5px] text-text font-light leading-[1.5]">
+                    {item}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <p className="text-[13px] text-text-dim text-center mt-8 max-w-[480px] mx-auto font-light leading-[1.6]">
+          Use raw tmux if you run a single agent in a single session. Use
+          cmuxLayer when you need agents to see each other&apos;s work.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/site/components/hero.tsx
+++ b/site/components/hero.tsx
@@ -6,7 +6,7 @@ export function Hero() {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText("npm install cmuxlayer").then(() => {
+    navigator.clipboard.writeText("npm install -g cmuxlayer").then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -55,14 +55,20 @@ export function Hero() {
 
       <div className="max-w-[960px] mx-auto px-6">
         <h1 className="font-display text-[clamp(40px,6vw,68px)] font-bold tracking-[-0.035em] leading-[1.08] mb-6 max-w-[700px] mx-auto relative hero-fade">
-          Your agents can&apos;t touch
+          One terminal.
           <br />
-          the terminal. <em className="italic text-accent">Fix that.</em>
+          <em className="italic text-accent">Many agents.</em>
         </h1>
 
-        <p className="text-[17px] text-text-secondary max-w-[500px] mx-auto mb-10 leading-[1.65] font-light relative hero-fade hero-fade-d1">
-          MCP server that gives AI agents programmatic control over terminal
-          panes. Split, read, send, automate &mdash; through one Unix socket.
+        <p className="text-[17px] text-text-secondary max-w-[540px] mx-auto mb-4 leading-[1.65] font-light relative hero-fade hero-fade-d1">
+          Claude Code in one tab, Codex in another, Gemini in a third &mdash;
+          and you&apos;re the message bus between them. cmuxLayer gives AI
+          agents programmatic control over terminal workspaces. Spawn, monitor,
+          coordinate &mdash; all through MCP.
+        </p>
+
+        <p className="text-[13px] text-text-dim mb-10 relative hero-fade hero-fade-d1">
+          free &middot; open source &middot; 22 MCP tools
         </p>
 
         <div className="flex items-center justify-center gap-3 mb-12 relative hero-fade hero-fade-d2 max-[480px]:flex-col">
@@ -89,7 +95,7 @@ export function Hero() {
             onClick={handleCopy}
           >
             <code className="text-text flex-1">
-              <span className="text-text-dim">$</span> npm install cmuxlayer
+              <span className="text-text-dim">$</span> npm install -g cmuxlayer
             </code>
             <button
               className="bg-transparent border-none text-text-dim cursor-pointer p-0 transition-colors duration-200 flex items-center justify-center w-6 h-6 shrink-0 hover:text-accent"


### PR DESCRIPTION
## Summary
- **Hero rewrite**: "One terminal. Many agents." — emotional hook replacing technical opener. User is positioned as the bottleneck. Added "free · open source · 22 MCP tools" proof line. Install command: `npm install -g cmuxlayer`
- **With vs Without comparison**: Side-by-side cards inspired by lawn.video's "THE RIVAL" pattern. Makes manual terminal management feel absurd next to programmatic orchestration
- Honest advice footer: "Use raw tmux for single agents. Use cmuxLayer when agents need to see each other's work."

## What changed
| Before | After |
|--------|-------|
| "Your agents can't touch the terminal. Fix that." | "One terminal. Many agents." |
| Technical subhead about MCP/socket | "You're the message bus between them" |
| `npm install cmuxlayer` | `npm install -g cmuxlayer` + "free · open source · 22 MCP tools" |
| No comparison section | Full With vs Without section between StatStrip and Terminal |

## Test plan
- [x] `npm run build` passes in `site/`
- [x] Comparison section renders with 5 items per column
- [x] Mobile responsive (stacks to single column)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hero rewrite and comparison section to home page for R62 differentiation
> - Updates the [Hero component](https://github.com/EtanHey/cmuxlayer/pull/54/files#diff-69ecd1572a65d28023e5232fe92903934f6d2f0b256e8381a2e7c24b04b20d4c) headline to 'One terminal. Many agents.', changes the copy command to `npm install -g cmuxlayer`, and adds a subtext line 'free · open source · 22 MCP tools'.
> - Adds a new [Comparison component](https://github.com/EtanHey/cmuxlayer/pull/54/files#diff-09bfb467bf237be5dcde40db53146b694f8e46a84220a4c4f4115df93ef2b2ef) with side-by-side lists contrasting workflows with and without cmuxLayer, using inline checkmark and X SVG icons.
> - Inserts the Comparison section between StatStrip and Terminal on the [home page](https://github.com/EtanHey/cmuxlayer/pull/54/files#diff-afe7ea2226e7ebccca4193c76f7733c88010cbc883d4d86826b6c8cc22342113), wrapped in dividers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9901673.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->