### PR TITLE
fix: submit chunked cmux input once

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -189,6 +189,12 @@ export class CmuxClient {
     };
   }
 
+  private pasteBufferName(surface: string, workspace?: string): string {
+    const raw = `cmuxlayer-${workspace ?? "global"}-${surface}`;
+    const safe = raw.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 120);
+    return safe || "cmuxlayer-buffer";
+  }
+
   private async resolveWorkspaceFromSurface(surface: string): Promise<string> {
     const identified = await this.identify(surface);
     const workspace =
@@ -352,6 +358,19 @@ export class CmuxClient {
     const args = ["send", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
     args.push(text);
+    await this.run(args);
+  }
+
+  async pasteText(
+    surface: string,
+    text: string,
+    opts?: { workspace?: string },
+  ): Promise<void> {
+    const bufferName = this.pasteBufferName(surface, opts?.workspace);
+    await this.run(["set-buffer", "--name", bufferName, "--", text]);
+
+    const args = ["paste-buffer", "--name", bufferName, "--surface", surface];
+    if (opts?.workspace) args.push("--workspace", opts.workspace);
     await this.run(args);
   }
 

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -4,6 +4,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import type {
   CmuxPane,
@@ -192,7 +193,7 @@ export class CmuxClient {
   private pasteBufferName(surface: string, workspace?: string): string {
     const raw = `cmuxlayer-${workspace ?? "global"}-${surface}`;
     const safe = raw.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 120);
-    return safe || "cmuxlayer-buffer";
+    return `${safe || "cmuxlayer-buffer"}-${randomUUID()}`;
   }
 
   private async resolveWorkspaceFromSurface(surface: string): Promise<string> {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -329,6 +329,20 @@ export class CmuxSocketClient {
     await this.call("surface.send_text", params);
   }
 
+  async pasteText(
+    surface: string,
+    text: string,
+    opts?: { workspace?: string },
+  ): Promise<void> {
+    if (!this.cliFallback) {
+      throw new CmuxSocketError(
+        "paste-text is only available through the CLI fallback",
+        "method_not_found",
+      );
+    }
+    await this.cliFallback.pasteText(surface, text, opts);
+  }
+
   async sendKey(
     surface: string,
     key: string,

--- a/src/server.ts
+++ b/src/server.ts
@@ -313,6 +313,19 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
   return chunks;
 }
 
+function shouldPasteInputChunk(text: string, totalChunks: number): boolean {
+  return totalChunks > 1 || /[\n\r\t]|\\[nrt]/.test(text);
+}
+
+function isMethodNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    String((error as { code?: unknown }).code) === "method_not_found"
+  );
+}
+
 function getBootPromptPath(value: string | null | undefined): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
@@ -717,7 +730,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     while (attempt < SEND_INPUT_RETRY_ATTEMPTS) {
       try {
-        await client.send(surface, chunk, opts);
+        const shouldPaste =
+          shouldPasteInputChunk(chunk, totalChunks) &&
+          typeof client.pasteText === "function";
+        if (shouldPaste) {
+          try {
+            await client.pasteText(surface, chunk, opts);
+          } catch (error) {
+            if (!isMethodNotFoundError(error)) {
+              throw error;
+            }
+            await client.send(surface, chunk, opts);
+          }
+        } else {
+          await client.send(surface, chunk, opts);
+        }
         return;
       } catch (error) {
         lastError = error;
@@ -1788,7 +1815,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 6. send_input
   server.tool(
     "send_input",
-    "Send text input to a terminal surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
+    "Send text input to a terminal surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
     {
       surface: z.string().describe("Target surface ref"),
       text: z.string().describe("Text to send"),
@@ -1812,7 +1839,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .default(false)
         .describe(
-          "Press enter after sending text. For reliability with interactive programs, send text first, then use a separate send_key 'return' call.",
+          "Press return once after all chunks have landed.",
         ),
       rename_to_task: z
         .string()

--- a/src/server.ts
+++ b/src/server.ts
@@ -326,6 +326,12 @@ function isMethodNotFoundError(error: unknown): boolean {
   );
 }
 
+function pasteRequiredError(reason: string): Error {
+  return new Error(
+    `paste delivery is required for chunked or multiline input: ${reason}`,
+  );
+}
+
 function getBootPromptPath(value: string | null | undefined): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
@@ -730,17 +736,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     while (attempt < SEND_INPUT_RETRY_ATTEMPTS) {
       try {
-        const shouldPaste =
-          shouldPasteInputChunk(chunk, totalChunks) &&
-          typeof client.pasteText === "function";
+        const shouldPaste = shouldPasteInputChunk(chunk, totalChunks);
         if (shouldPaste) {
+          if (typeof client.pasteText !== "function") {
+            throw pasteRequiredError("client does not support pasteText");
+          }
           try {
             await client.pasteText(surface, chunk, opts);
           } catch (error) {
-            if (!isMethodNotFoundError(error)) {
-              throw error;
+            if (isMethodNotFoundError(error)) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              throw pasteRequiredError(`pasteText is unavailable (${message})`);
             }
-            await client.send(surface, chunk, opts);
+            throw error;
           }
         } else {
           await client.send(surface, chunk, opts);

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -354,20 +354,38 @@ describe("CmuxClient.pasteText", () => {
       "--json",
       "set-buffer",
       "--name",
-      "cmuxlayer-workspace-2-surface-1",
+      expect.stringMatching(/^cmuxlayer-workspace-2-surface-1-[a-f0-9-]+$/),
       "--",
       "line one\nline two",
     ]);
+    const bufferName = exec.mock.calls[0][1][3];
     expect(exec).toHaveBeenNthCalledWith(2, "cmux", [
       "--json",
       "paste-buffer",
       "--name",
-      "cmuxlayer-workspace-2-surface-1",
+      bufferName,
       "--surface",
       "surface:1",
       "--workspace",
       "workspace:2",
     ]);
+  });
+
+  it("uses a unique buffer name for each paste call", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.pasteText("surface:1", "first", {
+      workspace: "workspace:2",
+    });
+    await client.pasteText("surface:1", "second", {
+      workspace: "workspace:2",
+    });
+
+    const setBufferNames = exec.mock.calls
+      .filter(([, args]) => args.includes("set-buffer"))
+      .map(([, args]) => args[3]);
+    expect(setBufferNames).toHaveLength(2);
+    expect(setBufferNames[0]).not.toBe(setBufferNames[1]);
   });
 });
 

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -342,6 +342,35 @@ describe("CmuxClient.send", () => {
   });
 });
 
+describe("CmuxClient.pasteText", () => {
+  it("sets and pastes a workspace-scoped buffer without interpreting newlines", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.pasteText("surface:1", "line one\nline two", {
+      workspace: "workspace:2",
+    });
+
+    expect(exec).toHaveBeenNthCalledWith(1, "cmux", [
+      "--json",
+      "set-buffer",
+      "--name",
+      "cmuxlayer-workspace-2-surface-1",
+      "--",
+      "line one\nline two",
+    ]);
+    expect(exec).toHaveBeenNthCalledWith(2, "cmux", [
+      "--json",
+      "paste-buffer",
+      "--name",
+      "cmuxlayer-workspace-2-surface-1",
+      "--surface",
+      "surface:1",
+      "--workspace",
+      "workspace:2",
+    ]);
+  });
+});
+
 describe("CmuxClient.sendKey", () => {
   it("calls cmux send-key with surface and key", async () => {
     const { client, exec } = mockClient({});

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -516,6 +516,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
       closeSurface: async (surface: string, opts?: unknown) => {
         cliCalls.push({ method: "closeSurface", args: [surface, opts] });
       },
+      pasteText: async (surface: string, text: string, opts?: unknown) => {
+        cliCalls.push({ method: "pasteText", args: [surface, text, opts] });
+      },
     } as unknown as CmuxClient;
   }
 
@@ -587,6 +590,27 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
       workspace: "workspace:1",
     });
     expect(result.surface).toBe("surface:cli-tab");
