### PR TITLE
feat: add cmuxlayer daemon foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "daemon": "node dist/daemon.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -36,6 +36,7 @@ export class SocketJsonRpcTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: <T extends JSONRPCMessage>(message: T) => void;
+  onRequestObserved?: (message: JSONRPCMessage) => void;
   onSend?: (message: JSONRPCMessage) => void;
 
   private readBuffer = new ReadBuffer();
@@ -120,6 +121,9 @@ export class SocketJsonRpcTransport implements Transport {
         if (message === null) {
           break;
         }
+        if (isJsonRpcRequest(message)) {
+          this.onRequestObserved?.(message);
+        }
         this.onmessage?.(message);
       } catch (error) {
         this.onerror?.(
@@ -202,6 +206,52 @@ function isJsonRpcResponse(
   );
 }
 
+async function unlinkStaleSocket(path: string): Promise<void> {
+  const status = await probeSocket(path);
+  if (status === "live") {
+    throw new Error(`cmuxlayer daemon socket is already in use: ${path}`);
+  }
+  if (status === "missing") {
+    return;
+  }
+
+  await unlink(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  });
+}
+
+function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(path);
+    let settled = false;
+    const settle = (value: "live" | "missing" | "stale") => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+
+    socket.setTimeout(250, () => settle("live"));
+    socket.once("connect", () => settle("live"));
+    socket.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") {
+        settle("missing");
+        return;
+      }
+      if (error.code === "ECONNREFUSED") {
+        settle("stale");
+        return;
+      }
+      reject(error);
+    });
+  });
+}
+
 export class CmuxLayerDaemon {
   private server: net.Server | null = null;
   private context: CmuxServerContext | null;
@@ -231,6 +281,10 @@ export class CmuxLayerDaemon {
       throw new Error("cmuxlayer daemon already started");
     }
 
+    if (this.listenFd === undefined) {
+      await unlinkStaleSocket(this.socketPath);
+    }
+
     await this.getContext();
 
     this.server = (this.opts.serverFactory ?? net.createServer)(
@@ -247,11 +301,6 @@ export class CmuxLayerDaemon {
       return;
     }
 
-    await unlink(this.socketPath).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    });
     await this.listen(this.socketPath);
   }
 
