### PR TITLE
fix: expose columns and dock worker spawns

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -97,23 +97,33 @@ function describePaneLayouts(
   });
 }
 
-function byPaneIndex(a: PaneLayout, b: PaneLayout): number {
-  return a.pane.index - b.pane.index;
-}
+export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
+  const sortedGroups = [
+    ...new Map(
+      [...panes]
+        .sort((a, b) => {
+          const aPosition = a.pixel_frame?.x ?? a.index;
+          const bPosition = b.pixel_frame?.x ?? b.index;
+          return aPosition - bPosition || a.index - b.index;
+        })
+        .map((pane) => [
+          pane.pixel_frame ? `x:${pane.pixel_frame.x}` : `index:${pane.index}`,
+          pane,
+        ]),
+    ).keys(),
+  ];
+  const columnByGroup = new Map(
+    sortedGroups.map((group, index) => [group, index]),
+  );
 
-function leftmost(layouts: PaneLayout[]): PaneLayout | undefined {
-  return [...layouts].sort(byPaneIndex).at(0);
-}
-
-function rightmost(layouts: PaneLayout[]): PaneLayout | undefined {
-  return [...layouts].sort(byPaneIndex).at(-1);
-}
-
-function splitRightOfRightmost(layouts: PaneLayout[]): AgentSpawnPlacement {
-  const rightmostPane = rightmost(layouts);
-  return rightmostPane
-    ? { kind: "split", direction: "right", pane: rightmostPane.pane.ref }
-    : { kind: "split", direction: "right" };
+  return new Map(
+    panes.map((pane) => {
+      const group = pane.pixel_frame
+        ? `x:${pane.pixel_frame.x}`
+        : `index:${pane.index}`;
+      return [pane.ref, columnByGroup.get(group) ?? 0];
+    }),
+  );
 }
 
 function isDedicatedOrchestratorPane(layout: PaneLayout): boolean {
@@ -158,6 +168,18 @@ function isWorkerDockPane(layout: PaneLayout): boolean {
     layout.icCount === 0 &&
     layout.workerCount > 0 &&
     layout.workerCount > layout.nonRoleCount
+  );
+}
+
+function isNonLeadWorkerZonePane(
+  layout: PaneLayout,
+  leftPane: PaneLayout | undefined,
+): boolean {
+  return (
+    layout.pane.ref !== leftPane?.pane.ref &&
+    layout.orchestratorCount === 0 &&
+    layout.icCount === 0 &&
+    (layout.workerCount > 0 || layout.unknownCount > 0)
   );
 }
 
