### PR TITLE
fix: inject pane_ref so role-based dock placement actually works (#106)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -374,12 +374,13 @@ export class AgentEngine {
     try {
       const panes = await this.client.listPanes({ workspace });
       const paneSurfaces = await Promise.all(
-        panes.panes.map((pane) =>
-          this.client.listPaneSurfaces({
+        panes.panes.map(async (pane) => {
+          const ps = await this.client.listPaneSurfaces({
             workspace,
             pane: pane.ref,
-          }),
-        ),
+          });
+          return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
+        }),
       );
       const parentAgent = context?.parentAgent ?? null;
       const liveSurfaceIds = new Set(

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -156,7 +156,16 @@ export class CmuxSocketClient {
     const params: Record<string, unknown> = {};
     if (opts?.workspace) params.workspace_id = opts.workspace;
     if (opts?.pane) params.pane_id = opts.pane;
-    return this.call("surface.list", params);
+    const result = (await this.call(
+      "surface.list",
+      params,
+    )) as CmuxPaneSurfaces;
+    // The cmux socket omits pane_ref from the response; inject it from the
+    // known input so describePaneLayouts can match panes to their surfaces.
+    if (opts?.pane && !result.pane_ref) {
+      result.pane_ref = opts.pane;
+    }
+    return result;
   }
 
   async listPanes(opts?: { workspace?: string }): Promise<{

--- a/src/server.ts
+++ b/src/server.ts
@@ -1368,12 +1368,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           const panes = await client.listPanes({ workspace: args.workspace });
           const paneSurfaces = await Promise.all(
-            panes.panes.map((pane) =>
-              client.listPaneSurfaces({
+            panes.panes.map(async (pane) => {
+              const ps = await client.listPaneSurfaces({
                 workspace: args.workspace,
                 pane: pane.ref,
-              }),
-            ),
+              });
+              // cmux socket omits pane_ref; inject it so describePaneLayouts
+              // can match panes to their surfaces for role-based placement.
+              return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
+            }),
           );
           const liveSurfaceIds = new Set(
             paneSurfaces.flatMap((group) =>
@@ -2125,9 +2128,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (workspace) {
             const panes = await client.listPanes({ workspace });
             const paneSurfaces = await Promise.all(
-              panes.panes.map((pane) =>
-                client.listPaneSurfaces({ workspace, pane: pane.ref }),
-              ),
+              panes.panes.map(async (pane) => {
+                const ps = await client.listPaneSurfaces({ workspace, pane: pane.ref });
+                return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
+              }),
             );
             const workerSurfaceIds = new Set(
               stateMgr.listStates().map((record) => record.surface_id),

--- a/tests/dock-pane-ref.test.ts
+++ b/tests/dock-pane-ref.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression test for the pane_ref matching bug: the real cmux socket does NOT
+ * include pane_ref in the surface.list response, so describePaneLayouts can't
+ * match panes to their surfaces → workerCount=0 on every pane → dock always
+ * falls back to a fresh right split even when a worker-majority pane exists.
+ *
+ * The fix: cmux-socket-client.ts injects pane_ref from the opts.pane input
+ * when it is absent from the socket response.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-dock-pane-ref-test");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool.handler(args, {} as any);
+}
+
+/**
+ * Fake client that reproduces the REAL cmux socket format:
+ * - listPaneSurfaces does NOT return pane_ref (like the real socket)
+ * - two panes: commanders LEFT (pane:1), workers RIGHT (pane:2)
+ * - right pane has 2 Codex workers (no non-role surfaces)
+ */
+class RealCmuxFormatClient {
+  readonly sendCalls: string[] = [];
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: "workspace:1",
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: "pane:1",
+          index: 0,
+          focused: false,
+          surface_count: 2,
+          surface_refs: ["surface:orc", "surface:lead"],
+        },
+        {
+          ref: "pane:2",
+          index: 1,
+          focused: true,
+          surface_count: 2,
+          surface_refs: ["surface:w1", "surface:w2"],
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces(opts?: { workspace?: string; pane?: string }) {
+    const pane = opts?.pane ?? "";
+    // Real cmux socket format: NO pane_ref field in the response
+    return {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      // pane_ref intentionally ABSENT — this is what the real socket sends
+      surfaces:
+        pane === "pane:2"
+          ? [
+              {
+                ref: "surface:w1",
+                title: "brainlayerCodex-w1",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+              {
+                ref: "surface:w2",
+                title: "brainlayerCodex-w2",
+                type: "terminal",
+                index: 1,
+                selected: false,
+              },
+            ]
+          : [
+              {
+                ref: "surface:orc",
+                title: "orcClaude",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+              {
+                ref: "surface:lead",
+                title: "brainlayerClaude-LEAD",
+                type: "terminal",
+                index: 1,
+                selected: false,
+              },
+            ],
+    } as any; // pane_ref absent = real socket format
+  }
+
+  async newSurface(opts: { pane: string }) {
+    return {
+      workspace: "workspace:1",
+      surface: "surface:new",
+      pane: opts.pane,
+      title: "cmuxlayerCodex-test",
+      type: "terminal" as const,
+    };
+  }
+
+  async newSplit(direction: string) {
+    return {
+      workspace: "workspace:1",
+      surface: "surface:stray",
+      pane: "pane:3",
+      title: "",
+      type: "terminal" as const,
+    };
+  }
+
+  async send(surface: string, text: string) {
+    this.sendCalls.push(`${surface}:${text}`);
+  }
+  async sendKey() {}
+  async readScreen() {
+    return { surface: "", text: "", lines: 20, scrollback_used: false };
+  }
+  async renameTab() {}
+  async identify() {
+    return null;
+  }
+  async closeSurface() {}
+  async listWorkspaceSurfaces() {
+    return { workspaces: [], surfaces: [] };
+  }
+}
+
+function createDockServer(client: RealCmuxFormatClient) {
+  return createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+}
+
+function registerWorkers(server: any) {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+  const now = "2026-05-30T12:00:00Z";
+
+  const make = (id: string, surfaceId: string): AgentRecord => ({
+    agent_id: id,
+    surface_id: surfaceId,
+    workspace_id: "workspace:1",
+    state: "working",
+    repo: "brainlayer",
+    model: "gpt-5.3",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "dock test worker",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+  });
+
+  for (const [id, surfaceId] of [
+    ["w1", "surface:w1"],
+    ["w2", "surface:w2"],
+  ]) {
+    const r = make(id, surfaceId);
+    stateMgr.writeState(r);
+    registry.set(r.agent_id, r);
+  }
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") engine.dispose();
+}
+
+describe("dock pane-ref matching", () => {
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("new_split role=worker docks into the workers pane when listPaneSurfaces omits pane_ref", async () => {
+    const client = new RealCmuxFormatClient();
+    server = createDockServer(client);
+    registerWorkers(server);
+
+    const result = await callTool(server, "new_split", {
+      direction: "right",
+      role: "worker",
+      workspace: "workspace:1",
+    });
+    const parsed = parseResult(result);
+
+    // Must dock into the existing workers pane (pane:2), not create a new split.
+    expect(parsed.placement).toBe("surface");
+    expect(parsed.pane).toBe("pane:2");
+    expect(parsed.role).toBe("worker");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -235,10 +235,7 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["select_workspace"];
 
-    const result = await tool.handler(
-      { workspace: "workspace:3" },
-      {} as any,
-    );
+    const result = await tool.handler({ workspace: "workspace:3" }, {} as any);
 
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
@@ -412,9 +409,9 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.surfaces).toHaveLength(2);
-    expect(parsed.surfaces.map((surface: { ref: string }) => surface.ref)).toEqual(
-      ["surface:1", "surface:2"],
-    );
+    expect(
+      parsed.surfaces.map((surface: { ref: string }) => surface.ref),
+    ).toEqual(["surface:1", "surface:2"]);
     expect(parsed.workspaces).toEqual([
       {
         ref: "workspace:1",
@@ -905,9 +902,15 @@ describe("tool handler integration", () => {
       }),
     } as any;
 
+    // Use an isolated stateDir so enrichParsedScreen doesn't pick up live
+    // agent state from the default state directory and overwrite model/cost.
+    const isolatedStateDir = join(tmpdir(), "cmux-read-screen-isolation-test");
+    rmSync(isolatedStateDir, { recursive: true, force: true });
+    mkdirSync(isolatedStateDir, { recursive: true });
     const server = createServer({
       client: mockClient,
       skipAgentLifecycle: true,
+      stateDir: isolatedStateDir,
     });
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["read_screen"];
@@ -916,6 +919,7 @@ describe("tool handler integration", () => {
       { surface: "surface:1", parsed_only: true, lines: 40 },
       {} as any,
     );
+    rmSync(isolatedStateDir, { recursive: true, force: true });
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -1068,18 +1072,19 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:1",
-      "brainlayerCodex -s",
-    ]));
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:1",
-      "boot prompt",
-    ]));
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:1",
+        "brainlayerCodex -s",
+      ]),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
   });
 
   it("send_command reports timeout with last screen lines and leaves launcher surface alive", async () => {
@@ -1119,12 +1124,15 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Timed out");
     expect(parsed.last_10_lines).toContain("$ waiting");
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:1",
-      "brainlayerCodex -s",
-    ]));
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:1",
+        "brainlayerCodex -s",
+      ]),
+    );
   });
 
   it("send_command does not treat another CLI prompt as launcher readiness", async () => {
@@ -1161,12 +1169,10 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(false);
-    expect(mockExec).not.toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:1",
-      "boot prompt",
-    ]));
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
   });
 
   it("send_command requires consecutive low-confidence ready matches", async () => {
@@ -1205,12 +1211,10 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(reads).toBe(2);
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:1",
-      "boot prompt",
-    ]));
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
   });
 
   it("send_input chunks long text transparently before sending", async () => {
@@ -1389,14 +1393,16 @@ describe("tool handler integration", () => {
       {} as any,
     );
     const otherSurfaceParsed =
-      otherSurface.structuredContent ?? JSON.parse(otherSurface.content[0].text);
+      otherSurface.structuredContent ??
+      JSON.parse(otherSurface.content[0].text);
     expect(otherSurfaceParsed.ok).toBe(true);
     expect(otherSurfaceParsed.surface).toBe("surface:2");
   });
 
   it("send_input rejects concurrent foreground sends on the same surface", async () => {
-    let releaseSend: ((value: { stdout: string; stderr: string }) => void) | null =
-      null;
+    let releaseSend:
+      | ((value: { stdout: string; stderr: string }) => void)
+      | null = null;
     mockExec = vi.fn().mockImplementation((_cmd, args) => {
       if (args.includes("send") && !releaseSend) {
         return new Promise((resolve) => {
@@ -1474,7 +1480,8 @@ describe("tool handler integration", () => {
     );
     expect(renameResult.isError).toBe(true);
     const renameParsed =
-      renameResult.structuredContent ?? JSON.parse(renameResult.content[0].text);
+      renameResult.structuredContent ??
+      JSON.parse(renameResult.content[0].text);
     expect(renameParsed.error).toMatch(/delivery.*in progress/i);
   });
 
@@ -1507,7 +1514,9 @@ describe("tool handler integration", () => {
       if (args.includes("send")) {
         sendAttempts += 1;
         if (sendAttempts === 1) {
-          return Promise.reject(new Error("socket closed before receiving response"));
+          return Promise.reject(
+            new Error("socket closed before receiving response"),
+          );
         }
       }
       return Promise.resolve({ stdout: "{}", stderr: "" });
@@ -1669,8 +1678,24 @@ describe("tool handler integration", () => {
             pane_ref: pane,
             surfaces:
               pane === "pane:right"
-                ? [{ ref: "surface:worker-1", title: "", type: "terminal", index: 0, selected: true }]
-                : [{ ref: "surface:orc", title: "", type: "terminal", index: 0, selected: true }],
+                ? [
+                    {
+                      ref: "surface:worker-1",
+                      title: "",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : [
+                    {
+                      ref: "surface:orc",
+                      title: "",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ],
           }),
           stderr: "",
         };
@@ -2037,7 +2062,8 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             workspace,
             surface,
-            pane: workspace === "workspace:1" ? "pane:w1-right" : "pane:w2-right",
+            pane:
+              workspace === "workspace:1" ? "pane:w1-right" : "pane:w2-right",
             title: "",
             type: "terminal",
           }),
@@ -2189,7 +2215,8 @@ describe("tool handler integration", () => {
       {} as any,
     );
     const parsed =
-      workerResult.structuredContent ?? JSON.parse(workerResult.content[0].text);
+      workerResult.structuredContent ??
+      JSON.parse(workerResult.content[0].text);
 
     expect(mockExec).not.toHaveBeenCalledWith(
       "cmux",
@@ -2535,10 +2562,7 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["new_surface"];
 
-    await tool.handler(
-      { pane: "pane:1", title: "Build Logs" },
-      {} as any,
-    );
+    await tool.handler({ pane: "pane:1", title: "Build Logs" }, {} as any);
 
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
@@ -2902,7 +2926,10 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["close_surface"];
 
-    const result = await tool.handler({ surface: "surface:worker-1" }, {} as any);
+    const result = await tool.handler(
+      { surface: "surface:worker-1" },
+      {} as any,
+    );
 
     expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:worker-1", {
       workspace: undefined,


### PR DESCRIPTION
## Root cause

The cmux socket `surface.list` response does **not** include `pane_ref`. `describePaneLayouts` builds a `Map` keyed on `group.pane_ref`; when absent, every pane resolves to `surfaces:[]` → `workerCount=0` on every pane → `chooseAgentSpawnPlacement` always falls through to a fresh right split.

**The worker-majority placement rule (#105) was always correct — this missing fix is why it never worked in production.** Confirmed by probing the live socket:

```
pane.ref=[pane:1] pane_ref_back=[undefined] MATCH=false
```

## Fixes

1. **`cmux-socket-client.ts`** — inject `pane_ref: opts.pane` after `surface.list` when absent (production socket path)
2. **`server.ts` `new_split`** — `ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref }` (general client interface)
3. **`agent-engine.ts` spawn placement** — same pattern

## Also fixes

**`tests/server.test.ts`** — one pre-existing test failure: a `read_screen` enrichment test that creates a server without an isolated `stateDir`, causing `enrichParsedScreen` to pick up real live agent state from disk (current model name), overwriting `model: null`. Added an isolated tmpdir — now hermetic.

## Tests

- New `tests/dock-pane-ref.test.ts`: fake client returns **no `pane_ref`** (real cmux format), two workers in right pane, `new_split(role=worker)` must dock as `placement:"surface"` into `pane:2`. RED before, GREEN after.
- **513/513 passing** (was 512/513 with pre-existing isolation failure), typecheck clean.
- After next MCP process restart, `new_split(role=worker)` will actually dock — fixing the recurring pane-sprawl frustration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted compatibility shim around socket responses plus tests; behavior only changes when `pane_ref` was missing, restoring intended layout policy rather than altering unrelated paths.
> 
> **Overview**
> Fixes **role-based docking** (`new_split` / spawn placement) against the real cmux socket, which returns `surface.list` results **without** `pane_ref`. Layout code keys panes by `pane_ref`, so every pane looked empty and worker placement always fell back to a new right split.
> 
> **`listPaneSurfaces`** now sets `pane_ref` from the `pane` argument when the response omits it (socket client). The same fallback is applied when aggregating per-pane surfaces in **`agent-engine`** spawn placement, **`new_split`**, and **`close_surface`** layout hints.
> 
> Adds **`tests/dock-pane-ref.test.ts`** (socket-shaped mock, no `pane_ref`) asserting `new_split(role=worker)` docks as `placement: surface` into the worker pane. **`tests/server.test.ts`** uses an isolated `stateDir` for a `read_screen` enrichment test so live agent state on disk cannot skew expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4aa8f19b86c1d0774d03ad3f685bd1832266478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix role-based dock placement by injecting `pane_ref` when the cmux socket omits it
> - The cmux socket's `surface.list` RPC response omits `pane_ref`, causing downstream pane/surface matching to fail and role-based `new_split` requests to open a new pane instead of docking into an existing one.
> - `pane_ref` is now injected in [`src/cmux-socket-client.ts`](https://github.com/EtanHey/cmuxlayer/pull/113/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) and at each `listPaneSurfaces` call site in [`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/113/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) and [`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/113/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) when the server response lacks it.
> - A new regression test in [`tests/dock-pane-ref.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/113/files#diff-839e7da6e725ee5fa4fd7455054eafc57a185c8771cee9fb968448ae7cf90c8d) simulates the real socket behavior and asserts that `new_split` with `role=worker` docks into the existing workers pane rather than creating a split.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4aa8f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->