### PR TITLE
feat: enforce deterministic worker layout policy

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -4,10 +4,52 @@ export type AgentSpawnPlacement =
   | { kind: "split"; direction: "right" }
   | { kind: "surface"; pane: string };
 
+export interface SurfaceClosePolicy {
+  surface: string;
+  pane: string | null;
+  collapsePane: boolean;
+}
+
+interface PaneLayout {
+  pane: CmuxPane;
+  surfaces: CmuxPaneSurfaces["surfaces"];
+  workerCount: number;
+  nonWorkerCount: number;
+}
+
+function describePaneLayouts(
+  panes: CmuxPane[],
+  paneSurfaces: CmuxPaneSurfaces[],
+  workerSurfaceIds: ReadonlySet<string>,
+): PaneLayout[] {
+  const groupsByPane = new Map(
+    paneSurfaces.map((group) => [group.pane_ref, group.surfaces]),
+  );
+
+  return panes.map((pane) => {
+    const surfaces = groupsByPane.get(pane.ref) ?? [];
+    const workerCount = surfaces.filter((surface) =>
+      workerSurfaceIds.has(surface.ref),
+    ).length;
+    return {
+      pane,
+      surfaces,
+      workerCount,
+      nonWorkerCount: surfaces.length - workerCount,
+    };
+  });
+}
+
+function isDedicatedWorkerPane(layout: PaneLayout): boolean {
+  return layout.workerCount > 0 && layout.nonWorkerCount === 0;
+}
+
 /**
  * Deterministic worker placement:
  * - first worker creates the right split
- * - subsequent workers become tabs in the rightmost terminal pane
+ * - subsequent workers become tabs in the rightmost dedicated worker pane
+ * - mixed interactive/worker panes are treated as invalid and repaired with
+ *   a fresh right split to preserve the left-interactive/right-worker invariant
  */
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
@@ -18,23 +60,64 @@ export function chooseAgentSpawnPlacement(
     return { kind: "split", direction: "right" };
   }
 
-  const groupsByPane = new Map(
-    paneSurfaces.map((group) => [group.pane_ref, group]),
-  );
-  const workerPanes = panes.filter((pane) =>
-    groupsByPane
-      .get(pane.ref)
-      ?.surfaces.some((surface) => workerSurfaceIds.has(surface.ref)),
-  );
+  const workerPanes = describePaneLayouts(
+    panes,
+    paneSurfaces,
+    workerSurfaceIds,
+  ).filter(isDedicatedWorkerPane);
 
   if (workerPanes.length === 0) {
     return { kind: "split", direction: "right" };
   }
 
-  const rightmostPane = [...workerPanes].sort((a, b) => a.index - b.index).at(-1);
+  const rightmostPane = [...workerPanes]
+    .sort((a, b) => a.pane.index - b.pane.index)
+    .at(-1);
   if (!rightmostPane) {
     return { kind: "split", direction: "right" };
   }
 
