### PR TITLE
fix: rename_tab was silently failing — V1 protocol has no rename command

### DIFF
--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -194,7 +194,7 @@ export class CmuxSocketClient {
 
   /**
    * Send a V1 plain-text command. Some cmux operations (set_status,
-   * set_progress, log, rename_tab) only exist as V1 commands.
+   * set_progress, log) only exist as V1 commands.
    */
   private sendV1(command: string): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -451,14 +451,15 @@ export class CmuxSocketClient {
     title: string,
     opts?: { workspace?: string },
   ): Promise<void> {
-    const args: V1Arg[] = [this.rawV1Arg("--surface"), surface];
-    if (opts?.workspace) {
-      args.push(this.rawV1Arg("--workspace"), opts.workspace);
-    }
-    // Title is a positional arg (matching CLI: cmux rename-tab --surface X "title")
-    // NOT a --title flag — the V1 protocol ignores unknown flags silently.
-    args.push(title);
-    await this.sendV1Args("rename_tab", args);
+    // Use V2 tab.action — the V1 protocol has no rename command.
+    // The old V1 "rename_tab" silently failed with "Unknown command".
+    const params: Record<string, unknown> = {
+      action: "rename",
+      surface_id: surface,
+      title,
+    };
+    if (opts?.workspace) params.workspace_id = opts.workspace;
+    await this.call("tab.action", params);
   }
 
   async notify(opts?: {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -75,6 +75,15 @@ const MOCK_RESPONSES: Record<string, unknown> = {
     type: "terminal",
   },
   "surface.rename": {},
+  "tab.action": {
+    surface_ref: "surface:1",
+    action: "rename",
+    title: "",
+    workspace_ref: "workspace:1",
+    tab_ref: "tab:1",
+    pane_ref: "pane:1",
+    window_ref: "window:1",
+  },
   "status.set": {},
   "status.clear": {},
   "status.list": { entries: [{ key: "agent", value: "active", icon: "bolt" }] },
@@ -93,6 +102,8 @@ const MOCK_RESPONSES: Record<string, unknown> = {
 
 let mockServer: net.Server;
 let lastV1Command = "";
+let lastV2Request: { method: string; params: Record<string, unknown> } | null =
+  null;
 
 function startMockServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -116,6 +127,7 @@ function startMockServer(): Promise<void> {
           try {
             const req = JSON.parse(line);
             const method = req.method as string;
+            lastV2Request = { method, params: req.params ?? {} };
             const result = MOCK_RESPONSES[method];
 
             if (result !== undefined) {
@@ -147,7 +159,6 @@ function startMockServer(): Promise<void> {
                 "clear_progress",
                 "log",
                 "list_status",
-                "rename_tab",
               ].includes(cmd)
             ) {
               if (cmd === "list_status") {
@@ -192,6 +203,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   lastV1Command = "";
+  lastV2Request = null;
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -358,25 +370,35 @@ describe("CmuxSocketClient", () => {
     );
   });
 
-  it("sends title as positional arg for renameTab V1 command", async () => {
+  it("renameTab sends V2 tab.action with rename params", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 
     await client.renameTab("surface:1", "build logs", {
       workspace: "workspace:1",
     });
 
-    // Title is positional (matching CLI format), NOT a --title flag
-    expect(lastV1Command).toBe(
-      `rename_tab --surface surface:1 --workspace workspace:1 "build logs"`,
-    );
+    expect(lastV2Request).not.toBeNull();
+    expect(lastV2Request!.method).toBe("tab.action");
+    expect(lastV2Request!.params).toEqual({
+      action: "rename",
+      surface_id: "surface:1",
+      title: "build logs",
+      workspace_id: "workspace:1",
+    });
   });
 
-  it("sends title as positional arg for renameTab without workspace", async () => {
+  it("renameTab sends V2 tab.action without workspace when omitted", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 
     await client.renameTab("surface:1", "agent run");
 
-    expect(lastV1Command).toBe(`rename_tab --surface surface:1 "agent run"`);
+    expect(lastV2Request).not.toBeNull();
+    expect(lastV2Request!.method).toBe("tab.action");
+    expect(lastV2Request!.params).toEqual({
+      action: "rename",
+      surface_id: "surface:1",
+      title: "agent run",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- **Root cause**: `renameTab()` in the socket client sent `rename_tab` via V1 plain-text protocol, but cmux's socket server has no such V1 command. It returned `ERROR: Unknown command 'rename_tab'` which was silently swallowed.
- **Effect**: `rename_tab` MCP tool returned `ok` but the rename never reached cmux. Sidebar title never changed.
- **Fix**: Switch from V1 to V2 JSON-RPC `tab.action` method with `action: "rename"` — this is what cmux's CLI uses internally.
- **Verified**: V2 `tab.action` returns `ok:true` and cmux sidebar updates immediately.

### Evidence
```bash
# V1 (broken - what cmuxlayer was sending):
$ echo 'rename_tab --surface surface:5 "test"' | socat - UNIX-CONNECT:cmux.sock
ERROR: Unknown command 'rename_tab'

# V2 (fixed - what cmuxlayer now sends):
$ echo '{"method":"tab.action","params":{"action":"rename","surface_id":"surface:5","title":"test"}}' | socat - cmux.sock
{"ok":true,"result":{"action":"rename","title":"test",...}}
```

## Test plan
- [x] 335/335 tests pass
- [x] TypeScript typecheck clean
- [x] Verified V2 tab.action works against real cmux socket
- [x] Updated socket client tests to verify V2 params

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `renameTab` to use V2 `tab.action` protocol instead of non-existent V1 rename command
> The V1 protocol has no `rename_tab` command, so `CmuxSocketClient.renameTab` was silently failing. The method now calls `this.call("tab.action", { action: "rename", surface_id, title, workspace_id? })` via V2. Tests are updated to assert on the V2 request shape and the mock server no longer treats `rename_tab` as a valid V1 command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84c1060.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->