### PR TITLE
refactor: reuse cmux socket connections

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,7 +42,7 @@ if ! bun test ./tests/regression/test_terminal_state.ts; then
   ((EXIT_STATUS |= 8))
 fi
 
-if ! bun test; then
+if ! bun run test; then
   ((EXIT_STATUS |= 4))
 fi
 

--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -9,8 +9,7 @@ import {
   CmuxSocketClient,
   type CmuxSocketClientOptions,
 } from "./cmux-socket-client.js";
-
-const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
+import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 
 export interface CreateCmuxClientOptions {
   socketPath?: string;

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -8,24 +8,25 @@
 
 import * as net from "node:net";
 import * as crypto from "node:crypto";
-import {
-  CmuxSocketError,
-  type CmuxSocketClientOptions,
-} from "./cmux-socket-client.js";
+import { CmuxSocketError } from "./cmux-socket-error.js";
+import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 
-const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_IN_FLIGHT = 256;
 
 export interface BackoffOptions {
-  /** Base delay in milliseconds (default: 100) */
+  /** Base delay in milliseconds (default: 1000) */
   baseMs?: number;
-  /** Maximum delay in milliseconds (default: 10_000) */
+  /** Maximum delay in milliseconds (default: 30_000) */
   maxMs?: number;
   /** Apply random jitter to prevent thundering herd (default: true) */
   jitter?: boolean;
 }
 
-export interface CmuxPersistentSocketOptions extends CmuxSocketClientOptions {
+export interface CmuxPersistentSocketOptions {
+  socketPath?: string;
+  timeoutMs?: number;
+  maxInFlight?: number;
   backoff?: BackoffOptions;
 }
 
@@ -54,8 +55,15 @@ export class CmuxPersistentSocket {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  private pendingV1: Array<{
+    resolve: (v: string) => void;
+    reject: (e: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+    payload: string;
+  }> = [];
   private connected = false;
   private timeoutMs: number;
+  private maxInFlight: number;
   /** Guards against concurrent connect() calls */
   private connectPromise: Promise<void> | null = null;
 
@@ -70,8 +78,9 @@ export class CmuxPersistentSocket {
     this.socketPath =
       opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
-    this.backoffBaseMs = opts?.backoff?.baseMs ?? 100;
-    this.backoffMaxMs = opts?.backoff?.maxMs ?? 10_000;
+    this.maxInFlight = opts?.maxInFlight ?? MAX_IN_FLIGHT;
+    this.backoffBaseMs = opts?.backoff?.baseMs ?? 1000;
+    this.backoffMaxMs = opts?.backoff?.maxMs ?? 30_000;
     this.backoffJitter = opts?.backoff?.jitter ?? true;
   }
 
@@ -155,12 +164,35 @@ export class CmuxPersistentSocket {
     return this.connectPromise;
   }
 
+  private async ensureConnected(): Promise<void> {
+    if (this.connected && this.socket) return;
+    if (this.connectPromise) return this.connectPromise;
+
+    if (this._currentBackoffMs > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, this._currentBackoffMs),
+      );
+    }
+
+    try {
+      await this.connect();
+    } catch (error) {
+      this.incrementBackoff();
+      throw error;
+    }
+  }
+
   private rejectAllPending(error: CmuxSocketError): void {
     for (const [, entry] of this.pending) {
       clearTimeout(entry.timer);
       entry.reject(error);
     }
     this.pending.clear();
+    for (const entry of this.pendingV1) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pendingV1 = [];
   }
 
   private processBuffer(): void {
@@ -172,16 +204,45 @@ export class CmuxPersistentSocket {
       if (!line.trim()) continue;
 
       try {
-        const parsed = JSON.parse(line) as V2Response;
-        const entry = this.pending.get(parsed.id);
-        if (entry) {
+        const parsed = JSON.parse(line) as Partial<V2Response>;
+        const entry =
+          typeof parsed.id === "string" ? this.pending.get(parsed.id) : null;
+        if (entry && typeof parsed.id === "string") {
           clearTimeout(entry.timer);
           this.pending.delete(parsed.id);
-          entry.resolve(parsed);
+          entry.resolve(parsed as V2Response);
+        } else if (this.pendingV1.length > 0) {
+          this.resolveNextV1(line);
         }
       } catch {
-        // Skip non-JSON lines
+        if (this.pendingV1.length > 0) {
+          this.resolveNextV1(line);
+        }
       }
+    }
+  }
+
+  private resolveNextV1(line: string): void {
+    const entry = this.pendingV1.shift();
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    entry.resolve(line.trim());
+    this.writeNextV1();
+  }
+
+  private writeNextV1(): void {
+    if (!this.socket || this.pendingV1.length === 0) return;
+    const entry = this.pendingV1[0];
+    this.socket.write(entry.payload);
+  }
+
+  private assertInFlightCapacity(): void {
+    const inFlight = this.pending.size + this.pendingV1.length;
+    if (inFlight >= this.maxInFlight) {
+      throw new CmuxSocketError(
+        `Too many in-flight cmux socket requests (${inFlight}/${this.maxInFlight})`,
+        "too_many_requests",
+      );
     }
   }
 
@@ -189,13 +250,8 @@ export class CmuxPersistentSocket {
     method: string,
     params: Record<string, unknown> = {},
   ): Promise<T> {
-    if (!this.connected || !this.socket) {
-      if (this._currentBackoffMs > 0) {
-        await new Promise((r) => setTimeout(r, this._currentBackoffMs));
-      }
-      this.incrementBackoff();
-      await this.connect();
-    }
+    this.assertInFlightCapacity();
+    await this.ensureConnected();
 
     const id = crypto.randomUUID();
     const request: V2Request = { id, method, params };
@@ -227,6 +283,34 @@ export class CmuxPersistentSocket {
       });
 
       this.socket!.write(payload);
+    });
+  }
+
+  async sendLine(command: string): Promise<string> {
+    this.assertInFlightCapacity();
+    await this.ensureConnected();
+
+    const shouldWriteNow = this.pendingV1.length === 0;
+    const payload = command + "\n";
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const index = this.pendingV1.findIndex((entry) => entry.timer === timer);
+        const wasHead = index === 0;
+        if (index !== -1) this.pendingV1.splice(index, 1);
+        reject(
+          new CmuxSocketError(
+            `Timeout after ${this.timeoutMs}ms waiting for V1: ${command.split(" ")[0]}`,
+            "timeout",
+          ),
+        );
+        if (wasHead) this.writeNextV1();
+      }, this.timeoutMs);
+
+      this.pendingV1.push({ resolve, reject, timer, payload });
+      if (shouldWriteNow) {
+        this.writeNextV1();
+      }
     });
   }
 

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -8,8 +8,6 @@
  *        or {"id":"<uuid>","ok":false,"error":{"code":"...","message":"..."}}\n
  */
 
