### PR TITLE
feat: multi-workspace spawn + create_workspace + cursor launcher fix

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -182,6 +182,7 @@ interface AgentEngineClient {
     title?: string;
     url?: string;
   }): Promise<CmuxNewSurfaceResult>;
+  selectWorkspace(workspace: string): Promise<void>;
   listPanes(opts?: { workspace?: string }): Promise<{
     workspace_ref?: string;
     panes: CmuxPane[];
@@ -225,7 +226,7 @@ const LIFECYCLE_LOGS = {
  * which handle cd, model, iTerm profile, MCP config, and contexts.
  * No `cd` prefix needed — the launcher does it.
  *
- * For other CLIs: uses `cd ~/Gits/<repo> && <cli>` since they
+ * For gemini/kiro: uses `cd ~/Gits/<repo> && <cli>` since they
  * don't have launcher functions yet.
  */
 // Env vars for headless/spawned agent sessions:
@@ -256,6 +257,7 @@ export function buildLaunchCommand(cli: CliType, repo: string): string {
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli`;
     case "cursor":
+      // repoGolem launcher - requires registration via golem-powers.
       return `${safeRepo}Cursor -s`;
   }
 }
@@ -293,21 +295,23 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
-async function assertLauncherAvailable(
+export async function assertLauncherAvailable(
   repo: string,
   suffix: "Claude" | "Codex" | "Cursor",
 ): Promise<void> {
   const launcher = `${sanitizeRepoName(repo)}${suffix}`;
-  const shell = process.env.SHELL || "/bin/sh";
+  const shell = process.env.SHELL || "/bin/zsh";
   const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
 
   try {
-    await execFileAsync(shell, ["-lc", probe]);
+    await execFileAsync(shell, ["-ilc", probe]);
   } catch {
     throw new Error(
-      `Launcher "${launcher}" not found. For repo "${repo}" with hyphens, ` +
-        `the launcher name strips the hyphen (e.g. "skill-creator" → "skillcreatorClaude"). ` +
-        `Use the direct shell spawn path, or fix the repoGolem config.`,
+      `Launcher "${launcher}" not found. ` +
+        `For repo "${repo}" with hyphens the launcher strips hyphens ` +
+        `(e.g. "skill-creator" -> "skillcreatorCursor"). ` +
+        `Register the launcher in golem-powers or use cli="gemini"/"kiro" ` +
+        `which use direct cd+exec paths.`,
     );
   }
 }
@@ -371,6 +375,15 @@ export class AgentEngine {
       parentAgent?: AgentRecord | null;
     },
   ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
+    if (workspace) {
+      try {
+        await this.client.selectWorkspace(workspace);
+      } catch {
+        // Best-effort: the workspace may already be focused, or the client may
+        // be an older test/fallback implementation.
+      }
+    }
+
     try {
       const panes = await this.client.listPanes({ workspace });
       const paneSurfaces = await Promise.all(

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -128,6 +128,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       setProgress: async () => {},
       newSplit: (direction, splitOpts) => this.client.newSplit(direction, splitOpts),
       newSurface: (surfaceOpts) => this.client.newSurface(surfaceOpts),
+      selectWorkspace: (workspace) => this.client.selectWorkspace(workspace),
       listPanes: (paneOpts) => this.client.listPanes(paneOpts),
       listPaneSurfaces: (surfaceOpts) => this.client.listPaneSurfaces(surfaceOpts),
       closeSurface: (surface, closeOpts) =>

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -371,6 +371,18 @@ export class CmuxClient {
     await this.run(args);
   }
 
+  async createWorkspace(
+    title: string,
+  ): Promise<{ workspace: string; title: string }> {
+    const raw = await this.run(["new-workspace", "--title", title]);
+    const parsed = this.parse<Record<string, unknown>>(raw, "new-workspace");
+    return {
+      workspace:
+        (parsed.workspace_ref as string) ?? (parsed.workspace as string) ?? "",
+      title: (parsed.title as string) ?? title,
+    };
+  }
+
   async readScreen(
     surface: string,
     opts?: {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -149,6 +149,27 @@ export class CmuxSocketClient {
     }
   }
 
+  async createWorkspace(
+    title: string,
+  ): Promise<{ workspace: string; title: string }> {
+    try {
+      const result = await this.call<Record<string, unknown>>(
+        "workspace.create",
+        { title },
+      );
+      return {
+        workspace:
+          (result.workspace_ref as string) ?? (result.workspace as string) ?? "",
+        title: (result.title as string) ?? title,
+      };
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallback.createWorkspace(title);
+      }
+      throw e;
+    }
+  }
+
   async listPaneSurfaces(opts?: {
     workspace?: string;
     pane?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 29 MCP tools across two categories:
- *   Core (16): list_surfaces, select_workspace, new_split, new_surface,
- *              move_surface, reorder_surface, send_input, send_command,
- *              send_key, read_screen, rename_tab, notify, set_status,
- *              set_progress, close_surface, browser_surface
- *   Agent lifecycle (13): spawn_agent, resync_agents,
+ * 31 MCP tools across two categories:
+ *   Core (17): list_surfaces, select_workspace, create_workspace, new_split,
+ *              new_surface, move_surface, reorder_surface, send_input,
+ *              send_command, send_key, read_screen, rename_tab, notify,
+ *              set_status, set_progress, close_surface, browser_surface
+ *   Agent lifecycle (14): spawn_agent, spawn_in_workspace, resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         read_agent_output, get_agent_state, list_agents,
  *                         my_agents, wait_for, wait_for_all, stop_agent,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers 16 core tools + 13 agent lifecycle tools.
+ * cmux MCP server — registers core tools + agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -1291,6 +1291,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
+  server.tool(
+    "create_workspace",
+    "Create a new workspace tab. Returns the new workspace ref and title.",
+    {
+      title: z.string().describe("Workspace title"),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const result = await client.createWorkspace(args.title);
+        const data = {
+          workspace: result.workspace,
+          title: result.title,
+        };
+        return okFormatted(formatOk("create_workspace", data), data);
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
   // 2. new_split
   server.tool(
     "new_split",
@@ -2336,6 +2357,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         newSplit: (direction, splitOpts) =>
           client.newSplit(direction, splitOpts),
         newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
+        selectWorkspace: (workspace) => client.selectWorkspace(workspace),
         listPanes: (paneOpts) => client.listPanes(paneOpts),
         listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
         closeSurface: (surface, closeOpts) =>
@@ -2655,6 +2677,114 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 inferAgentRole({ role: args.role, cli: args.cli }),
               boot_prompt_delivered: Boolean(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
+            },
+          );
+        } catch (e) {
+          return err(e);
+        }
+      },
+    );
+
+    server.tool(
+      "spawn_in_workspace",
+      "Create a workspace and spawn a set of agents into it as a clean 2-pane grid (commanders LEFT, workers RIGHT). Handles workspace creation, selection, and role-based pane placement atomically. Use this instead of repeated spawn_agent calls when standing up a multi-agent team.",
+      {
+        workspace_title: z
+          .string()
+          .describe("Title for the new workspace (e.g. 'red-team')"),
+        agents: z
+          .array(
+            z.object({
+              repo: z.string(),
+              model: z.string(),
+              cli: z.enum(["claude", "codex", "cursor", "gemini", "kiro"]),
+              role: z.enum(["orchestrator", "worker", "ic"]).optional(),
+              prompt: z.string().optional(),
+            }),
+          )
+          .min(1)
+          .describe("Agents to spawn, in order"),
+        reuse_workspace: z
+          .string()
+          .optional()
+          .describe("Ref of an existing workspace to use instead of creating a new one"),
+      },
+      ANNOTATIONS.mutating,
+      async (args) => {
+        try {
+          const workspaceResult = args.reuse_workspace
+            ? { workspace: args.reuse_workspace, title: args.workspace_title }
+            : await client.createWorkspace(args.workspace_title);
+          const workspace = workspaceResult.workspace;
+          if (!workspace) {
+            throw new Error("create_workspace returned an empty workspace ref");
+          }
+
+          await client.selectWorkspace(workspace);
+
+          const spawnedAgents: Array<{
+            agent_id: string;
+            surface_id: string;
+            repo: string;
+            cli: CliType;
+          }> = [];
+
+          for (const agent of args.agents) {
+            const hasPrompt = hasInlinePrompt(agent.prompt);
+            const result = await engine.spawnAgent({
+              repo: agent.repo,
+              model: agent.model,
+              cli: agent.cli,
+              prompt: agent.prompt ?? "",
+              boot_prompt_pending: hasPrompt,
+              workspace,
+              role: agent.role,
+              auto_archive_on_done: true,
+            });
+
+            if (hasPrompt) {
+              const bootPromptDelivery = await deliverBootPrompt({
+                surface: result.surface_id,
+                workspace,
+                cli: agent.cli,
+                prompt: agent.prompt,
+                timeout_ms: BOOT_PROMPT_TIMEOUT_MS,
+              });
+
+              const updated = stateMgr.updateRecord(result.agent_id, {
+                task_summary:
+                  bootPromptDelivery.prompt_text ?? agent.prompt ?? "",
+                boot_prompt_pending: false,
+              });
+              registry.set(result.agent_id, updated);
+
+              const current = engine.getAgentState(result.agent_id);
+              if (current?.state === "booting") {
+                const ready = stateMgr.transition(result.agent_id, "ready");
+                registry.set(result.agent_id, ready);
+                result.state = "ready";
+              } else if (current?.state === "ready") {
+                result.state = "ready";
+              }
+            }
+
+            spawnedAgents.push({
+              agent_id: result.agent_id,
+              surface_id: result.surface_id,
+              repo: agent.repo,
+              cli: agent.cli,
+            });
+          }
+
+          return okFormatted(
+            formatOk("spawn_in_workspace", {
+              workspace,
+              agents: spawnedAgents.length,
+            }),
+            {
+              workspace,
+              title: workspaceResult.title,
+              agents: spawnedAgents,
             },
           );
         } catch (e) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   AgentEngine,
+  assertLauncherAvailable,
   buildLaunchCommand,
   buildResumeCommand,
   extractSessionId,
@@ -49,6 +56,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
     listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     listPanes: vi.fn().mockResolvedValue({ panes: [] }),
     listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
+    selectWorkspace: vi.fn().mockResolvedValue(undefined),
     clearStatus: vi.fn().mockResolvedValue(undefined),
     setProgress: vi.fn().mockResolvedValue(undefined),
     clearProgress: vi.fn().mockResolvedValue(undefined),
@@ -99,6 +107,10 @@ describe("AgentEngine", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((_cmd, _args, callback) => {
+      callback(new Error("missing launcher"), "", "");
+    });
     stateMgr = new StateManager(TEST_DIR);
     mockClient = makeMockClient();
     liveSurfaces = [];
@@ -216,6 +228,47 @@ describe("AgentEngine", () => {
         type: "terminal",
       });
       expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
+    it("selects the target workspace before creating an agent surface", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "workspace:red-team",
+        window_ref: "window:1",
+        pane_ref: "pane:left",
+        surfaces: [makeSurface("surface:interactive")],
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+        workspace: "workspace:red-team",
+      });
+
+      expect(mockClient.selectWorkspace).toHaveBeenCalledWith("workspace:red-team");
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        workspace: "workspace:red-team",
+        type: "terminal",
+      });
+      expect(
+        (mockClient.selectWorkspace as ReturnType<typeof vi.fn>).mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(
+        (mockClient.newSplit as ReturnType<typeof vi.fn>).mock
+          .invocationCallOrder[0],
+      );
     });
 
     it("creates the first worker as a right split even when user panes already exist", async () => {
@@ -1653,6 +1706,48 @@ describe("buildLaunchCommand", () => {
     const cmd = buildLaunchCommand("claude", "brainlayer");
     expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
     expect(cmd).not.toContain("CLAUDE_CODE_NO_FLICKER");
+  });
+});
+
+describe("assertLauncherAvailable", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    vi.stubEnv("SHELL", "/bin/zsh");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("passes when the interactive shell probe returns 0", async () => {
+    execFileMock.mockImplementation((_cmd, _args, callback) => {
+      callback(null, "", "");
+    });
+
+    await expect(
+      assertLauncherAvailable("brainlayer", "Cursor"),
+    ).resolves.toBeUndefined();
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      "/bin/zsh",
+      [
+        "-ilc",
+        "type brainlayerCursor >/dev/null 2>&1 || command -v brainlayerCursor >/dev/null 2>&1",
+      ],
+      expect.any(Function),
+    );
+  });
+
+  it("throws a clear launcher registration message when the probe fails", async () => {
+    execFileMock.mockImplementation((_cmd, _args, callback) => {
+      callback(new Error("missing launcher"), "", "");
+    });
+
+    await expect(
+      assertLauncherAvailable("skill-creator", "Cursor"),
+    ).rejects.toThrow(
+      /Launcher "skill-creatorCursor" not found.*skillcreatorCursor.*cli="gemini"\/"kiro"/s,
+    );
   });
 });
 

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -43,6 +43,7 @@ describe("B1: ToolAnnotations on all tools", () => {
 
   const MUTATING_TOOLS = [
     "select_workspace",
+    "create_workspace",
     "new_split",
     "new_surface",
     "move_surface",
@@ -56,6 +57,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "set_progress",
     "browser_surface",
     "spawn_agent",
+    "spawn_in_workspace",
     "resync_agents",
     "send_to",
     "send_to_agent",
@@ -79,9 +81,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 29 tools have annotations", () => {
+  it("all 31 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(29);
+    expect(toolNames.length).toBe(31);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for the 7 agent lifecycle MCP tools registered in server.ts.
+ * Integration tests for the agent lifecycle MCP tools registered in server.ts.
  * Tests tool registration and handler dispatch with mocked cmux client.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -13,6 +13,7 @@ const TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 
 const AGENT_TOOLS = [
   "spawn_agent",
+  "spawn_in_workspace",
   "resync_agents",
   "send_to",
   "wait_for",
@@ -126,7 +127,7 @@ function createLifecycleServer(exec: ExecFn) {
 }
 
 describe("agent lifecycle tool registration", () => {
-  it("registers all 11 agent lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 12 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -154,11 +155,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 29 (16 low-level + 11 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 31 (17 low-level + 12 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(29);
+    expect(Object.keys(registeredTools)).toHaveLength(31);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -12,6 +12,7 @@ import { AgentRegistry } from "../src/agent-registry.js";
 const EXPECTED_TOOLS = [
   "list_surfaces",
   "select_workspace",
+  "create_workspace",
   "new_split",
   "new_surface",
   "move_surface",
@@ -72,7 +73,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 16 core tools", () => {
+  it("registers all 17 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;
@@ -250,6 +251,122 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.workspace).toBe("workspace:3");
+  });
+
+  it("create_workspace handler calls client.createWorkspace", async () => {
+    const mockClient = {
+      createWorkspace: vi.fn().mockResolvedValue({
+        workspace: "workspace:7",
+        title: "red-team",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["create_workspace"];
+
+    const result = await tool.handler({ title: "red-team" }, {} as any);
+
+    expect(mockClient.createWorkspace).toHaveBeenCalledWith("red-team");
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed).toMatchObject({
+      ok: true,
+      workspace: "workspace:7",
+      title: "red-team",
+    });
+  });
+
+  it("spawn_in_workspace tool handler creates, selects, then spawns agents", async () => {
+    const calls: string[] = [];
+    let surfaceIndex = 0;
+    const mockClient = {
+      createWorkspace: vi.fn().mockImplementation(async (title: string) => {
+        calls.push(`create:${title}`);
+        return { workspace: "workspace:grid", title };
+      }),
+      selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+        calls.push(`select:${workspace}`);
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [{ ref: "workspace:grid", title: "grid" }],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:grid",
+        window_ref: "window:1",
+        panes: [],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:grid",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [],
+      }),
+      newSplit: vi.fn().mockImplementation(async (_direction, opts) => {
+        surfaceIndex += 1;
+        calls.push(`spawn:${opts.workspace}:surface:${surfaceIndex}`);
+        return {
+          workspace: opts.workspace,
+          surface: `surface:${surfaceIndex}`,
+          pane: `pane:${surfaceIndex}`,
+          title: "",
+          type: "terminal",
+        };
+      }),
+      newSurface: vi.fn(),
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:1",
+        text: "$ ",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      log: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue(undefined),
+      clearStatus: vi.fn().mockResolvedValue(undefined),
+      setProgress: vi.fn().mockResolvedValue(undefined),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+      identify: vi.fn().mockResolvedValue({}),
+      browser: vi.fn().mockResolvedValue({}),
+    };
+    const stateDir = join(CHANNEL_TEST_DIR, "spawn-in-workspace-sequence");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_in_workspace"];
+
+    const result = await tool.handler(
+      {
+        workspace_title: "red-team",
+        agents: [
+          { repo: "brainlayer", model: "sonnet", cli: "claude", role: "orchestrator" },
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace).toBe("workspace:grid");
+    expect(parsed.agents).toHaveLength(2);
+    expect(calls.slice(0, 4)).toEqual([
+      "create:red-team",
+      "select:workspace:grid",
+      "select:workspace:grid",
+      "spawn:workspace:grid:surface:1",
+    ]);
+    expect(calls).toContain("spawn:workspace:grid:surface:2");
+
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("list_surfaces dedupes overlapping pane results and returns the condensed default schema", async () => {

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-spawn-workspace-test");
+
+function makeWorkspaceClient() {
+  let surfaceIndex = 0;
+  const calls: string[] = [];
+  const client = {
+    calls,
+    createWorkspace: vi.fn().mockImplementation(async (title: string) => {
+      calls.push(`create:${title}`);
+      return { workspace: "workspace:grid", title };
+    }),
+    selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+      calls.push(`select:${workspace}`);
+    }),
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [{ ref: "workspace:grid", title: "grid" }],
+    }),
+    listPanes: vi.fn().mockResolvedValue({
+      workspace_ref: "workspace:grid",
+      window_ref: "window:1",
+      panes: [],
+    }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({
+      workspace_ref: "workspace:grid",
+      window_ref: "window:1",
+      pane_ref: "pane:1",
+      surfaces: [],
+    }),
+    newSplit: vi.fn().mockImplementation(async (_direction, opts) => {
+      surfaceIndex += 1;
+      calls.push(`spawn:${opts.workspace}:surface:${surfaceIndex}`);
+      return {
+        workspace: opts.workspace,
+        surface: `surface:${surfaceIndex}`,
+        pane: `pane:${surfaceIndex}`,
+        title: "",
+        type: "terminal",
+      };
+    }),
+    newSurface: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:1",
+      text: "$ ",
+      lines: 1,
+      scrollback_used: false,
+    }),
+    log: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn().mockResolvedValue(undefined),
+    identify: vi.fn().mockResolvedValue({}),
+    browser: vi.fn().mockResolvedValue({}),
+  };
+  return client;
+}
+
+describe("workspace spawn tools", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("create_workspace tool returns a workspace ref", async () => {
+    const client = makeWorkspaceClient();
+    const server = createServer({
+      client: client as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["create_workspace"];
+
+    const result = await tool.handler({ title: "red-team" }, {} as any);
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(client.createWorkspace).toHaveBeenCalledWith("red-team");
+    expect(parsed).toMatchObject({
+      ok: true,
+      workspace: "workspace:grid",
+      title: "red-team",
+    });
+  });
+
+  it("spawn_in_workspace spawns agents into the created workspace", async () => {
+    const client = makeWorkspaceClient();
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_in_workspace"];
+
+    const result = await tool.handler(
+      {
+        workspace_title: "red-team",
+        agents: [
+          { repo: "brainlayer", model: "sonnet", cli: "claude", role: "orchestrator" },
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.workspace).toBe("workspace:grid");
+    expect(parsed.agents).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:1",
+        repo: "brainlayer",
+        cli: "claude",
+      }),
+      expect.objectContaining({
+        surface_id: "surface:2",
+        repo: "cmuxlayer",
+        cli: "codex",
+      }),
+    ]);
+    expect(client.createWorkspace).toHaveBeenCalledTimes(1);
+    expect(client.newSplit).toHaveBeenCalledTimes(2);
+    expect(
+      client.newSplit.mock.calls.map(([, opts]) => opts.workspace),
+    ).toEqual(["workspace:grid", "workspace:grid"]);
+  });
+
+  it("spawn_in_workspace with reuse_workspace skips workspace creation", async () => {
+    const client = makeWorkspaceClient();
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_in_workspace"];
+
+    const result = await tool.handler(
+      {
+        workspace_title: "ignored-title",
+        reuse_workspace: "workspace:existing",
+        agents: [
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.workspace).toBe("workspace:existing");
+    expect(client.createWorkspace).not.toHaveBeenCalled();
+    expect(client.selectWorkspace).toHaveBeenCalledWith("workspace:existing");
+    expect(client.newSplit).toHaveBeenCalledWith("right", {
+      workspace: "workspace:existing",
+      type: "terminal",
+    });
+  });
+});

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -48,14 +48,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 29 (16 low-level + 11 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 31 (17 low-level + 12 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(29);
+    expect(count).toBe(31);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `create_workspace` and `spawn_in_workspace` MCP tools for workspace-first multi-agent spawning.
- Add workspace pre-focus before agent surface creation so explicit workspace spawns do not leak into the focused workspace.
- Run launcher preflight through an interactive login shell and clarify cursor launcher registration errors.

## Tests
- RED first: targeted tests failed before implementation for missing tools/export and missing workspace pre-focus.
- `bun run test tests/spawn-workspace.test.ts tests/agent-engine.test.ts tests/server.test.ts tests/server-agent-tools.test.ts tests/v2-interact-kill.test.ts tests/security-hardening.test.ts` -> 201 passed
- `bun run typecheck` -> passed
- `bun run test` -> 521 passed
- pre-push hook reran full tests -> 521 passed

## Notes
- Left `src/layout-policy.ts`, `CLAUDE.md`, and `README.md` untouched per task constraints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutating orchestration paths (workspace create + multi-agent spawn) and spawn placement behavior changes could misplace agents if workspace selection fails silently; launcher probe changes affect spawn preflight for all repoGolem CLIs.
> 
> **Overview**
> Adds **`create_workspace`** and **`spawn_in_workspace`** MCP tools (CLI + socket clients with **`createWorkspace`**) so callers can stand up a tab and spawn a multi-agent team in one flow; **`spawn_in_workspace`** optionally reuses an existing workspace ref and delivers boot prompts like **`spawn_agent`**.
> 
> **Agent spawning** now **selects the target workspace** before creating surfaces so explicit workspace spawns do not land in the currently focused tab; **`selectWorkspace`** is wired through the agent engine and app-server runtime.
> 
> **Launcher preflight** for Claude/Codex/Cursor runs via an **interactive login shell** (`-ilc`, default `/bin/zsh`); **`assertLauncherAvailable`** is exported with clearer Cursor/golem-powers registration errors. Docs/comments note Cursor uses repoGolem launchers and gemini/kiro use direct `cd` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14c0921c5247fea6914159ee8bcfefc4ad26b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `create_workspace` and `spawn_in_workspace` MCP tools with Cursor launcher fix
> - Adds a `create_workspace` tool that creates a new tmux workspace via socket RPC or CLI fallback, returning `{ workspace, title }`.
> - Adds a `spawn_in_workspace` tool that optionally creates or reuses a workspace, selects it, then spawns one or more agents into it with optional boot prompts.
> - `AgentEngine.createAgentSurface` now calls `selectWorkspace` before creating a surface so new terminals open in the correct workspace.
> - Fixes `assertLauncherAvailable` to probe using an interactive login zsh shell (`-ilc`) so launchers like Cursor (registered via shell config) are correctly detected; updates the error message to guide users toward `golem-powers` registration or `cli="gemini"`/`cli="kiro"`.
> - Behavioral Change: launcher probing now uses `/bin/zsh -ilc` instead of `/bin/sh`, which may change detection results in environments without zsh.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f14c092. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->