### PR TITLE
feat: add new_surface MCP tool

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -10,6 +10,7 @@ import type {
   CmuxWorkspace,
   CmuxPaneSurfaces,
   CmuxNewSplitResult,
+  CmuxNewSurfaceResult,
   CmuxReadScreenResult,
   CmuxStatusEntry,
 } from "./types.js";
@@ -133,6 +134,21 @@ export class CmuxClient {
     };
   }
 
+  private mapSurfaceResult(
+    parsed: Record<string, unknown>,
+    fallbackType: "terminal" | "browser",
+  ): CmuxNewSurfaceResult {
+    return {
+      workspace:
+        (parsed.workspace_ref as string) ?? (parsed.workspace as string) ?? "",
+      surface:
+        (parsed.surface_ref as string) ?? (parsed.surface as string) ?? "",
+      pane: (parsed.pane_ref as string) ?? (parsed.pane as string) ?? "",
+      title: (parsed.title as string) ?? "",
+      type: (parsed.type as "terminal" | "browser") ?? fallbackType,
+    };
+  }
+
   private async resolveWorkspaceFromSurface(surface: string): Promise<string> {
     const identified = await this.identify(surface);
     const workspace =
@@ -213,6 +229,30 @@ export class CmuxClient {
     const raw = await this.run(args);
     const parsed = this.parse<Record<string, unknown>>(raw, "new-split");
     return this.mapSplitResult(parsed, "terminal");
+  }
+
+  async newSurface(opts: {
+    pane: string;
+    type?: "terminal" | "browser";
+    workspace?: string;
+    title?: string;
+    url?: string;
+  }): Promise<CmuxNewSurfaceResult> {
+    if (opts.type !== "browser" && opts.url) {
+      throw new Error("Terminal surfaces do not accept a browser URL");
+    }
+
+    // AIDEV-NOTE: cmux new-surface does not expose a title flag. Titles are
+    // applied by the server/tool layer via renameTab after creation, matching
+    // the existing new_split behavior.
+    const args = ["new-surface", "--pane", opts.pane];
+    if (opts.type) args.push("--type", opts.type);
+    if (opts.workspace) args.push("--workspace", opts.workspace);
+    if (opts.url) args.push("--url", opts.url);
+
+    const raw = await this.run(args);
+    const parsed = this.parse<Record<string, unknown>>(raw, "new-surface");
+    return this.mapSurfaceResult(parsed, opts.type ?? "terminal");
   }
 
   async send(

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -15,6 +15,7 @@ import type {
   CmuxPaneSurfaces,
   CmuxPane,
   CmuxNewSplitResult,
+  CmuxNewSurfaceResult,
   CmuxReadScreenResult,
   CmuxStatusEntry,
 } from "./types.js";
@@ -387,6 +388,21 @@ export class CmuxSocketClient {
       }
       throw e;
     }
+  }
+
+  async newSurface(opts: {
+    pane: string;
+    type?: "terminal" | "browser";
+    workspace?: string;
+    title?: string;
+    url?: string;
+  }): Promise<CmuxNewSurfaceResult> {
+    if (!this.cliFallback) {
+      throw new CmuxSocketError(
+        "new-surface is only available through the CLI fallback",
+      );
+    }
+    return this.cliFallback.newSurface(opts);
   }
 
   async send(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 22 MCP tools across two categories:
- *   Core (11): list_surfaces, new_split, send_input, send_key, read_screen,
- *              rename_tab, notify, set_status, set_progress, close_surface,
- *              browser_surface
+ * 23 MCP tools across two categories:
+ *   Core (12): list_surfaces, new_split, new_surface, send_input, send_key,
+ *              read_screen, rename_tab, notify, set_status, set_progress,
+ *              close_surface, browser_surface
  *   Agent lifecycle (11): spawn_agent, send_to_agent, read_agent_output,
  *                         get_agent_state, list_agents, my_agents, wait_for,
  *                         wait_for_all, stop_agent, kill, interact

--- a/src/server.ts
+++ b/src/server.ts
@@ -423,7 +423,53 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 3. send_input
+  // 3. new_surface
+  server.tool(
+    "new_surface",
+    "Create a new surface (tab) in an existing pane",
+    {
+      pane: z.string().describe("Target pane ref"),
+      workspace: z.string().optional().describe("Target workspace ref"),
+      type: z
+        .enum(["terminal", "browser"])
+        .optional()
+        .default("terminal")
+        .describe("Surface type"),
+      title: z.string().optional().describe("Tab title"),
+      url: z.string().optional().describe("URL for browser surfaces"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const result = await client.newSurface({
+          pane: args.pane,
+          workspace: args.workspace,
+          type: args.type,
+          url: args.url,
+        });
+        if (args.title) {
+          await client.renameTab(result.surface, args.title, {
+            workspace: result.workspace || args.workspace,
+          });
+          result.title = args.title;
+        }
+        const data = { ...result };
+        return okFormatted(
+          formatOk("new_surface", {
+            pane: args.pane,
+            surface: result.surface,
+            type: result.type,
+            title: result.title,
+          }),
+          data,
+        );
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 4. send_input
   server.tool(
     "send_input",
     "Send text input to a terminal surface. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ export interface CmuxNewSplitResult {
   type: "terminal" | "browser";
 }
 
+export interface CmuxNewSurfaceResult {
+  workspace: string;
+  surface: string;
+  pane: string;
+  title: string;
+  type: "terminal" | "browser";
+}
+
 export interface CmuxReadScreenResult {
   surface: string;
   text: string;

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -185,6 +185,46 @@ describe("CmuxClient.newSplit", () => {
   });
 });
 
+describe("CmuxClient.newSurface", () => {
+  it("calls cmux new-surface with pane and optional flags", async () => {
+    const data = {
+      workspace: "workspace:1",
+      surface: "surface:9",
+      pane: "pane:2",
+      title: "New Tab",
+      type: "browser",
+    };
+    const { client, exec } = mockClient(data);
+
+    const result = await client.newSurface({
+      pane: "pane:2",
+      workspace: "workspace:1",
+      type: "browser",
+      url: "https://example.com",
+    });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "new-surface",
+      "--pane",
+      "pane:2",
+      "--type",
+      "browser",
+      "--workspace",
+      "workspace:1",
+      "--url",
+      "https://example.com",
+    ]);
+    expect(result).toEqual({
+      workspace: "workspace:1",
+      surface: "surface:9",
+      pane: "pane:2",
+      title: "New Tab",
+      type: "browser",
+    });
+  });
+});
+
 describe("CmuxClient.send", () => {
   it("calls cmux send with surface and text", async () => {
     const { client, exec } = mockClient({});

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -418,6 +418,16 @@ describe("CmuxSocketClient V2→CLI fallback", () => {
           type: "terminal" as const,
         };
       },
+      newSurface: async (opts: unknown) => {
+        cliCalls.push({ method: "newSurface", args: [opts] });
+        return {
+          workspace: "workspace:1",
+          surface: "surface:cli-tab",
+          pane: "pane:cli",
+          title: "",
+          type: "terminal" as const,
+        };
+      },
       closeSurface: async (surface: string, opts?: unknown) => {
         cliCalls.push({ method: "closeSurface", args: [surface, opts] });
       },
@@ -474,6 +484,24 @@ describe("CmuxSocketClient V2→CLI fallback", () => {
     } finally {
       MOCK_RESPONSES["surface.close"] = saved;
     }
+  });
+
+  it("newSurface uses CLI fallback", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+    const result = await client.newSurface({
+      pane: "pane:1",
+      workspace: "workspace:1",
+    });
+    expect(cliCalls).toHaveLength(1);
+    expect(cliCalls[0].method).toBe("newSurface");
+    expect(cliCalls[0].args[0]).toMatchObject({
+      pane: "pane:1",
+      workspace: "workspace:1",
+    });
+    expect(result.surface).toBe("surface:cli-tab");
   });
 
   it("newSplit throws when no CLI fallback and method_not_found", async () => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -43,6 +43,7 @@ describe("B1: ToolAnnotations on all tools", () => {
 
   const MUTATING_TOOLS = [
     "new_split",
+    "new_surface",
     "send_input",
     "send_key",
     "rename_tab",
@@ -72,9 +73,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 22 tools have annotations", () => {
+  it("all 23 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(22);
+    expect(toolNames.length).toBe(23);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -57,7 +57,7 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 22 (11 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 23 (12 low-level + 9 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -67,7 +67,7 @@ describe("agent lifecycle tool registration", () => {
       stateDir: TEST_DIR,
     });
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(22);
+    expect(Object.keys(registeredTools)).toHaveLength(23);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,10 +7,11 @@ import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 
-// The 11 low-level tools from the design doc
+// The 12 low-level tools from the design doc
 const EXPECTED_TOOLS = [
   "list_surfaces",
   "new_split",
+  "new_surface",
   "send_input",
   "send_key",
   "read_screen",
@@ -54,7 +55,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 11 tools", () => {
+  it("registers all 12 tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;
@@ -785,6 +786,69 @@ describe("tool handler integration", () => {
         "--surface",
         "surface:2",
         "Build Task",
+      ]),
+    );
+  });
+
+  it("new_surface handler calls cmux new-surface", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:3",
+        pane: "pane:1",
+        title: "New Tab",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["new_surface"];
+
+    const result = await tool.handler({ pane: "pane:1" }, {} as any);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:1"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:3");
+  });
+
+  it("new_surface renames the new surface when a title is provided", async () => {
+    mockExec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          surface: "surface:3",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["new_surface"];
+
+    await tool.handler(
+      { pane: "pane:1", title: "Build Logs" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenNthCalledWith(
+      2,
+      "cmux",
+      expect.arrayContaining([
+        "rename-tab",
+        "--surface",
+        "surface:3",
+        "Build Logs",
       ]),
     );
   });

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -40,14 +40,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 22 (11 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 23 (12 low-level + 9 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(22);
+    expect(count).toBe(23);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `CmuxClient.newSurface()` for `cmux new-surface --pane ...`
- register a `new_surface` MCP tool that creates tabs in existing panes and optionally renames the tab title after creation
- expose the method on `CmuxSocketClient` through CLI fallback and update tool-count/annotation tests to cover the new core tool

## Testing
- `bun test tests/cmux-client.test.ts tests/cmux-socket-client.test.ts tests/server-agent-tools.test.ts tests/security-hardening.test.ts tests/v2-interact-kill.test.ts`
- `bun run typecheck`
- `bun test` *(still fails in pre-existing suites under this Bun/Vitest environment: `tests/quality-tracking.test.ts` uses `vi.mocked`, and `tests/server.test.ts` uses `vi.advanceTimersByTimeAsync`)*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `new_surface` MCP tool to create a new surface in a specified pane
> - Adds a `new_surface` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/69/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that accepts `pane` (required), `workspace`, `type` (default `terminal`), `title`, and `url` parameters.
> - Implements `CmuxClient.newSurface` in [cmux-client.ts](https://github.com/EtanHey/cmuxlayer/pull/69/files#diff-fa09fce9dc0db1d0fcfd897829a228dc976f365c0f36f4cbadacf6d03bd932d4) to invoke `cmux new-surface` CLI and parse the result; rejects URL input for non-browser types.
> - `CmuxSocketClient.newSurface` delegates to the CLI fallback or throws if no fallback is configured.
> - If `title` is provided, the handler calls `client.renameTab` after surface creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ef47ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->