### PR TITLE
feat: README quality audit — problem-first, tool annotations, agent list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 npm install -g cmuxlayer
 ```
 
-Add to your MCP config (Claude Code, Cursor, VS Code, etc.):
+Requires [cmux](https://github.com/manaflow-ai/cmux) to be running.
+
+Add to your MCP config (Claude Code, Cursor, VS Code, Claude Desktop):
 
 ```json
 {
@@ -29,82 +31,111 @@ Add to your MCP config (Claude Code, Cursor, VS Code, etc.):
 }
 ```
 
-Requires [cmux](https://github.com/manaflow-ai/cmux) to be running.
+> **Config locations:** Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-## What it does
+## What You Can Do
 
-Spawn split panes, send commands, read screen output, and manage agent lifecycles — all through typed MCP tools. `read_screen` returns raw terminal text alongside parsed agent metadata (status, model, tokens, context %, done signals) for Claude Code, Codex, Gemini, Cursor, and Kiro.
+Tell your AI agent things like:
+
+- *"Split a pane to the right and run my test suite there"*
+- *"Spawn a Claude Code agent in a new pane to refactor auth.ts"*
+- *"Read the screen of surface:2 and tell me if the build passed"*
+- *"Wait for all agents to finish, then read their output"*
+- *"Set the sidebar status to show our deploy progress"*
+
+Under the hood, cmuxLayer exposes 22 MCP tools for terminal control, screen reading, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, Cursor, and Kiro.
 
 ## MCP Tools (22)
 
-All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) so MCP clients can enforce safety policies automatically.
+All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
+
+**Terminal control** — `new_split` `send_input` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
+
+**Agent lifecycle** — `spawn_agent` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
+
+**Workspace** — `list_surfaces` `list_agents` `my_agents` `get_agent_state` `read_agent_output` `notify` `set_status` `set_progress`
+
+<details>
+<summary>Full tool reference (22 tools)</summary>
 
 ### Read-only (6)
 
-| Tool | Description |
+| Tool | What it does |
 |------|-------------|
 | `list_surfaces` | List all surfaces across workspaces |
-| `read_screen` | Read terminal screen with parsed agent status |
-| `get_agent_state` | Get full state of a tracked agent |
-| `list_agents` | List all agents with optional filters |
-| `my_agents` | Get children of a parent agent with live screen status |
-| `read_agent_output` | Extract structured output between delimiter markers |
+| `read_screen` | Read terminal output with parsed agent status |
+| `get_agent_state` | Full state of a tracked agent |
+| `list_agents` | All agents, with optional filters |
+| `my_agents` | Children of a parent agent with live screen status |
+| `read_agent_output` | Structured output between delimiter markers |
 
 ### Mutating (13)
 
-| Tool | Description |
+| Tool | What it does |
 |------|-------------|
-| `new_split` | Create a new terminal or browser split pane |
-| `send_input` | Send text input to a terminal surface |
+| `new_split` | Create a terminal or browser split pane |
+| `send_input` | Send text to a surface |
 | `send_key` | Send key press (return, escape, ctrl-c, etc.) |
 | `rename_tab` | Rename a surface tab |
 | `notify` | Show a cmux notification banner |
 | `set_status` | Set sidebar status key-value pair |
-| `set_progress` | Set sidebar progress indicator (0.0-1.0) |
-| `browser_surface` | Interact with browser surfaces (navigate, click, eval) |
+| `set_progress` | Set progress indicator (0.0-1.0) |
+| `browser_surface` | Interact with browser surfaces |
 | `spawn_agent` | Spawn a CLI agent in a new pane |
-| `send_to_agent` | Send a prompt or message to a running agent |
-| `wait_for` | Block until an agent reaches a target state |
+| `send_to_agent` | Send a prompt to a running agent |
+| `wait_for` | Block until agent reaches a target state |
 | `wait_for_all` | Block until multiple agents finish |
-| `interact` | Send interactive input (confirm, cancel, skill, resume) |
+| `interact` | Send interactive input (confirm, cancel, resume) |
 
 ### Destructive (3)
 
-| Tool | Description |
+| Tool | What it does |
 |------|-------------|
 | `close_surface` | Close a terminal or browser pane |
-| `stop_agent` | Gracefully stop a running agent |
-| `kill` | Force-kill one or more agent processes |
+| `stop_agent` | Gracefully stop an agent |
+| `kill` | Force-kill agent processes |
+
+</details>
 
 ## Supported Agents
 
-| CLI | Command |
-|-----|---------|
-| Claude Code | `claude` |
-| Codex | `codex` |
-| Gemini CLI | `gemini` |
-| Cursor | `cursor agent` |
-| Kiro | `kiro-cli` |
+| CLI | Command | Auto-detected |
+|-----|---------|---------------|
+| Claude Code | `claude` | status, model, tokens, context % |
+| Codex | `codex` | status, model |
+| Gemini CLI | `gemini` | status, model |
+| Cursor | `cursor agent` | status |
+| Kiro | `kiro-cli` | status |
 
-`read_screen` auto-detects agent type and parses status, model, token count, and context percentage from terminal output.
+`read_screen` auto-detects agent type and parses metadata from terminal output.
 
 ## Architecture
 
 ```
