### PR TITLE
test: phase-4c cmuxlayer run_tests.sh

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+EXIT_STATUS=0
+FIXTURE_PATH="$(pwd)/tests/fixtures/race_condition_screen.vt"
+EXPECTED_RENDER="| Waveform: [|=--]"
+export FIXTURE_PATH
+export EXPECTED_RENDER
+
+node --input-type=module - <<'NODE'
+import { readFileSync } from "node:fs";
+import TransformTTY from "transform-tty";
+
+const fixturePath = process.env.FIXTURE_PATH;
+const expected = process.env.EXPECTED_RENDER ?? "";
+
+try {
+  const raw = readFileSync(fixturePath, "utf8");
+  const terminal = new TransformTTY({ rows: 8, columns: 120 });
+  terminal.write(raw);
+  const rendered = terminal.toString();
+
+  if (rendered !== expected) {
+    console.error(`Unexpected render result:\n${JSON.stringify(rendered)}`);
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+NODE
+
+if [ $? -ne 0 ]; then
+  ((EXIT_STATUS |= 1))
+fi
+
+if ! bun test tests/race-condition-vt-fixture.test.ts; then
+  ((EXIT_STATUS |= 2))
+fi
+
+if ! bun test; then
+  ((EXIT_STATUS |= 4))
+fi
+
+echo "run_tests.sh finished with exit status $EXIT_STATUS"
+
+if [ "$EXIT_STATUS" -ne 0 ]; then
+  exit "$EXIT_STATUS"
+fi


### PR DESCRIPTION
Phase 4c of ecosystem-regression-harness. Fixture + test verifying ANSI escape determinism on rapid send_input/send_key sequences. transform-tty used as vttest/vtclean substitute (not on npm).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone test runner script without changing application/runtime logic. Main risk is CI/local test behavior differences due to new Node/Bun invocation and terminal rendering expectations.
> 
> **Overview**
> Adds `scripts/run_tests.sh`, a bash test harness that first renders a VT fixture via `transform-tty` and fails if the output is not deterministic, then runs a targeted Bun test (`tests/race-condition-vt-fixture.test.ts`) followed by the full Bun test suite.
> 
> The script aggregates failures into a bitmask exit code to make it clear which phase failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd7789a70ea0ceeffc4e3ea1f8f84fcff43270b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `run_tests.sh` script to aggregate terminal rendering and Bun test steps
> [`scripts/run_tests.sh`](https://github.com/EtanHey/cmuxlayer/pull/91/files#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2) combines three test steps into a single runner: a Node ESM script that reads a VT fixture and compares rendered output via `transform-tty`, a targeted Bun test for `tests/race-condition-vt-fixture.test.ts`, and the full Bun test suite. Exit codes from each step are OR-ed into a bitmask (1, 2, 4) so failures are distinguishable and the script exits non-zero if any step fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cd7789.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->