### PR TITLE
chore: add cmuxlayer pre-push regression hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pre-push hook — regression harness gate
+# DO NOT BYPASS with --no-verify. DO NOT SILENCE failures.
+# Failures = real bugs, not friction. Treat as CRITICAL REVIEW TIME.
+
+set -uo pipefail
+
+[ ! -f scripts/run_tests.sh ] && { echo "⚠️  no scripts/run_tests.sh"; exit 0; }
+
+bash scripts/run_tests.sh
+exit_status=$?
+
+if [ "$exit_status" -ne 0 ]; then
+  cat <<'BANNER'
+
+🛑 PUSH BLOCKED — regression harness failed. Read failure → reproduce → fix bug.
+DO NOT bypass with --no-verify or silence the test.
+
+BANNER
+  exit "$exit_status"
+fi

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ bun run test        # 406 tests via vitest
 npm run typecheck   # Type checking
 ```
 
+## Git hooks
+
+Enable project hooks to run the regression gate automatically on `git push`:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This enables `.githooks/pre-push`, which runs `scripts/run_tests.sh` and blocks pushes on regression failures.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Phase 6c of ecosystem-regression-harness. Add .githooks/pre-push to run scripts/run_tests.sh and block pushes on regression failures. Include explicit anti-bypass guidance and README note for .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adds a local `git` workflow guard and documentation; it doesn’t change runtime code or shipped artifacts, but may block developer pushes when the regression harness fails.
> 
> **Overview**
> Adds a `.githooks/pre-push` hook that runs `scripts/run_tests.sh` and blocks `git push` when the regression harness fails (while no-oping if the script is missing).
> 
> Updates `README.md` with instructions to enable the hook via `git config core.hooksPath .githooks` and explains that pushes are gated on the regression test results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa799d35677f4bb6340f88138be1487031e59d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-push Git hook to block pushes on regression failures
> - Adds [.githooks/pre-push](.githooks/pre-push) which runs `scripts/run_tests.sh` before every `git push`, blocking the push and displaying a banner if the script exits non-zero.
> - If `scripts/run_tests.sh` is absent, the hook prints a warning and allows the push to proceed.
> - Updates [README.md](https://github.com/EtanHey/cmuxlayer/pull/92/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a 'Git hooks' section instructing users to configure `core.hooksPath=.githooks` to activate the hook.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afa799d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->