-AI Agent  ─── MCP ───>  cmuxLayer
-                         ├── Persistent Unix socket (0.1ms, 1,423x faster than CLI)
-                         ├── Agent lifecycle engine (spawn → monitor → teardown)
-                         ├── Screen parser (auto-detect Claude/Codex/Gemini/Cursor/Kiro)
-                         ├── Mode policy (autonomous vs manual control)
+AI Agent  ─── MCP ───>  cmuxLayer  ─── Unix socket ───>  cmux
+                         ├── Agent engine (spawn → monitor → teardown)
+                         ├── Screen parser (5 agent formats)
+                         ├── Mode policy (autonomous vs manual)
                          └── State manager + event log
 ```
 
-The socket client connects to cmux via Unix socket at the path from `cmux socket-path`. Auto-reconnects on disconnect, falls back to CLI subprocess if socket is unavailable.
+The socket client connects to cmux via Unix socket. Auto-reconnects on disconnect, falls back to CLI subprocess if socket is unavailable.
 
-| Method | Latency |
-|--------|---------|
-| CLI subprocess | ~142ms |
-| Persistent socket | ~0.1ms (**1,423x faster**) |
+| Connection | Latency | Speedup |
+|------------|---------|---------|
+| CLI subprocess | ~142ms | baseline |
+| Unix socket | ~0.1ms | **1,423x** |
+
+## Troubleshooting
+
+**cmux is not running**
+cmuxLayer requires a running [cmux](https://github.com/manaflow-ai/cmux) instance. Install it first, then start a cmux session before using cmuxLayer.
+
+**Tools not appearing in Claude Code**
+Restart Claude Code after adding the MCP config. Run `claude mcp list` to verify cmuxlayer is connected.
+
+**Socket connection failed**
+cmuxLayer auto-discovers the socket at `~/Library/Application Support/cmux/cmux.sock`. If you're using a custom socket path, set `CMUX_SOCKET_PATH` in your environment.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add to your MCP config (Claude Code, Cursor, VS Code, Claude Desktop):
 }
 ```
 
-> **Config locations:** Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop `~/Library/Application Support/Claude/claude_desktop_config.json`
+> **Config locations:** Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
 
 ## What You Can Do
 
@@ -111,7 +111,7 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 
 ## Architecture
 
-```
+```text
 AI Agent  ─── MCP ───>  cmuxLayer  ─── Unix socket ───>  cmux
                          ├── Agent engine (spawn → monitor → teardown)
                          ├── Screen parser (5 agent formats)
@@ -135,7 +135,7 @@ cmuxLayer requires a running [cmux](https://github.com/manaflow-ai/cmux) instanc
 Restart Claude Code after adding the MCP config. Run `claude mcp list` to verify cmuxlayer is connected.
 
 **Socket connection failed**
-cmuxLayer auto-discovers the socket at `~/Library/Application Support/cmux/cmux.sock`. If you're using a custom socket path, set `CMUX_SOCKET_PATH` in your environment.
+cmuxLayer auto-discovers the cmux socket (macOS: `~/Library/Application Support/cmux/cmux.sock`). Override with `CMUX_SOCKET_PATH` if needed.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
Five iteration rounds comparing against top MCP server READMEs (Playwright MCP, browser-use, Claude Code):

- **Multi-client configs**: Single JSON block + file path reference for Claude Code, Cursor, VS Code, Claude Desktop
- **"What You Can Do" section**: Natural language examples showing what users can tell their agents
- **Scannable tool overview**: Inline tool groups by capability (terminal/agent/workspace) + collapsible full reference table
- **Agent table**: Added "Auto-detected" column showing what metadata each agent parser extracts
- **Troubleshooting FAQ**: 3 most common issues (cmux not running, tools not appearing, socket connection failed)
- **Tighter architecture**: Simplified diagram showing full data flow (agent -> cmuxLayer -> cmux)

## Test plan
- [x] 335/335 tests pass
- [x] All tool names verified against server.ts annotations (6 RO + 13 mutating + 3 destructive = 22)
- [x] Badge links verified
- [x] Logo and OG image verified

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overhaul README with problem-first structure, tool annotations, and troubleshooting guide
> - Restructures [README.md](https://github.com/EtanHey/cmuxlayer/pull/63/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to lead with prerequisites (cmux must be running) and a 'What You Can Do' section with example commands
> - Reorganizes 22 MCP tools into Terminal control, Agent lifecycle, and Workspace categories with a collapsible full reference
> - Expands the Supported Agents table with an 'Auto-detected' metadata column and broadens the MCP client list to include Claude Desktop
> - Revises the Architecture section to specify Unix socket connection to cmux and replaces the latency comparison with a CLI vs Unix socket performance table
> - Adds a Troubleshooting section covering cmux not running, missing tools, and socket connection failures with environment override details
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f401478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Setup instructions updated — cmux requirement now explicitly stated
  * Configuration guide expanded — consolidated paths for Claude Desktop, Claude Code, Cursor, VS Code
  * MCP tools documentation reorganized — improved categorization and clearer descriptions
  * Troubleshooting section added — addresses cmux connectivity and socket configuration issues
  * Agent metadata enhanced — supported agents now display auto-detected status and metadata fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->