### PR TITLE
feat: add resilient chunked send_input delivery

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6,7 +6,11 @@
 import { StateManager } from "./state-manager.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
-import type { CmuxNewSplitResult, CmuxReadScreenResult } from "./types.js";
+import type {
+  CmuxNewSplitResult,
+  CmuxReadScreenResult,
+  CmuxSendOptions,
+} from "./types.js";
 import {
   generateAgentId,
   MAX_SPAWN_DEPTH,
@@ -67,7 +71,7 @@ interface AgentEngineClient {
   send(
     surface: string,
     text: string,
-    opts?: { workspace?: string },
+    opts?: CmuxSendOptions,
   ): Promise<void>;
   sendKey(
     surface: string,

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -120,6 +120,19 @@ export class CmuxClient {
     return new Error(`cmux ${args[0]} failed: ${error.message}${suffix}`);
   }
 
+  private assertSupportedSendOptions(opts?: CmuxSendOptions): void {
+    const unsupported = [
+      opts?.chunk_size !== undefined ? "chunk_size" : null,
+      opts?.chunk_delay_ms !== undefined ? "chunk_delay_ms" : null,
+    ].filter((value): value is string => value !== null);
+
+    if (unsupported.length > 0) {
+      throw new Error(
+        `CmuxClient.send does not support ${unsupported.join(", ")}; chunking is handled by send_input in the server layer`,
+      );
+    }
+  }
+
   private mapSplitResult(
     parsed: Record<string, unknown>,
     fallbackType: "terminal" | "browser",
@@ -261,6 +274,7 @@ export class CmuxClient {
     text: string,
     opts?: CmuxSendOptions,
   ): Promise<void> {
+    this.assertSupportedSendOptions(opts);
     const args = ["send", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
     args.push(text);

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -12,6 +12,7 @@ import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
   CmuxReadScreenResult,
+  CmuxSendOptions,
   CmuxStatusEntry,
 } from "./types.js";
 
@@ -258,7 +259,7 @@ export class CmuxClient {
   async send(
     surface: string,
     text: string,
-    opts?: { workspace?: string },
+    opts?: CmuxSendOptions,
   ): Promise<void> {
     const args = ["send", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -86,6 +86,20 @@ export class CmuxSocketClient {
     this.cliFallback = opts?.cliFallback;
   }
 
+  private assertSupportedSendOptions(opts?: CmuxSendOptions): void {
+    const unsupported = [
+      opts?.chunk_size !== undefined ? "chunk_size" : null,
+      opts?.chunk_delay_ms !== undefined ? "chunk_delay_ms" : null,
+    ].filter((value): value is string => value !== null);
+
+    if (unsupported.length > 0) {
+      throw new CmuxSocketError(
+        `CmuxSocketClient.send does not support ${unsupported.join(", ")}; chunking is handled by send_input in the server layer`,
+        "unsupported_send_option",
+      );
+    }
+  }
+
   // ── Low-level: send a V2 request, get a V2 response ────────────────
 
   private sendV2(
@@ -411,6 +425,7 @@ export class CmuxSocketClient {
     text: string,
     opts?: CmuxSendOptions,
   ): Promise<void> {
+    this.assertSupportedSendOptions(opts);
     const workspace = await this.resolveWorkspace(surface, opts?.workspace);
     const params: Record<string, unknown> = {
       surface_id: surface,

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -17,6 +17,7 @@ import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
   CmuxReadScreenResult,
+  CmuxSendOptions,
   CmuxStatusEntry,
 } from "./types.js";
 import type { CmuxClient } from "./cmux-client.js";
@@ -408,7 +409,7 @@ export class CmuxSocketClient {
   async send(
     surface: string,
     text: string,
-    opts?: { workspace?: string },
+    opts?: CmuxSendOptions,
   ): Promise<void> {
     const workspace = await this.resolveWorkspace(surface, opts?.workspace);
     const params: Record<string, unknown> = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
@@ -67,6 +68,40 @@ const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmux agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
+const SEND_INPUT_CHUNK_THRESHOLD = 500;
+const SEND_INPUT_CHUNK_DELAY_MS = 5;
+const SEND_INPUT_RETRY_ATTEMPTS = 3;
+const SEND_INPUT_RETRY_DELAY_MS = 25;
+
+type DeliveryStatus = "delivering" | "delivered" | "failed";
+
+interface DeliveryRecord {
+  delivery_id: string;
+  surface: string;
+  workspace?: string;
+  status: DeliveryStatus;
+  total_chunks: number;
+  sent_chunks: number;
+  chunk_size: number;
+  chunk_delay_ms: number;
+  chunks: string[];
+  press_enter: boolean;
+  rename_to_task?: string;
+  started_at: string;
+  completed_at?: string;
+  error?: string;
+  failed_chunk?: number;
+}
+
+class DeliveryError extends Error {
+  constructor(
+    message: string,
+    readonly failed_chunk?: number,
+  ) {
+    super(message);
+    this.name = "DeliveryError";
+  }
+}
 
 function ok(data: Record<string, unknown>): ToolReturn {
   const payload = { ok: true, ...data };
@@ -105,6 +140,37 @@ function requireValue(
   if (value === undefined || value === "") {
     throw new Error(message);
   }
+}
+
+function chunkTerminalInput(text: string, chunkSize: number): string[] {
+  if (!text || text.length <= chunkSize) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > chunkSize) {
+    const newlineIndex = remaining.lastIndexOf("\n", chunkSize);
+    const splitAt = newlineIndex >= 0 ? newlineIndex + 1 : chunkSize;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableDeliveryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /socket|connection_|connection closed|timeout/i.test(message);
 }
 
 function pickLatestSurfaceModel(
@@ -219,6 +285,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const stateDir =
     opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
   const stateMgr = new StateManager(stateDir);
+  const deliveries = new Map<string, DeliveryRecord>();
+  const latestDeliveryBySurface = new Map<string, string>();
+  const activeDeliveryBySurface = new Map<string, string>();
   const enableClaudeChannels =
     opts?.enableClaudeChannels ??
     process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1";
@@ -240,6 +309,218 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
     });
   }
+
+  const snapshotDelivery = (record: DeliveryRecord) => ({
+    delivery_id: record.delivery_id,
+    surface: record.surface,
+    status: record.status,
+    sent_chunks: record.sent_chunks,
+    total_chunks: record.total_chunks,
+    chunk_size: record.chunk_size,
+    started_at: record.started_at,
+    completed_at: record.completed_at ?? null,
+    failed_chunk: record.failed_chunk ?? null,
+    error: record.error ?? null,
+  });
+
+  const getSurfaceDelivery = (surface: string) => {
+    const deliveryId = latestDeliveryBySurface.get(surface);
+    if (!deliveryId) {
+      return null;
+    }
+
+    const record = deliveries.get(deliveryId);
+    return record ? snapshotDelivery(record) : null;
+  };
+
+  const assertNoActiveDelivery = (surface: string) => {
+    const activeDeliveryId = activeDeliveryBySurface.get(surface);
+    if (!activeDeliveryId) {
+      return;
+    }
+
+    const record = deliveries.get(activeDeliveryId);
+    if (record?.status === "delivering") {
+      throw new Error(
+        `delivery ${activeDeliveryId} is still in progress for ${surface}`,
+      );
+    }
+
+    activeDeliveryBySurface.delete(surface);
+  };
+
+  const finishDelivery = (
+    record: DeliveryRecord,
+    status: DeliveryStatus,
+    error?: string,
+    failedChunk?: number,
+  ) => {
+    record.status = status;
+    record.completed_at = new Date().toISOString();
+    record.error = error;
+    record.failed_chunk = failedChunk;
+    latestDeliveryBySurface.set(record.surface, record.delivery_id);
+    if (activeDeliveryBySurface.get(record.surface) === record.delivery_id) {
+      activeDeliveryBySurface.delete(record.surface);
+    }
+  };
+
+  const sendChunkWithRetry = async (
+    surface: string,
+    chunk: string,
+    opts: { workspace?: string; chunk_size: number; chunk_delay_ms: number },
+    chunkNumber: number,
+    totalChunks: number,
+  ) => {
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt < SEND_INPUT_RETRY_ATTEMPTS) {
+      try {
+        await client.send(surface, chunk, opts);
+        return;
+      } catch (error) {
+        lastError = error;
+        attempt += 1;
+        if (
+          !isRetryableDeliveryError(error) ||
+          attempt >= SEND_INPUT_RETRY_ATTEMPTS
+        ) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          throw new DeliveryError(
+            `chunk ${chunkNumber}/${totalChunks} failed: ${message}`,
+            chunkNumber,
+          );
+        }
+        await delay(SEND_INPUT_RETRY_DELAY_MS);
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new DeliveryError(
+      `chunk ${chunkNumber}/${totalChunks} failed: ${message}`,
+      chunkNumber,
+    );
+  };
+
+  const sendKeyWithRetry = async (
+    surface: string,
+    key: string,
+    workspace?: string,
+  ) => {
+    let attempt = 0;
+
+    while (attempt < SEND_INPUT_RETRY_ATTEMPTS) {
+      try {
+        await client.sendKey(surface, key, { workspace });
+        return;
+      } catch (error) {
+        attempt += 1;
+        if (
+          !isRetryableDeliveryError(error) ||
+          attempt >= SEND_INPUT_RETRY_ATTEMPTS
+        ) {
+          throw error;
+        }
+        await delay(SEND_INPUT_RETRY_DELAY_MS);
+      }
+    }
+  };
+
+  const applySendInputPostActions = async (opts: {
+    surface: string;
+    workspace?: string;
+    press_enter: boolean;
+    rename_to_task?: string;
+  }) => {
+    if (opts.press_enter) {
+      await delay(50);
+      await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+    }
+
+    if (opts.rename_to_task) {
+      const surfaces = await client.listPaneSurfaces({
+        workspace: opts.workspace,
+      });
+      const surface = surfaces.surfaces.find((s) => s.ref === opts.surface);
+      const currentTitle = surface?.title ?? "";
+      const newTitle = replaceTaskSuffix(currentTitle, opts.rename_to_task);
+      await client.renameTab(opts.surface, newTitle, {
+        workspace: opts.workspace,
+      });
+    }
+  };
+
+  const deliverInputChunks = async (opts: {
+    surface: string;
+    workspace?: string;
+    chunks: string[];
+    chunk_size: number;
+    chunk_delay_ms: number;
+    press_enter: boolean;
+    rename_to_task?: string;
+    onChunkDelivered?: (sentChunks: number) => void;
+  }) => {
+    for (const [index, chunk] of opts.chunks.entries()) {
+      await sendChunkWithRetry(
+        opts.surface,
+        chunk,
+        {
+          workspace: opts.workspace,
+          chunk_size: opts.chunk_size,
+          chunk_delay_ms: opts.chunk_delay_ms,
+        },
+        index + 1,
+        opts.chunks.length,
+      );
+      opts.onChunkDelivered?.(index + 1);
+      if (index < opts.chunks.length - 1) {
+        await delay(opts.chunk_delay_ms);
+      }
+    }
+
+    await applySendInputPostActions({
+      surface: opts.surface,
+      workspace: opts.workspace,
+      press_enter: opts.press_enter,
+      rename_to_task: opts.rename_to_task,
+    });
+  };
+
+  const startBackgroundDelivery = (record: DeliveryRecord) => {
+    deliveries.set(record.delivery_id, record);
+    latestDeliveryBySurface.set(record.surface, record.delivery_id);
+    activeDeliveryBySurface.set(record.surface, record.delivery_id);
+
+    const run = async () => {
+      try {
+        await deliverInputChunks({
+          surface: record.surface,
+          workspace: record.workspace,
+          chunks: record.chunks,
+          chunk_size: record.chunk_size,
+          chunk_delay_ms: record.chunk_delay_ms,
+          press_enter: record.press_enter,
+          rename_to_task: record.rename_to_task,
+          onChunkDelivered: (sentChunks) => {
+            record.sent_chunks = sentChunks;
+          },
+        });
+        finishDelivery(record, "delivered");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const failedChunk =
+          error instanceof DeliveryError ? error.failed_chunk : undefined;
+        finishDelivery(record, "failed", message, failedChunk);
+      }
+    };
+
+    setTimeout(() => {
+      void run();
+    }, 0);
+  };
 
   const findSurfaceByRef = async (
     surfaceRef: string,
@@ -472,11 +753,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 4. send_input
   server.tool(
     "send_input",
-    "Send text input to a terminal surface. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",
+    "Send text input to a terminal surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Set background=true to return immediately with a delivery_id while chunking continues in the background. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",
     {
       surface: z.string().describe("Target surface ref"),
       text: z.string().describe("Text to send"),
       workspace: z.string().optional().describe("Target workspace ref"),
+      chunk_size: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .default(200)
+        .describe("Chunk size for automatic long-text delivery"),
+      background: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Return immediately with a delivery_id and continue chunked delivery in the background",
+        ),
       press_enter: z
         .boolean()
         .optional()
@@ -492,34 +787,64 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        assertNoActiveDelivery(args.surface);
+
         const sanitizedText = sanitizeTerminalInput(args.text);
-        await client.send(args.surface, sanitizedText, {
+        const chunks =
+          sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
+            ? chunkTerminalInput(sanitizedText, args.chunk_size)
+            : [sanitizedText];
+
+        if (args.background) {
+          const record: DeliveryRecord = {
+            delivery_id: randomUUID(),
+            surface: args.surface,
+            workspace: args.workspace,
+            status: "delivering",
+            total_chunks: chunks.length,
+            sent_chunks: 0,
+            chunk_size: args.chunk_size,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            chunks,
+            press_enter: args.press_enter,
+            rename_to_task: args.rename_to_task,
+            started_at: new Date().toISOString(),
+          };
+          startBackgroundDelivery(record);
+
+          const data = {
+            surface: args.surface,
+            delivery_id: record.delivery_id,
+            status: record.status,
+          };
+          return okFormatted(formatOk("send_input", data), data);
+        }
+
+        await deliverInputChunks({
+          surface: args.surface,
           workspace: args.workspace,
+          chunks,
+          chunk_size: args.chunk_size,
+          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+          press_enter: args.press_enter,
+          rename_to_task: args.rename_to_task,
         });
-        if (args.press_enter) {
-          // Small delay to let the terminal process the text input before
-          // sending the return key. Without this, the enter keypress can
-          // arrive before the text is fully inserted into the terminal's
-          // input buffer, causing the enter to be swallowed.
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          await client.sendKey(args.surface, "return", {
-            workspace: args.workspace,
-          });
-        }
-        if (args.rename_to_task) {
-          const surfaces = await client.listPaneSurfaces({
-            workspace: args.workspace,
-          });
-          const surface = surfaces.surfaces.find((s) => s.ref === args.surface);
-          const currentTitle = surface?.title ?? "";
-          const newTitle = replaceTaskSuffix(currentTitle, args.rename_to_task);
-          await client.renameTab(args.surface, newTitle, {
-            workspace: args.workspace,
-          });
-        }
+
         const data = { surface: args.surface };
         return okFormatted(formatOk("send_input", data), data);
       } catch (e) {
+        if (e instanceof DeliveryError) {
+          const payload = {
+            ok: false,
+            error: e.message,
+            failed_chunk: e.failed_chunk ?? null,
+          };
+          return {
+            content: [{ type: "text", text: JSON.stringify(payload) }],
+            structuredContent: payload,
+            isError: true,
+          };
+        }
         return err(e);
       }
     },
@@ -551,7 +876,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 5. read_screen
   server.tool(
     "read_screen",
-    "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors. Use parsed_only=true for monitoring (omits raw terminal content).",
+    "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors, plus delivery metadata for the current or most recent background send_input operation. Use parsed_only=true for monitoring (omits raw terminal content).",
     {
       surface: z.string().describe("Target surface ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
@@ -596,6 +921,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface: result.surface,
             title: surface?.title ?? null,
             parsed,
+            delivery: getSurfaceDelivery(result.surface),
           };
           const formatted = formatReadScreen(
             result.surface,
@@ -615,6 +941,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           content: result.text,
           scrollback_used: result.scrollback_used,
           parsed,
+          delivery: getSurfaceDelivery(result.surface),
         };
         const formatted = formatReadScreen(
           result.surface,

--- a/src/server.ts
+++ b/src/server.ts
@@ -123,9 +123,12 @@ function okFormatted(
   };
 }
 
-function err(error: unknown): ToolReturn {
+function err(
+  error: unknown,
+  extra: Record<string, unknown> = {},
+): ToolReturn {
   const message = error instanceof Error ? error.message : String(error);
-  const payload = { ok: false, error: message };
+  const payload = { ok: false, error: message, ...extra };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
@@ -288,6 +291,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const deliveries = new Map<string, DeliveryRecord>();
   const latestDeliveryBySurface = new Map<string, string>();
   const activeDeliveryBySurface = new Map<string, string>();
+  const activeSurfaceWrites = new Map<string, string>();
   const enableClaudeChannels =
     opts?.enableClaudeChannels ??
     process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1";
@@ -333,20 +337,62 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return record ? snapshotDelivery(record) : null;
   };
 
-  const assertNoActiveDelivery = (surface: string) => {
+  const getSurfaceWriteConflict = (surface: string) => {
     const activeDeliveryId = activeDeliveryBySurface.get(surface);
-    if (!activeDeliveryId) {
-      return;
+    if (activeDeliveryId) {
+      const record = deliveries.get(activeDeliveryId);
+      if (record?.status === "delivering") {
+        return new Error(
+          `delivery ${activeDeliveryId} is still in progress for ${surface}`,
+        );
+      }
+
+      activeDeliveryBySurface.delete(surface);
     }
 
-    const record = deliveries.get(activeDeliveryId);
-    if (record?.status === "delivering") {
-      throw new Error(
-        `delivery ${activeDeliveryId} is still in progress for ${surface}`,
-      );
+    if (activeSurfaceWrites.has(surface)) {
+      return new Error(`surface ${surface} is busy`);
     }
 
-    activeDeliveryBySurface.delete(surface);
+    return null;
+  };
+
+  const acquireSurfaceWrite = (surface: string, owner: string) => {
+    const conflict = getSurfaceWriteConflict(surface);
+    if (conflict) {
+      throw conflict;
+    }
+
+    activeSurfaceWrites.set(surface, owner);
+  };
+
+  const releaseSurfaceWrite = (surface: string, owner: string) => {
+    if (activeSurfaceWrites.get(surface) === owner) {
+      activeSurfaceWrites.delete(surface);
+    }
+  };
+
+  const withSurfaceWrite = async <T>(
+    surface: string,
+    fn: () => Promise<T>,
+    owner = `surface-write:${randomUUID()}`,
+  ): Promise<T> => {
+    acquireSurfaceWrite(surface, owner);
+    try {
+      return await fn();
+    } finally {
+      releaseSurfaceWrite(surface, owner);
+    }
+  };
+
+  const pruneCompletedDeliveryHistory = (surface: string) => {
+    const latestDeliveryId = latestDeliveryBySurface.get(surface);
+    for (const [deliveryId, record] of deliveries.entries()) {
+      if (record.surface !== surface) continue;
+      if (deliveryId === latestDeliveryId) continue;
+      if (record.status === "delivering") continue;
+      deliveries.delete(deliveryId);
+    }
   };
 
   const finishDelivery = (
@@ -359,16 +405,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     record.completed_at = new Date().toISOString();
     record.error = error;
     record.failed_chunk = failedChunk;
+    record.chunks = [];
     latestDeliveryBySurface.set(record.surface, record.delivery_id);
     if (activeDeliveryBySurface.get(record.surface) === record.delivery_id) {
       activeDeliveryBySurface.delete(record.surface);
     }
+    releaseSurfaceWrite(record.surface, record.delivery_id);
+    pruneCompletedDeliveryHistory(record.surface);
   };
 
   const sendChunkWithRetry = async (
     surface: string,
     chunk: string,
-    opts: { workspace?: string; chunk_size: number; chunk_delay_ms: number },
+    opts: { workspace?: string },
     chunkNumber: number,
     totalChunks: number,
   ) => {
@@ -469,8 +518,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         chunk,
         {
           workspace: opts.workspace,
-          chunk_size: opts.chunk_size,
-          chunk_delay_ms: opts.chunk_delay_ms,
         },
         index + 1,
         opts.chunks.length,
@@ -490,9 +537,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   const startBackgroundDelivery = (record: DeliveryRecord) => {
+    acquireSurfaceWrite(record.surface, record.delivery_id);
     deliveries.set(record.delivery_id, record);
     latestDeliveryBySurface.set(record.surface, record.delivery_id);
     activeDeliveryBySurface.set(record.surface, record.delivery_id);
+    pruneCompletedDeliveryHistory(record.surface);
 
     const run = async () => {
       try {
@@ -787,8 +836,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
-        assertNoActiveDelivery(args.surface);
-
         const sanitizedText = sanitizeTerminalInput(args.text);
         const chunks =
           sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
@@ -820,30 +867,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return okFormatted(formatOk("send_input", data), data);
         }
 
-        await deliverInputChunks({
-          surface: args.surface,
-          workspace: args.workspace,
-          chunks,
-          chunk_size: args.chunk_size,
-          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-          press_enter: args.press_enter,
-          rename_to_task: args.rename_to_task,
+        await withSurfaceWrite(args.surface, async () => {
+          await deliverInputChunks({
+            surface: args.surface,
+            workspace: args.workspace,
+            chunks,
+            chunk_size: args.chunk_size,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: args.press_enter,
+            rename_to_task: args.rename_to_task,
+          });
         });
 
         const data = { surface: args.surface };
         return okFormatted(formatOk("send_input", data), data);
       } catch (e) {
         if (e instanceof DeliveryError) {
-          const payload = {
-            ok: false,
-            error: e.message,
-            failed_chunk: e.failed_chunk ?? null,
-          };
-          return {
-            content: [{ type: "text", text: JSON.stringify(payload) }],
-            structuredContent: payload,
-            isError: true,
-          };
+          return err(e, { failed_chunk: e.failed_chunk ?? null });
         }
         return err(e);
       }
@@ -862,8 +902,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
-        await client.sendKey(args.surface, args.key, {
-          workspace: args.workspace,
+        await withSurfaceWrite(args.surface, async () => {
+          await sendKeyWithRetry(args.surface, args.key, args.workspace);
         });
         const data = { surface: args.surface, key: args.key };
         return okFormatted(formatOk("send_key", data), data);
@@ -984,8 +1024,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const currentTitle = surface?.title ?? "";
           finalTitle = replaceTaskSuffix(currentTitle, args.title);
         }
-        await client.renameTab(args.surface, finalTitle, {
-          workspace: args.workspace,
+        await withSurfaceWrite(args.surface, async () => {
+          await client.renameTab(args.surface, finalTitle, {
+            workspace: args.workspace,
+          });
         });
         const data = { surface: args.surface, title: finalTitle };
         return okFormatted(formatOk("rename_tab", data), data);
@@ -1276,8 +1318,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         client.setStatus(key, value, statusOpts),
       clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
       readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
-      send: (surface, text, sendOpts) => client.send(surface, text, sendOpts),
-      sendKey: (surface, key, keyOpts) => client.sendKey(surface, key, keyOpts),
+      send: (surface, text, sendOpts) =>
+        withSurfaceWrite(surface, () => client.send(surface, text, sendOpts)),
+      sendKey: (surface, key, keyOpts) =>
+        withSurfaceWrite(surface, () => client.sendKey(surface, key, keyOpts)),
       setProgress: (value, progressOpts) =>
         client.setProgress(value, progressOpts),
       newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),
@@ -1694,7 +1738,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return okFormatted(formatOk("interact:send", d), d);
             }
             case "interrupt": {
-              await client.sendKey(agent.surface_id, "c-c", {});
+              await withSurfaceWrite(agent.surface_id, () =>
+                client.sendKey(agent.surface_id, "c-c", {}),
+              );
               const d = { agent_id: args.agent, action: "interrupt" };
               return okFormatted(formatOk("interact:interrupt", d), d);
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,12 @@ export interface CmuxReadScreenResult {
   scrollback_used: boolean;
 }
 
+export interface CmuxSendOptions {
+  workspace?: string;
+  chunk_size?: number;
+  chunk_delay_ms?: number;
+}
+
 export type ParsedScreenAgentType =
   | "claude"
   | "codex"

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -256,24 +256,17 @@ describe("CmuxClient.send", () => {
     ]);
   });
 
-  it("accepts chunking options without changing the CLI command shape", async () => {
+  it("rejects server-only chunking options at the client boundary", async () => {
     const { client, exec } = mockClient({});
 
-    await client.send("surface:1", "chunk me", {
-      workspace: "workspace:2",
-      chunk_size: 180,
-      chunk_delay_ms: 7,
-    });
-
-    expect(exec).toHaveBeenCalledWith("cmux", [
-      "--json",
-      "send",
-      "--surface",
-      "surface:1",
-      "--workspace",
-      "workspace:2",
-      "chunk me",
-    ]);
+    await expect(
+      client.send("surface:1", "chunk me", {
+        workspace: "workspace:2",
+        chunk_size: 180,
+        chunk_delay_ms: 7,
+      }),
+    ).rejects.toThrow(/does not support chunk_size, chunk_delay_ms/i);
+    expect(exec).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -255,6 +255,26 @@ describe("CmuxClient.send", () => {
       "ls",
     ]);
   });
+
+  it("accepts chunking options without changing the CLI command shape", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.send("surface:1", "chunk me", {
+      workspace: "workspace:2",
+      chunk_size: 180,
+      chunk_delay_ms: 7,
+    });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "send",
+      "--surface",
+      "surface:1",
+      "--workspace",
+      "workspace:2",
+      "chunk me",
+    ]);
+  });
 });
 
 describe("CmuxClient.sendKey", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -231,6 +231,17 @@ describe("CmuxSocketClient", () => {
     await client.send("surface:1", "echo hello", { workspace: "workspace:1" });
   });
 
+  it("rejects server-only chunking options at the socket boundary", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await expect(
+      client.send("surface:1", "echo hello", {
+        workspace: "workspace:1",
+        chunk_size: 180,
+      }),
+    ).rejects.toThrow(/does not support chunk_size/i);
+  });
+
   it("readScreen returns screen content", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
     const result = await client.readScreen("surface:1", {

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -154,7 +154,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // Mock readScreen: 160K tokens on Sonnet (200K window) = 80% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $3.50",
       lines: 5,
@@ -182,7 +182,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // Mock readScreen: 170K tokens on Haiku (200K window) = 85% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:2",
       text: "✻ Working…\nToken usage: total=170,000\n🤖 Haiku 3.5 | 💰 $0.10",
       lines: 5,
@@ -214,7 +214,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 160K tokens on Sonnet (200K window) = 80% used
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=160,000\n🤖 Sonnet 4.6 | 💰 $2.00",
       lines: 5,
@@ -241,7 +241,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 100K tokens on Sonnet (200K window) = 50% used — below threshold
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:1",
       text: "✻ Working…\nToken usage: total=100,000\n🤖 Sonnet 4.6 | 💰 $1.00",
       lines: 5,
@@ -278,7 +278,7 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 180K tokens on Haiku (200K window) = 90% used — above threshold
-    vi.mocked(mockClient.readScreen).mockResolvedValue({
+    (mockClient.readScreen as any).mockResolvedValue({
       surface: "s:2",
       text: "✻ Working…\nToken usage: total=180,000\n🤖 Haiku 3.5 | 💰 $0.15",
       lines: 5,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -25,6 +25,18 @@ const EXPECTED_TOOLS = [
 
 const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
 
+async function advanceTimers(ms: number): Promise<void> {
+  const advanceAsync = (vi as any).advanceTimersByTimeAsync;
+  if (typeof advanceAsync === "function") {
+    await advanceAsync.call(vi, ms);
+    return;
+  }
+
+  vi.advanceTimersByTime(ms);
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("createServer", () => {
   it("returns an McpServer with a connect method", async () => {
     const server = createServer({ skipAgentLifecycle: true });
@@ -71,8 +83,12 @@ describe("tool registration", () => {
 
 describe("Claude channels", () => {
   afterEach(() => {
+    try {
+      vi.clearAllTimers();
+    } catch {
+      // Bun's Vitest shim throws here when fake timers were never activated.
+    }
     vi.useRealTimers();
-    vi.clearAllTimers();
     rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
   });
 
@@ -155,7 +171,7 @@ describe("Claude channels", () => {
     };
 
     await server.connect(serverTransport);
-    await vi.advanceTimersByTimeAsync(5000);
+    await advanceTimers(5000);
 
     const notifications = messages.filter(
       (message) =>
@@ -728,6 +744,250 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["send-key"]),
     );
+  });
+
+  it("send_input chunks long text transparently before sending", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+    const longText = [
+      "abcdef".repeat(20),
+      "ghijkl".repeat(20),
+      "mnopqr".repeat(20),
+      "stuvwx".repeat(20),
+      "yz1234".repeat(20),
+    ].join("\n");
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: longText, chunk_size: 120 },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledTimes(5);
+    for (const [index, call] of mockExec.mock.calls.entries()) {
+      expect(call[0]).toBe("cmux");
+      expect(call[1]).toEqual(expect.arrayContaining(["send"]));
+      const chunk = call[1][call[1].length - 1];
+      expect(typeof chunk).toBe("string");
+      expect((chunk as string).length).toBeLessThanOrEqual(121);
+      if (index < mockExec.mock.calls.length - 1) {
+        expect((chunk as string).endsWith("\n")).toBe(true);
+      }
+    }
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("send_input can deliver long text in the background and expose status via read_screen", async () => {
+    vi.useFakeTimers();
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:1",
+            text: "$ ",
+            lines: 1,
+          }),
+          stderr: "",
+        });
+      }
+      if (args.includes("list-workspaces")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({ workspaces: [] }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const sendTool = registeredTools["send_input"];
+    const readTool = registeredTools["read_screen"];
+    const longText = [
+      "abcdef".repeat(20),
+      "ghijkl".repeat(20),
+      "mnopqr".repeat(20),
+      "stuvwx".repeat(20),
+      "yz1234".repeat(20),
+    ].join("\n");
+
+    const result = await sendTool.handler(
+      {
+        surface: "surface:1",
+        text: longText,
+        chunk_size: 120,
+        background: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.status).toBe("delivering");
+    expect(parsed.delivery_id).toEqual(expect.any(String));
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("send")),
+    ).toHaveLength(0);
+
+    const readWhileDelivering = await readTool.handler(
+      { surface: "surface:1", parsed_only: true },
+      {} as any,
+    );
+    const readWhileDeliveringParsed =
+      readWhileDelivering.structuredContent ??
+      JSON.parse(readWhileDelivering.content[0].text);
+    expect(readWhileDeliveringParsed.delivery).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      status: "delivering",
+      sent_chunks: 0,
+      total_chunks: 5,
+    });
+
+    for (let i = 0; i < 50; i++) {
+      await advanceTimers(5);
+      if (
+        mockExec.mock.calls.filter(([, args]) => args.includes("send"))
+          .length === 5
+      ) {
+        break;
+      }
+    }
+
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("send")),
+    ).toHaveLength(5);
+
+    await Promise.resolve();
+
+    const readAfterDelivery = await readTool.handler(
+      { surface: "surface:1", parsed_only: true },
+      {} as any,
+    );
+    const readAfterDeliveryParsed =
+      readAfterDelivery.structuredContent ??
+      JSON.parse(readAfterDelivery.content[0].text);
+    expect(readAfterDeliveryParsed.delivery).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      status: "delivered",
+      sent_chunks: 5,
+      total_chunks: 5,
+    });
+  });
+
+  it("send_input background mode blocks the same surface but allows other surfaces", async () => {
+    vi.useFakeTimers();
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+    const longText = [
+      "abcdef".repeat(20),
+      "ghijkl".repeat(20),
+      "mnopqr".repeat(20),
+      "stuvwx".repeat(20),
+      "yz1234".repeat(20),
+    ].join("\n");
+
+    const first = await tool.handler(
+      {
+        surface: "surface:1",
+        text: longText,
+        chunk_size: 120,
+        background: true,
+      },
+      {} as any,
+    );
+    const firstParsed =
+      first.structuredContent ?? JSON.parse(first.content[0].text);
+    expect(firstParsed.status).toBe("delivering");
+
+    const sameSurface = await tool.handler(
+      { surface: "surface:1", text: "echo nope" },
+      {} as any,
+    );
+    expect(sameSurface.isError).toBe(true);
+    const sameSurfaceParsed =
+      sameSurface.structuredContent ?? JSON.parse(sameSurface.content[0].text);
+    expect(sameSurfaceParsed.error).toMatch(/delivery.*in progress/i);
+
+    const otherSurface = await tool.handler(
+      { surface: "surface:2", text: "echo ok" },
+      {} as any,
+    );
+    const otherSurfaceParsed =
+      otherSurface.structuredContent ?? JSON.parse(otherSurface.content[0].text);
+    expect(otherSurfaceParsed.ok).toBe(true);
+    expect(otherSurfaceParsed.surface).toBe("surface:2");
+  });
+
+  it("send_input retries a transient socket failure before succeeding", async () => {
+    vi.useFakeTimers();
+    let sendAttempts = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("send")) {
+        sendAttempts += 1;
+        if (sendAttempts === 1) {
+          return Promise.reject(new Error("socket closed before receiving response"));
+        }
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+
+    const resultPromise = tool.handler(
+      { surface: "surface:1", text: "echo retry me" },
+      {} as any,
+    );
+
+    await advanceTimers(25);
+
+    const result = await resultPromise;
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(sendAttempts).toBe(2);
+  });
+
+  it("send_input reports the failed chunk when retries are exhausted", async () => {
+    vi.useFakeTimers();
+    let sendAttempts = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("send")) {
+        sendAttempts += 1;
+        return Promise.reject(new Error("socket connection_error"));
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+
+    const resultPromise = tool.handler(
+      { surface: "surface:1", text: "echo fail me" },
+      {} as any,
+    );
+
+    await advanceTimers(50);
+
+    const result = await resultPromise;
+    expect(result.isError).toBe(true);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.failed_chunk).toBe(1);
+    expect(parsed.error).toMatch(/chunk 1\/1 failed/i);
+    expect(sendAttempts).toBe(3);
   });
 
   it("new_split handler calls cmux new-split", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -927,6 +927,90 @@ describe("tool handler integration", () => {
     expect(otherSurfaceParsed.surface).toBe("surface:2");
   });
 
+  it("send_input rejects concurrent foreground sends on the same surface", async () => {
+    let releaseSend: ((value: { stdout: string; stderr: string }) => void) | null =
+      null;
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("send") && !releaseSend) {
+        return new Promise((resolve) => {
+          releaseSend = resolve;
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+
+    const firstPromise = tool.handler(
+      { surface: "surface:1", text: "echo first" },
+      {} as any,
+    );
+    await Promise.resolve();
+
+    const second = await tool.handler(
+      { surface: "surface:1", text: "echo second" },
+      {} as any,
+    );
+    expect(second.isError).toBe(true);
+    const secondParsed =
+      second.structuredContent ?? JSON.parse(second.content[0].text);
+    expect(secondParsed.error).toMatch(/surface surface:1 is busy/i);
+
+    releaseSend?.({ stdout: "{}", stderr: "" });
+    const first = await firstPromise;
+    const firstParsed =
+      first.structuredContent ?? JSON.parse(first.content[0].text);
+    expect(firstParsed.ok).toBe(true);
+  });
+
+  it("background delivery blocks other same-surface write tools", async () => {
+    vi.useFakeTimers();
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const sendInput = registeredTools["send_input"];
+    const sendKey = registeredTools["send_key"];
+    const renameTab = registeredTools["rename_tab"];
+    const longText = [
+      "abcdef".repeat(20),
+      "ghijkl".repeat(20),
+      "mnopqr".repeat(20),
+      "stuvwx".repeat(20),
+      "yz1234".repeat(20),
+    ].join("\n");
+
+    await sendInput.handler(
+      {
+        surface: "surface:1",
+        text: longText,
+        chunk_size: 120,
+        background: true,
+      },
+      {} as any,
+    );
+
+    const keyResult = await sendKey.handler(
+      { surface: "surface:1", key: "return" },
+      {} as any,
+    );
+    expect(keyResult.isError).toBe(true);
+    const keyParsed =
+      keyResult.structuredContent ?? JSON.parse(keyResult.content[0].text);
+    expect(keyParsed.error).toMatch(/delivery.*in progress/i);
+
+    const renameResult = await renameTab.handler(
+      { surface: "surface:1", title: "blocked" },
+      {} as any,
+    );
+    expect(renameResult.isError).toBe(true);
+    const renameParsed =
+      renameResult.structuredContent ?? JSON.parse(renameResult.content[0].text);
+    expect(renameParsed.error).toMatch(/delivery.*in progress/i);
+  });
+
   it("send_input retries a transient socket failure before succeeding", async () => {
     vi.useFakeTimers();
     let sendAttempts = 0;


### PR DESCRIPTION
## Summary
- add resilient chunked `send_input` delivery with per-chunk acknowledgment and retry handling
- add `background: true` mode with per-surface delivery tracking exposed through `read_screen.delivery`
- expand tests for chunking, background delivery, lockout, retry handling, and failure reporting

## Validation
- `bun run test`
- `bun run typecheck`
- live cmux validation on temporary surfaces in `workspace:4` via the actual local `send_input`/`read_screen` handlers:
  - blocking long-text delivery showed the final marker on screen
  - background delivery returned a `delivery_id`, blocked same-surface sends, and reached `status: delivered`

## Note
- `bun test` under Bun 1.3.9 still prints passing output and then hangs because it invokes Bun's built-in runner rather than the repo's configured `vitest run` script. The project test command (`bun run test`) passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic long-text chunking for inputs exceeding 500 characters
  * Background delivery mode for asynchronous sending with tracking
  * Chunk-level retry logic for transient network errors
  * Delivery progress visibility in screen reads
  * Enhanced error reporting with failed chunk details

* **Chores**
  * Consolidated send method type signatures across client implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chunked, retriable, and background delivery for `send_input` in the MCP server
> - Long terminal input is automatically split into newline-aware chunks in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/71/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), with configurable `chunk_size` and `chunk_delay_ms` options (server-side only).
> - `send_input` can run in the background, returning a `delivery_id` and status; `read_screen` exposes a snapshot of the current delivery state.
> - Transient send failures are retried automatically; error responses include a `failed_chunk` field when chunked delivery fails mid-stream.
> - Per-surface write locks (`withSurfaceWrite`) serialize `send_input`, `send_key`, `rename_tab`, and engine sends, returning an error when a surface is busy.
> - `CmuxClient` and `CmuxSocketClient` now accept `CmuxSendOptions` but throw immediately if `chunk_size` or `chunk_delay_ms` are passed, since chunking is handled server-side.
> - Risk: write locking changes the behavior of concurrent tool calls — they now fail fast with a busy error instead of racing.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 64bc66c. 6 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->