### PR TITLE
feat: deterministic role-based pane layout

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -28,13 +28,21 @@ import {
   MAX_RESPAWN_ATTEMPTS,
   type AgentRoute,
   type AgentRecord,
+  type AgentRole,
   type AgentState,
   type CliType,
   type PublicAgent,
   type WaitResult,
 } from "./agent-types.js";
 import { parseScreen } from "./screen-parser.js";
-import { chooseAgentSpawnPlacement } from "./layout-policy.js";
+import {
+  chooseAgentSpawnPlacement,
+  collectRoleSurfaceIds,
+  inferAgentRole,
+  inferRecordRole,
+  launcherNameForCli,
+  type RoleSurfaceIds,
+} from "./layout-policy.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 
 export interface SpawnAgentParams {
@@ -45,6 +53,8 @@ export interface SpawnAgentParams {
   boot_prompt_pending?: boolean;
   workspace?: string;
   parent_agent_id?: string;
+  role?: AgentRole;
+  auto_archive_on_done?: boolean;
   max_cost_per_agent?: number;
   crash_recover?: boolean;
 }
@@ -57,6 +67,10 @@ export interface SpawnAgentResult {
 
 export interface AgentEngineOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+  roleSurfaceIdsProvider?: (
+    liveSurfaceIds?: ReadonlySet<string>,
+    workspace?: string,
+  ) => RoleSurfaceIds;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored";
@@ -67,6 +81,8 @@ const SWEEP_INTERVAL_MS = 1000;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
+const TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS = 30 * 60_000;
+const TASK_DONE_CONFIRMATION_MS = 5_000;
 const SESSION_ID_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const SESSION_ID_RE =
@@ -78,6 +94,35 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
 const execFileAsync = promisify(execFile);
+
+function autoArchiveEnabledByEnv(): boolean {
+  return !["0", "false", "off", "no"].includes(
+    (process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE ?? "").toLowerCase(),
+  );
+}
+
+function tailScreenLines(text: string, lines: number): string {
+  return text.split(/\r?\n/).slice(-lines).join("\n");
+}
+
+function taskDoneAutoArchiveMs(): number {
+  const rawMs = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
+  if (rawMs !== undefined) {
+    const parsed = Number(rawMs);
+    return Number.isFinite(parsed) && parsed >= 0
+      ? parsed
+      : TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
+  }
+
+  const rawMinutes = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES;
+  if (rawMinutes === undefined) {
+    return TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
+  }
+  const parsed = Number(rawMinutes);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? parsed * 60_000
+    : TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
+}
 
 interface AgentEngineClient {
   log(
@@ -145,6 +190,10 @@ interface AgentEngineClient {
     workspace?: string;
     pane?: string;
   }): Promise<CmuxPaneSurfaces>;
+  closeSurface(
+    surface: string,
+    opts?: { workspace?: string; collapsePane?: boolean },
+  ): Promise<void>;
   notifyLifecycleEvent(
     event: AgentLifecycleEvent,
     agent: AgentRecord,
@@ -268,6 +317,10 @@ export class AgentEngine {
   private registry: AgentRegistry;
   private client: AgentEngineClient;
   private spawnPreflight: (params: SpawnAgentParams) => Promise<void>;
+  private roleSurfaceIdsProvider?: (
+    liveSurfaceIds?: ReadonlySet<string>,
+    workspace?: string,
+  ) => RoleSurfaceIds;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   /** agentId → last-pushed status string */
   private sidebarSnapshot = new Map<string, string>();
@@ -285,6 +338,7 @@ export class AgentEngine {
     this.stateMgr = stateMgr;
     this.registry = registry;
     this.client = client;
+    this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.spawnPreflight =
       opts?.spawnPreflight ??
       (async (params) => {
@@ -302,8 +356,20 @@ export class AgentEngine {
     return this.registry;
   }
 
+  private hasTrailingTaskDoneSignal(text: string): boolean {
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return lines.at(-1) === "TASK_DONE";
+  }
+
   private async createAgentSurface(
     workspace?: string,
+    context?: {
+      role?: AgentRole;
+      parentAgent?: AgentRecord | null;
+    },
   ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
     try {
       const panes = await this.client.listPanes({ workspace });
@@ -315,13 +381,40 @@ export class AgentEngine {
           }),
         ),
       );
-      const workerSurfaceIds = new Set(
-        this.registry.list().map((agent) => agent.surface_id),
+      const parentAgent = context?.parentAgent ?? null;
+      const liveSurfaceIds = new Set(
+        paneSurfaces.flatMap((group) =>
+          group.surfaces.map((surface) => surface.ref),
+        ),
+      );
+      const roleSurfaceIds = collectRoleSurfaceIds(this.registry.list());
+      const extraRoleSurfaceIds =
+        this.roleSurfaceIdsProvider?.(liveSurfaceIds, workspace) ?? null;
+      if (extraRoleSurfaceIds) {
+        for (const role of ["orchestrator", "ic", "worker"] as const) {
+          for (const surfaceId of extraRoleSurfaceIds[role]) {
+            roleSurfaceIds[role].add(surfaceId);
+          }
+        }
+      }
+      const childWorkerSurfaceIds = new Set(
+        parentAgent
+          ? this.registry
+              .getChildren(parentAgent.agent_id)
+              .filter((agent) => inferRecordRole(agent) === "worker")
+              .map((agent) => agent.surface_id)
+          : [],
       );
       const placement = chooseAgentSpawnPlacement(
         panes.panes,
         paneSurfaces,
-        workerSurfaceIds,
+        roleSurfaceIds,
+        {
+          role: context?.role ?? "worker",
+          parentRole: parentAgent ? inferRecordRole(parentAgent) : null,
+          parentSurfaceId: parentAgent?.surface_id ?? null,
+          childWorkerSurfaceIds,
+        },
       );
       return placement.kind === "surface"
         ? this.client.newSurface({
@@ -330,6 +423,7 @@ export class AgentEngine {
             workspace,
           })
         : this.client.newSplit(placement.direction, {
+            ...(placement.pane ? { pane: placement.pane } : {}),
             workspace,
             type: "terminal",
           });
@@ -427,6 +521,80 @@ export class AgentEngine {
     }
   }
 
+  private async maybeMarkTaskDone(
+    agent: AgentRecord,
+  ): Promise<{ agent: AgentRecord; screenText?: string }> {
+    if (TERMINAL_STATES.has(agent.state)) return { agent };
+    if (agent.cli !== "codex" || inferRecordRole(agent) !== "worker") {
+      return { agent };
+    }
+    if (agent.boot_prompt_pending) return { agent };
+
+    try {
+      const screen = await this.client.readScreen(agent.surface_id, {
+        lines: BOOT_SESSION_CAPTURE_LINES,
+      });
+      if (!this.hasTrailingTaskDoneSignal(screen.text)) {
+        if (agent.task_done_candidate_at) {
+          const updated = this.stateMgr.updateRecord(agent.agent_id, {
+            task_done_candidate_at: null,
+          });
+          this.registry.set(agent.agent_id, updated);
+          return { agent: updated, screenText: screen.text };
+        }
+        return { agent, screenText: screen.text };
+      }
+
+      const candidateAt = Date.parse(agent.task_done_candidate_at ?? "");
+      if (!agent.task_done_candidate_at || Number.isNaN(candidateAt)) {
+        const updated = this.stateMgr.updateRecord(agent.agent_id, {
+          task_done_candidate_at: new Date().toISOString(),
+        });
+        this.registry.set(agent.agent_id, updated);
+        return { agent: updated, screenText: screen.text };
+      }
+      if (Date.now() - candidateAt < TASK_DONE_CONFIRMATION_MS) {
+        return { agent, screenText: screen.text };
+      }
+
+      const marked = this.stateMgr.updateRecord(agent.agent_id, {
+        task_done_candidate_at: null,
+        task_done_detected_at: new Date().toISOString(),
+      });
+      this.registry.set(agent.agent_id, marked);
+      const updated = this.stateMgr.transition(agent.agent_id, "done");
+      this.registry.set(agent.agent_id, updated);
+      return { agent: updated, screenText: screen.text };
+    } catch {
+      return { agent };
+    }
+  }
+
+  private async maybeArchiveDoneAgent(agent: AgentRecord): Promise<boolean> {
+    if (agent.state !== "done") return false;
+    if (agent.cli !== "codex" || inferRecordRole(agent) !== "worker") {
+      return false;
+    }
+    if (agent.auto_archive_on_done !== true || !autoArchiveEnabledByEnv()) {
+      return false;
+    }
+    if (!agent.task_done_detected_at) return false;
+
+    const detectedAt = Date.parse(agent.task_done_detected_at);
+    if (Number.isNaN(detectedAt)) return false;
+    if (Date.now() - detectedAt < taskDoneAutoArchiveMs()) return false;
+
+    try {
+      await this.client.closeSurface(agent.surface_id, {
+        workspace: agent.workspace_id ?? undefined,
+      });
+      return true;
+    } catch {
+      // Best-effort archive; the next sweep will retry if the surface remains.
+      return false;
+    }
+  }
+
   private isRecoverableCrash(agent: AgentRecord): boolean {
     return isCrashRecoveryEligible(agent);
   }
@@ -502,7 +670,12 @@ export class AgentEngine {
         });
         this.registry.set(agent.agent_id, attempted);
 
-        const surface = await this.createAgentSurface(agent.workspace_id ?? undefined);
+        const surface = await this.createAgentSurface(agent.workspace_id ?? undefined, {
+          role: inferRecordRole(agent),
+          parentAgent: agent.parent_agent_id
+            ? this.registry.get(agent.parent_agent_id)
+            : null,
+        });
         const creating = this.stateMgr.transition(agent.agent_id, "creating", {
           error: null,
           pid: null,
@@ -587,7 +760,9 @@ export class AgentEngine {
 
     for (const originalAgent of agents) {
       const capturedAgent = await this.maybeCaptureBootSessionId(originalAgent);
-      const agent = await this.maybeMarkBootReady(capturedAgent);
+      const readyAgent = await this.maybeMarkBootReady(capturedAgent);
+      const taskDoneResult = await this.maybeMarkTaskDone(readyAgent);
+      const agent = taskDoneResult.agent;
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
         state === "error" ? `${repo}: error` : `${repo}: ${state}`;
@@ -607,6 +782,21 @@ export class AgentEngine {
         await this.emitLifecycleEvent(agent, "errored");
       }
 
+      const archived = await this.maybeArchiveDoneAgent(agent);
+      if (archived) {
+        try {
+          await this.client.clearStatus(agentId, {
+            workspace: agent.workspace_id ?? undefined,
+          });
+        } catch {
+          // Best-effort sidebar cleanup; the surface has already been closed.
+        }
+        this.registry.remove(agentId);
+        this.stateMgr.removeState(agentId);
+        this.sidebarSnapshot.delete(agentId);
+        continue;
+      }
+
       // Status diff — only push if changed
       const prev = this.sidebarSnapshot.get(agentId);
       if (prev !== statusValue) {
@@ -624,8 +814,10 @@ export class AgentEngine {
       // Replaces legacy parseContextPercent which only matched "X% context" text patterns.
       if (!TERMINAL_STATES.has(state)) {
         try {
-          const screen = await this.client.readScreen(surface_id, { lines: 5 });
-          const parsed = parseScreen(screen.text);
+          const screenText =
+            taskDoneResult.screenText ??
+            (await this.client.readScreen(surface_id, { lines: 5 })).text;
+          const parsed = parseScreen(tailScreenLines(screenText, 5));
           const contextPct = parsed.context_pct;
           if (
             contextPct !== null &&
@@ -747,6 +939,12 @@ export class AgentEngine {
     // Resolve parent hierarchy
     let spawnDepth = 0;
     let parentAgentId: string | null = null;
+    let parentAgent: AgentRecord | null = null;
+    const role = inferAgentRole({
+      role: params.role,
+      cli: params.cli,
+      launcherName: launcherNameForCli(params.repo, params.cli),
+    });
 
     if (params.parent_agent_id) {
       const parent = this.registry.get(params.parent_agent_id);
@@ -762,12 +960,16 @@ export class AgentEngine {
       }
       spawnDepth = parent.spawn_depth + 1;
       parentAgentId = params.parent_agent_id;
+      parentAgent = parent;
     }
 
     await this.spawnPreflight(params);
 
     // 1. Create cmux surface using the deterministic worker layout policy.
-    const surface = await this.createAgentSurface(params.workspace);
+    const surface = await this.createAgentSurface(params.workspace, {
+      role,
+      parentAgent,
+    });
 
     // 2. Write initial state (creating → booting)
     const now = new Date().toISOString();
@@ -788,6 +990,8 @@ export class AgentEngine {
       error: null,
       parent_agent_id: parentAgentId,
       spawn_depth: spawnDepth,
+      role,
+      auto_archive_on_done: params.auto_archive_on_done,
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: params.max_cost_per_agent ?? null,

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -15,6 +15,7 @@ export type AgentState =
 export type CliType = "claude" | "codex" | "gemini" | "kiro" | "cursor";
 
 export type AgentQuality = "unknown" | "verified" | "suspect" | "degraded";
+export type AgentRole = "orchestrator" | "ic" | "worker";
 
 export const MAX_SPAWN_DEPTH = 2;
 export const MAX_CHILDREN = 10;
@@ -38,6 +39,10 @@ export interface AgentRecord {
   // Hierarchy fields (Task 18)
   parent_agent_id: string | null;
   spawn_depth: number;
+  role?: AgentRole;
+  auto_archive_on_done?: boolean;
+  task_done_candidate_at?: string | null;
+  task_done_detected_at?: string | null;
   deletion_intent: boolean;
   // Quality fields (Task 19)
   quality: AgentQuality;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -130,6 +130,10 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       newSurface: (surfaceOpts) => this.client.newSurface(surfaceOpts),
       listPanes: (paneOpts) => this.client.listPanes(paneOpts),
       listPaneSurfaces: (surfaceOpts) => this.client.listPaneSurfaces(surfaceOpts),
+      closeSurface: (surface, closeOpts) =>
+        this.withSurfaceWrite(surface, () =>
+          this.client.closeSurface(surface, closeOpts),
+        ),
       notifyLifecycleEvent: async () => {},
     });
   }

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -1,7 +1,8 @@
 import type { CmuxPane, CmuxPaneSurfaces } from "./types.js";
+import type { AgentRecord, AgentRole, CliType } from "./agent-types.js";
 
 export type AgentSpawnPlacement =
-  | { kind: "split"; direction: "right" }
+  | { kind: "split"; direction: "left" | "right" | "up" | "down"; pane?: string }
   | { kind: "surface"; pane: string };
 
 export interface SurfaceClosePolicy {
@@ -13,14 +14,51 @@ export interface SurfaceClosePolicy {
 interface PaneLayout {
   pane: CmuxPane;
   surfaces: CmuxPaneSurfaces["surfaces"];
+  orchestratorCount: number;
+  icCount: number;
   workerCount: number;
-  nonWorkerCount: number;
+  roleCount: number;
+  nonRoleCount: number;
+}
+
+export interface RoleSurfaceIds {
+  orchestrator: Set<string>;
+  ic: Set<string>;
+  worker: Set<string>;
+}
+
+export interface AgentPlacementContext {
+  role?: AgentRole;
+  parentRole?: AgentRole | null;
+  parentSurfaceId?: string | null;
+  childWorkerSurfaceIds?: ReadonlySet<string>;
+}
+
+function emptyRoleSurfaceIds(): RoleSurfaceIds {
+  return {
+    orchestrator: new Set(),
+    ic: new Set(),
+    worker: new Set(),
+  };
+}
+
+function normalizeRoleSurfaceIds(
+  input: ReadonlySet<string> | RoleSurfaceIds,
+): RoleSurfaceIds {
+  if (!("worker" in input)) {
+    return {
+      orchestrator: new Set(),
+      ic: new Set(),
+      worker: new Set(input),
+    };
+  }
+  return input;
 }
 
 function describePaneLayouts(
   panes: CmuxPane[],
   paneSurfaces: CmuxPaneSurfaces[],
-  workerSurfaceIds: ReadonlySet<string>,
+  roleSurfaceIds: RoleSurfaceIds,
 ): PaneLayout[] {
   const groupsByPane = new Map(
     paneSurfaces.map((group) => [group.pane_ref, group.surfaces]),
@@ -28,20 +66,153 @@ function describePaneLayouts(
 
   return panes.map((pane) => {
     const surfaces = groupsByPane.get(pane.ref) ?? [];
-    const workerCount = surfaces.filter((surface) =>
-      workerSurfaceIds.has(surface.ref),
+    const orchestratorCount = surfaces.filter((surface) =>
+      roleSurfaceIds.orchestrator.has(surface.ref),
     ).length;
+    const icCount = surfaces.filter((surface) =>
+      roleSurfaceIds.ic.has(surface.ref),
+    ).length;
+    const workerCount = surfaces.filter((surface) =>
+      roleSurfaceIds.worker.has(surface.ref),
+    ).length;
+    const roleCount = orchestratorCount + icCount + workerCount;
     return {
       pane,
       surfaces,
+      orchestratorCount,
+      icCount,
       workerCount,
-      nonWorkerCount: surfaces.length - workerCount,
+      roleCount,
+      nonRoleCount: surfaces.length - roleCount,
     };
   });
 }
 
+function byPaneIndex(a: PaneLayout, b: PaneLayout): number {
+  return a.pane.index - b.pane.index;
+}
+
+function leftmost(layouts: PaneLayout[]): PaneLayout | undefined {
+  return [...layouts].sort(byPaneIndex).at(0);
+}
+
+function rightmost(layouts: PaneLayout[]): PaneLayout | undefined {
+  return [...layouts].sort(byPaneIndex).at(-1);
+}
+
+function isDedicatedOrchestratorPane(layout: PaneLayout): boolean {
+  return (
+    layout.orchestratorCount > 0 &&
+    layout.icCount === 0 &&
+    layout.workerCount === 0 &&
+    layout.nonRoleCount === 0
+  );
+}
+
+function isDedicatedIcPane(layout: PaneLayout): boolean {
+  return (
+    layout.icCount > 0 &&
+    layout.orchestratorCount === 0 &&
+    layout.workerCount === 0 &&
+    layout.nonRoleCount === 0
+  );
+}
+
 function isDedicatedWorkerPane(layout: PaneLayout): boolean {
-  return layout.workerCount > 0 && layout.nonWorkerCount === 0;
+  return (
+    layout.workerCount > 0 &&
+    layout.orchestratorCount === 0 &&
+    layout.icCount === 0 &&
+    layout.nonRoleCount === 0
+  );
+}
+
+function paneContainingSurface(
+  layouts: PaneLayout[],
+  surfaceId?: string | null,
+): PaneLayout | undefined {
+  if (!surfaceId) return undefined;
+  return layouts.find((layout) =>
+    layout.surfaces.some((surface) => surface.ref === surfaceId),
+  );
+}
+
+function paneContainingAnySurface(
+  layouts: PaneLayout[],
+  surfaceIds: ReadonlySet<string>,
+): PaneLayout | undefined {
+  if (surfaceIds.size === 0) return undefined;
+  return layouts.find((layout) =>
+    layout.surfaces.some((surface) => surfaceIds.has(surface.ref)),
+  );
+}
+
+export function inferAgentRole(input: {
+  role?: AgentRole;
+  launcherName?: string;
+  title?: string;
+  cli?: string;
+}): AgentRole {
+  if (input.role) return input.role;
+
+  const launcherName = input.launcherName ?? input.title ?? "";
+  if (/Claude$/i.test(launcherName)) return "orchestrator";
+  if (/(Codex|Cursor)$/i.test(launcherName)) return "worker";
+
+  switch (input.cli) {
+    case "claude":
+      return "orchestrator";
+    case "codex":
+    case "cursor":
+    case "gemini":
+    case "kiro":
+      return "worker";
+    default:
+      return "worker";
+  }
+}
+
+export function launcherNameForCli(repo: string, cli: CliType): string {
+  switch (cli) {
+    case "claude":
+      return `${repo}Claude`;
+    case "codex":
+      return `${repo}Codex`;
+    case "cursor":
+      return `${repo}Cursor`;
+    case "gemini":
+      return `${repo}Gemini`;
+    case "kiro":
+      return `${repo}Kiro`;
+    default:
+      return repo;
+  }
+}
+
+export function inferRecordRole(
+  agent: Pick<AgentRecord, "role" | "cli" | "repo">,
+): AgentRole {
+  return (
+    agent.role ??
+    inferAgentRole({
+      cli: agent.cli,
+      launcherName: launcherNameForCli(agent.repo, agent.cli),
+    })
+  );
+}
+
+export function collectRoleSurfaceIds(
+  agents: Iterable<Pick<AgentRecord, "role" | "cli" | "repo" | "surface_id">>,
+): RoleSurfaceIds {
+  const ids: RoleSurfaceIds = {
+    orchestrator: new Set(),
+    ic: new Set(),
+    worker: new Set(),
+  };
+  for (const agent of agents) {
+    ids[inferRecordRole(agent)].add(agent.surface_id);
+  }
+  return ids;
 }
 
 /**
@@ -54,30 +225,82 @@ function isDedicatedWorkerPane(layout: PaneLayout): boolean {
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
   paneSurfaces: CmuxPaneSurfaces[],
-  workerSurfaceIds: ReadonlySet<string>,
+  roleSurfaceIdsInput: ReadonlySet<string> | RoleSurfaceIds,
+  context: AgentPlacementContext = {},
 ): AgentSpawnPlacement {
-  if (workerSurfaceIds.size === 0) {
+  const roleSurfaceIds = normalizeRoleSurfaceIds(roleSurfaceIdsInput);
+  const role = context.role ?? "worker";
+  const layouts = describePaneLayouts(panes, paneSurfaces, roleSurfaceIds);
+  const leftPane = leftmost(layouts);
+
+  if (layouts.length === 0) {
     return { kind: "split", direction: "right" };
   }
 
-  const workerPanes = describePaneLayouts(
-    panes,
-    paneSurfaces,
-    workerSurfaceIds,
-  ).filter(isDedicatedWorkerPane);
+  if (role === "orchestrator") {
+    const orchestratorPane =
+      leftmost(layouts.filter(isDedicatedOrchestratorPane)) ??
+      (leftPane && leftPane.icCount === 0 && leftPane.workerCount === 0
+        ? leftPane
+        : undefined);
+    return orchestratorPane
+      ? { kind: "surface", pane: orchestratorPane.pane.ref }
+      : { kind: "split", direction: "left" };
+  }
 
-  if (workerPanes.length === 0) {
+  const workerPanes = layouts.filter(isDedicatedWorkerPane);
+  const icPanes = layouts.filter(isDedicatedIcPane);
+
+  if (role === "ic") {
+    const icPane = rightmost(icPanes);
+    if (icPane) {
+      return { kind: "surface", pane: icPane.pane.ref };
+    }
+    const workerPane = rightmost(workerPanes);
+    if (workerPane) {
+      return {
+        kind: "split",
+        direction: "up",
+        pane: workerPane.pane.ref,
+      };
+    }
     return { kind: "split", direction: "right" };
   }
 
-  const rightmostPane = [...workerPanes]
-    .sort((a, b) => a.pane.index - b.pane.index)
-    .at(-1);
-  if (!rightmostPane) {
-    return { kind: "split", direction: "right" };
+  if (context.parentRole === "ic") {
+    const childPane = paneContainingAnySurface(
+      layouts,
+      context.childWorkerSurfaceIds ?? new Set(),
+    );
+    if (childPane && isDedicatedWorkerPane(childPane)) {
+      return { kind: "surface", pane: childPane.pane.ref };
+    }
+
+    const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
+    if (parentPane) {
+      return {
+        kind: "split",
+        direction: "down",
+        pane: parentPane.pane.ref,
+      };
+    }
   }
 
-  return { kind: "surface", pane: rightmostPane.pane.ref };
+  const rightmostWorkerPane = rightmost(workerPanes);
+  if (rightmostWorkerPane) {
+    return { kind: "surface", pane: rightmostWorkerPane.pane.ref };
+  }
+
+  const rightmostIcPane = rightmost(icPanes);
+  if (rightmostIcPane) {
+    return {
+      kind: "split",
+      direction: "down",
+      pane: rightmostIcPane.pane.ref,
+    };
+  }
+
+  return { kind: "split", direction: "right" };
 }
 
 /**
@@ -94,7 +317,7 @@ export function chooseSurfaceClosePolicy(
   const layout = describePaneLayouts(
     panes,
     paneSurfaces,
-    workerSurfaceIds,
+    { ...emptyRoleSurfaceIds(), worker: new Set(workerSurfaceIds) },
   ).find((candidate) =>
     candidate.surfaces.some((surface) => surface.ref === surfaceId),
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { AgentDiscovery } from "./agent-discovery.js";
 import { toPublicAgent } from "./agent-facade.js";
 import type {
   AgentRecord,
+  AgentRole,
   AgentState,
   CliType,
   DeliveryEventType,
@@ -39,7 +40,12 @@ import {
 } from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
-import { chooseSurfaceClosePolicy } from "./layout-policy.js";
+import {
+  collectRoleSurfaceIds,
+  chooseAgentSpawnPlacement,
+  chooseSurfaceClosePolicy,
+  inferAgentRole,
+} from "./layout-policy.js";
 import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
@@ -519,6 +525,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const stateDir =
     opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
   const stateMgr = new StateManager(stateDir);
+  const roleSurfaceOverrides = new Map<
+    string,
+    { role: AgentRole; workspace: string | null }
+  >();
+  let lifecycleRegistry: AgentRegistry | null = null;
   const eventLog = stateMgr.getEventLog();
   const deliveries = new Map<string, DeliveryRecord>();
   const latestDeliveryBySurface = new Map<string, string>();
@@ -558,6 +569,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     failed_chunk: record.failed_chunk ?? null,
     error: record.error ?? null,
   });
+
+  const collectServerRoleSurfaceIds = (
+    liveSurfaceIds?: ReadonlySet<string>,
+    workspace?: string,
+  ) => {
+    const roleRecords = lifecycleRegistry?.list() ?? [];
+    const ids = collectRoleSurfaceIds(roleRecords);
+    if (liveSurfaceIds) {
+      for (const role of ["orchestrator", "ic", "worker"] as const) {
+        for (const surfaceId of ids[role]) {
+          if (!liveSurfaceIds.has(surfaceId)) {
+            ids[role].delete(surfaceId);
+          }
+        }
+      }
+    }
+    for (const [surfaceId, override] of roleSurfaceOverrides) {
+      if (liveSurfaceIds && !liveSurfaceIds.has(surfaceId)) {
+        if (workspace && override.workspace === workspace) {
+          roleSurfaceOverrides.delete(surfaceId);
+        }
+        continue;
+      }
+      ids[override.role].add(surfaceId);
+    }
+    return ids;
+  };
 
   const getSurfaceDelivery = (surface: string) => {
     const deliveryId = latestDeliveryBySurface.get(surface);
@@ -1261,6 +1299,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .describe("Surface type"),
       url: z.string().optional().describe("URL for browser surfaces"),
       title: z.string().optional().describe("Tab title"),
+      role: z
+        .enum(["orchestrator", "ic", "worker"])
+        .optional()
+        .describe(
+          "Optional agent role used for deterministic placement. Defaults from title launcher suffix: *Claude=orchestrator, *Codex/*Cursor=worker.",
+        ),
       focus: z
         .boolean()
         .optional()
@@ -1293,20 +1337,91 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await preflightBootPromptFile(bootPromptPath);
         }
 
-        result = await client.newSplit(args.direction, {
-          workspace: args.workspace,
-          surface: args.surface,
-          pane: args.pane,
-          type: args.type,
-          url: args.url,
-          title: args.title,
-          focus: args.focus,
-        });
+        const shouldInferRole =
+          Boolean(args.role) ||
+          Boolean(
+            args.title &&
+              /(Claude|Codex|Cursor)$/i.test(args.title) &&
+              !args.pane &&
+              !args.surface,
+          );
+        const inferredRole = shouldInferRole
+          ? inferAgentRole({ role: args.role, title: args.title })
+          : null;
+        let actualPlacement: "split" | "surface" = "split";
+        let actualDirection: string | null = args.direction;
+        if (inferredRole && (args.type ?? "terminal") === "terminal") {
+          if (args.pane || args.surface) {
+            throw new Error(
+              "pane/surface cannot be combined with role-based new_split; omit the explicit target or omit role",
+            );
+          }
+          const panes = await client.listPanes({ workspace: args.workspace });
+          const paneSurfaces = await Promise.all(
+            panes.panes.map((pane) =>
+              client.listPaneSurfaces({
+                workspace: args.workspace,
+                pane: pane.ref,
+              }),
+            ),
+          );
+          const liveSurfaceIds = new Set(
+            paneSurfaces.flatMap((group) =>
+              group.surfaces.map((surface) => surface.ref),
+            ),
+          );
+          const placement = chooseAgentSpawnPlacement(
+            panes.panes,
+            paneSurfaces,
+            collectServerRoleSurfaceIds(liveSurfaceIds, args.workspace),
+            { role: inferredRole },
+          );
+          actualPlacement = placement.kind;
+          actualDirection =
+            placement.kind === "split" ? placement.direction : null;
+          if (placement.kind === "surface" && args.focus === false) {
+            throw new Error(
+              "focus=false is not supported when role-based new_split reuses an existing pane as a tab",
+            );
+          }
+          result =
+            placement.kind === "surface"
+              ? await client.newSurface({
+                  pane: placement.pane,
+                  workspace: args.workspace,
+                  type: "terminal",
+                })
+              : await client.newSplit(placement.direction, {
+                  workspace: args.workspace,
+                  ...(placement.pane ? { pane: placement.pane } : {}),
+                  surface: args.surface,
+                  type: args.type,
+                  url: args.url,
+                  title: args.title,
+                  focus: args.focus,
+                });
+        } else {
+          result = await client.newSplit(args.direction, {
+            workspace: args.workspace,
+            surface: args.surface,
+            pane: args.pane,
+            type: args.type,
+            url: args.url,
+            title: args.title,
+            focus: args.focus,
+          });
+        }
         if (args.title) {
           await client.renameTab(result.surface, args.title, {
             workspace: result.workspace || args.workspace,
           });
           result.title = args.title;
+        }
+        if (inferredRole && (args.type ?? "terminal") === "terminal") {
+          roleSurfaceOverrides.set(result.surface, {
+            role: inferredRole,
+            workspace: result.workspace ?? args.workspace ?? null,
+          });
         }
         let bootPromptDelivery:
           | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -1320,6 +1435,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
         }
         const data: Record<string, unknown> = { ...result };
+        data.placement = actualPlacement;
+        data.direction = actualDirection;
+        if (inferredRole) {
+          data.role = inferredRole;
+        }
         if (bootPromptDelivery) {
           data.boot_prompt_delivered = true;
           data.boot_prompt_bytes = bootPromptDelivery.bytes;
@@ -1327,9 +1447,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return okFormatted(
           formatOk("new_split", {
             surface: result.surface,
-            direction: args.direction,
+            direction: actualDirection,
+            placement: actualPlacement,
             type: args.type,
             title: result.title,
+            role: inferredRole ?? undefined,
             boot_prompt_delivered: Boolean(bootPromptDelivery),
           }),
           data,
@@ -2158,6 +2280,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
     };
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
+    lifecycleRegistry = registry;
     const discovery = new AgentDiscovery({
       listSurfaces: surfaceProvider,
       readScreen: (surface, opts) => client.readScreen(surface, opts),
@@ -2201,12 +2324,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
         listPanes: (paneOpts) => client.listPanes(paneOpts),
         listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
+        closeSurface: (surface, closeOpts) =>
+          withSurfaceWrite(surface, () =>
+            client.closeSurface(surface, closeOpts),
+          ),
         notifyLifecycleEvent,
       },
       {
         spawnPreflight:
           opts?.spawnPreflight ??
           (opts?.disableSpawnPreflight ? async () => {} : undefined),
+        roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
       },
     );
 
@@ -2301,6 +2429,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "ID of the parent agent for hierarchical spawning. Parent must exist.",
           ),
+        role: z
+          .enum(["orchestrator", "ic", "worker"])
+          .optional()
+          .describe(
+            "Optional placement role. Defaults from launcher: *Claude=orchestrator, *Codex/*Cursor=worker.",
+          ),
+        auto_archive_on_done: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "When true, Codex worker panes that emit TASK_DONE are auto-closed after the inactivity window.",
+          ),
         max_cost_per_agent: z
           .number()
           .optional()
@@ -2330,6 +2471,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             boot_prompt_pending: hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
+            role: args.role,
+            auto_archive_on_done: args.auto_archive_on_done ?? true,
             max_cost_per_agent: args.max_cost_per_agent,
             crash_recover: args.crash_recover,
           });
@@ -2405,10 +2548,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               repo: args.repo,
               model: args.model,
               surface: result.surface_id,
+              role:
+                engine.getAgentState(result.agent_id)?.role ??
+                inferAgentRole({ role: args.role, cli: args.cli }),
               boot_prompt_delivered: Boolean(bootPromptDelivery),
             }),
             {
               ...result,
+              role:
+                engine.getAgentState(result.agent_id)?.role ??
+                inferAgentRole({ role: args.role, cli: args.cli }),
               boot_prompt_delivered: Boolean(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
             },

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -212,6 +212,13 @@ export class StateManager {
       error: null,
       parent_agent_id: null,
       spawn_depth: 0,
+      role:
+        discovered.cli === "claude"
+          ? "orchestrator"
+          : discovered.cli === "unknown"
+            ? "orchestrator"
+            : "worker",
+      auto_archive_on_done: false,
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: null,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -205,8 +205,8 @@ describe("AgentEngine", () => {
 
       await engine.spawnAgent({
         repo: "brainlayer",
-        model: "sonnet",
-        cli: "claude",
+        model: "gpt-5.4",
+        cli: "codex",
         prompt: "Fix gap F",
         workspace: "ws:1",
       });
@@ -251,8 +251,8 @@ describe("AgentEngine", () => {
 
       await engine.spawnAgent({
         repo: "brainlayer",
-        model: "sonnet",
-        cli: "claude",
+        model: "gpt-5.4",
+        cli: "codex",
         prompt: "Fix gap F",
         workspace: "ws:1",
       });
@@ -321,8 +321,8 @@ describe("AgentEngine", () => {
 
       await engine.spawnAgent({
         repo: "brainlayer",
-        model: "sonnet",
-        cli: "claude",
+        model: "gpt-5.4",
+        cli: "codex",
         prompt: "Fix gap F",
         workspace: "ws:1",
       });
@@ -333,6 +333,480 @@ describe("AgentEngine", () => {
         workspace: "ws:1",
       });
       expect(mockClient.newSplit).not.toHaveBeenCalled();
+    });
+
+    it("persists explicit role on spawned agents", async () => {
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Coordinate work",
+        role: "ic",
+      });
+
+      expect(stateMgr.readState(result.agent_id)?.role).toBe("ic");
+    });
+
+    it("infers worker role for Codex spawns and uses the worker pane", async () => {
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+      });
+
+      expect(stateMgr.readState(result.agent_id)?.role).toBe("worker");
+      expect(stateMgr.readState(result.agent_id)?.auto_archive_on_done).toBeUndefined();
+    });
+
+    it("uses role panes created by new_split when placing spawned agents", async () => {
+      engine.dispose();
+      const surfaceProvider = async () => liveSurfaces;
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        roleSurfaceIdsProvider: () => ({
+          orchestrator: new Set(),
+          ic: new Set(),
+          worker: new Set(["surface:worker-shell"]),
+        }),
+      });
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:orc"],
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:worker-shell"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ pane }: { pane?: string }) => ({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: pane ?? "pane:left",
+          surfaces:
+            pane === "pane:right"
+              ? [makeSurface("surface:worker-shell")]
+              : [makeSurface("surface:orc")],
+        }),
+      );
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right",
+        type: "terminal",
+        workspace: "ws:1",
+      });
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+    });
+
+    it("splits a child worker under its parent IC pane", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "ic-1",
+          state: "ready",
+          surface_id: "surface:ic",
+          cli: "claude",
+          role: "ic",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:ic")];
+      await engine.getRegistry().reconstitute();
+
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:orc"],
+          },
+          {
+            ref: "pane:ic",
+            index: 1,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:ic"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ pane }: { pane?: string }) => ({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: pane ?? "pane:left",
+          surfaces:
+            pane === "pane:ic"
+              ? [makeSurface("surface:ic")]
+              : [makeSurface("surface:orc")],
+        }),
+      );
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Implement delegated task",
+        workspace: "ws:1",
+        parent_agent_id: "ic-1",
+      });
+
+      expect(mockClient.newSplit).toHaveBeenCalledWith("down", {
+        pane: "pane:ic",
+        workspace: "ws:1",
+        type: "terminal",
+      });
+    });
+
+    it("auto-closes archived Codex worker panes after TASK_DONE inactivity", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(doneAt);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-done",
+            state: "ready",
+            surface_id: "surface:done-worker",
+            cli: "codex",
+            role: "worker",
+            auto_archive_on_done: true,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:done-worker")];
+        await engine.getRegistry().reconstitute();
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:done-worker",
+          text: "gpt-5.4\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+
+        await engine.runSweep();
+        expect(engine.getAgentState("worker-done")?.state).toBe("ready");
+        expect(
+          engine.getAgentState("worker-done")?.task_done_candidate_at,
+        ).toBe(doneAt.toISOString());
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 5_001));
+        await engine.runSweep();
+        expect(engine.getAgentState("worker-done")?.state).toBe("done");
+        expect(
+          engine.getAgentState("worker-done")?.task_done_detected_at,
+        ).toBeDefined();
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 5_001 + 30 * 60_000 + 1));
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).toHaveBeenCalledWith(
+          "surface:done-worker",
+          { workspace: undefined },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("prefers TASK_DONE auto-archive milliseconds over minutes when both env vars are set", async () => {
+      const previousMs = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
+      const previousMinutes =
+        process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES;
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS = "1";
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES = "1";
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(doneAt);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-done-ms",
+            state: "done",
+            surface_id: "surface:done-worker-ms",
+            cli: "codex",
+            role: "worker",
+            updated_at: doneAt.toISOString(),
+            auto_archive_on_done: true,
+            task_done_detected_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:done-worker-ms")];
+        await engine.getRegistry().reconstitute();
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 2));
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).toHaveBeenCalledWith(
+          "surface:done-worker-ms",
+          { workspace: undefined },
+        );
+      } finally {
+        if (previousMs === undefined) {
+          delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
+        } else {
+          process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS = previousMs;
+        }
+        if (previousMinutes === undefined) {
+          delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES;
+        } else {
+          process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES =
+            previousMinutes;
+        }
+        vi.useRealTimers();
+      }
+    });
+
+    it("measures TASK_DONE auto-archive delay from detection time, not updated_at", async () => {
+      vi.useFakeTimers();
+      try {
+        const detectedAt = new Date("2026-05-25T12:00:00.000Z");
+        const updatedAt = new Date(detectedAt.getTime() + 29 * 60_000);
+        vi.setSystemTime(new Date(detectedAt.getTime() + 30 * 60_000 + 1));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-detected-done",
+            state: "done",
+            surface_id: "surface:detected-done-worker",
+            cli: "codex",
+            role: "worker",
+            updated_at: updatedAt.toISOString(),
+            auto_archive_on_done: true,
+            task_done_detected_at: detectedAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:detected-done-worker")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).toHaveBeenCalledWith(
+          "surface:detected-done-worker",
+          { workspace: undefined },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips sidebar status writes after auto-archiving a done worker surface", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(doneAt.getTime() + 31 * 60_000));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-archived-before-status",
+            state: "done",
+            surface_id: "surface:archived-before-status",
+            cli: "codex",
+            role: "worker",
+            auto_archive_on_done: true,
+            task_done_detected_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:archived-before-status")];
+        await engine.getRegistry().reconstitute();
+        (mockClient.setStatus as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new Error("surface missing"),
+        );
+
+        await expect(engine.runSweep()).resolves.toBeUndefined();
+
+        expect(mockClient.closeSurface).toHaveBeenCalledWith(
+          "surface:archived-before-status",
+          { workspace: undefined },
+        );
+        expect(mockClient.clearStatus).toHaveBeenCalledWith(
+          "worker-archived-before-status",
+          { workspace: undefined },
+        );
+        expect(mockClient.setStatus).not.toHaveBeenCalled();
+        expect(engine.getAgentState("worker-archived-before-status")).toBeNull();
+        expect(stateMgr.readState("worker-archived-before-status")).toBeNull();
+
+        (mockClient.setStatus as ReturnType<typeof vi.fn>).mockClear();
+        await engine.runSweep();
+        expect(mockClient.setStatus).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not rewrite TASK_DONE candidates during the confirmation window", async () => {
+      vi.useFakeTimers();
+      try {
+        const candidateAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(candidateAt.getTime() + 1_000));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-task-done-candidate",
+            state: "ready",
+            surface_id: "surface:task-done-candidate",
+            cli: "codex",
+            role: "worker",
+            auto_archive_on_done: true,
+            task_done_candidate_at: candidateAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:task-done-candidate")];
+        await engine.getRegistry().reconstitute();
+        const before = stateMgr.readState("worker-task-done-candidate");
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:task-done-candidate",
+          text: "gpt-5.4\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+
+        await engine.runSweep();
+
+        const after = stateMgr.readState("worker-task-done-candidate");
+        expect(after?.version).toBe(before?.version);
+        expect(after?.updated_at).toBe(before?.updated_at);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not auto-close done Codex workers without TASK_DONE provenance", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(doneAt.getTime() + 31 * 60_000));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-manual-done",
+            state: "done",
+            surface_id: "surface:manual-done-worker",
+            cli: "codex",
+            role: "worker",
+            updated_at: doneAt.toISOString(),
+            auto_archive_on_done: true,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:manual-done-worker")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not auto-close legacy Codex workers without explicit archive opt-in", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(doneAt.getTime() + 31 * 60_000));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-legacy-done",
+            state: "done",
+            surface_id: "surface:legacy-done-worker",
+            cli: "codex",
+            role: "worker",
+            updated_at: doneAt.toISOString(),
+            auto_archive_on_done: undefined,
+            task_done_detected_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:legacy-done-worker")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not mark a worker done when TASK_DONE is stale scrollback before active work", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-active",
+          state: "ready",
+          surface_id: "surface:active-worker",
+          cli: "codex",
+          role: "worker",
+          auto_archive_on_done: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:active-worker")];
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:active-worker",
+        text: "gpt-5.4\nTASK_DONE\nWorking (1m 02s • esc to interrupt)",
+        lines: 20,
+        scrollback_used: false,
+      });
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("worker-active")?.state).toBe("ready");
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses only the current screen tail for quality parsing when reusing the TASK_DONE read", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-quality",
+          state: "ready",
+          surface_id: "surface:quality-worker",
+          cli: "codex",
+          role: "worker",
+          auto_archive_on_done: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:quality-worker")];
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:quality-worker",
+        text: [
+          "gpt-5.4 high · 5% left · ~/Gits/cmuxlayer",
+          "older work",
+          "older work",
+          "older work",
+          "older work",
+          "older work",
+          "gpt-5.4 high · 90% left · ~/Gits/cmuxlayer",
+          "current prompt",
+        ].join("\n"),
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("worker-quality")?.quality).toBe("unknown");
+      expect(mockClient.send).not.toHaveBeenCalledWith(
+        "surface:quality-worker",
+        "/compact",
+        {},
+      );
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
     });
 
     it("respawns a crashed agent with its captured session id when crash recovery is enabled", async () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
+  inferAgentRole,
+  launcherNameForCli,
 } from "../src/layout-policy.js";
 import type { CmuxPane, CmuxPaneSurfaces, CmuxSurface } from "../src/types.js";
 
@@ -43,6 +45,150 @@ function makePaneSurfaces(
 }
 
 describe("layout policy", () => {
+  it("infers default role from repoGolem launcher names", () => {
+    expect(inferAgentRole({ launcherName: "orcClaude" })).toBe(
+      "orchestrator",
+    );
+    expect(inferAgentRole({ launcherName: "cmuxlayerCodex" })).toBe("worker");
+    expect(inferAgentRole({ launcherName: "brainlayerCursor" })).toBe(
+      "worker",
+    );
+  });
+
+  it("lets an explicit role override launcher inference", () => {
+    expect(
+      inferAgentRole({ launcherName: "skillcreatorClaude", role: "ic" }),
+    ).toBe("ic");
+  });
+
+  it("does not let repo names that end with launcher suffixes affect non-launcher CLIs", () => {
+    expect(
+      inferAgentRole({
+        launcherName: launcherNameForCli("apiClaude", "gemini"),
+        cli: "gemini",
+      }),
+    ).toBe("worker");
+  });
+
+  it("places orchestrators as tabs in the left orchestrator pane", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orc"]),
+      makePane("pane:right", 1, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orc"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orc"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
+  });
+
+  it("places the first IC in the right column above existing workers", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orc"]),
+      makePane("pane:right", 1, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orc"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orc"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
+      },
+      { role: "ic" },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "up",
+      pane: "pane:right",
+    });
+  });
+
+  it("places the first worker under its parent IC", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orc"]),
+      makePane("pane:ic", 1, ["surface:ic"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orc"]),
+      makePaneSurfaces("pane:ic", ["surface:ic"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orc"]),
+        ic: new Set(["surface:ic"]),
+        worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "ic",
+        parentSurfaceId: "surface:ic",
+        childWorkerSurfaceIds: new Set(),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "down",
+      pane: "pane:ic",
+    });
+  });
+
+  it("reuses an existing worker pane under the parent IC for sibling workers", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orc"]),
+      makePane("pane:ic", 1, ["surface:ic"]),
+      makePane("pane:children", 2, ["surface:child-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orc"]),
+      makePaneSurfaces("pane:ic", ["surface:ic"]),
+      makePaneSurfaces("pane:children", ["surface:child-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orc"]),
+        ic: new Set(["surface:ic"]),
+        worker: new Set(["surface:child-1"]),
+      },
+      {
+        role: "worker",
+        parentRole: "ic",
+        parentSurfaceId: "surface:ic",
+        childWorkerSurfaceIds: new Set(["surface:child-1"]),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "surface",
+      pane: "pane:children",
+    });
+  });
+
   it("creates a fresh right split when the only existing worker shares a pane with interactive surfaces", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -195,6 +195,45 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toMatch(/^sonnet-brainlayer-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
+
+    const stateTool = (server as any)._registeredTools["get_agent_state"];
+    const stateResult = await stateTool.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const persisted =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(persisted.auto_archive_on_done).toBe(true);
+  });
+
+  it("spawn_agent accepts explicit role and returns persisted role", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        role: "ic",
+        prompt: "coordinate task",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.role).toBe("ic");
+
+    const stateTool = (server as any)._registeredTools["get_agent_state"];
+    const stateResult = await stateTool.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const persisted =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(persisted.role).toBe("ic");
   });
 
   it("spawn_agent sends inline prompt after the agent is ready", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1590,6 +1590,790 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:2");
   });
 
+  it("new_split with role=worker reuses the existing worker pane", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-1",
+      surface_id: "surface:worker-1",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "existing worker",
+      pid: null,
+      version: 1,
+      created_at: "2026-05-25T12:00:00.000Z",
+      updated_at: "2026-05-25T12:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      role: "worker",
+    });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:orc"],
+              },
+              {
+                ref: "pane:right",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:worker-1"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces:
+              pane === "pane:right"
+                ? [{ ref: "surface:worker-1", title: "", type: "terminal", index: 0, selected: true }]
+                : [{ ref: "surface:orc", title: "", type: "terminal", index: 0, selected: true }],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:right"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:2");
+    expect(parsed.role).toBe("worker");
+    expect(parsed.placement).toBe("surface");
+    expect(parsed.direction).toBeNull();
+  });
+
+  it("new_split ignores disk-only role state when no live lifecycle registry is available", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-stale-role-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "stale-worker",
+      surface_id: "surface:recycled",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "old-repo",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "stale worker",
+      pid: null,
+      version: 1,
+      created_at: "2026-05-25T12:00:00.000Z",
+      updated_at: "2026-05-25T12:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      role: "worker",
+    });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            panes: [
+              {
+                ref: "pane:only",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:recycled"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:only",
+            surfaces: [
+              {
+                ref: "surface:recycled",
+                title: "manual shell",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:new-worker",
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:new-worker");
+    expect(parsed.placement).toBe("split");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:only"]),
+    );
+  });
+
+  it("new_split remembers role-created surfaces for subsequent placement", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-memory-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    let workerSurface: string | null = null;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            panes: workerSurface
+              ? [
+                  {
+                    ref: "pane:left",
+                    index: 0,
+                    focused: false,
+                    surface_count: 1,
+                    surface_refs: ["surface:orc"],
+                  },
+                  {
+                    ref: "pane:right",
+                    index: 1,
+                    focused: true,
+                    surface_count: 1,
+                    surface_refs: [workerSurface],
+                  },
+                ]
+              : [
+                  {
+                    ref: "pane:left",
+                    index: 0,
+                    focused: true,
+                    surface_count: 1,
+                    surface_refs: ["surface:orc"],
+                  },
+                ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces:
+              pane === "pane:right" && workerSurface
+                ? [
+                    {
+                      ref: workerSurface,
+                      title: "",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : [
+                    {
+                      ref: "surface:orc",
+                      title: "",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        workerSurface = "surface:worker-created";
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: workerSurface,
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:worker-tab",
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const first = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+    const firstParsed =
+      first.structuredContent ?? JSON.parse(first.content[0].text);
+    expect(firstParsed.surface).toBe("surface:worker-created");
+    expect(firstParsed.placement).toBe("split");
+
+    const second = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+    const secondParsed =
+      second.structuredContent ?? JSON.parse(second.content[0].text);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:right"]),
+    );
+    expect(secondParsed.surface).toBe("surface:worker-tab");
+    expect(secondParsed.placement).toBe("surface");
+    expect(secondParsed.direction).toBeNull();
+  });
+
+  it("new_split does not prune role overrides from other workspaces", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-workspace-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    let workerSurfaceWorkspace1: string | null = null;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      const workspace = args.includes("--workspace")
+        ? String(args[args.indexOf("--workspace") + 1])
+        : "workspace:1";
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: workspace,
+            panes:
+              workspace === "workspace:1" && workerSurfaceWorkspace1
+                ? [
+                    {
+                      ref: "pane:w1-left",
+                      index: 0,
+                      focused: false,
+                      surface_count: 1,
+                      surface_refs: ["surface:w1-orc"],
+                    },
+                    {
+                      ref: "pane:w1-right",
+                      index: 1,
+                      focused: true,
+                      surface_count: 1,
+                      surface_refs: [workerSurfaceWorkspace1],
+                    },
+                  ]
+                : [
+                    {
+                      ref: `${workspace}:pane:only`,
+                      index: 0,
+                      focused: true,
+                      surface_count: 1,
+                      surface_refs: [`${workspace}:surface:manual`],
+                    },
+                  ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        const surfaces =
+          pane === "pane:w1-right" && workerSurfaceWorkspace1
+            ? [
+                {
+                  ref: workerSurfaceWorkspace1,
+                  title: "",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [
+                {
+                  ref: pane.includes("workspace:2")
+                    ? "workspace:2:surface:manual"
+                    : "surface:w1-orc",
+                  title: "",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ];
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: workspace,
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces,
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        const surface =
+          workspace === "workspace:1" && !workerSurfaceWorkspace1
+            ? "surface:w1-worker"
+            : "surface:w2-worker";
+        if (workspace === "workspace:1") {
+          workerSurfaceWorkspace1 = surface;
+        }
+        return {
+          stdout: JSON.stringify({
+            workspace,
+            surface,
+            pane: workspace === "workspace:1" ? "pane:w1-right" : "pane:w2-right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:w1-worker-tab",
+            pane: "pane:w1-right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+    await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:2" },
+      {} as any,
+    );
+    const third = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+
+    const parsed = third.structuredContent ?? JSON.parse(third.content[0].text);
+    expect(parsed.surface).toBe("surface:w1-worker-tab");
+    expect(parsed.placement).toBe("surface");
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:w1-right"]),
+    );
+  });
+
+  it("new_split does not remember browser surfaces as role panes", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-browser-role-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            panes: [
+              {
+                ref: "pane:browser",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:browser-codex"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:browser",
+            surfaces: [
+              {
+                ref: "surface:browser-codex",
+                title: "researchCodex",
+                type: "browser",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split") && args.includes("browser")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:browser-codex",
+            pane: "pane:browser",
+            title: "researchCodex",
+            type: "browser",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:worker-split",
+            pane: "pane:worker",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:unexpected-tab",
+            pane: "pane:browser",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    await tool.handler(
+      {
+        direction: "right",
+        type: "browser",
+        role: "worker",
+        url: "https://example.com",
+        workspace: "workspace:1",
+      },
+      {} as any,
+    );
+    const workerResult = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+    const parsed =
+      workerResult.structuredContent ?? JSON.parse(workerResult.content[0].text);
+
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface"]),
+    );
+    expect(parsed.surface).toBe("surface:worker-split");
+    expect(parsed.placement).toBe("split");
+    expect(parsed.direction).toBe("right");
+  });
+
+  it("new_split with role rejects explicit pane targets", async () => {
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        role: "worker",
+        pane: "pane:manual",
+        workspace: "workspace:1",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/pane\/surface cannot be combined/);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("new_split with launcher-style title honors explicit pane when role is omitted", async () => {
+    mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:manual-title",
+        pane: "pane:manual",
+        title: "brainlayerCodex",
+        type: "terminal",
+      }),
+      stderr: "",
+    });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        title: "brainlayerCodex",
+        pane: "pane:manual",
+        workspace: "workspace:1",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.role).toBeUndefined();
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-split", "right", "--panel", "pane:manual"]),
+    );
+  });
+
+  it("new_split with role=worker rejects focus=false when placement becomes a tab", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-focus-state");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-1",
+      surface_id: "surface:worker-1",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "existing worker",
+      pid: null,
+      version: 1,
+      created_at: "2026-05-25T12:00:00.000Z",
+      updated_at: "2026-05-25T12:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      role: "worker",
+    });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            panes: [
+              {
+                ref: "pane:right",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:worker-1"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:right",
+            surfaces: [
+              {
+                ref: "surface:worker-1",
+                title: "",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        role: "worker",
+        workspace: "workspace:1",
+        focus: false,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("focus=false");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface"]),
+    );
+  });
+
   it("new_split rejects missing boot_prompt_path before creating a pane", async () => {
     mockExec = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -188,4 +188,63 @@ describe("StateManager", () => {
       expect(() => mgr.removeState("nonexistent")).not.toThrow();
     });
   });
+
+  describe("ensureAutoRecord", () => {
+    it("does not enable TASK_DONE auto-archive for auto-discovered agents", () => {
+      const mgr = new StateManager(TEST_DIR);
+
+      const record = mgr.ensureAutoRecord("auto-codex", {
+        surface_id: "surface:auto-codex",
+        surface_title: "brainlayerCodex",
+        cli: "codex",
+        parsed_status: "idle",
+        model: "gpt-5.4",
+        token_count: null,
+        context_pct: null,
+        has_agent: true,
+        read_error: false,
+      });
+
+      expect(record.role).toBe("worker");
+      expect(record.auto_archive_on_done).toBe(false);
+    });
+
+    it("assigns orchestrator role for auto-discovered Claude agents", () => {
+      const mgr = new StateManager(TEST_DIR);
+
+      const record = mgr.ensureAutoRecord("auto-claude", {
+        surface_id: "surface:auto-claude",
+        surface_title: "brainlayerClaude",
+        cli: "claude",
+        parsed_status: "idle",
+        model: "sonnet",
+        token_count: null,
+        context_pct: null,
+        has_agent: true,
+        read_error: false,
+      });
+
+      expect(record.role).toBe("orchestrator");
+      expect(record.auto_archive_on_done).toBe(false);
+    });
+
+    it("assigns orchestrator role when the discovered cli is unknown", () => {
+      const mgr = new StateManager(TEST_DIR);
+
+      const record = mgr.ensureAutoRecord("auto-unknown", {
+        surface_id: "surface:auto-unknown",
+        surface_title: "mystery-agent",
+        cli: "unknown",
+        parsed_status: "idle",
+        model: null,
+        token_count: null,
+        context_pct: null,
+        has_agent: true,
+        read_error: false,
+      });
+
+      expect(record.role).toBe("orchestrator");
+      expect(record.auto_archive_on_done).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add role-aware placement for `spawn_agent` and `new_split` with `orchestrator | ic | worker`
- infer default roles from launcher suffixes: `*Claude` orchestrator, `*Codex`/`*Cursor` worker
- place workers under parent IC panes when `parent_agent_id` points at an IC
- auto-close Codex worker panes after `TASK_DONE` plus the inactivity window, with per-spawn and env opt-outs

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (27 files, 486 tests)
- [x] `git diff --check`
- [x] `cr review --plain` (no findings)

Note: cmux app restart is required for running users to pick up the new binary after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default spawn/split layout and can close terminal surfaces automatically; mis-inferred roles or TASK_DONE false positives could affect live sessions, though behavior is gated by role, CLI, explicit opt-in, and env flags.
> 
> **Overview**
> Adds **orchestrator / IC / worker** roles to agent state and rewires spawn and `new_split` placement so panes land in predictable columns (left orchestrator, IC above workers, workers under parent IC or in the worker column).
> 
> **`spawn_agent`** and **`new_split`** accept optional `role` (with defaults from `*Claude` / `*Codex` / `*Cursor` titles). The server tracks role-only surfaces from role-based splits so later spawns reuse the right pane. **`spawn_agent`** defaults **`auto_archive_on_done`** to true for Codex workers.
> 
> The sweep loop detects a trailing **`TASK_DONE`** line (debounced), marks those workers **done**, then optionally **closes** the surface after an env-configurable idle window when archival is enabled and provenance is recorded—discovered agents stay off auto-archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98406d0acea23257ee8d6175ce16b9c43772dc96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic role-based pane layout for orchestrator, IC, and worker agents
> - Introduces an `AgentRole` type (`orchestrator | ic | worker`) persisted on `AgentRecord`, with role inferred from CLI/launcher name or set explicitly at spawn time.
> - Rewrites `chooseAgentSpawnPlacement` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/98/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to place agents deterministically: orchestrators go to the left pane, ICs split above workers in the right column, and workers split down under their parent IC or reuse an existing worker pane.
> - Adds TASK_DONE auto-archive to `AgentEngine`: Codex worker terminals printing `TASK_DONE` transition to `done` after a short confirmation window and their surfaces are closed after a configurable inactivity delay (env vars `CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS` / `CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES`).
> - Extends the `new_split` and `spawn_agent` server tools to accept `role` and `auto_archive_on_done`; `new_split` returns `placement` and `direction` metadata and rejects combining `role` with explicit `pane`/`surface` targets.
> - Auto-discovered agents in `StateManager.discoverFromSurface` now default to `role=orchestrator` (Claude/unknown) or `role=worker` (Codex) with `auto_archive_on_done=false`.
> - Risk: `new_split` calls with `role` + explicit `pane` now return an error instead of proceeding, which is a breaking change for callers that pass both.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98406d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can detect task completion and auto-archive (configurable per agent).
  * Role-aware spawn and surface placement: orchestrator/IC/worker are placed deterministically and layout-aware.
  * Tools expose/respect role and auto-archive options and return placement/role info.

* **Tests**
  * Expanded tests for role inference, placement behaviors, and task-done auto-archiving (including timing/env cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/cmuxlayer/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->