### PR TITLE
fix: partition unfiltered pane surface lists

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -49,6 +49,7 @@ import {
 import { matchReadyPattern } from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { SpawnGuard } from "./spawn-guard.js";
+import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -204,6 +205,7 @@ interface AgentEngineClient {
   selectWorkspace(workspace: string): Promise<void>;
   listPanes(opts?: { workspace?: string }): Promise<{
     workspace_ref?: string;
+    window_ref?: string;
     panes: CmuxPane[];
   }>;
   listPaneSurfaces(opts?: {
@@ -472,7 +474,7 @@ export class AgentEngine {
 
     try {
       const panes = await this.client.listPanes({ workspace });
-      const paneSurfaces = await Promise.all(
+      const rawPaneSurfaces = await Promise.all(
         panes.panes.map(async (pane) => {
           const ps = await this.client.listPaneSurfaces({
             workspace,
@@ -480,6 +482,14 @@ export class AgentEngine {
           });
           return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
         }),
+      );
+      const paneSurfaces = partitionPaneSurfacesByMembership(
+        panes.panes,
+        rawPaneSurfaces,
+        {
+          workspace_ref: panes.workspace_ref ?? workspace,
+          window_ref: panes.window_ref,
+        },
       );
       const parentAgent = context?.parentAgent ?? null;
       const liveSurfaceIds = new Set(

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -9,6 +9,7 @@ import { StateManager } from "./state-manager.js";
 import { parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { matchReadyPattern } from "./pattern-registry.js";
+import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import type {
   AppServerBridgeRuntime,
   BridgeScreenSnapshot,
@@ -109,13 +110,20 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
             panes: await this.client.listPanes({ workspace: ws.ref }),
           })),
         );
-        const surfaceGroups = await Promise.all(
-          panesByWorkspace.flatMap(({ ref, panes }) =>
-            panes.panes.map((pane) =>
-              this.client.listPaneSurfaces({ workspace: ref, pane: pane.ref }),
-            ),
-          ),
+        const surfaceGroupsByWorkspace = await Promise.all(
+          panesByWorkspace.map(async ({ ref, panes }) => {
+            const rawGroups = await Promise.all(
+              panes.panes.map((pane) =>
+                this.client.listPaneSurfaces({ workspace: ref, pane: pane.ref }),
+              ),
+            );
+            return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+              workspace_ref: panes.workspace_ref ?? ref,
+              window_ref: panes.window_ref,
+            });
+          }),
         );
+        const surfaceGroups = surfaceGroupsByWorkspace.flat();
         return surfaceGroups.flatMap((group) =>
           group.surfaces.map((surface) => ({
             ...surface,

--- a/src/pane-surfaces.ts
+++ b/src/pane-surfaces.ts
@@ -1,0 +1,81 @@
+import type { CmuxPane, CmuxPaneSurfaces, CmuxSurface } from "./types.js";
+
+interface SurfaceEntry {
+  surface: CmuxSurface;
+  groupPaneRefs: Set<string>;
+}
+
+function surfaceKey(
+  surface: CmuxSurface,
+  group: CmuxPaneSurfaces,
+  anonymousIndex: number,
+): string {
+  return (
+    surface.id ??
+    surface.ref ??
+    `${group.workspace_ref}:${group.pane_ref}:anonymous:${anonymousIndex}`
+  );
+}
+
+function surfaceBelongsToPane(
+  surface: CmuxSurface,
+  pane: CmuxPane,
+  groupPaneRefs: ReadonlySet<string>,
+): boolean {
+  if (surface.pane_id && pane.id) {
+    return surface.pane_id === pane.id;
+  }
+  if (surface.id && pane.surface_ids?.includes(surface.id)) {
+    return true;
+  }
+  if (surface.ref && pane.surface_refs?.includes(surface.ref)) {
+    return true;
+  }
+  if (surface.pane_ref) {
+    return surface.pane_ref === pane.ref;
+  }
+  return groupPaneRefs.size === 1 && groupPaneRefs.has(pane.ref);
+}
+
+export function partitionPaneSurfacesByMembership(
+  panes: CmuxPane[],
+  rawGroups: CmuxPaneSurfaces[],
+  fallback?: {
+    workspace_ref?: string;
+    window_ref?: string;
+  },
+): CmuxPaneSurfaces[] {
+  const entries = new Map<string, SurfaceEntry>();
+  let anonymousIndex = 0;
+
+  for (const group of rawGroups) {
+    for (const surface of group.surfaces ?? []) {
+      const key = surfaceKey(surface, group, anonymousIndex++);
+      const entry = entries.get(key);
+      if (entry) {
+        if (group.pane_ref) {
+          entry.groupPaneRefs.add(group.pane_ref);
+        }
+        continue;
+      }
+
+      entries.set(key, {
+        surface,
+        groupPaneRefs: new Set(group.pane_ref ? [group.pane_ref] : []),
+      });
+    }
+  }
+
+  const firstGroup = rawGroups[0];
+  return panes.map((pane) => ({
+    workspace_ref:
+      firstGroup?.workspace_ref ?? fallback?.workspace_ref ?? "",
+    window_ref: firstGroup?.window_ref ?? fallback?.window_ref ?? "",
+    pane_ref: pane.ref,
+    surfaces: [...entries.values()]
+      .filter((entry) =>
+        surfaceBelongsToPane(entry.surface, pane, entry.groupPaneRefs),
+      )
+      .map((entry) => entry.surface),
+  }));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,7 @@ import type {
 import { normalizeKeyName } from "./key-names.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
+import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -1336,21 +1337,28 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             new Set(columnIndex.values()).size,
           );
         }
-        const surfaceGroups = await Promise.all(
-          panesByWorkspace.flatMap(({ workspaceRef, panes }) =>
-            panes.panes.map(async (pane) => {
-              const group = await client.listPaneSurfaces({
-                workspace: workspaceRef,
-                pane: pane.ref,
-              });
-              return {
-                ...group,
-                workspace_ref: group.workspace_ref ?? workspaceRef,
-                pane_ref: group.pane_ref ?? pane.ref,
-              };
-            }),
-          ),
+        const surfaceGroupsByWorkspace = await Promise.all(
+          panesByWorkspace.map(async ({ workspaceRef, panes }) => {
+            const rawGroups = await Promise.all(
+              panes.panes.map(async (pane) => {
+                const group = await client.listPaneSurfaces({
+                  workspace: workspaceRef,
+                  pane: pane.ref,
+                });
+                return {
+                  ...group,
+                  workspace_ref: group.workspace_ref ?? workspaceRef,
+                  pane_ref: group.pane_ref ?? pane.ref,
+                };
+              }),
+            );
+            return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+              workspace_ref: panes.workspace_ref ?? workspaceRef,
+              window_ref: panes.window_ref,
+            });
+          }),
         );
+        const surfaceGroups = surfaceGroupsByWorkspace.flat();
         const uniqueSurfaceEntries: Array<{
           group: {
             workspace_ref: string;
@@ -1566,7 +1574,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
           const panes = await client.listPanes({ workspace: targetWorkspace });
-          const paneSurfaces = await Promise.all(
+          const rawPaneSurfaces = await Promise.all(
             panes.panes.map(async (pane) => {
               const ps = await client.listPaneSurfaces({
                 workspace: targetWorkspace,
@@ -1576,6 +1584,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               // can match panes to their surfaces for role-based placement.
               return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
             }),
+          );
+          const paneSurfaces = partitionPaneSurfacesByMembership(
+            panes.panes,
+            rawPaneSurfaces,
+            {
+              workspace_ref: panes.workspace_ref ?? targetWorkspace,
+              window_ref: panes.window_ref,
+            },
           );
           const liveSurfaceIds = new Set(
             paneSurfaces.flatMap((group) =>
@@ -2326,11 +2342,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             identified?.focused?.workspace_ref;
           if (workspace) {
             const panes = await client.listPanes({ workspace });
-            const paneSurfaces = await Promise.all(
+            const rawPaneSurfaces = await Promise.all(
               panes.panes.map(async (pane) => {
                 const ps = await client.listPaneSurfaces({ workspace, pane: pane.ref });
                 return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
               }),
+            );
+            const paneSurfaces = partitionPaneSurfacesByMembership(
+              panes.panes,
+              rawPaneSurfaces,
+              {
+                workspace_ref: panes.workspace_ref ?? workspace,
+                window_ref: panes.window_ref,
+              },
             );
             const workerSurfaceIds = new Set(
               stateMgr.listStates().map((record) => record.surface_id),
@@ -2480,13 +2504,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             panes: await client.listPanes({ workspace: ws.ref }),
           })),
         );
-        const surfaceGroups = await Promise.all(
-          panesByWorkspace.flatMap(({ ref, panes }) =>
-            panes.panes.map((p) =>
-              client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
-            ),
-          ),
+        const surfaceGroupsByWorkspace = await Promise.all(
+          panesByWorkspace.map(async ({ ref, panes }) => {
+            const rawGroups = await Promise.all(
+              panes.panes.map((p) =>
+                client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
+              ),
+            );
+            return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+              workspace_ref: panes.workspace_ref ?? ref,
+              window_ref: panes.window_ref,
+            });
+          }),
         );
+        const surfaceGroups = surfaceGroupsByWorkspace.flat();
         return surfaceGroups.flatMap((group) =>
           group.surfaces.map((surface) => ({
             ...surface,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface CmuxWorkspace {
 }
 
 export interface CmuxSurface {
+  id?: string;
   ref: string;
   title: string;
   type: "terminal" | "browser";
@@ -26,14 +27,17 @@ export interface CmuxSurface {
   selected: boolean;
   workspace_ref?: string;
   pane_ref?: string;
+  pane_id?: string;
 }
 
 export interface CmuxPane {
+  id?: string;
   ref: string;
   index: number;
   focused: boolean;
   surface_count: number;
   surface_refs: string[];
+  surface_ids?: string[];
   selected_surface_ref?: string;
   pixel_frame?: {
     x: number;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -574,6 +574,85 @@ describe("AgentEngine", () => {
       expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
 
+    it("partitions unfiltered surface lists by pane membership when placing spawned agents", async () => {
+      engine.dispose();
+      const surfaceProvider = async () => liveSurfaces;
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        roleSurfaceIdsProvider: () => ({
+          orchestrator: new Set(["surface:orc"]),
+          ic: new Set(),
+          worker: new Set(["surface:worker-shell"]),
+        }),
+      });
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            id: "pane-left-id",
+            index: 0,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:orc"],
+            surface_ids: ["surface-orc-id"],
+            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+          },
+          {
+            ref: "pane:right",
+            id: "pane-right-id",
+            index: 1,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:worker-shell"],
+            surface_ids: ["surface-worker-id"],
+            pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        surfaces: [
+          {
+            id: "surface-orc-id",
+            pane_id: "pane-left-id",
+            ref: "surface:orc",
+            title: "orc",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+          {
+            id: "surface-worker-id",
+            pane_id: "pane-right-id",
+            ref: "surface:worker-shell",
+            title: "worker",
+            type: "terminal",
+            index: 1,
+            selected: false,
+          },
+        ],
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right",
+        type: "terminal",
+        workspace: "ws:1",
+      });
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+    });
+
     it("does not abort placement when an existing parent or sibling has an unclassifiable role", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const parent = makeRecord({

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -718,18 +718,22 @@ describe("tool handler integration", () => {
             panes: [
               {
                 ref: "pane:left",
+                id: "pane-left-id",
                 index: 0,
                 focused: false,
                 surface_count: 1,
                 surface_refs: ["surface:left"],
+                surface_ids: ["surface-left-id"],
                 pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
               },
               {
                 ref: "pane:right",
+                id: "pane-right-id",
                 index: 1,
                 focused: true,
                 surface_count: 1,
                 surface_refs: ["surface:right"],
+                surface_ids: ["surface-right-id"],
                 pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
               },
             ],
@@ -745,11 +749,22 @@ describe("tool handler integration", () => {
             window_ref: "window:1",
             surfaces: [
               {
-                ref: pane === "pane:left" ? "surface:left" : "surface:right",
-                title: pane,
+                id: "surface-left-id",
+                pane_id: "pane-left-id",
+                ref: "surface:left",
+                title: "left",
                 type: "terminal",
                 index: 0,
                 selected: true,
+              },
+              {
+                id: "surface-right-id",
+                pane_id: "pane-right-id",
+                ref: "surface:right",
+                title: "right",
+                type: "terminal",
+                index: 1,
+                selected: false,
               },
             ],
           }),
@@ -2379,6 +2394,150 @@ describe("tool handler integration", () => {
     expect(parsed.role).toBe("worker");
     expect(parsed.placement).toBe("surface");
     expect(parsed.direction).toBeNull();
+  });
+
+  it("new_split with role=worker partitions unfiltered surface lists by pane membership", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-unfiltered-surfaces");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-1",
+      surface_id: "surface:worker-1",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "existing worker",
+      pid: null,
+      version: 1,
+      created_at: "2026-05-25T12:00:00.000Z",
+      updated_at: "2026-05-25T12:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      role: "worker",
+    });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:left",
+                id: "pane-left-id",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:orc"],
+                surface_ids: ["surface-orc-id"],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right",
+                id: "pane-right-id",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:worker-1"],
+                surface_ids: ["surface-worker-id"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            surfaces: [
+              {
+                id: "surface-orc-id",
+                pane_id: "pane-left-id",
+                ref: "surface:orc",
+                title: "orc",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+              {
+                id: "surface-worker-id",
+                pane_id: "pane-right-id",
+                ref: "surface:worker-1",
+                title: "worker",
+                type: "terminal",
+                index: 1,
+                selected: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:unexpected-split",
+            pane: "pane:third",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", role: "worker", workspace: "workspace:1" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:right"]),
+    );
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-split"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:2");
+    expect(parsed.placement).toBe("surface");
   });
 
   it("new_split ignores disk-only role state when no live lifecycle registry is available", async () => {


### PR DESCRIPTION
## Summary
- Add shared pane-surface partitioning based on durable cmux membership: `surface.pane_id` to `pane.id`, with pane `surface_ids`/`surface_refs` fallbacks.
- Use that partitioning in `list_surfaces`, worker placement, close placement policy context, lifecycle registry providers, agent spawn placement, and the app bridge runtime.
- Add F5 regression coverage where mocked `listPaneSurfaces` returns the full workspace surface list regardless of pane argument, matching the live socket behavior.

## Test plan
- [x] `bunx vitest run tests/server.test.ts tests/agent-engine.test.ts tests/app-server-runtime.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test` (582 tests)

## Notes
- No eval harness added per F5 spec; this PR uses unit/regression tests only.
- `cr review --plain` was attempted pre-commit, but the CLI review limit was reached before findings could be generated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pane/surface membership is derived across spawn placement, surface listing, and close policy; wrong partitioning would misplace agents or collapse panes, though behavior is covered by targeted regression tests.
> 
> **Overview**
> Fixes incorrect layout and listing when **cmux socket `listPaneSurfaces` ignores the pane argument** and returns every workspace surface on each call.
> 
> Introduces **`partitionPaneSurfacesByMembership`** in `pane-surfaces.ts`, which dedupes surfaces and assigns each tab to a pane using **`surface.pane_id` → `pane.id`**, with fallbacks on pane **`surface_ids` / `surface_refs`** and **`pane_ref`**. **`CmuxPane` / `CmuxSurface`** types gain optional **`id`** fields (and **`pane_id`** on surfaces); **`listPanes`** responses can include **`window_ref`**.
> 
> **`agent-engine`**, **`server`** (`list_surfaces`, role-based **`new_split`**, **`close_surface`**, lifecycle **`surfaceProvider`**), and **`app-server-runtime`** now partition raw per-pane groups **per workspace** before **`chooseAgentSpawnPlacement`**, **`chooseSurfaceClosePolicy`**, or flattening for the registry—instead of trusting each API response as pane-scoped.
> 
> Regression tests mock the **unfiltered full-list** socket behavior so worker spawn / **`new_split`** still pick **`new-surface`** on the correct pane rather than mis-splitting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cde849a5c2cc381ab21f3eb446623f3cd32b891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix surface partitioning by pane membership when pane surface lists are unfiltered
> - Adds a new `partitionPaneSurfacesByMembership` utility in [pane-surfaces.ts](https://github.com/EtanHey/cmuxlayer/pull/124/files#diff-b7bc5b2b94a405eeb8acf152baf6259f0685a2bba584cb3a2f6bb16017bc9389) that groups surfaces into their correct panes by matching `pane_id`/`id`, `surface_ids`/refs, or `surface.pane_ref`.
> - Applies partitioning in `spawnAgent`, the `list_surfaces` tool, `new_split` role-based placement, close policy computation, and all `surfaceProvider` closures in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/124/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5), [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/124/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3), and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/124/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595).
> - Adds optional `id`/`pane_id` fields to `CmuxSurface` and `id`/`surface_ids` to `CmuxPane` in [types.ts](https://github.com/EtanHey/cmuxlayer/pull/124/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) to support membership matching.
> - Behavioral Change: placement decisions for agent spawning and `new_split` may select a different pane than before when `listPaneSurfaces` returns unscoped/unfiltered results.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1cde849. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->