### PR TITLE
fix(send): allow_busy opt-in for send_to / send_to_agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 bun.lock
+docs.local/

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,10 +133,7 @@ function okFormatted(
   };
 }
 
-function err(
-  error: unknown,
-  extra: Record<string, unknown> = {},
-): ToolReturn {
+function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
   const message = error instanceof Error ? error.message : String(error);
   const payload = { ok: false, error: message, ...extra };
   return {
@@ -189,8 +186,7 @@ function summarizeRemoteState(remoteValue: unknown): ListSurfacesRemoteState {
     remote.has_identity_file === true ||
     (typeof remote.destination === "string" && remote.destination.length > 0) ||
     (remote.port !== null && remote.port !== undefined) ||
-    (remote.local_proxy_port !== null &&
-      remote.local_proxy_port !== undefined);
+    (remote.local_proxy_port !== null && remote.local_proxy_port !== undefined);
 
   if (!hasRemoteHints && (state === undefined || state === "disconnected")) {
     return "local";
@@ -709,7 +705,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .boolean()
         .optional()
         .default(false)
-        .describe("Return the current full schema instead of the condensed default"),
+        .describe(
+          "Return the current full schema instead of the condensed default",
+        ),
       include_screen_preview: z
         .boolean()
         .optional()
@@ -1130,7 +1128,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     "Atomically send a command and press return on the same surface. Prefer this over separate send_input + send_key calls when launching or resuming agents.",
     {
       surface: z.string().describe("Target surface ref"),
-      command: z.string().describe("Command text to send before pressing return"),
+      command: z
+        .string()
+        .describe("Command text to send before pressing return"),
       workspace: z.string().optional().describe("Target workspace ref"),
     },
     ANNOTATIONS.mutating,
@@ -1630,39 +1630,49 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       });
     };
-    const engine = new AgentEngine(stateMgr, registry, {
-      log: (message, eventOpts) => client.log(message, eventOpts),
-      setStatus: (key, value, statusOpts) =>
-        client.setStatus(key, value, statusOpts),
-      clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
-      readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
-      send: (surface, text, sendOpts) =>
-        withSurfaceWrite(surface, () => client.send(surface, text, sendOpts)),
-      sendKey: (surface, key, keyOpts) =>
-        withSurfaceWrite(surface, () => client.sendKey(surface, key, keyOpts)),
-      setProgress: (value, progressOpts) =>
-        client.setProgress(value, progressOpts),
-      newSplit: (direction, splitOpts) => client.newSplit(direction, splitOpts),
-      newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
-      listPanes: (paneOpts) => client.listPanes(paneOpts),
-      listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
-      notifyLifecycleEvent,
-    }, {
-      spawnPreflight:
-        opts?.spawnPreflight ??
-        (opts?.disableSpawnPreflight ? async () => {} : undefined),
-    });
+    const engine = new AgentEngine(
+      stateMgr,
+      registry,
+      {
+        log: (message, eventOpts) => client.log(message, eventOpts),
+        setStatus: (key, value, statusOpts) =>
+          client.setStatus(key, value, statusOpts),
+        clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
+        readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
+        send: (surface, text, sendOpts) =>
+          withSurfaceWrite(surface, () => client.send(surface, text, sendOpts)),
+        sendKey: (surface, key, keyOpts) =>
+          withSurfaceWrite(surface, () =>
+            client.sendKey(surface, key, keyOpts),
+          ),
+        setProgress: (value, progressOpts) =>
+          client.setProgress(value, progressOpts),
+        newSplit: (direction, splitOpts) =>
+          client.newSplit(direction, splitOpts),
+        newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
+        listPanes: (paneOpts) => client.listPanes(paneOpts),
+        listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
+        notifyLifecycleEvent,
+      },
+      {
+        spawnPreflight:
+          opts?.spawnPreflight ??
+          (opts?.disableSpawnPreflight ? async () => {} : undefined),
+      },
+    );
 
     const deliverAgentInput = async (args: {
       agent_id: string;
       text: string;
       press_enter: boolean;
+      allow_busy?: boolean;
     }) => {
       const route = engine.resolveAgentRoute(args.agent_id);
-      if (!INTERACTIVE_AGENT_STATES.has(route.state)) {
+      if (!args.allow_busy && !INTERACTIVE_AGENT_STATES.has(route.state)) {
         throw new Error(
           `Agent "${args.agent_id}" is not in an interactive state (current: ${route.state}). ` +
-            `Must be in: ${[...INTERACTIVE_AGENT_STATES].join(", ")}`,
+            `Must be in: ${[...INTERACTIVE_AGENT_STATES].join(", ")}. ` +
+            `Pass allow_busy: true to bypass this gate and deliver raw keystrokes regardless of state.`,
         );
       }
 
@@ -1912,7 +1922,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async () => {
         try {
-          const beforeIds = new Set(registry.list().map((agent) => agent.agent_id));
+          const beforeIds = new Set(
+            registry.list().map((agent) => agent.agent_id),
+          );
           discovery.invalidate();
           const after = await registry.listMerged(discovery, { force: true });
           const afterIds = new Set(after.map((agent) => agent.agent_id));
@@ -1974,6 +1986,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default(true)
           .describe("Press enter after sending text"),
+        allow_busy: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior). Use to interject while an agent is working — e.g., to cancel, steer, or stack an instruction.",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
@@ -1982,6 +2001,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             agent_id: args.agent_id,
             text: args.text,
             press_enter: args.press_enter,
+            allow_busy: args.allow_busy,
           });
           const data = { agent_id: args.agent_id };
           return okFormatted(formatOk("send_to", data), data);
@@ -2003,6 +2023,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default(true)
           .describe("Press enter after sending text"),
+        allow_busy: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior).",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
@@ -2011,6 +2038,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             agent_id: args.agent_id,
             text: args.text,
             press_enter: args.press_enter,
+            allow_busy: args.allow_busy,
           });
           const data = { agent_id: args.agent_id };
           return okFormatted(formatOk("send_to_agent", data), data);
