### PR TITLE
feat: ecosystem cross-linking — Golems badge, footer, cross-sell

### DIFF
--- a/site/components/cta.tsx
+++ b/site/components/cta.tsx
@@ -2,6 +2,18 @@ export function Cta() {
   return (
     <section className="py-[100px] pb-20 text-center">
       <div className="max-w-[960px] mx-auto px-6">
+        {/* Contextual cross-sell */}
+        <p className="text-[13px] text-text-dim mb-12 font-light">
+          Pair with{" "}
+          <a
+            href="https://brainlayer.etanheyman.com"
+            className="text-[#d4956a] no-underline hover:underline"
+          >
+            BrainLayer
+          </a>{" "}
+          to give orchestrated agents persistent memory across sessions.
+        </p>
+
         <h2 className="font-display text-[clamp(26px,4vw,42px)] font-semibold tracking-[-0.03em] mb-3">
           Stop being the clipboard.
         </h2>

--- a/site/components/shared/footer.tsx
+++ b/site/components/shared/footer.tsx
@@ -1,23 +1,69 @@
 type Product = "brainlayer" | "voicelayer" | "cmuxlayer";
 
-const SIBLING_LINKS: Record<Product, { label: string; href: string }[]> = {
+interface EcosystemProduct {
+  name: string;
+  tagline: string;
+  href: string;
+  accent: string;
+}
+
+const ECOSYSTEM: Record<Product, EcosystemProduct[]> = {
+  cmuxlayer: [
+    {
+      name: "BrainLayer",
+      tagline: "Persistent memory for AI agents",
+      href: "https://brainlayer.etanheyman.com",
+      accent: "#d4956a",
+    },
+    {
+      name: "VoiceLayer",
+      tagline: "Voice I/O for AI agents",
+      href: "https://voicelayer.etanheyman.com",
+      accent: "#38BDF8",
+    },
+  ],
+  voicelayer: [
+    {
+      name: "BrainLayer",
+      tagline: "Persistent memory for AI agents",
+      href: "https://brainlayer.etanheyman.com",
+      accent: "#d4956a",
+    },
+    {
+      name: "cmuxLayer",
+      tagline: "Agent orchestration across terminals",
+      href: "https://cmuxlayer.etanheyman.com",
+      accent: "#22c55e",
+    },
+  ],
+  brainlayer: [
+    {
+      name: "VoiceLayer",
+      tagline: "Voice I/O for AI agents",
+      href: "https://voicelayer.etanheyman.com",
+      accent: "#38BDF8",
+    },
+    {
+      name: "cmuxLayer",
+      tagline: "Agent orchestration across terminals",
+      href: "https://cmuxlayer.etanheyman.com",
+      accent: "#22c55e",
+    },
+  ],
+};
+
+const PRODUCT_LINKS: Record<Product, { label: string; href: string }[]> = {
   cmuxlayer: [
     { label: "GitHub", href: "https://github.com/EtanHey/cmuxlayer" },
     { label: "npm", href: "https://github.com/EtanHey/cmuxlayer#install" },
-    { label: "VoiceLayer", href: "https://voicelayer.etanheyman.com" },
-    { label: "BrainLayer", href: "https://brainlayer.etanheyman.com" },
   ],
   voicelayer: [
     { label: "GitHub", href: "https://github.com/EtanHey/voicelayer" },
     { label: "npm", href: "https://npmjs.com/package/voicelayer-mcp" },
-    { label: "cmuxLayer", href: "https://cmuxlayer.etanheyman.com" },
-    { label: "BrainLayer", href: "https://brainlayer.etanheyman.com" },
   ],
   brainlayer: [
     { label: "GitHub", href: "https://github.com/EtanHey/brainlayer" },
     { label: "PyPI", href: "https://pypi.org/project/brainlayer/" },
-    { label: "cmuxLayer", href: "https://cmuxlayer.etanheyman.com" },
-    { label: "VoiceLayer", href: "https://voicelayer.etanheyman.com" },
   ],
 };
 
@@ -26,30 +72,63 @@ interface FooterProps {
 }
 
 export function Footer({ product }: FooterProps) {
-  const links = SIBLING_LINKS[product];
+  const siblings = ECOSYSTEM[product];
+  const links = PRODUCT_LINKS[product];
 
   return (
-    <footer className="py-8 border-t border-border">
-      <div className="max-w-[960px] mx-auto px-6 flex items-center justify-between max-md:flex-col max-md:gap-3">
-        <div className="text-[13px] text-text-dim font-light">
-          Built by{" "}
-          <a
-            href="https://etanheyman.com"
-            className="text-text-secondary no-underline hover:text-accent transition-colors"
-          >
-            Etan Heyman
-          </a>
+    <footer className="border-t border-border">
+      {/* Ecosystem section */}
+      <div className="max-w-[960px] mx-auto px-6 py-10">
+        <div className="text-[11px] uppercase tracking-[0.1em] text-text-dim mb-5 font-medium text-center">
+          Golems Ecosystem
         </div>
-        <div className="flex gap-5">
-          {links.map((link) => (
+        <div className="flex justify-center gap-8 max-md:flex-col max-md:items-center max-md:gap-4">
+          {siblings.map((sib) => (
             <a
-              key={link.href}
-              href={link.href}
-              className="text-[13px] text-text-dim no-underline hover:text-text-secondary transition-colors"
+              key={sib.href}
+              href={sib.href}
+              className="group flex flex-col items-center gap-1 no-underline"
             >
-              {link.label}
+              <span
+                className="text-sm font-medium transition-colors"
+                style={{ color: sib.accent }}
+              >
+                {sib.name}
+              </span>
+              <span className="text-[12px] text-text-dim group-hover:text-text-secondary transition-colors">
+                {sib.tagline}
+              </span>
             </a>
           ))}
+        </div>
+        <p className="text-[12px] text-text-dim text-center mt-6 font-light">
+          Three open-source MCP servers. One agent toolkit.
+        </p>
+      </div>
+
+      {/* Bottom bar */}
+      <div className="border-t border-border">
+        <div className="max-w-[960px] mx-auto px-6 py-5 flex items-center justify-between max-md:flex-col max-md:gap-3">
+          <div className="text-[13px] text-text-dim font-light">
+            Built by{" "}
+            <a
+              href="https://etanheyman.com"
+              className="text-text-secondary no-underline hover:text-accent transition-colors"
+            >
+              Etan Heyman
+            </a>
+          </div>
+          <div className="flex gap-5">
+            {links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="text-[13px] text-text-dim no-underline hover:text-text-secondary transition-colors"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </footer>

--- a/site/components/shared/nav.tsx
+++ b/site/components/shared/nav.tsx
@@ -51,15 +51,24 @@ export function Nav({ product, links = [] }: NavProps) {
       style={{ background: "rgba(9, 9, 11, 0.8)" }}
     >
       <div className="max-w-[960px] mx-auto px-6 flex items-center justify-between">
-        <a
-          href="#"
-          className="font-mono font-medium text-[15px] tracking-tight opacity-90 hover:opacity-100 transition-opacity no-underline text-text"
-        >
-          <span style={{ color: current.accent }}>
-            {product === "cmuxlayer" ? "cmux" : current.label.slice(0, -5)}
-          </span>
-          Layer
-        </a>
+        <div className="flex items-center gap-3">
+          <a
+            href="#"
+            className="font-mono font-medium text-[15px] tracking-tight opacity-90 hover:opacity-100 transition-opacity no-underline text-text"
+          >
+            <span style={{ color: current.accent }}>
+              {product === "cmuxlayer" ? "cmux" : current.label.slice(0, -5)}
+            </span>
+            Layer
+          </a>
+          <a
+            href="https://etanheyman.com"
+            className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] text-text-dim no-underline border border-border hover:border-border-hover hover:text-text-secondary transition-colors"
+          >
+            Part of Golems
+            <span className="text-[10px]">&#8599;</span>
+          </a>
+        </div>
 
         <div className="flex items-center gap-6">
           {links.map((link) => (


### PR DESCRIPTION
## Summary
- **Nav badge**: "Part of Golems" pill next to logo, links to etanheyman.com (hidden on mobile)
- **Footer ecosystem section**: Sibling products with taglines and accent colors. "Three open-source MCP servers. One agent toolkit."
- **Contextual cross-sell**: "Pair with BrainLayer for persistent agent memory across sessions" above CTA

## Test plan
- [x] `npm run build` passes
- [x] Badge renders on desktop, hidden on mobile (`hidden sm:inline-flex`)
- [x] Footer shows BrainLayer + VoiceLayer with correct accent colors
- [x] Cross-sell link goes to brainlayer.etanheyman.com

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Golems ecosystem cross-linking via nav badge, footer section, and CTA cross-sell
> - [nav.tsx](https://github.com/EtanHey/cmuxlayer/pull/55/files#diff-4ebe63145d5d71c42f79ba8ec40b5aa0c1f874d2dd742c73df55e43741653190) adds a 'Part of Golems' pill link next to the brand logo, visible on sm+ screens.
> - [footer.tsx](https://github.com/EtanHey/cmuxlayer/pull/55/files#diff-4b0dd0baaff7f433685c1b0780f168716996a10b221cb119da289b64ade52b26) adds a 'Golems Ecosystem' section displaying sibling products (cmuxlayer, voicelayer, brainlayer) with colored accents and taglines; product links (GitHub, npm/PyPI) move to a bottom bar.
> - [cta.tsx](https://github.com/EtanHey/cmuxlayer/pull/55/files#diff-cdb4e62cfff19221a2b54a4d8e19739176432b143e9297145f49522d9bb31a16) adds a cross-sell line linking to BrainLayer above the main CTA headline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58f124f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->