### PR TITLE
fix: harden crash recovery bookkeeping

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -52,8 +52,16 @@ const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
+const SESSION_ID_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const SESSION_ID_RE =
-  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+  new RegExp(`\\b${SESSION_ID_PATTERN}\\b`, "gi");
+const CONTEXTUAL_SESSION_ID_PATTERNS = [
+  new RegExp(`(?:codex\\s+resume|--resume(?:-id)?|resume-id)\\s+(${SESSION_ID_PATTERN})`, "i"),
+  new RegExp(`session\\s+id:\\s*(${SESSION_ID_PATTERN})`, "i"),
+  new RegExp(`chatid:\\s*(${SESSION_ID_PATTERN})`, "i"),
+  new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
+] as const;
 
 interface AgentEngineClient {
   log(
@@ -208,7 +216,16 @@ export function buildResumeCommand(
 }
 
 export function extractSessionId(text: string): string | null {
-  return text.match(SESSION_ID_RE)?.[0] ?? null;
+  for (const pattern of CONTEXTUAL_SESSION_ID_PATTERNS) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  const matches = [...text.matchAll(SESSION_ID_RE)].map((match) => match[0]);
+  const uniqueMatches = [...new Set(matches)];
+  return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
 export class AgentEngine {
@@ -310,6 +327,47 @@ export class AgentEngine {
     return isCrashRecoveryEligible(agent);
   }
 
+  private async persistCrashRecoveryFailure(
+    agentId: string,
+    message: string,
+  ): Promise<void> {
+    const current = this.registry.get(agentId);
+    if (!current) {
+      return;
+    }
+
+    try {
+      if (TERMINAL_STATES.has(current.state)) {
+        const failed = this.stateMgr.updateRecord(agentId, {
+          error: `Crash recovery failed: ${message}`,
+        });
+        this.registry.set(agentId, failed);
+        return;
+      }
+
+      const failed = this.stateMgr.transition(agentId, "error", {
+        error: `Crash recovery failed: ${message}`,
+      });
+      this.registry.set(agentId, failed);
+    } catch (persistError) {
+      const persistMessage =
+        persistError instanceof Error ? persistError.message : String(persistError);
+      if (persistMessage.includes("Agent not found")) {
+        this.registry.remove(agentId);
+        await this.client.log(
+          `crash-recovery: dropped missing agent ${agentId} after failure`,
+          { level: "warning", source: "cmux-mcp" },
+        );
+        return;
+      }
+
+      await this.client.log(
+        `crash-recovery: failed to persist error for ${agentId}: ${persistMessage}`,
+        { level: "error", source: "cmux-mcp" },
+      );
+    }
+  }
+
   private async markCrashRecoveryExhausted(agent: AgentRecord): Promise<void> {
     const updated = this.stateMgr.updateRecord(agent.agent_id, {
       error: `Max crash recoveries exceeded: ${MAX_RESPAWN_ATTEMPTS}`,
@@ -328,12 +386,18 @@ export class AgentEngine {
         continue;
       }
 
-      if ((agent.respawn_attempts ?? 0) >= MAX_RESPAWN_ATTEMPTS) {
+      const nextRespawnAttempt = (agent.respawn_attempts ?? 0) + 1;
+      if (nextRespawnAttempt > MAX_RESPAWN_ATTEMPTS) {
         await this.markCrashRecoveryExhausted(agent);
         continue;
       }
 
       try {
+        const attempted = this.stateMgr.updateRecord(agent.agent_id, {
+          respawn_attempts: nextRespawnAttempt,
+        });
+        this.registry.set(agent.agent_id, attempted);
+
         const surface = await this.createAgentSurface(agent.workspace_id ?? undefined);
         const creating = this.stateMgr.transition(agent.agent_id, "creating", {
           error: null,
@@ -346,7 +410,7 @@ export class AgentEngine {
           surface_id: surface.surface,
           workspace_id: surface.workspace,
           crash_recover: true,
-          respawn_attempts: (agent.respawn_attempts ?? 0) + 1,
+          respawn_attempts: nextRespawnAttempt,
           user_killed: false,
           deletion_intent: false,
           error: null,
@@ -378,18 +442,7 @@ export class AgentEngine {
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        const current = this.registry.get(agent.agent_id);
-        if (current && !TERMINAL_STATES.has(current.state)) {
-          const failed = this.stateMgr.transition(agent.agent_id, "error", {
-            error: `Crash recovery failed: ${message}`,
-          });
-          this.registry.set(agent.agent_id, failed);
-        } else {
-          const failed = this.stateMgr.updateRecord(agent.agent_id, {
-            error: `Crash recovery failed: ${message}`,
-          });
-          this.registry.set(agent.agent_id, failed);
-        }
+        await this.persistCrashRecoveryFailure(agent.agent_id, message);
       }
     }
   }
@@ -822,24 +875,36 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    const marked = this.stateMgr.updateRecord(agentId, {
-      user_killed: opts?.userInitiated ?? true,
-    });
-    this.registry.set(agentId, marked);
+    const userInitiated = opts?.userInitiated ?? true;
 
     if (TERMINAL_STATES.has(agent.state)) {
+      if (agent.state === "error" && userInitiated && agent.user_killed !== true) {
+        const marked = this.stateMgr.updateRecord(agentId, {
+          user_killed: true,
+        });
+        this.registry.set(agentId, marked);
+      }
       return; // Already stopped
     }
 
-    if (force && marked.pid) {
+    if (force && agent.pid) {
       try {
-        process.kill(marked.pid, "SIGKILL");
+        process.kill(agent.pid, "SIGKILL");
       } catch {
         // Process may already be dead — that's fine
       }
     } else {
       // Graceful: send Ctrl+C
-      await this.client.sendKey(marked.surface_id, "c-c", {});
+      await this.client.sendKey(agent.surface_id, "c-c", {});
+    }
+
+    const current = this.registry.get(agentId) ?? agent;
+    let marked = current;
+    if ((current.user_killed ?? false) !== userInitiated) {
+      marked = this.stateMgr.updateRecord(agentId, {
+        user_killed: userInitiated,
+      });
+      this.registry.set(agentId, marked);
     }
 
     // Transition to done

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -6,6 +6,7 @@ import {
   AgentEngine,
   buildLaunchCommand,
   buildResumeCommand,
+  extractSessionId,
 } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
@@ -482,6 +483,76 @@ describe("AgentEngine", () => {
         error: "Crash recovery failed: boot fail",
       });
     });
+
+    it("counts failed recovery attempts even when surface creation fails immediately", async () => {
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("cmux unavailable"),
+      );
+
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-preflight",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-preflight")).toMatchObject({
+        state: "error",
+        respawn_attempts: 1,
+        error: "Crash recovery failed: cmux unavailable",
+      });
+    });
+
+    it("continues recovering other agents when one recovery record disappears mid-catch", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-missing",
+          state: "error",
+          surface_id: "surface:gone-1",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+          error: "Surface surface:gone-1 disappeared",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-ok",
+          state: "error",
+          surface_id: "surface:gone-2",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+          error: "Surface surface:gone-2 disappeared",
+        }),
+      );
+      await engine.getRegistry().reconstitute();
+
+      stateMgr.removeState("agent-missing");
+
+      await expect(engine.runSweep()).resolves.toBeUndefined();
+
+      expect(engine.getAgentState("agent-missing")).toBeNull();
+      expect(engine.getAgentState("agent-ok")).toMatchObject({
+        state: "booting",
+        respawn_attempts: 1,
+      });
+    });
   });
 
   describe("boot session capture", () => {
@@ -763,6 +834,47 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       expect(["done", "error"]).toContain(state!.state);
     });
 
