### PR TITLE
fix: refuse relays to a surface recycled to a different-CLI agent

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2398,6 +2398,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         route = reresolved;
       }
+      // Identity guard: a live surface ref may have been RECYCLED — a crashed
+      // agent's pane reused by a different agent. If the live surface now hosts
+      // a known CLI that differs from this agent's recorded CLI, refuse rather
+      // than delivering to the new occupant. Fails OPEN when the live CLI is
+      // unknown/unreadable so a parse miss never blocks a healthy relay.
+      const expectedCli = engine.getAgentState(args.agent_id)?.cli;
+      if (expectedCli) {
+        const occupant = (await discovery.scan(false)).find(
+          (entry) => entry.surface_id === route.surface_id,
+        );
+        if (
+          occupant &&
+          occupant.has_agent &&
+          !occupant.read_error &&
+          occupant.cli !== "unknown" &&
+          occupant.cli !== expectedCli
+        ) {
+          throw new Error(
+            `Agent "${args.agent_id}" (${expectedCli}) no longer occupies ` +
+              `surface ${route.surface_id} — it now hosts a ${occupant.cli} ` +
+              `agent (surface recycled). Run resync_agents and retry.`,
+          );
+        }
+      }
       if (!args.allow_busy && !INTERACTIVE_AGENT_STATES.has(route.state)) {
         throw new Error(
           `Agent "${args.agent_id}" is not in an interactive state (current: ${route.state}). ` +

--- a/src/server.ts
+++ b/src/server.ts
@@ -2405,21 +2405,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // unknown/unreadable so a parse miss never blocks a healthy relay.
       const expectedCli = engine.getAgentState(args.agent_id)?.cli;
       if (expectedCli) {
-        const occupant = (await discovery.scan(false)).find(
+        const cachedOccupant = (await discovery.scan(false)).find(
           (entry) => entry.surface_id === route.surface_id,
         );
-        if (
-          occupant &&
-          occupant.has_agent &&
-          !occupant.read_error &&
-          occupant.cli !== "unknown" &&
-          occupant.cli !== expectedCli
-        ) {
-          throw new Error(
-            `Agent "${args.agent_id}" (${expectedCli}) no longer occupies ` +
-              `surface ${route.surface_id} — it now hosts a ${occupant.cli} ` +
-              `agent (surface recycled). Run resync_agents and retry.`,
+        const isForeign = (occ: typeof cachedOccupant): boolean =>
+          Boolean(
+            occ &&
+              occ.has_agent &&
+              !occ.read_error &&
+              occ.cli !== "unknown" &&
+              occ.cli !== expectedCli,
           );
+        if (isForeign(cachedOccupant)) {
+          // Confirm against a FRESH scan before refusing. discovery.scan(false)
+          // serves a 2s cache that can predate the current occupant; refusing
+          // on it alone would false-refuse a healthy relay (adversarial-review
+          // finding). Only a mismatch confirmed live is a recycled surface.
+          discovery.invalidate();
+          const freshOccupant = (await discovery.scan(true)).find(
+            (entry) => entry.surface_id === route.surface_id,
+          );
+          if (isForeign(freshOccupant)) {
+            throw new Error(
+              `Agent "${args.agent_id}" (${expectedCli}) no longer occupies ` +
+                `surface ${route.surface_id} — it now hosts a ${freshOccupant?.cli} ` +
+                `agent (surface recycled). Run resync_agents and retry.`,
+            );
+          }
         }
       }
       if (!args.allow_busy && !INTERACTIVE_AGENT_STATES.has(route.state)) {

--- a/tests/recycled-surface-identity.test.ts
+++ b/tests/recycled-surface-identity.test.ts
@@ -108,6 +108,95 @@ class RecycledSurfaceClient {
   async renameTab() {}
 }
 
+/**
+ * The discovery cache (scan(false)) momentarily shows a FOREIGN cli for the
+ * agent's surface (e.g. a transient parse, or a just-resolved pre-move read),
+ * but a fresh scan confirms the agent's OWN cli. The guard must confirm before
+ * refusing, so this healthy relay proceeds rather than being false-refused.
+ */
+class FlappingSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:1";
+  readonly sendTargets: string[] = [];
+  readonly sendKeyTargets: string[] = [];
+  private reads = 0;
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: "brainlayerClaude",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, _text: string) {
+    this.sendTargets.push(surface);
+  }
+
+  async sendKey(surface: string, _key: string) {
+    this.sendKeyTargets.push(surface);
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    // First read (the cached scan) looks like a Codex; every read after the
+    // cache invalidation shows the real Claude occupant.
+    this.reads += 1;
+    const text =
+      this.reads === 1
+        ? "gpt-5.3-codex \u00b7 80% left\n\ncodex>\n"
+        : "Claude Code\n> \nCLAUDE_COUNTER:1\n";
+    return {
+      surface,
+      text,
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab() {}
+}
+
 function createRelayServer(client: any) {
   return createServer({
     client,
@@ -190,5 +279,23 @@ describe("recycled surface identity", () => {
     // Nothing was sent to the recycled surface.
     expect(client.sendTargets).not.toContain(client.surface);
     expect(client.sendKeyTargets).not.toContain(client.surface);
+  });
+
+  it("does not false-refuse when a fresh scan confirms the agent's own CLI", async () => {
+    const client = new FlappingSurfaceClient();
+    server = createRelayServer(client);
+    registerClaudeAgentOnSurface1(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "hi",
+      press_enter: false,
+    });
+    const parsed = parseResult(result);
+
+    // The cached scan looked foreign, but the fresh scan confirms Claude — the
+    // healthy relay must proceed (no false refusal) and deliver.
+    expect(parsed.ok).toBe(true);
+    expect(client.sendTargets).toContain("surface:1");
   });
 });

--- a/tests/recycled-surface-identity.test.ts
+++ b/tests/recycled-surface-identity.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-recycled-surface-identity-test");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  return tool.handler(args, {} as any);
+}
+
+/**
+ * The agent was recorded as a Claude agent on surface:1. That surface still
+ * exists (so the #101 liveness guard passes), but it has been RECYCLED — it now
+ * hosts a *different* agent (a Codex). A relay by the original agent_id must NOT
+ * deliver keystrokes to the new occupant; it must detect the identity mismatch
+ * and refuse.
+ */
+class RecycledSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:1";
+  readonly sendTargets: string[] = [];
+  readonly sendKeyTargets: string[] = [];
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          // Title still reads like the old Claude agent, but the live screen
+          // (below) is a Codex — identity must be judged by the live content.
+          ref: this.surface,
+          title: "brainlayerCodex",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, _text: string) {
+    this.sendTargets.push(surface);
+  }
+
+  async sendKey(surface: string, _key: string) {
+    this.sendKeyTargets.push(surface);
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    // surface:1 now hosts a Codex agent (the pane was recycled).
+    return {
+      surface,
+      text: "gpt-5.3-codex · 80% left\n\ncodex>\n",
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab() {}
+}
+
+function createRelayServer(client: any) {
+  return createServer({
+    client,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
+function registerClaudeAgentOnSurface1(server: any): AgentRecord {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+
+  const now = "2026-05-29T12:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: "surface:1",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude", // recorded as Claude — but surface:1 now hosts a Codex
+    cli_session_id: null,
+    task_summary: "recycled surface identity test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+  };
+
+  stateMgr.writeState(record);
+  registry.set(record.agent_id, record);
+  return record;
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") {
+    engine.dispose();
+  }
+}
+
+describe("recycled surface identity", () => {
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("send_to refuses when the surface was recycled to a different-CLI agent", async () => {
+    const client = new RecycledSurfaceClient();
+    server = createRelayServer(client);
+    registerClaudeAgentOnSurface1(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "still you?",
+    });
+    const parsed = parseResult(result);
+
+    // The relay must refuse rather than deliver to the new occupant.
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/recycl|different|no longer|identity|codex/i);
+    // Nothing was sent to the recycled surface.
+    expect(client.sendTargets).not.toContain(client.surface);
+    expect(client.sendKeyTargets).not.toContain(client.surface);
+  });
+});


### PR DESCRIPTION
## What

gen-10 **cmuxLayer track-1** — closes the identity-binding gap documented in #101 (stale-surface-ref).

#101 caught a relay to a *vanished* surface. This catches one **recycled** to a *different live agent*: after a crash/respawn a pane ref can be reused by another agent, and a relay by the original `agent_id` would deliver keystrokes to the **new occupant** while still reporting ok.

## Change (`deliverAgentInput` in `server.ts`)

After re-resolving the route, an **identity guard**: look up the live occupant of the resolved surface via `discovery.scan`; if it hosts a **known CLI that differs** from the agent's recorded `cli`, throw (surface recycled) instead of delivering. **Fails OPEN** when the live CLI is unknown/unreadable/missing — a parse miss never blocks a healthy relay (matches #101's conservative posture).

## Tests (TDD red→green)

- **New `tests/recycled-surface-identity.test.ts`** — an agent recorded as Claude whose surface now hosts a Codex agent gets its relay **refused**, with nothing sent to the recycled surface (RED: `isError` undefined + delivered; GREEN: errors, no send).
- Full suite **509 passing**, typecheck clean.

## Residual (documented)

Same-CLI recycle (a Claude pane reused by a *different* Claude) is still not distinguished — needs a stable per-agent token (session id). Deeper follow-up. This PR closes the **cross-CLI** recycle, the common case in a multi-CLI orchestration.

## Live verification (this session)

Drove real cmux panes to verify the sibling **dock primitive** — and found it spawns a stray pane instead of docking when the workers pane contains a non-worker tab (separate fix incoming). Identity guard itself proven by the unit test above (a true live recycle demo needs the dev build hot-swapped into the running MCP, which would disrupt a 13-agent session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keystroke delivery for all agent relay paths; incorrect guard logic could block valid sends or (if too permissive) misdeliver, though fail-open and fresh-scan confirmation mitigate false positives.
> 
> **Overview**
> **Agent relay safety:** After route resolution in `deliverAgentInput` (used by `send_to`, `interact`, etc.), a new **identity guard** compares the agent’s recorded `cli` to the live occupant on that surface via `discovery.scan`. If the surface still exists but now hosts a **known, different CLI** (recycled pane), delivery is **refused** with an error pointing at `resync_agents`—instead of sending keystrokes to the wrong agent.
> 
> The guard **fails open** when the live CLI is unknown, unreadable, or missing, so parse/cache glitches do not block healthy relays. A cached mismatch triggers **cache invalidation and a fresh scan** before refusing, avoiding false refusals from stale discovery data.
> 
> **Tests:** New `tests/recycled-surface-identity.test.ts` covers cross-CLI recycle (refuse, no `send`/`sendKey`) and the flapping-cache case (relay proceeds after fresh scan confirms the expected CLI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa1e8a6a1723dbed1eff25e1df412399e49e0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse keystroke relay when a terminal surface has been recycled to a different CLI agent
> - Adds an identity guard in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/104/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that checks whether the live surface occupant's CLI matches the CLI recorded for the target agent before delivering keystrokes.
> - On a mismatch in the cached scan, invalidates the discovery cache and performs a fresh `discovery.scan(true)` to confirm; only throws if the fresh scan also shows a foreign CLI.
> - If no CLI is recorded for the agent, or the live CLI is `"unknown"` or unreadable, the guard fails open and delivery proceeds.
> - New test suite in [`recycled-surface-identity.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/104/files#diff-1a6681bf0ba95b53a8e018e6e510377b4baa50905238a6aa5a6289370197c8d0) covers the recycled-surface refusal case and a flapping-scan false-positive case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aa1e8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure keystrokes are delivered to the correct agent on recycled terminal surfaces.

* **Tests**
  * Added test coverage for recycled surface identity protection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EtanHey/cmuxlayer/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->