-  return { kind: "surface", pane: rightmostPane.ref };
+  return { kind: "surface", pane: rightmostPane.pane.ref };
+}
+
+/**
+ * Closing the last tab in a dedicated worker pane should collapse the pane.
+ * Mixed panes are not considered valid worker panes and therefore do not claim
+ * collapse semantics.
+ */
+export function chooseSurfaceClosePolicy(
+  panes: CmuxPane[],
+  paneSurfaces: CmuxPaneSurfaces[],
+  workerSurfaceIds: ReadonlySet<string>,
+  surfaceId: string,
+): SurfaceClosePolicy {
+  const layout = describePaneLayouts(
+    panes,
+    paneSurfaces,
+    workerSurfaceIds,
+  ).find((candidate) =>
+    candidate.surfaces.some((surface) => surface.ref === surfaceId),
+  );
+
+  if (!layout) {
+    return {
+      surface: surfaceId,
+      pane: null,
+      collapsePane: false,
+    };
+  }
+
+  const remainingSurfaces = layout.surfaces.filter(
+    (surface) => surface.ref !== surfaceId,
+  );
+  const collapsePane =
+    workerSurfaceIds.has(surfaceId) &&
+    isDedicatedWorkerPane(layout) &&
+    remainingSurfaces.length === 0;
+
+  return {
+    surface: surfaceId,
+    pane: layout.pane.ref,
+    collapsePane,
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import {
 } from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
+import { chooseSurfaceClosePolicy } from "./layout-policy.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 type TextContent = { type: "text"; text: string };
@@ -1227,10 +1228,47 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.destructive,
     async (args) => {
       try {
+        let closePolicy:
+          | ReturnType<typeof chooseSurfaceClosePolicy>
+          | undefined;
+
+        try {
+          const identified = args.workspace
+            ? null
+            : await client.identify(args.surface);
+          const workspace =
+            args.workspace ??
+            identified?.caller?.workspace_ref ??
+            identified?.focused?.workspace_ref;
+          if (workspace) {
+            const panes = await client.listPanes({ workspace });
+            const paneSurfaces = await Promise.all(
+              panes.panes.map((pane) =>
+                client.listPaneSurfaces({ workspace, pane: pane.ref }),
+              ),
+            );
+            const workerSurfaceIds = new Set(
+              stateMgr.listStates().map((record) => record.surface_id),
+            );
+            closePolicy = chooseSurfaceClosePolicy(
+              panes.panes,
+              paneSurfaces,
+              workerSurfaceIds,
+              args.surface,
+            );
+          }
+        } catch {
+          // Layout hints are best-effort only; the close itself must still run.
+        }
+
         await client.closeSurface(args.surface, {
           workspace: args.workspace,
         });
-        const data = { surface: args.surface };
+        const data = {
+          surface: args.surface,
+          pane: closePolicy?.pane ?? undefined,
+          collapse_pane: closePolicy?.collapsePane ?? false,
+        };
         return okFormatted(formatOk("close_surface", data), data);
       } catch (e) {
         return err(e);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -259,7 +259,14 @@ describe("AgentEngine", () => {
           surface_id: "surface:worker-1",
         }),
       );
-      liveSurfaces = [makeSurface("surface:worker-1")];
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-2",
+          state: "working",
+          surface_id: "surface:worker-2",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:worker-1"), makeSurface("surface:worker-2")];
       await engine.getRegistry().reconstitute();
 
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -124,4 +124,69 @@ describe("layout policy", () => {
       collapsePane: false,
     });
   });
+
+  it("does not collapse when closing a non-worker surface while a dedicated worker pane exists elsewhere", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive"]),
+      makePane("pane:right", 1, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+    ];
+
+    const policy = chooseSurfaceClosePolicy(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1"]),
+      "surface:interactive",
+    );
+
+    expect(policy).toEqual({
+      surface: "surface:interactive",
+      pane: "pane:left",
+      collapsePane: false,
+    });
+  });
+
+  it("does not claim collapse semantics when no surfaces are classified as workers", () => {
+    const panes = [makePane("pane:left", 0, ["surface:interactive"])];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive"]),
+    ];
+
+    const policy = chooseSurfaceClosePolicy(
+      panes,
+      paneSurfaces,
+      new Set(),
+      "surface:interactive",
+    );
+
+    expect(policy).toEqual({
+      surface: "surface:interactive",
+      pane: "pane:left",
+      collapsePane: false,
+    });
+  });
+
+  it("reuses the rightmost dedicated worker pane when multiple worker panes exist", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive"]),
+      makePane("pane:right", 1, ["surface:worker-1"]),
+      makePane("pane:rightmost", 2, ["surface:worker-2"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+      makePaneSurfaces("pane:rightmost", ["surface:worker-2"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1", "surface:worker-2"]),
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:rightmost" });
+  });
 });

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  chooseAgentSpawnPlacement,
+  chooseSurfaceClosePolicy,
+} from "../src/layout-policy.js";
+import type { CmuxPane, CmuxPaneSurfaces, CmuxSurface } from "../src/types.js";
+
+function makePane(
+  ref: string,
+  index: number,
+  surfaceRefs: string[],
+): CmuxPane {
+  return {
+    ref,
+    index,
+    focused: index === 0,
+    surface_count: surfaceRefs.length,
+    surface_refs: surfaceRefs,
+    selected_surface_ref: surfaceRefs[0],
+  };
+}
+
+function makeSurface(ref: string, index: number): CmuxSurface {
+  return {
+    ref,
+    title: "",
+    type: "terminal",
+    index,
+    selected: index === 0,
+  };
+}
+
+function makePaneSurfaces(
+  pane: string,
+  surfaceRefs: string[],
+): CmuxPaneSurfaces {
+  return {
+    workspace_ref: "ws:1",
+    window_ref: "window:1",
+    pane_ref: pane,
+    surfaces: surfaceRefs.map((ref, index) => makeSurface(ref, index)),
+  };
+}
+
+describe("layout policy", () => {
+  it("creates a fresh right split when the only existing worker shares a pane with interactive surfaces", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive", "surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1"]),
+    );
+
+    expect(placement).toEqual({ kind: "split", direction: "right" });
+  });
+
+  it("reuses the rightmost dedicated worker pane for subsequent workers", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive"]),
+      makePane("pane:right", 1, ["surface:worker-1", "surface:worker-2"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1", "surface:worker-2"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1", "surface:worker-2"]),
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
+  it("marks a dedicated single-worker pane as collapsible when its last tab closes", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive"]),
+      makePane("pane:right", 1, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+    ];
+
+    const policy = chooseSurfaceClosePolicy(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1"]),
+      "surface:worker-1",
+    );
+
+    expect(policy).toEqual({
+      surface: "surface:worker-1",
+      pane: "pane:right",
+      collapsePane: true,
+    });
+  });
+
+  it("does not mark mixed panes as collapsible worker panes", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:interactive", "surface:worker-1"]),
+    ];
+
+    const policy = chooseSurfaceClosePolicy(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1"]),
+      "surface:worker-1",
+    );
+
+    expect(policy).toEqual({
+      surface: "surface:worker-1",
+      pane: "pane:left",
+      collapsePane: false,
+    });
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1380,6 +1380,107 @@ describe("tool handler integration", () => {
     );
   });
 
