### PR TITLE
fix: extract more Codex Cursor and Gemini screen metadata

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -94,14 +94,16 @@ const MODEL_EMOJI_RE =
 const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CODEX_HEADER_RE =
-  /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*(?:[·•]\s*(?:(\d+)%\s+left(?:\s*[·•]\s*[^\n]+)?|[^\n]+))$/m;
+  /^\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)(?:\s*[·•]\s*[^\n]*)?\s*$/m;
+const CODEX_CONTEXT_LEFT_RE =
+  /^\s*gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?\s*[·•]\s*(\d+)%\s+left(?:\s*[·•]\s*[^\n]*)?\s*$/m;
 const CODEX_WORKING_RE =
   /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
 const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
 const CODEX_ACTION_RE = /^\s*[•·]\s+(.+)$/gm;
 const GEMINI_MODEL_RE =
   /(?:^|\n)\s*(?:-\s*)?(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
-const GEMINI_WORKING_RE = /(?:^|\n)\s*(?:✦\s*)?Working\b/im;
+const GEMINI_WORKING_RE = /^\s*(?:✦\s*)?Working(?:\.\.\.|…)?\s*$/im;
 const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
@@ -360,8 +362,8 @@ function parseModelAndCost(
 }
 
 function parseCodexContextPct(text: string): number | null {
-  const match = text.match(CODEX_HEADER_RE);
-  return match?.[2] ? Number.parseInt(match[2], 10) : null;
+  const match = text.match(CODEX_CONTEXT_LEFT_RE);
+  return match?.[1] ? Number.parseInt(match[1], 10) : null;
 }
 
 function parseCodexActions(text: string): string[] {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -93,14 +93,15 @@ const MODEL_EMOJI_RE =
 // Last resort: 🤖 + bare model family name (for narrow panes where version is cut off)
 const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
-const CODEX_MODEL_RE =
-  /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*[·•]\s*(\d+)%\s+left/m;
+const CODEX_HEADER_RE =
+  /^(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\s*(?:[·•]\s*(?:(\d+)%\s+left(?:\s*[·•]\s*[^\n]+)?|[^\n]+))$/m;
 const CODEX_WORKING_RE =
   /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
 const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
 const CODEX_ACTION_RE = /^\s*[•·]\s+(.+)$/gm;
 const GEMINI_MODEL_RE =
-  /(?:^|\n)\s*(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
+  /(?:^|\n)\s*(?:-\s*)?(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
+const GEMINI_WORKING_RE = /(?:^|\n)\s*(?:✦\s*)?Working\b/im;
 const CLAUDE_DONE_LINE_RE = /^\s*[⏺●]\s+Completed(?: successfully)?\s*$/im;
 const CLAUDE_WORKING_LINE_RE =
   /^\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
@@ -114,8 +115,10 @@ const CURSOR_HEX_RUNNING_RE = /⬡\s+Running\.\.\./i;
 const CURSOR_HEX_IDLE_RE = /⬡\s+Idle\b/i;
 const CURSOR_TOKEN_LINE_RE =
   /⬡\s+(?:Running\.\.\.|Idle)\s+([0-9][0-9,]*(?:\.[0-9]+)?)\s*([km])?\s*tokens\b/i;
+const CURSOR_ACTIVITY_TOKEN_RE =
+  /(?:^|\n)\s*(?:⬢|⬡|•)?\s*(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating)\s+([0-9][0-9,]*(?:\.[0-9]+)?)\s*([km])?\s*tokens\b/im;
 const CURSOR_STATUS_PCT_RE =
-  /(?:^|\n)\s*(?:Auto|Agent)\s*·\s*(\d+(?:\.\d+)?)\s*%\s*·/i;
+  /(?:^|\n)\s*(?:Auto|Agent)\s*·\s*(\d+(?:\.\d+)?)\s*%(?:\s*·|\s*(?:\n|$))/i;
 const CURSOR_FOLLOWUP_RE = /→\s*Add a follow-up/i;
 const CURSOR_STOP_RE = /ctrl\+c to stop/i;
 const CURSOR_SESSION_COMPLETE_RE =
@@ -170,7 +173,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   }
 
   if (
-    CODEX_MODEL_RE.test(text) ||
+    CODEX_HEADER_RE.test(text) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {
@@ -180,7 +183,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (/Gemini CLI/i.test(text)) {
     return "gemini";
   }
-  if (GEMINI_MODEL_RE.test(text) && !CODEX_MODEL_RE.test(text)) {
+  if (GEMINI_MODEL_RE.test(text) && !CODEX_HEADER_RE.test(text)) {
     return "gemini";
   }
 
@@ -313,7 +316,7 @@ function parseModelAndCost(
   agentType: ParsedScreenAgentType,
 ): { model: string | null; cost: number | null } {
   if (agentType === "codex") {
-    const codexMatch = text.match(CODEX_MODEL_RE);
+    const codexMatch = text.match(CODEX_HEADER_RE);
     return {
       model: codexMatch?.[1]?.trim() ?? null,
       cost: null,
@@ -357,8 +360,8 @@ function parseModelAndCost(
 }
 
 function parseCodexContextPct(text: string): number | null {
-  const match = text.match(CODEX_MODEL_RE);
-  return match ? Number.parseInt(match[2], 10) : null;
+  const match = text.match(CODEX_HEADER_RE);
+  return match?.[2] ? Number.parseInt(match[2], 10) : null;
 }
 
 function parseCodexActions(text: string): string[] {
@@ -375,7 +378,7 @@ function parseCursorScaledTokenCount(raw: string, suffix?: string): number {
 }
 
 function parseCursorTokenCount(text: string): number | null {
-  const m = text.match(CURSOR_TOKEN_LINE_RE);
+  const m = text.match(CURSOR_TOKEN_LINE_RE) ?? text.match(CURSOR_ACTIVITY_TOKEN_RE);
   if (!m) return null;
   const value = parseCursorScaledTokenCount(m[1], m[2]);
   return Number.isFinite(value) ? value : null;
@@ -473,9 +476,12 @@ function inferStatus(
 
   if (
     agentType === "gemini" &&
-    /Gemini CLI/i.test(text) &&
-    /Thinking/i.test(text)
+    (/Gemini CLI/i.test(text) && /Thinking/i.test(text))
   ) {
+    return "working";
+  }
+
+  if (agentType === "gemini" && GEMINI_WORKING_RE.test(text)) {
     return "working";
   }
 

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -167,6 +167,17 @@ Working (2m 08s • esc to interrupt)
     expect(parsed.context_pct).toBeNull();
   });
 
+  it("parses Codex context-left headers with trailing whitespace", () => {
+    const parsed = parseScreen(`
+gpt-5.4 high · 87% left   
+Working (2m 06s • esc to interrupt)
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.model).toBe("gpt-5.4 high");
+    expect(parsed.context_pct).toBe(13);
+  });
+
   it("parses Gemini-style output from explicit Gemini CLI markers", () => {
     const parsed = parseScreen(`
 Gemini CLI
@@ -193,6 +204,18 @@ Gemini CLI
     expect(parsed.model).toBe("gemini-2.5-flash-lite");
     expect(parsed.token_count).toBe(100000);
     expect(parsed.context_pct).toBe(10);
+  });
+
+  it("does not treat Gemini prose that starts with Working as a working status line", () => {
+    const parsed = parseScreen(`
+Gemini CLI
+Model: gemini-2.5-flash
+Working with existing APIs is the safer migration path here.
+`);
+
+    expect(parsed.agent_type).toBe("gemini");
+    expect(parsed.model).toBe("gemini-2.5-flash");
+    expect(parsed.status).toBe("idle");
   });
 
   it("parses Cursor Agent thinking state with status strip, k tokens, and mode bar", () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -153,6 +153,20 @@ Working (2m 06s • esc to interrupt)
     expect(parsed.actions).toContain('Ran rg -n "read_screen" src tests');
   });
 
+  it("parses Codex model when the header omits the context-left segment", () => {
+    const parsed = parseScreen(`
+Improve documentation in @filename
+
+gpt-5.4 xhigh · ~/Gits/cmuxlayer
+Working (2m 08s • esc to interrupt)
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.status).toBe("working");
+    expect(parsed.model).toBe("gpt-5.4 xhigh");
+    expect(parsed.context_pct).toBeNull();
+  });
+
   it("parses Gemini-style output from explicit Gemini CLI markers", () => {
     const parsed = parseScreen(`
 Gemini CLI
@@ -164,6 +178,21 @@ Thinking...
     expect(parsed.agent_type).toBe("gemini");
     expect(parsed.status).toBe("thinking");
     expect(parsed.model).toBe("gemini-3.1-pro");
+  });
+
+  it("parses Gemini model bullets and working status icons", () => {
+    const parsed = parseScreen(`
+Gemini CLI
+✦ Working
+- Model: gemini-2.5-flash-lite
+100,000 tokens
+`);
+
+    expect(parsed.agent_type).toBe("gemini");
+    expect(parsed.status).toBe("working");
+    expect(parsed.model).toBe("gemini-2.5-flash-lite");
+    expect(parsed.token_count).toBe(100000);
+    expect(parsed.context_pct).toBe(10);
   });
 
   it("parses Cursor Agent thinking state with status strip, k tokens, and mode bar", () => {
@@ -201,6 +230,24 @@ Model: gpt-5.2 high
     expect(parsed.token_count).toBe(12450);
     expect(parsed.context_pct).toBe(10);
     expect(parsed.model).toBe("gpt-5.2 high");
+  });
+
+  it("parses Cursor token counts from calling status lines", () => {
+    const parsed = parseScreen(`
+⬢ Calling     1.59k tokens
+
+│ → Add a follow-up
+ctrl+c to stop │
+
+▶︎ Auto-run all commands (shift+tab to turn off)
+
+Auto · 16.1%
+/ commands · @ files · ! shell
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.token_count).toBe(1590);
+    expect(parsed.context_pct).toBe(16);
   });
 
   it("detects Cursor session completion as done_signal and status done", () => {


### PR DESCRIPTION
## Summary
- broaden Codex header parsing so model extraction still works when  is absent
- parse Cursor token counts from  status lines and accept bare  context strips
- support Gemini  lines and  status markers with regression tests

## Test plan
- bun run test tests/screen-parser.test.ts
- bun run test
- bun run typecheck
- bun run build
- real MCP stdio client verification against  on live cmux surfaces

## Notes
- CodeRabbit pre-commit review could not run because the review service was rate-limited during this session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Regex changes affect agent-type detection and status/model extraction, which could cause misclassification on unseen screen formats. Risk is mitigated by added targeted regression tests for the new patterns.
> 
> **Overview**
> Improves `parseScreen` metadata extraction across multiple CLIs by broadening Codex header matching to extract the model even when the `% left` segment is missing, and by parsing context-left percent separately (including trailing whitespace).
> 
> Extends Cursor parsing to read token counts from activity lines (e.g. “Calling … tokens”) and relaxes context-strip parsing so `Auto · NN%` works without a trailing separator.
> 
> Enhances Gemini parsing to accept bullet-prefixed `Model:` lines and to treat standalone `Working`/`✦ Working` status lines as `working` without misclassifying prose, with new tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cba78c18376b0ceab2d05bf03cbacd2308378a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix screen metadata extraction for Codex, Cursor, and Gemini agents
> Improves [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/73/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to handle more header and status line variants across three agent types:
>
> - Codex: new `CODEX_HEADER_RE` matches headers with or without context-left and trailing segments; `CODEX_CONTEXT_LEFT_RE` handles `% left` parsing with extra trailing whitespace
> - Gemini: `GEMINI_MODEL_RE` now accepts bullet-prefixed `- Model:` lines; `GEMINI_WORKING_RE` detects `✦ Working` status lines; agent detection no longer misclassifies Codex headers as Gemini
> - Cursor: `CURSOR_ACTIVITY_TOKEN_RE` parses token counts from activity lines like `Calling 1.59k tokens`; `CURSOR_STATUS_PCT_RE` now tolerates missing trailing middle-dot segment
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cba78c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and parsing accuracy for Codex, Gemini, and Cursor models across various output formats
  * Enhanced status and token count information extraction with more robust fallback mechanisms
  * Better handling of edge cases in model identification and percent-status parsing

* **Tests**
  * Expanded test coverage for model detection, status parsing, and token count extraction scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->