### PR TITLE
feat: auto-capture agent sessions and recover crashed PTYs

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -19,6 +19,7 @@ import {
   isCrashRecoveryEligible,
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
+  MAX_RESPAWN_ATTEMPTS,
   type AgentRecord,
   type AgentState,
   type CliType,
@@ -311,7 +312,7 @@ export class AgentEngine {
 
   private async markCrashRecoveryExhausted(agent: AgentRecord): Promise<void> {
     const updated = this.stateMgr.updateRecord(agent.agent_id, {
-      error: `Max crash recoveries exceeded: ${MAX_CHILDREN}`,
+      error: `Max crash recoveries exceeded: ${MAX_RESPAWN_ATTEMPTS}`,
     });
     this.registry.set(agent.agent_id, updated);
     await this.client.log(
@@ -327,7 +328,7 @@ export class AgentEngine {
         continue;
       }
 
-      if ((agent.respawn_attempts ?? 0) >= MAX_CHILDREN) {
+      if ((agent.respawn_attempts ?? 0) >= MAX_RESPAWN_ATTEMPTS) {
         await this.markCrashRecoveryExhausted(agent);
         continue;
       }
@@ -378,7 +379,7 @@ export class AgentEngine {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const current = this.registry.get(agent.agent_id);
-        if (current && current.state === "booting") {
+        if (current && !TERMINAL_STATES.has(current.state)) {
           const failed = this.stateMgr.transition(agent.agent_id, "error", {
             error: `Crash recovery failed: ${message}`,
           });
@@ -821,14 +822,14 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    if (TERMINAL_STATES.has(agent.state)) {
-      return; // Already stopped
-    }
-
     const marked = this.stateMgr.updateRecord(agentId, {
       user_killed: opts?.userInitiated ?? true,
     });
     this.registry.set(agentId, marked);
+
+    if (TERMINAL_STATES.has(agent.state)) {
+      return; // Already stopped
+    }
 
     if (force && marked.pid) {
       try {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -34,6 +34,7 @@ export interface SpawnAgentParams {
   workspace?: string;
   parent_agent_id?: string;
   max_cost_per_agent?: number;
+  crash_recover?: boolean;
 }
 
 export interface SpawnAgentResult {
@@ -47,6 +48,10 @@ export type AgentLifecycleEvent = "spawned" | "done" | "errored";
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
+const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
+const BOOT_SESSION_CAPTURE_LINES = 80;
+const SESSION_ID_RE =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
 
 interface AgentEngineClient {
   log(
@@ -153,13 +158,18 @@ const LIFECYCLE_LOGS = {
 // - CLAUDE_CODE_NO_FLICKER: stable alt-screen rendering for terminal parsing
 const AGENT_ENV = "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
 
-export function buildLaunchCommand(cli: CliType, repo: string): string {
+function sanitizeRepoName(repo: string): string {
   const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
   if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {
     throw new Error(
       `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed. "." and ".." are not permitted.`,
     );
   }
+  return safeRepo;
+}
+
+export function buildLaunchCommand(cli: CliType, repo: string): string {
+  const safeRepo = sanitizeRepoName(repo);
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry
@@ -173,6 +183,30 @@ export function buildLaunchCommand(cli: CliType, repo: string): string {
     case "cursor":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} cursor agent`;
   }
+}
+
+export function buildResumeCommand(
+  cli: CliType,
+  repo: string,
+  sessionId: string,
+): string {
+  const safeRepo = sanitizeRepoName(repo);
+  switch (cli) {
+    case "claude":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} claude --dangerously-skip-permissions --resume ${sessionId}`;
+    case "codex":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} codex resume ${sessionId}`;
+    case "gemini":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini --resume ${sessionId}`;
+    case "kiro":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
+    case "cursor":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} cursor agent --resume ${sessionId}`;
+  }
+}
+
+export function extractSessionId(text: string): string | null {
+  return text.match(SESSION_ID_RE)?.[0] ?? null;
 }
 
 export class AgentEngine {
@@ -197,6 +231,171 @@ export class AgentEngine {
 
   getRegistry(): AgentRegistry {
     return this.registry;
+  }
+
+  private async createAgentSurface(
+    workspace?: string,
+  ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
+    try {
+      const panes = await this.client.listPanes({ workspace });
+      const paneSurfaces = await Promise.all(
+        panes.panes.map((pane) =>
+          this.client.listPaneSurfaces({
+            workspace,
+            pane: pane.ref,
+          }),
+        ),
+      );
+      const workerSurfaceIds = new Set(
+        this.registry.list().map((agent) => agent.surface_id),
+      );
+      const placement = chooseAgentSpawnPlacement(
+        panes.panes,
+        paneSurfaces,
+        workerSurfaceIds,
+      );
+      return placement.kind === "surface"
+        ? this.client.newSurface({
+            pane: placement.pane,
+            type: "terminal",
+            workspace,
+          })
+        : this.client.newSplit(placement.direction, {
+            workspace,
+            type: "terminal",
+          });
+    } catch {
+      return this.client.newSplit("right", {
+        workspace,
+        type: "terminal",
+      });
+    }
+  }
+
+  private isBootCaptureWindowOpen(agent: AgentRecord): boolean {
+    if (agent.state !== "booting") return false;
+    const since = Date.parse(agent.updated_at);
+    if (Number.isNaN(since)) return false;
+    return Date.now() - since <= BOOT_SESSION_CAPTURE_WINDOW_MS;
+  }
+
+  private async maybeCaptureBootSessionId(agent: AgentRecord): Promise<AgentRecord> {
+    if (agent.cli_session_id || !this.isBootCaptureWindowOpen(agent)) {
+      return agent;
+    }
+
+    try {
+      const screen = await this.client.readScreen(agent.surface_id, {
+        lines: BOOT_SESSION_CAPTURE_LINES,
+        scrollback: true,
+      });
+      const sessionId = extractSessionId(screen.text);
+      if (!sessionId) {
+        return agent;
+      }
+
+      const updated = this.stateMgr.updateRecord(agent.agent_id, {
+        cli_session_id: sessionId,
+      });
+      this.registry.set(agent.agent_id, updated);
+      return updated;
+    } catch {
+      return agent;
+    }
+  }
+
+  private isRecoverableCrash(agent: AgentRecord): boolean {
+    return (
+      agent.state === "error" &&
+      agent.crash_recover === true &&
+      agent.user_killed !== true &&
+      !!agent.cli_session_id &&
+      (agent.error?.includes("disappeared") ?? false)
+    );
+  }
+
+  private async markCrashRecoveryExhausted(agent: AgentRecord): Promise<void> {
+    const updated = this.stateMgr.updateRecord(agent.agent_id, {
+      error: `Max crash recoveries exceeded: ${MAX_CHILDREN}`,
+    });
+    this.registry.set(agent.agent_id, updated);
+    await this.client.log(
+      `crash-recovery: max crash recoveries exceeded for ${agent.agent_id}`,
+      { level: "error", source: "cmux-mcp" },
+    );
+  }
+
+  private async recoverCrashedAgents(): Promise<void> {
+    const erroredAgents = this.registry.list({ state: "error" });
+    for (const agent of erroredAgents) {
+      if (!this.isRecoverableCrash(agent)) {
+        continue;
+      }
+
+      if ((agent.respawn_attempts ?? 0) >= MAX_CHILDREN) {
+        await this.markCrashRecoveryExhausted(agent);
+        continue;
+      }
+
+      try {
+        const surface = await this.createAgentSurface(agent.workspace_id ?? undefined);
+        const creating = this.stateMgr.transition(agent.agent_id, "creating", {
+          error: null,
+          pid: null,
+          cli_session_id: agent.cli_session_id,
+        });
+        this.registry.set(agent.agent_id, creating);
+
+        const patched = this.stateMgr.updateRecord(agent.agent_id, {
+          surface_id: surface.surface,
+          workspace_id: surface.workspace,
+          crash_recover: true,
+          respawn_attempts: (agent.respawn_attempts ?? 0) + 1,
+          user_killed: false,
+          deletion_intent: false,
+          error: null,
+          pid: null,
+        });
+        this.registry.set(agent.agent_id, patched);
+
+        const booting = this.stateMgr.transition(agent.agent_id, "booting", {
+          error: null,
+          pid: null,
+          cli_session_id: agent.cli_session_id,
+        });
+        this.registry.set(agent.agent_id, booting);
+
+        const resumeCmd = buildResumeCommand(
+          agent.cli,
+          agent.repo,
+          agent.cli_session_id!,
+        );
+        await this.client.send(surface.surface, resumeCmd, {
+          workspace: surface.workspace,
+        });
+        await this.client.sendKey(surface.surface, "return", {
+          workspace: surface.workspace,
+        });
+        await this.client.log(
+          `crash-recovery: respawned ${agent.agent_id} on ${surface.surface}`,
+          { level: "warning", source: "cmux-mcp" },
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const current = this.registry.get(agent.agent_id);
+        if (current && current.state === "booting") {
+          const failed = this.stateMgr.transition(agent.agent_id, "error", {
+            error: `Crash recovery failed: ${message}`,
+          });
+          this.registry.set(agent.agent_id, failed);
+        } else {
+          const failed = this.stateMgr.updateRecord(agent.agent_id, {
+            error: `Crash recovery failed: ${message}`,
+          });
+          this.registry.set(agent.agent_id, failed);
+        }
+      }
+    }
   }
 
   private async emitLifecycleEvent(
@@ -233,7 +432,8 @@ export class AgentEngine {
     const total = agents.length;
     const done = agents.filter((a) => a.state === "done").length;
 
-    for (const agent of agents) {
+    for (const originalAgent of agents) {
+      const agent = await this.maybeCaptureBootSessionId(originalAgent);
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
         state === "error" ? `${repo}: error` : `${repo}: ${state}`;
@@ -293,7 +493,7 @@ export class AgentEngine {
               // 1. Respawn loses all work-in-progress context (new agent starts from scratch)
               // 2. The parent orchestrator should decide retry strategy, not the sweep
               // 3. Each respawn adds a dead child — repeated cycles hit MAX_CHILDREN with corpses
-              await this.stopAgent(agentId, false);
+              await this.stopAgent(agentId, false, { userInitiated: false });
               await this.client.log(
                 `context-limit: killing depth ${agent.spawn_depth} agent ${repo}`,
                 { level: "warning", source: "cmux-mcp" },
@@ -346,6 +546,7 @@ export class AgentEngine {
    */
   async runSweep(): Promise<void> {
     await this.registry.reconcile();
+    await this.recoverCrashedAgents();
 
     if (this.startupPurgePending) {
       this.startupPurgePending = false;
@@ -410,48 +611,14 @@ export class AgentEngine {
     }
 
     // 1. Create cmux surface using the deterministic worker layout policy.
-    let surface: CmuxNewSplitResult | CmuxNewSurfaceResult;
-    try {
-      const panes = await this.client.listPanes({ workspace: params.workspace });
-      const paneSurfaces = await Promise.all(
-        panes.panes.map((pane) =>
-          this.client.listPaneSurfaces({
-            workspace: params.workspace,
-            pane: pane.ref,
-          }),
-        ),
-      );
-      const workerSurfaceIds = new Set(
-        this.registry.list().map((agent) => agent.surface_id),
-      );
-      const placement = chooseAgentSpawnPlacement(
-        panes.panes,
-        paneSurfaces,
-        workerSurfaceIds,
-      );
-      surface =
-        placement.kind === "surface"
-          ? await this.client.newSurface({
-              pane: placement.pane,
-              type: "terminal",
-              workspace: params.workspace,
-            })
-          : await this.client.newSplit(placement.direction, {
-              workspace: params.workspace,
-              type: "terminal",
-            });
-    } catch {
-      surface = await this.client.newSplit("right", {
-        workspace: params.workspace,
-        type: "terminal",
-      });
-    }
+    const surface = await this.createAgentSurface(params.workspace);
 
     // 2. Write initial state (creating → booting)
     const now = new Date().toISOString();
     const record: AgentRecord = {
       agent_id: agentId,
       surface_id: surface.surface,
+      workspace_id: surface.workspace,
       state: "booting",
       repo: params.repo,
       model: params.model,
@@ -468,6 +635,9 @@ export class AgentEngine {
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: params.max_cost_per_agent ?? null,
+      crash_recover: params.crash_recover ?? false,
+      respawn_attempts: 0,
+      user_killed: false,
     };
     this.stateMgr.writeState(record);
     this.registry.set(agentId, record);
@@ -646,7 +816,11 @@ export class AgentEngine {
   /**
    * Stop an agent gracefully (Ctrl+C) or forcefully (kill PID).
    */
-  async stopAgent(agentId: string, force?: boolean): Promise<void> {
+  async stopAgent(
+    agentId: string,
+    force?: boolean,
+    opts?: { userInitiated?: boolean },
+  ): Promise<void> {
     const agent = this.registry.get(agentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
@@ -656,15 +830,20 @@ export class AgentEngine {
       return; // Already stopped
     }
 
-    if (force && agent.pid) {
+    const marked = this.stateMgr.updateRecord(agentId, {
+      user_killed: opts?.userInitiated ?? true,
+    });
+    this.registry.set(agentId, marked);
+
+    if (force && marked.pid) {
       try {
-        process.kill(agent.pid, "SIGKILL");
+        process.kill(marked.pid, "SIGKILL");
       } catch {
         // Process may already be dead — that's fine
       }
     } else {
       // Graceful: send Ctrl+C
-      await this.client.sendKey(agent.surface_id, "c-c", {});
+      await this.client.sendKey(marked.surface_id, "c-c", {});
     }
 
     // Transition to done

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types.js";
 import {
   generateAgentId,
+  isCrashRecoveryEligible,
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
   type AgentRecord,
@@ -305,13 +306,7 @@ export class AgentEngine {
   }
 
   private isRecoverableCrash(agent: AgentRecord): boolean {
-    return (
-      agent.state === "error" &&
-      agent.crash_recover === true &&
-      agent.user_killed !== true &&
-      !!agent.cli_session_id &&
-      (agent.error?.includes("disappeared") ?? false)
-    );
+    return isCrashRecoveryEligible(agent);
   }
 
   private async markCrashRecoveryExhausted(agent: AgentRecord): Promise<void> {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -5,7 +5,12 @@
  */
 
 import { StateManager } from "./state-manager.js";
-import type { AgentRecord, AgentState } from "./agent-types.js";
+import {
+  isCrashRecoveryEligible,
+  shouldRetainCrashRecoveryError,
+  type AgentRecord,
+  type AgentState,
+} from "./agent-types.js";
 import type { CmuxSurface } from "./types.js";
 
 export type SurfaceProvider = () => Promise<CmuxSurface[]>;
@@ -140,7 +145,7 @@ export class AgentRegistry {
     const purgedIds: string[] = [];
 
     for (const [id, agent] of this.agents) {
-      if (agent.state === "error" && agent.crash_recover === true) {
+      if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
       if (TERMINAL_STATES.has(agent.state)) {
@@ -164,7 +169,7 @@ export class AgentRegistry {
     let purged = 0;
 
     for (const [id, agent] of this.agents) {
-      if (agent.state === "error" && agent.crash_recover === true) {
+      if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
       if (

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -140,6 +140,9 @@ export class AgentRegistry {
     const purgedIds: string[] = [];
 
     for (const [id, agent] of this.agents) {
+      if (agent.state === "error" && agent.crash_recover === true) {
+        continue;
+      }
       if (TERMINAL_STATES.has(agent.state)) {
         this.agents.delete(id);
         this.stateMgr.removeState(id);
@@ -161,6 +164,9 @@ export class AgentRegistry {
     let purged = 0;
 
     for (const [id, agent] of this.agents) {
+      if (agent.state === "error" && agent.crash_recover === true) {
+        continue;
+      }
       if (
         TERMINAL_STATES.has(agent.state) &&
         !liveSurfaceRefs.has(agent.surface_id)

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -22,6 +22,7 @@ export const MAX_CHILDREN = 10;
 export interface AgentRecord {
   agent_id: string;
   surface_id: string;
+  workspace_id?: string | null;
   state: AgentState;
   repo: string;
   model: string;
@@ -40,6 +41,10 @@ export interface AgentRecord {
   // Quality fields (Task 19)
   quality: AgentQuality;
   max_cost_per_agent: number | null;
+  // Crash recovery fields (Task 20)
+  crash_recover?: boolean;
+  respawn_attempts?: number;
+  user_killed?: boolean;
 }
 
 export interface StateTransition {

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -47,6 +47,41 @@ export interface AgentRecord {
   user_killed?: boolean;
 }
 
+export function hasRecoverableCrashError(error: string | null): boolean {
+  if (!error) return false;
+  return (
+    error.includes("disappeared") || error.startsWith("Crash recovery failed:")
+  );
+}
+
+export function isCrashRecoveryExhausted(error: string | null): boolean {
+  return error?.startsWith("Max crash recoveries exceeded:") ?? false;
+}
+
+export function isCrashRecoveryEligible(
+  agent: Pick<
+    AgentRecord,
+    "state" | "crash_recover" | "user_killed" | "cli_session_id" | "error"
+  >,
+): boolean {
+  return (
+    agent.state === "error" &&
+    agent.crash_recover === true &&
+    agent.user_killed !== true &&
+    !!agent.cli_session_id &&
+    hasRecoverableCrashError(agent.error)
+  );
+}
+
+export function shouldRetainCrashRecoveryError(
+  agent: Pick<
+    AgentRecord,
+    "state" | "crash_recover" | "user_killed" | "cli_session_id" | "error"
+  >,
+): boolean {
+  return isCrashRecoveryEligible(agent) || isCrashRecoveryExhausted(agent.error);
+}
+
 export interface StateTransition {
   ts: string;
   agent_id: string;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -18,6 +18,7 @@ export type AgentQuality = "unknown" | "verified" | "suspect" | "degraded";
 
 export const MAX_SPAWN_DEPTH = 2;
 export const MAX_CHILDREN = 10;
+export const MAX_RESPAWN_ATTEMPTS = 10;
 
 export interface AgentRecord {
   agent_id: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1608,6 +1608,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .number()
           .optional()
           .describe("Maximum cost cap in USD for this agent"),
+        crash_recover: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "When true, automatically respawn the agent after unexpected PTY death using its captured CLI session ID.",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
@@ -1620,6 +1627,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
             max_cost_per_agent: args.max_cost_per_agent,
+            crash_recover: args.crash_recover,
           });
           return okFormatted(
             formatOk("spawn_agent", {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -22,6 +22,10 @@ import {
   type StateTransition,
 } from "./agent-types.js";
 
+type AgentRecordPatch = Partial<
+  Omit<AgentRecord, "agent_id" | "created_at" | "updated_at" | "version" | "state">
+>;
+
 export class StateManager {
   private baseDir: string;
   private eventLog: EventLog;
@@ -114,18 +118,9 @@ export class StateManager {
   }
 
   /**
-   * Update arbitrary fields on an agent record without state-transition validation.
-   * Used for quality and deletion_intent updates.
+   * Update arbitrary non-state fields on an agent record without transition validation.
    */
-  updateRecord(
-    agentId: string,
-    fields: Partial<
-      Pick<
-        AgentRecord,
-        "deletion_intent" | "quality" | "max_cost_per_agent" | "parent_agent_id"
-      >
-    >,
-  ): AgentRecord {
+  updateRecord(agentId: string, fields: AgentRecordPatch): AgentRecord {
     const current = this.readState(agentId);
     if (!current) {
       throw new Error(`Agent not found: ${agentId}`);
@@ -150,7 +145,7 @@ export class StateManager {
       event: "transition",
       from_state: current.state,
       to_state: current.state,
-      surface_id: current.surface_id,
+      surface_id: updated.surface_id,
       source: "updateRecord",
       error: null,
     });

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -10,7 +10,10 @@ import {
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
-import { MAX_CHILDREN, type AgentRecord } from "../src/agent-types.js";
+import {
+  MAX_RESPAWN_ATTEMPTS,
+  type AgentRecord,
+} from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
@@ -364,23 +367,26 @@ describe("AgentEngine", () => {
       expect(recovered?.respawn_attempts).toBe(1);
     });
 
-    it("does not respawn an agent the user intentionally stopped", async () => {
+    it("does not respawn an errored agent the user intentionally stopped", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-stop",
-          state: "working",
+          state: "error",
           surface_id: "surface:42",
           repo: "brainlayer",
           cli: "codex",
           cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
           crash_recover: true,
+          error: "Surface surface:42 disappeared",
         }),
       );
-      liveSurfaces = [makeSurface("surface:42")];
       await engine.getRegistry().reconstitute();
 
       await engine.stopAgent("agent-stop");
-      expect(engine.getAgentState("agent-stop")?.user_killed).toBe(true);
+      expect(engine.getAgentState("agent-stop")).toMatchObject({
+        state: "error",
+        user_killed: true,
+      });
 
       liveSurfaces = [];
       await engine.runSweep();
@@ -399,7 +405,7 @@ describe("AgentEngine", () => {
           cli: "codex",
           cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
           crash_recover: true,
-          respawn_attempts: MAX_CHILDREN,
+          respawn_attempts: MAX_RESPAWN_ATTEMPTS,
           error: "Surface surface:gone disappeared",
         }),
       );
@@ -409,7 +415,7 @@ describe("AgentEngine", () => {
 
       expect(mockClient.newSplit).not.toHaveBeenCalled();
       expect(engine.getAgentState("agent-loop")?.error).toContain(
-        `Max crash recoveries exceeded: ${MAX_CHILDREN}`,
+        `Max crash recoveries exceeded: ${MAX_RESPAWN_ATTEMPTS}`,
       );
     });
 
@@ -440,6 +446,41 @@ describe("AgentEngine", () => {
       expect(mockClient.newSplit).toHaveBeenCalledTimes(2);
       expect(engine.getAgentState("agent-retry")?.state).toBe("booting");
       expect(engine.getAgentState("agent-retry")?.respawn_attempts).toBe(2);
+    });
+
+    it("transitions crash recovery failures in creating state back to error", async () => {
+      const transition = stateMgr.transition.bind(stateMgr);
+      vi.spyOn(stateMgr, "transition").mockImplementation((...args) => {
+        const [agentId, nextState] = args;
+        if (agentId === "agent-creating" && nextState === "booting") {
+          throw new Error("boot fail");
+        }
+        return transition(...args);
+      });
+
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-creating",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(engine.getAgentState("agent-creating")).toMatchObject({
+        state: "error",
+        error: "Crash recovery failed: boot fail",
+      });
     });
   });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -412,6 +412,35 @@ describe("AgentEngine", () => {
         `Max crash recoveries exceeded: ${MAX_CHILDREN}`,
       );
     });
+
+    it("keeps crash recovery eligible after a transient respawn failure", async () => {
+      (mockClient.send as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error("send failed"))
+        .mockResolvedValue(undefined);
+
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-retry",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+      await engine.runSweep();
+
+      expect(mockClient.newSplit).toHaveBeenCalledTimes(2);
+      expect(engine.getAgentState("agent-retry")?.state).toBe("booting");
+      expect(engine.getAgentState("agent-retry")?.respawn_attempts).toBe(2);
+    });
   });
 
   describe("boot session capture", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { AgentEngine, buildLaunchCommand } from "../src/agent-engine.js";
+import {
+  AgentEngine,
+  buildLaunchCommand,
+  buildResumeCommand,
+} from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
-import type { AgentRecord } from "../src/agent-types.js";
+import { MAX_CHILDREN, type AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
@@ -75,6 +79,9 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
     deletion_intent: false,
     quality: "unknown",
     max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
     ...overrides,
   };
 }
@@ -321,6 +328,153 @@ describe("AgentEngine", () => {
       });
       expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
+
+    it("respawns a crashed agent with its captured session id when crash recovery is enabled", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-crash",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(mockClient.newSplit).toHaveBeenCalled();
+      expect(mockClient.send).toHaveBeenCalledWith(
+        "surface:new",
+        "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        { workspace: "ws:1" },
+      );
+      expect(mockClient.sendKey).toHaveBeenCalledWith("surface:new", "return", {
+        workspace: "ws:1",
+      });
+
+      const recovered = engine.getAgentState("agent-crash");
+      expect(recovered?.state).toBe("booting");
+      expect(recovered?.surface_id).toBe("surface:new");
+      expect(recovered?.respawn_attempts).toBe(1);
+    });
+
+    it("does not respawn an agent the user intentionally stopped", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-stop",
+          state: "working",
+          surface_id: "surface:42",
+          repo: "brainlayer",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.stopAgent("agent-stop");
+      expect(engine.getAgentState("agent-stop")?.user_killed).toBe(true);
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+    });
+
+    it("stops retrying once crash recovery hits the max respawn ceiling", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-loop",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+          respawn_attempts: MAX_CHILDREN,
+          error: "Surface surface:gone disappeared",
+        }),
+      );
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(engine.getAgentState("agent-loop")?.error).toContain(
+        `Max crash recoveries exceeded: ${MAX_CHILDREN}`,
+      );
+    });
+  });
+
+  describe("boot session capture", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it.each([
+      [
+        "codex",
+        "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        `gpt-5.4
+Working (12s • esc to interrupt)
+To continue this session, run codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e`,
+      ],
+      [
+        "claude",
+        "5b9f4f35-2942-4c8b-b1af-d89d4e36c95d",
+        `Claude Code
+Session ID: 5b9f4f35-2942-4c8b-b1af-d89d4e36c95d`,
+      ],
+      [
+        "cursor",
+        "9e26fe1a-2374-4b15-b9b2-646ac7a8c2ef",
+        `Cursor Agent
+chatId: 9e26fe1a-2374-4b15-b9b2-646ac7a8c2ef`,
+      ],
+      [
+        "gemini",
+        "8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274",
+        `Gemini CLI
+Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
+      ],
+    ] as const)(
+      "captures %s session ids from the boot banner within the first sweep",
+      async (cli, sessionId, banner) => {
+        liveSurfaces = [makeSurface("surface:new")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:new",
+          text: banner,
+          lines: 80,
+          scrollback_used: true,
+        });
+
+        engine.startSweep(1000);
+        const result = await engine.spawnAgent({
+          repo: "brainlayer",
+          model: "sonnet",
+          cli,
+          prompt: "Fix gap F",
+        });
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(engine.getAgentState(result.agent_id)?.cli_session_id).toBe(
+          sessionId,
+        );
+      },
+    );
   });
 
   describe("waitFor", () => {
@@ -703,5 +857,27 @@ describe("buildLaunchCommand", () => {
     const cmd = buildLaunchCommand("claude", "brainlayer");
     expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
     expect(cmd).not.toContain("CLAUDE_CODE_NO_FLICKER");
+  });
+});
+
+describe("buildResumeCommand", () => {
+  const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+
+  it("uses the verified resume command for each supported CLI", () => {
+    expect(buildResumeCommand("claude", "brainlayer", sessionId)).toBe(
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(buildResumeCommand("codex", "brainlayer", sessionId)).toBe(
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(buildResumeCommand("cursor", "brainlayer", sessionId)).toBe(
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 cursor agent --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(buildResumeCommand("gemini", "brainlayer", sessionId)).toBe(
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(buildResumeCommand("kiro", "brainlayer", sessionId)).toBe(
+      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli chat --resume-id 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
   });
 });

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -241,4 +241,28 @@ describe("AgentRegistry", () => {
       expect(registry.get("new-agent")!.state).toBe("ready");
     });
   });
+
+  describe("purgeTerminal", () => {
+    it("purges crash_recover errors that are no longer recoverable", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "stale-recovery-error",
+          state: "error",
+          surface_id: "surface:gone",
+          crash_recover: true,
+          cli_session_id: null,
+          error: "Crash recovery failed: missing session id",
+        }),
+      );
+
+      const surfaceProvider = async () => [] as CmuxSurface[];
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+
+      const purged = await registry.purgeTerminal();
+
+      expect(purged).toBe(1);
+      expect(registry.get("stale-recovery-error")).toBeNull();
+    });
+  });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -118,6 +118,69 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.state).toBe("booting");
   });
 
+  it("spawn_agent persists crash_recover=true in agent state", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "fix gap F",
+        crash_recover: true,
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+
+    expect(state.crash_recover).toBe(true);
+  });
+
+  it("spawn_agent defaults crash_recover to false", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "fix gap F",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+
+    expect(state.crash_recover).toBe(false);
+  });
+
   it("list_agents returns agents after spawn", async () => {
     const server = createServer({
       exec: mockExec,


### PR DESCRIPTION
## Summary
- auto-capture CLI session IDs from early boot banners so spawned agents persist resumable `cli_session_id` values instead of staying `null`
- add opt-in `crash_recover: true` recovery that respawns unexpected PTY deaths with per-CLI resume commands, a user-killed guard, and a bounded retry ceiling

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`
- [ ] Live cmux crash-recovery exercise against a real agent pane

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automatic respawn behavior and new persisted state fields (`cli_session_id`, retry counters, user-killed flag), which can change lifecycle semantics and create retry loops if eligibility detection is wrong, though retries are capped.
> 
> **Overview**
> Adds **boot-time session ID capture**: during early `booting`, `AgentEngine` reads recent terminal output and persists a detected UUID as `cli_session_id` for later resume.
> 
> Adds **opt-in PTY crash recovery** via `crash_recover`: sweeps now attempt to respawn eligible errored agents onto a new surface and run a per-CLI `buildResumeCommand`, with `MAX_RESPAWN_ATTEMPTS` capping retries and `user_killed` preventing recovery when a stop was user-initiated.
> 
> Extends the agent schema/state updates to track `workspace_id`, `respawn_attempts`, and `user_killed`, updates purge logic to retain recoverable/exhausted crash errors, and exposes `crash_recover` on the `spawn_agent` tool; tests were added/updated to cover capture, resume commands, retry ceiling, and stop-agent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f59a68d1464c4b0c8151449012bc768548feb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-capture of agent session IDs and crash recovery with PTY resume
> - During each sweep, crashed agents with `crash_recover=true` are auto-respawned up to `MAX_RESPAWN_ATTEMPTS` (10) by sending a CLI-specific resume command using the stored `cli_session_id`.
> - During boot, `maybeCaptureBootSessionId` reads the terminal screen and extracts a session UUID from output, persisting it to the agent record for use in future recovery.
> - `stopAgent` now accepts a `userInitiated` flag (default `true`); agents stopped by context-limit eviction are not marked `user_killed`, keeping them eligible for recovery.
> - The registry's purge logic retains error-state agents that are recovery-eligible or have exhausted respawns, so they remain visible rather than being silently deleted.
> - Risk: recovery attempts create a new terminal surface and send keystrokes; if the CLI session no longer exists, recovery fails and writes a diagnostic error to the agent record.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66f59a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->