### PR TITLE
feat: add surface layout management tools

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -11,6 +11,8 @@ import type {
   CmuxPaneSurfaces,
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
+  CmuxMoveSurfaceResult,
+  CmuxReorderSurfaceResult,
   CmuxReadScreenResult,
   CmuxStatusEntry,
 } from "./types.js";
@@ -149,6 +151,29 @@ export class CmuxClient {
     };
   }
 
+  private mapMoveSurfaceResult(
+    parsed: Record<string, unknown>,
+  ): CmuxMoveSurfaceResult {
+    return {
+      ok: (parsed.ok as boolean) ?? true,
+      workspace:
+        (parsed.workspace_ref as string) ?? (parsed.workspace as string) ?? "",
+      surface:
+        (parsed.surface_ref as string) ?? (parsed.surface as string) ?? "",
+      pane: (parsed.pane_ref as string) ?? (parsed.pane as string) ?? "",
+    };
+  }
+
+  private mapReorderSurfaceResult(
+    parsed: Record<string, unknown>,
+  ): CmuxReorderSurfaceResult {
+    return {
+      ok: (parsed.ok as boolean) ?? true,
+      surface:
+        (parsed.surface_ref as string) ?? (parsed.surface as string) ?? "",
+    };
+  }
+
   private async resolveWorkspaceFromSurface(surface: string): Promise<string> {
     const identified = await this.identify(surface);
     const workspace =
@@ -253,6 +278,54 @@ export class CmuxClient {
     const raw = await this.run(args);
     const parsed = this.parse<Record<string, unknown>>(raw, "new-surface");
     return this.mapSurfaceResult(parsed, opts.type ?? "terminal");
+  }
+
+  async moveSurface(opts: {
+    surface: string;
+    pane?: string;
+    workspace?: string;
+    before?: string;
+    after?: string;
+    index?: number;
+    focus?: boolean;
+  }): Promise<CmuxMoveSurfaceResult> {
+    const args = ["move-surface", "--surface", opts.surface];
+    if (opts.pane) args.push("--pane", opts.pane);
+    if (opts.workspace) args.push("--workspace", opts.workspace);
+    if (opts.before) args.push("--before", opts.before);
+    if (opts.after) args.push("--after", opts.after);
+    if (opts.index !== undefined) args.push("--index", String(opts.index));
+    if (opts.focus !== undefined) args.push("--focus", String(opts.focus));
+
+    const raw = await this.run(args);
+    const parsed = this.parse<Record<string, unknown>>(raw, "move-surface");
+    return this.mapMoveSurfaceResult(parsed);
+  }
+
+  async reorderSurface(opts: {
+    surface: string;
+    index?: number;
+    before?: string;
+    after?: string;
+  }): Promise<CmuxReorderSurfaceResult> {
+    const targetCount =
+      Number(opts.index !== undefined) +
+      Number(Boolean(opts.before)) +
+      Number(Boolean(opts.after));
+    if (targetCount !== 1) {
+      throw new Error(
+        "reorder-surface requires exactly one of index, before, or after",
+      );
+    }
+
+    const args = ["reorder-surface", "--surface", opts.surface];
+    if (opts.index !== undefined) args.push("--index", String(opts.index));
+    if (opts.before) args.push("--before", opts.before);
+    if (opts.after) args.push("--after", opts.after);
+
+    const raw = await this.run(args);
+    const parsed = this.parse<Record<string, unknown>>(raw, "reorder-surface");
+    return this.mapReorderSurfaceResult(parsed);
   }
 
   async send(

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -16,6 +16,8 @@ import type {
   CmuxPane,
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
+  CmuxMoveSurfaceResult,
+  CmuxReorderSurfaceResult,
   CmuxReadScreenResult,
   CmuxStatusEntry,
 } from "./types.js";
@@ -403,6 +405,37 @@ export class CmuxSocketClient {
       );
     }
     return this.cliFallback.newSurface(opts);
+  }
+
+  async moveSurface(opts: {
+    surface: string;
+    pane?: string;
+    workspace?: string;
+    before?: string;
+    after?: string;
+    index?: number;
+    focus?: boolean;
+  }): Promise<CmuxMoveSurfaceResult> {
+    if (!this.cliFallback) {
+      throw new CmuxSocketError(
+        "move-surface is only available through the CLI fallback",
+      );
+    }
+    return this.cliFallback.moveSurface(opts);
+  }
+
+  async reorderSurface(opts: {
+    surface: string;
+    index?: number;
+    before?: string;
+    after?: string;
+  }): Promise<CmuxReorderSurfaceResult> {
+    if (!this.cliFallback) {
+      throw new CmuxSocketError(
+        "reorder-surface is only available through the CLI fallback",
+      );
+    }
+    return this.cliFallback.reorderSurface(opts);
   }
 
   async send(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 23 MCP tools across two categories:
- *   Core (12): list_surfaces, new_split, new_surface, send_input, send_key,
- *              read_screen, rename_tab, notify, set_status, set_progress,
- *              close_surface, browser_surface
+ * 25 MCP tools across two categories:
+ *   Core (14): list_surfaces, new_split, new_surface, move_surface,
+ *              reorder_surface, send_input, send_key, read_screen, rename_tab,
+ *              notify, set_status, set_progress, close_surface, browser_surface
  *   Agent lifecycle (11): spawn_agent, send_to_agent, read_agent_output,
  *                         get_agent_state, list_agents, my_agents, wait_for,
  *                         wait_for_all, stop_agent, kill, interact

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 11 core tools + 11 agent lifecycle tools.
+ * cmux MCP server — registers 14 core tools + 11 agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -469,7 +469,82 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 4. send_input
+  // 4. move_surface
+  server.tool(
+    "move_surface",
+    "Move a surface (tab) between panes or workspaces",
+    {
+      surface: z.string().describe("Surface ref to move"),
+      pane: z.string().optional().describe("Target pane ref"),
+      workspace: z.string().optional().describe("Target workspace ref"),
+      before: z.string().optional().describe("Insert before this surface ref"),
+      after: z.string().optional().describe("Insert after this surface ref"),
+      index: z.number().int().optional().describe("Insert at this tab index"),
+      focus: z
+        .boolean()
+        .optional()
+        .describe("Whether to focus the moved surface"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const result = await client.moveSurface({
+          surface: args.surface,
+          pane: args.pane,
+          workspace: args.workspace,
+          before: args.before,
+          after: args.after,
+          index: args.index,
+          focus: args.focus,
+        });
+        const data = { ...result };
+        return okFormatted(
+          formatOk("move_surface", {
+            surface: result.surface,
+            pane: result.pane,
+            workspace: result.workspace,
+          }),
+          data,
+        );
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 5. reorder_surface
+  server.tool(
+    "reorder_surface",
+    "Reorder a surface (tab) within its current pane",
+    {
+      surface: z.string().describe("Surface ref to reorder"),
+      index: z.number().int().optional().describe("Move to this tab index"),
+      before: z.string().optional().describe("Insert before this surface ref"),
+      after: z.string().optional().describe("Insert after this surface ref"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const result = await client.reorderSurface({
+          surface: args.surface,
+          index: args.index,
+          before: args.before,
+          after: args.after,
+        });
+        const data = { ...result };
+        return okFormatted(
+          formatOk("reorder_surface", {
+            surface: result.surface,
+          }),
+          data,
+        );
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 6. send_input
   server.tool(
     "send_input",
     "Send text input to a terminal surface. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",
@@ -525,7 +600,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 4. send_key
+  // 7. send_key
   server.tool(
     "send_key",
     "Send a key press to a terminal surface. Use this after send_input to reliably submit commands — especially when targeting interactive programs like Claude sessions.",
@@ -548,7 +623,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 5. read_screen
+  // 8. read_screen
   server.tool(
     "read_screen",
     "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors. Use parsed_only=true for monitoring (omits raw terminal content).",

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,18 @@ export interface CmuxNewSurfaceResult {
   type: "terminal" | "browser";
 }
 
+export interface CmuxMoveSurfaceResult {
+  ok: boolean;
+  workspace: string;
+  surface: string;
+  pane: string;
+}
+
+export interface CmuxReorderSurfaceResult {
+  ok: boolean;
+  surface: string;
+}
+
 export interface CmuxReadScreenResult {
   surface: string;
   text: string;

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -225,6 +225,78 @@ describe("CmuxClient.newSurface", () => {
   });
 });
 
+describe("CmuxClient.moveSurface", () => {
+  it("calls cmux move-surface with surface and optional flags", async () => {
+    const data = {
+      ok: true,
+      workspace: "workspace:2",
+      surface: "surface:9",
+      pane: "pane:3",
+    };
+    const { client, exec } = mockClient(data);
+
+    const result = await client.moveSurface({
+      surface: "surface:9",
+      pane: "pane:3",
+      workspace: "workspace:2",
+      before: "surface:10",
+      index: 1,
+      focus: false,
+    });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "move-surface",
+      "--surface",
+      "surface:9",
+      "--pane",
+      "pane:3",
+      "--workspace",
+      "workspace:2",
+      "--before",
+      "surface:10",
+      "--index",
+      "1",
+      "--focus",
+      "false",
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      workspace: "workspace:2",
+      surface: "surface:9",
+      pane: "pane:3",
+    });
+  });
+});
+
+describe("CmuxClient.reorderSurface", () => {
+  it("calls cmux reorder-surface with index placement", async () => {
+    const data = {
+      ok: true,
+      surface: "surface:9",
+    };
+    const { client, exec } = mockClient(data);
+
+    const result = await client.reorderSurface({
+      surface: "surface:9",
+      index: 2,
+    });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "reorder-surface",
+      "--surface",
+      "surface:9",
+      "--index",
+      "2",
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      surface: "surface:9",
+    });
+  });
+});
+
 describe("CmuxClient.send", () => {
   it("calls cmux send with surface and text", async () => {
     const { client, exec } = mockClient({});

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -428,6 +428,22 @@ describe("CmuxSocketClient V2→CLI fallback", () => {
           type: "terminal" as const,
         };
       },
+      moveSurface: async (opts: unknown) => {
+        cliCalls.push({ method: "moveSurface", args: [opts] });
+        return {
+          ok: true,
+          workspace: "workspace:2",
+          surface: "surface:cli-tab",
+          pane: "pane:cli",
+        };
+      },
+      reorderSurface: async (opts: unknown) => {
+        cliCalls.push({ method: "reorderSurface", args: [opts] });
+        return {
+          ok: true,
+          surface: "surface:cli-tab",
+        };
+      },
       closeSurface: async (surface: string, opts?: unknown) => {
         cliCalls.push({ method: "closeSurface", args: [surface, opts] });
       },
@@ -500,6 +516,44 @@ describe("CmuxSocketClient V2→CLI fallback", () => {
     expect(cliCalls[0].args[0]).toMatchObject({
       pane: "pane:1",
       workspace: "workspace:1",
+    });
+    expect(result.surface).toBe("surface:cli-tab");
+  });
+
+  it("moveSurface uses CLI fallback", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+    const result = await client.moveSurface({
+      surface: "surface:1",
+      workspace: "workspace:1",
+      pane: "pane:2",
+    });
+    expect(cliCalls).toHaveLength(1);
+    expect(cliCalls[0].method).toBe("moveSurface");
+    expect(cliCalls[0].args[0]).toMatchObject({
+      surface: "surface:1",
+      workspace: "workspace:1",
+      pane: "pane:2",
+    });
+    expect(result.surface).toBe("surface:cli-tab");
+  });
+
+  it("reorderSurface uses CLI fallback", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+    const result = await client.reorderSurface({
+      surface: "surface:1",
+      after: "surface:2",
+    });
+    expect(cliCalls).toHaveLength(1);
+    expect(cliCalls[0].method).toBe("reorderSurface");
+    expect(cliCalls[0].args[0]).toMatchObject({
+      surface: "surface:1",
+      after: "surface:2",
     });
     expect(result.surface).toBe("surface:cli-tab");
   });

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -154,7 +154,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // Mock readScreen: 160K tokens on Sonnet (200K window) = 80% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $3.50",
       lines: 5,
@@ -182,7 +182,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // Mock readScreen: 170K tokens on Haiku (200K window) = 85% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:2",
       text: "✻ Working…\nToken usage: total=170,000\n🤖 Haiku 3.5 | 💰 $0.10",
       lines: 5,
@@ -214,7 +214,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 160K tokens on Sonnet (200K window) = 80% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $2.00",
       lines: 5,
@@ -241,7 +241,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 100K tokens on Sonnet (200K window) = 50% used — below threshold
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=100,000\n🤖 Sonnet 4.6 | 💰 $1.00",
       lines: 5,
@@ -278,7 +278,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 180K tokens on Haiku (200K window) = 90% used — above threshold
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:2",
       text: "✻ Working…\nToken usage: total=180,000\n🤖 Haiku 3.5 | 💰 $0.15",
       lines: 5,

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -44,6 +44,8 @@ describe("B1: ToolAnnotations on all tools", () => {
   const MUTATING_TOOLS = [
     "new_split",
     "new_surface",
+    "move_surface",
+    "reorder_surface",
     "send_input",
     "send_key",
     "rename_tab",
@@ -73,9 +75,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 23 tools have annotations", () => {
+  it("all 25 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(23);
+    expect(toolNames.length).toBe(25);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -57,7 +57,7 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 23 (12 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 25 (14 low-level + 9 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -67,7 +67,7 @@ describe("agent lifecycle tool registration", () => {
       stateDir: TEST_DIR,
     });
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(23);
+    expect(Object.keys(registeredTools)).toHaveLength(25);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -12,6 +12,8 @@ const EXPECTED_TOOLS = [
   "list_surfaces",
   "new_split",
   "new_surface",
+  "move_surface",
+  "reorder_surface",
   "send_input",
   "send_key",
   "read_screen",
@@ -55,7 +57,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 12 tools", () => {
+  it("registers all 14 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;
@@ -71,8 +73,12 @@ describe("tool registration", () => {
 
 describe("Claude channels", () => {
   afterEach(() => {
+    try {
+      vi.clearAllTimers();
+    } catch {
+      // Bun's Vitest shim throws here when fake timers were never activated.
+    }
     vi.useRealTimers();
-    vi.clearAllTimers();
     rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
   });
 
@@ -155,7 +161,8 @@ describe("Claude channels", () => {
     };
 
     await server.connect(serverTransport);
-    await vi.advanceTimersByTimeAsync(5000);
+    vi.advanceTimersByTime(5000);
+    await Promise.resolve();
 
     const notifications = messages.filter(
       (message) =>
@@ -851,6 +858,94 @@ describe("tool handler integration", () => {
         "Build Logs",
       ]),
     );
+  });
+
+  it("move_surface handler calls cmux move-surface", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        ok: true,
+        workspace: "workspace:1",
+        surface: "surface:3",
+        pane: "pane:2",
+      }),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["move_surface"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:3",
+        pane: "pane:2",
+        workspace: "workspace:1",
+        index: 1,
+        focus: false,
+      },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "move-surface",
+        "--surface",
+        "surface:3",
+        "--pane",
+        "pane:2",
+        "--workspace",
+        "workspace:1",
+        "--index",
+        "1",
+        "--focus",
+        "false",
+      ]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed).toMatchObject({
+      ok: true,
+      surface: "surface:3",
+      pane: "pane:2",
+      workspace: "workspace:1",
+    });
+  });
+
+  it("reorder_surface handler calls cmux reorder-surface", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        ok: true,
+        surface: "surface:3",
+      }),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["reorder_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:3", after: "surface:4" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "reorder-surface",
+        "--surface",
+        "surface:3",
+        "--after",
+        "surface:4",
+      ]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed).toMatchObject({
+      ok: true,
+      surface: "surface:3",
+    });
   });
 
   it("set_status handler calls cmux set-status", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -40,14 +40,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 23 (12 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 25 (14 low-level + 9 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(23);
+    expect(count).toBe(25);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `move_surface` and `reorder_surface` MCP tools following the `new_surface` implementation pattern from PR #69
- wire the new commands through the CLI client, socket client CLI fallback, server registration, and result types
- add coverage for the new tools and update tool inventory assertions from 23 to 25
- patch two Bun/Vitest compatibility issues in existing tests so `bun test` passes locally under Bun 1.3.9 (`advanceTimersByTimeAsync` and `vi.mocked` are unavailable in this runtime)

## Test plan
- [x] `bun test`

## Notes
- left unrelated local `.gitignore` and `.gemini/` changes out of this PR


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `move_surface` and `reorder_surface` MCP tools for surface layout management
> - Adds `moveSurface` and `reorderSurface` methods to `CmuxClient` ([src/cmux-client.ts](https://github.com/EtanHey/cmuxlayer/pull/70/files#diff-fa09fce9dc0db1d0fcfd897829a228dc976f365c0f36f4cbadacf6d03bd932d4)), wrapping the `cmux move-surface` and `cmux reorder-surface` CLI commands with full flag support.
> - Registers two new MCP tools (`move_surface`, `reorder_surface`) in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/70/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), bringing the core tool count from 11 to 14.
> - `CmuxSocketClient` ([src/cmux-socket-client.ts](https://github.com/EtanHey/cmuxlayer/pull/70/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2)) delegates both methods to the CLI fallback when available, or throws a `CmuxSocketError`.
> - `reorderSurface` validates that exactly one of `index`, `before`, or `after` is provided before invoking the CLI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0255f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->