@@ -365,7 +387,17 @@ export function chooseAgentSpawnPlacement(
   const roleSurfaceIds = normalizeRoleSurfaceIds(roleSurfaceIdsInput);
   const role = context.role ?? "worker";
   const layouts = describePaneLayouts(panes, paneSurfaces, roleSurfaceIds);
-  const leftPane = leftmost(layouts);
+  const columnByPane = deriveColumnIndex(panes);
+  const byColumnThenIndex = (a: PaneLayout, b: PaneLayout): number => {
+    const aColumn = columnByPane.get(a.pane.ref) ?? a.pane.index;
+    const bColumn = columnByPane.get(b.pane.ref) ?? b.pane.index;
+    return aColumn - bColumn || a.pane.index - b.pane.index;
+  };
+  const leftmostByColumn = (candidates: PaneLayout[]) =>
+    [...candidates].sort(byColumnThenIndex).at(0);
+  const rightmostByColumn = (candidates: PaneLayout[]) =>
+    [...candidates].sort(byColumnThenIndex).at(-1);
+  const leftPane = leftmostByColumn(layouts);
 
   if (layouts.length === 0) {
     return { kind: "split", direction: "right" };
@@ -373,7 +405,7 @@ export function chooseAgentSpawnPlacement(
 
   if (role === "orchestrator") {
     const orchestratorPane =
-      leftmost(layouts.filter(isDedicatedOrchestratorPane)) ??
+      leftmostByColumn(layouts.filter(isDedicatedOrchestratorPane)) ??
       (leftPane && leftPane.icCount === 0 && leftPane.workerCount === 0
         ? leftPane
         : undefined);
@@ -386,11 +418,11 @@ export function chooseAgentSpawnPlacement(
   const icPanes = layouts.filter(isDedicatedIcPane);
 
   if (role === "ic") {
-    const icPane = rightmost(icPanes);
+    const icPane = rightmostByColumn(icPanes);
     if (icPane) {
       return { kind: "surface", pane: icPane.pane.ref };
     }
-    const workerPane = rightmost(workerPanes);
+    const workerPane = rightmostByColumn(workerPanes);
     if (workerPane) {
       return {
         kind: "split",
@@ -408,6 +440,13 @@ export function chooseAgentSpawnPlacement(
     );
     if (childPane && isDedicatedWorkerPane(childPane)) {
       return { kind: "surface", pane: childPane.pane.ref };
+    }
+
+    const workerZonePane = rightmostByColumn(
+      layouts.filter((layout) => isNonLeadWorkerZonePane(layout, leftPane)),
+    );
+    if (workerZonePane) {
+      return { kind: "surface", pane: workerZonePane.pane.ref };
     }
 
     const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
@@ -429,6 +468,13 @@ export function chooseAgentSpawnPlacement(
       return { kind: "surface", pane: childPane.pane.ref };
     }
 
+    const workerZonePane = rightmostByColumn(
+      layouts.filter((layout) => isNonLeadWorkerZonePane(layout, leftPane)),
+    );
+    if (workerZonePane) {
+      return { kind: "surface", pane: workerZonePane.pane.ref };
+    }
+
     const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
     if (parentPane) {
       return {
@@ -442,7 +488,9 @@ export function chooseAgentSpawnPlacement(
   // Dock into the rightmost pane workers already own — including one that
   // carries a stray non-role tab — so a populated workers pane never gets a
   // redundant third pane split off beside it.
-  const rightmostWorkerPane = rightmost(layouts.filter(isWorkerDockPane));
+  const rightmostWorkerPane = rightmostByColumn(
+    layouts.filter(isWorkerDockPane),
+  );
   if (rightmostWorkerPane) {
     return { kind: "surface", pane: rightmostWorkerPane.pane.ref };
   }
@@ -451,7 +499,7 @@ export function chooseAgentSpawnPlacement(
     (layout) => layout.workerCount > 0 || layout.unknownCount > 0,
   );
   if (!hasLiveWorkerOrUnknownSurface) {
-    const sparseWorkerZonePane = rightmost(
+    const sparseWorkerZonePane = rightmostByColumn(
       layouts.filter(
         (layout) =>
           layout.pane.ref !== leftPane?.pane.ref &&
@@ -463,7 +511,7 @@ export function chooseAgentSpawnPlacement(
     }
   }
 
-  const mixedWorkerPane = rightmost(
+  const mixedWorkerPane = rightmostByColumn(
     layouts.filter(
       (layout) =>
         (layout.workerCount > 0 || layout.unknownCount > 0) &&
@@ -471,6 +519,10 @@ export function chooseAgentSpawnPlacement(
     ),
   );
   if (mixedWorkerPane) {
+    if (isNonLeadWorkerZonePane(mixedWorkerPane, leftPane)) {
+      return { kind: "surface", pane: mixedWorkerPane.pane.ref };
+    }
+
     return {
       kind: "split",
       direction: "right",
@@ -478,7 +530,7 @@ export function chooseAgentSpawnPlacement(
     };
   }
 
-  const rightmostIcPane = rightmost(icPanes);
+  const rightmostIcPane = rightmostByColumn(icPanes);
   if (rightmostIcPane) {
     return {
       kind: "split",
@@ -487,7 +539,10 @@ export function chooseAgentSpawnPlacement(
     };
   }
 
-  return splitRightOfRightmost(layouts);
+  const rightmostPane = rightmostByColumn(layouts);
+  return rightmostPane
+    ? { kind: "split", direction: "right", pane: rightmostPane.pane.ref }
+    : { kind: "split", direction: "right" };
 }
 
 /**

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -98,16 +98,17 @@ function describePaneLayouts(
 }
 
 export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
+  const useGeometry = panes.every((pane) => pane.pixel_frame);
   const sortedGroups = [
     ...new Map(
       [...panes]
         .sort((a, b) => {
-          const aPosition = a.pixel_frame?.x ?? a.index;
-          const bPosition = b.pixel_frame?.x ?? b.index;
+          const aPosition = useGeometry ? a.pixel_frame!.x : a.index;
+          const bPosition = useGeometry ? b.pixel_frame!.x : b.index;
           return aPosition - bPosition || a.index - b.index;
         })
         .map((pane) => [
-          pane.pixel_frame ? `x:${pane.pixel_frame.x}` : `index:${pane.index}`,
+          useGeometry ? `x:${pane.pixel_frame!.x}` : `index:${pane.index}`,
           pane,
         ]),
     ).keys(),
@@ -118,8 +119,8 @@ export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
 
   return new Map(
     panes.map((pane) => {
-      const group = pane.pixel_frame
-        ? `x:${pane.pixel_frame.x}`
+      const group = useGeometry
+        ? `x:${pane.pixel_frame!.x}`
         : `index:${pane.index}`;
       return [pane.ref, columnByGroup.get(group) ?? 0];
     }),
@@ -175,11 +176,19 @@ function isNonLeadWorkerZonePane(
   layout: PaneLayout,
   leftPane: PaneLayout | undefined,
 ): boolean {
+  const workerZoneCount = layout.workerCount + layout.unknownCount;
+  const nonWorkerZoneCount =
+    layout.surfaces.length -
+    layout.orchestratorCount -
+    layout.icCount -
+    workerZoneCount;
+
   return (
     layout.pane.ref !== leftPane?.pane.ref &&
     layout.orchestratorCount === 0 &&
     layout.icCount === 0 &&
-    (layout.workerCount > 0 || layout.unknownCount > 0)
+    workerZoneCount > 0 &&
+    workerZoneCount > nonWorkerZoneCount
   );
 }
 
@@ -442,13 +451,6 @@ export function chooseAgentSpawnPlacement(
       return { kind: "surface", pane: childPane.pane.ref };
     }
 
-    const workerZonePane = rightmostByColumn(
-      layouts.filter((layout) => isNonLeadWorkerZonePane(layout, leftPane)),
-    );
-    if (workerZonePane) {
-      return { kind: "surface", pane: workerZonePane.pane.ref };
-    }
-
     const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
     if (parentPane) {
       return {
@@ -466,13 +468,6 @@ export function chooseAgentSpawnPlacement(
     );
     if (childPane && isWorkerDockPane(childPane)) {
       return { kind: "surface", pane: childPane.pane.ref };
-    }
-
-    const workerZonePane = rightmostByColumn(
-      layouts.filter((layout) => isNonLeadWorkerZonePane(layout, leftPane)),
-    );
-    if (workerZonePane) {
-      return { kind: "surface", pane: workerZonePane.pane.ref };
     }
 
     const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import {
   collectRoleSurfaceIds,
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
+  deriveColumnIndex,
   inferAgentRole,
   launcherNameForCli,
 } from "./layout-policy.js";
@@ -283,6 +284,12 @@ function toMinimalSurface(
       typeof surface.workspace_ref === "string" ? surface.workspace_ref : "",
   };
 
+  if (typeof surface.pane_ref === "string") {
+    minimal.pane_ref = surface.pane_ref;
+  }
+  if (typeof surface.column === "number") {
+    minimal.column = surface.column;
+  }
   if (typeof surface.screen_preview === "string") {
     minimal.screen_preview = surface.screen_preview;
   }
@@ -868,6 +875,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     verify_submit: boolean;
   }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
     if (!opts.verify_submit) {
+      // null means submit verification was not attempted, usually because the
+      // command was at or below SEND_INPUT_CHUNK_THRESHOLD; it is not a failure.
       return { submit_verified: null, retry_count: 0 };
     }
 
@@ -1317,14 +1326,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             panes: await client.listPanes({ workspace: workspaceRef }),
           })),
         );
+        const columnIndexByWorkspace = new Map<string, Map<string, number>>();
+        const columnCountByWorkspace = new Map<string, number>();
+        for (const { workspaceRef, panes } of panesByWorkspace) {
+          const columnIndex = deriveColumnIndex(panes.panes);
+          columnIndexByWorkspace.set(workspaceRef, columnIndex);
+          columnCountByWorkspace.set(
+            workspaceRef,
+            new Set(columnIndex.values()).size,
+          );
+        }
         const surfaceGroups = await Promise.all(
           panesByWorkspace.flatMap(({ workspaceRef, panes }) =>
-            panes.panes.map((pane) =>
-              client.listPaneSurfaces({
+            panes.panes.map(async (pane) => {
+              const group = await client.listPaneSurfaces({
                 workspace: workspaceRef,
                 pane: pane.ref,
-              }),
-            ),
+              });
+              return {
+                ...group,
+                workspace_ref: group.workspace_ref ?? workspaceRef,
+                pane_ref: group.pane_ref ?? pane.ref,
+              };
+            }),
           ),
         );
         const uniqueSurfaceEntries: Array<{
@@ -1363,6 +1387,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               window_ref: group.window_ref,
               pane_ref: group.pane_ref,
             };
+            const column = columnIndexByWorkspace
+              .get(group.workspace_ref)
+              ?.get(group.pane_ref);
+            if (typeof column === "number") {
+              enrichedSurface.column = column;
+            }
 
             if (args.include_screen_preview && surface.type === "terminal") {
               try {
@@ -1394,6 +1424,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const data: Record<string, unknown> = {
           workspaces: responseWorkspaces,
           surfaces: responseSurfaces,
+          column_count: targetWorkspaceRefs.reduce(
+            (max, workspaceRef) =>
+              Math.max(max, columnCountByWorkspace.get(workspaceRef) ?? 0),
+            0,
+          ),
         };
         if (args.workspace) {
           data.workspace_ref = args.workspace;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,12 @@ export interface CmuxPane {
   surface_count: number;
   surface_refs: string[];
   selected_surface_ref?: string;
+  pixel_frame?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
 }
 
 export interface CmuxPaneSurfaces {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
+  deriveColumnIndex,
   inferAgentRole,
   launcherNameForCli,
 } from "../src/layout-policy.js";
@@ -11,6 +12,7 @@ function makePane(
   ref: string,
   index: number,
   surfaceRefs: string[],
+  pixelFrame?: CmuxPane["pixel_frame"],
 ): CmuxPane {
   return {
     ref,
@@ -19,6 +21,7 @@ function makePane(
     surface_count: surfaceRefs.length,
     surface_refs: surfaceRefs,
     selected_surface_ref: surfaceRefs[0],
+    ...(pixelFrame ? { pixel_frame: pixelFrame } : {}),
   };
 }
 
@@ -45,6 +48,52 @@ function makePaneSurfaces(
 }
 
 describe("layout policy", () => {
+  it("derives columns from distinct pane x positions", () => {
+    const columns = deriveColumnIndex([
+      makePane("pane:left", 0, [], { x: 10, y: 0, width: 300, height: 800 }),
+      makePane("pane:middle", 1, [], { x: 320, y: 0, width: 300, height: 800 }),
+      makePane("pane:right", 2, [], { x: 640, y: 0, width: 300, height: 800 }),
+    ]);
+
+    expect(columns.get("pane:left")).toBe(0);
+    expect(columns.get("pane:middle")).toBe(1);
+    expect(columns.get("pane:right")).toBe(2);
+  });
+
+  it("assigns the same column to panes sharing an x position", () => {
+    const columns = deriveColumnIndex([
+      makePane("pane:left", 0, [], { x: 10, y: 0, width: 300, height: 400 }),
+      makePane("pane:right-top", 1, [], {
+        x: 320,
+        y: 0,
+        width: 300,
+        height: 400,
+      }),
+      makePane("pane:right-bottom", 2, [], {
+        x: 320,
+        y: 400,
+        width: 300,
+        height: 400,
+      }),
+    ]);
+
+    expect(columns.get("pane:left")).toBe(0);
+    expect(columns.get("pane:right-top")).toBe(1);
+    expect(columns.get("pane:right-bottom")).toBe(1);
+  });
+
+  it("falls back to pane index ordering when geometry is missing", () => {
+    const columns = deriveColumnIndex([
+      makePane("pane:third", 2, []),
+      makePane("pane:first", 0, []),
+      makePane("pane:second", 1, []),
+    ]);
+
+    expect(columns.get("pane:first")).toBe(0);
+    expect(columns.get("pane:second")).toBe(1);
+    expect(columns.get("pane:third")).toBe(2);
+  });
+
   it("infers default role from repoGolem launcher names", () => {
     expect(inferAgentRole({ launcherName: "orcClaude" })).toBe(
       "orchestrator",
@@ -419,6 +468,76 @@ describe("layout policy", () => {
       direction: "right",
       pane: "pane:left",
     });
+  });
+
+  it("docks into an existing non-lead unknown worker zone instead of creating a third column", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+      makePane("pane:right", 1, ["surface:unknown-worker"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", ["surface:unknown-worker"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+        unknown: new Set(["surface:unknown-worker"]),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
+  it("uses geometry columns, not pane indexes, to identify the non-lead worker zone", () => {
+    const panes = [
+      makePane("pane:right", 0, ["surface:unknown-worker"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+      makePane("pane:left", 1, ["surface:orchestrator"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:right", ["surface:unknown-worker"]),
+      makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+        unknown: new Set(["surface:unknown-worker"]),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
   it("docks a parentless worker into the rightmost non-lead pane when roles are sparse", () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -94,6 +94,28 @@ describe("layout policy", () => {
     expect(columns.get("pane:third")).toBe(2);
   });
 
+  it("falls back to index ordering for all panes when any pane lacks geometry", () => {
+    const columns = deriveColumnIndex([
+      makePane("pane:geometric-left", 2, [], {
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 800,
+      }),
+      makePane("pane:index-first", 0, []),
+      makePane("pane:geometric-right", 1, [], {
+        x: 600,
+        y: 0,
+        width: 300,
+        height: 800,
+      }),
+    ]);
+
+    expect(columns.get("pane:index-first")).toBe(0);
+    expect(columns.get("pane:geometric-right")).toBe(1);
+    expect(columns.get("pane:geometric-left")).toBe(2);
+  });
+
   it("infers default role from repoGolem launcher names", () => {
     expect(inferAgentRole({ launcherName: "orcClaude" })).toBe(
       "orchestrator",
@@ -216,6 +238,41 @@ describe("layout policy", () => {
     });
   });
 
+  it("keeps a parent IC's first child local even when an unrelated worker zone exists", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orc"]),
+      makePane("pane:ic", 1, ["surface:ic"]),
+      makePane("pane:other-workers", 2, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orc"]),
+      makePaneSurfaces("pane:ic", ["surface:ic"]),
+      makePaneSurfaces("pane:other-workers", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orc"]),
+        ic: new Set(["surface:ic"]),
+        worker: new Set(["surface:worker-1"]),
+      },
+      {
+        role: "worker",
+        parentRole: "ic",
+        parentSurfaceId: "surface:ic",
+        childWorkerSurfaceIds: new Set(),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "down",
+      pane: "pane:ic",
+    });
+  });
+
   it("reuses an existing worker pane under the parent IC for sibling workers", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
@@ -267,6 +324,39 @@ describe("layout policy", () => {
         orchestrator: new Set(["surface:orchestrator"]),
         ic: new Set(),
         worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        childWorkerSurfaceIds: new Set(),
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+      pane: "pane:lead",
+    });
+  });
+
+  it("keeps a parent orchestrator's first child local even when an unrelated worker zone exists", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"]),
+      makePane("pane:other-workers", 1, ["surface:worker-1"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:other-workers", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
       },
       {
         role: "worker",
@@ -538,6 +628,35 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
+  it("repairs a contaminated non-lead unknown worker zone instead of docking into it", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"]),
+      makePane("pane:right", 1, ["surface:unknown-worker", "surface:shell"]),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", ["surface:unknown-worker", "surface:shell"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+        unknown: new Set(["surface:unknown-worker"]),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+      pane: "pane:right",
+    });
   });
 
   it("docks a parentless worker into the rightmost non-lead pane when roles are sparse", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -546,15 +546,213 @@ describe("tool handler integration", () => {
     expect(parsed.surfaces[0]).toEqual({
       ref: "surface:1",
       workspace_ref: "workspace:1",
+      pane_ref: "pane:1",
+      column: 0,
       title: "One",
       type: "terminal",
     });
     expect(parsed.surfaces[1]).toEqual({
       ref: "surface:2",
       workspace_ref: "workspace:1",
+      pane_ref: "pane:2",
+      column: 1,
       title: "Two",
       type: "browser",
     });
+  });
+
+  it("list_surfaces reports pane_ref, column, and column_count in condensed and verbose output", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:left"],
+            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+          },
+          {
+            ref: "pane:right-top",
+            index: 1,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:right-top"],
+            pixel_frame: { x: 500, y: 0, width: 500, height: 450 },
+          },
+          {
+            ref: "pane:right-bottom",
+            index: 2,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:right-bottom"],
+            pixel_frame: { x: 500, y: 450, width: 500, height: 450 },
+          },
+        ],
+      }),
+      listPaneSurfaces: vi
+        .fn()
+        .mockImplementation(async ({ pane }: { pane: string }) => ({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces: [
+            {
+              ref:
+                pane === "pane:left"
+                  ? "surface:left"
+                  : pane === "pane:right-top"
+                    ? "surface:right-top"
+                    : "surface:right-bottom",
+              title: pane,
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        })),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["list_surfaces"];
+
+    const condensedResult = await tool.handler({}, {} as any);
+    const condensed =
+      condensedResult.structuredContent ??
+      JSON.parse(condensedResult.content[0].text);
+
+    expect(condensed.column_count).toBe(2);
+    expect(condensed.surfaces).toEqual([
+      expect.objectContaining({
+        ref: "surface:left",
+        pane_ref: "pane:left",
+        column: 0,
+      }),
+      expect.objectContaining({
+        ref: "surface:right-top",
+        pane_ref: "pane:right-top",
+        column: 1,
+      }),
+      expect.objectContaining({
+        ref: "surface:right-bottom",
+        pane_ref: "pane:right-bottom",
+        column: 1,
+      }),
+    ]);
+
+    const verboseResult = await tool.handler({ verbose: true }, {} as any);
+    const verbose =
+      verboseResult.structuredContent ?? JSON.parse(verboseResult.content[0].text);
+
+    expect(verbose.column_count).toBe(2);
+    expect(verbose.surfaces).toEqual([
+      expect.objectContaining({
+        ref: "surface:left",
+        pane_ref: "pane:left",
+        column: 0,
+      }),
+      expect.objectContaining({
+        ref: "surface:right-top",
+        pane_ref: "pane:right-top",
+        column: 1,
+      }),
+      expect.objectContaining({
+        ref: "surface:right-bottom",
+        pane_ref: "pane:right-bottom",
+        column: 1,
+      }),
+    ]);
+  });
+
+  it("list_surfaces backfills pane_ref before assigning columns when the client omits it", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:left"],
+            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:right"],
+            pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+          },
+        ],
+      }),
+      listPaneSurfaces: vi
+        .fn()
+        .mockImplementation(async ({ pane }: { pane: string }) => ({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          surfaces: [
+            {
+              ref: pane === "pane:left" ? "surface:left" : "surface:right",
+              title: pane,
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        })),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["list_surfaces"];
+
+    const result = await tool.handler({}, {} as any);
+    const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.surfaces).toEqual([
+      expect.objectContaining({
+        ref: "surface:left",
+        pane_ref: "pane:left",
+        column: 0,
+      }),
+      expect.objectContaining({
+        ref: "surface:right",
+        pane_ref: "pane:right",
+        column: 1,
+      }),
+    ]);
+    expect(parsed.column_count).toBe(2);
   });
 
   it("list_surfaces keeps working when a screen preview fails", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -562,74 +562,86 @@ describe("tool handler integration", () => {
   });
 
   it("list_surfaces reports pane_ref, column, and column_count in condensed and verbose output", async () => {
-    const mockClient = {
-      listWorkspaces: vi.fn().mockResolvedValue({
-        workspaces: [
-          {
-            ref: "workspace:1",
-            title: "Main",
-            index: 0,
-            selected: true,
-            pinned: false,
-          },
-        ],
-      }),
-      listPanes: vi.fn().mockResolvedValue({
-        workspace_ref: "workspace:1",
-        window_ref: "window:1",
-        panes: [
-          {
-            ref: "pane:left",
-            index: 0,
-            focused: false,
-            surface_count: 1,
-            surface_refs: ["surface:left"],
-            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
-          },
-          {
-            ref: "pane:right-top",
-            index: 1,
-            focused: true,
-            surface_count: 1,
-            surface_refs: ["surface:right-top"],
-            pixel_frame: { x: 500, y: 0, width: 500, height: 450 },
-          },
-          {
-            ref: "pane:right-bottom",
-            index: 2,
-            focused: false,
-            surface_count: 1,
-            surface_refs: ["surface:right-bottom"],
-            pixel_frame: { x: 500, y: 450, width: 500, height: 450 },
-          },
-        ],
-      }),
-      listPaneSurfaces: vi
-        .fn()
-        .mockImplementation(async ({ pane }: { pane: string }) => ({
-          workspace_ref: "workspace:1",
-          window_ref: "window:1",
-          pane_ref: pane,
-          surfaces: [
-            {
-              ref:
-                pane === "pane:left"
-                  ? "surface:left"
-                  : pane === "pane:right-top"
-                    ? "surface:right-top"
-                    : "surface:right-bottom",
-              title: pane,
-              type: "terminal",
-              index: 0,
-              selected: true,
-            },
-          ],
-        })),
-    };
-    const server = createServer({
-      client: mockClient as any,
-      skipAgentLifecycle: true,
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:left"],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right-top",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:right-top"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 450 },
+              },
+              {
+                ref: "pane:right-bottom",
+                index: 2,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:right-bottom"],
+                pixel_frame: { x: 500, y: 450, width: 500, height: 450 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces: [
+              {
+                ref:
+                  pane === "pane:left"
+                    ? "surface:left"
+                    : pane === "pane:right-top"
+                      ? "surface:right-top"
+                      : "surface:right-bottom",
+                title: pane,
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
     });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["list_surfaces"];
 
     const condensedResult = await tool.handler({}, {} as any);
@@ -681,60 +693,72 @@ describe("tool handler integration", () => {
   });
 
   it("list_surfaces backfills pane_ref before assigning columns when the client omits it", async () => {
-    const mockClient = {
-      listWorkspaces: vi.fn().mockResolvedValue({
-        workspaces: [
-          {
-            ref: "workspace:1",
-            title: "Main",
-            index: 0,
-            selected: true,
-            pinned: false,
-          },
-        ],
-      }),
-      listPanes: vi.fn().mockResolvedValue({
-        workspace_ref: "workspace:1",
-        window_ref: "window:1",
-        panes: [
-          {
-            ref: "pane:left",
-            index: 0,
-            focused: false,
-            surface_count: 1,
-            surface_refs: ["surface:left"],
-            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
-          },
-          {
-            ref: "pane:right",
-            index: 1,
-            focused: true,
-            surface_count: 1,
-            surface_refs: ["surface:right"],
-            pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
-          },
-        ],
-      }),
-      listPaneSurfaces: vi
-        .fn()
-        .mockImplementation(async ({ pane }: { pane: string }) => ({
-          workspace_ref: "workspace:1",
-          window_ref: "window:1",
-          surfaces: [
-            {
-              ref: pane === "pane:left" ? "surface:left" : "surface:right",
-              title: pane,
-              type: "terminal",
-              index: 0,
-              selected: true,
-            },
-          ],
-        })),
-    };
-    const server = createServer({
-      client: mockClient as any,
-      skipAgentLifecycle: true,
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:left"],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:right"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            surfaces: [
+              {
+                ref: pane === "pane:left" ? "surface:left" : "surface:right",
+                title: pane,
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
     });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["list_surfaces"];
 
     const result = await tool.handler({}, {} as any);


### PR DESCRIPTION
## Summary
- Expose pane geometry through `CmuxPane.pixel_frame` and derive stable 0-based columns from distinct `pixel_frame.x` values, falling back to pane indexes when geometry is absent.
- Return `pane_ref`, `column`, and top-level `column_count` from `list_surfaces` in both condensed and verbose output, including raw-client `pane_ref` backfill.
- Dock worker spawns into an existing non-lead worker/unknown worker zone using derived column ordering, preventing a third column while preserving the first-worker split.

## F2 note
- `submit_verified: null` means submit verification was not attempted, usually because the command is at or below `SEND_INPUT_CHUNK_THRESHOLD`; it is not a failure.

## Test plan
- [x] `bunx vitest run tests/layout-policy.test.ts tests/server.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Push hook `scripts/run_tests.sh` completed with exit status 0

## Review notes
- Pre-commit `cr review --plain` reported two major findings; both were fixed with failing regression tests first.
- A follow-up `cr review --plain` hit the free review limit before producing a second review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic agent spawn and split behavior for multi-pane layouts; wrong column inference could misplace workers, though index fallback and expanded tests reduce that risk.
> 
> **Overview**
> **Pane columns and spawn placement** now use on-screen geometry when every pane has `pixel_frame`: `deriveColumnIndex` maps panes to 0-based columns from distinct `x` values (stacked panes share a column), and falls back to pane index if any pane lacks geometry. `chooseAgentSpawnPlacement` replaces index-only left/right with column-aware ordering, adds **non-lead worker zone** docking via `isNonLeadWorkerZonePane` (tab into a worker/unknown-majority column instead of splitting a third column), and still splits to repair mixed/contaminated worker panes.
> 
> **`list_surfaces`** enriches each surface with `pane_ref`, per-pane `column`, and response-level `column_count` (condensed and verbose), backfilling `pane_ref` when the client omits it. **`CmuxPane`** gains optional `pixel_frame`.
> 
> Minor: comment clarifies `submit_verified: null` on short sends is “not attempted,” not failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f586bcb77786680a894fff21ff26099aea3d169f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose pane columns and dock worker spawns using geometry-aware layout placement
> - Adds `deriveColumnIndex` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/123/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to compute zero-based column indices per pane, using `pixel_frame.x` geometry when available and falling back to pane index order.
> - Reworks `chooseAgentSpawnPlacement` to use column-based ordering instead of pane index, so left/right semantics respect actual on-screen positions.
> - Adds `isNonLeadWorkerZonePane` predicate to allow workers to dock into an existing worker-majority pane rather than always splitting a new column.
> - Extends `list_surfaces` responses in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/123/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to include `pane_ref`, `column`, and `column_count`; backfills `pane_ref` when the client omits it.
> - Adds optional `pixel_frame` geometry field to `CmuxPane` in [types.ts](https://github.com/EtanHey/cmuxlayer/pull/123/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f586bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Surfaces list now includes terminal layout column metadata, with computed column positions for each pane and total column counts.

* **Improvements**
  * Pane positioning enhanced to use pixel-location-based column ordering, improving consistency and reliability in spawn placement and worker zone docking decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->