### PR TITLE
feat: deliver boot prompts after agent launch

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -35,6 +35,7 @@ import {
 } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
 import { chooseAgentSpawnPlacement } from "./layout-policy.js";
+import { matchReadyPattern } from "./pattern-registry.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -361,6 +362,28 @@ export class AgentEngine {
     }
   }
 
+  private async maybeMarkBootReady(agent: AgentRecord): Promise<AgentRecord> {
+    if (agent.state !== "booting") {
+      return agent;
+    }
+
+    try {
+      const screen = await this.client.readScreen(agent.surface_id, {
+        lines: 20,
+      });
+      const match = matchReadyPattern(agent.cli, screen.text);
+      if (!match.matched || match.confidence !== "high") {
+        return agent;
+      }
+
+      const updated = this.stateMgr.transition(agent.agent_id, "ready");
+      this.registry.set(agent.agent_id, updated);
+      return updated;
+    } catch {
+      return agent;
+    }
+  }
+
   private isRecoverableCrash(agent: AgentRecord): boolean {
     return isCrashRecoveryEligible(agent);
   }
@@ -520,7 +543,8 @@ export class AgentEngine {
     const done = agents.filter((a) => a.state === "done").length;
 
     for (const originalAgent of agents) {
-      const agent = await this.maybeCaptureBootSessionId(originalAgent);
+      const capturedAgent = await this.maybeCaptureBootSessionId(originalAgent);
+      const agent = await this.maybeMarkBootReady(capturedAgent);
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
         state === "error" ? `${repo}: error` : `${repo}: ${state}`;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -218,15 +218,15 @@ export function buildResumeCommand(
   const safeRepo = sanitizeRepoName(repo);
   switch (cli) {
     case "claude":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} claude --dangerously-skip-permissions --resume ${sessionId}`;
+      return `${safeRepo}Claude -s --resume ${sessionId}`;
     case "codex":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} codex resume ${sessionId}`;
+      return `${safeRepo}Codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
     case "gemini":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini --resume ${sessionId}`;
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
     case "cursor":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} cursor agent --resume ${sessionId}`;
+      return `${safeRepo}Cursor -s --resume ${sessionId}`;
   }
 }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -66,6 +66,7 @@ const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const SWEEP_INTERVAL_MS = 1000;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
+const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
 const SESSION_ID_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const SESSION_ID_RE =
@@ -379,12 +380,31 @@ export class AgentEngine {
     }
     if (agent.boot_prompt_pending) {
       this.readyPatternMatches.delete(agent.agent_id);
-      return agent;
+      const since = Date.parse(agent.updated_at);
+      if (
+        Number.isNaN(since) ||
+        Date.now() - since < BOOT_PROMPT_PENDING_STALE_MS
+      ) {
+        return agent;
+      }
+
+      try {
+        this.stateMgr.updateRecord(agent.agent_id, {
+          boot_prompt_pending: false,
+        });
+        const failed = this.stateMgr.transition(agent.agent_id, "error", {
+          error: "Boot prompt delivery interrupted before completion",
+        });
+        this.registry.set(agent.agent_id, failed);
+        return failed;
+      } catch {
+        return agent;
+      }
     }
 
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
-        lines: 20,
+        lines: BOOT_SESSION_CAPTURE_LINES,
       });
       const match = matchReadyPattern(agent.cli, screen.text);
       if (!match.matched) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -42,6 +42,7 @@ export interface SpawnAgentParams {
   model: string;
   cli: CliType;
   prompt: string;
+  boot_prompt_pending?: boolean;
   workspace?: string;
   parent_agent_id?: string;
   max_cost_per_agent?: number;
@@ -242,8 +243,11 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
-async function assertClaudeLauncherAvailable(repo: string): Promise<void> {
-  const launcher = `${sanitizeRepoName(repo)}Claude`;
+async function assertLauncherAvailable(
+  repo: string,
+  suffix: "Claude" | "Codex" | "Cursor",
+): Promise<void> {
+  const launcher = `${sanitizeRepoName(repo)}${suffix}`;
   const shell = process.env.SHELL || "/bin/sh";
   const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
 
@@ -268,6 +272,8 @@ export class AgentEngine {
   private sidebarSnapshot = new Map<string, string>();
   /** e.g. "a1:spawned", "a1:done", "a1:error" */
   private loggedEvents = new Set<string>();
+  /** agentId → consecutive ready-prompt matches */
+  private readyPatternMatches = new Map<string, number>();
 
   constructor(
     stateMgr: StateManager,
@@ -282,7 +288,11 @@ export class AgentEngine {
       opts?.spawnPreflight ??
       (async (params) => {
         if (params.cli === "claude") {
-          await assertClaudeLauncherAvailable(params.repo);
+          await assertLauncherAvailable(params.repo, "Claude");
+        } else if (params.cli === "codex") {
+          await assertLauncherAvailable(params.repo, "Codex");
+        } else if (params.cli === "cursor") {
+          await assertLauncherAvailable(params.repo, "Cursor");
         }
       });
   }
@@ -364,6 +374,11 @@ export class AgentEngine {
 
   private async maybeMarkBootReady(agent: AgentRecord): Promise<AgentRecord> {
     if (agent.state !== "booting") {
+      this.readyPatternMatches.delete(agent.agent_id);
+      return agent;
+    }
+    if (agent.boot_prompt_pending) {
+      this.readyPatternMatches.delete(agent.agent_id);
       return agent;
     }
 
@@ -372,12 +387,20 @@ export class AgentEngine {
         lines: 20,
       });
       const match = matchReadyPattern(agent.cli, screen.text);
-      if (!match.matched || match.confidence !== "high") {
+      if (!match.matched) {
+        this.readyPatternMatches.delete(agent.agent_id);
+        return agent;
+      }
+
+      const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+      this.readyPatternMatches.set(agent.agent_id, count);
+      if (count < Math.max(1, match.consecutive)) {
         return agent;
       }
 
       const updated = this.stateMgr.transition(agent.agent_id, "ready");
       this.registry.set(agent.agent_id, updated);
+      this.readyPatternMatches.delete(agent.agent_id);
       return updated;
     } catch {
       return agent;
@@ -751,6 +774,7 @@ export class AgentEngine {
       crash_recover: params.crash_recover ?? false,
       respawn_attempts: 0,
       user_killed: false,
+      boot_prompt_pending: params.boot_prompt_pending ?? false,
     };
     this.stateMgr.writeState(record);
     this.registry.set(agentId, record);

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -198,13 +198,13 @@ export function buildLaunchCommand(cli: CliType, repo: string): string {
       // repoGolem launcher handles env vars via ralph-registry
       return `${safeRepo}Claude -s`;
     case "codex":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} codex`;
+      return `${safeRepo}Codex -s`;
     case "gemini":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini`;
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli`;
     case "cursor":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} cursor agent`;
+      return `${safeRepo}Cursor -s`;
   }
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -46,6 +46,8 @@ export interface AgentRecord {
   crash_recover?: boolean;
   respawn_attempts?: number;
   user_killed?: boolean;
+  // Boot prompt delivery guard
+  boot_prompt_pending?: boolean;
 }
 
 export interface MergedAgent extends AgentRecord {

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,12 @@ import {
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { chooseSurfaceClosePolicy } from "./layout-policy.js";
-import type { CmuxSurface, ParsedScreenResult } from "./types.js";
+import type {
+  CmuxNewSplitResult,
+  CmuxNewSurfaceResult,
+  CmuxSurface,
+  ParsedScreenResult,
+} from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 
@@ -915,7 +920,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const screen = await client.readScreen(opts.surface, {
           workspace: opts.workspace,
           lines: 80,
-          scrollback: true,
+          scrollback: false,
         });
         lastText = screen.text;
 
@@ -1278,6 +1283,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
     ANNOTATIONS.mutating,
     async (args) => {
+      let result: CmuxNewSplitResult | undefined;
       try {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         if (bootPromptPath) {
@@ -1287,7 +1293,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await preflightBootPromptFile(bootPromptPath);
         }
 
-        const result = await client.newSplit(args.direction, {
+        result = await client.newSplit(args.direction, {
           workspace: args.workspace,
           surface: args.surface,
           pane: args.pane,
@@ -1329,6 +1335,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof BootPromptTimeoutError) {
+          return err(e, {
+            surface: result?.surface,
+            last_10_lines: e.last_10_lines,
+          });
+        }
+        if (e instanceof BootPromptDeliveryError) {
+          return err(e, {
+            surface: result?.surface,
+            delivered_chars: e.delivered_chars,
+          });
+        }
         return err(e);
       }
     },
@@ -1365,6 +1383,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
     ANNOTATIONS.mutating,
     async (args) => {
+      let result: CmuxNewSurfaceResult | undefined;
       try {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         if (bootPromptPath) {
@@ -1374,7 +1393,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await preflightBootPromptFile(bootPromptPath);
         }
 
-        const result = await client.newSurface({
+        result = await client.newSurface({
           pane: args.pane,
           workspace: args.workspace,
           type: args.type,
@@ -1413,6 +1432,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof BootPromptTimeoutError) {
+          return err(e, {
+            surface: result?.surface,
+            last_10_lines: e.last_10_lines,
+          });
+        }
+        if (e instanceof BootPromptDeliveryError) {
+          return err(e, {
+            surface: result?.surface,
+            delivered_chars: e.delivered_chars,
+          });
+        }
         return err(e);
       }
     },
@@ -2296,6 +2327,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             model: args.model,
             cli: args.cli,
             prompt: args.prompt ?? "",
+            boot_prompt_pending: hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
             max_cost_per_agent: args.max_cost_per_agent,
@@ -2319,6 +2351,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               if (bootPromptDelivery.prompt_text !== null) {
                 const updated = stateMgr.updateRecord(result.agent_id, {
                   task_summary: bootPromptDelivery.prompt_text,
+                  boot_prompt_pending: false,
+                });
+                registry.set(result.agent_id, updated);
+              } else {
+                const updated = stateMgr.updateRecord(result.agent_id, {
+                  boot_prompt_pending: false,
                 });
                 registry.set(result.agent_id, updated);
               }

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,13 +97,7 @@ const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
-const READY_PATTERN_CLIS: CliType[] = [
-  "claude",
-  "codex",
-  "gemini",
-  "kiro",
-  "cursor",
-];
+const READY_PATTERN_CLIS: CliType[] = ["claude", "codex", "gemini", "kiro", "cursor"];
 const SendToArgsSchema = z.object({
   agent_id: z.string(),
   text: z.string(),
@@ -358,14 +352,8 @@ function inferLauncherCli(command: string): CliType | null {
   return match[1].toLowerCase() as CliType;
 }
 
-function screenHasKnownReadyPrompt(text: string, cli?: CliType): boolean {
-  if (cli && matchReadyPattern(cli, text).matched) {
-    return true;
-  }
-
-  return READY_PATTERN_CLIS.some((candidate) =>
-    candidate !== cli && matchReadyPattern(candidate, text).matched,
-  );
+function readyPatternCandidates(cli?: CliType): CliType[] {
+  return cli ? [cli] : READY_PATTERN_CLIS;
 }
 
 async function delay(ms: number): Promise<void> {
@@ -919,6 +907,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   }): Promise<void> => {
     const start = Date.now();
     let lastText = "";
+    const consecutiveMatches = new Map<CliType, number>();
+    const candidates = readyPatternCandidates(opts.cli);
 
     while (Date.now() - start < opts.timeout_ms) {
       try {
@@ -929,13 +919,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         });
         lastText = screen.text;
 
-        if (screenHasKnownReadyPrompt(screen.text, opts.cli)) {
-          return;
-        }
-
-        const parsed = parseScreen(screen.text);
-        if (parsed.agent_type !== "unknown" && parsed.status === "idle") {
-          return;
+        for (const candidate of candidates) {
+          const match = matchReadyPattern(candidate, screen.text);
+          const count = match.matched
+            ? (consecutiveMatches.get(candidate) ?? 0) + 1
+            : 0;
+          consecutiveMatches.set(candidate, count);
+          if (count >= match.consecutive) {
+            return;
+          }
         }
       } catch (error) {
         lastText = error instanceof Error ? error.message : String(error);
@@ -961,11 +953,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     prompt?: string;
     boot_prompt_path?: string | null;
     timeout_ms?: number;
-  }): Promise<{ bytes: number; retry_count: number; submit_verified: boolean | null }> => {
+  }): Promise<{
+    bytes: number;
+    retry_count: number;
+    submit_verified: boolean | null;
+    prompt_text: string | null;
+  }> => {
     const bootPromptPath = getBootPromptPath(opts.boot_prompt_path);
     assertBootPromptMode(opts.prompt, bootPromptPath);
     if (!hasInlinePrompt(opts.prompt) && !bootPromptPath) {
-      return { bytes: 0, retry_count: 0, submit_verified: null };
+      return {
+        bytes: 0,
+        retry_count: 0,
+        submit_verified: null,
+        prompt_text: null,
+      };
     }
 
     await waitForBootPromptReady({
@@ -986,7 +988,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let sentChunks = 0;
 
     try {
-      return await withSurfaceWrite(opts.surface, async () =>
+      const delivery = await withSurfaceWrite(opts.surface, async () =>
         deliverInputChunks({
           surface: opts.surface,
           workspace: opts.workspace,
@@ -1000,6 +1002,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           verify_submit: sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD,
         }),
       );
+      return { ...delivery, prompt_text: rawPrompt };
     } catch (error) {
       const deliveredChars = chunks
         .slice(0, sentChunks)
@@ -2292,7 +2295,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             repo: args.repo,
             model: args.model,
             cli: args.cli,
-            prompt: args.prompt ?? bootPromptPath ?? "",
+            prompt: args.prompt ?? "",
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
             max_cost_per_agent: args.max_cost_per_agent,
@@ -2302,24 +2305,45 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           let bootPromptDelivery:
             | Awaited<ReturnType<typeof deliverBootPrompt>>
             | undefined;
-          if (hasInlinePrompt(args.prompt) || bootPromptPath) {
-            bootPromptDelivery = await deliverBootPrompt({
-              surface: result.surface_id,
-              workspace: args.workspace,
-              cli: args.cli,
-              prompt: args.prompt,
-              boot_prompt_path: bootPromptPath,
-              timeout_ms: args.boot_prompt_timeout_ms,
-            });
+          try {
+            if (hasInlinePrompt(args.prompt) || bootPromptPath) {
+              bootPromptDelivery = await deliverBootPrompt({
+                surface: result.surface_id,
+                workspace: args.workspace,
+                cli: args.cli,
+                prompt: args.prompt,
+                boot_prompt_path: bootPromptPath,
+                timeout_ms: args.boot_prompt_timeout_ms,
+              });
 
-            const current = engine.getAgentState(result.agent_id);
-            if (current?.state === "booting") {
-              const ready = stateMgr.transition(result.agent_id, "ready");
-              registry.set(result.agent_id, ready);
-              result.state = "ready";
-            } else if (current?.state === "ready") {
-              result.state = "ready";
+              if (bootPromptDelivery.prompt_text !== null) {
+                const updated = stateMgr.updateRecord(result.agent_id, {
+                  task_summary: bootPromptDelivery.prompt_text,
+                });
+                registry.set(result.agent_id, updated);
+              }
+
+              const current = engine.getAgentState(result.agent_id);
+              if (current?.state === "booting") {
+                const ready = stateMgr.transition(result.agent_id, "ready");
+                registry.set(result.agent_id, ready);
+                result.state = "ready";
+              } else if (current?.state === "ready") {
+                result.state = "ready";
+              }
             }
+          } catch (e) {
+            const extra = {
+              agent_id: result.agent_id,
+              surface_id: result.surface_id,
+            };
+            if (e instanceof BootPromptTimeoutError) {
+              return err(e, { ...extra, last_10_lines: e.last_10_lines });
+            }
+            if (e instanceof BootPromptDeliveryError) {
+              return err(e, { ...extra, delivered_chars: e.delivered_chars });
+            }
+            return err(e, extra);
           }
 
           return okFormatted(
@@ -2337,12 +2361,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
-          if (e instanceof BootPromptTimeoutError) {
-            return err(e, { last_10_lines: e.last_10_lines });
-          }
-          if (e instanceof BootPromptDeliveryError) {
-            return err(e, { delivered_chars: e.delivered_chars });
-          }
           return err(e);
         }
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -2371,6 +2371,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
           } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            try {
+              let updated = stateMgr.updateRecord(result.agent_id, {
+                boot_prompt_pending: false,
+              });
+              registry.set(result.agent_id, updated);
+              if (updated.state !== "done" && updated.state !== "error") {
+                updated = stateMgr.transition(result.agent_id, "error", {
+                  error: `Boot prompt failed: ${message}`,
+                });
+                registry.set(result.agent_id, updated);
+              }
+            } catch {
+              // Preserve the original boot prompt error response.
+            }
             const extra = {
               agent_id: result.agent_id,
               surface_id: result.surface_id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
@@ -23,6 +25,7 @@ import { toPublicAgent } from "./agent-facade.js";
 import type {
   AgentRecord,
   AgentState,
+  CliType,
   DeliveryEventType,
   DeliveryTelemetryEvent,
 } from "./agent-types.js";
@@ -39,6 +42,7 @@ import { sanitizeTerminalInput } from "./sanitize.js";
 import { chooseSurfaceClosePolicy } from "./layout-policy.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
+import { matchReadyPattern } from "./pattern-registry.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -90,7 +94,16 @@ const SEND_INPUT_ENTER_DELAY_MS = 50;
 const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
 const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
+const BOOT_PROMPT_TIMEOUT_MS = 60_000;
+const BOOT_PROMPT_READY_POLL_MS = 250;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
+const READY_PATTERN_CLIS: CliType[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "kiro",
+  "cursor",
+];
 const SendToArgsSchema = z.object({
   agent_id: z.string(),
   text: z.string(),
@@ -125,6 +138,26 @@ class DeliveryError extends Error {
   ) {
     super(message);
     this.name = "DeliveryError";
+  }
+}
+
+class BootPromptTimeoutError extends Error {
+  constructor(
+    message: string,
+    readonly last_10_lines: string[],
+  ) {
+    super(message);
+    this.name = "BootPromptTimeoutError";
+  }
+}
+
+class BootPromptDeliveryError extends Error {
+  constructor(
+    message: string,
+    readonly delivered_chars: number,
+  ) {
+    super(message);
+    this.name = "BootPromptDeliveryError";
   }
 }
 
@@ -269,6 +302,70 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
   }
 
   return chunks;
+}
+
+function getBootPromptPath(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function hasInlinePrompt(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function assertBootPromptMode(
+  prompt: string | undefined,
+  bootPromptPath: string | null,
+): void {
+  if (hasInlinePrompt(prompt) && bootPromptPath) {
+    throw new Error("prompt and boot_prompt_path are mutually exclusive");
+  }
+}
+
+function tailLines(text: string, count: number): string[] {
+  return text.split(/\r?\n/).filter(Boolean).slice(-count);
+}
+
+async function preflightBootPromptFile(path: string): Promise<void> {
+  try {
+    await access(path, fsConstants.R_OK);
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as NodeJS.ErrnoException).code)
+        : "ERROR";
+    if (code === "ENOENT") {
+      throw new Error(`boot_prompt_path ENOENT: ${path}`);
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      throw new Error(`boot_prompt_path permission denied: ${path}`);
+    }
+    throw error;
+  }
+}
+
+function inferLauncherCli(command: string): CliType | null {
+  if (!/(^|\s)-s(?:\s|$)/.test(command)) {
+    return null;
+  }
+
+  const match = command.match(
+    /(?:^|\s)[A-Za-z0-9_.-]+(Claude|Codex|Cursor|Gemini|Kiro)\b/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  return match[1].toLowerCase() as CliType;
+}
+
+function screenHasKnownReadyPrompt(text: string, cli?: CliType): boolean {
+  if (cli && matchReadyPattern(cli, text).matched) {
+    return true;
+  }
+
+  return READY_PATTERN_CLIS.some((candidate) =>
+    candidate !== cli && matchReadyPattern(candidate, text).matched,
+  );
 }
 
 async function delay(ms: number): Promise<void> {
@@ -814,6 +911,107 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return { bytes, retry_count, submit_verified };
   };
 
+  const waitForBootPromptReady = async (opts: {
+    surface: string;
+    workspace?: string;
+    cli?: CliType;
+    timeout_ms: number;
+  }): Promise<void> => {
+    const start = Date.now();
+    let lastText = "";
+
+    while (Date.now() - start < opts.timeout_ms) {
+      try {
+        const screen = await client.readScreen(opts.surface, {
+          workspace: opts.workspace,
+          lines: 80,
+          scrollback: true,
+        });
+        lastText = screen.text;
+
+        if (screenHasKnownReadyPrompt(screen.text, opts.cli)) {
+          return;
+        }
+
+        const parsed = parseScreen(screen.text);
+        if (parsed.agent_type !== "unknown" && parsed.status === "idle") {
+          return;
+        }
+      } catch (error) {
+        lastText = error instanceof Error ? error.message : String(error);
+      }
+
+      const remaining = opts.timeout_ms - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(BOOT_PROMPT_READY_POLL_MS, remaining));
+    }
+
+    throw new BootPromptTimeoutError(
+      `Timed out after ${opts.timeout_ms}ms waiting for boot prompt readiness on ${opts.surface}`,
+      tailLines(lastText, 10),
+    );
+  };
+
+  const deliverBootPrompt = async (opts: {
+    surface: string;
+    workspace?: string;
+    cli?: CliType;
+    prompt?: string;
+    boot_prompt_path?: string | null;
+    timeout_ms?: number;
+  }): Promise<{ bytes: number; retry_count: number; submit_verified: boolean | null }> => {
+    const bootPromptPath = getBootPromptPath(opts.boot_prompt_path);
+    assertBootPromptMode(opts.prompt, bootPromptPath);
+    if (!hasInlinePrompt(opts.prompt) && !bootPromptPath) {
+      return { bytes: 0, retry_count: 0, submit_verified: null };
+    }
+
+    await waitForBootPromptReady({
+      surface: opts.surface,
+      workspace: opts.workspace,
+      cli: opts.cli,
+      timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
+    });
+
+    const rawPrompt = bootPromptPath
+      ? await readFile(bootPromptPath, "utf8")
+      : opts.prompt!;
+    const sanitizedText = sanitizeTerminalInput(rawPrompt);
+    const chunks =
+      sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
+        ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
+        : [sanitizedText];
+    let sentChunks = 0;
+
+    try {
+      return await withSurfaceWrite(opts.surface, async () =>
+        deliverInputChunks({
+          surface: opts.surface,
+          workspace: opts.workspace,
+          chunks,
+          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+          press_enter: true,
+          onChunkDelivered: (count) => {
+            sentChunks = count;
+          },
+          verify_submit: sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD,
+        }),
+      );
+    } catch (error) {
+      const deliveredChars = chunks
+        .slice(0, sentChunks)
+        .reduce((sum, chunk) => sum + chunk.length, 0);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BootPromptDeliveryError(
+        `Boot prompt delivery failed after ${deliveredChars} chars: ${message}`,
+        deliveredChars,
+      );
+    }
+  };
+
   const startBackgroundDelivery = (record: DeliveryRecord) => {
     acquireSurfaceWrite(record.surface, record.delivery_id);
     deliveries.set(record.delivery_id, record);
@@ -1040,7 +1238,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 2. new_split
   server.tool(
     "new_split",
-    "Create a new split pane (terminal or browser)",
+    "Create a new split pane (terminal or browser). For terminal panes that boot an agent, boot_prompt_path can deliver a file prompt after the agent reaches a ready prompt.",
     {
       direction: z
         .enum(["left", "right", "up", "down"])
@@ -1060,10 +1258,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .default(true)
         .describe("Focus the new pane"),
+      boot_prompt_path: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Optional path to a prompt file to read after readiness and submit to the new terminal surface. Checked before pane creation. Mutually exclusive with inline prompt fields.",
+        ),
+      boot_prompt_timeout_ms: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(BOOT_PROMPT_TIMEOUT_MS)
+        .describe("Timeout in milliseconds waiting for the agent ready prompt"),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
+        if (bootPromptPath) {
+          if ((args.type ?? "terminal") !== "terminal") {
+            throw new Error("boot_prompt_path is only supported for terminal surfaces");
+          }
+          await preflightBootPromptFile(bootPromptPath);
+        }
+
         const result = await client.newSplit(args.direction, {
           workspace: args.workspace,
           surface: args.surface,
@@ -1079,13 +1299,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
           result.title = args.title;
         }
-        const data = { ...result };
+        let bootPromptDelivery:
+          | Awaited<ReturnType<typeof deliverBootPrompt>>
+          | undefined;
+        if (bootPromptPath) {
+          bootPromptDelivery = await deliverBootPrompt({
+            surface: result.surface,
+            workspace: result.workspace || args.workspace,
+            boot_prompt_path: bootPromptPath,
+            timeout_ms: args.boot_prompt_timeout_ms,
+          });
+        }
+        const data: Record<string, unknown> = { ...result };
+        if (bootPromptDelivery) {
+          data.boot_prompt_delivered = true;
+          data.boot_prompt_bytes = bootPromptDelivery.bytes;
+        }
         return okFormatted(
           formatOk("new_split", {
             surface: result.surface,
             direction: args.direction,
             type: args.type,
             title: result.title,
+            boot_prompt_delivered: Boolean(bootPromptDelivery),
           }),
           data,
         );
@@ -1098,7 +1334,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 3. new_surface
   server.tool(
     "new_surface",
-    "Create a new surface (tab) in an existing pane",
+    "Create a new surface (tab) in an existing pane. For terminal tabs that boot an agent, boot_prompt_path can deliver a file prompt after the agent reaches a ready prompt.",
     {
       pane: z.string().describe("Target pane ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
@@ -1109,10 +1345,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .describe("Surface type"),
       title: z.string().optional().describe("Tab title"),
       url: z.string().optional().describe("URL for browser surfaces"),
+      boot_prompt_path: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Optional path to a prompt file to read after readiness and submit to the new terminal surface. Checked before tab creation.",
+        ),
+      boot_prompt_timeout_ms: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(BOOT_PROMPT_TIMEOUT_MS)
+        .describe("Timeout in milliseconds waiting for the agent ready prompt"),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
+        if (bootPromptPath) {
+          if ((args.type ?? "terminal") !== "terminal") {
+            throw new Error("boot_prompt_path is only supported for terminal surfaces");
+          }
+          await preflightBootPromptFile(bootPromptPath);
+        }
+
         const result = await client.newSurface({
           pane: args.pane,
           workspace: args.workspace,
@@ -1125,13 +1383,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
           result.title = args.title;
         }
-        const data = { ...result };
+        let bootPromptDelivery:
+          | Awaited<ReturnType<typeof deliverBootPrompt>>
+          | undefined;
+        if (bootPromptPath) {
+          bootPromptDelivery = await deliverBootPrompt({
+            surface: result.surface,
+            workspace: result.workspace || args.workspace,
+            boot_prompt_path: bootPromptPath,
+            timeout_ms: args.boot_prompt_timeout_ms,
+          });
+        }
+        const data: Record<string, unknown> = { ...result };
+        if (bootPromptDelivery) {
+          data.boot_prompt_delivered = true;
+          data.boot_prompt_bytes = bootPromptDelivery.bytes;
+        }
         return okFormatted(
           formatOk("new_surface", {
             pane: args.pane,
             surface: result.surface,
             type: result.type,
             title: result.title,
+            boot_prompt_delivered: Boolean(bootPromptDelivery),
           }),
           data,
         );
@@ -1310,17 +1584,44 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 7. send_command
   server.tool(
     "send_command",
-    "Atomically send a command and press return on the same surface. Prefer this over separate send_input + send_key calls when launching or resuming agents.",
+    "Atomically send a command and press return on the same surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path reads a prompt file after the launcher reaches readiness and submits it; passing boot_prompt_path for plain shell commands is rejected.",
     {
       surface: z.string().describe("Target surface ref"),
       command: z
         .string()
         .describe("Command text to send before pressing return"),
       workspace: z.string().optional().describe("Target workspace ref"),
+      boot_prompt_path: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Optional path to a prompt file for launcher commands matching <repo>Codex|Claude|Cursor|Gemini|Kiro with -s. File is checked before sending the launcher and read after readiness.",
+        ),
+      boot_prompt_timeout_ms: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(BOOT_PROMPT_TIMEOUT_MS)
+        .describe("Timeout in milliseconds waiting for the agent ready prompt"),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
+        const launcherCli = bootPromptPath
+          ? inferLauncherCli(args.command)
+          : null;
+        if (bootPromptPath && !launcherCli) {
+          throw new Error(
+            "boot_prompt_path is only supported for agent launcher commands with -s",
+          );
+        }
+        if (bootPromptPath) {
+          await preflightBootPromptFile(bootPromptPath);
+        }
+
         const sanitizedCommand = sanitizeTerminalInput(args.command);
         const chunks =
           sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
@@ -1341,14 +1642,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }),
         );
 
+        let bootPromptDelivery:
+          | Awaited<ReturnType<typeof deliverBootPrompt>>
+          | undefined;
+        if (bootPromptPath && launcherCli) {
+          bootPromptDelivery = await deliverBootPrompt({
+            surface: args.surface,
+            workspace: args.workspace,
+            cli: launcherCli,
+            boot_prompt_path: bootPromptPath,
+            timeout_ms: args.boot_prompt_timeout_ms,
+          });
+        }
+
         const data = {
           surface: args.surface,
           command: sanitizedCommand,
           retry_count: delivery.retry_count,
           submit_verified: delivery.submit_verified,
+          boot_prompt_delivered: Boolean(bootPromptDelivery),
+          boot_prompt_bytes: bootPromptDelivery?.bytes,
         };
         return okFormatted(formatOk("send_command", data), data);
       } catch (e) {
+        if (e instanceof BootPromptTimeoutError) {
+          return err(e, { last_10_lines: e.last_10_lines });
+        }
+        if (e instanceof BootPromptDeliveryError) {
+          return err(e, { delivered_chars: e.delivered_chars });
+        }
         if (e instanceof DeliveryError) {
           return err(e, { failed_chunk: e.failed_chunk ?? null });
         }
@@ -1907,7 +2229,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      "Spawn an AI agent in a new terminal surface. Returns immediately — use wait_for to block until ready.",
+      "Spawn an AI agent in a new terminal surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot prompt, and returns after submission. boot_prompt_path is checked before spawning and read after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.",
       {
         repo: z
           .string()
@@ -1918,7 +2240,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])
           .describe("CLI tool to launch"),
-        prompt: z.string().describe("Task prompt to send after agent is ready"),
+        prompt: z
+          .string()
+          .optional()
+          .describe(
+            "Inline task prompt to send after the agent is ready. Mutually exclusive with boot_prompt_path.",
+          ),
+        boot_prompt_path: z
+          .string()
+          .nullable()
+          .optional()
+          .describe(
+            "Optional path to a prompt file. The file is checked before spawning, read after readiness, sent with chunked delivery, then submitted with return. Mutually exclusive with prompt.",
+          ),
+        boot_prompt_timeout_ms: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .default(BOOT_PROMPT_TIMEOUT_MS)
+          .describe("Timeout in milliseconds waiting for the agent ready prompt"),
         workspace: z.string().optional().describe("Target workspace ref"),
         parent_agent_id: z
           .string()
@@ -1941,26 +2282,67 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
+          const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
+          assertBootPromptMode(args.prompt, bootPromptPath);
+          if (bootPromptPath) {
+            await preflightBootPromptFile(bootPromptPath);
+          }
+
           const result = await engine.spawnAgent({
             repo: args.repo,
             model: args.model,
             cli: args.cli,
-            prompt: args.prompt,
+            prompt: args.prompt ?? bootPromptPath ?? "",
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
             max_cost_per_agent: args.max_cost_per_agent,
             crash_recover: args.crash_recover,
           });
+
+          let bootPromptDelivery:
+            | Awaited<ReturnType<typeof deliverBootPrompt>>
+            | undefined;
+          if (hasInlinePrompt(args.prompt) || bootPromptPath) {
+            bootPromptDelivery = await deliverBootPrompt({
+              surface: result.surface_id,
+              workspace: args.workspace,
+              cli: args.cli,
+              prompt: args.prompt,
+              boot_prompt_path: bootPromptPath,
+              timeout_ms: args.boot_prompt_timeout_ms,
+            });
+
+            const current = engine.getAgentState(result.agent_id);
+            if (current?.state === "booting") {
+              const ready = stateMgr.transition(result.agent_id, "ready");
+              registry.set(result.agent_id, ready);
+              result.state = "ready";
+            } else if (current?.state === "ready") {
+              result.state = "ready";
+            }
+          }
+
           return okFormatted(
             formatOk("spawn_agent", {
               agent_id: result.agent_id,
               repo: args.repo,
               model: args.model,
               surface: result.surface_id,
+              boot_prompt_delivered: Boolean(bootPromptDelivery),
             }),
-            { ...result },
+            {
+              ...result,
+              boot_prompt_delivered: Boolean(bootPromptDelivery),
+              boot_prompt_bytes: bootPromptDelivery?.bytes,
+            },
           );
         } catch (e) {
+          if (e instanceof BootPromptTimeoutError) {
+            return err(e, { last_10_lines: e.last_10_lines });
+          }
+          if (e instanceof BootPromptDeliveryError) {
+            return err(e, { delivered_chars: e.delivered_chars });
+          }
           return err(e);
         }
       },

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -692,6 +692,31 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       expect(result.agent?.state).toBe("ready");
     });
 
+    it("promotes booting agents to ready when their CLI prompt appears", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "codex",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: "codex> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+      engine.startSweep(50);
+
+      const result = await engine.waitFor("agent-boot", "ready", 5000);
+
+      expect(result.matched).toBe(true);
+      expect(result.state).toBe("ready");
+    });
+
     it("throws for non-existent agent", async () => {
       await expect(
         engine.waitFor("nonexistent", "ready", 1000),

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -717,11 +717,87 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       expect(result.state).toBe("ready");
     });
 
+    it("does not promote booting agents while boot prompt delivery is pending", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "codex",
+          boot_prompt_pending: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: "codex> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot")?.state).toBe("booting");
+    });
+
+    it("promotes low-confidence CLI prompts after consecutive matches", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-gemini",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "gemini",
+          task_summary: "",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: "ready\n> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+      expect(engine.getAgentState("agent-gemini")?.state).toBe("booting");
+
+      await engine.runSweep();
+      expect(engine.getAgentState("agent-gemini")?.state).toBe("ready");
+    });
+
     it("throws for non-existent agent", async () => {
       await expect(
         engine.waitFor("nonexistent", "ready", 1000),
       ).rejects.toThrow(/not found/);
     });
+  });
+
+  describe("default preflight", () => {
+    it.each([
+      ["codex", "Codex"],
+      ["cursor", "Cursor"],
+    ] as const)(
+      "rejects missing %s repoGolem launchers before creating a surface",
+      async (cli, suffix) => {
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        const defaultEngine = new AgentEngine(stateMgr, registry, mockClient);
+        try {
+          await expect(
+            defaultEngine.spawnAgent({
+              repo: `missinglauncher${suffix}`,
+              model: "test",
+              cli,
+              prompt: "",
+            }),
+          ).rejects.toThrow(`missinglauncher${suffix}${suffix}`);
+          expect(mockClient.newSplit).not.toHaveBeenCalled();
+        } finally {
+          defaultEngine.dispose();
+        }
+      },
+    );
   });
 
   describe("waitForAll", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -715,6 +715,9 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
 
       expect(result.matched).toBe(true);
       expect(result.state).toBe("ready");
+      expect(mockClient.readScreen).toHaveBeenCalledWith("surface:42", {
+        lines: 80,
+      });
     });
 
     it("does not promote booting agents while boot prompt delivery is pending", async () => {
@@ -725,6 +728,7 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
           surface_id: "surface:42",
           cli: "codex",
           boot_prompt_pending: true,
+          updated_at: new Date().toISOString(),
         }),
       );
       liveSurfaces = [makeSurface("surface:42")];
@@ -739,6 +743,29 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       await engine.runSweep();
 
       expect(engine.getAgentState("agent-boot")?.state).toBe("booting");
+    });
+
+    it("marks stale pending boot prompt agents as errored", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "codex",
+          boot_prompt_pending: true,
+          updated_at: new Date(Date.now() - 6 * 60_000).toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot")).toMatchObject({
+        state: "error",
+        boot_prompt_pending: false,
+        error: "Boot prompt delivery interrupted before completion",
+      });
     });
 
     it("promotes low-confidence CLI prompts after consecutive matches", async () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -980,9 +980,9 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("claude", "golems")).toBe("golemsClaude -s");
   });
 
-  it("uses cd + env vars + raw command for codex", () => {
+  it("uses repoGolem launcher for codex (no positional prompt)", () => {
     expect(buildLaunchCommand("codex", "brainlayer")).toBe(
-      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex",
+      "brainlayerCodex -s",
     );
   });
 
@@ -998,9 +998,9 @@ describe("buildLaunchCommand", () => {
     );
   });
 
-  it("uses cd + env vars + cursor agent for cursor", () => {
+  it("uses repoGolem launcher for cursor (no positional prompt)", () => {
     expect(buildLaunchCommand("cursor", "cmuxlayer")).toBe(
-      "cd ~/Gits/cmuxlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 cursor agent",
+      "cmuxlayerCursor -s",
     );
   });
 
@@ -1036,9 +1036,10 @@ describe("buildLaunchCommand", () => {
     );
   });
 
-  it("includes CLAUDE_CODE_NO_FLICKER=1 for non-Claude CLIs", () => {
+  it("does NOT include env vars for codex (launcher handles them)", () => {
     const cmd = buildLaunchCommand("codex", "brainlayer");
-    expect(cmd).toContain("CLAUDE_CODE_NO_FLICKER=1");
+    expect(cmd).not.toContain("CLAUDE_CODE_NO_FLICKER");
+    expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
   });
 
   it("includes MCP_CONNECTION_NONBLOCKING=1 for non-Claude CLIs", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -357,7 +357,7 @@ describe("AgentEngine", () => {
       expect(mockClient.newSplit).toHaveBeenCalled();
       expect(mockClient.send).toHaveBeenCalledWith(
         "surface:new",
-        "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
         { workspace: "ws:1" },
       );
       expect(mockClient.sendKey).toHaveBeenCalledWith("surface:new", "return", {
@@ -1160,13 +1160,13 @@ describe("buildResumeCommand", () => {
 
   it("uses the verified resume command for each supported CLI", () => {
     expect(buildResumeCommand("claude", "brainlayer", sessionId)).toBe(
-      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("codex", "brainlayer", sessionId)).toBe(
-      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("cursor", "brainlayer", sessionId)).toBe(
-      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 cursor agent --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerCursor -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("gemini", "brainlayer", sessionId)).toBe(
       "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -306,7 +306,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
     // First spawn a parent
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const parentResult = await spawn.handler(
-      { repo: "test", model: "sonnet", cli: "claude", prompt: "parent task" },
+      { repo: "test", model: "sonnet", cli: "claude" },
       {} as any,
     );
     const parentId = (
@@ -319,7 +319,6 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
         repo: "test",
         model: "haiku",
         cli: "claude",
-        prompt: "child task",
         parent_agent_id: parentId,
       },
       {} as any,
@@ -339,7 +338,6 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
         repo: "test",
         model: "opus",
         cli: "claude",
-        prompt: "expensive task",
         max_cost_per_agent: 5.0,
       },
       {} as any,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3,7 +3,7 @@
  * Tests tool registration and handler dispatch with mocked cmux client.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -88,7 +88,7 @@ function makeLifecycleExec(): ExecFn {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: "$ ",
+          text: "codex> ",
           lines: 20,
           scrollback_used: false,
         }),
@@ -186,7 +186,117 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toMatch(/^sonnet-brainlayer-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
-    expect(parsed.state).toBe("booting");
+    expect(parsed.state).toBe("ready");
+  });
+
+  it("spawn_agent sends inline prompt after the agent is ready", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "fix prompt delivery",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:new",
+    ]));
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:new",
+      "fix prompt delivery",
+    ]));
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send-key",
+      "--surface",
+      "surface:new",
+      "return",
+    ]));
+  });
+
+  it("spawn_agent sends boot_prompt_path contents after readiness", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:new",
+      "file prompt body",
+    ]));
+  });
+
+  it("spawn_agent rejects prompt and boot_prompt_path together", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "inline",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("mutually exclusive");
+  });
+
+  it("spawn_agent rejects missing boot_prompt_path before creating a surface", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: join(TEST_DIR, "missing.md"),
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("ENOENT");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-split"]),
+    );
   });
 
   it("spawn_agent persists crash_recover=true in agent state", async () => {
@@ -318,7 +428,6 @@ describe("agent lifecycle tool handlers", () => {
         repo: "test",
         model: "sonnet",
         cli: "claude",
-        prompt: "test",
       },
       {} as any,
     );
@@ -526,7 +635,6 @@ describe("agent lifecycle tool handlers", () => {
         repo: "brainlayer",
         model: "sonnet",
         cli: "claude",
-        prompt: "task 1",
       },
       {} as any,
     );

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -26,7 +26,15 @@ const AGENT_TOOLS = [
 ] as const;
 
 function makeLifecycleExec(): ExecFn {
+  let readyText = "What can I help you with?\n>";
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("send")) {
+      const text = String(args[args.length - 1] ?? "");
+      if (text.includes("Codex")) readyText = "codex> ";
+      if (text.includes("Claude")) readyText = "What can I help you with?\n>";
+      if (text.includes("Cursor")) readyText = "cursor> ";
+    }
+
     if (args.includes("list-workspaces")) {
       return {
         stdout: JSON.stringify({
@@ -88,7 +96,7 @@ function makeLifecycleExec(): ExecFn {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: "codex> ",
+          text: readyText,
           lines: 20,
           scrollback_used: false,
         }),
@@ -250,6 +258,35 @@ describe("agent lifecycle tool handlers", () => {
       "surface:new",
       "file prompt body",
     ]));
+  });
+
+  it("spawn_agent stores boot_prompt_path contents as task_summary after delivery", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(state.task_summary).toBe("file prompt body");
   });
 
   it("spawn_agent rejects prompt and boot_prompt_path together", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -336,6 +336,69 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
+  it("spawn_agent marks the agent errored when boot prompt delivery times out", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
+      }
+      if (args.includes("list-panes")) {
+        return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: "$ waiting",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          workspace: "ws:1",
+          surface: "surface:new",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    });
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 20,
+      },
+      {} as any,
+    );
+    const parsed =
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.agent_id).toBeDefined();
+    expect(parsed.surface_id).toBe("surface:new");
+
+    const stateResult = await getState.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(state.state).toBe("error");
+    expect(state.boot_prompt_pending).toBe(false);
+    expect(state.error).toContain("Boot prompt failed");
+  });
+
   it("spawn_agent persists crash_recover=true in agent state", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1621,6 +1621,57 @@ describe("tool handler integration", () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 
+  it("new_split reports boot prompt timeout with surface and last screen lines", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "line 1\nline 2\n$ waiting",
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 20,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.surface).toBe("surface:2");
+    expect(parsed.last_10_lines).toContain("$ waiting");
+  });
+
   it("new_split renames the new surface when a title is provided", async () => {
     mockExec = vi
       .fn()
@@ -1746,6 +1797,57 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("ENOENT");
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("new_surface reports boot prompt timeout with surface and last screen lines", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "surface-mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:3",
+            pane: "pane:1",
+            title: "New Tab",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:3",
+            text: "line 1\nline 2\n$ waiting",
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_surface"];
+
+    const result = await tool.handler(
+      {
+        pane: "pane:1",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 20,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.surface).toBe("surface:3");
+    expect(parsed.last_10_lines).toContain("$ waiting");
   });
 
   it("move_surface handler calls cmux move-surface", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -1009,6 +1009,124 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:6");
   });
 
+  it("send_command rejects boot_prompt_path for non-launcher commands before sending", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "echo hello",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("launcher");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("send_command sends boot_prompt_path contents after launcher readiness", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "codex> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerCodex -s",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:1",
+      "brainlayerCodex -s",
+    ]));
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:1",
+      "boot prompt",
+    ]));
+  });
+
+  it("send_command reports timeout with last screen lines and leaves launcher surface alive", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "line 1\nline 2\n$ waiting",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerCodex -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 20,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Timed out");
+    expect(parsed.last_10_lines).toContain("$ waiting");
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:1",
+      "brainlayerCodex -s",
+    ]));
+  });
+
   it("send_input chunks long text transparently before sending", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
@@ -1386,6 +1504,37 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:2");
   });
 
+  it("new_split rejects missing boot_prompt_path before creating a pane", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:2",
+        pane: "pane:1",
+        title: "New",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: join(CHANNEL_TEST_DIR, "missing.md"),
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("ENOENT");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it("new_split renames the new surface when a title is provided", async () => {
     mockExec = vi
       .fn()
@@ -1480,6 +1629,37 @@ describe("tool handler integration", () => {
         "Build Logs",
       ]),
     );
+  });
+
+  it("new_surface rejects missing boot_prompt_path before creating a tab", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:3",
+        pane: "pane:1",
+        title: "New Tab",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["new_surface"];
+
+    const result = await tool.handler(
+      {
+        pane: "pane:1",
+        boot_prompt_path: join(CHANNEL_TEST_DIR, "missing.md"),
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("ENOENT");
+    expect(mockExec).not.toHaveBeenCalled();
   });
 
   it("move_surface handler calls cmux move-surface", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1127,6 +1127,92 @@ describe("tool handler integration", () => {
     ]));
   });
 
+  it("send_command does not treat another CLI prompt as launcher readiness", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "codex> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 20,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(mockExec).not.toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:1",
+      "boot prompt",
+    ]));
+  });
+
+  it("send_command requires consecutive low-confidence ready matches", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let reads = 0;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        reads += 1;
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: reads === 1 ? "booting\n>" : "ready\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerGemini -s",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(reads).toBe(2);
+    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
+      "send",
+      "--surface",
+      "surface:1",
+      "boot prompt",
+    ]));
+  });
+
   it("send_input chunks long text transparently before sending", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -122,7 +122,6 @@ describe("interact — runtime validation", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test",
     });
     // Get the agent_id
     const listResult = await callTool(server, "list_agents", {});
@@ -194,7 +193,6 @@ describe("interact — agent resolution", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test",
     });
     const agentId = parseResult(spawnResult).agent_id;
 
@@ -247,7 +245,6 @@ describe("kill — scoped targets", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test",
     });
     const agentId = parseResult(spawn).agent_id;
 
@@ -264,13 +261,11 @@ describe("kill — scoped targets", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test1",
     });
     const spawn2 = await callTool(server, "spawn_agent", {
       repo: "voicelayer",
       model: "haiku",
       cli: "claude",
-      prompt: "test2",
     });
     const id1 = parseResult(spawn1).agent_id;
     const id2 = parseResult(spawn2).agent_id;
@@ -288,13 +283,11 @@ describe("kill — scoped targets", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test1",
     });
     await callTool(server, "spawn_agent", {
       repo: "voicelayer",
       model: "haiku",
       cli: "claude",
-      prompt: "test2",
     });
 
     const result = await callTool(server, "kill", { target: "all" });
@@ -316,7 +309,6 @@ describe("kill — scoped targets", () => {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
-      prompt: "test",
     });
     const agentId = parseResult(spawn).agent_id;
 


### PR DESCRIPTION
## Summary
- Fix `spawn_agent.prompt` so inline prompts are delivered after the launched agent reaches a ready prompt.
- Add `boot_prompt_path` + `boot_prompt_timeout_ms` to `spawn_agent`, `new_split`, `new_surface`, and launcher-only `send_command`.
- Preflight prompt files before creating surfaces or sending launchers, preserve surfaces on readiness timeout, and report last screen lines for debugging.
- Route Codex and Cursor `spawn_agent` launches through repoGolem launchers with bare `-s`, matching the new boot-prompt delivery path.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (27 files, 462 tests)
- [x] pre-push hook full test suite (27 files, 462 tests)

CodeRabbit CLI note: local `cr review --plain` was attempted before commit, but the CLI returned "Review limit reached". CodeRabbit review is requested on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent spawn semantics (optional prompt, blocking delivery, launcher requirements for Codex/Cursor) and terminal input timing; failures are surfaced but mis-timed readiness could still send prompts to the wrong surface state.
> 
> **Overview**
> This PR adds a **boot prompt pipeline**: after a terminal shows a CLI-specific ready pattern, the server can read an inline `prompt` or `boot_prompt_path` file (preflighted first), chunk-deliver it, and submit with return. **`spawn_agent`** now optionally blocks until that delivery finishes; **`new_split`**, **`new_surface`**, and launcher-only **`send_command`** gain the same file-based path plus configurable **`boot_prompt_timeout_ms`**. Failures return **`last_10_lines`** or **`delivered_chars`** without tearing down the surface.
> 
> **Codex** and **Cursor** launches/resumes move from `cd ~/Gits/...` shell invocations to **`{repo}Codex -s`** / **`{repo}Cursor -s`** (and matching resume commands), with spawn preflight extended to require those launchers like Claude already did.
> 
> The sweep loop gains **`maybeMarkBootReady`**, which promotes **`booting` → `ready`** when **`matchReadyPattern`** hits (including consecutive matches for low-confidence patterns), but **skips** promotion while **`boot_prompt_pending`** is set so prompts are not sent before the orchestrator finishes delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c9271107abebddd1579dce5865488b4cce511a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deliver boot prompts to agents after launcher readiness is detected
> - Adds `waitForBootPromptReady` and `deliverBootPrompt` internal functions in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/97/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that poll the terminal screen for a CLI readiness pattern before chunking and sending a boot prompt (inline or file-based).
> - Extends `spawn_agent`, `send_command`, `new_split`, and `new_surface` tool handlers with `boot_prompt_path` and `boot_prompt_timeout_ms` options; `spawn_agent` now treats `prompt` as optional and mutually exclusive with `boot_prompt_path`.
> - Adds `maybeMarkBootReady` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/97/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to transition booting agents to `ready` on consecutive prompt matches, or to `error` if `boot_prompt_pending` remains stale beyond 5 minutes.
> - Updates launch and resume commands for `codex` and `cursor` to use repoGolem launcher binaries (e.g. `<repo>Codex -s`) instead of raw shell `cd`/env invocations.
> - Risk: `spawn_agent` now transitions the agent to `error` with no retry if boot prompt delivery times out or fails mid-send, and the agent's previous `booting` state is not recoverable from the API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0c8440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boot prompt delivery support for agent spawning and terminal surfaces, enabling initialization of terminal environments with custom prompts.
  * Introduced boot prompt timeout configuration and readiness detection to ensure prompts are delivered when terminals are ready.
  * Extended tool contracts to accept boot prompt files and inline prompts with configurable timeout handling.

* **Tests**
  * Updated test cases to validate boot prompt handling across agent spawning and terminal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/cmuxlayer/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->