+    it("does not mark naturally completed agents as user-killed", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-done",
+          state: "done",
+          surface_id: "surface:42",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.stopAgent("agent-done");
+
+      expect(engine.getAgentState("agent-done")).toMatchObject({
+        state: "done",
+        user_killed: false,
+      });
+      expect(mockClient.sendKey).not.toHaveBeenCalled();
+    });
+
+    it("does not mark user_killed when the stop signal fails", async () => {
+      (mockClient.sendKey as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("tty busy"),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-busy",
+          state: "working",
+          surface_id: "surface:42",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await expect(engine.stopAgent("agent-busy")).rejects.toThrow("tty busy");
+      expect(engine.getAgentState("agent-busy")).toMatchObject({
+        state: "working",
+        user_killed: false,
+      });
+    });
+
     it("throws for non-existent agent", async () => {
       await engine.getRegistry().reconstitute();
       await expect(engine.stopAgent("nonexistent")).rejects.toThrow(
@@ -949,5 +1061,27 @@ describe("buildResumeCommand", () => {
     expect(buildResumeCommand("kiro", "brainlayer", sessionId)).toBe(
       "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli chat --resume-id 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
+  });
+});
+
+describe("extractSessionId", () => {
+  it("prefers contextual session markers over unrelated earlier UUIDs", () => {
+    const traceId = "11111111-2222-3333-4444-555555555555";
+    const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+
+    expect(
+      extractSessionId(
+        `trace_id=${traceId}\nTo continue this session, run codex resume ${sessionId}`,
+      ),
+    ).toBe(sessionId);
+    expect(
+      extractSessionId(`request ${traceId}\nSession ID: ${sessionId}`),
+    ).toBe(sessionId);
+    expect(
+      extractSessionId(`request ${traceId}\nchatId: ${sessionId}`),
+    ).toBe(sessionId);
+    expect(
+      extractSessionId(`request ${traceId}\nResumable session: ${sessionId}`),
+    ).toBe(sessionId);
   });
 });


### PR DESCRIPTION
## Summary
- count every crash-recovery attempt before surface creation so early failures still hit `MAX_RESPAWN_ATTEMPTS`
- make crash-recovery failure persistence resilient to missing state files and continue processing remaining agents
- tighten `stopAgent()` user-killed writes and session-ID extraction to avoid false intent/session capture

## Context
PR #77 was admin-merged at `62feb14` while review follow-ups were still in flight. This PR carries only the post-merge hardening delta that was verified locally afterward.

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crash-recovery and stop semantics in `AgentEngine`, which can affect agent lifecycle state transitions and retry behavior; changes are contained and backed by added tests for edge cases.
> 
> **Overview**
> Improves crash-recovery robustness by incrementing `respawn_attempts` *before* surface creation so early failures still count toward `MAX_RESPAWN_ATTEMPTS`, and by centralizing failure persistence in `persistCrashRecoveryFailure` (including handling missing agent state mid-recovery without breaking the sweep loop).
> 
> Refines `stopAgent()` bookkeeping so `user_killed` is only written when appropriate (e.g., not for already-`done` agents, and not if sending the stop signal fails), and tightens boot session ID extraction to prefer contextual “resume/session id” markers and avoid ambiguous UUID matches.
> 
> Adds targeted tests covering preflight/surface-creation failures, disappearing recovery records, `stopAgent` intent edge cases, and contextual `extractSessionId` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4317cc2dbb915099053ea6aff15397f3aa30ecd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden crash recovery bookkeeping and session ID extraction in `AgentEngine`
> - Adds `AgentEngine.persistCrashRecoveryFailure` to centralize crash recovery error persistence, handling missing-agent cases by removing the registry entry and logging a warning instead of erroring.
> - Fixes `recoverCrashedAgents` to always increment `respawn_attempts` even when surface creation fails before completion, preventing attempts from being undercounted.
> - Fixes `stopAgent` so naturally-completed agents are never marked `user_killed`, and `user_killed` is not set if sending the stop signal fails.
> - Rewrites `extractSessionId` to prefer UUIDs preceded by contextual markers (e.g. `--resume`, `session id:`) and returns `null` when multiple unrelated UUIDs are present.
> - Behavioral Change: `stopAgent` on an error-state agent now sets `user_killed` only when explicitly user-initiated and not already set; other callers are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4317cc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved crash recovery error handling and state management
  * Enhanced agent stopping logic for user-initiated terminations
  * Better session ID recognition across multiple formats

* **Tests**
  * Added tests for session ID extraction with multiple patterns
  * Added crash recovery and agent stopping scenario coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->