### PR TITLE
fix: typed AgentNotFoundError sentinel replaces substring match (PR #82 follow-up)

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -32,6 +32,17 @@ export interface AgentFilter {
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const BOOTING_GHOST_TIMEOUT_MS = 30_000;
 
+class AgentNotFoundError extends Error {
+  readonly code = "AGENT_NOT_FOUND";
+  readonly agentId: string;
+
+  constructor(agentId: string) {
+    super(`Agent not found: ${agentId}`);
+    this.name = "AgentNotFoundError";
+    this.agentId = agentId;
+  }
+}
+
 export class AgentRegistry {
   private agents = new Map<string, AgentRecord>();
   private stateMgr: StateManager;
@@ -91,7 +102,7 @@ export class AgentRegistry {
           this.agents.set(id, updated);
           crashedIds.add(id);
         } catch (error) {
-          if (this.evictMissingStateAgent(id, error)) {
+          if (this.evictMissingStateAgent(id)) {
             crashedIds.add(id);
             continue;
           }
@@ -112,7 +123,7 @@ export class AgentRegistry {
             });
             this.agents.set(id, reparented);
           } catch (error) {
-            if (this.evictMissingStateAgent(id, error)) {
+            if (this.evictMissingStateAgent(id)) {
               continue;
             }
             throw error;
@@ -242,6 +253,15 @@ export class AgentRegistry {
     return filtered;
   }
 
+  /**
+   * Sync an auto-discovered record with the latest parsed surface state.
+   *
+   * Metadata patches go through updateRecord and are treated as hard errors:
+   * if they fail for anything other than a missing state file, callers should
+   * see the failure rather than silently continuing. Synthetic transitions are
+   * best-effort only because parser snapshots can temporarily lag behind the
+   * persisted state machine.
+   */
   private syncAutoRecord(
     record: AgentRecord,
     discoveredEntry: DiscoveredAgent,
@@ -266,7 +286,7 @@ export class AgentRegistry {
         record = this.stateMgr.updateRecord(agentId, patch);
         this.agents.set(agentId, record);
       } catch (error) {
-        if (this.evictMissingStateAgent(agentId, error)) {
+        if (this.evictMissingStateAgent(agentId)) {
           return null;
         }
         throw error;
@@ -283,7 +303,7 @@ export class AgentRegistry {
         });
         this.agents.set(agentId, record);
       } catch (error) {
-        if (this.evictMissingStateAgent(agentId, error)) {
+        if (this.evictMissingStateAgent(agentId)) {
           return null;
         }
         // Best-effort only — invalid synthetic transitions can keep the prior state.
@@ -305,8 +325,8 @@ export class AgentRegistry {
     this.agents.delete(agentId);
   }
 
-  private evictMissingStateAgent(agentId: string, error: unknown): boolean {
-    if (!this.isMissingStateAgentError(agentId, error)) {
+  private evictMissingStateAgent(agentId: string): boolean {
+    if (!this.getMissingStateAgentError(agentId)) {
       return false;
     }
 
@@ -315,9 +335,12 @@ export class AgentRegistry {
     return true;
   }
 
-  private isMissingStateAgentError(agentId: string, error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-    return message === `Agent not found: ${agentId}`;
+  private getMissingStateAgentError(agentId: string): AgentNotFoundError | null {
+    if (this.stateMgr.readState(agentId) !== null) {
+      return null;
+    }
+
+    return new AgentNotFoundError(agentId);
   }
 
   private async evictBootingGhosts(

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -326,7 +326,7 @@ export class AgentRegistry {
   }
 
   private evictMissingStateAgent(agentId: string): boolean {
-    if (!this.getMissingStateAgentError(agentId)) {
+    if (this.getMissingStateSentinel(agentId) === null) {
       return false;
     }
 
@@ -335,7 +335,7 @@ export class AgentRegistry {
     return true;
   }
 
-  private getMissingStateAgentError(agentId: string): AgentNotFoundError | null {
+  private getMissingStateSentinel(agentId: string): AgentNotFoundError | null {
     if (this.stateMgr.readState(agentId) !== null) {
       return null;
     }

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -240,6 +240,49 @@ describe("AgentRegistry", () => {
       expect(registry.list()).toHaveLength(1);
       expect(registry.get("new-agent")!.state).toBe("ready");
     });
+
+    it("does not evict auto agents for plain substring-matching errors", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-42",
+          surface_id: "surface:42",
+          repo: "stale-repo",
+          model: "old-model",
+          cli: "claude",
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:42"),
+      ]);
+      await registry.reconstitute();
+
+      const removeStateSpy = vi.spyOn(stateMgr, "removeState");
+      vi.spyOn(stateMgr, "updateRecord").mockImplementation(() => {
+        throw new Error("Agent not found: auto-claude-surface-42");
+      });
+
+      const discovery = {
+        scan: vi.fn().mockResolvedValue([
+          {
+            surface_id: "surface:42",
+            surface_title: "brainlayerClaude",
+            cli: "claude",
+            parsed_status: "working",
+            model: "Sonnet 4.6",
+            token_count: null,
+            context_pct: null,
+            has_agent: true,
+            read_error: false,
+          },
+        ]),
+      };
+
+      await expect(registry.listMerged(discovery as any)).rejects.toThrow(
+        "Agent not found: auto-claude-surface-42",
+      );
+      expect(removeStateSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("purgeTerminal", () => {


### PR DESCRIPTION
## Summary
- replace the missing-agent substring/equality fallback in `AgentRegistry` with a typed `AgentNotFoundError` sentinel derived from actual missing persisted state
- keep phantom eviction behavior for real missing state while refusing to evict on unrelated errors that merely reuse the same message text
- document `syncAutoRecord` so the `updateRecord` branch is treated as hard-error and the synthetic `transition` branch remains best-effort

## Files changed
- `src/agent-registry.ts`
- `tests/agent-registry.test.ts`

## Test plan
- RED: `3722801` `test: cover typed sentinel resync follow-up`
- Local tracked suite: `25` files / `424` tests passed
- `bun run typecheck` ✅
- `bun run build` ✅

## Honesty note
CodeRabbit CLI rate-limited 52m at time of PR open — see handoff §15.12 authorized fallback chain (Bugbot primary + orc-manual-audit if needed). Merge will WAIT for Bugbot on latest HEAD per §15.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts agent eviction behavior during reconciliation by changing how missing state is detected; mistakes could cause leaked stale agents or unintended state-file deletion.
> 
> **Overview**
> **Tightens “missing agent” detection during reconciliation.** `AgentRegistry` no longer evicts agents based on an error message match; it now evicts only when `StateManager.readState(agentId)` confirms the persisted state file is actually missing, using a typed `AgentNotFoundError` sentinel.
> 
> **Clarifies auto-agent syncing semantics.** `syncAutoRecord` is documented and continues to treat metadata `updateRecord` failures as hard errors (unless the state is truly missing), while synthetic `transition` updates remain best-effort.
> 
> Adds a regression test ensuring auto agents are *not* evicted (and `removeState` not called) when an unrelated error merely reuses the "Agent not found" message text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ae9a3bdbbb5d4f66b45c26680c2eb836adc0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for agent reconciliation error handling.

* **Refactor**
  * Improved error handling for missing agent states with clearer error representation and decoupled cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace substring error matching with typed `AgentNotFoundError` and state-existence check in `AgentRegistry`
> - Adds `AgentNotFoundError` class with a stable `code` and `name`, capturing the missing `agentId` for structured error handling.
> - Replaces error-message substring matching in `evictMissingStateAgent` with a concrete state-existence check via a new `getMissingStateSentinel` helper that calls `StateManager.readState`.
> - `reconstitute` and `syncAutoRecord` now only evict an agent if its persisted state is actually absent; update errors propagate to callers instead of silently triggering eviction.
> - Behavioral Change: auto-discovered agents that throw errors with messages matching `'Agent not found: <id>'` are no longer evicted if their state still exists in storage — callers now receive the error instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3ae9a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->