@@ -324,7 +373,7 @@ export class CmuxLayerDaemon {
     this.activeTransports.add(transport);
     this.activeServers.add(mcpServer);
 
-    transport.onmessage = (message) => {
+    transport.onRequestObserved = (message) => {
       if (!isJsonRpcRequest(message)) {
         return;
       }
@@ -348,6 +397,11 @@ export class CmuxLayerDaemon {
       this.activeTransports.delete(transport);
       this.activeServers.delete(mcpServer);
       this.resolveDrainWaiters();
+      void mcpServer.close().catch((error) => {
+        if (!this.draining) {
+          console.error("[cmuxlayer-daemon] MCP server close failed", error);
+        }
+      });
     };
     transport.onerror = (error) => {
       if (!this.draining) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -65,6 +65,7 @@ export class SocketJsonRpcTransport implements Transport {
     this.socket.on("data", this.onData);
     this.socket.on("error", this.onError);
     this.socket.on("close", this.onClose);
+    this.socket.resume();
   }
 
   async send(
@@ -230,6 +231,8 @@ export class CmuxLayerDaemon {
       throw new Error("cmuxlayer daemon already started");
     }
 
+    await this.getContext();
+
     this.server = (this.opts.serverFactory ?? net.createServer)(
       (socket) => void this.acceptConnection(socket),
     );
@@ -305,6 +308,7 @@ export class CmuxLayerDaemon {
       socket.destroy();
       return;
     }
+    socket.pause();
 
     let context: CmuxServerContext;
     try {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -62,6 +62,9 @@ export class SocketJsonRpcTransport implements Transport {
     if (this.started) {
       throw new Error("SocketJsonRpcTransport already started");
     }
+    if (this.closed) {
+      throw new Error("SocketJsonRpcTransport is closed");
+    }
     this.started = true;
     this.socket.on("data", this.onData);
     this.socket.on("error", this.onError);
@@ -226,12 +229,14 @@ function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(path);
     let settled = false;
+    const ignoreLateError = () => {};
     const settle = (value: "live" | "missing" | "stale") => {
       if (settled) {
         return;
       }
       settled = true;
       socket.removeAllListeners();
+      socket.on("error", ignoreLateError);
       socket.destroy();
       resolve(value);
     };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+
+import net from "node:net";
+import { unlink } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type {
+  Transport,
+  TransportSendOptions,
+} from "@modelcontextprotocol/sdk/shared/transport.js";
+import type {
+  JSONRPCMessage,
+  RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createCmuxClient } from "./cmux-client-factory.js";
+import { createServer, createServerContext } from "./server.js";
+import type { ExecFn } from "./cmux-client.js";
+import type { CmuxSocketClient } from "./cmux-socket-client.js";
+import type { CmuxClient } from "./cmux-client.js";
+import type {
+  CmuxServerContext,
+  CreateServerOptions,
+} from "./server.js";
+
+const DEFAULT_SOCKET_PATH = "/tmp/cmuxlayer.sock";
+const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
+const LISTEN_FD_START = 3;
+
+type CmuxLayerClient = CmuxClient | CmuxSocketClient;
+
+export class SocketJsonRpcTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: <T extends JSONRPCMessage>(message: T) => void;
+  onSend?: (message: JSONRPCMessage) => void;
+
+  private readBuffer = new ReadBuffer();
+  private started = false;
+  private closed = false;
+
+  private readonly onData = (chunk: Buffer) => {
+    this.readBuffer.append(chunk);
+    this.processReadBuffer();
+  };
+
+  private readonly onError = (error: Error) => {
+    this.onerror?.(error);
+  };
+
+  private readonly onClose = () => {
+    this.finishClose();
+  };
+
+  constructor(private readonly socket: net.Socket) {}
+
+  async start(): Promise<void> {
+    if (this.started) {
+      throw new Error("SocketJsonRpcTransport already started");
+    }
+    this.started = true;
+    this.socket.on("data", this.onData);
+    this.socket.on("error", this.onError);
+    this.socket.on("close", this.onClose);
+  }
+
+  async send(
+    message: JSONRPCMessage,
+    _options?: TransportSendOptions,
+  ): Promise<void> {
+    if (this.closed) {
+      throw new Error("SocketJsonRpcTransport is closed");
+    }
+    this.onSend?.(message);
+    const payload = serializeMessage(message);
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        this.socket.off("drain", onDrain);
+        reject(error);
+      };
+      const onDrain = () => {
+        this.socket.off("error", onError);
+        resolve();
+      };
+      this.socket.once("error", onError);
+      if (this.socket.write(payload)) {
+        this.socket.off("error", onError);
+        resolve();
+      } else {
+        this.socket.once("drain", onDrain);
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.finishClose();
+    if (!this.socket.destroyed) {
+      this.socket.end();
+    }
+  }
+
+  destroy(): void {
+    this.finishClose();
+    if (!this.socket.destroyed) {
+      this.socket.destroy();
+    }
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      try {
+        const message = this.readBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        this.onmessage?.(message);
+      } catch (error) {
+        this.onerror?.(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
+  }
+
+  private finishClose(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.socket.off("data", this.onData);
+    this.socket.off("error", this.onError);
+    this.socket.off("close", this.onClose);
+    this.readBuffer.clear();
+    this.onclose?.();
+  }
+}
+
+export interface CmuxLayerDaemonOptions
+  extends Omit<CreateServerOptions, "context" | "client"> {
+  socketPath?: string;
+  listenFd?: number;
+  drainTimeoutMs?: number;
+  context?: CmuxServerContext;
+  client?: CmuxLayerClient;
+  createClient?: () => Promise<CmuxLayerClient>;
+  serverFactory?: (
+    connectionListener: (socket: net.Socket) => void,
+  ) => net.Server;
+}
+
+export interface DaemonShutdownResult {
+  forced: boolean;
+  activeConnections: number;
+  inFlightRequests: number;
+}
+
+function parseListenFd(env: NodeJS.ProcessEnv): number | undefined {
+  const explicit = env.CMUXLAYER_DAEMON_FD;
+  if (explicit) {
+    const fd = Number(explicit);
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new Error(`Invalid CMUXLAYER_DAEMON_FD: ${explicit}`);
+    }
+    return fd;
+  }
+
+  const listenFds = Number(env.LISTEN_FDS ?? 0);
+  if (Number.isInteger(listenFds) && listenFds > 0) {
+    return LISTEN_FD_START;
+  }
+
+  return undefined;
+}
+
+function isJsonRpcRequest(
+  message: JSONRPCMessage,
+): message is JSONRPCMessage & { id: RequestId; method: string } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    "method" in message &&
+    typeof message.method === "string"
+  );
+}
+
+function isJsonRpcResponse(
+  message: JSONRPCMessage,
+): message is JSONRPCMessage & { id: RequestId } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    ("result" in message || "error" in message)
+  );
+}
+
+export class CmuxLayerDaemon {
+  private server: net.Server | null = null;
+  private context: CmuxServerContext | null;
+  private contextPromise: Promise<CmuxServerContext> | null = null;
+  private readonly socketPath: string;
+  private readonly listenFd?: number;
+  private readonly drainTimeoutMs: number;
+  private readonly activeTransports = new Set<SocketJsonRpcTransport>();
+  private readonly activeServers = new Set<McpServer>();
+  private readonly drainWaiters = new Set<() => void>();
+  private inFlightRequests = 0;
+  private draining = false;
+  private shutdownPromise: Promise<DaemonShutdownResult> | null = null;
+
+  constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
+    this.context = opts.context ?? null;
+    this.socketPath =
+      opts.socketPath ??
+      process.env.CMUXLAYER_DAEMON_SOCKET ??
+      DEFAULT_SOCKET_PATH;
+    this.listenFd = opts.listenFd ?? parseListenFd(process.env);
+    this.drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      throw new Error("cmuxlayer daemon already started");
+    }
+
+    this.server = (this.opts.serverFactory ?? net.createServer)(
+      (socket) => void this.acceptConnection(socket),
+    );
+    this.server.on("error", (error) => {
+      if (!this.draining) {
+        console.error("[cmuxlayer-daemon] server error", error);
+      }
+    });
+
+    if (this.listenFd !== undefined) {
+      await this.listen({ fd: this.listenFd });
+      return;
+    }
+
+    await unlink(this.socketPath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    });
+    await this.listen(this.socketPath);
+  }
+
+  async shutdown(
+    _signal: NodeJS.Signals | "manual" = "manual",
+  ): Promise<DaemonShutdownResult> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise;
+    }
+
+    this.shutdownPromise = this.doShutdown();
+    return this.shutdownPromise;
+  }
+
+  activeConnectionCount(): number {
+    return this.activeTransports.size;
+  }
+
+  inFlightRequestCount(): number {
+    return this.inFlightRequests;
+  }
+
+  private async getContext(): Promise<CmuxServerContext> {
+    if (this.context) {
+      return this.context;
+    }
+    if (!this.contextPromise) {
+      this.contextPromise = (async () => {
+        const client =
+          this.opts.client ??
+          (this.opts.createClient
+            ? await this.opts.createClient()
+            : this.opts.exec || this.opts.bin
+              ? undefined
+              : await createCmuxClient());
+        this.context = createServerContext({
+          exec: this.opts.exec,
+          bin: this.opts.bin,
+          client,
+          stateDir: this.opts.stateDir,
+          skipAgentLifecycle: this.opts.skipAgentLifecycle,
+          enableClaudeChannels: this.opts.enableClaudeChannels,
+          spawnPreflight: this.opts.spawnPreflight,
+          disableSpawnPreflight: this.opts.disableSpawnPreflight,
+        });
+        return this.context;
+      })();
+    }
+    return this.contextPromise;
+  }
+
+  private async acceptConnection(socket: net.Socket): Promise<void> {
+    if (this.draining) {
+      socket.destroy();
+      return;
+    }
+
+    let context: CmuxServerContext;
+    try {
+      context = await this.getContext();
+    } catch (error) {
+      socket.destroy(error instanceof Error ? error : undefined);
+      return;
+    }
+
+    const transport = new SocketJsonRpcTransport(socket);
+    const mcpServer = createServer({ context });
+    const pendingRequestIds = new Set<RequestId>();
+    this.activeTransports.add(transport);
+    this.activeServers.add(mcpServer);
+
+    transport.onmessage = (message) => {
+      if (!isJsonRpcRequest(message)) {
+        return;
+      }
+      pendingRequestIds.add(message.id);
+      this.inFlightRequests += 1;
+    };
+    transport.onSend = (message) => {
+      if (!isJsonRpcResponse(message)) {
+        return;
+      }
+      if (pendingRequestIds.delete(message.id)) {
+        this.inFlightRequests -= 1;
+        this.resolveDrainWaiters();
+      }
+    };
+    transport.onclose = () => {
+      if (pendingRequestIds.size > 0) {
+        this.inFlightRequests -= pendingRequestIds.size;
+        pendingRequestIds.clear();
+      }
+      this.activeTransports.delete(transport);
+      this.activeServers.delete(mcpServer);
+      this.resolveDrainWaiters();
+    };
+    transport.onerror = (error) => {
+      if (!this.draining) {
+        console.error("[cmuxlayer-daemon] transport error", error);
+      }
+    };
+
+    try {
+      await mcpServer.connect(transport);
+    } catch (error) {
+      transport.onerror?.(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      transport.destroy();
+    }
+  }
+
+  private async doShutdown(): Promise<DaemonShutdownResult> {
+    this.draining = true;
+    const listenerClosed = this.closeListener();
+
+    const forced = !(await this.waitForDrain());
+    for (const server of [...this.activeServers]) {
+      await server.close().catch(() => {});
+    }
+    for (const transport of [...this.activeTransports]) {
+      if (forced) {
+        transport.destroy();
+      } else {
+        await transport.close().catch(() => {});
+      }
+    }
+    await listenerClosed;
+    this.context?.dispose();
+
+    return {
+      forced,
+      activeConnections: this.activeTransports.size,
+      inFlightRequests: this.inFlightRequests,
+    };
+  }
+
+  private listen(options: string | { fd: number }): Promise<void> {
+    const server = this.server;
+    if (!server) {
+      throw new Error("daemon server was not created");
+    }
+    return new Promise((resolve, reject) => {
+      const onError = (error: Error) => {
+        server.off("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      if (typeof options === "string") {
+        server.listen(options, onListening);
+      } else {
+        server.listen(options, onListening);
+      }
+    });
+  }
+
+  private closeListener(): Promise<void> {
+    const server = this.server;
+    if (!server) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+
+  private waitForDrain(): Promise<boolean> {
+    if (this.inFlightRequests === 0) {
+      return Promise.resolve(true);
+    }
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        this.drainWaiters.delete(onDrained);
+        resolve(false);
+      }, this.drainTimeoutMs);
+
+      const onDrained = () => {
+        clearTimeout(timeout);
+        resolve(true);
+      };
+      this.drainWaiters.add(onDrained);
+    });
+  }
+
+  private resolveDrainWaiters(): void {
+    if (this.inFlightRequests !== 0) {
+      return;
+    }
+    for (const waiter of this.drainWaiters) {
+      waiter();
+    }
+    this.drainWaiters.clear();
+  }
+}
+
+export async function runDaemon(
+  opts: CmuxLayerDaemonOptions = {},
+): Promise<CmuxLayerDaemon> {
+  const daemon = new CmuxLayerDaemon(opts);
+  const shutdown = (signal: NodeJS.Signals) => {
+    daemon
+      .shutdown(signal)
+      .then((result) => {
+        process.exit(result.forced ? 1 : 0);
+      })
+      .catch((error) => {
+        console.error("[cmuxlayer-daemon] shutdown failed", error);
+        process.exit(1);
+      });
+  };
+
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+  await daemon.start();
+  return daemon;
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  runDaemon().catch((error) => {
+    console.error("[cmuxlayer-daemon] fatal", error);
+    process.exit(1);
+  });
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -106,7 +106,14 @@ export class SocketJsonRpcTransport implements Transport {
     }
     this.finishClose();
     if (!this.socket.destroyed) {
+      this.socket.resume();
       this.socket.end();
+    }
+  }
+
+  pauseInput(): void {
+    if (!this.closed) {
+      this.socket.pause();
     }
   }
 