-import * as net from "node:net";
-import * as crypto from "node:crypto";
 import type {
   CmuxWorkspace,
   CmuxPaneSurfaces,
@@ -24,10 +22,13 @@ import type {
 } from "./types.js";
 import type { CmuxClient } from "./cmux-client.js";
 import { normalizeKeyName } from "./key-names.js";
+import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
+import { CmuxSocketError } from "./cmux-socket-error.js";
+import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
+export { CmuxSocketError } from "./cmux-socket-error.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
 
-const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const REQUEST_TIMEOUT_MS = 10_000;
 const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
 
@@ -40,37 +41,11 @@ type V1Arg = string | V1RawArg;
 export interface CmuxSocketClientOptions {
   socketPath?: string;
   timeoutMs?: number;
+  maxInFlight?: number;
   /** Password for socket access mode "password" */
   password?: string;
   /** CLI client fallback for V2 methods not supported by the daemon */
   cliFallback?: CmuxClient;
-}
-
-// ── Socket-level errors ────────────────────────────────────────────────
-
-export class CmuxSocketError extends Error {
-  constructor(
-    message: string,
-    public readonly code?: string,
-  ) {
-    super(message);
-    this.name = "CmuxSocketError";
-  }
-}
-
-// ── V2 JSON-RPC types ──────────────────────────────────────────────────
-
-interface V2Request {
-  id: string;
-  method: string;
-  params: Record<string, unknown>;
-}
-
-interface V2Response {
-  id: string;
-  ok: boolean;
-  result?: Record<string, unknown>;
-  error?: { code: string; message: string; data?: unknown };
 }
 
 // ── The Client ─────────────────────────────────────────────────────────
@@ -80,6 +55,7 @@ export class CmuxSocketClient {
   private timeoutMs: number;
   private password?: string;
   private cliFallback?: CmuxClient;
+  private transport: CmuxPersistentSocket;
 
   constructor(opts?: CmuxSocketClientOptions) {
     this.socketPath =
@@ -87,6 +63,11 @@ export class CmuxSocketClient {
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
     this.password = opts?.password;
     this.cliFallback = opts?.cliFallback;
+    this.transport = new CmuxPersistentSocket({
+      socketPath: this.socketPath,
+      timeoutMs: this.timeoutMs,
+      maxInFlight: opts?.maxInFlight,
+    });
   }
 
   private assertSupportedSendOptions(opts?: CmuxSendOptions): void {
@@ -103,170 +84,12 @@ export class CmuxSocketClient {
     }
   }
 
-  // ── Low-level: send a V2 request, get a V2 response ────────────────
-
-  private sendV2(
-    method: string,
-    params: Record<string, unknown> = {},
-  ): Promise<V2Response> {
-    return new Promise((resolve, reject) => {
-      const id = crypto.randomUUID();
-      const request: V2Request = { id, method, params };
-      const payload = JSON.stringify(request) + "\n";
-
-      let authId: string | null = null;
-
-      const socket = net.createConnection({ path: this.socketPath }, () => {
-        if (this.password) {
-          // Send auth first — payload is deferred until auth succeeds
-          authId = crypto.randomUUID();
-          const authReq: V2Request = {
-            id: authId,
-            method: "auth.login",
-            params: { password: this.password },
-          };
-          socket.write(JSON.stringify(authReq) + "\n");
-        } else {
-          socket.write(payload);
-        }
-      });
-
-      let buffer = "";
-      let authDone = !this.password;
-      const timeout = setTimeout(() => {
-        socket.destroy();
-        reject(
-          new CmuxSocketError(
-            `Timeout after ${this.timeoutMs}ms waiting for ${method}`,
-            "timeout",
-          ),
-        );
-      }, this.timeoutMs);
-
-      socket.on("data", (chunk: Buffer) => {
-        buffer += chunk.toString("utf-8");
-
-        // Process all complete lines
-        let newlineIdx: number;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx);
-          buffer = buffer.slice(newlineIdx + 1);
-
-          if (!line.trim()) continue;
-
-          try {
-            const parsed = JSON.parse(line) as V2Response;
-
-            // If we sent an auth request, consume its response first
-            if (!authDone && authId && parsed.id === authId) {
-              authDone = true;
-              if (!parsed.ok) {
-                clearTimeout(timeout);
-                socket.destroy();
-                reject(
-                  new CmuxSocketError(
-                    `Auth failed: ${parsed.error?.message ?? "unknown"}`,
-                    "auth_failed",
-                  ),
-                );
-                return;
-              }
-              // Auth succeeded — now send the actual request
-              socket.write(payload);
-              continue;
-            }
-
-            // This is our actual response
-            if (parsed.id === id) {
-              clearTimeout(timeout);
-              socket.destroy();
-              resolve(parsed);
-            }
-          } catch {
-            // Non-JSON line (v1 fallback?) — skip
-          }
-        }
-      });
-
-      socket.on("error", (err: Error) => {
-        clearTimeout(timeout);
-        reject(
-          new CmuxSocketError(
-            `Socket error: ${err.message}`,
-            "connection_error",
-          ),
-        );
-      });
-
-      socket.on("close", () => {
-        clearTimeout(timeout);
-        // Reject immediately if we haven't received a response
-        reject(
-          new CmuxSocketError(
-            "Socket closed before receiving response",
-            "connection_closed",
-          ),
-        );
-      });
-    });
-  }
-
   /**
    * Send a V1 plain-text command. Some cmux operations (set_status,
    * set_progress, log) only exist as V1 commands.
    */
   private sendV1(command: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const payload = command + "\n";
-
-      const socket = net.createConnection({ path: this.socketPath }, () => {
-        socket.write(payload);
-      });
-
-      let buffer = "";
-      const timeout = setTimeout(() => {
-        socket.destroy();
-        reject(
-          new CmuxSocketError(
-            `Timeout after ${this.timeoutMs}ms waiting for V1: ${command.split(" ")[0]}`,
-            "timeout",
-          ),
-        );
-      }, this.timeoutMs);
-
-      socket.on("data", (chunk: Buffer) => {
-        buffer += chunk.toString("utf-8");
-        if (buffer.includes("\n")) {
-          clearTimeout(timeout);
-          socket.destroy();
-          resolve(buffer.trim());
-        }
-      });
-
-      socket.on("error", (err: Error) => {
-        clearTimeout(timeout);
-        reject(
-          new CmuxSocketError(
-            `Socket error: ${err.message}`,
-            "connection_error",
-          ),
-        );
-      });
-
-      socket.on("close", () => {
-        clearTimeout(timeout);
-        if (buffer.trim()) {
-          resolve(buffer.trim());
-        } else {
-          reject(
-            new CmuxSocketError(
-              "Socket closed before receiving response",
-              "connection_closed",
-            ),
-          );
-        }
-      });
-    });
+    return this.transport.sendLine(command);
   }
 
   private quoteV1Arg(arg: string): string {
@@ -297,15 +120,11 @@ export class CmuxSocketClient {
     method: string,
     params: Record<string, unknown> = {},
   ): Promise<T> {
-    const response = await this.sendV2(method, params);
-
-    if (!response.ok) {
-      const errCode = response.error?.code ?? "unknown";
-      const errMsg = response.error?.message ?? "Unknown error";
-      throw new CmuxSocketError(`${errCode}: ${errMsg}`, errCode);
+    if (this.password) {
+      await this.transport.call("auth.login", { password: this.password });
+      this.password = undefined;
     }
-
-    return (response.result ?? {}) as T;
+    return this.transport.call<T>(method, params);
   }
 
   // ── Public API (mirrors CmuxClient interface) ──────────────────────
@@ -722,6 +541,10 @@ export class CmuxSocketClient {
       }
     }
     return this.call(method, params);
+  }
+
+  disconnect(): void {
+    this.transport.disconnect();
   }
 
   /**

--- a/src/cmux-socket-error.ts
+++ b/src/cmux-socket-error.ts
@@ -1,0 +1,9 @@
+export class CmuxSocketError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "CmuxSocketError";
+  }
+}

--- a/src/cmux-socket-path.ts
+++ b/src/cmux-socket-path.ts
@@ -1,0 +1,10 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_SOCKET_PATH = join(
+  homedir(),
+  "Library",
+  "Application Support",
+  "cmux",
+  "cmux.sock",
+);

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -106,6 +106,8 @@ let mockServer: net.Server;
 let lastV1Command = "";
 let lastV2Request: { method: string; params: Record<string, unknown> } | null =
   null;
+let connectionCount = 0;
+const activeConnections = new Set<net.Socket>();
 
 function startMockServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -117,6 +119,9 @@ function startMockServer(): Promise<void> {
     }
 
     mockServer = net.createServer((conn) => {
+      connectionCount++;
+      activeConnections.add(conn);
+      conn.on("close", () => activeConnections.delete(conn));
       let buffer = "";
       conn.on("data", (chunk) => {
         buffer += chunk.toString("utf-8");
@@ -182,6 +187,9 @@ function startMockServer(): Promise<void> {
 
 function stopMockServer(): Promise<void> {
   return new Promise((resolve) => {
+    for (const conn of activeConnections) {
+      conn.destroy();
+    }
     mockServer.close(() => {
       try {
         fs.unlinkSync(MOCK_SOCKET_PATH);
@@ -212,6 +220,7 @@ afterAll(async () => {
 beforeEach(() => {
   lastV1Command = "";
   lastV2Request = null;
+  connectionCount = 0;
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -318,6 +327,20 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(result.surfaces).toBeInstanceOf(Array);
     expect(result.surfaces[0].ref).toBe("surface:1");
     expect(result.surfaces[0].type).toBe("terminal");
+  });
+
+  it("reuses one socket connection for 100 concurrent listPaneSurfaces calls", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    const startedAt = Date.now();
+    await Promise.all(
+      Array.from({ length: 100 }, () =>
+        client.listPaneSurfaces({ workspace: "workspace:1" }),
+      ),
+    );
+
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+    expect(connectionCount).toBe(1);
   });
 
   it("listPanes returns panes", async () => {


### PR DESCRIPTION
## Summary
- Reuse one persistent Unix domain socket inside `CmuxSocketClient` instead of opening a fresh socket per V2/V1 request.
- Default socket discovery now targets the cmux app socket at `~/Library/Application Support/cmux/cmux.sock`, with the existing CLI fallback preserved when the socket is unavailable or unusable.
- Add bounded in-flight request protection, serialized V1 line-command handling, 1s→30s reconnect backoff, and an explicit `disconnect()` for short-lived clients/tests.
- Fix the pre-push regression harness to run the repo's Vitest script (`bun run test`) for the full suite; raw `bun test` is incompatible with the existing Vitest API usage.

## Socket protocol discovered
- Path: `/Users/etanheyman/Library/Application Support/cmux/cmux.sock`
- Protocol: newline-delimited JSON for V2 requests/responses, e.g. `{"id":"probe-1","method":"system.ping","params":{}}\n` returns `{"result":{"pong":true},"id":"probe-1","ok":true}`.
- V1 plain-text socket commands are still used for sidebar/status commands and are serialized over the same persistent connection.

## Process-count evidence
- Sprint incident baseline from Lane E plan: 3,231 simultaneous `cmux --json list-*` subprocesses in the manual fork-bomb snapshot.
- Local daemon-gate check on the current live system: 100 concurrent `listPaneSurfaces` calls through `createCmuxClient()` returned `CmuxSocketClient`; exact-process matcher showed `cmux --json` subprocesses `before=5307 after=5307` (no new CLI subprocesses from the 100-call burst). The high absolute number is pre-existing live fork-bomb residue, not created by this patch.

## Test plan
- [x] Failing test first: `CmuxSocketClient` 100 concurrent `listPaneSurfaces` calls expected one socket connection; old code opened 100.
- [x] `bun test tests/cmux-socket-client.test.ts --runInBand`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (27 files, 453 tests)
- [x] `bash scripts/run_tests.sh`
- [x] Direct cmux app socket probe: `system.ping` over `/Users/etanheyman/Library/Application Support/cmux/cmux.sock`
- [x] Manual 100-call client burst verified no additional `cmux --json` subprocesses.

## Review notes
- `cr review --plain` was attempted before commit. The first run hung in limited/free mode; a scoped retry with `--type uncommitted --base main` returned CodeRabbit usage limit / rate-limit exceeded, so no CLI CodeRabbit findings were available before commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cmux socket transport to a long-lived, multiplexed connection with new backoff/queueing and in-flight limits; bugs here could cause hangs, dropped responses, or reduced reliability under load.
> 
> **Overview**
> **Reworks `CmuxSocketClient` to reuse a single persistent Unix socket** via a new `CmuxPersistentSocket` transport, instead of opening/closing a connection per V1/V2 request.
> 
> This adds bounded in-flight request protection, serialized V1 line-command handling on the shared connection, reconnect backoff, and an explicit `disconnect()` for cleanup. It also centralizes `CmuxSocketError` and switches the default socket location to the cmux app socket (`~/Library/Application Support/cmux/cmux.sock`).
> 
> Tests are updated to assert connection reuse under concurrency, and `scripts/run_tests.sh` now runs the full suite through `bun run test` (Vitest) instead of raw `bun test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30e385bdea0416d7d92b32ed54861ce62003142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse persistent cmux socket connections across concurrent V1 and V2 calls
> - Replaces per-request socket creation in [`CmuxSocketClient`](https://github.com/EtanHey/cmuxlayer/pull/96/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) with a [`CmuxPersistentSocket`](https://github.com/EtanHey/cmuxlayer/pull/96/files#diff-4241cd7c196a7c577e98f44bd5ac5ad678fbfa738d9a631f6422e7ff2135cd03) transport that maintains a single shared connection.
> - V2 JSON-RPC calls are multiplexed by request ID; V1 line commands are serialized in a FIFO queue with per-request timeouts.
> - Authentication (`auth.login`) is performed once before the first call and the session is reused for subsequent calls.
> - Enforces a max of 256 concurrent in-flight requests (V1 + V2 combined), throwing a `too_many_requests` `CmuxSocketError` when exceeded.
> - Reconnect backoff defaults increase from 100 ms / 10 s to 1000 ms / 30 s; default socket path moves from `/tmp/cmux.sock` to `~/Library/Application Support/cmux/cmux.sock`.
> - Risk: existing consumers relying on a fresh socket per call will now share state across calls; disconnect must be called explicitly to close the connection.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f30e385. 5 files reviewed, 5 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->