### PR TITLE
fix(F8): honor spawn_agent model param (silent model-drift)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -270,7 +270,6 @@ const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
     haiku: "haiku",
   },
   codex: {
-    codex: "gpt-5.3-codex-spark",
     "gpt-5": "gpt-5",
     "gpt-5-codex": "gpt-5-codex",
     "gpt-5.3": "gpt-5.3",

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6,7 +6,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
-import { sanitizeTerminalInput } from "./sanitize.js";
+import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import {
   resolveAgentRoute as resolvePublicAgentRoute,
@@ -263,21 +263,82 @@ function sanitizeRepoName(repo: string): string {
   return safeRepo;
 }
 
-export function buildLaunchCommand(cli: CliType, repo: string): string {
+const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
+  claude: {
+    opus: "opus",
+    sonnet: "sonnet",
+    haiku: "haiku",
+  },
+  codex: {
+    codex: "gpt-5.3-codex-spark",
+    "gpt-5": "gpt-5",
+    "gpt-5-codex": "gpt-5-codex",
+    "gpt-5.3": "gpt-5.3",
+    "gpt-5.3-codex": "gpt-5.3-codex",
+    "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+    "gpt-5.4": "gpt-5.4",
+    "gpt-5.4-mini": "gpt-5.4-mini",
+    "gpt-5.5": "gpt-5.5",
+    "gpt-5.5-mini": "gpt-5.5-mini",
+  },
+  cursor: {
+    codex: "gpt-5",
+    "gpt-5": "gpt-5",
+    "gpt-5.2-codex-high": "gpt-5.2-codex-high",
+    "gpt-5.2-codex-xhigh": "gpt-5.2-codex-xhigh",
+    sonnet: "sonnet-4",
+    "sonnet-4": "sonnet-4",
+    "sonnet-4-thinking": "sonnet-4-thinking",
+  },
+  gemini: {
+    "gemini-2.5-pro": "gemini-2.5-pro",
+    "gemini-2.5-flash": "gemini-2.5-flash",
+    "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+    "gemini-3.1-pro": "gemini-3.1-pro",
+  },
+  kiro: {
+    opus: "opus",
+    sonnet: "sonnet",
+    haiku: "haiku",
+  },
+};
+
+function resolveModelFlag(cli: CliType, model?: string): string | null {
+  const normalized = model?.trim().toLowerCase();
+  if (!normalized || !isSafeShellToken(normalized)) {
+    return null;
+  }
+
+  const mapped = MODEL_FLAG_ALIASES[cli][normalized];
+  if (!mapped || !isSafeShellToken(mapped)) {
+    return null;
+  }
+
+  return mapped;
+}
+
+export function buildLaunchCommand(
+  cli: CliType,
+  repo: string,
+  model?: string,
+): string {
   const safeRepo = sanitizeRepoName(repo);
+  const modelFlag = resolveModelFlag(cli, model);
+  const launcherModelArgs = modelFlag ? ` -m ${modelFlag}` : "";
+  const rawModelArgs = modelFlag ? ` --model ${modelFlag}` : "";
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry
-      return `${safeRepo}Claude -s`;
+      return `${safeRepo}Claude -s${launcherModelArgs}`;
     case "codex":
-      return `${safeRepo}Codex -s`;
+      return `${safeRepo}Codex -s${launcherModelArgs}`;
     case "gemini":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini${rawModelArgs}`;
     case "kiro":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli`;
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli${rawModelArgs}`;
     case "cursor":
       // repoGolem launcher - requires registration via golem-powers.
-      return `${safeRepo}Cursor -s`;
+      return `${safeRepo}Cursor -s${launcherModelArgs}`;
   }
 }
 
@@ -1107,7 +1168,7 @@ export class AgentEngine {
     this.registry.set(agentId, record);
 
     // 3. Send launch command
-    const launchCmd = buildLaunchCommand(params.cli, params.repo);
+    const launchCmd = buildLaunchCommand(params.cli, params.repo, params.model);
     try {
       await this.sendLaunchCommand(surface.surface, surface.workspace, launchCmd);
     } catch (error) {

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -16,3 +16,7 @@ export function sanitizeTerminalInput(text: string): string {
   result = result.replace(/[\x80-\x9f]/g, "");
   return result;
 }
+
+export function isSafeShellToken(text: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(text);
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -197,7 +197,7 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).toHaveBeenCalled();
     });
 
-    it("launches Claude via repoGolem launcher", async () => {
+    it("launches Claude via repoGolem launcher with requested model tier", async () => {
       await engine.spawnAgent({
         repo: "brainlayer",
         model: "sonnet",
@@ -210,7 +210,7 @@ describe("AgentEngine", () => {
       ).mock.calls[0];
       expect(surface).toBe("surface:new");
       expect(opts).toEqual({ workspace: "ws:1" });
-      expect(launchCmd).toBe("brainlayerClaude -s");
+      expect(launchCmd).toBe("brainlayerClaude -s -m sonnet");
     });
 
     it("writes initial state file", async () => {
@@ -1785,9 +1785,51 @@ describe("buildLaunchCommand", () => {
     );
   });
 
+  it("adds safe model flags for recognized launcher model aliases", () => {
+    expect(buildLaunchCommand("claude", "brainlayer", "sonnet")).toBe(
+      "brainlayerClaude -s -m sonnet",
+    );
+    expect(
+      buildLaunchCommand("codex", "brainlayer", "gpt-5.3-codex-spark"),
+    ).toBe("brainlayerCodex -s -m gpt-5.3-codex-spark");
+    expect(buildLaunchCommand("codex", "brainlayer", "codex")).toBe(
+      "brainlayerCodex -s -m gpt-5.3-codex-spark",
+    );
+    expect(buildLaunchCommand("cursor", "cmuxlayer", "sonnet")).toBe(
+      "cmuxlayerCursor -s -m sonnet-4",
+    );
+  });
+
+  it("preserves launcher defaults when model is omitted", () => {
+    expect(buildLaunchCommand("claude", "brainlayer", undefined)).toBe(
+      "brainlayerClaude -s",
+    );
+  });
+
+  it("omits unsafe or unrecognized model values instead of passing them raw", () => {
+    expect(
+      buildLaunchCommand("claude", "brainlayer", "Opus 4.8 (1M context)"),
+    ).toBe("brainlayerClaude -s");
+    expect(buildLaunchCommand("codex", "brainlayer", "gpt-5.5 xhigh")).toBe(
+      "brainlayerCodex -s",
+    );
+    expect(buildLaunchCommand("codex", "brainlayer", "codex;rm-rf")).toBe(
+      "brainlayerCodex -s",
+    );
+  });
+
   it("uses cd + env vars + raw command for gemini", () => {
     expect(buildLaunchCommand("gemini", "voicelayer")).toBe(
       "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini",
+    );
+  });
+
+  it("adds safe --model flags for recognized raw CLI model aliases", () => {
+    expect(buildLaunchCommand("gemini", "voicelayer", "gemini-2.5-pro")).toBe(
+      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini --model gemini-2.5-pro",
+    );
+    expect(buildLaunchCommand("kiro", "golems", "sonnet")).toBe(
+      "cd ~/Gits/golems && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli --model sonnet",
     );
   });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1793,7 +1793,7 @@ describe("buildLaunchCommand", () => {
       buildLaunchCommand("codex", "brainlayer", "gpt-5.3-codex-spark"),
     ).toBe("brainlayerCodex -s -m gpt-5.3-codex-spark");
     expect(buildLaunchCommand("codex", "brainlayer", "codex")).toBe(
-      "brainlayerCodex -s -m gpt-5.3-codex-spark",
+      "brainlayerCodex -s",
     );
     expect(buildLaunchCommand("cursor", "cmuxlayer", "sonnet")).toBe(
       "cmuxlayerCursor -s -m sonnet-4",

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -367,7 +367,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s") {
+        if (lastSentText === "voicelayerCodex -s -m gpt-5.3-codex-spark") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -380,7 +380,7 @@ describe("agent lifecycle tool handlers", () => {
               lastSentText === ""
                 ? "$ "
                 : launcherReturnCount < 2
-                ? "$ voicelayerCodex -s"
+                ? "$ voicelayerCodex -s -m gpt-5.3-codex-spark"
                 : "codex> ",
             lines: 20,
             scrollback_used: false,
@@ -509,7 +509,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s") {
+        if (lastSentText === "voicelayerCodex -s -m gpt-5.3-codex-spark") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -521,7 +521,7 @@ describe("agent lifecycle tool handlers", () => {
             text:
               lastSentText === ""
                 ? "$ "
-                : "$ voicelayerCodex -s\ncodex> ",
+                : "$ voicelayerCodex -s -m gpt-5.3-codex-spark\ncodex> ",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -367,7 +367,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s -m gpt-5.3-codex-spark") {
+        if (lastSentText === "voicelayerCodex -s") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -380,7 +380,7 @@ describe("agent lifecycle tool handlers", () => {
               lastSentText === ""
                 ? "$ "
                 : launcherReturnCount < 2
-                ? "$ voicelayerCodex -s -m gpt-5.3-codex-spark"
+                ? "$ voicelayerCodex -s"
                 : "codex> ",
             lines: 20,
             scrollback_used: false,
@@ -509,7 +509,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s -m gpt-5.3-codex-spark") {
+        if (lastSentText === "voicelayerCodex -s") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -521,7 +521,7 @@ describe("agent lifecycle tool handlers", () => {
             text:
               lastSentText === ""
                 ? "$ "
-                : "$ voicelayerCodex -s -m gpt-5.3-codex-spark\ncodex> ",
+                : "$ voicelayerCodex -s\ncodex> ",
             lines: 20,
             scrollback_used: false,
           }),


### PR DESCRIPTION
## Bug

F8: `spawn_agent({ model })` persisted the requested model on the agent record, but the value never reached the launch command. `buildLaunchCommand` only accepted `cli` and `repo`, so repoGolem launchers and raw Gemini/Kiro commands kept using their defaults, creating silent model drift.

## Fix

- Threaded `params.model` into `buildLaunchCommand(cli, repo, model)`.
- Added per-CLI alias mapping before any launch flag is emitted.
- Added a shared safe shell token predicate allowing only `[A-Za-z0-9._-]+`.
- RepoGolem launchers now receive `-m <mapped>` for Claude, Codex, and Cursor when the model is explicitly recognized.
- Raw Gemini/Kiro commands now receive `--model <mapped>` after the binary when the model is explicitly recognized.

## Mapping and fallback

Implemented alias-to-flag mapping:

- Claude: `opus -> opus`, `sonnet -> sonnet`, `haiku -> haiku`
- Codex: `gpt-5`, `gpt-5-codex`, `gpt-5.3`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.5-mini`
- Cursor: `codex -> gpt-5`, `gpt-5`, `gpt-5.2-codex-high`, `gpt-5.2-codex-xhigh`, `sonnet -> sonnet-4`, `sonnet-4`, `sonnet-4-thinking`
- Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-pro`
- Kiro: `opus -> opus`, `sonnet -> sonnet`, `haiku -> haiku`

Codex-specific fallback: generic `model: "codex"` intentionally resolves to null and omits `-m`, preserving the repoGolem launcher default/main pool. Explicit `model: "gpt-5.3-codex-spark"` still maps through for callers that intentionally request Spark.

If the requested model is omitted, empty, unrecognized, a display string like `Opus 4.8 (1M context)`, or fails the safe-token check, cmuxlayer omits the model flag and preserves the launcher default. It never forwards raw unrecognized values.

## Tests

- RED observed for original F8: `bun run test tests/agent-engine.test.ts` failed on missing model flags.
- RED observed for Codex fallback update: `bun run test tests/agent-engine.test.ts` failed while generic `codex` still emitted Spark.
- Focused regression: `bun run test tests/agent-engine.test.ts` -> 82 passed.
- Typecheck: `bun run typecheck` -> exit 0.
- Full suite: `bun run test` -> 35 files passed, 569 tests passed.
- Push hook also reran Bun regression checks plus full suite and finished with exit status 0.

review-required, do not merge. orc merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)