### PR TITLE
fix: auto-focus unfocused writes and harden graceful stop flow

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -64,6 +64,9 @@ const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
+const STOP_AGENT_RETRY_ATTEMPTS = 3;
+const STOP_AGENT_RETRY_DELAY_MS = 75;
+const SHELL_PROMPT_RE = /(^|\n)\s*(?:❯|>>>|\$|%|>)\s*$/m;
 const SESSION_ID_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const SESSION_ID_RE =
@@ -189,6 +192,21 @@ function sanitizeRepoName(repo: string): string {
     );
   }
   return safeRepo;
+}
+
+function stopKeysForCli(cli: CliType): string[] {
+  switch (cli) {
+    case "claude":
+      return ["c-c", "c-c", "c-c", "c-c", "c-c"];
+    case "codex":
+      return ["escape", "c-c"];
+    default:
+      return ["c-c"];
+  }
+}
+
+function screenShowsShellPrompt(text: string): boolean {
+  return SHELL_PROMPT_RE.test(text);
 }
 
 export function buildLaunchCommand(cli: CliType, repo: string): string {
@@ -954,8 +972,34 @@ export class AgentEngine {
         // Process may already be dead — that's fine
       }
     } else {
-      // Graceful: send Ctrl+C
-      await this.client.sendKey(agent.surface_id, "c-c", {});
+      let stopped = false;
+
+      for (let attempt = 0; attempt < STOP_AGENT_RETRY_ATTEMPTS; attempt++) {
+        for (const key of stopKeysForCli(agent.cli)) {
+          await this.client.sendKey(agent.surface_id, key, {});
+        }
+
+        const screen = await this.client.readScreen(agent.surface_id, {
+          lines: 40,
+          scrollback: true,
+        });
+        if (screenShowsShellPrompt(screen.text)) {
+          stopped = true;
+          break;
+        }
+
+        if (attempt < STOP_AGENT_RETRY_ATTEMPTS - 1) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, STOP_AGENT_RETRY_DELAY_MS),
+          );
+        }
+      }
+
+      if (!stopped) {
+        throw new Error(
+          `Agent "${agentId}" is still running after graceful stop attempts`,
+        );
+      }
     }
 
     const current = this.registry.get(agentId) ?? agent;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -197,6 +197,8 @@ function sanitizeRepoName(repo: string): string {
 function stopKeysForCli(cli: CliType): string[] {
   switch (cli) {
     case "claude":
+      // Claude permission prompts can absorb the first interrupt, so bias for
+      // a short burst instead of a single best-effort Ctrl+C.
       return ["c-c", "c-c", "c-c", "c-c", "c-c"];
     case "codex":
       return ["escape", "c-c"];

--- a/src/server.ts
+++ b/src/server.ts
@@ -485,6 +485,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  // Some terminals drop synthetic input in background workspaces. When we know
+  // the target surface lives outside the selected workspace, temporarily focus
+  // it for the write and then restore the user's original selection.
   const planSurfaceWorkspaceFocus = async (
     surface: string,
     workspace?: string,
@@ -494,10 +497,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     restoreWorkspace?: string;
   }> => {
     try {
+      const identified = workspace ? null : await client.identify(surface);
       const focusWorkspace =
         workspace ??
-        (await client.identify(surface)).caller?.workspace_ref ??
-        (await client.identify(surface)).focused?.workspace_ref;
+        identified?.caller?.workspace_ref ??
+        identified?.focused?.workspace_ref;
       if (!focusWorkspace) {
         return { workspaceWasUnfocused: false };
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,9 @@ interface DeliveryRecord {
   delivery_id: string;
   surface: string;
   workspace?: string;
+  workspace_was_unfocused?: boolean;
+  focus_workspace?: string;
+  restore_workspace?: string;
   status: DeliveryStatus;
   total_chunks: number;
   sent_chunks: number;
@@ -482,6 +485,95 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  const planSurfaceWorkspaceFocus = async (
+    surface: string,
+    workspace?: string,
+  ): Promise<{
+    workspaceWasUnfocused: boolean;
+    focusWorkspace?: string;
+    restoreWorkspace?: string;
+  }> => {
+    try {
+      const focusWorkspace =
+        workspace ??
+        (await client.identify(surface)).caller?.workspace_ref ??
+        (await client.identify(surface)).focused?.workspace_ref;
+      if (!focusWorkspace) {
+        return { workspaceWasUnfocused: false };
+      }
+
+      const originalWorkspace = (await client.listWorkspaces()).workspaces.find(
+        (entry) => entry.selected,
+      )?.ref;
+      if (!originalWorkspace || originalWorkspace === focusWorkspace) {
+        return {
+          workspaceWasUnfocused: false,
+          focusWorkspace,
+          restoreWorkspace: originalWorkspace,
+        };
+      }
+
+      return {
+        workspaceWasUnfocused: true,
+        focusWorkspace,
+        restoreWorkspace: originalWorkspace,
+      };
+    } catch {
+      return { workspaceWasUnfocused: false };
+    }
+  };
+
+  const withSurfaceWorkspaceFocus = async <T>(
+    plan: {
+      workspaceWasUnfocused: boolean;
+      focusWorkspace?: string;
+      restoreWorkspace?: string;
+    },
+    fn: () => Promise<T>,
+  ): Promise<{ result: T; workspaceWasUnfocused: boolean }> => {
+    if (plan.workspaceWasUnfocused && plan.focusWorkspace) {
+      await client.selectWorkspace(plan.focusWorkspace);
+    }
+
+    try {
+      const result = await fn();
+      return {
+        result,
+        workspaceWasUnfocused: plan.workspaceWasUnfocused,
+      };
+    } finally {
+      if (plan.workspaceWasUnfocused && plan.restoreWorkspace) {
+        await client.selectWorkspace(plan.restoreWorkspace);
+      }
+    }
+  };
+
+  const performManagedSurfaceWrite = async <T>(
+    surface: string,
+    workspace: string | undefined,
+    fn: () => Promise<T>,
+    owner = `surface-write:${randomUUID()}`,
+  ): Promise<{ result: T; workspaceWasUnfocused: boolean }> =>
+    withSurfaceWrite(
+      surface,
+      async () =>
+        withSurfaceWorkspaceFocus(
+          await planSurfaceWorkspaceFocus(surface, workspace),
+          fn,
+        ),
+      owner,
+    );
+
+  const writeToSurface = async <T>(
+    surface: string,
+    workspace: string | undefined,
+    fn: () => Promise<T>,
+    owner = `surface-write:${randomUUID()}`,
+  ): Promise<T> =>
+    (
+      await performManagedSurfaceWrite(surface, workspace, fn, owner)
+    ).result;
+
   const pruneCompletedDeliveryHistory = (surface: string) => {
     const latestDeliveryId = latestDeliveryBySurface.get(surface);
     for (const [deliveryId, record] of deliveries.entries()) {
@@ -642,18 +734,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const run = async () => {
       try {
-        await deliverInputChunks({
-          surface: record.surface,
-          workspace: record.workspace,
-          chunks: record.chunks,
-          chunk_size: record.chunk_size,
-          chunk_delay_ms: record.chunk_delay_ms,
-          press_enter: record.press_enter,
-          rename_to_task: record.rename_to_task,
-          onChunkDelivered: (sentChunks) => {
-            record.sent_chunks = sentChunks;
+        await withSurfaceWorkspaceFocus(
+          {
+            workspaceWasUnfocused: record.workspace_was_unfocused ?? false,
+            focusWorkspace: record.focus_workspace,
+            restoreWorkspace: record.restore_workspace,
           },
-        });
+          async () => {
+            await deliverInputChunks({
+              surface: record.surface,
+              workspace: record.workspace,
+              chunks: record.chunks,
+              chunk_size: record.chunk_size,
+              chunk_delay_ms: record.chunk_delay_ms,
+              press_enter: record.press_enter,
+              rename_to_task: record.rename_to_task,
+              onChunkDelivered: (sentChunks) => {
+                record.sent_chunks = sentChunks;
+              },
+            });
+          },
+        );
         finishDelivery(record, "delivered");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1075,12 +1176,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
             ? chunkTerminalInput(sanitizedText, args.chunk_size)
             : [sanitizedText];
+        const focusPlan = await planSurfaceWorkspaceFocus(
+          args.surface,
+          args.workspace,
+        );
 
         if (args.background) {
           const record: DeliveryRecord = {
             delivery_id: randomUUID(),
             surface: args.surface,
             workspace: args.workspace,
+            workspace_was_unfocused: focusPlan.workspaceWasUnfocused,
+            focus_workspace: focusPlan.focusWorkspace,
+            restore_workspace: focusPlan.restoreWorkspace,
             status: "delivering",
             total_chunks: chunks.length,
             sent_chunks: 0,
@@ -1097,11 +1205,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface: args.surface,
             delivery_id: record.delivery_id,
             status: record.status,
+            workspace_was_unfocused: focusPlan.workspaceWasUnfocused,
           };
           return okFormatted(formatOk("send_input", data), data);
         }
 
-        await withSurfaceWrite(args.surface, async () => {
+        const { workspaceWasUnfocused } = await performManagedSurfaceWrite(
+          args.surface,
+          args.workspace,
+          async () => {
           await deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
@@ -1111,9 +1223,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             press_enter: args.press_enter,
             rename_to_task: args.rename_to_task,
           });
-        });
+          },
+        );
 
-        const data = { surface: args.surface };
+        const data = {
+          surface: args.surface,
+          workspace_was_unfocused: workspaceWasUnfocused,
+        };
         return okFormatted(formatOk("send_input", data), data);
       } catch (e) {
         if (e instanceof DeliveryError) {
@@ -1142,7 +1258,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
             : [sanitizedCommand];
 
-        await withSurfaceWrite(args.surface, async () => {
+        const { workspaceWasUnfocused } = await performManagedSurfaceWrite(
+          args.surface,
+          args.workspace,
+          async () => {
           await deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
@@ -1151,9 +1270,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: true,
           });
-        });
+          },
+        );
 
-        const data = { surface: args.surface, command: sanitizedCommand };
+        const data = {
+          surface: args.surface,
+          command: sanitizedCommand,
+          workspace_was_unfocused: workspaceWasUnfocused,
+        };
         return okFormatted(formatOk("send_command", data), data);
       } catch (e) {
         if (e instanceof DeliveryError) {
@@ -1179,10 +1303,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         const key = normalizeKeyName(args.key);
-        await withSurfaceWrite(args.surface, async () => {
-          await sendKeyWithRetry(args.surface, key, args.workspace);
-        });
-        const data = { surface: args.surface, key };
+        const { workspaceWasUnfocused } = await performManagedSurfaceWrite(
+          args.surface,
+          args.workspace,
+          async () => {
+            await sendKeyWithRetry(args.surface, key, args.workspace);
+          },
+        );
+        const data = {
+          surface: args.surface,
+          key,
+          workspace_was_unfocused: workspaceWasUnfocused,
+        };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
         return err(e);
@@ -1637,9 +1769,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
       readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
       send: (surface, text, sendOpts) =>
-        withSurfaceWrite(surface, () => client.send(surface, text, sendOpts)),
+        writeToSurface(surface, sendOpts?.workspace, () =>
+          client.send(surface, text, sendOpts),
+        ),
       sendKey: (surface, key, keyOpts) =>
-        withSurfaceWrite(surface, () => client.sendKey(surface, key, keyOpts)),
+        writeToSurface(surface, keyOpts?.workspace, () =>
+          client.sendKey(surface, key, keyOpts),
+        ),
       setProgress: (value, progressOpts) =>
         client.setProgress(value, progressOpts),
       newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),
@@ -2172,7 +2308,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return okFormatted(formatOk("interact:send", d), d);
             }
             case "interrupt": {
-              await withSurfaceWrite(agent.surface_id, () =>
+              await writeToSurface(agent.surface_id, undefined, () =>
                 client.sendKey(agent.surface_id, "c-c", {}),
               );
               const d = { agent_id: args.agent, action: "interrupt" };

--- a/src/server.ts
+++ b/src/server.ts
@@ -535,6 +535,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
     fn: () => Promise<T>,
   ): Promise<{ result: T; workspaceWasUnfocused: boolean }> => {
+    let writeError: unknown = null;
+
     if (plan.workspaceWasUnfocused && plan.focusWorkspace) {
       await client.selectWorkspace(plan.focusWorkspace);
     }
@@ -545,9 +547,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         result,
         workspaceWasUnfocused: plan.workspaceWasUnfocused,
       };
+    } catch (error) {
+      writeError = error;
+      throw error;
     } finally {
       if (plan.workspaceWasUnfocused && plan.restoreWorkspace) {
-        await client.selectWorkspace(plan.restoreWorkspace);
+        try {
+          await client.selectWorkspace(plan.restoreWorkspace);
+        } catch (restoreError) {
+          if (writeError === null) {
+            throw restoreError;
+          }
+        }
       }
     }
   };

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -789,12 +789,14 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
   });
 
   describe("stopAgent", () => {
-    it("sends Ctrl+C for graceful stop", async () => {
+    it("sends repeated Ctrl+C for graceful Claude stops", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-stop",
           state: "working",
           surface_id: "surface:42",
+          cli: "claude",
+          model: "sonnet",
         }),
       );
       liveSurfaces = [makeSurface("surface:42")];
@@ -802,10 +804,39 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
 
       await engine.stopAgent("agent-stop");
 
-      expect(mockClient.sendKey).toHaveBeenCalledWith(
+      expect(mockClient.sendKey).toHaveBeenCalledTimes(5);
+      for (const call of (mockClient.sendKey as ReturnType<typeof vi.fn>).mock
+        .calls) {
+        expect(call).toEqual(["surface:42", "c-c", {}]);
+      }
+    });
+
+    it("sends escape then Ctrl+C for graceful Codex stops", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-codex-stop",
+          state: "working",
+          surface_id: "surface:42",
+          cli: "codex",
+          model: "gpt-5.4",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.stopAgent("agent-codex-stop");
+
+      expect(mockClient.sendKey).toHaveBeenNthCalledWith(
+        1,
+        "surface:42",
+        "escape",
+        {},
+      );
+      expect(mockClient.sendKey).toHaveBeenNthCalledWith(
+        2,
         "surface:42",
         "c-c",
-        expect.anything(),
+        {},
       );
     });
 
@@ -881,6 +912,34 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
 
       await expect(engine.stopAgent("agent-busy")).rejects.toThrow("tty busy");
       expect(engine.getAgentState("agent-busy")).toMatchObject({
+        state: "working",
+        user_killed: false,
+      });
+    });
+
+    it("does not mark user_killed when the agent is still running after graceful retries", async () => {
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: "Claude Code\n⏺ Working",
+        lines: 20,
+        scrollback_used: false,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-stuck",
+          state: "working",
+          surface_id: "surface:42",
+          cli: "claude",
+          model: "sonnet",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await expect(engine.stopAgent("agent-stuck")).rejects.toThrow(
+        /still running/i,
+      );
+      expect(engine.getAgentState("agent-stuck")).toMatchObject({
         state: "working",
         user_killed: false,
       });

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -184,12 +184,19 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // Mock readScreen: 170K tokens on Haiku (200K window) = 85% used
-    (mockClient.readScreen as any).mockResolvedValue({
-      surface: "s:2",
-      text: "✻ Working…\nToken usage: total=170,000\n🤖 Haiku 3.5 | 💰 $0.10",
-      lines: 5,
-      scrollback_used: false,
-    });
+    (mockClient.readScreen as any)
+      .mockResolvedValueOnce({
+        surface: "s:2",
+        text: "✻ Working…\nToken usage: total=170,000\n🤖 Haiku 3.5 | 💰 $0.10",
+        lines: 5,
+        scrollback_used: false,
+      })
+      .mockResolvedValue({
+        surface: "s:2",
+        text: "$ ",
+        lines: 5,
+        scrollback_used: false,
+      });
 
     await engine.runSweep();
 
@@ -280,12 +287,19 @@ describe("Quality Tracking (sweep)", () => {
     await engine.getRegistry().reconstitute();
 
     // 180K tokens on Haiku (200K window) = 90% used — above threshold
-    (mockClient.readScreen as any).mockResolvedValue({
-      surface: "s:2",
-      text: "✻ Working…\nToken usage: total=180,000\n🤖 Haiku 3.5 | 💰 $0.15",
-      lines: 5,
-      scrollback_used: false,
-    });
+    (mockClient.readScreen as any)
+      .mockResolvedValueOnce({
+        surface: "s:2",
+        text: "✻ Working…\nToken usage: total=180,000\n🤖 Haiku 3.5 | 💰 $0.15",
+        lines: 5,
+        scrollback_used: false,
+      })
+      .mockResolvedValue({
+        surface: "s:2",
+        text: "$ ",
+        lines: 5,
+        scrollback_used: false,
+      });
 
     await engine.runSweep();
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1296,6 +1296,118 @@ describe("tool handler integration", () => {
     expect(parsed.key).toBe("ctrl-c");
   });
 
+  it("send_key auto-focuses an unfocused workspace and restores the original selection", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+          {
+            ref: "workspace:2",
+            title: "Workers",
+            index: 1,
+            selected: false,
+            pinned: false,
+          },
+        ],
+      }),
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:2" },
+      }),
+      selectWorkspace: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_key"];
+
+    const result = await tool.handler(
+      { surface: "surface:2", key: "ctrl-c" },
+      {} as any,
+    );
+
+    expect(mockClient.selectWorkspace).toHaveBeenNthCalledWith(
+      1,
+      "workspace:2",
+    );
+    expect(mockClient.sendKey).toHaveBeenCalledWith("surface:2", "ctrl-c", {
+      workspace: undefined,
+    });
+    expect(mockClient.selectWorkspace).toHaveBeenNthCalledWith(
+      2,
+      "workspace:1",
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace_was_unfocused).toBe(true);
+  });
+
+  it("send_input reports when it temporarily focuses an unfocused workspace", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+          {
+            ref: "workspace:2",
+            title: "Workers",
+            index: 1,
+            selected: false,
+            pinned: false,
+          },
+        ],
+      }),
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:2" },
+      }),
+      selectWorkspace: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:2", text: "echo hi" },
+      {} as any,
+    );
+
+    expect(mockClient.selectWorkspace).toHaveBeenNthCalledWith(
+      1,
+      "workspace:2",
+    );
+    expect(mockClient.send).toHaveBeenCalledWith("surface:2", "echo hi", {
+      workspace: undefined,
+    });
+    expect(mockClient.selectWorkspace).toHaveBeenNthCalledWith(
+      2,
+      "workspace:1",
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace_was_unfocused).toBe(true);
+  });
+
   it("send_input retries a transient socket failure before succeeding", async () => {
     vi.useFakeTimers();
     let sendAttempts = 0;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -966,18 +966,22 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Should have called send and then send-key
-    expect(mockExec).toHaveBeenCalledTimes(2);
-    expect(mockExec).toHaveBeenNthCalledWith(
-      1,
+    const sendCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send"),
+    );
+    const sendKeyCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send-key"),
+    );
+    expect(sendCalls).toHaveLength(1);
+    expect(sendKeyCalls).toHaveLength(1);
+    expect(sendCalls[0]).toEqual([
       "cmux",
       expect.arrayContaining(["send"]),
-    );
-    expect(mockExec).toHaveBeenNthCalledWith(
-      2,
+    ]);
+    expect(sendKeyCalls[0]).toEqual([
       "cmux",
       expect.arrayContaining(["send-key"]),
-    );
+    ]);
   });
 
   it("send_command sends text and return to the same surface", async () => {
@@ -992,17 +996,22 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(2);
-    expect(mockExec).toHaveBeenNthCalledWith(
-      1,
+    const sendCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send"),
+    );
+    const sendKeyCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send-key"),
+    );
+    expect(sendCalls).toHaveLength(1);
+    expect(sendKeyCalls).toHaveLength(1);
+    expect(sendCalls[0]).toEqual([
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:6"]),
-    );
-    expect(mockExec).toHaveBeenNthCalledWith(
-      2,
+    ]);
+    expect(sendKeyCalls[0]).toEqual([
       "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
-    );
+    ]);
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
@@ -1028,14 +1037,17 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(5);
-    for (const [index, call] of mockExec.mock.calls.entries()) {
+    const sendCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send"),
+    );
+    expect(sendCalls).toHaveLength(5);
+    for (const [index, call] of sendCalls.entries()) {
       expect(call[0]).toBe("cmux");
       expect(call[1]).toEqual(expect.arrayContaining(["send"]));
       const chunk = call[1][call[1].length - 1];
       expect(typeof chunk).toBe("string");
       expect((chunk as string).length).toBeLessThanOrEqual(121);
-      if (index < mockExec.mock.calls.length - 1) {
+      if (index < sendCalls.length - 1) {
         expect((chunk as string).endsWith("\n")).toBe(true);
       }
     }
@@ -1210,7 +1222,9 @@ describe("tool handler integration", () => {
       { surface: "surface:1", text: "echo first" },
       {} as any,
     );
-    await Promise.resolve();
+    for (let attempt = 0; attempt < 5 && !releaseSend; attempt++) {
+      await Promise.resolve();
+    }
 
     const second = await tool.handler(
       { surface: "surface:1", text: "echo second" },

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1422,6 +1422,55 @@ describe("tool handler integration", () => {
     expect(parsed.workspace_was_unfocused).toBe(true);
   });
 
+  it("preserves the original write error when workspace restore also fails", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+          {
+            ref: "workspace:2",
+            title: "Workers",
+            index: 1,
+            selected: false,
+            pinned: false,
+          },
+        ],
+      }),
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:2" },
+      }),
+      selectWorkspace: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("restore failed")),
+      sendKey: vi.fn().mockRejectedValue(new Error("send failed")),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_key"];
+
+    const result = await tool.handler(
+      { surface: "surface:2", key: "ctrl-c" },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.error).toMatch(/send failed/i);
+    expect(parsed.error).not.toMatch(/restore failed/i);
+  });
+
   it("send_input retries a transient socket failure before succeeding", async () => {
     vi.useFakeTimers();
     let sendAttempts = 0;

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -36,6 +36,38 @@ function createV2Server(exec: ExecFn) {
   });
 }
 
