### PR TITLE
fix: re-resolve stale surface refs before relaying, never misdeliver

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2355,7 +2355,49 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       allow_busy?: boolean;
       source_event: DeliveryEventType;
     }) => {
-      const route = engine.resolveAgentRoute(args.agent_id);
+      let route = engine.resolveAgentRoute(args.agent_id);
+      // Guard against stale surface refs before sending. Registry refs drift
+      // after a crash/respawn (a pane closes or is recycled), so a cached
+      // surface_id can point at a dead surface. Check the resolved ref against
+      // the live surface list and, if it is positively gone, resync once and
+      // re-resolve; if it still cannot be confirmed live, refuse the relay
+      // rather than misdelivering keystrokes. Fail OPEN when the surface list
+      // is unavailable (empty) so a transient listing failure never blocks a
+      // healthy relay.
+      const liveSurfaceRefs = async (): Promise<Set<string> | null> => {
+        const surfaces = await surfaceProvider();
+        return surfaces.length > 0
+          ? new Set(surfaces.map((surface) => surface.ref))
+          : null;
+      };
+      const isPositivelyStale = (
+        refs: Set<string> | null,
+        surfaceId: string,
+      ): boolean => refs !== null && !refs.has(surfaceId);
+      if (isPositivelyStale(await liveSurfaceRefs(), route.surface_id)) {
+        discovery.invalidate();
+        await registry.listMerged(discovery, { force: true });
+        // Re-resolve after the resync. The agent may have been evicted (its
+        // surface vanished) or still point at a dead surface — either way,
+        // refuse with a clear stale-ref error instead of misdelivering.
+        let reresolved: ReturnType<typeof engine.resolveAgentRoute> | null;
+        try {
+          reresolved = engine.resolveAgentRoute(args.agent_id);
+        } catch {
+          reresolved = null;
+        }
+        if (
+          !reresolved ||
+          isPositivelyStale(await liveSurfaceRefs(), reresolved.surface_id)
+        ) {
+          throw new Error(
+            `Agent "${args.agent_id}" no longer maps to a live surface ` +
+              `(stale surface ref); its pane likely closed or was recycled. ` +
+              `Run resync_agents and retry.`,
+          );
+        }
+        route = reresolved;
+      }
       if (!args.allow_busy && !INTERACTIVE_AGENT_STATES.has(route.state)) {
         throw new Error(
           `Agent "${args.agent_id}" is not in an interactive state (current: ${route.state}). ` +

--- a/tests/stale-surface-ref.test.ts
+++ b/tests/stale-surface-ref.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-stale-surface-ref-test");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  return tool.handler(args, {} as any);
+}
+
+/**
+ * The registry believes the agent lives on `surface:stale`, but that surface no
+ * longer exists — only `surface:live` is currently open (a crash/respawn moved
+ * the agent, or the pane was recycled). A relay by agent_id must NOT blindly
+ * send keystrokes to the dead surface; it must re-resolve against live surfaces
+ * and, if the ref can't be confirmed, error clearly instead of misdelivering.
+ */
+class DriftedSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly liveSurface = "surface:live";
+  readonly staleSurface = "surface:stale";
+  // Every surface a send/sendKey was attempted against, so the test can assert
+  // nothing was delivered to the stale ref.
+  readonly sendTargets: string[] = [];
+  readonly sendKeyTargets: string[] = [];
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.liveSurface],
+          selected_surface_ref: this.liveSurface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.liveSurface,
+          title: "otherClaude",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, _text: string) {
+    // A zombie/recycled surface would silently accept input — record it so the
+    // test can prove the relay refused to deliver to the stale ref.
+    this.sendTargets.push(surface);
+  }
+
+  async sendKey(surface: string, _key: string) {
+    this.sendKeyTargets.push(surface);
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    return {
+      surface,
+      text: "Claude Code\n> \nCLAUDE_COUNTER:1\n",
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab() {}
+}
+
+function createRelayServer(client: any) {
+  return createServer({
+    client,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
+function registerStaleAgent(server: any): AgentRecord {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+
+  const now = "2026-05-29T12:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: "surface:stale", // registry ref is stale — surface no longer exists
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "stale surface ref test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+  };
+
+  stateMgr.writeState(record);
+  registry.set(record.agent_id, record);
+  return record;
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") {
+    engine.dispose();
+  }
+}
+
+describe("stale surface ref", () => {
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("send_to refuses to deliver to a surface that is no longer live", async () => {
+    const client = new DriftedSurfaceClient();
+    server = createRelayServer(client);
+    registerStaleAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "are you there?",
+    });
+    const parsed = parseResult(result);
+
+    // The relay must error rather than silently delivering to the dead ref.
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/stale|no longer live|resync|surface/i);
+    // Crucially: nothing was sent to the stale surface (no misdelivery).
+    expect(client.sendTargets).not.toContain(client.staleSurface);
+    expect(client.sendKeyTargets).not.toContain(client.staleSurface);
+  });
+});


