### PR TITLE
Add hybrid agent discovery resync

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -105,7 +105,11 @@ export class AgentDiscovery {
             has_agent: cli !== "unknown",
             read_error: false,
           };
-        } catch {
+        } catch (error) {
+          console.warn(
+            `[AgentDiscovery] Failed to scan surface ${surface.ref} (${surface.title})`,
+            error,
+          );
           return {
             surface_id: surface.ref,
             surface_title: surface.title,

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -1,0 +1,124 @@
+import { parseScreen } from "./screen-parser.js";
+import type { AgentState, CliType } from "./agent-types.js";
+import type {
+  CmuxReadScreenResult,
+  CmuxSurface,
+  ParsedScreenStatus,
+} from "./types.js";
+
+export interface DiscoveredAgent {
+  surface_id: string;
+  surface_title: string;
+  cli: CliType | "unknown";
+  parsed_status: ParsedScreenStatus | null;
+  model: string | null;
+  token_count: number | null;
+  context_pct: number | null;
+  has_agent: boolean;
+}
+
+export interface DiscoveryDeps {
+  listSurfaces: () => Promise<CmuxSurface[]>;
+  readScreen: (
+    surface: string,
+    opts: { lines: number },
+  ) => Promise<CmuxReadScreenResult>;
+}
+
+function stripKnownAgentSuffixes(title: string): string {
+  return title
+    .trim()
+    .replace(/-(?:resync|audit|worker|review)$/i, "")
+    .replace(/(?:Claude|Codex|Gemini|Cursor|Kiro)$/i, "")
+    .trim();
+}
+
+export function inferRepoFromTitle(title: string): string {
+  const stripped = stripKnownAgentSuffixes(title);
+  if (!stripped) return "";
+  return stripped.replace(/^[A-Z]/, (match) => match.toLowerCase());
+}
+
+export function discoveredStatusToAgentState(
+  status: ParsedScreenStatus | null,
+): AgentState {
+  switch (status) {
+    case "thinking":
+    case "working":
+      return "working";
+    case "idle":
+      return "idle";
+    case "done":
+      return "done";
+    case "frozen":
+      return "error";
+    default:
+      return "ready";
+  }
+}
+
+export function makeAutoAgentId(cli: CliType, surfaceId: string): string {
+  return `auto-${cli}-${surfaceId.replace(/[^a-zA-Z0-9-]/g, "-")}`;
+}
+
+export class AgentDiscovery {
+  private cache: { at: number; result: DiscoveredAgent[] } | null = null;
+  private deps: DiscoveryDeps;
+  private ttlMs: number;
+
+  constructor(deps: DiscoveryDeps, ttlMs: number = 2000) {
+    this.deps = deps;
+    this.ttlMs = ttlMs;
+  }
+
+  invalidate(): void {
+    this.cache = null;
+  }
+
+  async scan(force = false): Promise<DiscoveredAgent[]> {
+    if (!force && this.cache && Date.now() - this.cache.at < this.ttlMs) {
+      return this.cache.result;
+    }
+
+    const surfaces = (await this.deps.listSurfaces()).filter(
+      (surface) => surface.type === "terminal",
+    );
+    const result = await Promise.all(
+      surfaces.map(async (surface): Promise<DiscoveredAgent> => {
+        try {
+          const screen = await this.deps.readScreen(surface.ref, { lines: 30 });
+          const parsed = parseScreen(screen.text);
+          const cli =
+            parsed.agent_type === "unknown"
+              ? "unknown"
+              : (parsed.agent_type as CliType);
+
+          return {
+            surface_id: surface.ref,
+            surface_title: surface.title,
+            cli,
+            parsed_status: parsed.status,
+            model: parsed.model,
+            token_count: parsed.token_count,
+            context_pct: parsed.context_pct,
+            has_agent: cli !== "unknown",
+          };
+        } catch {
+          return {
+            surface_id: surface.ref,
+            surface_title: surface.title,
+            cli: "unknown",
+            parsed_status: null,
+            model: null,
+            token_count: null,
+            context_pct: null,
+            has_agent: false,
+          };
+        }
+      }),
+    );
+
+    this.cache = { at: Date.now(), result };
+    return result;
+  }
+}

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -15,6 +15,7 @@ export interface DiscoveredAgent {
   token_count: number | null;
   context_pct: number | null;
   has_agent: boolean;
+  read_error: boolean;
 }
 
 export interface DiscoveryDeps {
@@ -102,6 +103,7 @@ export class AgentDiscovery {
             token_count: parsed.token_count,
             context_pct: parsed.context_pct,
             has_agent: cli !== "unknown",
+            read_error: false,
           };
         } catch {
           return {
@@ -113,6 +115,7 @@ export class AgentDiscovery {
             token_count: null,
             context_pct: null,
             has_agent: false,
+            read_error: true,
           };
         }
       }),

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3,6 +3,8 @@
  * These 7 functions are the engine that MCP tools (and later the 2-tool facade) drive.
  */
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
@@ -51,6 +53,10 @@ export interface SpawnAgentResult {
   state: AgentState;
 }
 
+export interface AgentEngineOptions {
+  spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+}
+
 export type AgentLifecycleEvent = "spawned" | "done" | "errored";
 
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
@@ -68,6 +74,7 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`chatid:\\s*(${SESSION_ID_PATTERN})`, "i"),
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
+const execFileAsync = promisify(execFile);
 
 interface AgentEngineClient {
   log(
@@ -234,10 +241,27 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
+async function assertClaudeLauncherAvailable(repo: string): Promise<void> {
+  const launcher = `${sanitizeRepoName(repo)}Claude`;
+  const shell = process.env.SHELL || "/bin/sh";
+  const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
+
+  try {
+    await execFileAsync(shell, ["-lc", probe]);
+  } catch {
+    throw new Error(
+      `Launcher "${launcher}" not found. For repo "${repo}" with hyphens, ` +
+        `the launcher name strips the hyphen (e.g. "skill-creator" → "skillcreatorClaude"). ` +
+        `Use the direct shell spawn path, or fix the repoGolem config.`,
+    );
+  }
+}
+
 export class AgentEngine {
   private stateMgr: StateManager;
   private registry: AgentRegistry;
   private client: AgentEngineClient;
+  private spawnPreflight: (params: SpawnAgentParams) => Promise<void>;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   /** agentId → last-pushed status string */
   private sidebarSnapshot = new Map<string, string>();
@@ -248,10 +272,18 @@ export class AgentEngine {
     stateMgr: StateManager,
     registry: AgentRegistry,
     client: AgentEngineClient,
+    opts?: AgentEngineOptions,
   ) {
     this.stateMgr = stateMgr;
     this.registry = registry;
     this.client = client;
+    this.spawnPreflight =
+      opts?.spawnPreflight ??
+      (async (params) => {
+        if (params.cli === "claude") {
+          await assertClaudeLauncherAvailable(params.repo);
+        }
+      });
   }
 
   getRegistry(): AgentRegistry {
@@ -664,6 +696,8 @@ export class AgentEngine {
       spawnDepth = parent.spawn_depth + 1;
       parentAgentId = params.parent_agent_id;
     }
+
+    await this.spawnPreflight(params);
 
     // 1. Create cmux surface using the deterministic worker layout policy.
     const surface = await this.createAgentSurface(params.workspace);

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -6,6 +6,14 @@
 
 import { StateManager } from "./state-manager.js";
 import {
+  AgentDiscovery,
+  discoveredStatusToAgentState,
+  inferRepoFromTitle,
+  makeAutoAgentId,
+  type DiscoveredAgent,
+} from "./agent-discovery.js";
+import {
+  type MergedAgent,
   isCrashRecoveryEligible,
   shouldRetainCrashRecoveryError,
   type AgentRecord,
@@ -22,6 +30,7 @@ export interface AgentFilter {
 }
 
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
+const BOOTING_GHOST_TIMEOUT_MS = 30_000;
 
 export class AgentRegistry {
   private agents = new Map<string, AgentRecord>();
@@ -116,6 +125,131 @@ export class AgentRegistry {
     return results;
   }
 
+  async listMerged(
+    discovery: AgentDiscovery,
+    opts?: { filter?: AgentFilter; force?: boolean },
+  ): Promise<MergedAgent[]> {
+    await this.reconcile();
+    await this.purgeTerminal();
+
+    const discovered = await discovery.scan(opts?.force ?? false);
+    await this.evictBootingGhosts(discovered);
+
+    const bySurface = new Map(discovered.map((entry) => [entry.surface_id, entry]));
+    const merged: MergedAgent[] = [];
+    const seenSurfaces = new Set<string>();
+
+    for (const record of this.list()) {
+      const discoveredEntry = bySurface.get(record.surface_id);
+      const isAutoRecord = record.agent_id.startsWith("auto-");
+      seenSurfaces.add(record.surface_id);
+
+      if (isAutoRecord && discoveredEntry && !discoveredEntry.has_agent) {
+        this.agents.delete(record.agent_id);
+        this.stateMgr.removeState(record.agent_id);
+        continue;
+      }
+
+      const repo =
+        isAutoRecord && discoveredEntry
+          ? inferRepoFromTitle(discoveredEntry.surface_title) || record.repo
+          : record.repo;
+      const model =
+        isAutoRecord && discoveredEntry?.model
+          ? discoveredEntry.model
+          : record.model;
+      const state =
+        isAutoRecord && discoveredEntry
+          ? discoveredStatusToAgentState(discoveredEntry.parsed_status)
+          : record.state;
+
+      merged.push({
+        ...record,
+        repo,
+        model,
+        state,
+        discovered: isAutoRecord,
+        parsed_cli_mismatch:
+          !isAutoRecord &&
+          discoveredEntry !== undefined &&
+          discoveredEntry.cli !== "unknown" &&
+          discoveredEntry.cli !== record.cli,
+      });
+    }
+
+    for (const discoveredEntry of discovered) {
+      if (!discoveredEntry.has_agent || discoveredEntry.cli === "unknown") {
+        continue;
+      }
+      if (seenSurfaces.has(discoveredEntry.surface_id)) {
+        continue;
+      }
+
+      const agentId = makeAutoAgentId(
+        discoveredEntry.cli,
+        discoveredEntry.surface_id,
+      );
+      let record = this.stateMgr.ensureAutoRecord(agentId, discoveredEntry);
+      this.agents.set(agentId, record);
+
+      const repo = inferRepoFromTitle(discoveredEntry.surface_title) || record.repo;
+      const model = discoveredEntry.model ?? record.model;
+      const desiredState = discoveredStatusToAgentState(
+        discoveredEntry.parsed_status,
+      );
+
+      const patch: Partial<AgentRecord> = {};
+      if (repo !== record.repo) patch.repo = repo;
+      if (model !== record.model) patch.model = model;
+      if (record.error !== null && desiredState !== "error") patch.error = null;
+
+      if (Object.keys(patch).length > 0) {
+        record = this.stateMgr.updateRecord(agentId, patch);
+        this.agents.set(agentId, record);
+      }
+
+      if (record.state !== desiredState) {
+        try {
+          record = this.stateMgr.transition(agentId, desiredState, {
+            error:
+              desiredState === "error"
+                ? "Auto-discovered agent reported a frozen state"
+                : null,
+          });
+          this.agents.set(agentId, record);
+        } catch {
+          // Best-effort only — invalid synthetic transitions can stay in-memory.
+        }
+      }
+
+      merged.push({
+        ...record,
+        repo,
+        model,
+        state: desiredState,
+        discovered: true,
+        parsed_cli_mismatch: false,
+      });
+    }
+
+    const filtered = opts?.filter
+      ? merged.filter((agent) => {
+          if (opts.filter?.state && agent.state !== opts.filter.state) {
+            return false;
+          }
+          if (opts.filter?.repo && agent.repo !== opts.filter.repo) {
+            return false;
+          }
+          if (opts.filter?.model && agent.model !== opts.filter.model) {
+            return false;
+          }
+          return true;
+        })
+      : merged;
+
+    return filtered;
+  }
+
   /**
    * Update an agent in the in-memory map. Used by tools that
    * write state through the StateManager and need to sync the registry.
@@ -126,6 +260,43 @@ export class AgentRegistry {
 
   remove(agentId: string): void {
     this.agents.delete(agentId);
+  }
+
+  private async evictBootingGhosts(
+    discovered: DiscoveredAgent[],
+  ): Promise<void> {
+    const now = Date.now();
+    const bySurface = new Map(discovered.map((entry) => [entry.surface_id, entry]));
+
+    for (const [id, agent] of [...this.agents.entries()]) {
+      if (agent.state !== "booting") {
+        continue;
+      }
+
+      const lastUpdated = Date.parse(agent.updated_at);
+      if (Number.isNaN(lastUpdated)) {
+        continue;
+      }
+      if (now - lastUpdated < BOOTING_GHOST_TIMEOUT_MS) {
+        continue;
+      }
+
+      const discoveredEntry = bySurface.get(agent.surface_id);
+      if (!discoveredEntry || discoveredEntry.has_agent) {
+        continue;
+      }
+
+      try {
+        this.stateMgr.transition(id, "error", {
+          error: "Launch failed — no agent detected in surface after boot timeout",
+        });
+      } catch {
+        // Best-effort transition before eviction.
+      }
+
+      this.agents.delete(id);
+      this.stateMgr.removeState(id);
+    }
   }
 
   /**

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -144,30 +144,29 @@ export class AgentRegistry {
       const isAutoRecord = record.agent_id.startsWith("auto-");
       seenSurfaces.add(record.surface_id);
 
-      if (isAutoRecord && discoveredEntry && !discoveredEntry.has_agent) {
+      if (
+        isAutoRecord &&
+        discoveredEntry &&
+        !discoveredEntry.read_error &&
+        !discoveredEntry.has_agent
+      ) {
         this.agents.delete(record.agent_id);
         this.stateMgr.removeState(record.agent_id);
         continue;
       }
 
-      const repo =
-        isAutoRecord && discoveredEntry
-          ? inferRepoFromTitle(discoveredEntry.surface_title) || record.repo
-          : record.repo;
-      const model =
-        isAutoRecord && discoveredEntry?.model
-          ? discoveredEntry.model
-          : record.model;
-      const state =
-        isAutoRecord && discoveredEntry
-          ? discoveredStatusToAgentState(discoveredEntry.parsed_status)
-          : record.state;
+      let liveRecord = record;
+      if (
+        isAutoRecord &&
+        discoveredEntry &&
+        discoveredEntry.has_agent &&
+        !discoveredEntry.read_error
+      ) {
+        liveRecord = this.syncAutoRecord(record, discoveredEntry);
+      }
 
       merged.push({
-        ...record,
-        repo,
-        model,
-        state,
+        ...liveRecord,
         discovered: isAutoRecord,
         parsed_cli_mismatch:
           !isAutoRecord &&
@@ -178,7 +177,11 @@ export class AgentRegistry {
     }
 
     for (const discoveredEntry of discovered) {
-      if (!discoveredEntry.has_agent || discoveredEntry.cli === "unknown") {
+      if (
+        !discoveredEntry.has_agent ||
+        discoveredEntry.cli === "unknown" ||
+        discoveredEntry.read_error
+      ) {
         continue;
       }
       if (seenSurfaces.has(discoveredEntry.surface_id)) {
@@ -191,42 +194,10 @@ export class AgentRegistry {
       );
       let record = this.stateMgr.ensureAutoRecord(agentId, discoveredEntry);
       this.agents.set(agentId, record);
-
-      const repo = inferRepoFromTitle(discoveredEntry.surface_title) || record.repo;
-      const model = discoveredEntry.model ?? record.model;
-      const desiredState = discoveredStatusToAgentState(
-        discoveredEntry.parsed_status,
-      );
-
-      const patch: Partial<AgentRecord> = {};
-      if (repo !== record.repo) patch.repo = repo;
-      if (model !== record.model) patch.model = model;
-      if (record.error !== null && desiredState !== "error") patch.error = null;
-
-      if (Object.keys(patch).length > 0) {
-        record = this.stateMgr.updateRecord(agentId, patch);
-        this.agents.set(agentId, record);
-      }
-
-      if (record.state !== desiredState) {
-        try {
-          record = this.stateMgr.transition(agentId, desiredState, {
-            error:
-              desiredState === "error"
-                ? "Auto-discovered agent reported a frozen state"
-                : null,
-          });
-          this.agents.set(agentId, record);
-        } catch {
-          // Best-effort only — invalid synthetic transitions can stay in-memory.
-        }
-      }
+      record = this.syncAutoRecord(record, discoveredEntry);
 
       merged.push({
         ...record,
-        repo,
-        model,
-        state: desiredState,
         discovered: true,
         parsed_cli_mismatch: false,
       });
@@ -248,6 +219,47 @@ export class AgentRegistry {
       : merged;
 
     return filtered;
+  }
+
+  private syncAutoRecord(
+    record: AgentRecord,
+    discoveredEntry: DiscoveredAgent,
+  ): AgentRecord {
+    const agentId = record.agent_id;
+    const repo = inferRepoFromTitle(discoveredEntry.surface_title) || record.repo;
+    const model = discoveredEntry.model ?? record.model;
+    const desiredState = discoveredStatusToAgentState(
+      discoveredEntry.parsed_status,
+    );
+
+    const patch: Partial<AgentRecord> = {};
+    if (repo !== record.repo) patch.repo = repo;
+    if (model !== record.model) patch.model = model;
+    if (record.error !== null && desiredState !== "error") patch.error = null;
+    if (record.error === null && desiredState === "error") {
+      patch.error = "Auto-discovered agent reported a frozen state";
+    }
+
+    if (Object.keys(patch).length > 0) {
+      record = this.stateMgr.updateRecord(agentId, patch);
+      this.agents.set(agentId, record);
+    }
+
+    if (record.state !== desiredState) {
+      try {
+        record = this.stateMgr.transition(agentId, desiredState, {
+          error:
+            desiredState === "error"
+              ? "Auto-discovered agent reported a frozen state"
+              : null,
+        });
+        this.agents.set(agentId, record);
+      } catch {
+        // Best-effort only — invalid synthetic transitions can keep the prior state.
+      }
+    }
+
+    return record;
   }
 
   /**
@@ -282,7 +294,11 @@ export class AgentRegistry {
       }
 
       const discoveredEntry = bySurface.get(agent.surface_id);
-      if (!discoveredEntry || discoveredEntry.has_agent) {
+      if (
+        !discoveredEntry ||
+        discoveredEntry.read_error ||
+        discoveredEntry.has_agent
+      ) {
         continue;
       }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -48,6 +48,11 @@ export interface AgentRecord {
   user_killed?: boolean;
 }
 
+export interface MergedAgent extends AgentRecord {
+  discovered: boolean;
+  parsed_cli_mismatch: boolean;
+}
+
 export interface PublicAgent {
   agent_id: string;
   repo: string;

--- a/src/format.ts
+++ b/src/format.ts
@@ -203,3 +203,14 @@ export function formatOk(
   }
   return `\u2714 ${action}${parts.length > 0 ? " \u2500 " + parts.join("  ") : ""}`;
 }
+
+export function formatResync(diff: {
+  added: string[];
+  evicted: string[];
+  mismatches: string[];
+}): string {
+  const added = diff.added.length;
+  const evicted = diff.evicted.length;
+  const mismatches = diff.mismatches.length;
+  return `✔ resync_agents — added: ${added}  evicted: ${evicted}  mismatches: ${mismatches}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,12 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 26 MCP tools across two categories:
+ * 27 MCP tools across two categories:
  *   Core (14): list_surfaces, new_split, new_surface, move_surface,
  *              reorder_surface, send_input, send_key, read_screen, rename_tab,
  *              notify, set_status, set_progress, close_surface, browser_surface
- *   Agent lifecycle (12): spawn_agent, send_to, send_to_agent,
+ *   Agent lifecycle (13): spawn_agent, resync_agents,
+ *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         read_agent_output, get_agent_state, list_agents,
  *                         my_agents, wait_for, wait_for_all, stop_agent,
  *                         kill, interact

--- a/src/server.ts
+++ b/src/server.ts
@@ -332,6 +332,8 @@ export interface CreateServerOptions {
   enableClaudeChannels?: boolean;
   /** Override spawn preflight checks (primarily for tests). */
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+  /** Explicitly disable spawn preflight checks (primarily for mocked tests). */
+  disableSpawnPreflight?: boolean;
 }
 
 function formatLifecycleChannelContent(
@@ -1585,7 +1587,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       notifyLifecycleEvent,
     }, {
       spawnPreflight:
-        opts?.spawnPreflight ?? (opts?.exec ? async () => {} : undefined),
+        opts?.spawnPreflight ??
+        (opts?.disableSpawnPreflight ? async () => {} : undefined),
     });
 
     const deliverAgentInput = async (args: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,13 @@ import { parseReservedModeKey } from "./mode-policy.js";
 import { replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
-import { AgentEngine, type AgentLifecycleEvent } from "./agent-engine.js";
+import {
+  AgentEngine,
+  type AgentLifecycleEvent,
+  type SpawnAgentParams,
+} from "./agent-engine.js";
+import { AgentDiscovery } from "./agent-discovery.js";
+import { toPublicAgent } from "./agent-facade.js";
 import type { AgentRecord, AgentState } from "./agent-types.js";
 import {
   formatListSurfaces,
@@ -21,6 +27,7 @@ import {
   formatListAgents,
   formatAgentState,
   formatOk,
+  formatResync,
 } from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
@@ -323,6 +330,8 @@ export interface CreateServerOptions {
   skipAgentLifecycle?: boolean;
   /** Opt into Claude Code channel notifications for lifecycle events */
   enableClaudeChannels?: boolean;
+  /** Override spawn preflight checks (primarily for tests). */
+  spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
 }
 
 function formatLifecycleChannelContent(
@@ -1536,6 +1545,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
     };
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
+    const discovery = new AgentDiscovery({
+      listSurfaces: surfaceProvider,
+      readScreen: (surface, opts) => client.readScreen(surface, opts),
+    });
     const notifyLifecycleEvent = async (
       event: AgentLifecycleEvent,
       agent: AgentRecord,
@@ -1570,6 +1583,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       listPanes: (paneOpts) => client.listPanes(paneOpts),
       listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
       notifyLifecycleEvent,
+    }, {
+      spawnPreflight:
+        opts?.spawnPreflight ?? (opts?.exec ? async () => {} : undefined),
     });
 
     const deliverAgentInput = async (args: {
@@ -1804,17 +1820,49 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.readOnly,
       async (args) => {
         try {
-          const agents = engine.listPublicAgents({
-            state: args.state,
-            repo: args.repo,
-            model: args.model,
+          const merged = await registry.listMerged(discovery, {
+            filter: {
+              state: args.state,
+              repo: args.repo,
+              model: args.model,
+            },
           });
+          const agents = merged.map(toPublicAgent);
           const data = {
             agents: agents as unknown as Record<string, unknown>[],
             count: agents.length,
           };
           const formatted = formatListAgents(agents, agents.length);
           return okFormatted(formatted, data);
+        } catch (e) {
+          return err(e);
+        }
+      },
+    );
+
+    server.tool(
+      "resync_agents",
+      "Force-refresh the agent registry by scanning all surfaces. Evicts ghosts, registers discovered agents, and returns a diff.",
+      {},
+      ANNOTATIONS.mutating,
+      async () => {
+        try {
+          const beforeIds = new Set(registry.list().map((agent) => agent.agent_id));
+          discovery.invalidate();
+          const after = await registry.listMerged(discovery, { force: true });
+          const afterIds = new Set(after.map((agent) => agent.agent_id));
+          const diff = {
+            added: [...afterIds].filter((id) => !beforeIds.has(id)),
+            evicted: [...beforeIds].filter((id) => !afterIds.has(id)),
+            mismatches: after
+              .filter((agent) => agent.parsed_cli_mismatch)
+              .map((agent) => agent.agent_id),
+          };
+
+          return okFormatted(formatResync(diff), {
+            diff,
+            count: after.length,
+          });
         } catch (e) {
           return err(e);
         }
@@ -2216,16 +2264,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.readOnly,
       async (args) => {
         try {
-          let agents: AgentRecord[];
-          if (args.parent_agent_id) {
-            // Look up children directly — parent record may be gone
-            // but children still reference it via parent_agent_id
-            agents = engine.getRegistry().getChildren(args.parent_agent_id);
-          } else {
-            agents = engine
-              .listAgents()
-              .filter((a) => a.parent_agent_id === null);
-          }
+          const merged = await registry.listMerged(discovery);
+          const agents = args.parent_agent_id
+            ? merged.filter((agent) => agent.parent_agent_id === args.parent_agent_id)
+            : merged.filter((agent) => agent.parent_agent_id === null);
 
           const SCREEN_TIMEOUT = 3000;
           const enriched = await Promise.all(

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -21,6 +21,11 @@ import {
   type AgentState,
   type StateTransition,
 } from "./agent-types.js";
+import {
+  discoveredStatusToAgentState,
+  inferRepoFromTitle,
+  type DiscoveredAgent,
+} from "./agent-discovery.js";
 
 type AgentRecordPatch = Partial<
   Omit<AgentRecord, "agent_id" | "created_at" | "updated_at" | "version" | "state">
@@ -181,5 +186,40 @@ export class StateManager {
     });
 
     rmSync(agentDir, { recursive: true, force: true });
+  }
+
+  ensureAutoRecord(agentId: string, discovered: DiscoveredAgent): AgentRecord {
+    const existing = this.readState(agentId);
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const record: AgentRecord = {
+      agent_id: agentId,
+      surface_id: discovered.surface_id,
+      workspace_id: null,
+      state: discoveredStatusToAgentState(discovered.parsed_status),
+      repo: inferRepoFromTitle(discovered.surface_title),
+      model: discovered.model ?? "unknown",
+      cli: discovered.cli === "unknown" ? "claude" : discovered.cli,
+      cli_session_id: null,
+      task_summary: "(auto-discovered)",
+      pid: null,
+      version: 1,
+      created_at: now,
+      updated_at: now,
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    };
+    this.writeState(record);
+    return record;
   }
 }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -104,7 +104,9 @@ describe("AgentEngine", () => {
     liveSurfaces = [];
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    engine = new AgentEngine(stateMgr, registry, mockClient);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+    });
   });
 
   afterEach(() => {

--- a/tests/agent-hierarchy.test.ts
+++ b/tests/agent-hierarchy.test.ts
@@ -92,7 +92,9 @@ describe("Agent Hierarchy", () => {
     liveSurfaces = [];
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    engine = new AgentEngine(stateMgr, registry, mockClient);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+    });
   });
 
   afterEach(() => {

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -16,6 +16,15 @@ import { CmuxSocketError } from "../src/cmux-socket-client.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-audit-fixes-test");
 
+function createAuditServer(exec: ExecFn, client?: Record<string, unknown>) {
+  return createServer({
+    exec,
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
 // ── 1. CRITICAL: read_agent_output uses .text ──────────────────────────
 
 describe("read_agent_output uses CmuxReadScreenResult.text", () => {
@@ -53,11 +62,7 @@ describe("read_agent_output uses CmuxReadScreenResult.text", () => {
       stderr: "",
     });
 
-    const server = createServer({
-      exec: mockExec,
-      client: mockClient as any,
-      stateDir: TEST_DIR,
-    });
+    const server = createAuditServer(mockExec, mockClient);
     const tool = (server as any)._registeredTools["read_agent_output"];
     expect(tool).toBeDefined();
 
@@ -95,11 +100,7 @@ describe("read_agent_output uses CmuxReadScreenResult.text", () => {
       stderr: "",
     });
 
-    const server = createServer({
-      exec: mockExec,
-      client: mockClient as any,
-      stateDir: TEST_DIR,
-    });
+    const server = createAuditServer(mockExec, mockClient);
     const tool = (server as any)._registeredTools["read_agent_output"];
 
     const result = await tool.handler(
@@ -300,10 +301,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
   });
 
   it("accepts parent_agent_id in spawn_agent", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createAuditServer(mockExec);
 
     // First spawn a parent
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -333,10 +331,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
   });
 
   it("accepts max_cost_per_agent in spawn_agent", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createAuditServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
     const result = await spawn.handler(
@@ -355,10 +350,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
   });
 
   it("rejects invalid parent_agent_id", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createAuditServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
     const result = await spawn.handler(

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -122,7 +122,9 @@ describe("Quality Tracking (sweep)", () => {
     liveSurfaces = [];
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    engine = new AgentEngine(stateMgr, registry, mockClient);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+    });
   });
 
   afterEach(() => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import { StateManager } from "../src/state-manager.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-agents-test-resync-tool");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+function makeDiscoveryExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 2,
+              surface_refs: ["surface:1", "surface:2"],
+              selected_surface_ref: "surface:1",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:1",
+              title: "brainlayerClaude",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+            {
+              ref: "surface:2",
+              title: "notes",
+              type: "terminal",
+              index: 1,
+              selected: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      const surface = args[args.indexOf("--surface") + 1];
+      if (surface === "surface:1") {
+        return {
+          stdout: JSON.stringify({
+            surface,
+            text: `
+✻ Working…
+  Reading files
+🤖 Sonnet 4.6 | 💰 $0.50 | ⏱️  41s
+`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
+function makeShellPromptExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:999"],
+              selected_surface_ref: "surface:999",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:999",
+              title: "shell",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:999",
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
+describe("resync_agents tool", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("registers resync_agents alongside the lifecycle tools", () => {
+    const mockExec: ExecFn = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+    });
+
+    expect((server as any)._registeredTools["resync_agents"]).toBeDefined();
+  });
+
+  it("list_agents discovers live agents from surfaces even with an empty registry", async () => {
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["list_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.agents[0].state).toBe("working");
+  });
+
+  it("my_agents returns discovered root agents even when no parent_agent_id is provided", async () => {
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["my_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.count).toBe(1);
+    expect(parsed.parent_agent_id).toBeNull();
+    expect(parsed.agents[0].state).toBe("working");
+  });
+
+  it("resync_agents force-refreshes discovery and reports added agents", async () => {
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const tool = (server as any)._registeredTools["resync_agents"];
+    const result = await tool.handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.added).toHaveLength(1);
+    expect(parsed.count).toBe(1);
+  });
+
+  it("resync_agents evicts ghost booting agents whose surface no longer exists", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "ghost-agent",
+      surface_id: "surface:999",
+      workspace_id: "workspace:1",
+      state: "booting",
+      repo: "skill-creator",
+      model: "sonnet",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "stuck boot",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-19T20:00:00.000Z",
+      updated_at: "2026-04-19T20:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const tool = (server as any)._registeredTools["resync_agents"];
+    const result = await tool.handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).toContain("ghost-agent");
+    expect(parsed.count).toBe(1);
+  });
+
+  it("resync_agents evicts booting ghosts when the surface is alive but no agent is detected", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "booting-ghost",
+      surface_id: "surface:999",
+      workspace_id: "workspace:1",
+      state: "booting",
+      repo: "skill-creator",
+      model: "sonnet",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "failed launcher",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-19T19:00:00.000Z",
+      updated_at: "2026-04-19T19:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const server = createServer({
+      exec: makeShellPromptExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const tool = (server as any)._registeredTools["resync_agents"];
+    const result = await tool.handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).toContain("booting-ghost");
+    expect(parsed.count).toBe(0);
+  });
+});

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -114,6 +114,47 @@ function makeDiscoveryExec(): ExecFn {
   });
 }
 
+function makeIdleDiscoveryExec(): ExecFn {
+  const base = makeDiscoveryExec();
+  return vi.fn().mockImplementation(async (cmd, args) => {
+    if (args.includes("read-screen")) {
+      const surface = args[args.indexOf("--surface") + 1];
+      if (surface === "surface:1") {
+        return {
+          stdout: JSON.stringify({
+            surface,
+            text: `
+✻ Working…
+  Reading src/server.ts
+
+No idle agents to reassign right now. Everything is either done or Codex is handling the last task.
+
+Token usage: total=356,835
+🤖 Sonnet 4.6
+CLAUDE_COUNTER: 92
+`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+    }
+
+    return base(cmd, args);
+  });
+}
+
+function makeReadErrorExec(): ExecFn {
+  const base = makeDiscoveryExec();
+  return vi.fn().mockImplementation(async (cmd, args) => {
+    if (args.includes("read-screen")) {
+      throw new Error("cmux read failed");
+    }
+    return base(cmd, args);
+  });
+}
+
 function makeShellPromptExec(): ExecFn {
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("list-workspaces")) {
@@ -262,6 +303,100 @@ describe("resync_agents tool", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.diff.added).toHaveLength(1);
     expect(parsed.count).toBe(1);
+  });
+
+  it("list_agents persists live state updates for existing auto-discovered agents", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "auto-claude-surface-1",
+      surface_id: "surface:1",
+      workspace_id: null,
+      state: "working",
+      repo: "brainlayer",
+      model: "Sonnet 4.6",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "(auto-discovered)",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-19T20:00:00.000Z",
+      updated_at: "2026-04-19T20:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const server = createServer({
+      exec: makeIdleDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const listResult = await (server as any)._registeredTools["list_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(listResult);
+
+    expect(parsed.count).toBe(1);
+    expect(parsed.agents[0].state).toBe("idle");
+    expect(stateMgr.readState("auto-claude-surface-1")?.state).toBe("idle");
+  });
+
+  it("resync_agents keeps existing auto agents when discovery hits read-screen errors", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "auto-claude-surface-1",
+      surface_id: "surface:1",
+      workspace_id: null,
+      state: "working",
+      repo: "brainlayer",
+      model: "Sonnet 4.6",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "(auto-discovered)",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-19T20:00:00.000Z",
+      updated_at: "2026-04-19T20:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const server = createServer({
+      exec: makeReadErrorExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const resyncResult = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(resyncResult);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).not.toContain("auto-claude-surface-1");
+    expect(stateMgr.readState("auto-claude-surface-1")?.state).toBe("working");
+
+    const listResult = await (server as any)._registeredTools["list_agents"].handler(
+      {},
+      {} as any,
+    );
+    const listed = parseResult(listResult);
+    expect(listed.count).toBe(1);
+    expect(listed.agents[0].agent_id).toBe("auto-claude-surface-1");
   });
 
   it("resync_agents evicts ghost booting agents whose surface no longer exists", async () => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -54,6 +54,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "set_progress",
     "browser_surface",
     "spawn_agent",
+    "resync_agents",
     "send_to",
     "send_to_agent",
     "wait_for",
@@ -76,9 +77,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 26 tools have annotations", () => {
+  it("all 27 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(26);
+    expect(toolNames.length).toBe(27);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -13,6 +13,7 @@ const TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 
 const AGENT_TOOLS = [
   "spawn_agent",
+  "resync_agents",
   "send_to",
   "wait_for",
   "wait_for_all",
@@ -24,12 +25,93 @@ const AGENT_TOOLS = [
   "my_agents",
 ] as const;
 
-describe("agent lifecycle tool registration", () => {
-  it("registers all 10 agent lifecycle tools when lifecycle is enabled", () => {
-    const mockExec: ExecFn = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({ workspaces: [] }),
+function makeLifecycleExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:new"],
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:new",
+              title: "agent-pane",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
       stderr: "",
-    });
+    };
+  });
+}
+
+describe("agent lifecycle tool registration", () => {
+  it("registers all 11 agent lifecycle tools when lifecycle is enabled", () => {
+    const mockExec = makeLifecycleExec();
     const server = createServer({
       exec: mockExec,
       stateDir: TEST_DIR,
@@ -59,17 +141,14 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 26 (14 low-level + 10 agent lifecycle + 2 v2)", () => {
-    const mockExec: ExecFn = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({ workspaces: [] }),
-      stderr: "",
-    });
+  it("total tool count is 27 (14 low-level + 11 agent lifecycle + 2 v2)", () => {
+    const mockExec = makeLifecycleExec();
     const server = createServer({
       exec: mockExec,
       stateDir: TEST_DIR,
     });
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(26);
+    expect(Object.keys(registeredTools)).toHaveLength(27);
   });
 });
 
@@ -79,16 +158,7 @@ describe("agent lifecycle tool handlers", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeLifecycleExec();
   });
 
   afterEach(() => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -109,13 +109,18 @@ function makeLifecycleExec(): ExecFn {
   });
 }
 
+function createLifecycleServer(exec: ExecFn) {
+  return createServer({
+    exec,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
 describe("agent lifecycle tool registration", () => {
   it("registers all 11 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
     const toolNames = Object.keys(registeredTools);
 
@@ -143,10 +148,7 @@ describe("agent lifecycle tool registration", () => {
 
   it("total tool count is 27 (14 low-level + 11 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
     expect(Object.keys(registeredTools)).toHaveLength(27);
   });
@@ -166,10 +168,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("spawn_agent returns agent_id and surface_id", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const tool = (server as any)._registeredTools["spawn_agent"];
 
     const result = await tool.handler(
@@ -191,10 +190,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("spawn_agent persists crash_recover=true in agent state", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
@@ -223,10 +219,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("spawn_agent defaults crash_recover to false", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
@@ -254,10 +247,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("list_agents returns agents after spawn", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const list = (server as any)._registeredTools["list_agents"];
 
@@ -282,10 +272,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("get_agent_state returns full record", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
@@ -311,10 +298,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("get_agent_state returns error for unknown agent", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const getState = (server as any)._registeredTools["get_agent_state"];
 
     const result = await getState.handler(
@@ -325,10 +309,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("send_to_agent rejects agents not in interactive state", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const sendTo = (server as any)._registeredTools["send_to_agent"];
 
@@ -355,10 +336,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("send_to sanitizes and chunks delivery through the agent surface", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const sendTo = (server as any)._registeredTools["send_to"];
 
@@ -409,10 +387,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("send_to returns an error for an unknown agent_id", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const sendTo = (server as any)._registeredTools["send_to"];
 
     const result = await sendTo.handler(
@@ -425,10 +400,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("wait_for defaults to done when target_state is omitted", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const waitFor = (server as any)._registeredTools["wait_for"];
 
@@ -469,10 +441,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("wait_for returns the engine snapshot without a second public-agent read", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const waitFor = (server as any)._registeredTools["wait_for"];
     const engine = (server as any)._registeredTools["interact"]._engine;
 
@@ -515,10 +484,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("wait_for returns an error for an unknown agent_id", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const waitFor = (server as any)._registeredTools["wait_for"];
 
     const result = await waitFor.handler(
@@ -531,10 +497,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("my_agents returns root agents when no parent_agent_id", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const myAgents = (server as any)._registeredTools["my_agents"];
 
@@ -563,10 +526,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("my_agents returns children of a specific parent", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const myAgents = (server as any)._registeredTools["my_agents"];
 
@@ -603,10 +563,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("my_agents returns empty array for nonexistent parent (orphan-safe)", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const myAgents = (server as any)._registeredTools["my_agents"];
 
     const result = await myAgents.handler(
@@ -619,10 +576,7 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("my_agents includes screen data fields (null when no real screen)", async () => {
-    const server = createServer({
-      exec: mockExec,
-      stateDir: TEST_DIR,
-    });
+    const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const myAgents = (server as any)._registeredTools["my_agents"];
 

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -91,7 +91,9 @@ describe("Sidebar Sync", () => {
     liveSurfaces = [];
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    engine = new AgentEngine(stateMgr, registry, mockClient);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+    });
   });
 
   afterEach(() => {

--- a/tests/spawn-agent-preflight.test.ts
+++ b/tests/spawn-agent-preflight.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AgentEngine } from "../src/agent-engine.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { StateManager } from "../src/state-manager.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import type { CmuxNewSplitResult } from "../src/types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-agents-test-preflight");
+
+function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
+  return {
+    newSplit: vi.fn().mockResolvedValue({
+      workspace: "ws:1",
+      surface: "surface:new",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    } satisfies CmuxNewSplitResult),
+    newSurface: vi.fn().mockResolvedValue({
+      workspace: "ws:1",
+      surface: "surface:new",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    }),
+    listPanes: vi.fn().mockResolvedValue({
+      workspace_ref: "ws:1",
+      window_ref: "window:1",
+      panes: [],
+    }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({
+      workspace_ref: "ws:1",
+      window_ref: "window:1",
+      pane_ref: "pane:1",
+      surfaces: [],
+    }),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:new",
+      text: "$ ",
+      lines: 20,
+      scrollback_used: false,
+    }),
+    renameTab: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn().mockResolvedValue(undefined),
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn().mockResolvedValue(undefined),
+    identify: vi.fn().mockResolvedValue({}),
+    browser: vi.fn().mockResolvedValue({}),
+    log: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as CmuxClient;
+}
+
+describe("spawn_agent launcher preflight", () => {
+  let stateMgr: StateManager;
+  let mockClient: CmuxClient;
+  let engine: AgentEngine;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    stateMgr = new StateManager(TEST_DIR);
+    mockClient = makeMockClient();
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    engine = new AgentEngine(stateMgr, registry, mockClient);
+  });
+
+  afterEach(() => {
+    engine.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("fails before creating surfaces or state when the Claude launcher does not exist", async () => {
+    await expect(
+      engine.spawnAgent({
+        repo: "skill-creator",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "design handoff",
+      }),
+    ).rejects.toThrow(/Launcher "skill-creatorClaude" not found/);
+
+    expect(stateMgr.listStates()).toHaveLength(0);
+    expect(engine.listAgents()).toHaveLength(0);
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/spawn-agent-preflight.test.ts
+++ b/tests/spawn-agent-preflight.test.ts
@@ -70,7 +70,13 @@ describe("spawn_agent launcher preflight", () => {
     stateMgr = new StateManager(TEST_DIR);
     mockClient = makeMockClient();
     const registry = new AgentRegistry(stateMgr, async () => []);
-    engine = new AgentEngine(stateMgr, registry, mockClient);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {
+        throw new Error(
+          'Launcher "skill-creatorClaude" not found in PATH. Expected repoGolem launcher.',
+        );
+      },
+    });
   });
 
   afterEach(() => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -40,14 +40,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 26 (14 low-level + 10 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 27 (14 low-level + 11 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(26);
+    expect(count).toBe(27);
   });
 });
 

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -28,13 +28,21 @@ function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
+function createV2Server(exec: ExecFn) {
+  return createServer({
+    exec,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
 describe("V2 tool registration", () => {
   it("registers interact and kill tools", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
-    const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
+    const server = createV2Server(mockExec);
     const tools = Object.keys((server as any)._registeredTools);
     expect(tools).toContain("interact");
     expect(tools).toContain("kill");
@@ -45,7 +53,7 @@ describe("V2 tool registration", () => {
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
-    const server = createServer({ exec: mockExec, stateDir: TEST_DIR });
+    const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
     expect(count).toBe(27);
   });
@@ -68,7 +76,7 @@ describe("interact — runtime validation", () => {
       }),
       stderr: "",
     });
-    server = createServer({ exec: mockExec, stateDir: TEST_DIR });
+    server = createV2Server(mockExec);
   });
 
   afterEach(() => {
@@ -164,7 +172,7 @@ describe("interact — agent resolution", () => {
       }),
       stderr: "",
     });
-    server = createServer({ exec: mockExec, stateDir: TEST_DIR });
+    server = createV2Server(mockExec);
   });
 
   afterEach(() => {
@@ -227,7 +235,7 @@ describe("kill — scoped targets", () => {
       }),
       stderr: "",
     });
-    server = createServer({ exec: mockExec, stateDir: TEST_DIR });
+    server = createV2Server(mockExec);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add hybrid agent discovery (`src/agent-discovery.ts`) that scans live terminal surfaces and parses screens, then overlay it onto the persisted registry
- make `list_agents` and `my_agents` return merged live agent state instead of spawn-only registry state
- add `resync_agents` to force discovery + report added/evicted/mismatch counts
- harden `spawn_agent` with launcher preflight and add booting-time ghost eviction for the FR-01 spawn ghost case

## Why
`list_agents` could return `[]` while real agents were visibly running in cmux because the registry only knew about agents spawned through cmuxlayer. This change makes live surface discovery the primary source of truth while preserving registry metadata as an overlay.

## Backward Compat
- existing `list_agents` callers such as `orcClaude` and `coachClaude` keep the same tool shape and can continue reading the same fields
- registry-backed agents still preserve their existing ids and metadata
- newly discovered agents that were not spawned through cmuxlayer now appear with synthetic ids in the format `auto-<cli>-<surface_ref>`
- the registry overlay only adds discovery metadata (`discovered`, mismatch visibility) without breaking existing consumers

## Testing
- added RED-first coverage for live discovery, merged list behavior, `my_agents`, `resync_agents`, ghost eviction, and spawn preflight
- `bun run test`
- `bun run typecheck`
- `bun run build`

## Notes
- this follows the hybrid auto-discovery-primary + registry-overlay design from the 2026-04-19 resync doc
- `send_to_agent` remains available as the existing alias; `send_to` stays canonical in docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces live surface scanning that mutates persisted agent state and eviction behavior, and adds a new preflight gate before spawning; mistakes could hide agents, incorrectly evict state, or block spawns in real environments.
> 
> **Overview**
> Adds **hybrid agent discovery** that scans live terminal surfaces, parses recent screen output, and synthesizes `auto-<cli>-<surface>` agents when they weren’t spawned through the server.
> 
> Updates `list_agents` and `my_agents` to return a merged view of persisted registry state plus live-discovered status (including CLI mismatch detection), and adds a new `resync_agents` tool to force a re-scan and report added/evicted/mismatch diffs.
> 
> Hardens spawning by running a Claude launcher availability preflight before creating surfaces/state, and evicts “booting ghost” agents after a timeout when no agent is detected; tests are updated/added for discovery, resync, ghost eviction, and preflight controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6792b0ccf695db5a20275942532202e6302a866b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic agent discovery from terminal surfaces
  * Introduced `resync_agents` command to synchronize discovered agents with registry, reporting additions, removals, and mismatches
  * Enhanced agent listing to include discovered agents alongside registered ones

* **Bug Fixes**
  * Improved handling of stale agent processes
  * Added CLI mismatch detection for discovered agents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hybrid agent discovery with `resync_agents` tool and spawn preflight checks
> - Adds `AgentDiscovery` in [agent-discovery.ts](https://github.com/EtanHey/cmuxlayer/pull/81/files#diff-807f6d10a04eec4ff3f6051d04898c5ab069352d5dbf40158a74d8b03245b081) that scans live cmux terminal surfaces, parses on-screen state (status, model, token count), and caches results with a TTL.
> - Adds `AgentRegistry.listMerged` in [agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/81/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) to reconcile persisted registry records with live discovered agents, evicting stale entries and creating state files for newly seen agents.
> - Exposes a new `resync_agents` MCP tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/81/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that invalidates the discovery cache, forces a re-merge, and returns a structured diff of added/evicted agents and CLI mismatches.
> - Adds `spawnPreflight` hook to `AgentEngine` that checks for a repo-specific Claude launcher before creating any surfaces or writing state, rejecting invalid spawns early.
> - Behavioral Change: `list_agents` and `my_agents` now return merged live+persisted state; total tool count increases from 26 to 27.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6792b0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->