@@ -426,6 +433,7 @@ export class CmuxLayerDaemon {
 
   private async doShutdown(): Promise<DaemonShutdownResult> {
     this.draining = true;
+    this.pauseActiveTransports();
     const listenerClosed = this.closeListener();
 
     const forced = !(await this.waitForDrain());
@@ -447,6 +455,12 @@ export class CmuxLayerDaemon {
       activeConnections: this.activeTransports.size,
       inFlightRequests: this.inFlightRequests,
     };
+  }
+
+  private pauseActiveTransports(): void {
+    for (const transport of this.activeTransports) {
+      transport.pauseInput();
+    }
   }
 
   private listen(options: string | { fd: number }): Promise<void> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -79,25 +79,41 @@ export class SocketJsonRpcTransport implements Transport {
     if (this.closed) {
       throw new Error("SocketJsonRpcTransport is closed");
     }
-    this.onSend?.(message);
     const payload = serializeMessage(message);
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
       const onError = (error: Error) => {
-        this.socket.off("drain", onDrain);
-        reject(error);
+        settle(error);
       };
-      const onDrain = () => {
+      const onClose = () => {
+        settle(new Error("SocketJsonRpcTransport closed before write completed"));
+      };
+      const cleanup = () => {
         this.socket.off("error", onError);
+        this.socket.off("close", onClose);
+      };
+      const settle = (error?: Error | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        if (error) {
+          reject(error);
+          return;
+        }
         resolve();
       };
+
       this.socket.once("error", onError);
-      if (this.socket.write(payload)) {
-        this.socket.off("error", onError);
-        resolve();
-      } else {
-        this.socket.once("drain", onDrain);
+      this.socket.once("close", onClose);
+      try {
+        this.socket.write(payload, settle);
+      } catch (error) {
+        settle(error instanceof Error ? error : new Error(String(error)));
       }
     });
+    this.onSend?.(message);
   }
 
   async close(): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2618,76 +2618,86 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       });
     };
