### PR TITLE
fix: verify every interactive relay, killing ok:true on frozen terminals

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -827,7 +827,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return { submit_verified: true, retry_count: retryCount };
       }
 
-      if (!retried && screenShowsPendingInput(snapshot.text, opts.text)) {
+      if (!screenShowsPendingInput(snapshot.text, opts.text)) {
+        // The submitted text is no longer echoed in the input box: the terminal
+        // accepted it and cleared the prompt, even if the agent has already
+        // settled back to idle. Treat that as a verified landing.
+        return { submit_verified: true, retry_count: retryCount };
+      }
+
+      // The submitted text is still pending in the input box. Retry Enter once,
+      // then keep polling; if it never clears (a frozen terminal) we fall
+      // through to the timeout below and report the relay as unverified.
+      if (!retried) {
         await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
         await sendKeyWithRetry(opts.surface, "return", opts.workspace);
         retryCount += 1;
@@ -2369,10 +2379,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           press_enter: args.press_enter,
           source_event: args.source_event,
           source_agent: args.agent_id,
+          // Verify every relay to an interactive agent — not just long ones.
+          // A short relay (the common agent-to-agent case) to a frozen
+          // terminal must be caught, never reported as ok. allow_busy sends to
+          // a non-interactive (working) agent stay unverified to avoid
+          // false-failing a legitimate interjection.
           verify_submit:
-            args.press_enter &&
-            INTERACTIVE_AGENT_STATES.has(route.state) &&
-            sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD,
+            args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
         }),
       );
     };

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -281,7 +281,7 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
-  it("does not verify short send_to submissions that settle back to idle", async () => {
+  it("verifies short send_to submissions once the input clears", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
     client.completionMode = "idle";
@@ -299,7 +299,9 @@ describe("enter reliability", () => {
     expect(parsed.ok).toBe(true);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
     expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBe(null);
+    // A short relay is now verified: the input cleared from the prompt, so the
+    // submit landed even though Claude settled straight back to idle.
+    expect(events[0]?.submit_verified).toBe(true);
     expect(events[0]?.retry_count).toBe(0);
   });
 

--- a/tests/verified-relay.test.ts
+++ b/tests/verified-relay.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-verified-relay-test");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  return tool.handler(args, {} as any);
+}
+
+/**
+ * A Claude surface whose terminal is FROZEN: keystrokes are echoed into the
+ * input box but Enter never submits — the text stays pending forever. This is
+ * the "ok:true on a frozen terminal" failure mode the verified-relay primitive
+ * must catch: a relay that cannot confirm the input landed must NOT report ok.
+ */
+class FrozenClaudeSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:agent";
+  readonly title = "brainlayerClaude";
+  readonly sendCalls: string[] = [];
+  readonly sendKeyCalls: string[] = [];
+  private pendingText = "";
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface)
+      throw new Error(`Unknown surface: ${surface}`);
+    this.sendCalls.push(text);
+    this.pendingText += text;
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (surface !== this.surface)
+      throw new Error(`Unknown surface: ${surface}`);
+    this.sendKeyCalls.push(key);
+    // FROZEN: Enter never submits — pendingText is never cleared.
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface)
+      throw new Error(`Unknown surface: ${surface}`);
+    const tail = this.pendingText.slice(-160);
+    return {
+      surface,
+      text: `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`,
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab() {}
+}
+
+function createRelayServer(client: any) {
+  return createServer({
+    client,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
+function registerAgent(
+  server: any,
+  overrides?: Partial<AgentRecord>,
+): AgentRecord {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+
+  const now = "2026-05-29T12:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: "surface:agent",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "verified relay test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+
+  stateMgr.writeState(record);
+  registry.set(record.agent_id, record);
+  return record;
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") {
+    engine.dispose();
+  }
+}
+
+describe("verified relay", () => {
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("send_to a frozen terminal returns an error instead of ok:true (short relay)", async () => {
+    const client = new FrozenClaudeSurfaceClient();
+    server = createRelayServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "ping", // short relay — the common agent-to-agent case
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    // A relay that cannot confirm the input landed must NOT report success.
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).not.toBe(true);
+    // It should have at least retried Enter before giving up.
+    expect(
+      client.sendKeyCalls.filter((key) => key === "return").length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## What

gen-10 **cmuxLayer track (track-1)** — the *verified-relay primitive*: a relay must confirm landing, never report `ok:true` on a frozen terminal.

`send_to` / `send_to_agent` only verified submission for payloads **over the 500-char chunk threshold**, so a **short relay — the common agent-to-agent case** — returned `ok:true` even when the target terminal was frozen and the input never landed.

## Changes (delivery path in `server.ts`)

1. **`deliverAgentInput`** — drop the payload-size gate from `verify_submit`, so *every* `press_enter` relay to a `ready`/`idle` agent is verified. `allow_busy` sends to a `working` (non-interactive) agent stay unverified to avoid false-failing a legitimate interjection.
2. **`verifySubmitAfterEnter`** — treat *"submitted text no longer echoed in the input box"* as a verified landing (the prompt cleared) even when the agent settled straight back to idle. Only text that **stays pending** after an Enter retry + the verify timeout reports unverified → the relay **errors** instead of claiming success.

## Tests (TDD red→green)

- **New `tests/verified-relay.test.ts`** — a short relay to a *frozen* terminal now **errors** (RED before this change: `result.isError` was `undefined`; GREEN after) and retries Enter before giving up.
- **`enter-reliability.test.ts`** — the short-send case updated: a settled short relay is now **verified (`true`)** rather than unverified (`null`).
- Full suite **507 passing**, `typecheck` clean.

## Scope

Focused on the **relay** path (`send_to`/`send_to_agent`). Phase-3 *stale-surface-ref re-resolution* (`send_to` by `agent_id` re-resolving the live surface after a crash/respawn) is a planned follow-up PR. `send_input`/`send_command` surface-level verification left unchanged (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delivery semantics for agent messaging; false negatives could block legitimate relays if screen parsing misreads the prompt, but scope is limited to interactive-state paths with explicit verify timeout and retry.
> 
> **Overview**
> **Interactive agent relays** (`send_to`, `send_to_agent`, `interact` sends) now always run **Enter submit verification** when `press_enter` is true and the agent is `ready`/`idle` — not only for payloads over the 500-character chunk threshold. Short agent-to-agent messages are included; **`allow_busy`** deliveries to non-interactive states stay unverified so interjections while an agent is working are not falsely rejected.
> 
> **`verifySubmitAfterEnter`** treats a cleared input prompt (submitted text no longer echoed) as a successful landing even if the screen shows idle again. Enter is retried once only while text remains stuck in the box; if it never clears within the verify timeout, delivery **errors** instead of returning `ok: true`.
> 
> Tests add **`verified-relay.test.ts`** for frozen terminals on short relays and update **`enter-reliability.test.ts`** so successful short relays report `submit_verified: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba367b65810171206f90a1b1942f1f4f0b9badf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix relay verification to error on frozen terminals instead of returning `ok:true`
> - Marks a submission as verified as soon as the input clears from the prompt, regardless of agent idle state, removing the prior length threshold on `verify_submit`.
> - When pending input persists (frozen terminal), performs a single Enter retry before continuing to poll until timeout, then returns an error instead of `ok:true`.
> - All interactive `press_enter` relays are now verified, not just those exceeding the previous chunk length threshold.
> - Adds [verified-relay.test.ts](https://github.com/EtanHey/cmuxlayer/pull/100/files#diff-03b80bd3dca31576e64aba2e3ac6c05df5a9b4c508e3417f1471b72f697efda5) with a `FrozenClaudeSurfaceClient` fixture to assert error behavior when Enter never clears the input.
> - Behavioral Change: short `send_to` submissions that previously returned unverified (`null`) now return `true` once input clears; frozen terminals now return an error instead of `ok:true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ba367b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->