### PR TITLE
fix: dedupe list_surfaces and condense defaults

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -788,7 +788,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }),
         );
 
-        const verboseWorkspaces = workspaces.workspaces as Array<
+        const verboseWorkspaces = workspaces.workspaces as unknown as Array<
           Record<string, unknown>
         >;
         const responseWorkspaces = args.verbose

--- a/src/server.ts
+++ b/src/server.ts
@@ -146,6 +146,89 @@ function requireValue(
   }
 }
 
+type ListSurfacesRemoteState =
+  | "local"
+  | "connected"
+  | "disconnected"
+  | "unavailable";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function summarizeRemoteState(remoteValue: unknown): ListSurfacesRemoteState {
+  const remote = asRecord(remoteValue);
+  if (!remote) {
+    return "local";
+  }
+
+  const state =
+    typeof remote.state === "string"
+      ? (remote.state as ListSurfacesRemoteState | string)
+      : undefined;
+  const connected = remote.connected === true || state === "connected";
+  if (connected) {
+    return "connected";
+  }
+
+  const hasRemoteHints =
+    remote.enabled === true ||
+    remote.has_ssh_options === true ||
+    remote.has_identity_file === true ||
+    (typeof remote.destination === "string" && remote.destination.length > 0) ||
+    (remote.port !== null && remote.port !== undefined) ||
+    (remote.local_proxy_port !== null &&
+      remote.local_proxy_port !== undefined);
+
+  if (!hasRemoteHints && (state === undefined || state === "disconnected")) {
+    return "local";
+  }
+
+  if (state === "unavailable") {
+    return hasRemoteHints ? "unavailable" : "local";
+  }
+
+  return "disconnected";
+}
+
+function toMinimalWorkspace(
+  workspace: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ref: typeof workspace.ref === "string" ? workspace.ref : "",
+    title: typeof workspace.title === "string" ? workspace.title : "",
+    current_directory:
+      typeof workspace.current_directory === "string"
+        ? workspace.current_directory
+        : null,
+    remote_state: summarizeRemoteState(workspace.remote),
+  };
+}
+
+function toMinimalSurface(
+  surface: Record<string, unknown>,
+): Record<string, unknown> {
+  const minimal: Record<string, unknown> = {
+    ref: typeof surface.ref === "string" ? surface.ref : "",
+    title: typeof surface.title === "string" ? surface.title : "",
+    type: typeof surface.type === "string" ? surface.type : "terminal",
+    workspace_ref:
+      typeof surface.workspace_ref === "string" ? surface.workspace_ref : "",
+  };
+
+  if (typeof surface.screen_preview === "string") {
+    minimal.screen_preview = surface.screen_preview;
+  }
+  if (typeof surface.screen_preview_error === "string") {
+    minimal.screen_preview_error = surface.screen_preview_error;
+  }
+
+  return minimal;
+}
+
 function chunkTerminalInput(text: string, chunkSize: number): string[] {
   if (!text || text.length <= chunkSize) {
     return [text];
@@ -609,6 +692,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     "List all surfaces (terminal/browser panes) across workspaces",
     {
       workspace: z.string().optional().describe("Filter by workspace ref"),
+      verbose: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Return the current full schema instead of the condensed default"),
       include_screen_preview: z
         .boolean()
         .optional()
@@ -646,40 +734,79 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ),
           ),
         );
