### PR TITLE
security: gitignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 dist/
 bun.lock
 docs.local/
+
+# Local MCP config — may contain secrets (cyberMaster H4 2026-04-23)
+.mcp.json
+.mcp.json.local


### PR DESCRIPTION
## What
Add `.mcp.json` and `.mcp.json.local` to `.gitignore`.

## Why
cyberMaster OSS audit 2026-04-23 (MASTER-findings H4) found that the local `.mcp.json` at the repo root contains a live `EXA_API_KEY`. The current `.gitignore` only covers `node_modules/`, `dist/`, `bun.lock`, `docs.local/` — a routine `git add -A` from a contributor or repo-hygiene agent would commit the key.

## Verification
- [x] `git check-ignore .mcp.json` prints `.mcp.json`
- [x] `git status` does not surface `.mcp.json`
- [ ] EXA key rotated at dashboard.exa.ai (tracked separately, Etan action)

🤖 cyberCodex p1 — spawned by cyberMaster s:40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore` entries to prevent accidentally committing local config files that may contain secrets.
> 
> **Overview**
> Prevents accidental commits of local MCP configuration by adding `.mcp.json` and `.mcp.json.local` to `.gitignore`, with a comment noting these files may contain secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405ca1924d87719b4bf5be718582945f15451951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.mcp.json` to `.gitignore` to prevent accidental secret exposure
> MCP config files (`.mcp.json`, `.mcp.json.local`) may contain secrets and should not be committed. Adds ignore patterns for both variants to [.gitignore](.gitignore).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 405ca19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->