### PR TITLE
fix: spawn-storm circuit breaker (rate limiter)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -48,6 +48,7 @@ import {
 } from "./layout-policy.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
+import { SpawnGuard } from "./spawn-guard.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -72,6 +73,7 @@ export interface SpawnAgentResult {
 
 export interface AgentEngineOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+  spawnGuard?: SpawnGuard;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -338,6 +340,7 @@ export class AgentEngine {
   private registry: AgentRegistry;
   private client: AgentEngineClient;
   private spawnPreflight: (params: SpawnAgentParams) => Promise<void>;
+  private spawnGuard: SpawnGuard;
   private roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -363,6 +366,7 @@ export class AgentEngine {
     this.client = client;
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
+    this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.spawnPreflight =
       opts?.spawnPreflight ??
       (async (params) => {
@@ -1058,6 +1062,8 @@ export class AgentEngine {
       parentAgentId = params.parent_agent_id;
       parentAgent = parent;
     }
+
+    this.spawnGuard.check(params.workspace);
 
     await this.spawnPreflight(params);
 

--- a/src/spawn-guard.ts
+++ b/src/spawn-guard.ts
@@ -1,0 +1,127 @@
+const DEFAULT_MAX_PER_WINDOW = 50;
+const DEFAULT_MAX_PER_WORKSPACE_PER_WINDOW = 25;
+const DEFAULT_WINDOW_MS = 10000;
+const DEFAULT_WORKSPACE_KEY = "__default__";
+
+export class SpawnRateLimitedError extends Error {
+  readonly code = "SPAWN_RATE_LIMITED";
+  readonly retryAfterMs: number;
+  readonly scope: string;
+
+  constructor(
+    scope: string,
+    retryAfterMs: number,
+    maxPerWindow: number,
+    windowMs: number,
+  ) {
+    super(
+      `Spawn rate limit exceeded for ${scope}: >${maxPerWindow} spawns per ${windowMs}ms; retry after ${retryAfterMs}ms`,
+    );
+    this.name = "SpawnRateLimitedError";
+    this.retryAfterMs = retryAfterMs;
+    this.scope = scope;
+  }
+}
+
+export interface SpawnGuardConfig {
+  maxPerWindow: number;
+  maxPerWorkspacePerWindow: number;
+  windowMs: number;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function defaultSpawnGuardConfig(): SpawnGuardConfig {
+  // Defaults sit above the legitimate per-parent fan-out floor
+  // (root + MAX_CHILDREN=10 = 11) and realistic multi-lead revivals, while
+  // a pathological 44-in-6s single-workspace burst still trips the
+  // per-workspace cap. Stricter environments can tune these down via env.
+  return {
+    maxPerWindow: positiveIntFromEnv(
+      "CMUXLAYER_MAX_SPAWNS_PER_WINDOW",
+      DEFAULT_MAX_PER_WINDOW,
+    ),
+    maxPerWorkspacePerWindow: positiveIntFromEnv(
+      "CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW",
+      DEFAULT_MAX_PER_WORKSPACE_PER_WINDOW,
+    ),
+    windowMs: positiveIntFromEnv(
+      "CMUXLAYER_SPAWN_WINDOW_MS",
+      DEFAULT_WINDOW_MS,
+    ),
+  };
+}
+
+export class SpawnGuard {
+  private readonly globalTimestamps: number[] = [];
+  private readonly workspaceTimestamps = new Map<string, number[]>();
+
+  constructor(
+    private readonly config: SpawnGuardConfig = defaultSpawnGuardConfig(),
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  check(workspace?: string): void {
+    const timestamp = this.now();
+    const cutoff = timestamp - this.config.windowMs;
+    const workspaceKey = workspace ?? DEFAULT_WORKSPACE_KEY;
+    let workspaceArr = this.workspaceTimestamps.get(workspaceKey);
+    if (!workspaceArr) {
+      workspaceArr = [];
+      this.workspaceTimestamps.set(workspaceKey, workspaceArr);
+    }
+
+    this.prune(this.globalTimestamps, cutoff);
+    this.prune(workspaceArr, cutoff);
+
+    if (this.globalTimestamps.length >= this.config.maxPerWindow) {
+      throw new SpawnRateLimitedError(
+        "global",
+        this.retryAfter(this.globalTimestamps, timestamp),
+        this.config.maxPerWindow,
+        this.config.windowMs,
+      );
+    }
+
+    if (
+      workspaceArr.length >= this.config.maxPerWorkspacePerWindow
+    ) {
+      throw new SpawnRateLimitedError(
+        `workspace ${workspaceKey}`,
+        this.retryAfter(workspaceArr, timestamp),
+        this.config.maxPerWorkspacePerWindow,
+        this.config.windowMs,
+      );
+    }
+
+    this.globalTimestamps.push(timestamp);
+    workspaceArr.push(timestamp);
+  }
+
+  private prune(timestamps: number[], cutoff: number): void {
+    let removeCount = 0;
+    while (
+      removeCount < timestamps.length &&
+      timestamps[removeCount] <= cutoff
+    ) {
+      removeCount++;
+    }
+
+    if (removeCount > 0) {
+      timestamps.splice(0, removeCount);
+    }
+  }
+
+  private retryAfter(timestamps: number[], timestamp: number): number {
+    const oldestInWindow = timestamps[0] ?? timestamp;
+    return Math.max(0, oldestInWindow + this.config.windowMs - timestamp);
+  }
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -22,6 +22,10 @@ import {
   MAX_RESPAWN_ATTEMPTS,
   type AgentRecord,
 } from "../src/agent-types.js";
+import {
+  SpawnGuard,
+  SpawnRateLimitedError,
+} from "../src/spawn-guard.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
@@ -127,6 +131,47 @@ describe("AgentEngine", () => {
   });
 
   describe("spawnAgent", () => {
+    it("rate-limits spawn storms before creating extra surfaces", async () => {
+      let nowMs = 0;
+      const guardedEngine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          spawnGuard: new SpawnGuard(
+            {
+              maxPerWindow: 8,
+              maxPerWorkspacePerWindow: 8,
+              windowMs: 6000,
+            },
+            () => nowMs,
+          ),
+        },
+      );
+
+      let rejected = 0;
+      for (let i = 0; i < 44; i++) {
+        try {
+          await guardedEngine.spawnAgent({
+            repo: "brainlayer",
+            model: "codex",
+            cli: "codex",
+            prompt: "Fix gap F",
+            workspace: "workspace:brainlayer",
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(SpawnRateLimitedError);
+          rejected++;
+        }
+      }
+
+      expect(rejected).toBe(36);
+      expect(mockClient.newSplit).toHaveBeenCalledTimes(8);
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+      guardedEngine.dispose();
+    });
+
     it("creates a cmux surface and returns agent handle", async () => {
       const result = await engine.spawnAgent({
         repo: "brainlayer",

--- a/tests/spawn-guard.test.ts
+++ b/tests/spawn-guard.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  defaultSpawnGuardConfig,
+  SpawnGuard,
+  SpawnRateLimitedError,
+} from "../src/spawn-guard.js";
+
+const ENV_KEYS = [
+  "CMUXLAYER_MAX_SPAWNS_PER_WINDOW",
+  "CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW",
+  "CMUXLAYER_SPAWN_WINDOW_MS",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function clearSpawnEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreSpawnEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("SpawnGuard", () => {
+  afterEach(() => {
+    restoreSpawnEnv();
+  });
+
+  it("limits a 44-spawn storm to the configured sliding-window cap", () => {
+    let nowMs = 0;
+    const guard = new SpawnGuard(
+      {
+        maxPerWindow: 8,
+        maxPerWorkspacePerWindow: 8,
+        windowMs: 6000,
+      },
+      () => nowMs,
+    );
+
+    let succeeded = 0;
+    let rejected = 0;
+    let lastError: SpawnRateLimitedError | null = null;
+
+    for (let i = 0; i < 44; i++) {
+      try {
+        guard.check("workspace:1");
+        succeeded++;
+      } catch (error) {
+        expect(error).toBeInstanceOf(SpawnRateLimitedError);
+        lastError = error as SpawnRateLimitedError;
+        rejected++;
+      }
+      nowMs += i < 5 ? 1 : 0;
+    }
+
+    expect(succeeded).toBe(8);
+    expect(rejected).toBe(36);
+    expect(lastError?.code).toBe("SPAWN_RATE_LIMITED");
+    expect(lastError?.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("allows a human-paced burst of six default-config spawns in one workspace", () => {
+    clearSpawnEnv();
+    let nowMs = 0;
+    const guard = new SpawnGuard(defaultSpawnGuardConfig(), () => nowMs);
+
+    for (let i = 0; i < 6; i++) {
+      expect(() => guard.check("workspace:leads")).not.toThrow();
+      nowMs += 400;
+    }
+  });
+
+  it("refills capacity after the sliding window passes", () => {
+    let nowMs = 0;
+    const guard = new SpawnGuard(
+      {
+        maxPerWindow: 10,
+        maxPerWorkspacePerWindow: 3,
+        windowMs: 1000,
+      },
+      () => nowMs,
+    );
+
+    guard.check("workspace:1");
+    guard.check("workspace:1");
+    guard.check("workspace:1");
+    expect(() => guard.check("workspace:1")).toThrow(SpawnRateLimitedError);
+
+    nowMs = 1001;
+
+    expect(() => guard.check("workspace:1")).not.toThrow();
+  });
+
+  it("isolates per-workspace caps while global capacity remains", () => {
+    let nowMs = 0;
+    const guard = new SpawnGuard(
+      {
+        maxPerWindow: 10,
+        maxPerWorkspacePerWindow: 2,
+        windowMs: 1000,
+      },
+      () => nowMs,
+    );
+
+    guard.check("workspace:A");
+    guard.check("workspace:A");
+    expect(() => guard.check("workspace:A")).toThrow(SpawnRateLimitedError);
+    expect(() => guard.check("workspace:B")).not.toThrow();
+  });
+
+  it("reads positive environment overrides and falls back for invalid values", () => {
+    clearSpawnEnv();
+    process.env.CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW = "2";
+    expect(defaultSpawnGuardConfig().maxPerWorkspacePerWindow).toBe(2);
+
+    process.env.CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW = "0";
+    process.env.CMUXLAYER_MAX_SPAWNS_PER_WINDOW = "garbage";
+    process.env.CMUXLAYER_SPAWN_WINDOW_MS = "-5";
+
+    expect(defaultSpawnGuardConfig()).toEqual({
+      maxPerWindow: 50,
+      maxPerWorkspacePerWindow: 25,
+      windowMs: 10000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a sliding-window spawn rate limiter at the AgentEngine.spawnAgent chokepoint, before surface creation.
- Caps spawns globally and per workspace with env-tunable defaults: CMUXLAYER_MAX_SPAWNS_PER_WINDOW=50, CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW=25, CMUXLAYER_SPAWN_WINDOW_MS=10000.
- Leaves recoverCrashedAgents un-limited and preserves parent hierarchy checks before the rate limiter.

## Problem
On 2026-06-02, an orchestrator fired roughly 44 spawn_agent calls in 6s. Root-level spawns were unguarded, so cmuxlayer accepted the storm and churned cmux surfaces.

## Fix
A rate-limiter-only circuit breaker records granted spawns in global and per-workspace sliding windows. Defaults sit above legitimate parent fan-out and multi-lead revivals, while 44-in-6s single-workspace storms trip the per-workspace cap. Stricter environments can tune the caps down with env vars.

## Tests
- bun run typecheck
- bun run test
- Money test: 44 rapid calls with injected 8/6s config yields 8 successes and 36 SPAWN_RATE_LIMITED rejections.
- Optional engine test verifies AgentEngine creates no more than 8 surfaces under the injected storm config.

NOTE: this changes live spawn behavior — hold merge for Etan's morning OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live spawn behavior with a new failure mode callers must handle; defaults are tuned to allow normal fan-out but mis-tuned env vars could block legitimate bursts.
> 
> **Overview**
> Adds a **spawn-storm circuit breaker** on `AgentEngine.spawnAgent`: after parent/depth checks and **before** preflight or cmux surface creation, `spawnGuard.check(workspace)` enforces sliding-window caps globally and per workspace.
> 
> New module **`spawn-guard.ts`** defines `SpawnGuard`, `SpawnRateLimitedError` (`code: SPAWN_RATE_LIMITED`, `retryAfterMs`, `scope`), and defaults (50 global / 25 per workspace / 10s) overridable via `CMUXLAYER_MAX_SPAWNS_PER_WINDOW`, `CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW`, and `CMUXLAYER_SPAWN_WINDOW_MS`. Engines accept an optional injectable `spawnGuard` for tests.
> 
> **Behavioral change:** orchestrators and MCP callers can now fail fast with `SpawnRateLimitedError` instead of creating surfaces. Crash recovery paths that bypass `spawnAgent` are unchanged by this PR.
> 
> Tests cover guard semantics (window refill, workspace isolation, env parsing) and an engine integration case where 44 rapid spawns only create eight surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d73811a549efb21e183e8c41df5d3024feb235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sliding-window spawn rate limiter to `AgentEngine` to prevent spawn storms
> - Introduces `SpawnGuard` in [spawn-guard.ts](https://github.com/EtanHey/cmuxlayer/pull/120/files#diff-02d0819b3c6d08822345e07738415b5628e0a3e65c6e7c1e01017cfa9ccc29d1), a sliding-window rate limiter that tracks spawn timestamps globally and per workspace, throwing `SpawnRateLimitedError` on violations before any cmux surface is created.
> - `AgentEngine` accepts an optional `spawnGuard` in its options and calls `spawnGuard.check(workspace)` at the start of `spawnAgent`, short-circuiting the spawn flow when limits are exceeded.
> - Limits are configured via environment variables (`CMUXLAYER_MAX_SPAWNS_PER_WINDOW`, `CMUXLAYER_MAX_SPAWNS_PER_WORKSPACE_PER_WINDOW`, `CMUXLAYER_SPAWN_WINDOW_MS`) with hard-coded defaults when variables are absent or invalid.
> - `SpawnRateLimitedError` includes `retryAfterMs` and `scope` fields so callers can handle back-off appropriately.
> - Behavioral Change: `spawnAgent` can now throw `SpawnRateLimitedError` before reaching preflight or surface creation, which is a new failure mode callers must handle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85d7381.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->