### PR TITLE
fix: evict phantom agents during resync

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -306,14 +306,18 @@ export class AgentRegistry {
   }
 
   private evictMissingStateAgent(agentId: string, error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes("Agent not found")) {
+    if (!this.isMissingStateAgentError(agentId, error)) {
       return false;
     }
 
     this.agents.delete(agentId);
     this.stateMgr.removeState(agentId);
     return true;
+  }
+
+  private isMissingStateAgentError(agentId: string, error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes(`Agent not found: ${agentId}`);
   }
 
   private async evictBootingGhosts(

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -317,7 +317,7 @@ export class AgentRegistry {
 
   private isMissingStateAgentError(agentId: string, error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
-    return message.includes(`Agent not found: ${agentId}`);
+    return message === `Agent not found: ${agentId}`;
   }
 
   private async evictBootingGhosts(

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -84,11 +84,19 @@ export class AgentRegistry {
       if (TERMINAL_STATES.has(agent.state)) continue;
 
       if (!liveSurfaceRefs.has(agent.surface_id)) {
-        const updated = this.stateMgr.transition(id, "error", {
-          error: `Surface ${agent.surface_id} disappeared`,
-        });
-        this.agents.set(id, updated);
-        crashedIds.add(id);
+        try {
+          const updated = this.stateMgr.transition(id, "error", {
+            error: `Surface ${agent.surface_id} disappeared`,
+          });
+          this.agents.set(id, updated);
+          crashedIds.add(id);
+        } catch (error) {
+          if (this.evictMissingStateAgent(id, error)) {
+            crashedIds.add(id);
+            continue;
+          }
+          throw error;
+        }
       }
     }
 
@@ -98,10 +106,17 @@ export class AgentRegistry {
     if (crashedIds.size > 0) {
       for (const [id, agent] of this.agents) {
         if (agent.parent_agent_id && crashedIds.has(agent.parent_agent_id)) {
-          const reparented = this.stateMgr.updateRecord(id, {
-            parent_agent_id: null,
-          });
-          this.agents.set(id, reparented);
+          try {
+            const reparented = this.stateMgr.updateRecord(id, {
+              parent_agent_id: null,
+            });
+            this.agents.set(id, reparented);
+          } catch (error) {
+            if (this.evictMissingStateAgent(id, error)) {
+              continue;
+            }
+            throw error;
+          }
         }
       }
     }
@@ -142,7 +157,6 @@ export class AgentRegistry {
     for (const record of this.list()) {
       const discoveredEntry = bySurface.get(record.surface_id);
       const isAutoRecord = record.agent_id.startsWith("auto-");
-      seenSurfaces.add(record.surface_id);
 
       if (
         isAutoRecord &&
@@ -155,7 +169,7 @@ export class AgentRegistry {
         continue;
       }
 
-      let liveRecord = record;
+      let liveRecord: AgentRecord | null = record;
       if (
         isAutoRecord &&
         discoveredEntry &&
@@ -163,8 +177,12 @@ export class AgentRegistry {
         !discoveredEntry.read_error
       ) {
         liveRecord = this.syncAutoRecord(record, discoveredEntry);
+        if (!liveRecord) {
+          continue;
+        }
       }
 
+      seenSurfaces.add(record.surface_id);
       merged.push({
         ...liveRecord,
         discovered: isAutoRecord,
@@ -192,12 +210,15 @@ export class AgentRegistry {
         discoveredEntry.cli,
         discoveredEntry.surface_id,
       );
-      let record = this.stateMgr.ensureAutoRecord(agentId, discoveredEntry);
+      const record = this.stateMgr.ensureAutoRecord(agentId, discoveredEntry);
       this.agents.set(agentId, record);
-      record = this.syncAutoRecord(record, discoveredEntry);
+      const liveRecord = this.syncAutoRecord(record, discoveredEntry);
+      if (!liveRecord) {
+        continue;
+      }
 
       merged.push({
-        ...record,
+        ...liveRecord,
         discovered: true,
         parsed_cli_mismatch: false,
       });
@@ -224,7 +245,7 @@ export class AgentRegistry {
   private syncAutoRecord(
     record: AgentRecord,
     discoveredEntry: DiscoveredAgent,
-  ): AgentRecord {
+  ): AgentRecord | null {
     const agentId = record.agent_id;
     const repo = inferRepoFromTitle(discoveredEntry.surface_title) || record.repo;
     const model = discoveredEntry.model ?? record.model;
@@ -241,8 +262,15 @@ export class AgentRegistry {
     }
 
     if (Object.keys(patch).length > 0) {
-      record = this.stateMgr.updateRecord(agentId, patch);
-      this.agents.set(agentId, record);
+      try {
+        record = this.stateMgr.updateRecord(agentId, patch);
+        this.agents.set(agentId, record);
+      } catch (error) {
+        if (this.evictMissingStateAgent(agentId, error)) {
+          return null;
+        }
+        throw error;
+      }
     }
 
     if (record.state !== desiredState) {
@@ -254,7 +282,10 @@ export class AgentRegistry {
               : null,
         });
         this.agents.set(agentId, record);
-      } catch {
+      } catch (error) {
+        if (this.evictMissingStateAgent(agentId, error)) {
+          return null;
+        }
         // Best-effort only — invalid synthetic transitions can keep the prior state.
       }
     }
@@ -272,6 +303,17 @@ export class AgentRegistry {
 
   remove(agentId: string): void {
     this.agents.delete(agentId);
+  }
+
+  private evictMissingStateAgent(agentId: string, error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Agent not found")) {
+      return false;
+    }
+
+    this.agents.delete(agentId);
+    this.stateMgr.removeState(agentId);
+    return true;
   }
 
   private async evictBootingGhosts(

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -480,4 +480,48 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.evicted).toContain("booting-ghost");
     expect(parsed.count).toBe(0);
   });
+
+  it("resync_agents evicts registry-only phantom agents instead of failing", async () => {
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    registry.set("gpt-5.4-mcplayer-1776645230-hmep", {
+      agent_id: "gpt-5.4-mcplayer-1776645230-hmep",
+      surface_id: "surface:phantom",
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "mcplayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "phantom",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-21T00:00:00.000Z",
+      updated_at: "2026-04-21T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).toContain("gpt-5.4-mcplayer-1776645230-hmep");
+    expect(parsed.count).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- evict registry-only phantom agents during registry reconciliation instead of letting StateManager missing-state errors abort `resync_agents`
- keep the eviction path narrow by only dropping the specific missing agent id, while preserving normal error handling for other registry failures
- add tool-level coverage that injects a phantom registry entry and proves `resync_agents` succeeds with an eviction diff instead of `{ ok: false }`

## Test Plan
- `bun test tests/resync-tool.test.ts tests/agent-registry.test.ts`
- `bun run typecheck`
- `bun run build`
- `bunx vitest run $(git ls-files 'tests/*.test.ts')`

## Notes
- This fixes Task #49 from today's cleanup plan.
- The local worktree has unrelated untracked landing-page test work; tracked test files are green for this branch diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reconciliation logic that can delete agent records/state files; while the eviction path is narrowly gated on a specific error message, mistakes here could lead to unintended agent eviction or skipped results during resync.
> 
> **Overview**
> Makes registry reconciliation resilient to *registry-only phantom agents* by catching `Agent not found: <id>` errors from `StateManager` during `reconcileSurfaces` and `syncAutoRecord`, then evicting the missing agent from both the in-memory map and disk state instead of aborting the sweep.
> 
> Updates `listMerged` to handle `syncAutoRecord` returning `null` on eviction (skipping the agent and delaying `seenSurfaces` marking so a replacement can still be auto-discovered), and adds a `resync_agents` test that injects a phantom registry entry and asserts the tool succeeds with the agent listed in `diff.evicted`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ab7f48e1b39eb0b3c7f4bb411927639ca98ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Evict phantom agents with missing state during resync instead of failing
> - Adds `evictMissingStateAgent` and `isMissingStateAgentError` helpers to [`agent-registry.ts`](https://github.com/EtanHey/cmuxlayer/pull/82/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) to centralize detection and removal of agents whose state no longer exists in the state store.
> - `reconcileSurfaces` now catches 'Agent not found' errors during surface disappearance and child reparenting, evicting the phantom agent instead of throwing.
> - `syncAutoRecord` now returns `null` and evicts the phantom entry when the underlying state is missing; callers skip evicted records in the merged output.
> - Adds a regression test in [`resync-tool.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/82/files#diff-20130406cfd111b11e268c9c9596fbecae728f276859958fb1a894fcbd917770) verifying that `resync_agents` reports evicted phantoms and returns `ok`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09ab7f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in agent registry operations; the system now gracefully manages missing or unavailable agents by cleaning up stale records and continuing normal operations.
  * Improved handling of agents that exist in the registry but lack corresponding system state, ensuring proper cleanup and synchronization.

* **Tests**
  * Added test coverage for edge cases where agents are registered but missing from the detected system state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->