### PR TITLE
feat: detect thinking screen status

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -104,6 +104,8 @@ const GEMINI_MODEL_RE =
 const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
+const THINKING_RE =
+  /(?:^|\n)\s*(?:(?:[✻✢✳✶]\s*)?thinking(?:\s+with\s+[a-z-]+\s+effort)?(?:\s*(?:\.{3,}|…))?|(?:Reticulating splines|Perambulating|Cooked|Crunched|Razzmatazzing|Schlepping|Nucleating|Seasoning)(?:\s*(?:\.{3,}|…))?|(?:⬡\s*)?(?:Running|Generating)(?:\s*(?:\.{3,}|…))?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens)\s*$/im;
 
 /** Cursor Agent CLI — mode bar, hex status, context strip, follow-up prompt */
 const CURSOR_MODE_BAR_RE =
@@ -426,6 +428,10 @@ function inferStatus(
     return "frozen";
   }
 
+  if (THINKING_RE.test(text)) {
+    return "thinking";
+  }
+
   if (agentType === "codex" && CODEX_WORKING_RE.test(joined)) {
     return "working";
   }
@@ -453,7 +459,6 @@ function inferStatus(
   }
 
   const workingMarkers = [
-    "thinking",
     " /loop",
     "bypass permissions on",
     "esc to interrupt",

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,12 @@ export type ParsedScreenAgentType =
   | "gemini"
   | "cursor"
   | "unknown";
-export type ParsedScreenStatus = "frozen" | "working" | "idle" | "done";
+export type ParsedScreenStatus =
+  | "frozen"
+  | "thinking"
+  | "working"
+  | "idle"
+  | "done";
 
 export interface ParsedScreenResult {
   agent_type: ParsedScreenAgentType;

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -162,11 +162,11 @@ Thinking...
 `);
 
     expect(parsed.agent_type).toBe("gemini");
-    expect(parsed.status).toBe("working");
+    expect(parsed.status).toBe("thinking");
     expect(parsed.model).toBe("gemini-3.1-pro");
   });
 
-  it("parses Cursor Agent working state with status strip, k tokens, and mode bar", () => {
+  it("parses Cursor Agent thinking state with status strip, k tokens, and mode bar", () => {
     const parsed = parseScreen(`
 Auto · 22.5% · 4 files edited
 
@@ -179,7 +179,7 @@ ctrl+c to stop
 `);
 
     expect(parsed.agent_type).toBe("cursor");
-    expect(parsed.status).toBe("working");
+    expect(parsed.status).toBe("thinking");
     expect(parsed.token_count).toBe(3300);
     expect(parsed.context_pct).toBe(23);
   });
@@ -238,6 +238,27 @@ Using claude-sonnet-4-20250514
 
     expect(parsed.agent_type).toBe("cursor");
     expect(parsed.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it.each([
+    ["Claude thinking indicator", "✶ thinking"],
+    ["Claude high-effort thinking indicator", "thinking with high effort"],
+    ["Claude whimsical loading phrase", "Reticulating splines..."],
+    ["Cursor running spinner", "Running 24k tokens"],
+    ["Cursor generating spinner", "Generating 5.2k tokens"],
+  ])("detects thinking status for %s", (_label, screen) => {
+    const parsed = parseScreen(screen);
+
+    expect(parsed.status).toBe("thinking");
+  });
+
+  it.each([
+    ["user prose", "I was thinking about cooking"],
+    ["non-spinner running text", "Running the tests"],
+  ])("does not misclassify %s as thinking", (_label, screen) => {
+    const parsed = parseScreen(screen);
+
+    expect(parsed.status).toBe("idle");
   });
 
   it("detects idle shell output and strips ANSI sequences", () => {


### PR DESCRIPTION
## Summary
- add a dedicated `thinking` parsed screen status
- detect Claude thinking indicators, whimsical loading phrases, and Cursor token spinners
- add parser coverage for positive and negative thinking cases
- reclassify explicit Gemini and Cursor thinking screens from `working` to `thinking`

## Testing
- `bun test tests/screen-parser.test.ts`
- `bun run typecheck`
- `bun test` *(fails in unrelated existing suites in this environment: `tests/quality-tracking.test.ts` uses `vi.mocked`, and `tests/server.test.ts` uses `vi.advanceTimersByTimeAsync`)*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect thinking screen status in screen parser
> - Adds a `'thinking'` status to the `ParsedScreenStatus` union in [types.ts](https://github.com/EtanHey/cmuxlayer/pull/68/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) alongside `'frozen'`, `'working'`, `'idle'`, and `'done'`.
> - Adds `THINKING_RE` regex in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/68/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to match spinner phrases like `thinking...`, `thinking with high effort`, whimsical loaders (e.g. `Reticulating splines...`), and Cursor-style `Running/Generating ... tokens` lines.
> - `inferStatus` now returns `'thinking'` when `THINKING_RE` matches, checked after the frozen error check but before working/done checks.
> - Behavioral Change: screens previously classified as `'working'` for Gemini `Thinking...` or Cursor token spinners now return `'thinking'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15b2049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->