### PR TITLE
fix: stabilize cmux agent launching and workspace state

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -9,6 +9,7 @@ import type {
 export interface DiscoveredAgent {
   surface_id: string;
   surface_title: string;
+  workspace_id?: string | null;
   cli: CliType | "unknown";
   parsed_status: ParsedScreenStatus | null;
   model: string | null;
@@ -86,6 +87,8 @@ export class AgentDiscovery {
     );
     const result = await Promise.all(
       surfaces.map(async (surface): Promise<DiscoveredAgent> => {
+        const workspaceId =
+          typeof surface.workspace_ref === "string" ? surface.workspace_ref : null;
         try {
           const screen = await this.deps.readScreen(surface.ref, { lines: 30 });
           const parsed = parseScreen(screen.text);
@@ -97,6 +100,7 @@ export class AgentDiscovery {
           return {
             surface_id: surface.ref,
             surface_title: surface.title,
+            workspace_id: workspaceId,
             cli,
             parsed_status: parsed.status,
             model: parsed.model,
@@ -113,6 +117,7 @@ export class AgentDiscovery {
           return {
             surface_id: surface.ref,
             surface_title: surface.title,
+            workspace_id: workspaceId,
             cli: "unknown",
             parsed_status: null,
             model: null,

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -23,7 +23,7 @@ export interface DiscoveryDeps {
   listSurfaces: () => Promise<CmuxSurface[]>;
   readScreen: (
     surface: string,
-    opts: { lines: number },
+    opts: { lines: number; workspace?: string },
   ) => Promise<CmuxReadScreenResult>;
 }
 
@@ -90,7 +90,10 @@ export class AgentDiscovery {
         const workspaceId =
           typeof surface.workspace_ref === "string" ? surface.workspace_ref : null;
         try {
-          const screen = await this.deps.readScreen(surface.ref, { lines: 30 });
+          const screen = await this.deps.readScreen(surface.ref, {
+            lines: 30,
+            workspace: workspaceId ?? undefined,
+          });
           const parsed = parseScreen(screen.text);
           const cli =
             parsed.agent_type === "unknown"

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -19,6 +19,7 @@ import type {
   CmuxNewSurfaceResult,
   CmuxReadScreenResult,
   CmuxSendOptions,
+  CmuxWorkspace,
 } from "./types.js";
 import {
   generateAgentId,
@@ -71,6 +72,11 @@ export interface AgentEngineOptions {
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
   ) => RoleSurfaceIds;
+  launchCommandSender?: (input: {
+    surface: string;
+    workspace?: string;
+    command: string;
+  }) => Promise<void>;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored";
@@ -94,6 +100,28 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
 const execFileAsync = promisify(execFile);
+
+function pathBaseName(path: string): string {
+  const normalized = path.trim().replace(/\/+$/, "");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+function repoNameMatchesWorkspaceDirectory(repo: string, cwd: string): boolean {
+  const normalizedRepo = repo.toLowerCase();
+  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
+  const directory = pathBaseName(cwd).toLowerCase();
+  return (
+    directory === normalizedRepo ||
+    directory.replace(/-/g, "") === normalizedRepoNoHyphen
+  );
+}
+
+interface SidebarStatusSnapshot {
+  statusValue: string;
+  surfaceId: string | null;
+  workspaceId: string | null;
+}
 
 function autoArchiveEnabledByEnv(): boolean {
   return !["0", "false", "off", "no"].includes(
@@ -125,6 +153,7 @@ function taskDoneAutoArchiveMs(): number {
 }
 
 interface AgentEngineClient {
+  listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }>;
   log(
     message: string,
     opts?: {
@@ -325,9 +354,11 @@ export class AgentEngine {
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
   ) => RoleSurfaceIds;
+  private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
-  /** agentId → last-pushed status string */
-  private sidebarSnapshot = new Map<string, string>();
+  /** agentId → last-pushed status target/value */
+  private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
+  private progressSnapshot: string | null = null;
   /** e.g. "a1:spawned", "a1:done", "a1:error" */
   private loggedEvents = new Set<string>();
   /** agentId → consecutive ready-prompt matches */
@@ -343,6 +374,7 @@ export class AgentEngine {
     this.registry = registry;
     this.client = client;
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
+    this.launchCommandSender = opts?.launchCommandSender;
     this.spawnPreflight =
       opts?.spawnPreflight ??
       (async (params) => {
@@ -373,8 +405,10 @@ export class AgentEngine {
     context?: {
       role?: AgentRole;
       parentAgent?: AgentRecord | null;
+      repo?: string;
     },
   ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
+    workspace = await this.resolveWorkspaceForRepo(workspace, context?.repo);
     if (workspace) {
       try {
         await this.client.selectWorkspace(workspace);
@@ -447,6 +481,38 @@ export class AgentEngine {
         type: "terminal",
       });
     }
+  }
+
+  private async resolveWorkspaceForRepo(
+    workspace: string | undefined,
+    repo: string | undefined,
+  ): Promise<string | undefined> {
+    if (workspace || !repo) return workspace;
+
+    try {
+      const { workspaces } = await this.client.listWorkspaces();
+      return workspaces.find(
+        (candidate) =>
+          typeof candidate.current_directory === "string" &&
+          repoNameMatchesWorkspaceDirectory(repo, candidate.current_directory),
+      )?.ref;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async sendLaunchCommand(
+    surface: string,
+    workspace: string | undefined,
+    command: string,
+  ): Promise<void> {
+    if (this.launchCommandSender) {
+      await this.launchCommandSender({ surface, workspace, command });
+      return;
+    }
+
+    await this.client.send(surface, command, { workspace });
+    await this.client.sendKey(surface, "return", { workspace });
   }
 
   private isBootCaptureWindowOpen(agent: AgentRecord): boolean {
@@ -689,6 +755,7 @@ export class AgentEngine {
           parentAgent: agent.parent_agent_id
             ? this.registry.get(agent.parent_agent_id)
             : null,
+          repo: agent.repo,
         });
         const creating = this.stateMgr.transition(agent.agent_id, "creating", {
           error: null,
@@ -721,12 +788,11 @@ export class AgentEngine {
           agent.repo,
           agent.cli_session_id!,
         );
-        await this.client.send(surface.surface, resumeCmd, {
-          workspace: surface.workspace,
-        });
-        await this.client.sendKey(surface.surface, "return", {
-          workspace: surface.workspace,
-        });
+        await this.sendLaunchCommand(
+          surface.surface,
+          surface.workspace,
+          resumeCmd,
+        );
         await this.client.log(
           `crash-recovery: respawned ${agent.agent_id} on ${surface.surface}`,
           { level: "warning", source: "cmux-mcp" },
@@ -780,6 +846,11 @@ export class AgentEngine {
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
         state === "error" ? `${repo}: error` : `${repo}: ${state}`;
+      const statusSnapshot: SidebarStatusSnapshot = {
+        statusValue,
+        surfaceId: surface_id,
+        workspaceId: agent.workspace_id ?? null,
+      };
 
       // Lifecycle log: spawned (first encounter)
       if (!this.sidebarSnapshot.has(agentId)) {
@@ -813,14 +884,32 @@ export class AgentEngine {
 
       // Status diff — only push if changed
       const prev = this.sidebarSnapshot.get(agentId);
-      if (prev !== statusValue) {
+      const statusChanged =
+        !prev ||
+        prev.statusValue !== statusSnapshot.statusValue ||
+        prev.surfaceId !== statusSnapshot.surfaceId ||
+        prev.workspaceId !== statusSnapshot.workspaceId;
+      if (statusChanged) {
+        if (
+          prev?.workspaceId &&
+          prev.workspaceId !== statusSnapshot.workspaceId
+        ) {
+          try {
+            await this.client.clearStatus(agentId, {
+              workspace: prev.workspaceId,
+            });
+          } catch {
+            // Best-effort cleanup of stale workspace-scoped status.
+          }
+        }
         const sidebar = STATE_SIDEBAR[state];
         await this.client.setStatus(agentId, statusValue, {
           icon: sidebar.icon,
           color: sidebar.color,
           surface: surface_id,
+          workspace: agent.workspace_id ?? undefined,
         });
-        this.sidebarSnapshot.set(agentId, statusValue);
+        this.sidebarSnapshot.set(agentId, statusSnapshot);
       }
 
       // Quality tracking: check context usage for non-terminal agents
@@ -868,10 +957,12 @@ export class AgentEngine {
 
     // Clean up sidebar entries for agents that were purged from the registry
     const currentAgentIds = new Set(agents.map((a) => a.agent_id));
-    for (const [agentId] of this.sidebarSnapshot) {
+    for (const [agentId, snapshot] of this.sidebarSnapshot) {
       if (!currentAgentIds.has(agentId)) {
         try {
-          await this.client.clearStatus(agentId);
+          await this.client.clearStatus(agentId, {
+            workspace: snapshot.workspaceId ?? undefined,
+          });
         } catch {
           // Best-effort sidebar cleanup
         }
@@ -881,9 +972,13 @@ export class AgentEngine {
 
     // Progress bar
     if (total > 0) {
-      await this.client.setProgress(done / total, {
-        label: `agents ${done}/${total}`,
-      });
+      const progressSnapshot = `${done}/${total}`;
+      if (this.progressSnapshot !== progressSnapshot) {
+        await this.client.setProgress(done / total, {
+          label: `agents ${done}/${total}`,
+        });
+        this.progressSnapshot = progressSnapshot;
+      }
     }
   }
 
@@ -913,7 +1008,11 @@ export class AgentEngine {
       const purgedIds = this.registry.purgeAllTerminal();
       // Seed sidebar snapshot so syncSidebar clears their cmux entries
       for (const id of purgedIds) {
-        this.sidebarSnapshot.set(id, "__purged__");
+        this.sidebarSnapshot.set(id, {
+          statusValue: "__purged__",
+          surfaceId: null,
+          workspaceId: null,
+        });
       }
     }
 
@@ -983,6 +1082,7 @@ export class AgentEngine {
     const surface = await this.createAgentSurface(params.workspace, {
       role,
       parentAgent,
+      repo: params.repo,
     });
 
     // 2. Write initial state (creating → booting)
@@ -1019,12 +1119,20 @@ export class AgentEngine {
 
     // 3. Send launch command
     const launchCmd = buildLaunchCommand(params.cli, params.repo);
-    await this.client.send(surface.surface, launchCmd, {
-      workspace: surface.workspace,
-    });
-    await this.client.sendKey(surface.surface, "return", {
-      workspace: surface.workspace,
-    });
+    try {
+      await this.sendLaunchCommand(surface.surface, surface.workspace, launchCmd);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      try {
+        const failed = this.stateMgr.transition(agentId, "error", {
+          error: `Launch failed: ${message}`,
+        });
+        this.registry.set(agentId, failed);
+      } catch {
+        // Preserve the original launch error for the caller.
+      }
+      throw error;
+    }
 
     return {
       agent_id: agentId,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -45,6 +45,7 @@ import {
   type RoleSurfaceIds,
 } from "./layout-policy.js";
 import { matchReadyPattern } from "./pattern-registry.js";
+import { repoNameMatchesWorkspaceDirectory } from "./repo-workspace.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -63,6 +64,7 @@ export interface SpawnAgentParams {
 export interface SpawnAgentResult {
   agent_id: string;
   surface_id: string;
+  workspace_id?: string;
   state: AgentState;
 }
 
@@ -100,22 +102,6 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
 const execFileAsync = promisify(execFile);
-
-function pathBaseName(path: string): string {
-  const normalized = path.trim().replace(/\/+$/, "");
-  const index = normalized.lastIndexOf("/");
-  return index >= 0 ? normalized.slice(index + 1) : normalized;
-}
-
-function repoNameMatchesWorkspaceDirectory(repo: string, cwd: string): boolean {
-  const normalizedRepo = repo.toLowerCase();
-  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
-  const directory = pathBaseName(cwd).toLowerCase();
-  return (
-    directory === normalizedRepo ||
-    directory.replace(/-/g, "") === normalizedRepoNoHyphen
-  );
-}
 
 interface SidebarStatusSnapshot {
   statusValue: string;
@@ -1137,6 +1123,7 @@ export class AgentEngine {
     return {
       agent_id: agentId,
       surface_id: surface.surface,
+      workspace_id: surface.workspace,
       state: "booting",
     };
   }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -45,7 +45,7 @@ import {
   type RoleSurfaceIds,
 } from "./layout-policy.js";
 import { matchReadyPattern } from "./pattern-registry.js";
-import { repoNameMatchesWorkspaceDirectory } from "./repo-workspace.js";
+import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -475,16 +475,7 @@ export class AgentEngine {
   ): Promise<string | undefined> {
     if (workspace || !repo) return workspace;
 
-    try {
-      const { workspaces } = await this.client.listWorkspaces();
-      return workspaces.find(
-        (candidate) =>
-          typeof candidate.current_directory === "string" &&
-          repoNameMatchesWorkspaceDirectory(repo, candidate.current_directory),
-      )?.ref;
-    } catch {
-      return undefined;
-    }
+    return resolveWorkspaceRefForRepo(repo, () => this.client.listWorkspaces());
   }
 
   private async sendLaunchCommand(
@@ -1336,7 +1327,9 @@ export class AgentEngine {
       }
     } else {
       // Graceful: send Ctrl+C
-      await this.client.sendKey(agent.surface_id, "c-c", {});
+      await this.client.sendKey(agent.surface_id, "c-c", {
+        workspace: agent.workspace_id ?? undefined,
+      });
     }
 
     const current = this.registry.get(agentId) ?? agent;
@@ -1386,9 +1379,12 @@ export class AgentEngine {
     }
 
     const route = this.resolveAgentRoute(agentId);
-    await this.client.send(route.surface_id, sanitizeTerminalInput(text), {});
+    const workspace = route.workspace_id ?? undefined;
+    await this.client.send(route.surface_id, sanitizeTerminalInput(text), {
+      workspace,
+    });
     if (pressEnter) {
-      await this.client.sendKey(route.surface_id, "return", {});
+      await this.client.sendKey(route.surface_id, "return", { workspace });
     }
   }
 }

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -19,6 +19,7 @@ export function buildRouteTable(
     const nextRoute: AgentRoute = {
       agent_id: record.agent_id,
       surface_id: record.surface_id,
+      workspace_id: record.workspace_id ?? null,
       state: record.state,
       session_id: record.cli_session_id,
     };

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -269,6 +269,7 @@ export class AgentRegistry {
     const agentId = record.agent_id;
     const repo = inferRepoFromTitle(discoveredEntry.surface_title) || record.repo;
     const model = discoveredEntry.model ?? record.model;
+    const workspaceId = discoveredEntry.workspace_id ?? null;
     const desiredState = discoveredStatusToAgentState(
       discoveredEntry.parsed_status,
     );
@@ -276,6 +277,9 @@ export class AgentRegistry {
     const patch: Partial<AgentRecord> = {};
     if (repo !== record.repo) patch.repo = repo;
     if (model !== record.model) patch.model = model;
+    if ((record.workspace_id ?? null) !== workspaceId) {
+      patch.workspace_id = workspaceId;
+    }
     if (record.error !== null && desiredState !== "error") patch.error = null;
     if (record.error === null && desiredState === "error") {
       patch.error = "Auto-discovered agent reported a frozen state";

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -122,6 +122,7 @@ export interface StateTransition {
 }
 
 export type DeliveryEventType =
+  | "spawn_agent"
   | "send_command"
   | "send_to"
   | "send_to_agent"

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -71,6 +71,7 @@ export interface PublicAgent {
 export interface AgentRoute {
   agent_id: string;
   surface_id: string;
+  workspace_id?: string | null;
   state: AgentState;
   session_id: string | null;
 }

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -8,6 +8,7 @@ import { AgentRegistry } from "./agent-registry.js";
 import { StateManager } from "./state-manager.js";
 import { parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
+import { matchReadyPattern } from "./pattern-registry.js";
 import type {
   AppServerBridgeRuntime,
   BridgeScreenSnapshot,
@@ -18,6 +19,8 @@ const SEND_INPUT_CHUNK_THRESHOLD = 500;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const THREAD_READY_TIMEOUT_MS = 30_000;
 const THREAD_READY_POLL_MS = 250;
+const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
+const LAUNCH_SHELL_READY_POLL_MS = 100;
 
 type CmuxLikeClient = CmuxClient | CmuxSocketClient;
 
@@ -45,6 +48,10 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function matchesShellPrompt(text: string): boolean {
+  return /(?:^|\n)[^\n]*[$%#]\s*$/.test(text);
 }
 
 function deriveRepoFromCwd(cwd: string): string {
@@ -144,8 +151,10 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         ),
       notifyLifecycleEvent: async () => {},
     }, {
-      launchCommandSender: ({ surface, workspace, command }) =>
-        this.sendCommand(surface, command, workspace),
+      launchCommandSender: async ({ surface, workspace, command }) => {
+        await this.waitForShellReady(surface, workspace);
+        await this.sendCommand(surface, command, workspace);
+      },
     });
   }
 
@@ -199,7 +208,11 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     text: string;
   }): Promise<void> {
     const route = this.engine.resolveAgentRoute(input.threadId);
-    await this.sendCommand(route.surface_id, input.text);
+    await this.sendCommand(
+      route.surface_id,
+      input.text,
+      route.workspace_id ?? undefined,
+    );
   }
 
   private async sendCommand(
@@ -225,13 +238,16 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
   async interruptTurn(threadId: string): Promise<void> {
     const route = this.engine.resolveAgentRoute(threadId);
     await this.withSurfaceWrite(route.surface_id, () =>
-      this.client.sendKey(route.surface_id, "c-c", {}),
+      this.client.sendKey(route.surface_id, "c-c", {
+        workspace: route.workspace_id ?? undefined,
+      }),
     );
   }
 
   async readScreen(threadId: string): Promise<BridgeScreenSnapshot> {
     const route = this.engine.resolveAgentRoute(threadId);
     const screen = await this.client.readScreen(route.surface_id, {
+      workspace: route.workspace_id ?? undefined,
       lines: 40,
       scrollback: true,
     });
@@ -260,6 +276,41 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     }
 
     throw new Error(`Timed out waiting for Codex prompt on thread ${threadId}`);
+  }
+
+  private async waitForShellReady(
+    surface: string,
+    workspace?: string,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    let lastText = "";
+
+    while (Date.now() - startedAt < LAUNCH_SHELL_READY_TIMEOUT_MS) {
+      try {
+        const screen = await this.client.readScreen(surface, {
+          workspace,
+          lines: 30,
+          scrollback: false,
+        });
+        const text = typeof screen === "string" ? screen : (screen.text ?? "");
+        lastText = text;
+        if (matchesShellPrompt(text) || matchReadyPattern("codex", text).matched) {
+          return;
+        }
+      } catch (error) {
+        lastText = error instanceof Error ? error.message : String(error);
+      }
+
+      const remaining = LAUNCH_SHELL_READY_TIMEOUT_MS - (Date.now() - startedAt);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(LAUNCH_SHELL_READY_POLL_MS, remaining));
+    }
+
+    throw new Error(
+      `Timed out waiting for shell readiness on ${surface}: ${lastText}`,
+    );
   }
 
   private async withSurfaceWrite<T>(

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -109,7 +109,13 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
             ),
           ),
         );
-        return surfaceGroups.flatMap((group) => group.surfaces);
+        return surfaceGroups.flatMap((group) =>
+          group.surfaces.map((surface) => ({
+            ...surface,
+            workspace_ref: group.workspace_ref,
+            pane_ref: group.pane_ref,
+          })),
+        );
       } catch {
         return [];
       }
@@ -118,6 +124,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     this.registry = new AgentRegistry(this.stateMgr, surfaceProvider);
     this.engine = new AgentEngine(this.stateMgr, this.registry, {
       log: async () => {},
+      listWorkspaces: () => this.client.listWorkspaces(),
       setStatus: async () => {},
       clearStatus: async () => {},
       readScreen: (surface, readOpts) => this.client.readScreen(surface, readOpts),
@@ -136,6 +143,9 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
           this.client.closeSurface(surface, closeOpts),
         ),
       notifyLifecycleEvent: async () => {},
+    }, {
+      launchCommandSender: ({ surface, workspace, command }) =>
+        this.sendCommand(surface, command, workspace),
     });
   }
 
@@ -189,18 +199,26 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     text: string;
   }): Promise<void> {
     const route = this.engine.resolveAgentRoute(input.threadId);
-    const sanitizedText = sanitizeTerminalInput(input.text);
+    await this.sendCommand(route.surface_id, input.text);
+  }
+
+  private async sendCommand(
+    surface: string,
+    text: string,
+    workspace?: string,
+  ): Promise<void> {
+    const sanitizedText = sanitizeTerminalInput(text);
     const chunks = chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD);
 
-    await this.withSurfaceWrite(route.surface_id, async () => {
+    await this.withSurfaceWrite(surface, async () => {
       for (const [index, chunk] of chunks.entries()) {
-        await this.client.send(route.surface_id, chunk, {});
+        await this.client.send(surface, chunk, { workspace });
         if (index < chunks.length - 1) {
           await delay(SEND_INPUT_CHUNK_DELAY_MS);
         }
       }
       await delay(50);
-      await this.client.sendKey(route.surface_id, "return", {});
+      await this.client.sendKey(surface, "return", { workspace });
     });
   }
 

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -307,6 +307,25 @@ export function chooseAgentSpawnPlacement(
     }
   }
 
+  if (context.parentRole === "orchestrator") {
+    const childPane = paneContainingAnySurface(
+      layouts,
+      context.childWorkerSurfaceIds ?? new Set(),
+    );
+    if (childPane && isWorkerDockPane(childPane)) {
+      return { kind: "surface", pane: childPane.pane.ref };
+    }
+
+    const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
+    if (parentPane) {
+      return {
+        kind: "split",
+        direction: "right",
+        pane: parentPane.pane.ref,
+      };
+    }
+  }
+
   // Dock into the rightmost pane workers already own — including one that
   // carries a stray non-role tab — so a populated workers pane never gets a
   // redundant third pane split off beside it.

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -25,7 +25,8 @@ export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
     consecutive: 1,
   },
   codex: {
-    pattern: /codex>/,
+    pattern:
+      /codex>|^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[\s\S]*~\/Gits\//,
     confidence: "high",
     consecutive: 1,
   },

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -26,7 +26,7 @@ export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
   },
   codex: {
     pattern:
-      /codex>|^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[\s\S]*~\/Gits\//,
+      /codex>|^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[^\n]+/,
     confidence: "high",
     consecutive: 1,
   },

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -1,0 +1,18 @@
+export function pathBaseName(path: string): string {
+  const normalized = path.trim().replace(/\/+$/, "");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+export function repoNameMatchesWorkspaceDirectory(
+  repo: string,
+  cwd: string,
+): boolean {
+  const normalizedRepo = repo.toLowerCase();
+  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
+  const directory = pathBaseName(cwd).toLowerCase();
+  return (
+    directory === normalizedRepo ||
+    directory.replace(/-/g, "") === normalizedRepoNoHyphen
+  );
+}

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -16,3 +16,40 @@ export function repoNameMatchesWorkspaceDirectory(
     directory.replace(/-/g, "") === normalizedRepoNoHyphen
   );
 }
+
+export function findWorkspaceRefForRepo(
+  workspaces: Iterable<{
+    ref: string;
+    current_directory?: string | null;
+  }>,
+  repo: string | null | undefined,
+): string | undefined {
+  if (!repo) return undefined;
+  for (const workspace of workspaces) {
+    if (
+      typeof workspace.current_directory === "string" &&
+      repoNameMatchesWorkspaceDirectory(repo, workspace.current_directory)
+    ) {
+      return workspace.ref;
+    }
+  }
+  return undefined;
+}
+
+export async function resolveWorkspaceRefForRepo(
+  repo: string | null | undefined,
+  listWorkspaces: () => Promise<{
+    workspaces: Array<{
+      ref: string;
+      current_directory?: string | null;
+    }>;
+  }>,
+): Promise<string | undefined> {
+  if (!repo) return undefined;
+  try {
+    const { workspaces } = await listWorkspaces();
+    return findWorkspaceRefForRepo(workspaces, repo);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,7 @@ import type {
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import { matchReadyPattern } from "./pattern-registry.js";
+import { repoNameMatchesWorkspaceDirectory } from "./repo-workspace.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -370,22 +371,6 @@ function inferRepoFromLauncherTitle(title?: string): string | null {
   const match = title.trim().match(/^(.+?)(?:Claude|Codex|Cursor|Gemini|Kiro)$/i);
   const repo = match?.[1]?.trim();
   return repo && repo !== "." && repo !== ".." ? repo : null;
-}
-
-function pathBaseName(path: string): string {
-  const normalized = path.trim().replace(/\/+$/, "");
-  const index = normalized.lastIndexOf("/");
-  return index >= 0 ? normalized.slice(index + 1) : normalized;
-}
-
-function repoNameMatchesWorkspaceDirectory(repo: string, cwd: string): boolean {
-  const normalizedRepo = repo.toLowerCase();
-  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
-  const directory = pathBaseName(cwd).toLowerCase();
-  return (
-    directory === normalizedRepo ||
-    directory.replace(/-/g, "") === normalizedRepoNoHyphen
-  );
 }
 
 function matchesShellPrompt(text: string): boolean {
@@ -2726,9 +2711,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             | undefined;
           try {
             if (hasInlinePrompt(args.prompt) || bootPromptPath) {
+              const deliveryWorkspace = result.workspace_id ?? args.workspace;
               bootPromptDelivery = await deliverBootPrompt({
                 surface: result.surface_id,
-                workspace: args.workspace,
+                workspace: deliveryWorkspace,
                 cli: args.cli,
                 prompt: args.prompt,
                 boot_prompt_path: bootPromptPath,

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,7 +54,7 @@ import type {
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import { matchReadyPattern } from "./pattern-registry.js";
-import { repoNameMatchesWorkspaceDirectory } from "./repo-workspace.js";
+import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -110,6 +110,7 @@ const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
+const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 const READY_PATTERN_CLIS: CliType[] = ["claude", "codex", "gemini", "kiro", "cursor"];
 const SendToArgsSchema = z.object({
@@ -614,17 +615,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const resolveWorkspaceForRepo = async (
     repo: string | null | undefined,
   ): Promise<string | undefined> => {
-    if (!repo) return undefined;
-    try {
-      const { workspaces } = await client.listWorkspaces();
-      return workspaces.find(
-        (workspace) =>
-          typeof workspace.current_directory === "string" &&
-          repoNameMatchesWorkspaceDirectory(repo, workspace.current_directory),
-      )?.ref;
-    } catch {
-      return undefined;
-    }
+    return resolveWorkspaceRefForRepo(repo, () => client.listWorkspaces());
   };
 
   const getSurfaceDelivery = (surface: string) => {
@@ -1065,6 +1056,47 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     throw new BootPromptTimeoutError(
       `Timed out after ${timeoutMs}ms waiting for shell readiness on ${opts.surface}`,
+      tailLines(lastText, 10),
+    );
+  };
+
+  const waitForAgentLaunchReady = async (opts: {
+    surface: string;
+    workspace?: string;
+    timeout_ms?: number;
+  }): Promise<void> => {
+    const timeoutMs = opts.timeout_ms ?? LAUNCH_SUBMIT_READY_TIMEOUT_MS;
+    const start = Date.now();
+    let lastText = "";
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const screen = await client.readScreen(opts.surface, {
+          workspace: opts.workspace,
+          lines: 80,
+          scrollback: false,
+        });
+        lastText = screen.text;
+        if (
+          READY_PATTERN_CLIS.some((cli) =>
+            matchReadyPattern(cli, screen.text).matched,
+          )
+        ) {
+          return;
+        }
+      } catch (error) {
+        lastText = error instanceof Error ? error.message : String(error);
+      }
+
+      const remaining = timeoutMs - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(LAUNCH_SHELL_READY_POLL_MS, remaining));
+    }
+
+    throw new BootPromptTimeoutError(
+      `Timed out after ${timeoutMs}ms waiting for agent launch readiness on ${opts.surface}`,
       tailLines(lastText, 10),
     );
   };
@@ -2479,7 +2511,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               // The command can remain visible in shell history while the
               // launcher is already booting. Verification still retried Enter;
-              // readiness detection below is the authoritative launch check.
+              // agent readiness detection is the authoritative launch check.
+              await waitForAgentLaunchReady({ surface, workspace });
             }
           });
         },
@@ -2589,6 +2622,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return withSurfaceWrite(route.surface_id, async () =>
         deliverInputChunks({
           surface: route.surface_id,
+          workspace: route.workspace_id ?? undefined,
           chunks,
           chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
           chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,6 +107,8 @@ const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
+const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
+const LAUNCH_SHELL_READY_POLL_MS = 100;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 const READY_PATTERN_CLIS: CliType[] = ["claude", "codex", "gemini", "kiro", "cursor"];
 const SendToArgsSchema = z.object({
@@ -363,6 +365,33 @@ function inferLauncherCli(command: string): CliType | null {
   return match[1].toLowerCase() as CliType;
 }
 
+function inferRepoFromLauncherTitle(title?: string): string | null {
+  if (!title) return null;
+  const match = title.trim().match(/^(.+?)(?:Claude|Codex|Cursor|Gemini|Kiro)$/i);
+  const repo = match?.[1]?.trim();
+  return repo && repo !== "." && repo !== ".." ? repo : null;
+}
+
+function pathBaseName(path: string): string {
+  const normalized = path.trim().replace(/\/+$/, "");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(index + 1) : normalized;
+}
+
+function repoNameMatchesWorkspaceDirectory(repo: string, cwd: string): boolean {
+  const normalizedRepo = repo.toLowerCase();
+  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
+  const directory = pathBaseName(cwd).toLowerCase();
+  return (
+    directory === normalizedRepo ||
+    directory.replace(/-/g, "") === normalizedRepoNoHyphen
+  );
+}
+
+function matchesShellPrompt(text: string): boolean {
+  return /(?:^|\n)[^\n]*[$%#]\s*$/.test(text);
+}
+
 function readyPatternCandidates(cli?: CliType): CliType[] {
   return cli ? [cli] : READY_PATTERN_CLIS;
 }
@@ -597,6 +626,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return ids;
   };
 
+  const resolveWorkspaceForRepo = async (
+    repo: string | null | undefined,
+  ): Promise<string | undefined> => {
+    if (!repo) return undefined;
+    try {
+      const { workspaces } = await client.listWorkspaces();
+      return workspaces.find(
+        (workspace) =>
+          typeof workspace.current_directory === "string" &&
+          repoNameMatchesWorkspaceDirectory(repo, workspace.current_directory),
+      )?.ref;
+    } catch {
+      return undefined;
+    }
+  };
+
   const getSurfaceDelivery = (surface: string) => {
     const deliveryId = latestDeliveryBySurface.get(surface);
     if (!deliveryId) {
@@ -819,7 +864,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return { submit_verified: null, retry_count: retryCount };
       }
 
-      if (snapshot.parsed.agent_type === "unknown" || !snapshot.text.trim()) {
+      if (!snapshot.text.trim()) {
         return { submit_verified: null, retry_count: retryCount };
       }
 
@@ -995,6 +1040,46 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     throw new BootPromptTimeoutError(
       `Timed out after ${opts.timeout_ms}ms waiting for boot prompt readiness on ${opts.surface}`,
+      tailLines(lastText, 10),
+    );
+  };
+
+  const waitForLaunchShellReady = async (opts: {
+    surface: string;
+    workspace?: string;
+    timeout_ms?: number;
+  }): Promise<void> => {
+    const timeoutMs = opts.timeout_ms ?? LAUNCH_SHELL_READY_TIMEOUT_MS;
+    const start = Date.now();
+    let lastText = "";
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const screen = await client.readScreen(opts.surface, {
+          workspace: opts.workspace,
+          lines: 30,
+          scrollback: false,
+        });
+        lastText = screen.text;
+        if (
+          matchesShellPrompt(screen.text) ||
+          READY_PATTERN_CLIS.some((cli) => matchReadyPattern(cli, screen.text).matched)
+        ) {
+          return;
+        }
+      } catch (error) {
+        lastText = error instanceof Error ? error.message : String(error);
+      }
+
+      const remaining = timeoutMs - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(LAUNCH_SHELL_READY_POLL_MS, remaining));
+    }
+
+    throw new BootPromptTimeoutError(
+      `Timed out after ${timeoutMs}ms waiting for shell readiness on ${opts.surface}`,
       tailLines(lastText, 10),
     );
   };
@@ -1361,6 +1446,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       let result: CmuxNewSplitResult | undefined;
       try {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
+        const targetWorkspace =
+          args.workspace ??
+          (await resolveWorkspaceForRepo(inferRepoFromLauncherTitle(args.title)));
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
             throw new Error("boot_prompt_path is only supported for terminal surfaces");
@@ -1387,11 +1475,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               "pane/surface cannot be combined with role-based new_split; omit the explicit target or omit role",
             );
           }
-          const panes = await client.listPanes({ workspace: args.workspace });
+          const panes = await client.listPanes({ workspace: targetWorkspace });
           const paneSurfaces = await Promise.all(
             panes.panes.map(async (pane) => {
               const ps = await client.listPaneSurfaces({
-                workspace: args.workspace,
+                workspace: targetWorkspace,
                 pane: pane.ref,
               });
               // cmux socket omits pane_ref; inject it so describePaneLayouts
@@ -1407,7 +1495,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const placement = chooseAgentSpawnPlacement(
             panes.panes,
             paneSurfaces,
-            collectServerRoleSurfaceIds(liveSurfaceIds, args.workspace),
+            collectServerRoleSurfaceIds(liveSurfaceIds, targetWorkspace),
             { role: inferredRole },
           );
           actualPlacement = placement.kind;
@@ -1422,11 +1510,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             placement.kind === "surface"
               ? await client.newSurface({
                   pane: placement.pane,
-                  workspace: args.workspace,
+                  workspace: targetWorkspace,
                   type: "terminal",
                 })
               : await client.newSplit(placement.direction, {
-                  workspace: args.workspace,
+                  workspace: targetWorkspace,
                   ...(placement.pane ? { pane: placement.pane } : {}),
                   surface: args.surface,
                   type: args.type,
@@ -1436,7 +1524,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 });
         } else {
           result = await client.newSplit(args.direction, {
-            workspace: args.workspace,
+            workspace: targetWorkspace,
             surface: args.surface,
             pane: args.pane,
             type: args.type,
@@ -1447,14 +1535,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         if (args.title) {
           await client.renameTab(result.surface, args.title, {
-            workspace: result.workspace || args.workspace,
+            workspace: result.workspace || targetWorkspace,
           });
           result.title = args.title;
         }
         if (inferredRole && (args.type ?? "terminal") === "terminal") {
           roleSurfaceOverrides.set(result.surface, {
             role: inferredRole,
-            workspace: result.workspace ?? args.workspace ?? null,
+            workspace: result.workspace ?? targetWorkspace ?? null,
           });
         }
         let bootPromptDelivery:
@@ -1463,7 +1551,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         if (bootPromptPath) {
           bootPromptDelivery = await deliverBootPrompt({
             surface: result.surface,
-            workspace: result.workspace || args.workspace,
+            workspace: result.workspace || targetWorkspace,
             boot_prompt_path: bootPromptPath,
             timeout_ms: args.boot_prompt_timeout_ms,
           });
@@ -2309,7 +2397,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ),
           ),
         );
-        return surfaceGroups.flatMap((g) => g.surfaces);
+        return surfaceGroups.flatMap((group) =>
+          group.surfaces.map((surface) => ({
+            ...surface,
+            workspace_ref: group.workspace_ref,
+            pane_ref: group.pane_ref,
+          })),
+        );
       } catch {
         return [];
       }
@@ -2342,6 +2436,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       registry,
       {
         log: (message, eventOpts) => client.log(message, eventOpts),
+        listWorkspaces: () => client.listWorkspaces(),
         setStatus: (key, value, statusOpts) =>
           client.setStatus(key, value, statusOpts),
         clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
@@ -2371,6 +2466,38 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           opts?.spawnPreflight ??
           (opts?.disableSpawnPreflight ? async () => {} : undefined),
         roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
+        launchCommandSender: async ({ surface, workspace, command }) => {
+          const sanitizedCommand = sanitizeTerminalInput(command);
+          const chunks =
+            sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
+              ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
+              : [sanitizedCommand];
+
+          await waitForLaunchShellReady({ surface, workspace });
+          await withSurfaceWrite(surface, async () => {
+            try {
+              await deliverInputChunks({
+                surface,
+                workspace,
+                chunks,
+                chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+                chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+                press_enter: true,
+                source_event: "spawn_agent",
+                verify_submit: true,
+              });
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              if (!/Enter submit could not be verified/.test(message)) {
+                throw error;
+              }
+              // The command can remain visible in shell history while the
+              // launcher is already booting. Verification still retried Enter;
+              // readiness detection below is the authoritative launch check.
+            }
+          });
+        },
       },
     );
 

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -198,7 +198,7 @@ export class StateManager {
     const record: AgentRecord = {
       agent_id: agentId,
       surface_id: discovered.surface_id,
-      workspace_id: null,
+      workspace_id: discovered.workspace_id ?? null,
       state: discoveredStatusToAgentState(discovered.parsed_status),
       repo: inferRepoFromTitle(discovered.surface_title),
       model: discovered.model ?? "unknown",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface CmuxWorkspace {
   index: number;
   selected: boolean;
   pinned: boolean;
+  current_directory?: string | null;
 }
 
 export interface CmuxSurface {
@@ -23,6 +24,8 @@ export interface CmuxSurface {
   type: "terminal" | "browser";
   index: number;
   selected: boolean;
+  workspace_ref?: string;
+  pane_ref?: string;
 }
 
 export interface CmuxPane {

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentDiscovery } from "../src/agent-discovery.js";
+
+describe("AgentDiscovery", () => {
+  it("reads each surface in its owning workspace", async () => {
+    const readScreen = vi.fn().mockResolvedValue({
+      surface: "surface:1",
+      text: "codex> ",
+      lines: 1,
+      scrollback_used: false,
+    });
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => [
+        {
+          ref: "surface:1",
+          title: "brainlayerCodex",
+          type: "terminal",
+          index: 0,
+          selected: true,
+          workspace_ref: "workspace:brainlayer",
+        },
+      ],
+      readScreen,
+    });
+
+    const result = await discovery.scan(true);
+
+    expect(result[0]?.workspace_id).toBe("workspace:brainlayer");
+    expect(readScreen).toHaveBeenCalledWith("surface:1", {
+      lines: 30,
+      workspace: "workspace:brainlayer",
+    });
+  });
+});

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -303,14 +303,22 @@ describe("AgentEngine", () => {
         pane_ref: "pane:voice",
         surfaces: [makeSurface("surface:voice")],
       });
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "workspace:voice",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      });
 
-      await engine.spawnAgent({
+      const result = await engine.spawnAgent({
         repo: "voicelayer",
         model: "gpt-5.4",
         cli: "codex",
         prompt: "Fix prompt delivery",
       });
 
+      expect(result.workspace_id).toBe("workspace:voice");
       expect(mockClient.selectWorkspace).toHaveBeenCalledWith("workspace:voice");
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
         workspace: "workspace:voice",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -271,6 +271,53 @@ describe("AgentEngine", () => {
       );
     });
 
+    it("inherits the workspace whose current directory matches the target repo", async () => {
+      (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:brainlayer",
+            title: "BrainLayer",
+            current_directory: "/Users/etanheyman/Gits/brainlayer",
+          },
+          {
+            ref: "workspace:voice",
+            title: "VoiceLayer",
+            current_directory: "/Users/etanheyman/Gits/voicelayer",
+          },
+        ],
+      });
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:voice",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:voice"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "workspace:voice",
+        window_ref: "window:1",
+        pane_ref: "pane:voice",
+        surfaces: [makeSurface("surface:voice")],
+      });
+
+      await engine.spawnAgent({
+        repo: "voicelayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix prompt delivery",
+      });
+
+      expect(mockClient.selectWorkspace).toHaveBeenCalledWith("workspace:voice");
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        workspace: "workspace:voice",
+        type: "terminal",
+      });
+    });
+
     it("creates the first worker as a right split even when user panes already exist", async () => {
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
         panes: [

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -59,6 +59,7 @@ describe("agent route table", () => {
     expect(table.get("agent-1")).toEqual({
       agent_id: "agent-1",
       surface_id: "surface:1",
+      workspace_id: "ws:1",
       state: "ready",
       session_id: "session-1",
     });

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CmuxAppServerRuntime } from "../src/app-server-runtime.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-app-server-runtime-test");
+
+function makeClient() {
+  return {
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    listPanes: vi.fn().mockResolvedValue({ panes: [] }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
+    newSplit: vi.fn().mockResolvedValue({
+      workspace: "workspace:app",
+      surface: "surface:1",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    }),
+    newSurface: vi.fn(),
+    selectWorkspace: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:1",
+      text: "codex> ",
+      lines: 1,
+      scrollback_used: false,
+    }),
+    closeSurface: vi.fn(),
+    log: vi.fn(),
+  } as any;
+}
+
+function makeRecord(): AgentRecord {
+  const now = new Date().toISOString();
+  return {
+    agent_id: "agent-1",
+    surface_id: "surface:1",
+    workspace_id: "workspace:app",
+    state: "ready",
+    repo: "brainlayer",
+    model: "codex",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    boot_prompt_pending: false,
+  };
+}
+
+describe("CmuxAppServerRuntime", () => {
+  it("scopes bridge turns, interrupts, and screen reads to the agent workspace", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const record = makeRecord();
+    (runtime as any).stateMgr.writeState(record);
+    (runtime as any).registry.set(record.agent_id, record);
+
+    await runtime.sendTurn({ threadId: "agent-1", text: "hello" });
+    await runtime.interruptTurn("agent-1");
+    await runtime.readScreen("agent-1");
+
+    expect(client.send).toHaveBeenCalledWith("surface:1", "hello", {
+      workspace: "workspace:app",
+    });
+    expect(client.sendKey).toHaveBeenCalledWith("surface:1", "return", {
+      workspace: "workspace:app",
+    });
+    expect(client.sendKey).toHaveBeenCalledWith("surface:1", "c-c", {
+      workspace: "workspace:app",
+    });
+    expect(client.readScreen).toHaveBeenCalledWith("surface:1", {
+      workspace: "workspace:app",
+      lines: 40,
+      scrollback: true,
+    });
+
+    runtime.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+});

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -25,6 +25,42 @@ function createAuditServer(exec: ExecFn, client?: Record<string, unknown>) {
   });
 }
 
+function makeSpawnReadyExec(): ExecFn {
+  let launchSent = false;
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("send")) {
+      launchSent = true;
+    }
+    if (args.includes("list-workspaces")) {
+      return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
+    }
+    if (args.includes("list-panes")) {
+      return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
+    }
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: launchSent ? "What can I help you with?\n>" : "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return {
+      stdout: JSON.stringify({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
 // ── 1. CRITICAL: read_agent_output uses .text ──────────────────────────
 
 describe("read_agent_output uses CmuxReadScreenResult.text", () => {
@@ -284,16 +320,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeSpawnReadyExec();
   });
 
   afterEach(() => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -189,6 +189,71 @@ describe("layout policy", () => {
     });
   });
 
+  it("splits the first child worker to the right of its parent orchestrator pane", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"]),
+      makePane("pane:notes", 1, ["surface:notes"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:notes", ["surface:notes"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        childWorkerSurfaceIds: new Set(),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+      pane: "pane:lead",
+    });
+  });
+
+  it("reuses an existing worker pane beside the parent orchestrator for sibling workers", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"]),
+      makePane("pane:children", 1, ["surface:child-1", "surface:child-2"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:children", ["surface:child-1", "surface:child-2"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:child-1", "surface:child-2"]),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        childWorkerSurfaceIds: new Set(["surface:child-1", "surface:child-2"]),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "surface",
+      pane: "pane:children",
+    });
+  });
+
   it("creates a fresh right split when the only existing worker shares a pane with interactive surfaces", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -124,6 +124,19 @@ gpt-5.5 xhigh · ~/Gits/brainlayer
     expect(result.matched).toBe(true);
   });
 
+  it("matches modern Codex idle prompt outside ~/Gits", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+› Explain this codebase
+
+gpt-5.5 xhigh · /workspaces/cmuxlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
   it("does not match modern Codex while it is working on a queued prompt", () => {
     const result = matchReadyPattern(
       "codex",

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -59,6 +59,85 @@ describe("matchReadyPattern", () => {
     expect(result.matched).toBe(true);
   });
 
+  it("matches modern Codex empty prompt with model footer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+›
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches modern Codex placeholder prompt with model footer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+› Implement {feature}
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches modern Codex skills hint prompt with model footer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+› Use /skills to list available
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches modern Codex explain-codebase prompt with model footer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+› Explain this codebase
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches modern Codex arbitrary idle suggestion prompt with model footer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+
+› Find and fix a bug in @filename
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("does not match modern Codex while it is working on a queued prompt", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+• Working (10m 57s • esc to interrupt)
+
+› Find and fix a bug in @filename
+
+gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(false);
+  });
+
   it("does not match unrelated output", () => {
     const result = matchReadyPattern("claude", "Installing dependencies...");
     expect(result.matched).toBe(false);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -416,8 +416,30 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
+    expect(parsed.workspace_id).toBe("workspace:voice");
     expect(launcherReturnCount).toBe(2);
     expect(promptDelivered).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "read-screen",
+        "--workspace",
+        "workspace:voice",
+        "--surface",
+        "surface:new",
+      ]),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--workspace",
+        "workspace:voice",
+        "--surface",
+        "surface:new",
+        "file prompt body",
+      ]),
+    );
   });
 
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -300,6 +300,244 @@ describe("agent lifecycle tool handlers", () => {
     ]));
   });
 
+  it("spawn_agent retries Enter when the launcher command remains pending at the shell", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    let launcherReturnCount = 0;
+    let promptDelivered = false;
+    let lastSentText = "";
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:voice",
+                title: "VoiceLayer",
+                current_directory: "/Users/etanheyman/Gits/voicelayer",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:voice",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:new"],
+                selected_surface_ref: "surface:new",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:voice",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:new",
+                title: "agent-pane",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        lastSentText = String(args.at(-1) ?? "");
+        if (lastSentText === "file prompt body") {
+          promptDelivered = true;
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      if (args.includes("send-key")) {
+        if (lastSentText === "voicelayerCodex -s") {
+          launcherReturnCount += 1;
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text:
+              lastSentText === ""
+                ? "$ "
+                : launcherReturnCount < 2
+                ? "$ voicelayerCodex -s"
+                : "codex> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:voice",
+          surface: "surface:new",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    });
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "voicelayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 1_000,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(launcherReturnCount).toBe(2);
+    expect(promptDelivered).toBe(true);
+  });
+
+  it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
+    const promptPath = join(TEST_DIR, "mandate.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    let launcherReturnCount = 0;
+    let promptDelivered = false;
+    let lastSentText = "";
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:voice",
+                title: "VoiceLayer",
+                current_directory: "/Users/etanheyman/Gits/voicelayer",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:voice",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:new"],
+                selected_surface_ref: "surface:new",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:voice",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:new",
+                title: "agent-pane",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        lastSentText = String(args.at(-1) ?? "");
+        if (lastSentText === "file prompt body") {
+          promptDelivered = true;
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      if (args.includes("send-key")) {
+        if (lastSentText === "voicelayerCodex -s") {
+          launcherReturnCount += 1;
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text:
+              lastSentText === ""
+                ? "$ "
+                : "$ voicelayerCodex -s\ncodex> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:voice",
+          surface: "surface:new",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    });
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "voicelayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 1_000,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(launcherReturnCount).toBeGreaterThanOrEqual(2);
+    expect(promptDelivered).toBe(true);
+  });
+
   it("spawn_agent stores boot_prompt_path contents as task_summary after delivery", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
@@ -379,7 +617,11 @@ describe("agent lifecycle tool handlers", () => {
   it("spawn_agent marks the agent errored when boot prompt delivery times out", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
+    let launchSent = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("send")) {
+        launchSent = true;
+      }
       if (args.includes("list-workspaces")) {
         return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
       }
@@ -390,7 +632,7 @@ describe("agent lifecycle tool handlers", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text: "$ waiting",
+            text: launchSent ? "$ waiting" : "$ ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -785,12 +1027,13 @@ describe("agent lifecycle tool handlers", () => {
     const engine = (server as any)._registeredTools["interact"]._engine;
     const stateMgr = engine["stateMgr"];
 
-    setTimeout(() => {
-      stateMgr.transition(agentId, "ready");
-      setTimeout(() => {
-        stateMgr.transition(agentId, "done");
-      }, 50);
-    }, 50);
+    stateMgr.transition(agentId, "ready");
+    stateMgr.transition(agentId, "done");
+    const doneState = stateMgr.readState(agentId);
+    if (!doneState) {
+      throw new Error("Expected done state to exist");
+    }
+    engine.getRegistry().set(agentId, doneState);
 
     const result = await waitFor.handler(
       { agent_id: agentId, timeout_ms: 5000 },
@@ -803,7 +1046,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.state).toBe("done");
     expect(parsed.agent.session_id).toBeNull();
-  });
+  }, 10_000);
 
   it("wait_for returns the engine snapshot without a second public-agent read", async () => {
     const server = createLifecycleServer(mockExec);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -892,6 +892,9 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
     expect(deliveredText).toBe("interject while working");
+    expect(sendCalls[0]?.[1]).toEqual(
+      expect.arrayContaining(["--workspace", "ws:1"]),
+    );
   });
 
   it("send_to without allow_busy still rejects working agents (backwards compat)", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1716,6 +1716,86 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:2");
   });
 
+  it("new_split inherits workspace from a launcher-style title repo", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:brainlayer",
+            title: "BrainLayer",
+            current_directory: "/Users/etanheyman/Gits/brainlayer",
+          },
+          {
+            ref: "workspace:voice",
+            title: "VoiceLayer",
+            current_directory: "/Users/etanheyman/Gits/voicelayer",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:voice",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:voice",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:shell"],
+            selected_surface_ref: "surface:shell",
+          },
+        ],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:voice",
+        window_ref: "window:1",
+        pane_ref: "pane:voice",
+        surfaces: [
+          {
+            ref: "surface:shell",
+            title: "shell",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:voice",
+        surface: "surface:voice-worker",
+        pane: "pane:worker",
+        title: "",
+        type: "terminal",
+      }),
+      newSurface: vi.fn(),
+      renameTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", title: "voicelayerCodex", role: "worker" },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.listPanes).toHaveBeenCalledWith({
+      workspace: "workspace:voice",
+    });
+    expect(mockClient.newSplit).toHaveBeenCalledWith(
+      "right",
+      expect.objectContaining({
+        workspace: "workspace:voice",
+        title: "voicelayerCodex",
+      }),
+    );
+  });
+
   it("new_split with role=worker reuses the existing worker pane", async () => {
     const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-state");
     rmSync(stateDir, { recursive: true, force: true });

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -107,6 +107,7 @@ describe("Sidebar Sync", () => {
         agent_id: "a1",
         state: "working",
         surface_id: "surface:42",
+        workspace_id: "workspace:coach",
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
@@ -120,6 +121,42 @@ describe("Sidebar Sync", () => {
       expect.objectContaining({
         icon: "bolt.fill",
         color: "#3B82F6",
+        workspace: "workspace:coach",
+        surface: "surface:42",
+      }),
+    );
+  });
+
+  it("refreshes sidebar status when an unchanged agent moves workspace", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "a1",
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:brainlayer",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    const moved = stateMgr.updateRecord("a1", {
+      surface_id: "surface:99",
+      workspace_id: "workspace:coach",
+    });
+    engine.getRegistry().set("a1", moved);
+    liveSurfaces = [makeSurface("surface:99")];
+
+    await engine.runSweep();
+
+    expect(mockClient.setStatus).toHaveBeenCalledTimes(2);
+    expect(mockClient.setStatus).toHaveBeenLastCalledWith(
+      "a1",
+      "brainlayer: working",
+      expect.objectContaining({
+        workspace: "workspace:coach",
+        surface: "surface:99",
       }),
     );
   });

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -228,6 +228,25 @@ describe("StateManager", () => {
       expect(record.auto_archive_on_done).toBe(false);
     });
 
+    it("preserves the discovered workspace for auto-discovered agents", () => {
+      const mgr = new StateManager(TEST_DIR);
+
+      const record = mgr.ensureAutoRecord("auto-coach", {
+        surface_id: "surface:auto-coach",
+        surface_title: "coachClaude",
+        workspace_id: "workspace:coach",
+        cli: "claude",
+        parsed_status: "idle",
+        model: "sonnet",
+        token_count: null,
+        context_pct: null,
+        has_agent: true,
+        read_error: false,
+      } as any);
+
+      expect(record.workspace_id).toBe("workspace:coach");
+    });
+
     it("assigns orchestrator role when the discovered cli is unknown", () => {
       const mgr = new StateManager(TEST_DIR);
 

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -28,6 +28,42 @@ function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
+function makeSpawnReadyExec(): ExecFn {
+  let launchSent = false;
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("send")) {
+      launchSent = true;
+    }
+    if (args.includes("list-workspaces")) {
+      return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
+    }
+    if (args.includes("list-panes")) {
+      return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
+    }
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: launchSent ? "What can I help you with?\n>" : "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return {
+      stdout: JSON.stringify({
+        workspace: "ws:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
 function createV2Server(exec: ExecFn) {
   return createServer({
     exec,
@@ -66,16 +102,7 @@ describe("interact — runtime validation", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeSpawnReadyExec();
     server = createV2Server(mockExec);
   });
 
@@ -161,16 +188,7 @@ describe("interact — agent resolution", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeSpawnReadyExec();
     server = createV2Server(mockExec);
   });
 
@@ -223,16 +241,7 @@ describe("kill — scoped targets", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "ws:1",
-        surface: "surface:new",
-        pane: "pane:1",
-        title: "",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = makeSpawnReadyExec();
     server = createV2Server(mockExec);
   });
 


### PR DESCRIPTION
## Summary
- Wait for a real shell prompt before sending agent launcher commands, then tolerate shell-history echo once Codex readiness is detected.
- Update Codex readiness detection for the current prompt UI so boot prompts are delivered instead of timing out.
- Preserve workspace/pane metadata through discovery, registry, sidebar state, and runtime surfaces so agents/status stay scoped to the correct repo workspace.
- Dock child workers beside their orchestrator pane and reuse the child worker pane for siblings.
- Reduce sidebar churn by diffing status/progress targets and clearing stale workspace-scoped status.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (535 tests)
- [x] Live daemon gate: built MCP server `spawn_agent` against live cmux returned `ok:true`, `state:"ready"`, `boot_prompt_delivered:true`, `boot_prompt_bytes:59`.
- [x] Pre-push hook reran `run_tests.sh` and `bun run test` (535 tests) successfully.

## Review notes
- `cr review --plain` was attempted before commit but CodeRabbit CLI returned `Review limit reached` before producing findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn, terminal delivery, and workspace routing; launch now blocks on shell readiness and mis-matched workspace resolution could target the wrong pane, though extensive tests were added.
> 
> **Overview**
> This PR hardens **multi-workspace cmux agent lifecycle**: spawns and splits can pick the workspace whose `current_directory` matches the repo (including launcher-style tab titles), and **discovery, routes, registry, and auto-records** carry `workspace_id` so `readScreen`, `send`, `sendKey`, and status updates stay scoped to the right workspace.
> 
> **Launch path:** a pluggable `launchCommandSender` waits for a shell prompt (or ready pattern) before sending launcher commands; the MCP server uses verified chunk delivery with a fallback when Enter verification fails but Codex readiness appears. Failed launch transitions the agent to **error**. **Codex** ready detection is expanded for modern `›` + model footer UIs and excludes working/waiting states.
> 
> **Sidebar:** status diffs track surface and workspace (not just the status string), clear stale workspace-scoped status on moves, and skip redundant progress updates.
> 
> **Layout:** child workers under an **orchestrator** split right on first spawn or tab into an existing worker dock pane for siblings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533eecef93de2241efd24be0f7ae0913bba98c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize cmux agent launching by adding shell readiness polling and workspace-scoped routing
> - Adds shell readiness polling before sending launch commands, waiting for a shell prompt or known agent ready pattern before proceeding, with timeout-based error transitions
> - Propagates `workspace_id` throughout agent discovery, routing, registry, sidebar sync, and input delivery so all cmux operations target the correct workspace-scoped surface
> - Infers the target workspace from a launcher title's repo prefix in `new_split`, so pane/surface operations and boot prompt delivery use the resolved workspace
> - Improves Codex ready-pattern detection to handle UI prompts with a leading chevron and GPT model indicator while excluding busy states
> - Risk: agents that never reach a shell-ready state now transition to error instead of silently proceeding, changing observable agent lifecycle behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 533eece.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->