### PR TITLE
feat: add Track 4 agent facade for GUI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cmuxLayer
 
-**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 25 MCP tools that give AI agents programmatic control over terminal workspaces.
+**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 26 MCP tools that give AI agents programmatic control over terminal workspaces.
 
 <p align="center">
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
@@ -8,8 +8,8 @@
 
 [![install](https://img.shields.io/badge/install-npm%20install%20--g%20cmuxlayer-22c55e)](https://github.com/EtanHey/cmuxlayer#quick-start)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP-25%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-361%20passing-brightgreen.svg)](#testing)
+[![MCP Tools](https://img.shields.io/badge/MCP-26%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-406%20passing-brightgreen.svg)](#testing)
 
 ## Quick Start
 
@@ -54,20 +54,20 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer exposes 25 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
+Under the hood, cmuxLayer exposes 26 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
-## MCP Tools (25)
+## MCP Tools (26)
 
 All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
 
 **Terminal control** — `new_split` `new_surface` `move_surface` `reorder_surface` `send_input` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
 
-**Agent lifecycle** — `spawn_agent` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
+**Agent lifecycle** — `spawn_agent` `send_to` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
 
 **Workspace** — `list_surfaces` `list_agents` `my_agents` `get_agent_state` `read_agent_output` `notify` `set_status` `set_progress`
 
 <details>
-<summary>Full tool reference (25 tools)</summary>
+<summary>Full tool reference (26 tools)</summary>
 
 ### Read-only (6)
 
@@ -80,7 +80,7 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `my_agents` | Children of a parent agent with live screen status |
 | `read_agent_output` | Structured output between delimiter markers |
 
-### Mutating (16)
+### Mutating (17)
 
 | Tool | What it does |
 |------|-------------|
@@ -96,8 +96,9 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `set_progress` | Set progress indicator (0.0-1.0) |
 | `browser_surface` | Interact with browser surfaces |
 | `spawn_agent` | Spawn a CLI agent in a new pane |
+| `send_to` | Send text to a tracked agent without knowing its surface |
 | `send_to_agent` | Send a prompt to a running agent |
-| `wait_for` | Block until agent reaches a target state |
+| `wait_for` | Block until agent reaches a target state (defaults to `done`) |
 | `wait_for_all` | Block until multiple agents finish |
 | `interact` | Send interactive input (confirm, cancel, resume) |
 
@@ -155,7 +156,7 @@ cmuxLayer auto-discovers the cmux socket (macOS: `~/Library/Application Support/
 ## Testing
 
 ```bash
-bun run test        # 361 tests via vitest
+bun run test        # 406 tests via vitest
 npm run typecheck   # Type checking
 ```
 

--- a/docs/design/track-4-send-to-wait-for-facade.md
+++ b/docs/design/track-4-send-to-wait-for-facade.md
@@ -1,0 +1,327 @@
+# Track 4: `send_to` / `wait_for` / `list_agents` Facade
+
+## Goal
+
+Give GUI clients a stable, agent-first control surface so they can drive `cmuxlayer` without knowing about panes, surfaces, or splits.
+
+This track does not solve logical agent naming or auto-spawn. It standardizes the public facade around `agent_id` and keeps pane math internal.
+
+## Current Problem
+
+`cmuxlayer` already has most of the machinery needed for agent routing, but the public tool surface is inconsistent:
+
+- `send_to_agent` is agent-first but exposed as a specialized engine tool rather than a stable client facade.
+- `wait_for` is agent-first but optimized for engine state choreography (`target_state` required) rather than default client completion semantics.
+- `list_agents` returns raw `AgentRecord`s, which leak `surface_id` and other internal fields directly to clients.
+- Surface-based tools like `send_input(surface, text)` remain necessary for operators and debugging, but they should not be the default integration contract for GUI clients.
+
+The result is that clients still have to reason about runtime topology even when they only want to talk to an agent.
+
+## Recommended Approach
+
+Ship a thin facade on top of the existing registry and engine:
+
+1. Add a new public `send_to` tool.
+2. Rework `wait_for` to support facade defaults while staying compatible with current agent-id routing.
+3. Rework `list_agents` to return public agent objects instead of raw `AgentRecord`s.
+4. Keep the raw tools (`send_to_agent`, `send_input`, `get_agent_state`, `my_agents`) for advanced and internal use.
+
+This is the smallest change that makes `cmuxlayer` GUI-agnostic today while leaving room for a later logical-name layer.
+
+## Alternatives Considered
+
+### A. Add logical agent names and auto-spawn now
+
+Pros:
+
+- Closest to the long-term north star (`send_to(agent_name, message)`).
+
+Cons:
+
+- Requires a spawn recipe model that does not exist in current persisted state.
+- Forces product decisions about name uniqueness, lifecycle ownership, and spawn defaults.
+- Expands Track 4 into a larger orchestration redesign.
+
+Decision: reject for this track.
+
+### B. Tell clients to use `interact`
+
+Pros:
+
+- No new tools.
+
+Cons:
+
+- `interact` is a mixed command multiplexer, not a clear public contract.
+- It still exposes action choreography instead of an obvious message-routing primitive.
+- It does not fix `list_agents` leaking surface data.
+
+Decision: reject as the primary facade.
+
+## Public Tool Surface
+
+### `list_agents`
+
+Keep the tool name, but change the structured payload from raw `AgentRecord[]` to public agent objects:
+
+```ts
+type PublicAgent = {
+  agent_id: string;
+  repo: string;
+  model: string;
+  state: AgentState;
+  session_id: string | null;
+};
+```
+
+Filters stay the same:
+
+- `state?`
+- `repo?`
+- `model?`
+
+Structured response:
+
+```ts
+{
+  ok: true,
+  agents: PublicAgent[],
+  count: number
+}
+```
+
+No `surface_id`, `pane`, `workspace`, or other topology fields are returned here.
+
+### `send_to`
+
+Add a new public tool:
+
+```ts
+{
+  agent_id: string,
+  text: string,
+  press_enter?: boolean
+}
+```
+
+Behavior:
+
+- Resolve the current route for `agent_id`.
+- Return `ok: false` when `agent_id` is unknown or route resolution fails.
+- Only allow interactive agents in `ready` or `idle` state.
+- Send sanitized input to the routed surface.
+- Optionally press enter.
+- Return immediately after delivering the input; command completion is handled separately via `wait_for`.
+- Return a lightweight acknowledgment containing `agent_id`.
+
+Structured response:
+
+```ts
+{
+  ok: true,
+  agent_id: string
+}
+```
+
+### `wait_for`
+
+Keep the tool name, but shift it toward facade semantics.
+
+Proposed schema:
+
+```ts
+{
+  agent_id: string,
+  timeout_ms?: number,
+  target_state?: "ready" | "working" | "idle" | "done" | "error"
+}
+```
+
+Behavior:
+
+- `target_state` becomes optional.
+- Default `target_state` is `"done"`, so GUI clients can call `wait_for(agent_id)` without learning engine choreography.
+- The tool still supports explicit states for internal and advanced clients.
+- The response includes the projected public agent object for the final state.
+
+Structured response:
+
+```ts
+{
+  ok: true,
+  agent_id: string,
+  state: AgentState,
+  matched: boolean,
+  elapsed: number,
+  source: "immediate" | "sweep" | "timeout",
+  error?: string,
+  agent: PublicAgent | null
+}
+```
+
+Response notes:
+
+- `state` stays at the top level for compatibility with existing callers that already read `wait_for().state`.
+- `agent` is the new first-class public object for facade clients.
+- `error` is allowed with `ok: true` for non-fatal outcomes such as timeout or terminal-state mismatch. Fatal lookup or routing failures return `ok: false`.
+
+## Agent Object Shape
+
+The facade promotes agents as first-class objects with the following stable shape:
+
+```ts
+{
+  agent_id,
+  repo,
+  model,
+  state,
+  session_id
+}
+```
+
+Notes:
+
+- `session_id` is the public projection of `cli_session_id`.
+- `agent_id` remains the routing key for this track.
+- `surface_id` stays internal because it is transport topology, not client identity.
+- `cli`, `spawn_depth`, `quality`, and parent/child fields remain available through debug-oriented tools such as `get_agent_state` and `my_agents`.
+
+## Routing Layer
+
+Add a small internal projection/routing module, e.g. `src/agent-facade.ts`, with two responsibilities:
+
+1. Project raw `AgentRecord`s into `PublicAgent`s.
+2. Resolve `agent_id -> surface_id` for message delivery.
+
+Suggested internal types:
+
+```ts
+type AgentRoute = {
+  agent_id: string;
+  surface_id: string;
+  state: AgentState;
+  session_id: string | null;
+};
+```
+
+Suggested helpers:
+
+```ts
+toPublicAgent(record: AgentRecord): PublicAgent
+buildRouteTable(records: AgentRecord[]): Map<string, AgentRoute>
+resolveAgentRoute(records: AgentRecord[], agentId: string): AgentRoute
+```
+
+### Why a dedicated routing layer?
+
+- It gives `server.ts` a clear boundary between public objects and internal transport state.
+- It centralizes collision detection instead of scattering ad hoc lookups.
+- It lets future logical-name routing swap in without rewriting every tool handler.
+
+### Collision Handling
+
+Even though the current registry map is keyed by `agent_id`, the facade should still reject contradictory route input:
+
+- If two `AgentRecord`s with the same `agent_id` point to different surfaces, route construction throws.
+- `send_to` and `wait_for` surface that error instead of guessing.
+
+That guard is mostly defensive today, but it becomes important if route data later comes from multiple sources.
+
+## Backwards Compatibility
+
+### Keep
+
+- `send_input(surface, text)` remains available for operators and low-level tools.
+- `send_to_agent(agent_id, text)` remains available as the legacy/internal path.
+- `wait_for_all`, `get_agent_state`, `my_agents`, and `interact` stay unchanged in purpose.
+
+### Deprecate for client use
+
+- `send_to_agent` description should explicitly say it is superseded by `send_to` for public integrations.
+- `send_input(surface, text)` should remain documented as a low-level surface tool, not the preferred GUI integration path.
+
+### Safe behavior changes
+
+- `list_agents` becomes less detailed, but only by removing internal topology leaks.
+- `wait_for` becomes easier to call because `target_state` defaults to `"done"`.
+
+If a caller needs raw topology, `get_agent_state` and `my_agents` remain the escape hatches.
+
+## Implementation Plan
+
+### Files to touch
+
+- `src/agent-types.ts`
+  - add `PublicAgent` and `AgentRoute` types
+- `src/agent-facade.ts`
+  - add projection and routing helpers
+- `src/agent-engine.ts`
+  - expose projected agent listing and route resolution helpers
+- `src/server.ts`
+  - register `send_to`
+  - project `list_agents`
+  - update `wait_for` defaults and response shape
+  - mark `send_to_agent` as deprecated for public use
+- `src/format.ts`
+  - add public-agent list formatting that does not print `surface_id`
+- `tests/agent-facade.test.ts`
+  - projection, routing, and collision tests
+- `tests/server-agent-tools.test.ts`
+  - `send_to`, `wait_for`, and `list_agents` handler behavior
+- `tests/security-hardening.test.ts`
+  - tool count and annotations
+- `README.md`
+  - tool count and public-tool docs
+
+### Expected tool-count change
+
+This track adds one tool:
+
+- before: 25 tools
+- after: 26 tools
+
+## Test Plan
+
+### Unit tests
+
+- `toPublicAgent()` strips `surface_id` and maps `cli_session_id -> session_id`.
+- `buildRouteTable()` creates a stable route per agent.
+- `buildRouteTable()` allows duplicate records when they agree on the same surface.
+- `buildRouteTable()` throws on duplicate `agent_id` with conflicting `surface_id`.
+
+### Server/tool tests
+
+- `list_agents` returns `PublicAgent[]` and does not leak `surface_id`.
+- `send_to` routes to the agent’s current surface and sends sanitized input.
+- `send_to(agent_id)` returns an error when the agent does not exist.
+- `send_to` rejects agents that are not interactive.
+- `wait_for(agent_id)` defaults to `"done"`.
+- `wait_for(agent_id)` returns an error when the agent does not exist.
+- `wait_for(agent_id, target_state="ready")` still works for advanced callers.
+
+### Regression coverage
+
+- `send_to_agent` still works.
+- `get_agent_state` still returns the full internal record.
+- Tool annotation coverage and total tool count stay accurate.
+
+## Client Consumption Path
+
+### T3 Code / DP Code flow
+
+1. Call `list_agents()` to populate agent objects.
+2. Store/display `agent_id` as the durable handle.
+3. Use `send_to(agent_id, text)` to deliver prompts.
+4. Use `wait_for(agent_id)` when the UI wants completion semantics.
+
+At no point does the client need to know which surface or pane owns the agent.
+
+## Non-Goals
+
+- Logical worker names
+- Auto-spawn on missing agent
+- Deterministic group layout policy
+- Portable repo launch configuration
+- T3/DP-specific UI code
+
+Those belong to later tracks.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6,6 +6,10 @@
 import { StateManager } from "./state-manager.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
+import {
+  resolveAgentRoute as resolvePublicAgentRoute,
+  toPublicAgent,
+} from "./agent-facade.js";
 import type {
   CmuxPane,
   CmuxPaneSurfaces,
@@ -20,9 +24,11 @@ import {
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
   MAX_RESPAWN_ATTEMPTS,
+  type AgentRoute,
   type AgentRecord,
   type AgentState,
   type CliType,
+  type PublicAgent,
   type WaitResult,
 } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
@@ -855,11 +861,24 @@ export class AgentEngine {
     return this.registry.get(agentId);
   }
 
+  getPublicAgent(agentId: string): PublicAgent | null {
+    const agent = this.registry.get(agentId);
+    return agent ? toPublicAgent(agent) : null;
+  }
+
   /**
    * List agents with optional filters.
    */
   listAgents(filter?: AgentFilter): AgentRecord[] {
     return this.registry.list(filter);
+  }
+
+  listPublicAgents(filter?: AgentFilter): PublicAgent[] {
+    return this.listAgents(filter).map(toPublicAgent);
+  }
+
+  resolveAgentRoute(agentId: string): AgentRoute {
+    return resolvePublicAgentRoute(this.listAgents(), agentId);
   }
 
   /**
@@ -944,9 +963,10 @@ export class AgentEngine {
       );
     }
 
-    await this.client.send(agent.surface_id, sanitizeTerminalInput(text), {});
+    const route = this.resolveAgentRoute(agentId);
+    await this.client.send(route.surface_id, sanitizeTerminalInput(text), {});
     if (pressEnter) {
-      await this.client.sendKey(agent.surface_id, "return", {});
+      await this.client.sendKey(route.surface_id, "return", {});
     }
   }
 }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -752,6 +752,7 @@ export class AgentEngine {
         state: initial.state,
         elapsed: Date.now() - start,
         source: "immediate",
+        agent: toPublicAgent(initial),
       };
     }
 
@@ -762,6 +763,7 @@ export class AgentEngine {
         state: initial.state,
         elapsed: Date.now() - start,
         source: "immediate",
+        agent: toPublicAgent(initial),
         error: initial.error ?? "Agent is in error state",
       };
     }
@@ -773,6 +775,7 @@ export class AgentEngine {
         state: initial.state,
         elapsed: Date.now() - start,
         source: "immediate",
+        agent: toPublicAgent(initial),
         error: "Agent has already completed",
       };
     }
@@ -789,6 +792,7 @@ export class AgentEngine {
             state: current?.state ?? "error",
             elapsed,
             source: "timeout",
+            agent: current ? toPublicAgent(current) : null,
             error: `Timed out after ${timeoutMs}ms waiting for state "${targetState}"`,
           });
           return;
@@ -804,6 +808,7 @@ export class AgentEngine {
             state: "error",
             elapsed,
             source: "sweep",
+            agent: null,
             error: "Agent disappeared during wait",
           });
           return;
@@ -816,6 +821,7 @@ export class AgentEngine {
             state: current.state,
             elapsed,
             source: "sweep",
+            agent: toPublicAgent(current),
           });
           return;
         }
@@ -831,6 +837,7 @@ export class AgentEngine {
             state: current.state,
             elapsed,
             source: "sweep",
+            agent: toPublicAgent(current),
             error:
               current.error ?? `Agent entered terminal state: ${current.state}`,
           });

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -1,0 +1,49 @@
+import type { AgentRecord, AgentRoute, PublicAgent } from "./agent-types.js";
+
+export function toPublicAgent(record: AgentRecord): PublicAgent {
+  return {
+    agent_id: record.agent_id,
+    repo: record.repo,
+    model: record.model,
+    state: record.state,
+    session_id: record.cli_session_id,
+  };
+}
+
+export function buildRouteTable(
+  records: AgentRecord[],
+): Map<string, AgentRoute> {
+  const routes = new Map<string, AgentRoute>();
+
+  for (const record of records) {
+    const nextRoute: AgentRoute = {
+      agent_id: record.agent_id,
+      surface_id: record.surface_id,
+      state: record.state,
+      session_id: record.cli_session_id,
+    };
+    const existing = routes.get(record.agent_id);
+
+    if (existing && existing.surface_id !== nextRoute.surface_id) {
+      throw new Error(
+        `Conflicting routes for agent "${record.agent_id}": ` +
+          `${existing.surface_id} vs ${nextRoute.surface_id}`,
+      );
+    }
+
+    routes.set(record.agent_id, nextRoute);
+  }
+
+  return routes;
+}
+
+export function resolveAgentRoute(
+  records: AgentRecord[],
+  agentId: string,
+): AgentRoute {
+  const route = buildRouteTable(records).get(agentId);
+  if (!route) {
+    throw new Error(`Agent not found: ${agentId}`);
+  }
+  return route;
+}

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -114,6 +114,7 @@ export interface WaitResult {
   state: AgentState;
   elapsed: number;
   source: "immediate" | "poll" | "sweep" | "watch" | "timeout";
+  agent: PublicAgent | null;
   error?: string;
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -48,6 +48,21 @@ export interface AgentRecord {
   user_killed?: boolean;
 }
 
+export interface PublicAgent {
+  agent_id: string;
+  repo: string;
+  model: string;
+  state: AgentState;
+  session_id: string | null;
+}
+
+export interface AgentRoute {
+  agent_id: string;
+  surface_id: string;
+  state: AgentState;
+  session_id: string | null;
+}
+
 export function hasRecoverableCrashError(error: string | null): boolean {
   if (!error) return false;
   return (

--- a/src/format.ts
+++ b/src/format.ts
@@ -5,7 +5,7 @@
  * No ANSI color codes (MCP tool output doesn't support them in Claude Code).
  */
 
-import type { AgentRecord } from "./agent-types.js";
+import type { AgentRecord, PublicAgent } from "./agent-types.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 function truncate(text: string, maxLen: number = 60): string {
@@ -139,7 +139,7 @@ export function formatReadScreen(
   return result.join("\n");
 }
 
-export function formatListAgents(agents: AgentRecord[], count: number): string {
+export function formatListAgents(agents: PublicAgent[], count: number): string {
   if (count === 0) {
     return "\u250c\u2500 cmux agents\n\u2502 No agents running.\n\u2514\u2500";
   }
@@ -149,10 +149,10 @@ export function formatListAgents(agents: AgentRecord[], count: number): string {
     `\u250c\u2500 cmux agents \u2500 ${count} agent${count !== 1 ? "s" : ""}`,
   );
   lines.push(
-    `\u2502 ${pad("ID", 20)} ${pad("Repo", 16)} ${pad("State", 8)} ${pad("Model", 18)} ${pad("Surface", 12)}`,
+    `\u2502 ${pad("ID", 20)} ${pad("Repo", 16)} ${pad("State", 8)} ${pad("Model", 18)} ${pad("Session", 14)}`,
   );
   lines.push(
-    `\u251c${"─".repeat(20)}${"─".repeat(17)}${"─".repeat(9)}${"─".repeat(19)}${"─".repeat(12)}`,
+    `\u251c${"─".repeat(20)}${"─".repeat(17)}${"─".repeat(9)}${"─".repeat(19)}${"─".repeat(14)}`,
   );
 
   for (const a of agents) {
@@ -160,11 +160,8 @@ export function formatListAgents(agents: AgentRecord[], count: number): string {
     const repo = pad(truncate(a.repo, 14), 16);
     const state = pad(a.state, 8);
     const model = pad(truncate(a.model, 16), 18);
-    const surface = pad(a.surface_id, 12);
-    lines.push(`\u2502 ${id} ${repo} ${state} ${model} ${surface}`);
-    if (a.error) {
-      lines.push(`\u2502   err: ${truncate(a.error, 60)}`);
-    }
+    const session = pad(a.session_id ?? "\u2014", 14);
+    lines.push(`\u2502 ${id} ${repo} ${state} ${model} ${session}`);
   }
 
   lines.push("\u2514\u2500");

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,14 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 25 MCP tools across two categories:
+ * 26 MCP tools across two categories:
  *   Core (14): list_surfaces, new_split, new_surface, move_surface,
  *              reorder_surface, send_input, send_key, read_screen, rename_tab,
  *              notify, set_status, set_progress, close_surface, browser_surface
- *   Agent lifecycle (11): spawn_agent, send_to_agent, read_agent_output,
- *                         get_agent_state, list_agents, my_agents, wait_for,
- *                         wait_for_all, stop_agent, kill, interact
+ *   Agent lifecycle (12): spawn_agent, send_to, send_to_agent,
+ *                         read_agent_output, get_agent_state, list_agents,
+ *                         my_agents, wait_for, wait_for_all, stop_agent,
+ *                         kill, interact
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 14 core tools + 11 agent lifecycle tools.
+ * cmux MCP server — registers 14 core tools + 12 agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -1647,11 +1647,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 12. wait_for
     server.tool(
       "wait_for",
-      "Block until an agent reaches a target state (ready, done, error). Checks retroactively first.",
+      "Block until an agent reaches a target state. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography.",
       {
         agent_id: z.string().describe("Agent ID from spawn_agent"),
         target_state: z
           .enum(["ready", "working", "idle", "done", "error"])
+          .optional()
+          .default("done")
           .describe("State to wait for"),
         timeout_ms: z
           .number()
@@ -1664,17 +1666,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
+          const targetState = args.target_state ?? "done";
           const result = await engine.waitFor(
             args.agent_id,
-            args.target_state,
+            targetState,
             args.timeout_ms,
           );
+          const agent = engine.getPublicAgent(args.agent_id);
           return okFormatted(
             formatOk("wait_for", {
               agent_id: args.agent_id,
               state: result.state,
             }),
-            { ...result },
+            {
+              agent_id: args.agent_id,
+              ...result,
+              agent,
+            },
           );
         } catch (e) {
           return err(e);
@@ -1767,7 +1775,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.readOnly,
       async (args) => {
         try {
-          const agents = engine.listAgents({
+          const agents = engine.listPublicAgents({
             state: args.state,
             repo: args.repo,
             model: args.model,
@@ -1812,10 +1820,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
     );
 
-    // 17. send_to_agent
+    // 17. send_to
+    server.tool(
+      "send_to",
+      "Send text input to an agent by `agent_id`. Resolves the backing surface internally so clients do not need pane or surface references.",
+      {
+        agent_id: z.string().describe("Agent ID"),
+        text: z.string().describe("Text to send"),
+        press_enter: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Press enter after sending text"),
+      },
+      ANNOTATIONS.mutating,
+      async (args) => {
+        try {
+          await engine.sendToAgent(args.agent_id, args.text, args.press_enter);
+          const data = { agent_id: args.agent_id };
+          return okFormatted(formatOk("send_to", data), data);
+        } catch (e) {
+          return err(e);
+        }
+      },
+    );
+
+    // 18. send_to_agent
     server.tool(
       "send_to_agent",
-      "Send text input to an agent. Agent must be in ready or idle state.",
+      "Deprecated for client integrations: use `send_to` instead. Internal/advanced path for sending text input to an agent in `ready` or `idle` state.",
       {
         agent_id: z.string().describe("Agent ID"),
         text: z.string().describe("Text to send"),
@@ -1836,7 +1869,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
       },
     );
-    // 18. read_agent_output
+    // 19. read_agent_output
     server.tool(
       "read_agent_output",
       "Extract structured output from an agent's terminal between delimiter markers (e.g., REVIEW_OUTPUT_START / REVIEW_OUTPUT_END). Returns the content between the markers, or null if not found.",

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { AgentEngine, type AgentLifecycleEvent } from "./agent-engine.js";
-import type { AgentRecord } from "./agent-types.js";
+import type { AgentRecord, AgentState } from "./agent-types.js";
 import {
   formatListSurfaces,
   formatReadScreen,
@@ -73,6 +73,7 @@ const SEND_INPUT_CHUNK_THRESHOLD = 500;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
+const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 
 type DeliveryStatus = "delivering" | "delivered" | "failed";
 
@@ -1571,6 +1572,36 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       notifyLifecycleEvent,
     });
 
+    const deliverAgentInput = async (args: {
+      agent_id: string;
+      text: string;
+      press_enter: boolean;
+    }) => {
+      const route = engine.resolveAgentRoute(args.agent_id);
+      if (!INTERACTIVE_AGENT_STATES.has(route.state)) {
+        throw new Error(
+          `Agent "${args.agent_id}" is not in an interactive state (current: ${route.state}). ` +
+            `Must be in: ${[...INTERACTIVE_AGENT_STATES].join(", ")}`,
+        );
+      }
+
+      const sanitizedText = sanitizeTerminalInput(args.text);
+      const chunks =
+        sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
+          ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
+          : [sanitizedText];
+
+      await withSurfaceWrite(route.surface_id, async () => {
+        await deliverInputChunks({
+          surface: route.surface_id,
+          chunks,
+          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+          press_enter: args.press_enter,
+        });
+      });
+    };
+
     // Reconstitute registry from disk on startup (async, best-effort).
     // Enable startup purge so the first sweep clears stale terminal-state
     // agents from previous cmux sessions.
@@ -1672,7 +1703,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             targetState,
             args.timeout_ms,
           );
-          const agent = engine.getPublicAgent(args.agent_id);
           return okFormatted(
             formatOk("wait_for", {
               agent_id: args.agent_id,
@@ -1681,7 +1711,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             {
               agent_id: args.agent_id,
               ...result,
-              agent,
             },
           );
         } catch (e) {
@@ -1836,7 +1865,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
-          await engine.sendToAgent(args.agent_id, args.text, args.press_enter);
+          await deliverAgentInput({
+            agent_id: args.agent_id,
+            text: args.text,
+            press_enter: args.press_enter,
+          });
           const data = { agent_id: args.agent_id };
           return okFormatted(formatOk("send_to", data), data);
         } catch (e) {
@@ -1861,7 +1894,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
-          await engine.sendToAgent(args.agent_id, args.text, args.press_enter);
+          await deliverAgentInput({
+            agent_id: args.agent_id,
+            text: args.text,
+            press_enter: args.press_enter,
+          });
           const data = { agent_id: args.agent_id };
           return okFormatted(formatOk("send_to_agent", data), data);
         } catch (e) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -630,6 +630,9 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       expect(result.matched).toBe(true);
       expect(result.source).toBe("immediate");
       expect(result.elapsed).toBeLessThan(100);
+      expect(result.agent?.agent_id).toBe("agent-ready");
+      expect(result.agent?.state).toBe("ready");
+      expect(result.agent?.session_id).toBeNull();
     });
 
     it("returns error result when agent is in error state", async () => {
@@ -646,6 +649,8 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       const result = await engine.waitFor("agent-err", "ready", 5000);
       expect(result.matched).toBe(false);
       expect(result.state).toBe("error");
+      expect(result.agent?.agent_id).toBe("agent-err");
+      expect(result.agent?.state).toBe("error");
     });
 
     it("times out when target state is never reached", async () => {
@@ -658,6 +663,8 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       const result = await engine.waitFor("agent-stuck", "ready", 500);
       expect(result.matched).toBe(false);
       expect(result.source).toBe("timeout");
+      expect(result.agent?.agent_id).toBe("agent-stuck");
+      expect(result.agent?.state).toBe("booting");
     });
 
     it("detects state change via sweep", async () => {
@@ -679,6 +686,8 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       const result = await engine.waitFor("agent-boot", "ready", 5000);
       expect(result.matched).toBe(true);
       expect(result.source).toBe("sweep");
+      expect(result.agent?.agent_id).toBe("agent-boot");
+      expect(result.agent?.state).toBe("ready");
     });
 
     it("throws for non-existent agent", async () => {

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRouteTable,
+  resolveAgentRoute,
+  toPublicAgent,
+} from "../src/agent-facade.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "agent-1",
+    surface_id: "surface:1",
+    workspace_id: "ws:1",
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: "session-1",
+    task_summary: "Fix the bug",
+    pid: null,
+    version: 1,
+    created_at: "2026-04-18T10:00:00Z",
+    updated_at: "2026-04-18T10:00:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+}
+
+describe("agent facade projections", () => {
+  it("projects a PublicAgent without leaking surface topology", () => {
+    const projected = toPublicAgent(makeRecord());
+
+    expect(projected).toEqual({
+      agent_id: "agent-1",
+      repo: "brainlayer",
+      model: "sonnet",
+      state: "ready",
+      session_id: "session-1",
+    });
+    expect((projected as any).surface_id).toBeUndefined();
+  });
+});
+
+describe("agent route table", () => {
+  it("builds routes keyed by agent_id", () => {
+    const table = buildRouteTable([
+      makeRecord({ agent_id: "agent-1", surface_id: "surface:1" }),
+      makeRecord({ agent_id: "agent-2", surface_id: "surface:2" }),
+    ]);
+
+    expect(table.get("agent-1")).toEqual({
+      agent_id: "agent-1",
+      surface_id: "surface:1",
+      state: "ready",
+      session_id: "session-1",
+    });
+    expect(table.get("agent-2")?.surface_id).toBe("surface:2");
+  });
+
+  it("resolves the route for a known agent", () => {
+    const route = resolveAgentRoute(
+      [makeRecord({ agent_id: "agent-1", surface_id: "surface:99" })],
+      "agent-1",
+    );
+
+    expect(route.surface_id).toBe("surface:99");
+  });
+
+  it("allows duplicate records when they agree on the same surface", () => {
+    const table = buildRouteTable([
+      makeRecord({ agent_id: "agent-1", surface_id: "surface:1" }),
+      makeRecord({ agent_id: "agent-1", surface_id: "surface:1" }),
+    ]);
+
+    expect(table.size).toBe(1);
+    expect(table.get("agent-1")?.surface_id).toBe("surface:1");
+  });
+
+  it("rejects conflicting routes for the same agent_id", () => {
+    expect(() =>
+      buildRouteTable([
+        makeRecord({ agent_id: "agent-1", surface_id: "surface:1" }),
+        makeRecord({ agent_id: "agent-1", surface_id: "surface:2" }),
+      ]),
+    ).toThrow(/Conflicting routes/);
+  });
+});

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -54,6 +54,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "set_progress",
     "browser_surface",
     "spawn_agent",
+    "send_to",
     "send_to_agent",
     "wait_for",
     "wait_for_all",
@@ -75,9 +76,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 25 tools have annotations", () => {
+  it("all 26 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(25);
+    expect(toolNames.length).toBe(26);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -13,6 +13,7 @@ const TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 
 const AGENT_TOOLS = [
   "spawn_agent",
+  "send_to",
   "wait_for",
   "wait_for_all",
   "get_agent_state",
@@ -23,7 +24,7 @@ const AGENT_TOOLS = [
 ] as const;
 
 describe("agent lifecycle tool registration", () => {
-  it("registers all 8 agent lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 10 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -57,7 +58,7 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 25 (14 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 26 (14 low-level + 10 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -67,7 +68,7 @@ describe("agent lifecycle tool registration", () => {
       stateDir: TEST_DIR,
     });
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(25);
+    expect(Object.keys(registeredTools)).toHaveLength(26);
   });
 });
 
@@ -205,6 +206,8 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.count).toBe(1);
     expect(parsed.agents[0].repo).toBe("brainlayer");
+    expect(parsed.agents[0].session_id).toBeNull();
+    expect(parsed.agents[0].surface_id).toBeUndefined();
   });
 
   it("get_agent_state returns full record", async () => {
@@ -278,6 +281,119 @@ describe("agent lifecycle tool handlers", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/not in an interactive state/);
+  });
+
+  it("send_to routes to the agent surface without exposing pane math", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "ready" });
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: "hello facade", press_enter: true },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(agentId);
+  });
+
+  it("send_to returns an error for an unknown agent_id", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const result = await sendTo.handler(
+      { agent_id: "missing-agent", text: "hello facade", press_enter: true },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.error).toMatch(/Agent not found/);
+  });
+
+  it("wait_for defaults to done when target_state is omitted", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const waitFor = (server as any)._registeredTools["wait_for"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "task 1",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const stateMgr = engine["stateMgr"];
+
+    setTimeout(() => {
+      stateMgr.transition(agentId, "ready");
+      setTimeout(() => {
+        stateMgr.transition(agentId, "done");
+      }, 50);
+    }, 50);
+
+    const result = await waitFor.handler(
+      { agent_id: agentId, timeout_ms: 5000 },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(agentId);
+    expect(parsed.state).toBe("done");
+    expect(parsed.agent.session_id).toBeNull();
+  });
+
+  it("wait_for returns an error for an unknown agent_id", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const waitFor = (server as any)._registeredTools["wait_for"];
+
+    const result = await waitFor.handler(
+      { agent_id: "missing-agent", timeout_ms: 5000 },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.error).toMatch(/Agent not found/);
   });
 
   it("my_agents returns root agents when no parent_agent_id", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -20,6 +20,7 @@ const AGENT_TOOLS = [
   "list_agents",
   "stop_agent",
   "send_to_agent",
+  "read_agent_output",
   "my_agents",
 ] as const;
 
@@ -283,7 +284,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(result.content[0].text).toMatch(/not in an interactive state/);
   });
 
-  it("send_to routes to the agent surface without exposing pane math", async () => {
+  it("send_to sanitizes and chunks delivery through the agent surface", async () => {
     const server = createServer({
       exec: mockExec,
       stateDir: TEST_DIR,
@@ -308,16 +309,33 @@ describe("agent lifecycle tool handlers", () => {
     const registry = engine.getRegistry();
     const agent = registry.get(agentId);
     registry.set(agentId, { ...agent, state: "ready" });
+    mockExec.mockClear();
+
+    const rawText =
+      `${"a".repeat(510)}\x1b[31mHELLO\x1b[0m\x07${"b".repeat(10)}`;
+    const sanitizedText = `${"a".repeat(510)}HELLO${"b".repeat(10)}`;
 
     const result = await sendTo.handler(
-      { agent_id: agentId, text: "hello facade", press_enter: true },
+      { agent_id: agentId, text: rawText, press_enter: true },
       {} as any,
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
+    const sendCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send"),
+    );
+    const sendKeyCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send-key"),
+    );
+    const deliveredText = sendCalls.map(([, args]) => args.at(-1)).join("");
 
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
+    expect(sendCalls).toHaveLength(2);
+    expect(sendKeyCalls).toHaveLength(1);
+    expect(deliveredText).toBe(sanitizedText);
+    expect(deliveredText).not.toContain("\x1b");
+    expect(deliveredText).not.toContain("\x07");
   });
 
   it("send_to returns an error for an unknown agent_id", async () => {
@@ -378,6 +396,52 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.state).toBe("done");
     expect(parsed.agent.session_id).toBeNull();
+  });
+
+  it("wait_for returns the engine snapshot without a second public-agent read", async () => {
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+    const waitFor = (server as any)._registeredTools["wait_for"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    vi.spyOn(engine, "waitFor").mockResolvedValue({
+      matched: true,
+      state: "done",
+      elapsed: 12,
+      source: "sweep",
+      agent: {
+        agent_id: "agent-1",
+        repo: "brainlayer",
+        model: "sonnet",
+        state: "done",
+        session_id: "sess-1",
+      },
+    } as any);
+    const getPublicAgentSpy = vi
+      .spyOn(engine, "getPublicAgent")
+      .mockImplementation(() => {
+        throw new Error("unexpected second public-agent read");
+      });
+
+    const result = await waitFor.handler(
+      { agent_id: "agent-1", timeout_ms: 5000 },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent).toEqual({
+      agent_id: "agent-1",
+      repo: "brainlayer",
+      model: "sonnet",
+      state: "done",
+      session_id: "sess-1",
+    });
+    expect(getPublicAgentSpy).not.toHaveBeenCalled();
   });
 
   it("wait_for returns an error for an unknown agent_id", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -40,14 +40,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 25 (14 low-level + 9 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 26 (14 low-level + 10 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(25);
+    expect(count).toBe(26);
   });
 });
 


### PR DESCRIPTION
## Summary
- add the Track 4 design doc at `docs/design/track-4-send-to-wait-for-facade.md`
- add a new `send_to` MCP tool and project `list_agents` to public agent objects `{ agent_id, repo, model, state, session_id }`
- make `wait_for` completion-first by default while keeping explicit target states for advanced callers
- keep `send_to_agent` as a deprecated/internal path and move routing/projection logic into a dedicated `agent-facade` module
- update tests, annotations, docs, and tool counts for the 26-tool surface

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `cr review --plain`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new mutating tool and changes the `list_agents`/`wait_for` response contracts, which may break existing clients that depended on `surface_id` or required `target_state`. Routing now goes through a new facade layer, so any mismatch between registry state and surface routing could impact agent message delivery.
> 
> **Overview**
> Adds a **GUI-friendly agent facade** by introducing a new `send_to` MCP tool that routes input by `agent_id` (sanitized + chunked) without clients needing surface topology.
> 
> Updates agent-facing APIs to be completion-oriented and less leaky: `wait_for` now defaults `target_state` to `done` and returns a projected public agent snapshot, while `list_agents` now returns `PublicAgent` objects (includes `session_id`, removes `surface_id`) and updates formatting accordingly.
> 
> Introduces `src/agent-facade.ts` for projection/routing (with conflict detection), refactors engine/server to use it, marks `send_to_agent` as deprecated for client use, and updates docs/tests/tool-count assertions from **25 → 26**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a478d309e6bcd75da3b888f144bb5e29736913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `send_to` tool for routing messages to agents by ID.
  * Made `wait_for` tool's `target_state` parameter optional, defaulting to "done."
  * Refined `list_agents` output to display session information instead of internal surface details.

* **Documentation**
  * Added design documentation for the new agent facade and tool interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `send_to` tool and agent facade for GUI clients to interact with agents by ID
> - Adds a new `send_to` tool in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/79/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that delivers input to an agent using only its `agent_id`, without requiring surface references; marks the existing `send_to_agent` tool as deprecated.
> - Introduces [`agent-facade.ts`](https://github.com/EtanHey/cmuxlayer/pull/79/files#diff-21529243acfc8d7743920399222a1c7fb45242bf7f4a3759b7be3344ffe98a61) with `toPublicAgent`, `buildRouteTable`, and `resolveAgentRoute` utilities that project internal `AgentRecord` to a stable `PublicAgent` shape and detect conflicting routes.
> - `list_agents` now returns `PublicAgent` objects (with `session_id`, without `surface_id` or `error`); `wait_for` defaults `target_state` to `done` and embeds a `PublicAgent` in its structured response.
> - Behavioral Change: `send_to_agent` delivery now routes through centralized route resolution and will throw if routes conflict or the agent is not found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7a478d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->