### PR TITLE
fix: ship session mining batch 1 quick wins

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -17,6 +17,7 @@ import type {
   CmuxSendOptions,
   CmuxStatusEntry,
 } from "./types.js";
+import { normalizeKeyName } from "./key-names.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -361,7 +362,12 @@ export class CmuxClient {
   ): Promise<void> {
     const args = ["send-key", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
-    args.push(key);
+    args.push(normalizeKeyName(key));
+    await this.run(args);
+  }
+
+  async selectWorkspace(workspace: string): Promise<void> {
+    const args = ["select-workspace", "--workspace", workspace];
     await this.run(args);
   }
 

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -23,6 +23,7 @@ import type {
   CmuxStatusEntry,
 } from "./types.js";
 import type { CmuxClient } from "./cmux-client.js";
+import { normalizeKeyName } from "./key-names.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
 
@@ -318,6 +319,17 @@ export class CmuxSocketClient {
     return this.call("workspace.list");
   }
 
+  async selectWorkspace(workspace: string): Promise<void> {
+    try {
+      await this.call("workspace.select", { workspace_id: workspace });
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallback.selectWorkspace(workspace);
+      }
+      throw e;
+    }
+  }
+
   async listPaneSurfaces(opts?: {
     workspace?: string;
     pane?: string;
@@ -476,7 +488,7 @@ export class CmuxSocketClient {
     const workspace = await this.resolveWorkspace(surface, opts?.workspace);
     const params: Record<string, unknown> = {
       surface_id: surface,
-      key,
+      key: normalizeKeyName(key),
       workspace_id: workspace,
     };
     await this.call("surface.send_key", params);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,11 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 27 MCP tools across two categories:
- *   Core (14): list_surfaces, new_split, new_surface, move_surface,
- *              reorder_surface, send_input, send_key, read_screen, rename_tab,
- *              notify, set_status, set_progress, close_surface, browser_surface
+ * 29 MCP tools across two categories:
+ *   Core (16): list_surfaces, select_workspace, new_split, new_surface,
+ *              move_surface, reorder_surface, send_input, send_command,
+ *              send_key, read_screen, rename_tab, notify, set_status,
+ *              set_progress, close_surface, browser_surface
  *   Agent lifecycle (13): spawn_agent, resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         read_agent_output, get_agent_state, list_agents,

--- a/src/key-names.ts
+++ b/src/key-names.ts
@@ -1,0 +1,15 @@
+const CTRL_C_ALIASES = new Set(["c-c", "ctrl-c", "ctrl+c", "^c"]);
+
+export function normalizeKeyName(key: string): string {
+  const trimmed = key.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const normalized = trimmed.toLowerCase().replace(/\s+/g, "");
+  if (CTRL_C_ALIASES.has(normalized)) {
+    return "ctrl-c";
+  }
+
+  return trimmed;
+}

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -10,7 +10,9 @@ const READ_ONLY_TOOLS = new Set(["list_surfaces", "read_screen"]);
 
 /** Tools that mutate state — blocked in manual mode */
 const MUTATING_TOOLS = new Set([
+  "select_workspace",
   "send_input",
+  "send_command",
   "send_key",
   "close_surface",
   "browser_surface",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 14 core tools + 12 agent lifecycle tools.
+ * cmux MCP server — registers 16 core tools + 13 agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -33,6 +33,7 @@ import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { chooseSurfaceClosePolicy } from "./layout-policy.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
+import { normalizeKeyName } from "./key-names.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -835,6 +836,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
+  server.tool(
+    "select_workspace",
+    "Focus a workspace tab so subsequent terminal input is delivered to the intended workspace.",
+    {
+      workspace: z.string().describe("Target workspace ref"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        await client.selectWorkspace(args.workspace);
+        const data = { workspace: args.workspace };
+        return okFormatted(formatOk("select_workspace", data), data);
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
   // 2. new_split
   server.tool(
     "new_split",
@@ -1017,7 +1036,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 6. send_input
   server.tool(
     "send_input",
-    "Send text input to a terminal surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Set background=true to return immediately with a delivery_id while chunking continues in the background. When sending commands to another Claude session, press_enter can be unreliable — for critical inputs, use send_input without press_enter, then call send_key with key 'return' separately.",
+    "Send text input to a terminal surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
     {
       surface: z.string().describe("Target surface ref"),
       text: z.string().describe("Text to send"),
@@ -1105,22 +1124,65 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 7. send_key
+  // 7. send_command
   server.tool(
-    "send_key",
-    "Send a key press to a terminal surface. Use this after send_input to reliably submit commands — especially when targeting interactive programs like Claude sessions.",
+    "send_command",
+    "Atomically send a command and press return on the same surface. Prefer this over separate send_input + send_key calls when launching or resuming agents.",
     {
       surface: z.string().describe("Target surface ref"),
-      key: z.string().describe("Key name (e.g. 'return', 'escape', 'tab')"),
+      command: z.string().describe("Command text to send before pressing return"),
       workspace: z.string().optional().describe("Target workspace ref"),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const sanitizedCommand = sanitizeTerminalInput(args.command);
+        const chunks =
+          sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
+            ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
+            : [sanitizedCommand];
+
         await withSurfaceWrite(args.surface, async () => {
-          await sendKeyWithRetry(args.surface, args.key, args.workspace);
+          await deliverInputChunks({
+            surface: args.surface,
+            workspace: args.workspace,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: true,
+          });
         });
-        const data = { surface: args.surface, key: args.key };
+
+        const data = { surface: args.surface, command: sanitizedCommand };
+        return okFormatted(formatOk("send_command", data), data);
+      } catch (e) {
+        if (e instanceof DeliveryError) {
+          return err(e, { failed_chunk: e.failed_chunk ?? null });
+        }
+        return err(e);
+      }
+    },
+  );
+
+  // 8. send_key
+  server.tool(
+    "send_key",
+    "Send a key press to a terminal surface. Accepted Ctrl+C aliases are normalized automatically: ctrl-c, C-c, ^c, Ctrl+C, Ctrl-C.",
+    {
+      surface: z.string().describe("Target surface ref"),
+      key: z
+        .string()
+        .describe("Key name (e.g. 'return', 'escape', 'tab', 'ctrl-c')"),
+      workspace: z.string().optional().describe("Target workspace ref"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const key = normalizeKeyName(args.key);
+        await withSurfaceWrite(args.surface, async () => {
+          await sendKeyWithRetry(args.surface, key, args.workspace);
+        });
+        const data = { surface: args.surface, key };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
         return err(e);
@@ -1128,7 +1190,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 8. read_screen
+  // 9. read_screen
   server.tool(
     "read_screen",
     "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors, plus delivery metadata for the current or most recent background send_input operation. Use parsed_only=true for monitoring (omits raw terminal content).",

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -356,6 +356,38 @@ describe("CmuxClient.sendKey", () => {
       "return",
     ]);
   });
+
+  it.each(["C-c", "ctrl-c", "^c", "Ctrl+C", "Ctrl-C"])(
+    "normalizes %s to ctrl-c",
+    async (key) => {
+      const { client, exec } = mockClient({});
+
+      await client.sendKey("surface:1", key);
+
+      expect(exec).toHaveBeenCalledWith("cmux", [
+        "--json",
+        "send-key",
+        "--surface",
+        "surface:1",
+        "ctrl-c",
+      ]);
+    },
+  );
+});
+
+describe("CmuxClient.selectWorkspace", () => {
+  it("calls cmux select-workspace with workspace", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.selectWorkspace("workspace:3");
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "select-workspace",
+      "--workspace",
+      "workspace:3",
+    ]);
+  });
 });
 
 describe("CmuxClient.readScreen", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -34,6 +34,7 @@ const MOCK_RESPONSES: Record<string, unknown> = {
       },
     ],
   },
+  "workspace.select": {},
   "surface.list": {
     workspace_ref: "workspace:1",
     window_ref: "window:1",
@@ -232,6 +233,16 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(result.workspaces[0]).toHaveProperty("selected");
   });
 
+  it("selectWorkspace sends a workspace.select request", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.selectWorkspace("workspace:1");
+
+    expect(lastV2Request).not.toBeNull();
+    expect(lastV2Request!.method).toBe("workspace.select");
+    expect(lastV2Request!.params).toEqual({ workspace_id: "workspace:1" });
+  });
+
   it("send delivers text to a surface", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
     // Should not throw
@@ -248,6 +259,23 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
       }),
     ).rejects.toThrow(/does not support chunk_size/i);
   });
