### PR TITLE
fix: dock workers into a worker-majority pane, not a stray third pane

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -127,6 +127,24 @@ function isDedicatedWorkerPane(layout: PaneLayout): boolean {
   );
 }
 
+/**
+ * A pane workers own for docking. Stricter than "has a worker": it must hold no
+ * orchestrators/ICs and workers must be the strict majority of its surfaces, so
+ * a real workers pane that also carries a stray non-role tab (a setup shell, a
+ * dashboard) still docks new workers as tabs instead of spawning a third pane.
+ * A pure dedicated worker pane (nonRoleCount === 0) trivially satisfies this.
+ * A lone worker tied with a non-role surface does NOT (1 is not > 1), so an
+ * accidental worker in someone's shell pane still splits out to a clean pane.
+ */
+function isWorkerDockPane(layout: PaneLayout): boolean {
+  return (
+    layout.orchestratorCount === 0 &&
+    layout.icCount === 0 &&
+    layout.workerCount > 0 &&
+    layout.workerCount > layout.nonRoleCount
+  );
+}
+
 function paneContainingSurface(
   layouts: PaneLayout[],
   surfaceId?: string | null,
@@ -218,9 +236,12 @@ export function collectRoleSurfaceIds(
 /**
  * Deterministic worker placement:
  * - first worker creates the right split
- * - subsequent workers become tabs in the rightmost dedicated worker pane
- * - mixed interactive/worker panes are treated as invalid and repaired with
- *   a fresh right split to preserve the left-interactive/right-worker invariant
+ * - subsequent workers become tabs in the rightmost worker-owned pane — a
+ *   worker-majority pane, which tolerates a stray non-role tab (a setup shell
+ *   or dashboard) so a populated workers pane never sprouts a redundant pane
+ * - a lone worker sharing a pane with an interactive/non-role surface is still
+ *   treated as invalid and repaired with a fresh right split, preserving the
+ *   left-interactive/right-worker invariant
  */
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
@@ -286,7 +307,10 @@ export function chooseAgentSpawnPlacement(
     }
   }
 
-  const rightmostWorkerPane = rightmost(workerPanes);
+  // Dock into the rightmost pane workers already own — including one that
+  // carries a stray non-role tab — so a populated workers pane never gets a
+  // redundant third pane split off beside it.
+  const rightmostWorkerPane = rightmost(layouts.filter(isWorkerDockPane));
   if (rightmostWorkerPane) {
     return { kind: "surface", pane: rightmostWorkerPane.pane.ref };
   }

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -225,6 +225,59 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
+  it("docks a worker into a worker-majority right pane that also holds a stray non-role tab", () => {
+    // Live scenario: the workers pane is dominated by workers but also holds a
+    // non-agent tab (e.g. a setup shell / dashboard). The worker must dock into
+    // it, NOT spawn a stray third pane.
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"]),
+      makePane("pane:right", 1, [
+        "surface:dashboard",
+        "surface:worker-1",
+        "surface:worker-2",
+      ]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", [
+        "surface:dashboard",
+        "surface:worker-1",
+        "surface:worker-2",
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      // surface:dashboard is unclassified (non-role); workers are the majority.
+      new Set(["surface:worker-1", "surface:worker-2"]),
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
+  it("still splits fresh when a lone worker shares a pane with one non-role surface", () => {
+    // Guard the worker-majority rule against over-reach: a single worker tied
+    // with a non-role surface is NOT a worker pane — split fresh (unchanged).
+    const panes = [
+      makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", [
+        "surface:interactive",
+        "surface:worker-1",
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      new Set(["surface:worker-1"]),
+    );
+
+    expect(placement).toEqual({ kind: "split", direction: "right" });
+  });
+
   it("marks a dedicated single-worker pane as collapsible when its last tab closes", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive"]),


### PR DESCRIPTION
## What

gen-10 **cmuxLayer track-1 — the core mission**: deterministic dock-on-spawn. **Found by driving real cmux panes this session.**

The dock primitive required a *dedicated* worker pane (workers only) to dock a new worker. In a real multi-agent workspace the workers pane almost always carries a stray non-role tab (a setup shell, a dashboard like `claudeDash-setup`), so `isDedicatedWorkerPane` returned false and `chooseAgentSpawnPlacement` fell back to a fresh right split — the worker landed in a **stray third pane** instead of docking. **This is the recurring pane-sprawl frustration.**

## Reproduced live (not just unit-theorized)

Drove a real spawn in the running cmux:
```
new_split(role=worker) → {placement:"split", pane:"pane:50"}   # a NEW pane beside the populated workers pane
```
The workers pane (`2A573A93`: 4 Codex workers + `claudeDash-setup`) was rejected as non-dedicated. Manually `move_surface`'d the worker into it to restore the clean 2-pane split.

## Fix (`layout-policy.ts`)

Select the dock target with a worker-**majority** rule (`isWorkerDockPane`: no orchestrators/ICs, workers strictly outnumber non-role surfaces) instead of strict dedication.
- Pure worker pane → still docks (unchanged).
- Workers pane + one dashboard tab → **now docks** (was: stray split).
- Lone worker tied 1:1 with an interactive surface → still splits to a clean pane (invariant preserved).

## Tests (TDD red→green)

- `tests/layout-policy.test.ts`: worker-majority dock case (RED: split → GREEN: surface) + explicit guard that a lone worker + non-role surface still splits.
- Full suite **510 passing**, typecheck + build clean.

## Note

Once this ships and the running cmux MCP is rebuilt, `new_split(role=worker)` will dock into the existing workers pane automatically — retiring the "every lead docks manually" workaround. Residual: role classification of discovered agents still depends on the registry; this fix makes placement robust to a *stray* non-role tab, which is the observed failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout-policy change with explicit unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Worker spawn placement** no longer requires a pane to be workers-only. New **`isWorkerDockPane`** treats a pane as the dock target when it has no orchestrators/ICs and **workers strictly outnumber** non-role tabs (e.g. a dashboard or setup shell).
> 
> **`chooseAgentSpawnPlacement`** picks the rightmost worker-dock pane for tab placement instead of only **`isDedicatedWorkerPane`**, so a populated workers column with one stray non-agent tab gets new workers as tabs instead of a **third pane split**.
> 
> A **1:1** lone worker plus one non-role surface still triggers a fresh **right split** (`workerCount > nonRoleCount` fails), preserving the left-interactive / right-worker layout.
> 
> Tests cover the worker-majority dock case and the tie guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535cd43ab8a3a4dc6c847fc40f69b5bb56499abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dock new workers into a worker-majority pane instead of a stray third pane
> - Adds `isWorkerDockPane` predicate in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/105/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) that classifies a pane as worker-owned when it has no orchestrators/ICs, at least one worker, and workers strictly outnumber non-role surfaces.
> - Updates `chooseAgentSpawnPlacement` to use this predicate (replacing the old worker-only pane check), so new workers tab into the rightmost qualifying pane rather than splitting a new pane unnecessarily.
> - A pane where a single worker ties with one non-role surface is not treated as worker-owned and still triggers a fresh right split.
> - Adds two test cases covering the majority-pane docking path and the tie/split path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 535cd43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->