### PR DESCRIPTION
## What

gen-10 **cmuxLayer track (track-1)** — *stale-surface-ref drift*, the Phase-3 follow-up to the verified-relay PR (#100).

A relay by `agent_id` (`send_to` / `send_to_agent` / `interact` send) resolved the target surface from the registry and sent keystrokes **with no liveness check**. After a crash/respawn a pane closes or is recycled, so the registry's cached `surface_id` can point at a **dead surface** — the relay delivered into the void (or, if the ref was reused, the wrong agent) and still reported `ok`.

## Change (`deliverAgentInput` in `server.ts`)

Before sending, check the resolved surface against the **live surface list**:
- **Positively gone** (surface list is known and does not contain the ref) → force a **resync** (`listMerged force` — the canonical recovery) and re-resolve. If it still can't be confirmed live, or the agent was evicted → throw a **clear stale-surface error** pointing at `resync_agents`, instead of misdelivering.
- **Fail OPEN**: when the surface list is unavailable (empty), the relay proceeds — a transient listing failure never blocks a healthy relay. Only a *positively-confirmed-missing* surface triggers refusal.

## Tests (TDD red→green)

- **New `tests/stale-surface-ref.test.ts`** — a relay to a vanished surface now **errors** and sends **nothing** to the stale ref (RED before: `isError` was `undefined` and the dead surface received the send; GREEN after).
- Full suite **508 passing**, `typecheck` clean.

## Known follow-up (documented, not in this PR)

The registry is **surface-keyed** with no identity-based remap, so a surface recycled to a *different live agent* (same ref, new occupant) isn't caught yet — that needs per-agent identity binding (`session_id`/title). Tracked as a separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared agent input delivery path used by multiple MCP tools; incorrect liveness logic could block valid relays or still misdeliver, though fail-open on empty listings limits blast radius.
> 
> **Overview**
> **Agent relays** (`send_to`, `send_to_agent`, `interact` send/model/resume/skill) now validate the resolved `surface_id` against the **live surface list** inside `deliverAgentInput` before any keystrokes go out.
> 
> If the ref is **positively missing** from that list, the server **invalidates discovery**, runs a forced **`listMerged` resync**, and re-resolves the route. When the agent is gone or still maps to a dead ref, it **throws a stale-surface error** (with guidance to run `resync_agents`) instead of sending to a closed or recycled pane. If the surface list is **empty** (listing failed), behavior stays **fail-open** so transient listing issues do not block healthy relays.
> 
> Adds **`tests/stale-surface-ref.test.ts`**, which asserts `send_to` errors and does **not** call `send`/`sendKey` on the stale ref when the registry still points at a vanished surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec1a3f26307878976475e367e78829538e15f1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse stale surface refs in `deliverAgentInput` and re-resolve before delivering
> - Before delivering agent input, checks whether the agent's mapped surface is live using a new `liveSurfaceRefs` helper in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/101/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595).
> - If the surface is stale, invalidates discovery, forces a registry resync via `registry.listMerged`, and re-resolves the agent route.
> - If the re-resolved route still maps to a non-live surface, throws a descriptive error instructing the caller to resync instead of delivering input.
> - If the live surface list is unavailable or empty, delivery is not blocked.
> - A new Vitest suite in [stale-surface-ref.test.ts](https://github.com/EtanHey/cmuxlayer/pull/101/files#diff-3f4ab96ce9dfd6a95e10000e7cc4db08362993ee2f5ea1c34dcbe3465da45ca8) verifies that no keystrokes are sent to a stale surface and the error mentions resync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec1a3f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->