+
+  it.each(["C-c", "ctrl-c", "^c", "Ctrl+C", "Ctrl-C"])(
+    "normalizes %s to ctrl-c before sending",
+    async (key) => {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.sendKey("surface:1", key, { workspace: "workspace:1" });
+
+      expect(lastV2Request).not.toBeNull();
+      expect(lastV2Request!.method).toBe("surface.send_key");
+      expect(lastV2Request!.params).toEqual({
+        surface_id: "surface:1",
+        key: "ctrl-c",
+        workspace_id: "workspace:1",
+      });
+    },
+  );
 
   it("readScreen returns screen content", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -33,6 +33,14 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("send_key")).toBe(true);
   });
 
+  it("returns true for send_command", () => {
+    expect(isMutatingTool("send_command")).toBe(true);
+  });
+
+  it("returns true for select_workspace", () => {
+    expect(isMutatingTool("select_workspace")).toBe(true);
+  });
+
   it("returns true for close_surface", () => {
     expect(isMutatingTool("close_surface")).toBe(true);
   });
@@ -72,6 +80,12 @@ describe("assertMutationAllowed", () => {
       /manual/i,
     );
     expect(() => assertMutationAllowed("send_key", "manual")).toThrow(
+      /manual/i,
+    );
+    expect(() => assertMutationAllowed("send_command", "manual")).toThrow(
+      /manual/i,
+    );
+    expect(() => assertMutationAllowed("select_workspace", "manual")).toThrow(
       /manual/i,
     );
     expect(() => assertMutationAllowed("close_surface", "manual")).toThrow(

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -42,11 +42,13 @@ describe("B1: ToolAnnotations on all tools", () => {
   const DESTRUCTIVE_TOOLS = ["kill", "close_surface", "stop_agent"];
 
   const MUTATING_TOOLS = [
+    "select_workspace",
     "new_split",
     "new_surface",
     "move_surface",
     "reorder_surface",
     "send_input",
+    "send_command",
     "send_key",
     "rename_tab",
     "notify",
@@ -77,9 +79,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 27 tools have annotations", () => {
+  it("all 29 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(27);
+    expect(toolNames.length).toBe(29);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -146,11 +146,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 27 (14 low-level + 11 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 29 (16 low-level + 11 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(27);
+    expect(Object.keys(registeredTools)).toHaveLength(29);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -11,11 +11,13 @@ import { AgentRegistry } from "../src/agent-registry.js";
 // The 12 low-level tools from the design doc
 const EXPECTED_TOOLS = [
   "list_surfaces",
+  "select_workspace",
   "new_split",
   "new_surface",
   "move_surface",
   "reorder_surface",
   "send_input",
+  "send_command",
   "send_key",
   "read_screen",
   "rename_tab",
@@ -70,7 +72,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 14 core tools", () => {
+  it("registers all 16 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;
@@ -221,6 +223,36 @@ describe("tool handler integration", () => {
     expect(result.content).toBeDefined();
     expect(result.content[0].type).toBe("text");
     expect(result.structuredContent.ok).toBe(true);
+  });
+
+  it("select_workspace handler calls cmux select-workspace", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({}),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["select_workspace"];
+
+    const result = await tool.handler(
+      { workspace: "workspace:3" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "--json",
+        "select-workspace",
+        "--workspace",
+        "workspace:3",
+      ]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace).toBe("workspace:3");
   });
 
   it("list_surfaces dedupes overlapping pane results and returns the condensed default schema", async () => {
@@ -948,6 +980,35 @@ describe("tool handler integration", () => {
     );
   });
 
+  it("send_command sends text and return to the same surface", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_command"];
+
+    const result = await tool.handler(
+      { surface: "surface:6", command: "codex resume 123" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenNthCalledWith(
+      1,
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      2,
+      "cmux",
+      expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.surface).toBe("surface:6");
+  });
+
   it("send_input chunks long text transparently before sending", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
@@ -1211,6 +1272,28 @@ describe("tool handler integration", () => {
     const renameParsed =
       renameResult.structuredContent ?? JSON.parse(renameResult.content[0].text);
     expect(renameParsed.error).toMatch(/delivery.*in progress/i);
+  });
+
+  it("send_key normalizes Ctrl+C aliases before dispatch", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_key"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", key: "Ctrl+C" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send-key", "--surface", "surface:1", "ctrl-c"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.key).toBe("ctrl-c");
   });
 
   it("send_input retries a transient socket failure before succeeding", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -48,14 +48,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 27 (14 low-level + 11 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 29 (16 low-level + 11 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(27);
+    expect(count).toBe(29);
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize `send_key` Ctrl+C aliases across both cmux client paths so `C-c`, `^c`, `Ctrl+C`, and `Ctrl-C` all dispatch as `ctrl-c`
- expose `select_workspace` as an MCP tool and add client support for workspace selection on both CLI and socket transports
- add `send_command(surface, command)` so command text plus return are delivered atomically to the same surface

## Files changed
- `src/key-names.ts`
- `src/cmux-client.ts`
- `src/cmux-socket-client.ts`
- `src/server.ts`
- `src/mode-policy.ts`
- `src/index.ts`
- `tests/server.test.ts`
- `tests/cmux-client.test.ts`
- `tests/cmux-socket-client.test.ts`
- `tests/security-hardening.test.ts`
- `tests/mode-policy.test.ts`
- `tests/server-agent-tools.test.ts`
- `tests/v2-interact-kill.test.ts`

## Test plan
- RED commit: `781ba27` `test: cover session mining batch 1 quick wins`
- GREEN commit: `bb22f04` `fix: ship session mining batch 1 quick wins`
- `bunx vitest run $(git ls-files 'tests/*.test.ts')` → `25` files / `441` tests passed
- `bun run typecheck` ✅
- `bun run build` ✅
- `cr review --plain --type committed --base main` from a clean detached worktree → `No findings ✔`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new mutating MCP tools (`select_workspace`, `send_command`) and changes `send_key` behavior via key normalization, which can affect how input is dispatched to terminals/workspaces. Risk is mitigated by being mostly additive and covered by new unit tests across CLI and socket transports.
> 
> **Overview**
> Adds two new core MCP tools: `select_workspace` to focus a workspace before sending input, and `send_command` to deliver a command plus Return *atomically* on the same surface.
> 
> Normalizes `send_key` inputs by introducing `normalizeKeyName` (currently handling Ctrl+C aliases) and applying it consistently across the CLI client, socket client, and server tool handler. Updates manual-mode mutation blocking and tool/annotation counts/tests to reflect the expanded 29-tool surface area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb22f043a5988000a633889695e4089f7cfef205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace selection capability to switch between configured workspaces.
  * Introduced new tool for sending complete commands with atomic delivery of text and return key in one operation.
  * Enhanced keyboard input handling to normalize multiple Ctrl+C key variants (C-c, ctrl-c, ^c, Ctrl+C, Ctrl-C) to a consistent format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `select_workspace` and `send_command` MCP tools and normalize Ctrl+C key aliases
> - Adds a `send_command` MCP tool that sends text and automatically presses Return on the target surface, removing the need to chain `send_key`.
> - Adds a `select_workspace` MCP tool that focuses a workspace tab via the cmux socket API with a CLI fallback when the RPC method is unavailable.
> - Extracts key normalization into [`src/key-names.ts`](https://github.com/EtanHey/cmuxlayer/pull/84/files#diff-2de22903e4e59949547e560a968d9cf88221bab0263c7cf9cebf44e2f688f68d), collapsing Ctrl+C aliases (`^c`, `Ctrl+C`, `ctrl+c`) to `ctrl-c` across `send_key`, `CmuxClient`, and `CmuxSocketClient`.
> - Marks both new tools as mutating in [`src/mode-policy.ts`](https://github.com/EtanHey/cmuxlayer/pull/84/files#diff-4a89bc8fb1fcb711b6f2d32068e35805abdfc196e1dfb023834f2d0c042f5884), so they are blocked in manual/read-only mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb22f04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->