+  });
+
+  it("pasteText uses CLI fallback", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+
+    await client.pasteText("surface:1", "line one\nline two", {
+      workspace: "workspace:1",
+    });
+
+    expect(cliCalls).toHaveLength(1);
+    expect(cliCalls[0]).toEqual({
+      method: "pasteText",
+      args: [
+        "surface:1",
+        "line one\nline two",
+        { workspace: "workspace:1" },
+      ],
+    });
   });
 
   it("moveSurface uses CLI fallback", async () => {

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -116,6 +116,10 @@ class FakeClaudeSurfaceClient {
     this.pendingText += text;
   }
 
+  async pasteText(surface: string, text: string) {
+    await this.send(surface, text);
+  }
+
   async sendKey(surface: string, key: string) {
     if (surface !== this.surface) {
       throw new Error(`Unknown surface: ${surface}`);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1002,21 +1002,117 @@ describe("agent lifecycle tool handlers", () => {
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    const sendCalls = mockExec.mock.calls.filter(
-      ([, args]) => Array.isArray(args) && args.includes("send"),
+    const setBufferCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("set-buffer"),
+    );
+    const pasteBufferCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("paste-buffer"),
     );
     const sendKeyCalls = mockExec.mock.calls.filter(
       ([, args]) => Array.isArray(args) && args.includes("send-key"),
     );
-    const deliveredText = sendCalls.map(([, args]) => args.at(-1)).join("");
+    const deliveredText = setBufferCalls.map(([, args]) => args.at(-1)).join("");
 
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
-    expect(sendCalls).toHaveLength(2);
+    expect(setBufferCalls).toHaveLength(2);
+    expect(pasteBufferCalls).toHaveLength(2);
     expect(sendKeyCalls).toHaveLength(1);
     expect(deliveredText).toBe(sanitizedText);
     expect(deliveredText).not.toContain("\x1b");
     expect(deliveredText).not.toContain("\x07");
+  });
+
+  it("send_to submits chunked multiline text as one receiver message", async () => {
+    const baseExec = makeLifecycleExec();
+    const buffers = new Map<string, string>();
+    let composer = "";
+    let collectReceiverInput = false;
+    const submittedMessages: string[] = [];
+    const submitComposer = () => {
+      submittedMessages.push(composer);
+      composer = "";
+    };
+    const typeCmuxSendText = (text: string) => {
+      for (const char of text) {
+        if (char === "\n" || char === "\r") {
+          submitComposer();
+        } else {
+          composer += char;
+        }
+      }
+    };
+    mockExec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (!collectReceiverInput) {
+        return baseExec(cmd, args);
+      }
+      if (args.includes("set-buffer")) {
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        buffers.set(name, args[args.length - 1]);
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("paste-buffer")) {
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        composer += buffers.get(name) ?? "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key")) {
+        const key = args[args.length - 1];
+        if (key === "return" || key === "enter") {
+          submitComposer();
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send")) {
+        typeCmuxSendText(args[args.length - 1]);
+        return { stdout: "{}", stderr: "" };
+      }
+      return baseExec(cmd, args);
+    });
+
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "ready" });
+    collectReceiverInput = true;
+    mockExec.mockClear();
+
+    const longText = [
+      "alpha ".repeat(24),
+      "bravo ".repeat(24),
+      "charlie ".repeat(24),
+      "delta ".repeat(24),
+      "echo ".repeat(24),
+    ].join("\n");
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: longText, press_enter: true },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(submittedMessages).toEqual([longText]);
   });
 
   it("send_to returns an error for an unknown agent_id", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1450,7 +1450,7 @@ describe("tool handler integration", () => {
     expect(submittedMessages).toEqual([longText]);
   });
 
-  it("send_input falls back to send when paste delivery is unsupported", async () => {
+  it("send_input fails instead of falling back to send when paste delivery is unsupported", async () => {
     const unsupportedPaste = Object.assign(new Error("method unavailable"), {
       code: "method_not_found",
     });
@@ -1472,9 +1472,35 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("paste delivery is required");
     expect(mockClient.pasteText).toHaveBeenCalled();
-    expect(mockClient.send).toHaveBeenCalled();
+    expect(mockClient.send).not.toHaveBeenCalled();
+  });
+
+  it("send_input fails instead of falling back to send when pasteText is absent", async () => {
+    const mockClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const longText = "fallback ".repeat(90);
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: longText, chunk_size: 120 },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("client does not support pasteText");
+    expect(mockClient.send).not.toHaveBeenCalled();
   });
 
   it("send_input can deliver long text in the background and expose status via read_screen", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1353,14 +1353,24 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(5);
-    for (const [index, call] of mockExec.mock.calls.entries()) {
+    const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("set-buffer"),
+    );
+    const pasteBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("paste-buffer"),
+    );
+    expect(setBufferCalls).toHaveLength(5);
+    expect(pasteBufferCalls).toHaveLength(5);
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("send")),
+    ).toHaveLength(0);
+    for (const [index, call] of setBufferCalls.entries()) {
       expect(call[0]).toBe("cmux");
-      expect(call[1]).toEqual(expect.arrayContaining(["send"]));
+      expect(call[1]).toEqual(expect.arrayContaining(["set-buffer"]));
       const chunk = call[1][call[1].length - 1];
       expect(typeof chunk).toBe("string");
       expect((chunk as string).length).toBeLessThanOrEqual(121);
-      if (index < mockExec.mock.calls.length - 1) {
+      if (index < setBufferCalls.length - 1) {
         expect((chunk as string).endsWith("\n")).toBe(true);
       }
     }
@@ -1368,6 +1378,103 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
+  });
+
+  it("send_input submits chunked multiline text as one receiver message", async () => {
+    const buffers = new Map<string, string>();
+    let composer = "";
+    const submittedMessages: string[] = [];
+    const submitComposer = () => {
+      submittedMessages.push(composer);
+      composer = "";
+    };
+    const typeCmuxSendText = (text: string) => {
+      for (const char of text) {
+        if (char === "\n" || char === "\r") {
+          submitComposer();
+        } else {
+          composer += char;
+        }
+      }
+    };
+    mockExec = vi.fn().mockImplementation((_cmd, args: string[]) => {
+      if (args.includes("set-buffer")) {
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        buffers.set(name, args[args.length - 1]);
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("paste-buffer")) {
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        composer += buffers.get(name) ?? "";
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("send-key")) {
+        const key = args[args.length - 1];
+        if (key === "return" || key === "enter") {
+          submitComposer();
+        }
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("send")) {
+        typeCmuxSendText(args[args.length - 1]);
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+    const longText = [
+      "section-one ".repeat(12),
+      "section-two ".repeat(12),
+      "section-three ".repeat(12),
+      "section-four ".repeat(12),
+      "section-five ".repeat(12),
+    ].join("\n");
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text: longText,
+        chunk_size: 120,
+        press_enter: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(submittedMessages).toEqual([longText]);
+  });
+
+  it("send_input falls back to send when paste delivery is unsupported", async () => {
+    const unsupportedPaste = Object.assign(new Error("method unavailable"), {
+      code: "method_not_found",
+    });
+    const mockClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      pasteText: vi.fn().mockRejectedValue(unsupportedPaste),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const longText = "fallback ".repeat(90);
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: longText, chunk_size: 120 },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.pasteText).toHaveBeenCalled();
+    expect(mockClient.send).toHaveBeenCalled();
   });
 
   it("send_input can deliver long text in the background and expose status via read_screen", async () => {
@@ -1420,7 +1527,7 @@ describe("tool handler integration", () => {
     expect(parsed.status).toBe("delivering");
     expect(parsed.delivery_id).toEqual(expect.any(String));
     expect(
-      mockExec.mock.calls.filter(([, args]) => args.includes("send")),
+      mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer")),
     ).toHaveLength(0);
 
     const readWhileDelivering = await readTool.handler(
@@ -1440,7 +1547,7 @@ describe("tool handler integration", () => {
     for (let i = 0; i < 50; i++) {
       await advanceTimers(5);
       if (
-        mockExec.mock.calls.filter(([, args]) => args.includes("send"))
+        mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer"))
           .length === 5
       ) {
         break;
@@ -1448,7 +1555,7 @@ describe("tool handler integration", () => {
     }
 
     expect(
-      mockExec.mock.calls.filter(([, args]) => args.includes("send")),
+      mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer")),
     ).toHaveLength(5);
 
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- route chunked or multiline input through cmux set-buffer/paste-buffer so embedded newlines do not submit partial messages
- keep chunk-level acknowledgements, but press return only once after the final chunk when `press_enter=true`
- add regression coverage for `send_input` and `send_to` proving >500-char multiline payloads submit as one receiver message, plus client/fallback tests

## Test plan
- `bunx vitest run tests/server.test.ts tests/server-agent-tools.test.ts tests/cmux-client.test.ts tests/cmux-socket-client.test.ts tests/enter-reliability.test.ts tests/verified-relay.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run test` (543 tests)
- live MCP gate via `node dist/index.js`: create real cmux split, send >500-char multiline `send_input` through built server, cleanup surface
- `cr review --plain` (second pass: no findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core terminal input delivery changed for all multiline/chunked paths; deployments using socket-only clients without CLI fallback will fail those inputs instead of partially submitting via send.
> 
> **Overview**
> **Chunked and multiline `send_input` (and shared chunk delivery for `send_to`, boot prompts, etc.) no longer uses `send` per chunk when paste is required.** The server picks paste when there is more than one chunk or the text has newlines, tabs, or `\n`/`\r`/`\t` escapes. Each chunk goes through **`pasteText`**, which writes a uniquely named buffer (`set-buffer` then `paste-buffer`) so embedded newlines stay in the composer instead of submitting early. **`press_enter=true` still sends return only after all chunks land.**
> 
> **Clients:** `CmuxClient` implements `pasteText`; `CmuxSocketClient` only supports it via **CLI fallback**—without fallback, paste errors surface as hard failures (no silent revert to `send`). Tool copy for `send_input` documents the new paste and enter behavior.
> 
> **Tests** assert buffer-based delivery for long/chunked input, one submitted message for multiline payloads, and explicit errors when `pasteText` is missing or unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee943e99e149500d30a674e9e7cd23c32978ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `send_input` to submit chunked or multiline input via paste-buffer instead of repeated sends
> - Adds `pasteText` to `CmuxClient` and `CmuxSocketClient` that stores text in a named tmux buffer (`set-buffer`) then pastes it into the target surface (`paste-buffer`), avoiding newline interpretation issues.
> - Updates the `send_input` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/116/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to route chunks through `pasteText` when the input spans multiple chunks or contains newlines/control characters; single plain-text chunks continue to use `send`.
> - Adds `shouldPasteInputChunk` helper to detect when paste delivery is required, and hard-fails with a clear error if `pasteText` is unavailable on the client.
> - Behavioral Change: chunked or multiline `send_input` calls now require paste support; if the client does not expose `pasteText`, the tool returns an error instead of falling back to `send`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ee943e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multiline text input handling for improved reliability when submitting text with embedded newlines.

* **Improvements**
  * Multiline and chunked text is now delivered and submitted as a single complete message.
  * Added automatic fallback to standard input delivery if advanced pasting methods are unsupported.

* **Documentation**
  * Updated tool descriptions to clarify multiline text and press-enter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->