### PR TITLE
feat: reuse worker pane tabs for agent spawns

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -421,7 +421,14 @@ export class AgentEngine {
           }),
         ),
       );
-      const placement = chooseAgentSpawnPlacement(panes.panes, paneSurfaces);
+      const workerSurfaceIds = new Set(
+        this.registry.list().map((agent) => agent.surface_id),
+      );
+      const placement = chooseAgentSpawnPlacement(
+        panes.panes,
+        paneSurfaces,
+        workerSurfaceIds,
+      );
       surface =
         placement.kind === "surface"
           ? await this.client.newSurface({
@@ -429,7 +436,7 @@ export class AgentEngine {
               type: "terminal",
               workspace: params.workspace,
             })
-          : await this.client.newSplit("right", {
+          : await this.client.newSplit(placement.direction, {
               workspace: params.workspace,
               type: "terminal",
             });

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7,7 +7,10 @@ import { StateManager } from "./state-manager.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import type {
+  CmuxPane,
+  CmuxPaneSurfaces,
   CmuxNewSplitResult,
+  CmuxNewSurfaceResult,
   CmuxReadScreenResult,
   CmuxSendOptions,
 } from "./types.js";
@@ -21,6 +24,7 @@ import {
   type WaitResult,
 } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
+import { chooseAgentSpawnPlacement } from "./layout-policy.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -95,6 +99,21 @@ interface AgentEngineClient {
       focus?: boolean;
     },
   ): Promise<CmuxNewSplitResult>;
+  newSurface(opts: {
+    pane: string;
+    type?: "terminal" | "browser";
+    workspace?: string;
+    title?: string;
+    url?: string;
+  }): Promise<CmuxNewSurfaceResult>;
+  listPanes(opts?: { workspace?: string }): Promise<{
+    workspace_ref?: string;
+    panes: CmuxPane[];
+  }>;
+  listPaneSurfaces(opts?: {
+    workspace?: string;
+    pane?: string;
+  }): Promise<CmuxPaneSurfaces>;
   notifyLifecycleEvent(
     event: AgentLifecycleEvent,
     agent: AgentRecord,
@@ -390,11 +409,36 @@ export class AgentEngine {
       parentAgentId = params.parent_agent_id;
     }
 
-    // 1. Create cmux surface
-    const surface = await this.client.newSplit("right", {
-      workspace: params.workspace,
-      type: "terminal",
-    });
+    // 1. Create cmux surface using the deterministic worker layout policy.
+    let surface: CmuxNewSplitResult | CmuxNewSurfaceResult;
+    try {
+      const panes = await this.client.listPanes({ workspace: params.workspace });
+      const paneSurfaces = await Promise.all(
+        panes.panes.map((pane) =>
+          this.client.listPaneSurfaces({
+            workspace: params.workspace,
+            pane: pane.ref,
+          }),
+        ),
+      );
+      const placement = chooseAgentSpawnPlacement(panes.panes, paneSurfaces);
+      surface =
+        placement.kind === "surface"
+          ? await this.client.newSurface({
+              pane: placement.pane,
+              type: "terminal",
+              workspace: params.workspace,
+            })
+          : await this.client.newSplit("right", {
+              workspace: params.workspace,
+              type: "terminal",
+            });
+    } catch {
+      surface = await this.client.newSplit("right", {
+        workspace: params.workspace,
+        type: "terminal",
+      });
+    }
 
     // 2. Write initial state (creating → booting)
     const now = new Date().toISOString();

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -1,0 +1,39 @@
+import type { CmuxPane, CmuxPaneSurfaces } from "./types.js";
+
+export type AgentSpawnPlacement =
+  | { kind: "split"; direction: "right" }
+  | { kind: "surface"; pane: string };
+
+/**
+ * Deterministic worker placement:
+ * - first worker creates the right split
+ * - subsequent workers become tabs in the rightmost terminal pane
+ */
+export function chooseAgentSpawnPlacement(
+  panes: CmuxPane[],
+  paneSurfaces: CmuxPaneSurfaces[],
+): AgentSpawnPlacement {
+  if (panes.length <= 1) {
+    return { kind: "split", direction: "right" };
+  }
+
+  const groupsByPane = new Map(
+    paneSurfaces.map((group) => [group.pane_ref, group]),
+  );
+  const terminalPanes = panes.filter((pane) =>
+    groupsByPane
+      .get(pane.ref)
+      ?.surfaces.some((surface) => surface.type === "terminal"),
+  );
+
+  if (terminalPanes.length === 0) {
+    return { kind: "split", direction: "right" };
+  }
+
+  const rightmostPane = [...terminalPanes].sort((a, b) => a.index - b.index).at(-1);
+  if (!rightmostPane) {
+    return { kind: "split", direction: "right" };
+  }
+
+  return { kind: "surface", pane: rightmostPane.ref };
+}

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -12,25 +12,26 @@ export type AgentSpawnPlacement =
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
   paneSurfaces: CmuxPaneSurfaces[],
+  workerSurfaceIds: ReadonlySet<string>,
 ): AgentSpawnPlacement {
-  if (panes.length <= 1) {
+  if (workerSurfaceIds.size === 0) {
     return { kind: "split", direction: "right" };
   }
 
   const groupsByPane = new Map(
     paneSurfaces.map((group) => [group.pane_ref, group]),
   );
-  const terminalPanes = panes.filter((pane) =>
+  const workerPanes = panes.filter((pane) =>
     groupsByPane
       .get(pane.ref)
-      ?.surfaces.some((surface) => surface.type === "terminal"),
+      ?.surfaces.some((surface) => workerSurfaceIds.has(surface.ref)),
   );
 
-  if (terminalPanes.length === 0) {
+  if (workerPanes.length === 0) {
     return { kind: "split", direction: "right" };
   }
 
-  const rightmostPane = [...terminalPanes].sort((a, b) => a.index - b.index).at(-1);
+  const rightmostPane = [...workerPanes].sort((a, b) => a.index - b.index).at(-1);
   if (!rightmostPane) {
     return { kind: "split", direction: "right" };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1400,6 +1400,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       setProgress: (value, progressOpts) =>
         client.setProgress(value, progressOpts),
       newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),
+      newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
+      listPanes: (paneOpts) => client.listPanes(paneOpts),
+      listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
       notifyLifecycleEvent,
     });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -205,7 +205,63 @@ describe("AgentEngine", () => {
       expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
 
+    it("creates the first worker as a right split even when user panes already exist", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive-left"],
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:interactive-right"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ pane }: { pane?: string }) => ({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: pane ?? "pane:left",
+          surfaces:
+            pane === "pane:right"
+              ? [makeSurface("surface:interactive-right")]
+              : [makeSurface("surface:interactive-left")],
+        }),
+      );
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        workspace: "ws:1",
+        type: "terminal",
+      });
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
     it("reuses the rightmost pane as worker tabs when a worker pane already exists", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-1",
+          state: "working",
+          surface_id: "surface:worker-1",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:worker-1")];
+      await engine.getRegistry().reconstitute();
+
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
         panes: [
           {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -20,6 +20,13 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
       title: "",
       type: "terminal",
     } satisfies CmuxNewSplitResult),
+    newSurface: vi.fn().mockResolvedValue({
+      workspace: "ws:1",
+      surface: "surface:new",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    }),
     send: vi.fn().mockResolvedValue(undefined),
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({
@@ -162,6 +169,94 @@ describe("AgentEngine", () => {
       const events = stateMgr.getEventLog().readForAgent(result.agent_id);
       expect(events.length).toBeGreaterThanOrEqual(1);
       expect(events.some((e) => e.to_state === "booting")).toBe(true);
+    });
+
+    it("creates the initial worker pane as a right split when only one pane exists", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: "pane:left",
+        surfaces: [makeSurface("surface:interactive")],
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        workspace: "ws:1",
+        type: "terminal",
+      });
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
+    it("reuses the rightmost pane as worker tabs when a worker pane already exists", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive"],
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: false,
+            surface_count: 2,
+            surface_refs: ["surface:worker-1", "surface:worker-2"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ pane }: { pane?: string }) => ({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: pane ?? "pane:left",
+          surfaces:
+            pane === "pane:right"
+              ? [makeSurface("surface:worker-1"), makeSurface("surface:worker-2")]
+              : [makeSurface("surface:interactive")],
+        }),
+      );
+      (mockClient.newSurface as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:right",
+        title: "",
+        type: "terminal",
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right",
+        type: "terminal",
+        workspace: "ws:1",
+      });
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- add a minimal deterministic layout policy for worker spawns
- keep the first worker as the initial right split, then reuse the rightmost terminal pane as tabs for later workers
- wire the new layout policy through `AgentEngine` and cover it with focused tests

