### PR TITLE
fix: verify enter delivery and emit telemetry

### DIFF
--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -114,6 +114,26 @@ export interface StateTransition {
   error: string | null;
 }
 
+export type DeliveryEventType =
+  | "send_command"
+  | "send_to"
+  | "send_to_agent"
+  | "interact"
+  | "press_enter";
+
+export interface DeliveryTelemetryEvent {
+  ts: string;
+  event_type: DeliveryEventType;
+  source_agent: string | null;
+  target_surface: string;
+  bytes: number;
+  press_enter: boolean | null;
+  submit_verified: boolean | null;
+  retry_count: number;
+}
+
+export type EventLogEntry = StateTransition | DeliveryTelemetryEvent;
+
 export interface WaitResult {
   matched: boolean;
   state: AgentState;

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -1,12 +1,16 @@
 /**
- * Append-only event log for agent state transitions.
+ * Append-only event log for agent state transitions and delivery telemetry.
  * Format: JSONL (one JSON object per line).
  * Path: {baseDir}/events.jsonl
  */
 
 import { appendFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import type { StateTransition } from "./agent-types.js";
+import type {
+  DeliveryTelemetryEvent,
+  EventLogEntry,
+  StateTransition,
+} from "./agent-types.js";
 
 export class EventLog {
   private filePath: string;
@@ -17,20 +21,34 @@ export class EventLog {
   }
 
   append(transition: StateTransition): void {
-    const line = JSON.stringify(transition) + "\n";
-    appendFileSync(this.filePath, line, "utf-8");
+    this.appendEntry(transition);
+  }
+
+  appendDelivery(event: DeliveryTelemetryEvent): void {
+    this.appendEntry(event);
   }
 
   readAll(): StateTransition[] {
+    return this.readEntries().filter(
+      (entry): entry is StateTransition => "agent_id" in entry,
+    );
+  }
+
+  readEntries(): EventLogEntry[] {
     if (!existsSync(this.filePath)) return [];
     const content = readFileSync(this.filePath, "utf-8").trim();
     if (!content) return [];
     return content
       .split("\n")
-      .map((line) => JSON.parse(line) as StateTransition);
+      .map((line) => JSON.parse(line) as EventLogEntry);
   }
 
   readForAgent(agentId: string): StateTransition[] {
-    return this.readAll().filter((t) => t.agent_id === agentId);
+    return this.readAll().filter((entry) => entry.agent_id === agentId);
+  }
+
+  private appendEntry(entry: EventLogEntry): void {
+    const line = JSON.stringify(entry) + "\n";
+    appendFileSync(this.filePath, line, "utf-8");
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
@@ -20,7 +21,12 @@ import {
 } from "./agent-engine.js";
 import { AgentDiscovery } from "./agent-discovery.js";
 import { toPublicAgent } from "./agent-facade.js";
-import type { AgentRecord, AgentState } from "./agent-types.js";
+import type {
+  AgentRecord,
+  AgentState,
+  DeliveryEventType,
+  DeliveryTelemetryEvent,
+} from "./agent-types.js";
 import {
   formatListSurfaces,
   formatReadScreen,
@@ -81,6 +87,10 @@ const SEND_INPUT_CHUNK_THRESHOLD = 500;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
+const SEND_INPUT_ENTER_DELAY_MS = 50;
+const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
+const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
+const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 
 type DeliveryStatus = "delivering" | "delivered" | "failed";
@@ -265,6 +275,39 @@ function isRetryableDeliveryError(error: unknown): boolean {
   return /socket|connection_|connection closed|timeout/i.test(message);
 }
 
+
+function formatToolValidationError(toolName: string, error: z.ZodError): string {
+  const details = error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "input";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+  return `${toolName} invalid arguments: ${details}`;
+}
+
+function isSubmitVerifiedStatus(
+  status: ParsedScreenResult["status"] | null | undefined,
+): boolean {
+  return status === "working" || status === "thinking" || status === "done";
+}
+
+function screenShowsPendingInput(screenText: string, submittedText: string): boolean {
+  const trimmed = submittedText.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const tail = trimmed.slice(-Math.min(80, trimmed.length));
+  return screenText.includes(tail);
+}
+
+function computeEnterDelayMs(bytes: number, chunkCount: number): number {
+  const extraChunks = Math.max(0, chunkCount - 1);
+  const longPayloadPenalty = bytes >= SEND_INPUT_CHUNK_THRESHOLD ? 100 : 0;
+  return Math.min(250, SEND_INPUT_ENTER_DELAY_MS + extraChunks * 50 + longPayloadPenalty);
+}
+
 function pickLatestSurfaceModel(
   stateMgr: StateManager,
   surfaceRef: string,
@@ -381,6 +424,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const stateDir =
     opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
   const stateMgr = new StateManager(stateDir);
+  const eventLog = stateMgr.getEventLog();
   const deliveries = new Map<string, DeliveryRecord>();
   const latestDeliveryBySurface = new Map<string, string>();
   const activeDeliveryBySurface = new Map<string, string>();
@@ -571,28 +615,130 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
-  const applySendInputPostActions = async (opts: {
+  const appendDeliveryEvent = (event: Omit<DeliveryTelemetryEvent, "ts">) => {
+    eventLog.appendDelivery({
+      ts: new Date().toISOString(),
+      ...event,
+    });
+  };
+
+  const logUnverifiedSubmit = (opts: {
+    source_event: DeliveryEventType;
+    source_agent?: string | null;
+    surface: string;
+    bytes: number;
+  }) => {
+    const filePath = join(
+      "/tmp",
+      `cmux-enter-fail-${new Date().toISOString().slice(0, 10)}.log`,
+    );
+    appendFileSync(
+      filePath,
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        event_type: opts.source_event,
+        source_agent: opts.source_agent ?? null,
+        target_surface: opts.surface,
+        bytes: opts.bytes,
+      }) + "\n",
+      "utf-8",
+    );
+  };
+
+  const readParsedSurface = async (
+    surface: string,
+    workspace?: string,
+  ): Promise<{ text: string; parsed: ParsedScreenResult } | null> => {
+    try {
+      const screen = await client.readScreen(surface, {
+        ...(workspace ? { workspace } : {}),
+        lines: 30,
+      });
+      const text = typeof screen === "string" ? screen : (screen.text ?? "");
+      const parsed = enrichParsedScreen(
+        parseScreen(text),
+        text,
+        pickLatestSurfaceModel(stateMgr, surface),
+      );
+      return { text, parsed };
+    } catch {
+      return null;
+    }
+  };
+
+  const maybeRenameTask = async (opts: {
     surface: string;
     workspace?: string;
-    press_enter: boolean;
     rename_to_task?: string;
   }) => {
-    if (opts.press_enter) {
-      await delay(50);
-      await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+    if (!opts.rename_to_task) {
+      return;
     }
 
-    if (opts.rename_to_task) {
-      const surfaces = await client.listPaneSurfaces({
-        workspace: opts.workspace,
-      });
-      const surface = surfaces.surfaces.find((s) => s.ref === opts.surface);
-      const currentTitle = surface?.title ?? "";
-      const newTitle = replaceTaskSuffix(currentTitle, opts.rename_to_task);
-      await client.renameTab(opts.surface, newTitle, {
-        workspace: opts.workspace,
-      });
+    const surfaces = await client.listPaneSurfaces({
+      workspace: opts.workspace,
+    });
+    const surface = surfaces.surfaces.find((s) => s.ref === opts.surface);
+    const currentTitle = surface?.title ?? "";
+    const newTitle = replaceTaskSuffix(currentTitle, opts.rename_to_task);
+    await client.renameTab(opts.surface, newTitle, {
+      workspace: opts.workspace,
+    });
+  };
+
+  const verifySubmitAfterEnter = async (opts: {
+    surface: string;
+    workspace?: string;
+    text: string;
+    bytes: number;
+    source_event: DeliveryEventType;
+    source_agent?: string | null;
+    verify_submit: boolean;
+  }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
+    if (!opts.verify_submit) {
+      return { submit_verified: null, retry_count: 0 };
     }
+
+    const startedAt = Date.now();
+    let retried = false;
+    let retryCount = 0;
+
+    while (Date.now() - startedAt < SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS) {
+      const snapshot = await readParsedSurface(opts.surface, opts.workspace);
+      if (!snapshot) {
+        return { submit_verified: null, retry_count: retryCount };
+      }
+
+      if (snapshot.parsed.agent_type === "unknown" || !snapshot.text.trim()) {
+        return { submit_verified: null, retry_count: retryCount };
+      }
+
+      if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
+        return { submit_verified: true, retry_count: retryCount };
+      }
+
+      if (!retried && screenShowsPendingInput(snapshot.text, opts.text)) {
+        await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
+        await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+        retryCount += 1;
+        appendDeliveryEvent({
+          event_type: "press_enter",
+          source_agent: opts.source_agent ?? null,
+          target_surface: opts.surface,
+          bytes: opts.bytes,
+          press_enter: true,
+          submit_verified: null,
+          retry_count: retryCount,
+        });
+        retried = true;
+        continue;
+      }
+
+      await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
+    }
+
+    logUnverifiedSubmit(opts);
+    return { submit_verified: false, retry_count: retryCount };
   };
 
   const deliverInputChunks = async (opts: {
@@ -604,7 +750,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     press_enter: boolean;
     rename_to_task?: string;
     onChunkDelivered?: (sentChunks: number) => void;
-  }) => {
+    source_event?: DeliveryEventType;
+    source_agent?: string | null;
+    verify_submit?: boolean;
+  }): Promise<{
+    bytes: number;
+    retry_count: number;
+    submit_verified: boolean | null;
+  }> => {
     for (const [index, chunk] of opts.chunks.entries()) {
       await sendChunkWithRetry(
         opts.surface,
@@ -621,12 +774,61 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
     }
 
-    await applySendInputPostActions({
+    const bytes = opts.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    let submit_verified: boolean | null = null;
+    let retry_count = 0;
+
+    if (opts.press_enter) {
+      await delay(computeEnterDelayMs(bytes, opts.chunks.length));
+      await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+      appendDeliveryEvent({
+        event_type: "press_enter",
+        source_agent: opts.source_agent ?? null,
+        target_surface: opts.surface,
+        bytes,
+        press_enter: true,
+        submit_verified: null,
+        retry_count,
+      });
+
+      const verification = await verifySubmitAfterEnter({
+        surface: opts.surface,
+        workspace: opts.workspace,
+        text: opts.chunks.join(""),
+        bytes,
+        source_event: opts.source_event ?? "send_command",
+        source_agent: opts.source_agent,
+        verify_submit: opts.verify_submit ?? false,
+      });
+      submit_verified = verification.submit_verified;
+      retry_count = verification.retry_count;
+    }
+
+    await maybeRenameTask({
       surface: opts.surface,
       workspace: opts.workspace,
-      press_enter: opts.press_enter,
       rename_to_task: opts.rename_to_task,
     });
+
+    if (opts.source_event) {
+      appendDeliveryEvent({
+        event_type: opts.source_event,
+        source_agent: opts.source_agent ?? null,
+        target_surface: opts.surface,
+        bytes,
+        press_enter: opts.press_enter,
+        submit_verified,
+        retry_count,
+      });
+    }
+
+    if (submit_verified === false) {
+      throw new Error(
+        `Enter submit could not be verified for ${opts.surface} within ${SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS}ms`,
+      );
+    }
+
+    return { bytes, retry_count, submit_verified };
   };
 
   const startBackgroundDelivery = (record: DeliveryRecord) => {
@@ -1142,18 +1344,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
             : [sanitizedCommand];
 
-        await withSurfaceWrite(args.surface, async () => {
-          await deliverInputChunks({
+        const delivery = await withSurfaceWrite(args.surface, async () =>
+          deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
             chunks,
             chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: true,
-          });
-        });
+            source_event: "send_command",
+            verify_submit:
+              sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD,
+          }),
+        );
 
-        const data = { surface: args.surface, command: sanitizedCommand };
+        const data = {
+          surface: args.surface,
+          command: sanitizedCommand,
+          retry_count: delivery.retry_count,
+          submit_verified: delivery.submit_verified,
+        };
         return okFormatted(formatOk("send_command", data), data);
       } catch (e) {
         if (e instanceof DeliveryError) {
@@ -1666,6 +1876,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       text: string;
       press_enter: boolean;
       allow_busy?: boolean;
+      source_event: DeliveryEventType;
     }) => {
       const route = engine.resolveAgentRoute(args.agent_id);
       if (!args.allow_busy && !INTERACTIVE_AGENT_STATES.has(route.state)) {
@@ -1682,15 +1893,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
           : [sanitizedText];
 
-      await withSurfaceWrite(route.surface_id, async () => {
-        await deliverInputChunks({
+      return withSurfaceWrite(route.surface_id, async () =>
+        deliverInputChunks({
           surface: route.surface_id,
           chunks,
           chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
           chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
           press_enter: args.press_enter,
-        });
-      });
+          source_event: args.source_event,
+          source_agent: args.agent_id,
+          verify_submit:
+            args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
+        }),
+      );
     };
 
     // Reconstitute registry from disk on startup (async, best-effort).
@@ -1995,15 +2210,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ),
       },
       ANNOTATIONS.mutating,
-      async (args) => {
+      async (rawArgs) => {
         try {
-          await deliverAgentInput({
+          const parsedArgs = z
+            .object({
+              agent_id: z.string(),
+              text: z.string(),
+              press_enter: z.boolean().optional().default(true),
+              allow_busy: z.boolean().optional().default(false),
+            })
+            .safeParse(rawArgs);
+          if (!parsedArgs.success) {
+            return err(
+              new Error(formatToolValidationError("send_to", parsedArgs.error)),
+            );
+          }
+
+          const args = parsedArgs.data;
+          const delivery = await deliverAgentInput({
             agent_id: args.agent_id,
             text: args.text,
             press_enter: args.press_enter,
             allow_busy: args.allow_busy,
+            source_event: "send_to",
           });
-          const data = { agent_id: args.agent_id };
+          const data = {
+            agent_id: args.agent_id,
+            retry_count: delivery.retry_count,
+            submit_verified: delivery.submit_verified,
+          };
           return okFormatted(formatOk("send_to", data), data);
         } catch (e) {
           return err(e);
@@ -2032,15 +2267,37 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ),
       },
       ANNOTATIONS.mutating,
-      async (args) => {
+      async (rawArgs) => {
         try {
-          await deliverAgentInput({
+          const parsedArgs = z
+            .object({
+              agent_id: z.string(),
+              text: z.string(),
+              press_enter: z.boolean().optional().default(true),
+              allow_busy: z.boolean().optional().default(false),
+            })
+            .safeParse(rawArgs);
+          if (!parsedArgs.success) {
+            return err(
+              new Error(
+                formatToolValidationError("send_to_agent", parsedArgs.error),
+              ),
+            );
+          }
+
+          const args = parsedArgs.data;
+          const delivery = await deliverAgentInput({
             agent_id: args.agent_id,
             text: args.text,
             press_enter: args.press_enter,
             allow_busy: args.allow_busy,
+            source_event: "send_to_agent",
           });
-          const data = { agent_id: args.agent_id };
+          const data = {
+            agent_id: args.agent_id,
+            retry_count: delivery.retry_count,
+            submit_verified: delivery.submit_verified,
+          };
           return okFormatted(formatOk("send_to_agent", data), data);
         } catch (e) {
           return err(e);
@@ -2195,8 +2452,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Dispatch action
           switch (args.action) {
             case "send": {
-              await engine.sendToAgent(args.agent, args.text!, true);
-              const d = { agent_id: args.agent, action: "send" };
+              const delivery = await deliverAgentInput({
+                agent_id: args.agent,
+                text: args.text!,
+                press_enter: true,
+                source_event: "interact",
+              });
+              const d = {
+                agent_id: args.agent,
+                action: "send",
+                retry_count: delivery.retry_count,
+                submit_verified: delivery.submit_verified,
+              };
               return okFormatted(formatOk("interact:send", d), d);
             }
             case "interrupt": {
@@ -2208,11 +2475,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
             case "model": {
               const modelCmd = `/model ${args.model}`;
-              await engine.sendToAgent(args.agent, modelCmd, true);
+              const delivery = await deliverAgentInput({
+                agent_id: args.agent,
+                text: modelCmd,
+                press_enter: true,
+                source_event: "interact",
+              });
               const d = {
                 agent_id: args.agent,
                 action: "model",
                 model: args.model,
+                retry_count: delivery.retry_count,
+                submit_verified: delivery.submit_verified,
               };
               return okFormatted(formatOk("interact:model", d), d);
             }
@@ -2220,20 +2494,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               const resumeCmd = args.session_id
                 ? `/resume ${args.session_id}`
                 : "/resume";
-              await engine.sendToAgent(args.agent, resumeCmd, true);
+              const delivery = await deliverAgentInput({
+                agent_id: args.agent,
+                text: resumeCmd,
+                press_enter: true,
+                source_event: "interact",
+              });
               const d = {
                 agent_id: args.agent,
                 action: "resume",
                 session_id: args.session_id,
+                retry_count: delivery.retry_count,
+                submit_verified: delivery.submit_verified,
               };
               return okFormatted(formatOk("interact:resume", d), d);
             }
             case "skill": {
-              await engine.sendToAgent(args.agent, args.command!, true);
+              const delivery = await deliverAgentInput({
+                agent_id: args.agent,
+                text: args.command!,
+                press_enter: true,
+                source_event: "interact",
+              });
               const d = {
                 agent_id: args.agent,
                 action: "skill",
                 command: args.command,
+                retry_count: delivery.retry_count,
+                submit_verified: delivery.submit_verified,
               };
               return okFormatted(formatOk("interact:skill", d), d);
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
-import { appendFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
@@ -92,6 +91,12 @@ const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
 const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
+const SendToArgsSchema = z.object({
+  agent_id: z.string(),
+  text: z.string(),
+  press_enter: z.boolean().optional().default(true),
+  allow_busy: z.boolean().optional().default(false),
+});
 
 type DeliveryStatus = "delivering" | "delivered" | "failed";
 
@@ -622,29 +627,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
   };
 
-  const logUnverifiedSubmit = (opts: {
-    source_event: DeliveryEventType;
-    source_agent?: string | null;
-    surface: string;
-    bytes: number;
-  }) => {
-    const filePath = join(
-      "/tmp",
-      `cmux-enter-fail-${new Date().toISOString().slice(0, 10)}.log`,
-    );
-    appendFileSync(
-      filePath,
-      JSON.stringify({
-        ts: new Date().toISOString(),
-        event_type: opts.source_event,
-        source_agent: opts.source_agent ?? null,
-        target_surface: opts.surface,
-        bytes: opts.bytes,
-      }) + "\n",
-      "utf-8",
-    );
-  };
-
   const readParsedSurface = async (
     surface: string,
     workspace?: string,
@@ -736,8 +718,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
-
-    logUnverifiedSubmit(opts);
     return { submit_verified: false, retry_count: retryCount };
   };
 
@@ -774,7 +754,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
     }
 
-    const bytes = opts.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const bytes = opts.chunks.reduce(
+      (sum, chunk) => sum + Buffer.byteLength(chunk, "utf-8"),
+      0,
+    );
     let submit_verified: boolean | null = null;
     let retry_count = 0;
 
@@ -1903,7 +1886,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           source_event: args.source_event,
           source_agent: args.agent_id,
           verify_submit:
-            args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
+            args.press_enter &&
+            INTERACTIVE_AGENT_STATES.has(route.state) &&
+            sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD,
         }),
       );
     };
@@ -2194,32 +2179,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       "send_to",
       "Send text input to an agent by `agent_id`. Resolves the backing surface internally so clients do not need pane or surface references.",
       {
-        agent_id: z.string().describe("Agent ID"),
-        text: z.string().describe("Text to send"),
-        press_enter: z
-          .boolean()
-          .optional()
-          .default(true)
-          .describe("Press enter after sending text"),
-        allow_busy: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe(
-            "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior). Use to interject while an agent is working — e.g., to cancel, steer, or stack an instruction.",
-          ),
+        ...SendToArgsSchema.shape,
+        press_enter: SendToArgsSchema.shape.press_enter.describe(
+          "Press enter after sending text",
+        ),
+        allow_busy: SendToArgsSchema.shape.allow_busy.describe(
+          "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior). Use to interject while an agent is working — e.g., to cancel, steer, or stack an instruction.",
+        ),
       },
       ANNOTATIONS.mutating,
       async (rawArgs) => {
         try {
-          const parsedArgs = z
-            .object({
-              agent_id: z.string(),
-              text: z.string(),
-              press_enter: z.boolean().optional().default(true),
-              allow_busy: z.boolean().optional().default(false),
-            })
-            .safeParse(rawArgs);
+          const parsedArgs = SendToArgsSchema.safeParse(rawArgs);
           if (!parsedArgs.success) {
             return err(
               new Error(formatToolValidationError("send_to", parsedArgs.error)),
@@ -2251,32 +2222,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       "send_to_agent",
       "Deprecated for client integrations: use `send_to` instead. Internal/advanced path for sending text input to an agent in `ready` or `idle` state.",
       {
-        agent_id: z.string().describe("Agent ID"),
-        text: z.string().describe("Text to send"),
-        press_enter: z
-          .boolean()
-          .optional()
-          .default(true)
-          .describe("Press enter after sending text"),
-        allow_busy: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe(
-            "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior).",
-          ),
+        ...SendToArgsSchema.shape,
+        press_enter: SendToArgsSchema.shape.press_enter.describe(
+          "Press enter after sending text",
+        ),
+        allow_busy: SendToArgsSchema.shape.allow_busy.describe(
+          "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior).",
+        ),
       },
       ANNOTATIONS.mutating,
       async (rawArgs) => {
         try {
-          const parsedArgs = z
-            .object({
-              agent_id: z.string(),
-              text: z.string(),
-              press_enter: z.boolean().optional().default(true),
-              allow_busy: z.boolean().optional().default(false),
-            })
-            .safeParse(rawArgs);
+          const parsedArgs = SendToArgsSchema.safeParse(rawArgs);
           if (!parsedArgs.success) {
             return err(
               new Error(

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -49,6 +49,7 @@ class FakeClaudeSurfaceClient {
   readonly sendKeyCalls: string[] = [];
   readonly renameTabCalls: string[] = [];
   requiredReturns = 2;
+  completionMode: "idle" | "working" = "working";
   private pendingText = "";
   private returnCount = 0;
   private mode: "idle" | "working" = "idle";
@@ -132,7 +133,7 @@ class FakeClaudeSurfaceClient {
     this.returnCount += 1;
     if (this.returnCount >= this.requiredReturns) {
       this.pendingText = "";
-      this.mode = "working";
+      this.mode = this.completionMode;
       return;
     }
 
@@ -280,6 +281,28 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
+  it("does not verify short send_to submissions that settle back to idle", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "ping",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter((event) => event.event_type === "send_to");
+
+    expect(parsed.ok).toBe(true);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBe(null);
+    expect(events[0]?.retry_count).toBe(0);
+  });
+
   it("retries Enter for send_command on a Claude surface", async () => {
     const client = new FakeClaudeSurfaceClient();
     server = createReliabilityServer(client);
@@ -361,5 +384,24 @@ describe("enter reliability", () => {
           event.submit_verified === true && event.retry_count === 1,
       ),
     ).toBe(true);
+  });
+
+  it("records UTF-8 byte counts in delivery telemetry", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    server = createReliabilityServer(client);
+
+    const command = "🙂".repeat(200);
+    const result = await callTool(server, "send_command", {
+      surface: client.surface,
+      command,
+    });
+    const parsed = parseResult(result);
+    const event = readEventLog().find(
+      (entry) => entry.event_type === "send_command",
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(event?.bytes).toBe(Buffer.byteLength(command, "utf-8"));
   });
 });

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-enter-reliability-test");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  return tool.handler(args, {} as any);
+}
+
+function readEventLog(): Array<Record<string, unknown>> {
+  const filePath = join(TEST_DIR, "events.jsonl");
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  const raw = readFileSync(filePath, "utf-8").trim();
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+class FakeClaudeSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:agent";
+  readonly title = "brainlayerClaude";
+  readonly sendCalls: string[] = [];
+  readonly sendKeyCalls: string[] = [];
+  readonly renameTabCalls: string[] = [];
+  requiredReturns = 2;
+  private pendingText = "";
+  private returnCount = 0;
+  private mode: "idle" | "working" = "idle";
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    if (!this.pendingText) {
+      this.returnCount = 0;
+      this.mode = "idle";
+    }
+
+    this.sendCalls.push(text);
+    this.pendingText += text;
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    this.sendKeyCalls.push(key);
+    if (key !== "return") {
+      return;
+    }
+
+    if (!this.pendingText) {
+      return;
+    }
+
+    this.returnCount += 1;
+    if (this.returnCount >= this.requiredReturns) {
+      this.pendingText = "";
+      this.mode = "working";
+      return;
+    }
+
+    this.mode = "idle";
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    return {
+      surface,
+      text: this.renderScreen(),
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab(_surface: string, title: string) {
+    this.renameTabCalls.push(title);
+  }
+
+  private renderScreen(): string {
+    if (this.mode === "working") {
+      return "Claude Code\n✻ Working\n";
+    }
+
+    const tail = this.pendingText.slice(-160);
+    return `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
+  }
+}
+
+function createReliabilityServer(client: FakeClaudeSurfaceClient) {
+  return createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
+function registerAgent(server: any, overrides?: Partial<AgentRecord>): AgentRecord {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+
+  const now = "2026-04-24T12:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: "surface:agent",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "enter reliability test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+
+  stateMgr.writeState(record);
+  registry.set(record.agent_id, record);
+  return record;
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") {
+    engine.dispose();
+  }
+}
+
+describe("enter reliability", () => {
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("rejects string booleans on raw send_to handler calls", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "wake up",
+      press_enter: "true",
+      allow_busy: "false",
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/press_enter|allow_busy|boolean/i);
+  });
+
+  it("retries Enter for send_to when the first submit leaves Claude idle", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "x".repeat(2000),
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(parsed.ok).toBe(true);
+    expect(client.sendCalls.join("")).toHaveLength(2000);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      2,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_to" &&
+          event.submit_verified === true &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+    expect(
+      events.some((event) => event.event_type === "press_enter"),
+    ).toBe(true);
+  });
+
+  it("retries Enter for send_command on a Claude surface", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+
+    const result = await callTool(server, "send_command", {
+      surface: client.surface,
+      command: "y".repeat(2000),
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(parsed.ok).toBe(true);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      2,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_command" &&
+          event.submit_verified === true &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the verified send path for interact(action=send)", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "interact", {
+      agent: "agent-1",
+      action: "send",
+      text: "z".repeat(2000),
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(parsed.ok).toBe(true);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      2,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "interact" &&
+          event.submit_verified === true &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("verifies each back-to-back send_to instead of assuming the previous submit pattern holds", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "first\n".repeat(300),
+      press_enter: true,
+    });
+    await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "second\n".repeat(300),
+      press_enter: true,
+    });
+
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_to",
+    );
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      4,
+    );
+    expect(events).toHaveLength(2);
+    expect(
+      events.every(
+        (event) =>
+          event.submit_verified === true && event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated enter-reliability regression suite that reproduces the missing-submit path on long Claude sends
- validate raw `send_to` / `send_to_agent` handler inputs so string booleans fail loudly instead of slipping through direct handler calls
- route `send_to`, `send_to_agent`, `send_command`, and `interact` send paths through a verified delivery helper that adapts Enter timing, retries one recovery Enter when the buffer stays idle, and logs delivery telemetry to `events.jsonl`

## Test plan
- [x] `bun run test tests/enter-reliability.test.ts`
- [x] `bun run test tests/server.test.ts tests/server-agent-tools.test.ts tests/v2-interact-kill.test.ts`
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`

## Notes
- CodeRabbit CLI pre-commit review is currently rate-limited for this org, so I could not get a local CR pass before PR creation.
- I was not able to run the requested live Node-to-cmux integration test because the local cmux daemon is refusing child-process/socket connections from this environment (`Connection refused` from both `execFile("cmux", ...)` and direct socket probes). The automated regression coverage and full suite are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core input-delivery path to add post-Enter screen polling and a recovery Enter, and can now fail deliveries when submission can’t be verified, which may affect existing clients and timing-sensitive flows.
> 
> **Overview**
> Improves reliability of long text submissions by routing `send_command`, `send_to`, `send_to_agent`, and `interact` through a unified delivery helper that *adapts Enter timing*, polls the screen to confirm submission, and issues a one-time recovery Enter when pending input is detected.
> 
> Adds delivery telemetry (`DeliveryTelemetryEvent`) to `events.jsonl` (including UTF-8 byte counts, `retry_count`, and `submit_verified`) by extending `EventLog` to store mixed entry types, and tightens `send_to`/`send_to_agent` argument handling via `zod.safeParse` so invalid raw handler inputs (e.g., string booleans) error clearly. Also introduces a dedicated `enter-reliability` regression test suite covering retries, verification behavior, and telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7585ed8e533ecc04dc393c3ab197252e8420da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Enter submission verification and delivery telemetry to all text delivery tools
> - After pressing Enter, all text delivery paths (`send_command`, `send_to`, `send_to_agent`, `interact` send/model/resume/skill) now poll the target surface to verify the submission was accepted within a 2-second window.
> - If pending input is detected during polling, a recovery Enter is sent after a delay and `retry_count` is incremented; if verification conclusively fails, the delivery throws an error.
> - All deliveries append a `DeliveryTelemetryEvent` to the event log (bytes, `press_enter`, `submit_verified`, `retry_count`, source tool), tracked via a new `appendDelivery` method on [`EventLog`](https://github.com/EtanHey/cmuxlayer/pull/88/files#diff-f71f2b1c91cb65f4fd1d7f3cc9909e02b16fb843bc782cc439c31e0b8a6f3fd2).
> - Tool responses for all delivery tools now include `retry_count` and `submit_verified` fields; `send_to` and `send_to_agent` arguments are validated via a shared `SendToArgsSchema`.
> - Risk: deliveries for long inputs that fail submit verification now throw instead of silently succeeding, which is a breaking behavior change for callers that did not handle errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a7585e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Submit verification now automatically verifies Enter key presses and triggers recovery when pending input is detected
  * Delivery telemetry tracking captures retry counts and submission verification status for enhanced debugging
  * Input validation improved with clearer error reporting for send operations

* **Tests**
  * Added comprehensive reliability test suite validating command submission and automatic retry scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->