-    const engine = new AgentEngine(
-      stateMgr,
-      registry,
-      {
-        log: (message, eventOpts) => client.log(message, eventOpts),
-        listWorkspaces: () => client.listWorkspaces(),
-        setStatus: (key, value, statusOpts) =>
-          client.setStatus(key, value, statusOpts),
-        clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
-        readScreen: (surface, readOpts) => client.readScreen(surface, readOpts),
-        send: (surface, text, sendOpts) =>
-          withSurfaceWrite(surface, () => client.send(surface, text, sendOpts)),
-        sendKey: (surface, key, keyOpts) =>
-          withSurfaceWrite(surface, () =>
-            client.sendKey(surface, key, keyOpts),
-          ),
-        setProgress: (value, progressOpts) =>
-          client.setProgress(value, progressOpts),
-        newSplit: (direction, splitOpts) =>
-          client.newSplit(direction, splitOpts),
-        newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
-        selectWorkspace: (workspace) => client.selectWorkspace(workspace),
-        listPanes: (paneOpts) => client.listPanes(paneOpts),
-        listPaneSurfaces: (surfaceOpts) => client.listPaneSurfaces(surfaceOpts),
-        closeSurface: (surface, closeOpts) =>
-          withSurfaceWrite(surface, () =>
-            client.closeSurface(surface, closeOpts),
-          ),
-        notifyLifecycleEvent,
-      },
-      {
-        spawnPreflight:
-          spawnPreflight ??
-          (disableSpawnPreflight ? async () => {} : undefined),
-        roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
-        launchCommandSender: async ({ surface, workspace, command }) => {
-          const sanitizedCommand = sanitizeTerminalInput(command);
-          const chunks =
-            sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
-              ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
-              : [sanitizedCommand];
-
-          await waitForLaunchShellReady({ surface, workspace });
-          await withSurfaceWrite(surface, async () => {
-            try {
-              await deliverInputChunks({
-                surface,
-                workspace,
-                chunks,
-                chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-                chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-                press_enter: true,
-                source_event: "spawn_agent",
-                verify_submit: true,
-              });
-            } catch (error) {
-              const message =
-                error instanceof Error ? error.message : String(error);
-              if (!/Enter submit could not be verified/.test(message)) {
-                throw error;
-              }
-              // The command can remain visible in shell history while the
-              // launcher is already booting. Verification still retried Enter;
-              // agent readiness detection is the authoritative launch check.
-              await waitForAgentLaunchReady({ surface, workspace });
-            }
-          });
+    const engine =
+      context.lifecycleSweepEngine ??
+      new AgentEngine(
+        stateMgr,
+        registry,
+        {
+          log: (message, eventOpts) => client.log(message, eventOpts),
+          listWorkspaces: () => client.listWorkspaces(),
+          setStatus: (key, value, statusOpts) =>
+            client.setStatus(key, value, statusOpts),
+          clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
+          readScreen: (surface, readOpts) =>
+            client.readScreen(surface, readOpts),
+          send: (surface, text, sendOpts) =>
+            withSurfaceWrite(surface, () =>
+              client.send(surface, text, sendOpts),
+            ),
+          sendKey: (surface, key, keyOpts) =>
+            withSurfaceWrite(surface, () =>
+              client.sendKey(surface, key, keyOpts),
+            ),
+          setProgress: (value, progressOpts) =>
+            client.setProgress(value, progressOpts),
+          newSplit: (direction, splitOpts) =>
+            client.newSplit(direction, splitOpts),
+          newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
+          selectWorkspace: (workspace) => client.selectWorkspace(workspace),
+          listPanes: (paneOpts) => client.listPanes(paneOpts),
+          listPaneSurfaces: (surfaceOpts) =>
+            client.listPaneSurfaces(surfaceOpts),
+          closeSurface: (surface, closeOpts) =>
+            withSurfaceWrite(surface, () =>
+              client.closeSurface(surface, closeOpts),
+            ),
+          notifyLifecycleEvent,
         },
-      },
-    );
+        {
+          spawnPreflight:
+            spawnPreflight ??
+            (disableSpawnPreflight ? async () => {} : undefined),
+          roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
+          launchCommandSender: async ({ surface, workspace, command }) => {
+            const sanitizedCommand = sanitizeTerminalInput(command);
+            const chunks =
+              sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
+                ? chunkTerminalInput(
+                    sanitizedCommand,
+                    SEND_INPUT_CHUNK_THRESHOLD,
+                  )
+                : [sanitizedCommand];
+
+            await waitForLaunchShellReady({ surface, workspace });
+            await withSurfaceWrite(surface, async () => {
+              try {
+                await deliverInputChunks({
+                  surface,
+                  workspace,
+                  chunks,
+                  chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+                  chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+                  press_enter: true,
+                  source_event: "spawn_agent",
+                  verify_submit: true,
+                });
+              } catch (error) {
+                const message =
+                  error instanceof Error ? error.message : String(error);
+                if (!/Enter submit could not be verified/.test(message)) {
+                  throw error;
+                }
+                // The command can remain visible in shell history while the
+                // launcher is already booting. Verification still retried Enter;
+                // agent readiness detection is the authoritative launch check.
+                await waitForAgentLaunchReady({ surface, workspace });
+              }
+            });
+          },
+        },
+      );
+    context.lifecycleSweepEngine = engine;
 
     const deliverAgentInput = async (args: {
       agent_id: string;
@@ -2815,7 +2825,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // agents from previous cmux sessions.
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
-      context.lifecycleSweepEngine = engine;
       context.lifecycleStartPromise = registry
         .reconstitute()
         .then(() => engine.enableStartupPurge())

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,7 +126,7 @@ const SendToArgsSchema = z.object({
 
 type DeliveryStatus = "delivering" | "delivered" | "failed";
 
-interface DeliveryRecord {
+export interface DeliveryRecord {
   delivery_id: string;
   surface: string;
   workspace?: string;
@@ -512,6 +512,8 @@ export interface CreateServerOptions {
   bin?: string;
   /** Pre-built client (socket or CLI). If omitted, creates a CLI client. */
   client?: CmuxClient | CmuxSocketClient;
+  /** Shared server-side world-model reused across many MCP connections. */
+  context?: CmuxServerContext;
   /** Base directory for agent state files. Defaults to ~/.local/state/cmux-agents */
   stateDir?: string;
   /** Skip agent lifecycle initialization (for testing low-level tools only) */
@@ -522,6 +524,71 @@ export interface CreateServerOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   /** Explicitly disable spawn preflight checks (primarily for mocked tests). */
   disableSpawnPreflight?: boolean;
+}
+
+type CmuxLayerClient = CmuxClient | CmuxSocketClient;
+
+export interface CmuxServerContext {
+  client: CmuxLayerClient;
+  stateDir: string;
+  stateMgr: StateManager;
+  roleSurfaceOverrides: Map<
+    string,
+    { role: AgentRole; workspace: string | null }
+  >;
+  eventLog: ReturnType<StateManager["getEventLog"]>;
+  deliveries: Map<string, DeliveryRecord>;
+  latestDeliveryBySurface: Map<string, string>;
+  activeDeliveryBySurface: Map<string, string>;
+  activeSurfaceWrites: Map<string, string>;
+  enableClaudeChannels: boolean;
+  skipAgentLifecycle: boolean;
+  spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+  disableSpawnPreflight?: boolean;
+  lifecycleRegistry: AgentRegistry | null;
+  lifecycleStarted: boolean;
+  lifecycleStartPromise: Promise<void> | null;
+  lifecycleSweepEngine: AgentEngine | null;
+  dispose(): void;
+}
+
+export function createServerContext(
+  opts?: Omit<CreateServerOptions, "context">,
+): CmuxServerContext {
+  const client =
+    opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  const stateDir =
+    opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
+  const stateMgr = new StateManager(stateDir);
+  const context: CmuxServerContext = {
+    client,
+    stateDir,
+    stateMgr,
+    roleSurfaceOverrides: new Map(),
+    eventLog: stateMgr.getEventLog(),
+    deliveries: new Map(),
+    latestDeliveryBySurface: new Map(),
+    activeDeliveryBySurface: new Map(),
+    activeSurfaceWrites: new Map(),
+    enableClaudeChannels:
+      opts?.enableClaudeChannels ??
+      process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1",
+    skipAgentLifecycle: opts?.skipAgentLifecycle ?? false,
+    spawnPreflight: opts?.spawnPreflight,
+    disableSpawnPreflight: opts?.disableSpawnPreflight,
+    lifecycleRegistry: null,
+    lifecycleStarted: false,
+    lifecycleStartPromise: null,
+    lifecycleSweepEngine: null,
+    dispose() {
+      context.lifecycleSweepEngine?.dispose();
+      context.lifecycleSweepEngine = null;
+      context.lifecycleStarted = false;
+      context.lifecycleStartPromise = null;
+    },
+  };
+
+  return context;
 }
 
 function formatLifecycleChannelContent(
@@ -567,24 +634,22 @@ function buildLifecycleChannelMeta(
 }
 
 export function createServer(opts?: CreateServerOptions): McpServer {
-  const client =
-    opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
-  const stateDir =
-    opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
-  const stateMgr = new StateManager(stateDir);
-  const roleSurfaceOverrides = new Map<
-    string,
-    { role: AgentRole; workspace: string | null }
-  >();
-  let lifecycleRegistry: AgentRegistry | null = null;
-  const eventLog = stateMgr.getEventLog();
-  const deliveries = new Map<string, DeliveryRecord>();
-  const latestDeliveryBySurface = new Map<string, string>();
-  const activeDeliveryBySurface = new Map<string, string>();
-  const activeSurfaceWrites = new Map<string, string>();
+  const context = opts?.context ?? createServerContext(opts);
+  const client = context.client;
+  const stateMgr = context.stateMgr;
+  const roleSurfaceOverrides = context.roleSurfaceOverrides;
+  const eventLog = context.eventLog;
+  const deliveries = context.deliveries;
+  const latestDeliveryBySurface = context.latestDeliveryBySurface;
+  const activeDeliveryBySurface = context.activeDeliveryBySurface;
+  const activeSurfaceWrites = context.activeSurfaceWrites;
   const enableClaudeChannels =
-    opts?.enableClaudeChannels ??
-    process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1";
+    opts?.enableClaudeChannels ?? context.enableClaudeChannels;
+  const skipAgentLifecycle =
+    opts?.skipAgentLifecycle ?? context.skipAgentLifecycle;
+  const spawnPreflight = opts?.spawnPreflight ?? context.spawnPreflight;
+  const disableSpawnPreflight =
+    opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
 
   const server = new McpServer(
     {
@@ -621,7 +686,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
   ) => {
-    const roleRecords = lifecycleRegistry?.list() ?? [];
+    const roleRecords = context.lifecycleRegistry?.list() ?? [];
     const ids = collectRoleSurfaceIds(roleRecords);
     if (liveSurfaceIds) {
       for (const role of ["orchestrator", "ic", "worker"] as const) {
@@ -2494,7 +2559,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   // --- Agent Lifecycle Tools (Phase 5) ---
 
-  if (!opts?.skipAgentLifecycle) {
+  if (!skipAgentLifecycle) {
     const surfaceProvider = async () => {
       try {
         const workspaces = await client.listWorkspaces();
@@ -2529,8 +2594,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return [];
       }
     };
-    const registry = new AgentRegistry(stateMgr, surfaceProvider);
-    lifecycleRegistry = registry;
+    const registry =
+      context.lifecycleRegistry ?? new AgentRegistry(stateMgr, surfaceProvider);
+    context.lifecycleRegistry = registry;
     const discovery = new AgentDiscovery({
       listSurfaces: surfaceProvider,
       readScreen: (surface, opts) => client.readScreen(surface, opts),
@@ -2584,8 +2650,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       {
         spawnPreflight:
-          opts?.spawnPreflight ??
-          (opts?.disableSpawnPreflight ? async () => {} : undefined),
+          spawnPreflight ??
+          (disableSpawnPreflight ? async () => {} : undefined),
         roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
         launchCommandSender: async ({ surface, workspace, command }) => {
           const sanitizedCommand = sanitizeTerminalInput(command);
@@ -2747,13 +2813,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // Reconstitute registry from disk on startup (async, best-effort).
     // Enable startup purge so the first sweep clears stale terminal-state
     // agents from previous cmux sessions.
-    registry
-      .reconstitute()
-      .then(() => engine.enableStartupPurge())
-      .catch((e) =>
-        console.error("[cmux-mcp] registry reconstitution failed:", e),
-      );
-    engine.startSweep(5000);
+    if (!context.lifecycleStarted) {
+      context.lifecycleStarted = true;
+      context.lifecycleSweepEngine = engine;
+      context.lifecycleStartPromise = registry
+        .reconstitute()
+        .then(() => engine.enableStartupPurge())
+        .catch((e) =>
+          console.error("[cmux-mcp] registry reconstitution failed:", e),
+        );
+      engine.startSweep(5000);
+    }
 
     // 11. spawn_agent
     server.tool(

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -559,6 +559,125 @@ describe("CmuxLayerDaemon", () => {
     await client.close();
   });
 
+  it("does not start new requests on existing connections after drain begins", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drain-blocks-new-work");
+    const gate = deferred<{ stdout: string; stderr: string }>();
+    const started = deferred<void>();
+    let listWorkspacesCalls = 0;
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        listWorkspacesCalls += 1;
+        if (listWorkspacesCalls === 1) {
+          started.resolve();
+          return gate.promise;
+        }
+        return {
+          stdout: JSON.stringify({ workspaces: [] }),
+          stderr: "",
+        };
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 500,
+    });
+
+    await daemon.start();
+    let socket: net.Socket | null = null;
+    try {
+      socket = net.createConnection(path);
+      socket.on("error", () => {});
+      const messages: Record<string, any>[] = [];
+      const messageEvents = new EventEmitter();
+      let buffer = "";
+      const send = (message: Record<string, unknown>) => {
+        socket?.write(`${JSON.stringify(message)}\n`);
+      };
+      const waitForResponse = (id: number) => {
+        const existing = messages.find((message) => message.id === id);
+        if (existing) {
+          return Promise.resolve(existing);
+        }
+        return new Promise<Record<string, any>>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            messageEvents.off("message", onMessage);
+            reject(new Error(`timed out waiting for response ${id}`));
+          }, 500);
+          const onMessage = (message: Record<string, any>) => {
+            if (message.id !== id) {
+              return;
+            }
+            clearTimeout(timeout);
+            messageEvents.off("message", onMessage);
+            resolve(message);
+          };
+          messageEvents.on("message", onMessage);
+        });
+      };
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          if (!line.trim()) {
+            continue;
+          }
+          const message = JSON.parse(line);
+          messages.push(message);
+          messageEvents.emit("message", message);
+        }
+      });
+
+      await once(socket, "connect");
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "raw-drain-test", version: "0.1.0" },
+        },
+      });
+      await waitForResponse(1);
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "list_surfaces", arguments: { verbose: false } },
+      });
+
+      await started.promise;
+      const shutdown = daemon.shutdown("SIGTERM");
+      await delay(10);
+      send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "list_surfaces", arguments: { verbose: false } },
+      });
+      await delay(30);
+
+      expect(listWorkspacesCalls).toBe(1);
+      gate.resolve({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+      await expect(waitForResponse(2)).resolves.toMatchObject({ id: 2 });
+      await expect(shutdown).resolves.toMatchObject({ forced: false });
+      expect(listWorkspacesCalls).toBe(1);
+    } finally {
+      socket?.destroy();
+      await daemon.shutdown().catch(() => {});
+    }
+  });
+
   it("forces shutdown after the drain timeout when a request hangs", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("drain-timeout");

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,0 +1,350 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { readFile } from "node:fs/promises";
+import {
+  CmuxLayerDaemon,
+  SocketJsonRpcTransport,
+} from "../src/daemon.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const TEST_ROOT = join(tmpdir(), "cmuxlayer-daemon-test");
+
+function socketPath(name: string): string {
+  return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);
+}
+
+function stateDir(name: string): string {
+  return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}`);
+}
+
+function createListSurfacesExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:1"],
+              selected_surface_ref: "surface:1",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:1",
+              title: "agent",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    return { stdout: "{}", stderr: "" };
+  });
+}
+
+function createLifecycleExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:new"],
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:new",
+              title: "agent",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: "codex> ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
+async function connectClient(path: string): Promise<Client> {
+  const socket = net.createConnection(path);
+  const transport = new SocketJsonRpcTransport(socket);
+  const client = new Client({ name: "daemon-test", version: "0.1.0" });
+  await client.connect(transport);
+  return client;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("CmuxLayerDaemon", () => {
+  afterEach(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("serves initialize and list_surfaces over a unix socket", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("basic");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+
+    await daemon.start();
+    const client = await connectClient(path);
+
+    const result = await client.callTool({
+      name: "list_surfaces",
+      arguments: { verbose: false },
+    });
+
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      column_count: 1,
+    });
+    expect(result.structuredContent?.surfaces).toHaveLength(1);
+
+    await client.close();
+    await daemon.shutdown();
+  });
+
+  it("shares one world-model across concurrent MCP connections", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("shared");
+    const dir = stateDir("shared-state");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createLifecycleExec(),
+      stateDir: dir,
+      disableSpawnPreflight: true,
+    });
+
+    await daemon.start();
+    const [clientA, clientB] = await Promise.all([
+      connectClient(path),
+      connectClient(path),
+    ]);
+
+    const spawned = await clientA.callTool({
+      name: "spawn_agent",
+      arguments: {
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+      },
+    });
+    const agentId = String(spawned.structuredContent?.agent_id);
+    const state = await clientB.callTool({
+      name: "get_agent_state",
+      arguments: { agent_id: agentId },
+    });
+
+    expect(state.structuredContent).toMatchObject({
+      ok: true,
+      agent_id: agentId,
+      surface_id: "surface:new",
+      cli: "codex",
+    });
+
+    await clientA.close();
+    await clientB.close();
+    await daemon.shutdown();
+  });
+
+  it("drains an in-flight request before shutdown completes", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drain");
+    const gate = deferred<{ stdout: string; stderr: string }>();
+    const started = deferred<void>();
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        started.resolve();
+        return gate.promise;
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 500,
+    });
+
+    await daemon.start();
+    const client = await connectClient(path);
+    const pending = client.callTool({
+      name: "list_surfaces",
+      arguments: { verbose: false },
+    });
+
+    await started.promise;
+    const shutdown = daemon.shutdown("SIGTERM");
+    gate.resolve({
+      stdout: JSON.stringify({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+        ],
+      }),
+      stderr: "",
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      structuredContent: expect.objectContaining({ ok: true }),
+    });
+    await expect(shutdown).resolves.toMatchObject({ forced: false });
+
+    await client.close();
+  });
+
+  it("uses listen({ fd }) for socket activation without unlinking the socket path", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("fd");
+    writeFileSync(path, "launchd-owned");
+    const fakeServer = new EventEmitter() as net.Server;
+    const listen = vi.fn((_opts: unknown, cb?: () => void) => {
+      cb?.();
+      return fakeServer;
+    });
+    const close = vi.fn((cb?: (err?: Error) => void) => {
+      cb?.();
+      return fakeServer;
+    });
+    Object.assign(fakeServer, {
+      listen,
+      close,
+      on: fakeServer.on.bind(fakeServer),
+      once: fakeServer.once.bind(fakeServer),
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      listenFd: 42,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+      serverFactory: () => fakeServer,
+    });
+
+    await daemon.start();
+
+    expect(listen).toHaveBeenCalledWith({ fd: 42 }, expect.any(Function));
+    await expect(readFile(path, "utf8")).resolves.toBe("launchd-owned");
+
+    await daemon.shutdown();
+  });
+});

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,15 +1,17 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import {
   CmuxLayerDaemon,
   SocketJsonRpcTransport,
 } from "../src/daemon.js";
+import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-daemon-test");
@@ -191,6 +193,16 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function listen(server: net.Server, path: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(path, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
 async function rawToolsList(path: string, timeoutMs = 500): Promise<{
   server?: string;
   toolCount?: number;
@@ -250,9 +262,41 @@ async function rawToolsList(path: string, timeoutMs = 500): Promise<{
   });
 }
 
+async function readOnce(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(path);
+    let data = "";
+    socket.on("data", (chunk) => {
+      data += chunk.toString("utf8");
+    });
+    socket.on("end", () => resolve(data));
+    socket.on("error", reject);
+  });
+}
+
 describe("CmuxLayerDaemon", () => {
   afterEach(() => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("reuses one lifecycle AgentEngine across servers sharing a context", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("shared-engine"),
+      disableSpawnPreflight: true,
+    });
+
+    try {
+      const firstServer = createServer({ context });
+      const secondServer = createServer({ context });
+
+      expect((firstServer as any)._registeredTools.interact._engine).toBe(
+        (secondServer as any)._registeredTools.interact._engine,
+      );
+    } finally {
+      context.dispose();
+    }
   });
 
   it("serves initialize and list_surfaces over a unix socket", async () => {
@@ -301,6 +345,66 @@ describe("CmuxLayerDaemon", () => {
     });
 
     await daemon.shutdown();
+  });
+
+  it("closes the per-connection MCP server when a client disconnects", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("connection-close");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    const closeSpy = vi.spyOn(McpServer.prototype, "close");
+
+    try {
+      await daemon.start();
+      const client = await connectClient(path);
+      closeSpy.mockClear();
+
+      await client.close();
+      await delay(10);
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await daemon.shutdown().catch(() => {});
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("observes incoming requests even when onmessage is replaced", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("request-observer");
+    const observed = deferred<Record<string, unknown>>();
+    const server = net.createServer(async (socket) => {
+      const transport = new SocketJsonRpcTransport(socket);
+      (transport as any).onRequestObserved = (message: Record<string, unknown>) =>
+        observed.resolve(message);
+      transport.onmessage = () => {};
+      await transport.start();
+      transport.onmessage = () => {};
+    });
+
+    await listen(server, path);
+    const socket = net.createConnection(path);
+    await once(socket, "connect");
+    socket.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 99, method: "ping" })}\n`,
+    );
+
+    try {
+      await expect(
+        Promise.race([
+          observed.promise,
+          delay(50).then(() => {
+            throw new Error("request observer was not called");
+          }),
+        ]),
+      ).resolves.toMatchObject({ id: 99, method: "ping" });
+    } finally {
+      socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("shares one world-model across concurrent MCP connections", async () => {
@@ -397,6 +501,94 @@ describe("CmuxLayerDaemon", () => {
     await client.close();
   });
 
+  it("keeps shutdown pending while a request is in-flight", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drain-waits");
+    const gate = deferred<{ stdout: string; stderr: string }>();
+    const started = deferred<void>();
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        started.resolve();
+        return gate.promise;
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 500,
+    });
+
+    await daemon.start();
+    const client = await connectClient(path);
+    const pending = client.callTool({
+      name: "list_surfaces",
+      arguments: { verbose: false },
+    });
+
+    await started.promise;
+    let shutdownSettled = false;
+    const shutdown = daemon.shutdown("SIGTERM").then((result) => {
+      shutdownSettled = true;
+      return result;
+    });
+    await delay(30);
+
+    expect(shutdownSettled).toBe(false);
+    expect(daemon.inFlightRequestCount()).toBe(1);
+
+    gate.resolve({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    await expect(pending).resolves.toMatchObject({
+      structuredContent: expect.objectContaining({ ok: true }),
+    });
+    await expect(shutdown).resolves.toMatchObject({ forced: false });
+    await client.close();
+  });
+
+  it("forces shutdown after the drain timeout when a request hangs", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drain-timeout");
+    const started = deferred<void>();
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        started.resolve();
+        return new Promise(() => {});
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 30,
+    });
+
+    await daemon.start();
+    const client = await connectClient(path);
+    const pending = client
+      .callTool({
+        name: "list_surfaces",
+        arguments: { verbose: false },
+      })
+      .then(
+        () => null,
+        (error) => error,
+      );
+
+    await started.promise;
+    await expect(daemon.shutdown("SIGTERM")).resolves.toMatchObject({
+      forced: true,
+    });
+    const error = await pending;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatch(/Connection closed|closed/i);
+    await client.close().catch(() => {});
+  });
+
   it("uses listen({ fd }) for socket activation without unlinking the socket path", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("fd");
@@ -430,5 +622,28 @@ describe("CmuxLayerDaemon", () => {
     await expect(readFile(path, "utf8")).resolves.toBe("launchd-owned");
 
     await daemon.shutdown();
+  });
+
+  it("does not unlink a live daemon socket when another daemon is running", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("live-socket");
+    const liveServer = net.createServer((socket) => {
+      socket.end("live\n");
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+
+    await listen(liveServer, path);
+
+    try {
+      await expect(daemon.start()).rejects.toThrow(/already.*running|in use/i);
+      await expect(readOnce(path)).resolves.toBe("live\n");
+    } finally {
+      await daemon.shutdown().catch(() => {});
+      await new Promise<void>((resolve) => liveServer.close(() => resolve()));
+    }
   });
 });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -417,6 +417,42 @@ describe("CmuxLayerDaemon", () => {
     }
   });
 