-        const surfaces = await Promise.all(
-          surfaceGroups.flatMap((group) =>
-            group.surfaces.map(async (surface) => {
-              const enrichedSurface: Record<string, unknown> = {
-                ...surface,
-                workspace_ref: group.workspace_ref,
-                window_ref: group.window_ref,
-                pane_ref: group.pane_ref,
-              };
+        const uniqueSurfaceEntries: Array<{
+          group: {
+            workspace_ref: string;
+            window_ref: string;
+            pane_ref: string;
+            surfaces: CmuxSurface[];
+          };
+          surface: CmuxSurface;
+        }> = [];
+        const seenSurfaceRefs = new Set<string>();
+        let anonymousSurfaceIndex = 0;
 
-              if (args.include_screen_preview && surface.type === "terminal") {
-                try {
-                  const preview = await client.readScreen(surface.ref, {
-                    workspace: group.workspace_ref,
-                    lines: args.preview_lines,
-                  });
-                  enrichedSurface.screen_preview = preview.text;
-                } catch (error) {
-                  enrichedSurface.screen_preview_error =
-                    error instanceof Error ? error.message : String(error);
-                }
+        for (const group of surfaceGroups) {
+          for (const surface of group.surfaces) {
+            const dedupeKey =
+              typeof surface.ref === "string" && surface.ref.length > 0
+                ? surface.ref
+                : `${group.workspace_ref}:${group.pane_ref}:anonymous:${anonymousSurfaceIndex++}`;
+
+            if (seenSurfaceRefs.has(dedupeKey)) {
+              continue;
+            }
+
+            seenSurfaceRefs.add(dedupeKey);
+            uniqueSurfaceEntries.push({ group, surface });
+          }
+        }
+
+        const verboseSurfaces = await Promise.all(
+          uniqueSurfaceEntries.map(async ({ group, surface }) => {
+            const enrichedSurface: Record<string, unknown> = {
+              ...surface,
+              workspace_ref: group.workspace_ref,
+              window_ref: group.window_ref,
+              pane_ref: group.pane_ref,
+            };
+
+            if (args.include_screen_preview && surface.type === "terminal") {
+              try {
+                const preview = await client.readScreen(surface.ref, {
+                  workspace: group.workspace_ref,
+                  lines: args.preview_lines,
+                });
+                enrichedSurface.screen_preview = preview.text;
+              } catch (error) {
+                enrichedSurface.screen_preview_error =
+                  error instanceof Error ? error.message : String(error);
               }
+            }
 
-              return enrichedSurface;
-            }),
-          ),
+            return enrichedSurface;
+          }),
         );
-        const data = {
-          workspaces: workspaces.workspaces,
-          surfaces,
-          workspace_ref: args.workspace,
+
+        const verboseWorkspaces = workspaces.workspaces as Array<
+          Record<string, unknown>
+        >;
+        const responseWorkspaces = args.verbose
+          ? verboseWorkspaces
+          : verboseWorkspaces.map((workspace) => toMinimalWorkspace(workspace));
+        const responseSurfaces = args.verbose
+          ? verboseSurfaces
+          : verboseSurfaces.map((surface) => toMinimalSurface(surface));
+
+        const data: Record<string, unknown> = {
+          workspaces: responseWorkspaces,
+          surfaces: responseSurfaces,
         };
+        if (args.workspace) {
+          data.workspace_ref = args.workspace;
+        }
         const formatted = formatListSurfaces(
-          surfaces as Array<{
+          responseSurfaces as Array<{
             ref?: string;
             title?: string;
             type?: string;
@@ -687,7 +814,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             pane_ref?: string;
             screen_preview?: string;
           }>,
-          workspaces.workspaces as Array<{ ref: string; title?: string }>,
+          responseWorkspaces as Array<{ ref: string; title?: string }>,
         );
         return okFormatted(formatted, data);
       } catch (e) {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -222,7 +222,7 @@ describe("tool handler integration", () => {
     expect(result.structuredContent.ok).toBe(true);
   });
 
-  it("list_surfaces aggregates pane surfaces and includes optional previews", async () => {
+  it("list_surfaces dedupes overlapping pane results and returns the condensed default schema", async () => {
     mockExec = vi
       .fn()
       .mockResolvedValueOnce({
@@ -231,9 +231,40 @@ describe("tool handler integration", () => {
             {
               ref: "workspace:1",
               title: "Main",
+              id: "workspace-uuid-1",
               index: 0,
               selected: true,
               pinned: false,
+              current_directory: "/tmp/main",
+              remote: {
+                state: "disconnected",
+                connected: false,
+                enabled: false,
+                destination: null,
+                detail: null,
+                daemon: { state: "unavailable" },
+                proxy: { state: "unavailable" },
+                heartbeat: { count: 0, age_seconds: null, last_seen_at: null },
+              },
+            },
+            {
+              ref: "workspace:2",
+              title: "Empty",
+              id: "workspace-uuid-2",
+              index: 1,
+              selected: false,
+              pinned: false,
+              current_directory: null,
+              remote: {
+                state: "disconnected",
+                connected: false,
+                enabled: false,
+                destination: null,
+                detail: null,
+                daemon: { state: "unavailable" },
+                proxy: { state: "unavailable" },
+                heartbeat: { count: 0, age_seconds: null, last_seen_at: null },
+              },
             },
           ],
         }),
@@ -256,11 +287,19 @@ describe("tool handler integration", () => {
               ref: "pane:2",
               index: 1,
               focused: false,
-              surface_count: 1,
-              surface_refs: ["surface:2"],
+              surface_count: 2,
+              surface_refs: ["surface:1", "surface:2"],
               selected_surface_ref: "surface:2",
             },
           ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:2",
+          window_ref: "window:2",
+          panes: [],
         }),
         stderr: "",
       })
@@ -275,7 +314,11 @@ describe("tool handler integration", () => {
               title: "One",
               type: "terminal",
               index: 0,
-              selected: true,
+              focused: true,
+              id: "surface-uuid-1",
+              pane_id: "pane-uuid-1",
+              index_in_pane: 0,
+              selected_in_pane: true,
             },
           ],
         }),
@@ -288,21 +331,28 @@ describe("tool handler integration", () => {
           pane_ref: "pane:2",
           surfaces: [
             {
+              ref: "surface:1",
+              title: "One",
+              type: "terminal",
+              index: 0,
+              focused: true,
+              id: "surface-uuid-1",
+              pane_id: "pane-uuid-1",
+              index_in_pane: 0,
+              selected_in_pane: true,
+            },
+            {
               ref: "surface:2",
               title: "Two",
               type: "browser",
               index: 0,
-              selected: true,
+              focused: false,
+              id: "surface-uuid-2",
+              pane_id: "pane-uuid-2",
+              index_in_pane: 1,
+              selected_in_pane: true,
             },
           ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          surface_ref: "surface:1",
-          text: "line1\nline2",
-          lines: 5,
         }),
         stderr: "",
       });
@@ -311,14 +361,7 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["list_surfaces"];
 
-    const result = await tool.handler(
-      {
-        workspace: "workspace:1",
-        include_screen_preview: true,
-        preview_lines: 5,
-      },
-      {} as any,
-    );
+    const result = await tool.handler({}, {} as any);
 
     expect(mockExec).toHaveBeenCalledWith("cmux", [
       "--json",
@@ -326,35 +369,45 @@ describe("tool handler integration", () => {
       "--workspace",
       "workspace:1",
     ]);
-    expect(mockExec).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining([
-        "--json",
-        "read-screen",
-        "--surface",
-        "surface:1",
-        "--workspace",
-        "workspace:1",
-        "--lines",
-        "5",
-      ]),
-    );
+    expect(mockExec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "list-panes",
+      "--workspace",
+      "workspace:2",
+    ]);
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.surfaces).toHaveLength(2);
-    expect(parsed.surfaces[0]).toMatchObject({
+    expect(parsed.surfaces.map((surface: { ref: string }) => surface.ref)).toEqual(
+      ["surface:1", "surface:2"],
+    );
+    expect(parsed.workspaces).toEqual([
+      {
+        ref: "workspace:1",
+        title: "Main",
+        current_directory: "/tmp/main",
+        remote_state: "local",
+      },
+      {
+        ref: "workspace:2",
+        title: "Empty",
+        current_directory: null,
+        remote_state: "local",
+      },
+    ]);
+    expect(parsed.surfaces[0]).toEqual({
       ref: "surface:1",
-      pane_ref: "pane:1",
       workspace_ref: "workspace:1",
-      screen_preview: "line1\nline2",
+      title: "One",
+      type: "terminal",
     });
-    expect(parsed.surfaces[1]).toMatchObject({
+    expect(parsed.surfaces[1]).toEqual({
       ref: "surface:2",
-      pane_ref: "pane:2",
       workspace_ref: "workspace:1",
+      title: "Two",
+      type: "browser",
     });
-    expect(parsed.workspace_ref).toBe("workspace:1");
   });
 
   it("list_surfaces keeps working when a screen preview fails", async () => {
@@ -429,6 +482,152 @@ describe("tool handler integration", () => {
     expect(parsed.surfaces[0].screen_preview_error).toMatch(
       /surface unavailable/,
     );
+  });
+
+  it("list_surfaces preserves the current full schema behind verbose=true while still deduping", async () => {
+    mockExec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              id: "workspace-uuid-1",
+              index: 0,
+              selected: true,
+              pinned: false,
+              current_directory: "/tmp/main",
+              remote: {
+                state: "connected",
+                connected: true,
+                enabled: true,
+                destination: "ssh://box",
+                detail: "ready",
+              },
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:1"],
+              selected_surface_ref: "surface:1",
+            },
+            {
+              ref: "pane:2",
+              index: 1,
+              focused: false,
+              surface_count: 2,
+              surface_refs: ["surface:1", "surface:2"],
+              selected_surface_ref: "surface:2",
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:1",
+              title: "One",
+              type: "terminal",
+              id: "surface-uuid-1",
+              pane_id: "pane-uuid-1",
+              index: 0,
+              index_in_pane: 0,
+              focused: true,
+              selected_in_pane: true,
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:2",
+          surfaces: [
+            {
+              ref: "surface:1",
+              title: "One",
+              type: "terminal",
+              id: "surface-uuid-1",
+              pane_id: "pane-uuid-1",
+              index: 0,
+              index_in_pane: 0,
+              focused: true,
+              selected_in_pane: true,
+            },
+            {
+              ref: "surface:2",
+              title: "Two",
+              type: "browser",
+              id: "surface-uuid-2",
+              pane_id: "pane-uuid-2",
+              index: 1,
+              index_in_pane: 1,
+              focused: false,
+              selected_in_pane: true,
+            },
+          ],
+        }),
+        stderr: "",
+      });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["list_surfaces"];
+
+    const result = await tool.handler({ verbose: true }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.surfaces).toHaveLength(2);
+    expect(parsed.workspaces[0]).toMatchObject({
+      ref: "workspace:1",
+      title: "Main",
+      id: "workspace-uuid-1",
+      index: 0,
+      selected: true,
+      pinned: false,
+      current_directory: "/tmp/main",
+      remote: {
+        state: "connected",
+        connected: true,
+        enabled: true,
+        destination: "ssh://box",
+        detail: "ready",
+      },
+    });
+    expect(parsed.surfaces[0]).toMatchObject({
+      ref: "surface:1",
+      title: "One",
+      type: "terminal",
+      id: "surface-uuid-1",
+      pane_id: "pane-uuid-1",
+      index: 0,
+      index_in_pane: 0,
+      focused: true,
+      selected_in_pane: true,
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      pane_ref: "pane:1",
+    });
   });
 
   it("read_screen handler calls cmux read-screen", async () => {


### PR DESCRIPTION
## Summary
- dedupe `list_surfaces` by `surface.ref` before preview enrichment so overlapping pane results no longer emit duplicate entries
- default `list_surfaces` to a condensed schema with minimal workspace and surface fields plus `remote_state`, while keeping preview and preview-error fields when explicitly requested
- add `verbose: true` to restore the existing full payload shape and cover the new contract with regression tests

## Test plan
- [x] `bun run test` (378 passed)
- [x] red-green regression on `tests/server.test.ts` for dedupe + condensed default + `verbose: true`
- [ ] live cmux manual check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `verbose` parameter to surface listing (defaults to condensed output; displays full details when enabled).

* **Improvements**
  * Optimized default list surfaces response with deduplicated entries and simplified workspace/surface format for improved performance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `list_surfaces` results and return a condensed schema by default
> - The `list_surfaces` tool now deduplicates surfaces that appear across multiple panes using a ref-based set, preventing duplicate entries in results.
> - The default response uses a new minimal schema (ref, title, type, workspace_ref, remote_state, current_directory) instead of the full schema. Pass `verbose=true` to restore the prior full schema.
> - `workspace_ref` is omitted from the top-level response unless a workspace filter is provided.
> - Behavioral Change: existing callers relying on the full response schema will receive fewer fields by default and must opt in with `verbose=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f83241e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `list_surfaces` response shape (potentially breaking existing consumers) and adds new deduping logic that could affect which surfaces are returned/previewed.
> 
> **Overview**
> `list_surfaces` now **dedupes surfaces across pane queries** (by `surface.ref`, with a fallback synthesized key) *before* optional screen-preview enrichment to avoid duplicate entries.
> 
> The tool’s default response is now a **condensed schema**: minimal workspace/surface fields plus a computed `remote_state`; callers can pass `verbose: true` to restore the prior full payload while keeping deduping. Tests were updated/added to cover dedupe behavior, condensed defaults, and the `verbose` escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f83241e1c1a30d69423a395a661060908ebf3d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->