### PR TITLE
feat: README quality audit — problem-first hook, annotation grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,23 @@
-# cmuxlayer
+# cmuxLayer
 
-> Terminal multiplexer MCP — multi-agent workspace orchestration for [cmux](https://github.com/manaflow-ai/cmux).
+**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 22 MCP tools that give AI agents programmatic control over terminal workspaces.
 
 <p align="center">
-  <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxlayer Split Pane Grid logo" width="96" height="96" />
+  <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
 </p>
 
+[![npm](https://img.shields.io/npm/v/cmuxlayer?color=22c55e)](https://www.npmjs.com/package/cmuxlayer)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-326%20passing-brightgreen.svg)](#testing)
-[![MCP](https://img.shields.io/badge/MCP-22%20tools-green.svg)](https://modelcontextprotocol.io)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
+[![MCP Tools](https://img.shields.io/badge/MCP-22%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-335%20passing-brightgreen.svg)](#testing)
 
----
-
-**326 tests** · **1,423x socket speedup** · **Native MCP in cmux Swift fork** · **22 MCP tools** · **Agent lifecycle engine**
-
-cmuxlayer gives AI agents programmatic control over terminal workspaces via MCP. Spawn split panes, send commands, read screen output, manage agent lifecycles — all through typed MCP tools that any MCP-compatible AI client can use.
-
-`read_screen` returns raw terminal text alongside structured parsed agent metadata for common CLI agents including Claude, Codex, and Gemini. That makes status checks, done-signal detection, token counting, and model extraction available directly through MCP without forcing each client to re-parse terminal output.
-
-## Install
+## Quick Start
 
 ```bash
 npm install -g cmuxlayer
 ```
 
-Or from source:
-
-```bash
-git clone https://github.com/EtanHey/cmuxlayer.git && cd cmuxlayer
-npm install && npm run build
-```
-
-## Quick Start
-
-Add to your editor's MCP config (Claude Code `settings.json`, VS Code, Cursor, etc.):
+Add to your MCP config (Claude Code, Cursor, VS Code, etc.):
 
 ```json
 {
@@ -46,123 +29,87 @@ Add to your editor's MCP config (Claude Code `settings.json`, VS Code, Cursor, e
 }
 ```
 
-Or with a local build:
+Requires [cmux](https://github.com/manaflow-ai/cmux) to be running.
 
-```json
-{
-  "mcpServers": {
-    "cmux": {
-      "command": "node",
-      "args": ["/path/to/cmuxlayer/dist/index.js"]
-    }
-  }
-}
-```
+## What it does
 
-Requires [cmux](https://github.com/manaflow-ai/cmux) to be installed and running.
-
-## Claude Channels Preview
-
-Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` in the server environment and launch Claude Code with `--channels <server-name>` plus `--dangerously-load-development-channels <server-name>` during preview. With that enabled, cmuxlayer advertises `experimental["claude/channel"]` and emits one-way `notifications/claude/channel` updates when tracked agents are spawned, finish, or error.
-
-See [docs/claude-channels-mobile.md](docs/claude-channels-mobile.md) for the notification format, OpenClaw pairing patterns worth stealing, and the remaining gaps for a real cmux mobile client.
+Spawn split panes, send commands, read screen output, and manage agent lifecycles — all through typed MCP tools. `read_screen` returns raw terminal text alongside parsed agent metadata (status, model, tokens, context %, done signals) for Claude Code, Codex, Gemini, Cursor, and Kiro.
 
 ## MCP Tools (22)
 
-All 22 tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) (`readOnlyHint`, `destructiveHint`, `idempotentHint`) so MCP clients can enforce safety policies automatically.
+All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) so MCP clients can enforce safety policies automatically.
 
-### Core (11)
+### Read-only (5)
 
-| Tool | Annotation | Description |
-|------|------------|-------------|
-| `list_surfaces` | readOnly | List all surfaces across workspaces |
-| `new_split` | mutating | Create a new split pane (terminal or browser) |
-| `send_input` | mutating | Send text to a terminal surface (with optional enter/rename) |
-| `send_key` | mutating | Send a key press to a surface |
-| `read_screen` | readOnly | Read raw screen text plus parsed agent state from a surface |
-| `rename_tab` | mutating | Rename a surface tab (with optional prefix preservation) |
-| `notify` | mutating | Show a cmux notification banner |
-| `set_status` | mutating | Set sidebar status key-value pair |
-| `set_progress` | mutating | Set sidebar progress indicator (0.0-1.0) |
-| `close_surface` | destructive | Close a surface |
-| `browser_surface` | mutating | Interact with browser surfaces |
+| Tool | Description |
+|------|-------------|
+| `list_surfaces` | List all surfaces across workspaces |
+| `read_screen` | Read terminal screen with parsed agent status |
+| `get_agent_state` | Get full state of a tracked agent |
+| `list_agents` | List all agents with optional filters |
+| `my_agents` | Get children of a parent agent with live screen status |
+| `read_agent_output` | Extract structured output between delimiter markers |
 
-### Agent Lifecycle (11)
+### Mutating (13)
 
-| Tool | Annotation | Description |
-|------|------------|-------------|
-| `spawn_agent` | mutating | Spawn a CLI agent in a new or existing surface |
-| `send_to_agent` | mutating | Send a prompt or message to a running agent |
-| `read_agent_output` | readOnly | Read recent output from an agent's surface |
-| `get_agent_state` | readOnly | Get current state of a tracked agent |
-| `list_agents` | readOnly | List all tracked agents and their states |
-| `my_agents` | readOnly | Get all children of a parent agent with live screen status |
-| `wait_for` | mutating | Wait for an agent to reach a target state (with timeout) |
-| `wait_for_all` | mutating | Wait for multiple agents to reach target states |
-| `stop_agent` | destructive | Gracefully stop a running agent |
-| `kill` | destructive | Force-kill one or more agent processes |
-| `interact` | mutating | Send interactive input (confirm, cancel, etc.) to an agent |
+| Tool | Description |
+|------|-------------|
+| `new_split` | Create a new terminal or browser split pane |
+| `send_input` | Send text input to a terminal surface |
+| `send_key` | Send key press (return, escape, ctrl-c, etc.) |
+| `rename_tab` | Rename a surface tab |
+| `notify` | Show a cmux notification banner |
+| `set_status` | Set sidebar status key-value pair |
+| `set_progress` | Set sidebar progress indicator (0.0-1.0) |
+| `browser_surface` | Interact with browser surfaces (navigate, click, eval) |
+| `spawn_agent` | Spawn a CLI agent in a new pane |
+| `send_to_agent` | Send a prompt or message to a running agent |
+| `wait_for` | Block until an agent reaches a target state |
+| `wait_for_all` | Block until multiple agents finish |
+| `interact` | Send interactive input (confirm, cancel, skill, resume) |
+
+### Destructive (3)
+
+| Tool | Description |
+|------|-------------|
+| `close_surface` | Close a terminal or browser pane |
+| `stop_agent` | Gracefully stop a running agent |
+| `kill` | Force-kill one or more agent processes |
+
+## Supported Agents
+
+| CLI | Command |
+|-----|---------|
+| Claude Code | `claude` |
+| Codex | `codex` |
+| Gemini CLI | `gemini` |
+| Cursor | `cursor agent` |
+| Kiro | `kiro-cli` |
+
+`read_screen` auto-detects agent type and parses status, model, token count, and context percentage from terminal output.
 
 ## Architecture
 
 ```
-AI Agent  ─── MCP ───>  cmuxlayer
-                         ├── Persistent socket connection (1,423x faster than CLI)
-                         ├── Agent lifecycle engine (spawn, monitor, teardown)
+AI Agent  ─── MCP ───>  cmuxLayer
+                         ├── Persistent Unix socket (0.1ms, 1,423x faster than CLI)
+                         ├── Agent lifecycle engine (spawn → monitor → teardown)
+                         ├── Screen parser (auto-detect Claude/Codex/Gemini/Cursor/Kiro)
                          ├── Mode policy (autonomous vs manual control)
-                         ├── Event log + state manager
-                         └── Pattern registry for naming conventions
+                         └── State manager + event log
 ```
 
-### Key Components
+The socket client connects to cmux via Unix socket at the path from `cmux socket-path`. Auto-reconnects on disconnect, falls back to CLI subprocess if socket is unavailable.
 
-| File | Role |
-|------|------|
-| `cmux-socket-client.ts` | Persistent Unix socket connection to cmux (1,423x speedup over CLI) |
-| `cmux-client.ts` | CLI wrapper fallback |
-| `server.ts` | MCP tool registration and handlers |
-| `agent-engine.ts` | Agent lifecycle — spawn, monitor, quality tracking |
-| `agent-registry.ts` | Registry of active agents across surfaces |
-| `naming.ts` | Surface naming rules (launcher prefix preservation) |
-| `mode-policy.ts` | Mode enforcement (autonomous = full access, manual = read-only) |
-| `state-manager.ts` | Sidebar state synchronization |
-| `screen-parser.ts` | Parse terminal output to extract agent type, model, token count, context % |
-| `event-log.ts` | Audit trail for all agent actions |
-| `pattern-registry.ts` | Reusable patterns for common workflows |
-
-## Mode Model
-
-Two axes per surface:
-
-- **control**: `autonomous` (full access) or `manual` (read-only for mutating tools)
-- **intent**: `chat` or `audit`
-
-Set via `set_status` with reserved keys `mode.control` / `mode.intent`.
-
-## Socket Performance
-
-cmuxlayer connects to cmux via a persistent Unix socket instead of spawning CLI subprocesses:
-
-| Method | Latency | Throughput |
-|--------|---------|------------|
-| CLI subprocess | ~142ms | Baseline |
-| Persistent socket | ~0.1ms | **1,423x faster** |
-
-The socket client auto-reconnects on disconnect and falls back to CLI if the socket is unavailable.
-
-## Upstream Contributions
-
-cmuxlayer development has contributed back to cmux:
-
-| PR | Status | What |
-|----|--------|------|
-| [#1522](https://github.com/manaflow-ai/cmux/pull/1522) | Open | Fix: background workspace PTY initialization |
-| [#1562](https://github.com/manaflow-ai/cmux/pull/1562) | Open | Fix: thread starvation in MCP server |
+| Method | Latency |
+|--------|---------|
+| CLI subprocess | ~142ms |
+| Persistent socket | ~0.1ms (**1,423x faster**) |
 
 ## Testing
 
 ```bash
-npm test            # 326 tests via vitest
+npm test            # 335 tests via vitest
 npm run typecheck   # Type checking
 ```
 
@@ -185,4 +132,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-Part of the [Golems](https://github.com/EtanHey/golems) AI agent ecosystem. Built by [@EtanHey](https://github.com/EtanHey).
+Part of the [Golems](https://github.com/EtanHey/golems) AI agent ecosystem. [cmuxlayer.etanheyman.com](https://cmuxlayer.etanheyman.com) | Built by [@EtanHey](https://github.com/EtanHey).


### PR DESCRIPTION
## Summary
- **Problem-first hook**: "Your AI agents can't see each other's terminals"
- **npm badge** added alongside license, MCP tools, tests (335)
- **Tools regrouped** by ToolAnnotation type: read-only (6), mutating (13), destructive (3)
- **Supported agents table**: Claude Code, Codex, Gemini, Cursor, Kiro with CLI commands
- **Trimmed**: removed Claude Channels Preview, Mode Model, Key Components file list (docs-level detail)
- **Added**: site link (cmuxlayer.etanheyman.com), simplified architecture diagram

Net: 126 lines removed, 73 added. Cleaner, scannable, benefit-driven.

## Test plan
- [x] README renders correctly on GitHub
- [x] All links valid (cmuxlayer.etanheyman.com, MCP spec, cmux, golems)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite README with problem-first hook, grouped tool annotations, and updated architecture narrative
> - Revises [README.md](https://github.com/EtanHey/cmuxlayer/pull/57/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a new tagline focused on multi-agent terminal orchestration and removes the long marketing stats line
> - Restructures the 22 tools into Read-only, Mutating, and Destructive categories with updated descriptions
> - Adds a Supported Agents section covering auto-detection details
> - Updates the architecture section to document Unix socket path resolution via `cmux socket-path`, auto-reconnect, and CLI fallback; consolidates performance notes into a latency table
> - Removes the Claude Channels Preview and Mode Model sections; simplifies Quick Start to remove from-source and local build examples
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcc3e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->