+  it("close_surface reports pane collapse when closing the last dedicated worker tab", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-layout");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-1",
+      surface_id: "surface:worker-1",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "Layout policy",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:1" },
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive"],
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:worker-1"],
+          },
+        ],
+      }),
+      listPaneSurfaces: vi.fn().mockImplementation(async ({ pane }) => ({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: pane,
+        surfaces:
+          pane === "pane:right"
+            ? [
+                {
+                  ref: "surface:worker-1",
+                  title: "worker",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [
+                {
+                  ref: "surface:interactive",
+                  title: "interactive",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ],
+      })),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["close_surface"];
+
+    const result = await tool.handler({ surface: "surface:worker-1" }, {} as any);
+
+    expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:worker-1", {
+      workspace: undefined,
+    });
+    expect(result.structuredContent).toMatchObject({
+      surface: "surface:worker-1",
+      pane: "pane:right",
+      collapse_pane: true,
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("rename_tab handler calls cmux rename-tab", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 


### PR DESCRIPTION
## Summary
- treat mixed interactive/worker panes as invalid so new workers repair layout with a fresh right split instead of reusing a polluted pane
- add close-surface layout metadata so the server reports when closing the last dedicated worker tab should collapse its pane
- cover the policy with layout-policy tests and update the existing agent-engine/server fixtures to model dedicated worker panes explicitly

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] MCP stdio smoke against `dist/index.js` (`25` tools listed; `list_surfaces` returned structured content)

## Notes
- PR #74 merged first and this branch starts from merged `main` (`126a7f8`).
- `cr review --plain` was attempted before commit but CodeRabbit returned a rate-limit error for this repo/user at `2026-04-16T15:57:17Z`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker placement and `close_surface` structured output/behavior, which can affect pane layout and downstream clients expecting previous semantics; adds best-effort extra cmux queries that could introduce latency or edge-case misclassification.
> 
> **Overview**
> Enforces a stricter worker layout invariant by only reusing *dedicated* worker panes for new agent tabs and forcing a fresh right split when workers are detected in mixed (interactive+worker) panes.
> 
> Adds `chooseSurfaceClosePolicy` and wires it into the `close_surface` tool so responses now include `pane` and `collapse_pane` hints (computed best-effort via `identify`/pane listing + current agent worker surfaces) indicating when closing the last worker tab should collapse its pane.
> 
> Updates and expands tests to cover the new layout policy, dedicated-worker-pane fixtures, and the new `close_surface` collapse reporting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b6c5bf5f4e8e75bcbcc282e0b1519d046e8893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects whether a pane should collapse when closing a surface and includes pane/collapse information in close responses.
* **Bug Fixes**
  * Improved agent spawn placement to prefer dedicated worker panes and pick the rightmost suitable pane.
* **Tests**
  * Added unit and integration tests for layout/close policies and updated agent-engine tests to cover multi-worker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce deterministic worker layout policy for agent spawn and surface close
> - Adds `chooseSurfaceClosePolicy` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/75/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to determine whether closing a surface should collapse its pane — only when it is the last tab in a dedicated worker pane.
> - Updates `chooseAgentSpawnPlacement` to target only dedicated worker panes (all surfaces are workers); mixed panes are now treated as invalid and trigger a fresh right split instead.
> - Augments the `close_surface` tool handler in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/75/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to perform best-effort layout introspection and return `pane` and `collapse_pane` fields in the response.
> - Behavioral Change: workers that previously shared a pane with interactive surfaces will no longer be reused for new agent placement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7b6c5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->