### PR TITLE
fix: anchor pane splits via surface

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -233,6 +233,18 @@ export class CmuxClient {
     return this.parse(raw, "list-panes");
   }
 
+  private async resolvePaneAnchorSurface(opts: {
+    workspace?: string;
+    pane: string;
+  }): Promise<string | undefined> {
+    const paneSurfaces = await this.listPaneSurfaces({
+      workspace: opts.workspace,
+      pane: opts.pane,
+    });
+    const surfaces = paneSurfaces.surfaces ?? [];
+    return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
+  }
+
   async newSplit(
     direction: string,
     opts?: {
@@ -271,8 +283,19 @@ export class CmuxClient {
 
     const args = ["new-split", direction];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
-    if (opts?.surface) args.push("--surface", opts.surface);
-    if (opts?.pane) args.push("--panel", opts.pane);
+    const anchorSurface =
+      opts?.surface ??
+      (opts?.pane
+        ? await this.resolvePaneAnchorSurface({
+            workspace: opts.workspace,
+            pane: opts.pane,
+          })
+        : undefined);
+    // AIDEV-NOTE(2026-06-01): raw cmux CLI reproduces
+    // `new-split --panel <pane>` failing with "Surface not found" after a cmux
+    // app update. Anchor terminal splits through a surface in the target pane;
+    // `new-surface --pane` is unaffected and intentionally stays as-is below.
+    if (anchorSurface) args.push("--surface", anchorSurface);
     const raw = await this.run(args);
     const parsed = this.parse<Record<string, unknown>>(raw, "new-split");
     return this.mapSplitResult(parsed, "terminal");

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -199,6 +199,18 @@ export class CmuxSocketClient {
     return this.call("pane.list", params);
   }
 
+  private async resolvePaneAnchorSurface(opts: {
+    workspace?: string;
+    pane: string;
+  }): Promise<string | undefined> {
+    const paneSurfaces = await this.listPaneSurfaces({
+      workspace: opts.workspace,
+      pane: opts.pane,
+    });
+    const surfaces = paneSurfaces.surfaces ?? [];
+    return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
+  }
+
   async newSplit(
     direction: string,
     opts?: {
@@ -251,8 +263,18 @@ export class CmuxSocketClient {
 
     const params: Record<string, unknown> = { direction };
     if (opts?.workspace) params.workspace_id = opts.workspace;
-    if (opts?.surface) params.surface_id = opts.surface;
-    if (opts?.pane) params.pane_id = opts.pane;
+    const anchorSurface =
+      opts?.surface ??
+      (opts?.pane
+        ? await this.resolvePaneAnchorSurface({
+            workspace: opts.workspace,
+            pane: opts.pane,
+          })
+        : undefined);
+    // AIDEV-NOTE(2026-06-01): keep socket terminal splits aligned with the CLI
+    // workaround for the cmux app `new-split --panel <pane>` regression. Raw CLI
+    // reproduces "Surface not found"; `new-surface --pane` is unaffected.
+    if (anchorSurface) params.surface_id = anchorSurface;
 
     try {
       const result = await this.call<Record<string, unknown>>(

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -122,29 +122,106 @@ describe("CmuxClient.newSplit", () => {
     ]);
   });
 
-  it("uses --panel when targeting a panel", async () => {
-    const data = {
+  it("resolves a pane target to the selected surface instead of using --panel", async () => {
+    const paneSurfaces = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      pane_ref: "pane:2",
+      surfaces: [
+        {
+          ref: "surface:old",
+          title: "Old tab",
+          type: "terminal",
+          index: 0,
+          selected: false,
+        },
+        {
+          ref: "surface:selected",
+          title: "Selected tab",
+          type: "terminal",
+          index: 1,
+          selected: true,
+        },
+      ],
+    };
+    const split = {
       workspace: "workspace:1",
       surface: "surface:3",
       pane: "pane:2",
       title: "Split",
       type: "terminal",
     };
-    const { client, exec } = mockClient(data);
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(paneSurfaces),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: JSON.stringify(split), stderr: "" });
+    const client = new CmuxClient({ exec });
 
     await client.newSplit("left", {
       workspace: "workspace:1",
       pane: "pane:2",
     });
 
-    expect(exec).toHaveBeenCalledWith("cmux", [
+    expect(exec).toHaveBeenNthCalledWith(1, "cmux", [
+      "--json",
+      "list-pane-surfaces",
+      "--workspace",
+      "workspace:1",
+      "--pane",
+      "pane:2",
+    ]);
+    expect(exec).toHaveBeenNthCalledWith(2, "cmux", [
       "--json",
       "new-split",
       "left",
       "--workspace",
       "workspace:1",
-      "--panel",
-      "pane:2",
+      "--surface",
+      "surface:selected",
+    ]);
+    expect(exec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["--panel"]),
+    );
+  });
+
+  it("omits the pane anchor when no surface can be resolved for the pane", async () => {
+    const paneSurfaces = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      pane_ref: "pane:empty",
+      surfaces: [],
+    };
+    const split = {
+      workspace: "workspace:1",
+      surface: "surface:3",
+      pane: "pane:2",
+      title: "Split",
+      type: "terminal",
+    };
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(paneSurfaces),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: JSON.stringify(split), stderr: "" });
+    const client = new CmuxClient({ exec });
+
+    await client.newSplit("left", {
+      workspace: "workspace:1",
+      pane: "pane:empty",
+    });
+
+    expect(exec).toHaveBeenNthCalledWith(2, "cmux", [
+      "--json",
+      "new-split",
+      "left",
+      "--workspace",
+      "workspace:1",
     ]);
   });
 

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -308,6 +308,53 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(result.type).toBe("terminal");
   });
 
+  it("newSplit resolves pane targets to surface_id for terminal splits", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.newSplit("right", {
+      workspace: "workspace:1",
+      pane: "pane:1",
+    });
+
+    expect(lastV2Request).toEqual({
+      method: "pane.split",
+      params: {
+        direction: "right",
+        workspace_id: "workspace:1",
+        surface_id: "surface:1",
+      },
+    });
+    expect(lastV2Request?.params).not.toHaveProperty("pane_id");
+  });
+
+  it("newSplit omits the pane anchor when the pane has no surfaces", async () => {
+    const saved = MOCK_RESPONSES["surface.list"];
+    MOCK_RESPONSES["surface.list"] = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      pane_ref: "pane:empty",
+      surfaces: [],
+    };
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.newSplit("right", {
+        workspace: "workspace:1",
+        pane: "pane:empty",
+      });
+
+      expect(lastV2Request).toEqual({
+        method: "pane.split",
+        params: {
+          direction: "right",
+          workspace_id: "workspace:1",
+        },
+      });
+    } finally {
+      MOCK_RESPONSES["surface.list"] = saved;
+    }
+  });
+
   it("handles unknown methods gracefully", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
     await expect(client.browser(["nonexistent"])).rejects.toThrow();

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2671,16 +2671,39 @@ describe("tool handler integration", () => {
   });
 
   it("new_split with launcher-style title honors explicit pane when role is omitted", async () => {
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "workspace:1",
-        surface: "surface:manual-title",
-        pane: "pane:manual",
-        title: "brainlayerCodex",
-        type: "terminal",
-      }),
-      stderr: "",
-    });
+    mockExec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:manual",
+          surfaces: [
+            {
+              ref: "surface:manual-anchor",
+              title: "existing",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          surface: "surface:manual-title",
+          pane: "pane:manual",
+          title: "brainlayerCodex",
+          type: "terminal",
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ ok: true }),
+        stderr: "",
+      });
     const server = createServer({
       exec: mockExec,
       skipAgentLifecycle: true,
@@ -2703,7 +2726,12 @@ describe("tool handler integration", () => {
     expect(parsed.role).toBeUndefined();
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining(["new-split", "right", "--panel", "pane:manual"]),
+      expect.arrayContaining([
+        "new-split",
+        "right",
+        "--surface",
+        "surface:manual-anchor",
+      ]),
     );
   });
 


### PR DESCRIPTION
## Summary
- Translate terminal `newSplit({ pane })` anchors to a selected/first surface in that pane before calling cmux.
- Keep explicit `surface` anchors unchanged and leave `newSurface --pane` untouched.
- Apply the same pane-to-surface anchor behavior to the socket `pane.split` path.

## Tests
- RED first: affected client/socket tests failed on old `--panel` / `pane_id` behavior.
- `bun run test tests/cmux-client.test.ts tests/cmux-socket-client.test.ts` -> 77/77 passed.
- `bun run test tests/cmux-client.test.ts tests/cmux-socket-client.test.ts tests/server.test.ts` -> 146/146 passed.
- `bun run test` -> 559/559 passed.
- `bun run typecheck` -> passed.
- push hook reran `run_tests.sh` -> 559/559 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Split placement now depends on an extra list-surfaces round trip and which tab is selected in the pane; empty panes may split without a pane anchor, but explicit `surface` is unchanged and scope is limited to terminal split anchoring.
> 
> **Overview**
> Fixes terminal splits that target a **pane** after a cmux app regression where `new-split --panel <pane>` returns **"Surface not found"**. **`newSurface --pane`** is unchanged.
> 
> **CLI and socket clients** add `resolvePaneAnchorSurface`: when `newSplit` gets `pane` but no explicit `surface`, they call `list-pane-surfaces` / `surface.list`, pick the **selected** surface or the **first** tab, then invoke split with **`--surface`** / **`surface_id`** instead of **`--panel`** / **`pane_id`**. If the pane has no surfaces, the anchor is omitted (same as before when only workspace/direction were sent).
> 
> Tests cover selected-surface resolution, empty-pane behavior, and server **`new_split`** flows that previously expected `--panel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5864337bf592da2d662d90fcd1a4cb560210910d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pane split anchoring by resolving to a surface ref instead of panel
> - `newSplit` in both [`cmux-client.ts`](https://github.com/EtanHey/cmuxlayer/pull/119/files#diff-fa09fce9dc0db1d0fcfd897829a228dc976f365c0f36f4cbadacf6d03bd932d4) and [`cmux-socket-client.ts`](https://github.com/EtanHey/cmuxlayer/pull/119/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) no longer passes `--panel`/`pane_id` when anchoring terminal splits to a pane
> - A new `resolvePaneAnchorSurface` helper calls `listPaneSurfaces` and returns the selected surface ref, or the first surface ref, or `undefined` if none exist
> - When a pane is targeted, the resolved surface ref is passed as `--surface`/`surface_id` instead; if no surface can be resolved, no anchor flag is sent
> - This is a workaround for a CLI regression where `--panel` no longer correctly anchors splits
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5864337.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal split creation when targeting panes by implementing surface-based anchoring. The system now resolves the appropriate terminal surface within the target pane for more reliable and consistent split operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->