### PR TITLE
fix: README read-only tool count 5→6

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Spawn split panes, send commands, read screen output, and manage agent lifecycle
 
 All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) so MCP clients can enforce safety policies automatically.
 
-### Read-only (5)
+### Read-only (6)
 
 | Tool | Description |
 |------|-------------|


### PR DESCRIPTION
## Summary
- Read-only section header said "(5)" but lists 6 tools — `read_agent_output` was added without updating the header count

## Test plan
- [x] Verified actual annotation counts in server.ts: 6 readOnly + 13 mutating + 3 destructive = 22 total

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix read-only tool count in README from 5 to 6
> Corrects the section header in [README.md](https://github.com/EtanHey/cmuxlayer/pull/62/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to match the actual number of listed read-only tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d474957.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->