+function makeV2Exec(): ExecFn {
+  return vi.fn().mockImplementation((_cmd, args: string[]) => {
+    if (args.includes("read-screen")) {
+      return Promise.resolve({
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      });
+    }
+    if (args.includes("list-workspaces")) {
+      return Promise.resolve({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      stdout: JSON.stringify({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+  });
+}
+
 describe("V2 tool registration", () => {
   it("registers interact and kill tools", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
@@ -66,16 +98,7 @@ describe("interact — runtime validation", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeV2Exec();
     server = createV2Server(mockExec);
   });
 
@@ -162,16 +185,7 @@ describe("interact — agent resolution", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeV2Exec();
     server = createV2Server(mockExec);
   });
 
@@ -225,16 +239,7 @@ describe("kill — scoped targets", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeV2Exec();
     server = createV2Server(mockExec);
   });
 


### PR DESCRIPTION
## Summary
- auto-focus the target workspace for `send_input`, `send_command`, `send_key`, and agent-mediated surface writes when the target surface lives in an unfocused workspace, and report `workspace_was_unfocused` in the low-level write responses
- make `stopAgent` agent-aware with Claude `ctrl-c` bursts, Codex `escape` then `ctrl-c`, and shell-prompt verification/retries before marking the agent done
- lock in the regressions with Batch 2 coverage, including shared kill/quality flows that now model the verified stop behavior

## Commits
- `0127bec` `test: cover session mining batch 2 regressions`
- `d83b298` `fix: ship session mining batch 2 behavior`
- `4e3a7d3` `refactor: document focused writes and stop sequences`

## Test Plan
- `bunx vitest run $(git ls-files 'tests/*.test.ts')`
- `bun run typecheck`
- `bun run build`

## Honesty Note
- local `cr review --plain --type committed --base main` was rate-limited for ~36 minutes at PR open, so the active CodeRabbit gate is the GitHub-side review/check on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-flow for terminal writes (workspace switching) and agent termination (now retries and can throw), which may affect callers and error handling if prompts/focus detection is wrong or cmux behaviors differ.
> 
> **Overview**
> Improves terminal write reliability by **auto-focusing the target workspace** when sending synthetic input to a surface that lives in an unfocused workspace, then restoring the original workspace afterward. This behavior is applied to `send_input`, `send_command`, `send_key`, agent-mediated `send`/`sendKey`, and background `send_input` deliveries, and responses now report `workspace_was_unfocused`.
> 
> Hardens `AgentEngine.stopAgent` by adding **CLI-specific graceful stop key sequences** (Claude Ctrl+C burst; Codex Escape then Ctrl+C), retrying with delays, and verifying success by detecting a shell prompt; it now throws if the agent is still running instead of silently proceeding. Tests are expanded/adjusted to cover workspace focus/restore, new stop behavior, and updated mock `readScreen` expectations in quality/kill-related flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d58ee1fb0cb7e009edf9fcb3b5ef5ebf19b166d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-focus unfocused workspaces on surface writes and harden graceful agent stop flow
> - Adds workspace focus management to all surface write operations (`send_input`, `send_command`, `send_key`): before writing, the server checks if the target surface is in an unfocused workspace, temporarily switches to it, then restores the original workspace after delivery.
> - Background deliveries in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/85/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) store focus/restore metadata on the `DeliveryRecord` and apply the workspace switch during chunk delivery.
> - Reworks `AgentEngine.stopAgent` in [`agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/85/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to retry graceful stop up to 3 times (75ms apart), sending CLI-specific key sequences (5× Ctrl+C for Claude, Escape then Ctrl+C for Codex) and verifying a shell prompt appears before marking the agent stopped.
> - Risk: `stopAgent` now throws if the agent is still running after all retry attempts rather than silently continuing, and `user_killed` is only set after stop is confirmed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d58ee1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->