@@ -2331,7 +2359,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         try {
           const merged = await registry.listMerged(discovery);
           const agents = args.parent_agent_id
-            ? merged.filter((agent) => agent.parent_agent_id === args.parent_agent_id)
+            ? merged.filter(
+                (agent) => agent.parent_agent_id === args.parent_agent_id,
+              )
             : merged.filter((agent) => agent.parent_agent_id === null);
 
           const SCREEN_TIMEOUT = 3000;

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -335,6 +335,124 @@ describe("agent lifecycle tool handlers", () => {
     expect(result.content[0].text).toMatch(/not in an interactive state/);
   });
 
+  it("send_to with allow_busy=true delivers to agents in working state", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "working" });
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "interject while working",
+        press_enter: true,
+        allow_busy: true,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const sendCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send"),
+    );
+    const deliveredText = sendCalls.map(([, args]) => args.at(-1)).join("");
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(agentId);
+    expect(deliveredText).toBe("interject while working");
+  });
+
+  it("send_to without allow_busy still rejects working agents (backwards compat)", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "working" });
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: "hello", press_enter: true },
+      {} as any,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not in an interactive state/);
+  });
+
+  it("send_to_agent with allow_busy=true delivers to agents in working state", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to_agent"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "working" });
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "force deliver",
+        press_enter: true,
+        allow_busy: true,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(agentId);
+  });
+
   it("send_to sanitizes and chunks delivery through the agent surface", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -359,8 +477,7 @@ describe("agent lifecycle tool handlers", () => {
     registry.set(agentId, { ...agent, state: "ready" });
     mockExec.mockClear();
 
-    const rawText =
-      `${"a".repeat(510)}\x1b[31mHELLO\x1b[0m\x07${"b".repeat(10)}`;
+    const rawText = `${"a".repeat(510)}\x1b[31mHELLO\x1b[0m\x07${"b".repeat(10)}`;
     const sanitizedText = `${"a".repeat(510)}HELLO${"b".repeat(10)}`;
 
     const result = await sendTo.handler(


### PR DESCRIPTION
## Summary

Adds `allow_busy: boolean` opt-in to `send_to` and `send_to_agent` MCP endpoints. When `true`, bypasses the `not in an interactive state` gate in `deliverAgentInput` and delivers raw keystrokes regardless of agent state (matches `send_input` behavior). Default unchanged: omitting `allow_busy` (or passing `false`) preserves the current gate.

Lets orchestrators interject while an agent is working — cancel, steer, or stack an instruction — without falling back to `send_input`.

## Motivation

Surfaced during session mining on 2026-04-23. When an orchestrator tries `send_to_agent` to an agent in `state=working`, the call rejects with `not in an interactive state`. There's no clean way to stack an instruction without waiting for idle or falling back to `send_input` (which has its own quirks). Inconsistent with `send_input`, which already delivers raw keystrokes regardless of agent state.

## Design choice

Raw delivery via opt-in flag was preferred over an auto-queue for three reasons:
- **minimal API surface change** — single boolean parameter, backwards-compatible default.
- **matches `send_input` semantics** — consistent mental model across the two entrypoints.
- **no hidden ordering guarantees** — callers that *want* FIFO queueing can build it on top; this primitive stays honest.

The error message now points callers at the opt-in so the next time the gate fires, the remediation is self-describing.

## TDD evidence

- Failing-test commit: `53da1b8` (test: failing case for send_to allow_busy opt-in)
- Fix commit: `a654a44` (fix(send): allow_busy opt-in…)
- Ignore commit: `b872377` (chore: ignore docs.local/) — unrelated housekeeping, happy to drop if noisy.

## Formatter note

The `src/server.ts` diff includes a handful of prettier-style reflows (`err` signature one-liner, `AgentEngine` constructor call, a few `.describe()` wraps). These came along automatically from the global post-edit formatter; they're not intentional scope creep and don't change behavior. Happy to isolate into a prior `chore:` commit if the review prefers.

## Test plan

- [x] `bun run test` — 444/448 pass. The 4 remaining failures are in `tests/landing-polish.test.ts`, which is **untracked** (not part of this branch) and pre-existing on `main`. Unrelated to this change.
- [x] `bun run typecheck` — clean.
- [x] New test `send_to with allow_busy=true delivers to agents in working state` passes.
- [x] New test `send_to_agent with allow_busy=true delivers to agents in working state` passes.
- [x] New test `send_to without allow_busy still rejects working agents (backwards compat)` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in path to bypass agent-state gating and send keystrokes to busy/working agents, which could change orchestrator behavior if misused; defaults remain unchanged and coverage is added via new tests.
> 
> **Overview**
> Enables orchestrators to *optionally* interject input while an agent is busy by adding `allow_busy` (default `false`) to the `send_to` and `send_to_agent` tools.
> 
> When `allow_busy: true`, `deliverAgentInput` bypasses the interactive-state check and the rejection error message now points callers to this flag; new integration tests cover both the working-state delivery and backwards-compatible rejection behavior. Also ignores `docs.local/` and includes a few formatter-only reflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8723776afc1bc8354e60a45def2a4915edae82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `allow_busy` parameter to agent message delivery tools, enabling messages to be sent to agents in non-interactive/busy states when `allow_busy: true` is specified.

* **Tests**
  * Added comprehensive integration tests validating agent message delivery behavior with the new `allow_busy` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `allow_busy` opt-in to `send_to` and `send_to_agent` tools to bypass interactive state check
> By default, `send_to` and `send_to_agent` reject delivery when an agent is not in an interactive state. This adds an optional `allow_busy` boolean parameter (default `false`) to both tools that skips this gate, allowing text to be delivered to agents in any state (e.g. `working`). The check is enforced in `deliverAgentInput` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/86/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), which now surfaces the `allow_busy` override in its error message when the gate fires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b872377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->