### PR TITLE
docs: refresh README metadata and Codex/T3 config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer exposes 25 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, Cursor, and Kiro.
+Under the hood, cmuxLayer exposes 25 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
 ## MCP Tools (25)
 
@@ -119,8 +119,6 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | Codex | `codex` | status, model, context % |
 | Gemini CLI | `gemini` | status, model, tokens, context % |
 | Cursor | `cursor agent` | status, model, tokens, context % |
-| Kiro | `kiro-cli` | status |
-
 `read_screen` auto-detects agent type and parses metadata from terminal output.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cmuxLayer
 
-**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 22 MCP tools that give AI agents programmatic control over terminal workspaces.
+**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 25 MCP tools that give AI agents programmatic control over terminal workspaces.
 
 <p align="center">
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
@@ -8,8 +8,8 @@
 
 [![install](https://img.shields.io/badge/install-npm%20install%20--g%20cmuxlayer-22c55e)](https://github.com/EtanHey/cmuxlayer#quick-start)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP-22%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-335%20passing-brightgreen.svg)](#testing)
+[![MCP Tools](https://img.shields.io/badge/MCP-25%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-361%20passing-brightgreen.svg)](#testing)
 
 ## Quick Start
 
@@ -19,7 +19,18 @@ npm install -g cmuxlayer
 
 Requires [cmux](https://github.com/manaflow-ai/cmux) to be running.
 
-Add to your MCP config (Claude Code, Cursor, VS Code, Claude Desktop):
+Add to your MCP config:
+
+**Codex CLI / T3 Code**
+
+T3 Code inherits MCP servers from the Codex CLI config file at `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`).
+
+```toml
+[mcp_servers.cmux]
+command = "cmuxlayer"
+```
+
+**Claude Code, Cursor, VS Code, Claude Desktop**
 
 ```json
 {
@@ -31,7 +42,7 @@ Add to your MCP config (Claude Code, Cursor, VS Code, Claude Desktop):
 }
 ```
 
-> **Config locations:** Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
+> **Config locations:** Codex CLI / T3 Code `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) | Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
 
 ## What You Can Do
 
@@ -43,20 +54,20 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer exposes 22 MCP tools for terminal control, screen reading, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, Cursor, and Kiro.
+Under the hood, cmuxLayer exposes 25 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, Cursor, and Kiro.
 
-## MCP Tools (22)
+## MCP Tools (25)
 
 All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
 
-**Terminal control** — `new_split` `send_input` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
+**Terminal control** — `new_split` `new_surface` `move_surface` `reorder_surface` `send_input` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
 
 **Agent lifecycle** — `spawn_agent` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
 
 **Workspace** — `list_surfaces` `list_agents` `my_agents` `get_agent_state` `read_agent_output` `notify` `set_status` `set_progress`
 
 <details>
-<summary>Full tool reference (22 tools)</summary>
+<summary>Full tool reference (25 tools)</summary>
 
 ### Read-only (6)
 
@@ -69,11 +80,14 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `my_agents` | Children of a parent agent with live screen status |
 | `read_agent_output` | Structured output between delimiter markers |
 
-### Mutating (13)
+### Mutating (16)
 
 | Tool | What it does |
 |------|-------------|
 | `new_split` | Create a terminal or browser split pane |
+| `new_surface` | Create a tab in an existing pane |
+| `move_surface` | Move a surface to another pane or position |
+| `reorder_surface` | Reorder tabs within a pane |
 | `send_input` | Send text to a surface |
 | `send_key` | Send key press (return, escape, ctrl-c, etc.) |
 | `rename_tab` | Rename a surface tab |
@@ -102,9 +116,9 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | CLI | Command | Auto-detected |
 |-----|---------|---------------|
 | Claude Code | `claude` | status, model, tokens, context % |
-| Codex | `codex` | status, model |
-| Gemini CLI | `gemini` | status, model |
-| Cursor | `cursor agent` | status |
+| Codex | `codex` | status, model, context % |
+| Gemini CLI | `gemini` | status, model, tokens, context % |
+| Cursor | `cursor agent` | status, model, tokens, context % |
 | Kiro | `kiro-cli` | status |
 
 `read_screen` auto-detects agent type and parses metadata from terminal output.
@@ -131,6 +145,9 @@ The socket client connects to cmux via Unix socket. Auto-reconnects on disconnec
 **cmux is not running**
 cmuxLayer requires a running [cmux](https://github.com/manaflow-ai/cmux) instance. Install it first, then start a cmux session before using cmuxLayer.
 
+**Tools not appearing in Codex CLI or T3 Code**
+Restart the client after adding `cmuxlayer` to `~/.codex/config.toml`. If you use a custom Codex home, verify `$CODEX_HOME/config.toml` contains the same `mcp_servers.cmux` entry.
+
 **Tools not appearing in Claude Code**
 Restart Claude Code after adding the MCP config. Run `claude mcp list` to verify cmuxlayer is connected.
 
@@ -140,7 +157,7 @@ cmuxLayer auto-discovers the cmux socket (macOS: `~/Library/Application Support/
 ## Testing
 
 ```bash
-npm test            # 335 tests via vitest
+bun run test        # 361 tests via vitest
 npm run typecheck   # Type checking
 ```
 


### PR DESCRIPTION
## Summary
- update README tool/test metadata to match the current repo state
- document the Codex CLI and T3 Code integration path via ~/.codex/config.toml
- add the missing layout-management tools to the public tool reference

## Test plan
- bun run test
- bun run typecheck

## Notes
- CodeRabbit pre-commit review could not run because the review service returned a rate-limit error during this session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only updates to configuration instructions and tool/support metadata; no runtime or API behavior changes.
> 
> **Overview**
> Updates `README.md` to reflect **25 MCP tools** (and **361 tests**) and expands the public tool reference to include the new surface/layout management tools (`new_surface`, `move_surface`, `reorder_surface`).
> 
> Adds Codex CLI / T3 Code setup instructions via `~/.codex/config.toml` (plus troubleshooting), updates supported-agent auto-detection fields for Codex/Gemini/Cursor, and changes the test command shown to `bun run test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caa16808c48c6064ca95f386b40dc9344fd04e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to reflect 25 MCP tools, add Codex CLI config path, and refresh test counts
> - Updates tool counts from 22 to 25 and test counts from 335 to 361 throughout [README.md](https://github.com/EtanHey/cmuxlayer/pull/72/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> - Adds Codex CLI / T3 Code Quick Start instructions with a TOML config snippet and troubleshooting note
> - Expands terminal control tools list with `new_surface`, `move_surface`, `reorder_surface` and notes layout management support
> - Removes Kiro from the Supported Agents table; updates auto-detected fields for Codex, Gemini CLI, and Cursor
> - Updates testing instructions to use `bun run test` with vitest
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1caa168.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP tool inventory from 22 to 25 tools with expanded terminal control references
  * Added new surface management operations to tool documentation
  * Extended configuration instructions with Codex CLI/T3 Code setup path using TOML config
  * Updated supported agent metadata fields across platforms
  * Revised testing command and guidance with expanded test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->