+  it("observes sent responses only after socket writes complete", async () => {
+    const writeCallbacks: Array<() => void> = [];
+    const fakeSocket = new EventEmitter() as net.Socket & {
+      destroyed: boolean;
+      write: ReturnType<typeof vi.fn>;
+    };
+    fakeSocket.destroyed = false;
+    fakeSocket.write = vi.fn((_payload, callback?: () => void) => {
+      if (callback) {
+        writeCallbacks.push(callback);
+      }
+      return true;
+    });
+
+    const transport = new SocketJsonRpcTransport(fakeSocket);
+    const sent: unknown[] = [];
+    transport.onSend = (message) => sent.push(message);
+    let sendSettled = false;
+    const send = transport
+      .send({ jsonrpc: "2.0", id: 1, result: {} })
+      .then(() => {
+        sendSettled = true;
+      });
+
+    await Promise.resolve();
+    expect(sent).toHaveLength(0);
+    expect(sendSettled).toBe(false);
+    expect(writeCallbacks).toHaveLength(1);
+
+    writeCallbacks[0]();
+    await send;
+
+    expect(sendSettled).toBe(true);
+    expect(sent).toEqual([{ jsonrpc: "2.0", id: 1, result: {} }]);
+  });
+
   it("shares one world-model across concurrent MCP connections", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("shared");
@@ -674,6 +710,110 @@ describe("CmuxLayerDaemon", () => {
       expect(listWorkspacesCalls).toBe(1);
     } finally {
       socket?.destroy();
+      await daemon.shutdown().catch(() => {});
+    }
+  });
+
+  it("keeps drain pending until response bytes finish writing", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drain-waits-for-write");
+    const gate = deferred<{ stdout: string; stderr: string }>();
+    const started = deferred<void>();
+    const responseWriteStarted = deferred<void>();
+    const responseWriteFlushed = deferred<void>();
+    let responseWriteCallback: (() => void) | null = null;
+    let delayNextResponseWrite = false;
+    const releaseResponseWrite = () => {
+      const callback = responseWriteCallback;
+      responseWriteCallback = null;
+      callback?.();
+    };
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        started.resolve();
+        return gate.promise;
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 500,
+      serverFactory: (connectionListener) =>
+        net.createServer((socket) => {
+          const originalWrite = socket.write.bind(socket) as typeof socket.write;
+          socket.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
+            const payload = Buffer.isBuffer(chunk)
+              ? chunk.toString("utf8")
+              : String(chunk);
+            const encoding =
+              typeof encodingOrCallback === "function"
+                ? undefined
+                : encodingOrCallback;
+            const writeCallback =
+              typeof encodingOrCallback === "function"
+                ? encodingOrCallback
+                : callback;
+            if (delayNextResponseWrite && payload.includes('"id"')) {
+              delayNextResponseWrite = false;
+              responseWriteStarted.resolve();
+              const deferredCallback = (error?: Error | null) => {
+                responseWriteCallback = () => writeCallback?.(error);
+                responseWriteFlushed.resolve();
+              };
+              if (encoding === undefined) {
+                return originalWrite(chunk, deferredCallback);
+              }
+              return originalWrite(chunk, encoding, deferredCallback);
+            }
+            return originalWrite(chunk, encodingOrCallback, callback);
+          }) as typeof socket.write;
+          connectionListener(socket);
+        }),
+    });
+
+    await daemon.start();
+    let client: Client | null = null;
+    try {
+      client = await connectClient(path);
+      const pending = client.callTool({
+        name: "list_surfaces",
+        arguments: { verbose: false },
+      });
+
+      await started.promise;
+      const shutdown = daemon.shutdown("SIGTERM");
+      let shutdownSettled = false;
+      const observedShutdown = shutdown.then((result) => {
+        shutdownSettled = true;
+        return result;
+      });
+      delayNextResponseWrite = true;
+      gate.resolve({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+      await responseWriteStarted.promise;
+      await responseWriteFlushed.promise;
+      await delay(30);
+
+      expect(daemon.inFlightRequestCount()).toBe(1);
+      expect(shutdownSettled).toBe(false);
+
+      releaseResponseWrite();
+
+      await expect(pending).resolves.toMatchObject({
+        structuredContent: expect.objectContaining({ ok: true }),
+      });
+      await expect(observedShutdown).resolves.toMatchObject({ forced: false });
+    } finally {
+      gate.resolve({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+      releaseResponseWrite();
+      await client?.close().catch(() => {});
       await daemon.shutdown().catch(() => {});
     }
   });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -187,6 +187,69 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function rawToolsList(path: string, timeoutMs = 500): Promise<{
+  server?: string;
+  toolCount?: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(path);
+    let buffer = "";
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`timed out waiting for tools/list after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const send = (message: Record<string, unknown>) => {
+      socket.write(`${JSON.stringify(message)}\n`);
+    };
+
+    socket.on("connect", () => {
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "raw-daemon-test", version: "0.1.0" },
+        },
+      });
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line.trim()) {
+          continue;
+        }
+        const message = JSON.parse(line);
+        if (message.id === 1) {
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+          continue;
+        }
+        if (message.id === 2) {
+          clearTimeout(timeout);
+          socket.end();
+          resolve({
+            server: message.result?.serverInfo?.name,
+            toolCount: message.result?.tools?.length,
+          });
+        }
+      }
+    });
+    socket.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
 describe("CmuxLayerDaemon", () => {
   afterEach(() => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
@@ -216,6 +279,27 @@ describe("CmuxLayerDaemon", () => {
     expect(result.structuredContent?.surfaces).toHaveLength(1);
 
     await client.close();
+    await daemon.shutdown();
+  });
+
+  it("serves the first cold connection after lazy context creation", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("cold-first");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      createClient: async () => {
+        await delay(200);
+        return {} as any;
+      },
+      skipAgentLifecycle: true,
+    });
+
+    await daemon.start();
+
+    await expect(rawToolsList(path, 100)).resolves.toMatchObject({
+      toolCount: 17,
+    });
+
     await daemon.shutdown();
   });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -279,6 +279,16 @@ describe("CmuxLayerDaemon", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
   });
 
+  it("rejects start after the socket transport has been closed", async () => {
+    const socket = new net.Socket();
+    const transport = new SocketJsonRpcTransport(socket);
+
+    await transport.close();
+
+    await expect(transport.start()).rejects.toThrow(/closed/i);
+    socket.destroy();
+  });
+
   it("reuses one lifecycle AgentEngine across servers sharing a context", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const context = createServerContext({
@@ -627,7 +637,11 @@ describe("CmuxLayerDaemon", () => {
   it("does not unlink a live daemon socket when another daemon is running", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("live-socket");
+    const acceptedSockets = new Set<net.Socket>();
     const liveServer = net.createServer((socket) => {
+      acceptedSockets.add(socket);
+      socket.on("error", () => {});
+      socket.on("close", () => acceptedSockets.delete(socket));
       socket.end("live\n");
     });
     const daemon = new CmuxLayerDaemon({
@@ -643,6 +657,9 @@ describe("CmuxLayerDaemon", () => {
       await expect(readOnce(path)).resolves.toBe("live\n");
     } finally {
       await daemon.shutdown().catch(() => {});
+      for (const socket of acceptedSockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve) => liveServer.close(() => resolve()));
     }
   });


### PR DESCRIPTION
## Summary
- Refactor `createServer` so fresh MCP server instances can share one server-side world-model context: cmux client, `StateManager`, `AgentRegistry`, role overrides, delivery/write maps, and lifecycle sweep ownership.
- Add `src/daemon.ts`, a flag-gated Unix-socket daemon entrypoint with lazy context initialization, SDK-compatible newline JSON-RPC framing over `net.Socket`, per-connection MCP servers, `server.listen({ fd })` socket-activation support, dev socket bind fallback, and SIGTERM/SIGINT drain with a hard timeout.
- Add `daemon` package script and daemon regression tests covering real Unix-socket MCP initialize/tools calls, concurrent shared world-model visibility, drain shutdown, and the fd-listen branch.

## Out of scope kept out
- No `.mcp.json` changes.
- No edge proxy or handshake replay.
- No launchd/native addon/SQLite migration.

## Test plan
- [x] TDD red: `bunx vitest run tests/daemon.test.ts` initially failed on missing daemon module.
- [x] `bunx vitest run tests/daemon.test.ts`
- [x] `bunx vitest run tests/server.test.ts tests/server-agent-tools.test.ts tests/daemon.test.ts`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (586 tests)
- [x] Push hook reran full test suite green (586 tests)

## Review notes
- `cr review --plain` returned one minor finding for the pre-existing untracked `claude.scratchpad.md`; it is not staged or included in this PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-running process path with shared mutable agent/lifecycle state across clients; shutdown/drain and socket binding behavior affect reliability under concurrent MCP connections.
> 
> **Overview**
> Introduces a **long-lived daemon** that serves MCP over a Unix socket (default `/tmp/cmuxlayer.sock`) instead of one stdio process per client. Each connection gets its own `McpServer`, but they share a single **`CmuxServerContext`**: cmux client, `StateManager`, delivery/write maps, `AgentRegistry`, and one **`AgentEngine`** sweep started only once.
> 
> **`src/daemon.ts`** adds `SocketJsonRpcTransport` (newline JSON-RPC on `net.Socket`, request/response tracking for drain), `CmuxLayerDaemon` (lazy context init, stale-socket cleanup vs live-socket probe, optional **`listen({ fd })`** via `CMUXLAYER_DAEMON_FD` / `LISTEN_FDS`), and graceful shutdown that pauses input, waits for in-flight RPCs (with timeout, then force).
> 
> **`src/server.ts`** refactors so `createServer` can take optional **`context`** from `createServerContext()`; lifecycle registry/engine are reused on the shared context and **`DeliveryRecord`** is exported for tests.
> 
> **`package.json`** adds **`npm run daemon`** → `node dist/daemon.js`. **`tests/daemon.test.ts`** covers socket MCP calls, shared agent state across clients, drain/shutdown, and FD activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e000837973a0060ed25e5976368b5e3cd101057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CmuxLayerDaemon` with Unix socket JSON-RPC transport and graceful shutdown
> - Introduces `CmuxLayerDaemon` in [src/daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/125/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539) that listens on a Unix socket (or systemd activation FD) and spawns a per-connection MCP server instance backed by a shared `CmuxServerContext`.
> - Adds `SocketJsonRpcTransport` to parse newline-delimited JSON-RPC messages over `net.Socket`, tracking in-flight requests to support graceful drain.
> - Adds `createServerContext` and `CmuxServerContext` in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/125/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) so multiple server instances share a single agent registry, state manager, and lifecycle engine without duplicate sweeps.
> - Shutdown drains in-flight requests up to a configurable timeout, then force-closes remaining connections; SIGTERM/SIGINT handlers exit with code 0 (graceful) or 1 (forced).
> - Stale Unix socket files are cleaned up on startup; a live socket causes startup to fail rather than clobber it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e00083.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->