## Verification
- `bun run test` → 368 passed
- `bun run typecheck` → passed
- `bun run build` → passed
- real MCP stdio client session against `dist/index.js` connected successfully, listed 25 tools, and completed a live `list_surfaces` call

## Why
- today’s live failure mode was workers spawning as many splits, making the workspace unreadable and forcing manual `move_surface` cleanup
- this is the smallest Track 3 slice that makes `workers=tabs-right` real before the larger facade work (`send_to` / `wait_for`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the agent spawn path and relies on live pane/surface introspection; incorrect placement or API failures could lead to workers appearing in unexpected panes (though it falls back to the prior right-split behavior).
> 
> **Overview**
> Agent spawning now uses a deterministic layout policy: the **first** worker spawn creates a `right` split, and **subsequent** spawns reuse the existing rightmost worker pane by creating new tabs (surfaces) instead of new splits.
> 
> This introduces `chooseAgentSpawnPlacement` (`layout-policy.ts`) and wires it into `AgentEngine.spawnAgent`, which queries cmux via `listPanes`/`listPaneSurfaces` and calls `newSurface` or `newSplit` accordingly, with a best-effort fallback to the previous `newSplit("right")` behavior on errors. Server wiring and tests were updated to expose/mock the new client methods and to cover the placement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa84c919482f0dca4c9c4e48739b59edb849f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse worker pane tabs for agent spawns instead of always splitting right
> - The first worker spawned still creates a right split, but subsequent workers open as tabs in the rightmost pane that already contains a worker surface, rather than creating additional splits.
> - `AgentEngine.spawnAgent` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/74/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now calls `listPanes` and `listPaneSurfaces` to inspect the current layout, then delegates to `chooseAgentSpawnPlacement` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/74/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to decide between `newSurface` (tab) and `newSplit` (right).
> - If placement determination fails for any reason, it falls back to the original `newSplit("right", ...)` behavior.
> - `newSurface`, `listPanes`, and `listPaneSurfaces` are wired through the Cmux client in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/74/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fa84c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->