### PR TITLE
fix: site bugfixes — step 2 overflow, npm 404, footer standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
 </p>
 
-[![npm](https://img.shields.io/npm/v/cmuxlayer?color=22c55e)](https://www.npmjs.com/package/cmuxlayer)
+[![install](https://img.shields.io/badge/install-npm%20install%20--g%20cmuxlayer-22c55e)](https://github.com/EtanHey/cmuxlayer#quick-start)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![MCP Tools](https://img.shields.io/badge/MCP-22%20tools-green.svg)](https://modelcontextprotocol.io)
 [![Tests](https://img.shields.io/badge/tests-335%20passing-brightgreen.svg)](#testing)

--- a/site/components/integrations.tsx
+++ b/site/components/integrations.tsx
@@ -85,7 +85,7 @@ function SetupCard({ step }: { step: SetupStep }) {
           className="flex items-center gap-2 bg-bg-card border border-border rounded-[6px] overflow-hidden whitespace-nowrap px-3 py-2 font-mono text-xs text-text cursor-pointer transition-[border-color] duration-200 hover:border-accent"
           onClick={handleCopy}
         >
-          <span className="flex-1">{step.code}</span>
+          <span className="flex-1 min-w-0 truncate">{step.code}</span>
           <span className="text-text-dim transition-colors duration-200 shrink-0 flex items-center justify-center hover:text-accent">
             {copied ? (
               <span className="text-[11px] text-accent font-mono">copied</span>
@@ -96,7 +96,9 @@ function SetupCard({ step }: { step: SetupStep }) {
         </div>
       ) : (
         <div className="flex items-center gap-2 bg-bg-card border border-border rounded-[6px] overflow-hidden whitespace-nowrap px-3 py-2 font-mono text-xs cursor-default">
-          <span className="flex-1 text-accent">It just works.</span>
+          <span className="flex-1 min-w-0 truncate text-accent">
+            It just works.
+          </span>
         </div>
       )}
     </div>

--- a/site/components/shared/footer.tsx
+++ b/site/components/shared/footer.tsx
@@ -135,7 +135,7 @@ export function Footer({ product }: FooterProps) {
                 href={link.href}
                 {...(link.external && {
                   target: "_blank",
-                  rel: "noopener",
+                  rel: "noopener noreferrer",
                 })}
                 className="text-[13px] text-text-dim no-underline hover:text-text-secondary transition-colors"
               >

--- a/site/components/shared/footer.tsx
+++ b/site/components/shared/footer.tsx
@@ -1,69 +1,78 @@
 type Product = "brainlayer" | "voicelayer" | "cmuxlayer";
 
-interface EcosystemProduct {
+interface EcoProduct {
   name: string;
-  tagline: string;
+  desc: string;
   href: string;
-  accent: string;
 }
 
-const ECOSYSTEM: Record<Product, EcosystemProduct[]> = {
-  cmuxlayer: [
-    {
-      name: "BrainLayer",
-      tagline: "Persistent memory for AI agents",
-      href: "https://brainlayer.etanheyman.com",
-      accent: "#d4956a",
-    },
-    {
-      name: "VoiceLayer",
-      tagline: "Voice I/O for AI agents",
-      href: "https://voicelayer.etanheyman.com",
-      accent: "#38BDF8",
-    },
-  ],
-  voicelayer: [
-    {
-      name: "BrainLayer",
-      tagline: "Persistent memory for AI agents",
-      href: "https://brainlayer.etanheyman.com",
-      accent: "#d4956a",
-    },
-    {
-      name: "cmuxLayer",
-      tagline: "Agent orchestration across terminals",
-      href: "https://cmuxlayer.etanheyman.com",
-      accent: "#22c55e",
-    },
-  ],
-  brainlayer: [
-    {
-      name: "VoiceLayer",
-      tagline: "Voice I/O for AI agents",
-      href: "https://voicelayer.etanheyman.com",
-      accent: "#38BDF8",
-    },
-    {
-      name: "cmuxLayer",
-      tagline: "Agent orchestration across terminals",
-      href: "https://cmuxlayer.etanheyman.com",
-      accent: "#22c55e",
-    },
-  ],
-};
+const ECOSYSTEM: EcoProduct[] = [
+  {
+    name: "BrainLayer",
+    desc: "Persistent memory for AI agents",
+    href: "https://brainlayer.etanheyman.com",
+  },
+  {
+    name: "VoiceLayer",
+    desc: "Voice I/O for AI agents",
+    href: "https://voicelayer.etanheyman.com",
+  },
+  {
+    name: "cmuxLayer",
+    desc: "Terminal orchestration for AI agents",
+    href: "https://cmuxlayer.etanheyman.com",
+  },
+];
 
-const PRODUCT_LINKS: Record<Product, { label: string; href: string }[]> = {
-  cmuxlayer: [
-    { label: "GitHub", href: "https://github.com/EtanHey/cmuxlayer" },
-    { label: "npm", href: "https://github.com/EtanHey/cmuxlayer#install" },
-  ],
+const PRODUCT_LINKS: Record<
+  Product,
+  { label: string; href: string; external?: boolean }[]
+> = {
   voicelayer: [
-    { label: "GitHub", href: "https://github.com/EtanHey/voicelayer" },
-    { label: "npm", href: "https://npmjs.com/package/voicelayer-mcp" },
+    {
+      label: "GitHub",
+      href: "https://github.com/EtanHey/voicelayer",
+      external: true,
+    },
+    {
+      label: "Docs",
+      href: "https://etanhey.github.io/voicelayer/docs/",
+      external: true,
+    },
+    {
+      label: "npm",
+      href: "https://npmjs.com/package/voicelayer-mcp",
+      external: true,
+    },
   ],
   brainlayer: [
-    { label: "GitHub", href: "https://github.com/EtanHey/brainlayer" },
-    { label: "PyPI", href: "https://pypi.org/project/brainlayer/" },
+    {
+      label: "GitHub",
+      href: "https://github.com/EtanHey/brainlayer",
+      external: true,
+    },
+    {
+      label: "Docs",
+      href: "https://brainlayer.etanheyman.com/docs",
+      external: true,
+    },
+    {
+      label: "PyPI",
+      href: "https://pypi.org/project/brainlayer/",
+      external: true,
+    },
+  ],
+  cmuxlayer: [
+    {
+      label: "GitHub",
+      href: "https://github.com/EtanHey/cmuxlayer",
+      external: true,
+    },
+    {
+      label: "npm",
+      href: "https://github.com/EtanHey/cmuxlayer#quick-start",
+      external: true,
+    },
   ],
 };
 
@@ -72,43 +81,44 @@ interface FooterProps {
 }
 
 export function Footer({ product }: FooterProps) {
-  const siblings = ECOSYSTEM[product];
   const links = PRODUCT_LINKS[product];
 
   return (
-    <footer className="border-t border-border">
-      {/* Ecosystem section */}
-      <div className="max-w-[960px] mx-auto px-6 py-10">
-        <div className="text-[11px] uppercase tracking-[0.1em] text-text-dim mb-5 font-medium text-center">
-          Golems Ecosystem
+    <footer className="py-10 border-t border-border">
+      <div className="mx-auto max-w-[960px] px-6">
+        {/* Ecosystem section */}
+        <div className="mb-8">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-dim mb-4">
+            Golems Ecosystem
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {ECOSYSTEM.map((p) => {
+              const isCurrent = p.href.includes(product);
+              return (
+                <a
+                  key={p.name}
+                  href={isCurrent ? "#" : p.href}
+                  className={`text-[13px] no-underline transition-colors ${
+                    isCurrent
+                      ? "text-text font-medium cursor-default"
+                      : "text-text-dim hover:text-text-secondary"
+                  }`}
+                >
+                  {p.name}
+                  <span className="block text-[11px] text-text-dim font-light mt-0.5">
+                    {p.desc}
+                  </span>
+                </a>
+              );
+            })}
+          </div>
+          <p className="text-[11px] text-text-dim font-light mt-4">
+            Three open-source MCP servers. One agent toolkit.
+          </p>
         </div>
-        <div className="flex justify-center gap-8 max-md:flex-col max-md:items-center max-md:gap-4">
-          {siblings.map((sib) => (
-            <a
-              key={sib.href}
-              href={sib.href}
-              className="group flex flex-col items-center gap-1 no-underline"
-            >
-              <span
-                className="text-sm font-medium transition-colors"
-                style={{ color: sib.accent }}
-              >
-                {sib.name}
-              </span>
-              <span className="text-[12px] text-text-dim group-hover:text-text-secondary transition-colors">
-                {sib.tagline}
-              </span>
-            </a>
-          ))}
-        </div>
-        <p className="text-[12px] text-text-dim text-center mt-6 font-light">
-          Three open-source MCP servers. One agent toolkit.
-        </p>
-      </div>
 
-      {/* Bottom bar */}
-      <div className="border-t border-border">
-        <div className="max-w-[960px] mx-auto px-6 py-5 flex items-center justify-between max-md:flex-col max-md:gap-3">
+        {/* Bottom row */}
+        <div className="flex items-center justify-between max-md:flex-col max-md:gap-3 pt-4 border-t border-border">
           <div className="text-[13px] text-text-dim font-light">
             Built by{" "}
             <a
@@ -121,8 +131,12 @@ export function Footer({ product }: FooterProps) {
           <div className="flex gap-5">
             {links.map((link) => (
               <a
-                key={link.href}
+                key={link.label}
                 href={link.href}
+                {...(link.external && {
+                  target: "_blank",
+                  rel: "noopener",
+                })}
                 className="text-[13px] text-text-dim no-underline hover:text-text-secondary transition-colors"
               >
                 {link.label}


### PR DESCRIPTION
## Summary
- **Step 2 copy icon overflow**: Added min-w-0 and text-ellipsis to flex text spans in Three Steps code blocks so long text clips instead of pushing the copy icon out of bounds
- **npm badge 404**: Changed README npm badge link from npmjs.com/package/cmuxlayer (404) to github.com/EtanHey/cmuxlayer#quick-start until package is published
- **Footer standardization**: Rewrote footer to match VoiceLayer style — all 3 ecosystem products in a responsive grid with current product highlighted, proper external link targets, Built by Etan Heyman with GitHub/npm links
- **README logo**: Verified assets/cmuxlayer-logo-split-pane-grid.svg exists and is correctly referenced — no change needed

## Test plan
- [x] 335/335 tests pass
- [x] TypeScript typecheck clean
- [x] Next.js site builds successfully
- [ ] Verify step 2 code block no longer overflows on narrow viewports
- [ ] Verify footer shows all 3 ecosystem products with cmuxLayer highlighted
- [ ] Verify README npm badge links to GitHub quick-start

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix step overflow, footer layout, and npm badge in site
> - Adds `min-w-0` and `truncate` classes to code and text spans in [integrations.tsx](https://github.com/EtanHey/cmuxlayer/pull/60/files#diff-20b715782c5d610b13bb04144b86b2494fddfaa3c6763a8992e3d2362eee9b40) so long strings truncate instead of overflowing their containers.
> - Refactors [footer.tsx](https://github.com/EtanHey/cmuxlayer/pull/60/files#diff-4b0dd0baaff7f433685c1b0780f168716996a10b221cb119da289b64ade52b26) to render all three ecosystem products from a flat `ECOSYSTEM` array, disabling navigation for the currently active product; external links now open in a new tab.
> - Replaces the npm version badge in [README.md](https://github.com/EtanHey/cmuxlayer/pull/60/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a custom install badge pointing to the Quick Start section.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dac3378.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation badge link to direct users to the Quick Start guide.

* **Style**
  * Improved text overflow behavior in setup cards for better readability.

* **UI Improvements**
  * Redesigned footer ecosystem section with cleaner layout and proper external link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->