### PR TITLE
feat: add reconnecting daemon proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "bin": {
     "cmuxlayer": "./dist/index.js",
-    "cmuxlayer-app-server": "./dist/app-server-index.js"
+    "cmuxlayer-app-server": "./dist/app-server-index.js",
+    "cmuxlayer-proxy": "./dist/proxy.js"
   },
   "author": "Etan Heyman",
   "license": "Apache-2.0",
@@ -44,6 +45,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "daemon": "node dist/daemon.js",
+    "proxy": "node dist/proxy.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,5 +1,19 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+// Pin Turbopack's root to this site directory. The repo root holds its own
+// package-lock.json (for the MCP server), so Next.js infers the monorepo root
+// as the workspace root via lockfile detection and then scans repo-root `src/`
+// for the `proxy.ts` file convention (the renamed middleware) — picking up the
+// MCP edge proxy at `../src/proxy.ts` and failing the build. Pinning the root
+// keeps Next's file-convention scanning and module resolution inside `site/`.
+const siteRoot = path.dirname(fileURLToPath(import.meta.url));
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: siteRoot,
+  },
+};
 
 export default nextConfig;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,682 @@
+#!/usr/bin/env node
+
+import net from "node:net";
+import { pathToFileURL } from "node:url";
+import type { Readable, Writable } from "node:stream";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type {
+  JSONRPCMessage,
+  RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const DEFAULT_SOCKET_PATH = "/tmp/cmuxlayer.sock";
+const DEFAULT_INITIAL_BACKOFF_MS = 100;
+const DEFAULT_MAX_BACKOFF_MS = 5_000;
+const DEFAULT_RECONNECT_JITTER_RATIO = 0.3;
+const DEFAULT_REQUEST_TIMEOUT_MS = 300_000;
+const DEFAULT_MAX_BUFFERED_REQUESTS = 100;
+const PROXY_ERROR_CODE = -32001;
+
+export interface ReconnectDelayOptions {
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  jitterRatio: number;
+  random: () => number;
+}
+
+export interface CmuxLayerProxyOptions {
+  socketPath?: string;
+  input?: Readable;
+  output?: Writable;
+  connect?: (socketPath: string) => net.Socket;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  reconnectJitterRatio?: number;
+  random?: () => number;
+  requestTimeoutMs?: number;
+  maxBufferedRequests?: number;
+  onReconnectDelay?: (delayMs: number, attempt: number) => void;
+  logger?: Pick<Console, "error">;
+}
+
+type JsonRpcRequest = JSONRPCMessage & {
+  id: RequestId;
+  method: string;
+};
+
+type JsonRpcNotification = JSONRPCMessage & {
+  method: string;
+};
+
+type JsonRpcResponse = JSONRPCMessage & {
+  id: RequestId;
+};
+
+interface QueuedMessage {
+  message: JSONRPCMessage;
+  sequence: number;
+  requestKey?: string;
+}
+
+interface PendingRequest extends QueuedMessage {
+  id: RequestId;
+  timeout: NodeJS.Timeout;
+  sent: boolean;
+}
+
+export function computeReconnectDelay(
+  attempt: number,
+  opts: ReconnectDelayOptions,
+): number {
+  const base = Math.min(
+    opts.maxBackoffMs,
+    opts.initialBackoffMs * 2 ** Math.max(0, attempt),
+  );
+  const jitter = base * opts.jitterRatio * opts.random();
+  return Math.min(opts.maxBackoffMs, Math.round(base + jitter));
+}
+
+function isJsonRpcRequest(message: JSONRPCMessage): message is JsonRpcRequest {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    "method" in message &&
+    typeof message.method === "string"
+  );
+}
+
+function isJsonRpcNotification(
+  message: JSONRPCMessage,
+): message is JsonRpcNotification {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    !("id" in message) &&
+    "method" in message &&
+    typeof message.method === "string"
+  );
+}
+
+function isJsonRpcResponse(message: JSONRPCMessage): message is JsonRpcResponse {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    ("result" in message || "error" in message)
+  );
+}
+
+function requestKey(id: RequestId): string {
+  return `${typeof id}:${String(id)}`;
+}
+
+function cloneMessage<T extends JSONRPCMessage>(message: T): T {
+  return JSON.parse(JSON.stringify(message)) as T;
+}
+
+function writeMessage(
+  stream: Pick<Writable, "write" | "once" | "off">,
+  message: JSONRPCMessage,
+): Promise<void> {
+  const payload = serializeMessage(message);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const onError = (error: Error) => settle(error);
+    const onClose = () => settle(new Error("stream closed before write completed"));
+    const cleanup = () => {
+      stream.off("error", onError);
+      stream.off("close", onClose);
+    };
+    function settle(error?: Error | null) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    }
+
+    stream.once("error", onError);
+    stream.once("close", onClose);
+    try {
+      stream.write(payload, settle);
+    } catch (error) {
+      settle(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+
+export class CmuxLayerProxy {
+  private readonly socketPath: string;
+  private readonly input: Readable;
+  private readonly output: Writable;
+  private readonly connect: (socketPath: string) => net.Socket;
+  private readonly initialBackoffMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly reconnectJitterRatio: number;
+  private readonly random: () => number;
+  private readonly requestTimeoutMs: number;
+  private readonly maxBufferedRequests: number;
+  private readonly onReconnectDelay?: (delayMs: number, attempt: number) => void;
+  private readonly logger: Pick<Console, "error">;
+
+  private readonly agentReadBuffer = new ReadBuffer();
+  private daemonReadBuffer: ReadBuffer | null = null;
+  private daemonSocket: net.Socket | null = null;
+  private running = false;
+  private connecting = false;
+  private daemonReady = false;
+  private flushing = false;
+  private replayingInitialize = false;
+  private initializeResultDelivered = false;
+  private initializeRequest: JsonRpcRequest | null = null;
+  private initializedNotification: JsonRpcNotification | null = null;
+  private nextSequence = 0;
+  private reconnectAttempt = 0;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private reconnectTimerResolve: (() => void) | null = null;
+  private readonly queue: QueuedMessage[] = [];
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly expiredRequestKeys = new Set<string>();
+
+  private readonly onAgentData = (chunk: Buffer) => {
+    this.agentReadBuffer.append(chunk);
+    this.processAgentBuffer();
+  };
+
+  private readonly onAgentError = (error: Error) => {
+    this.logger.error("[cmuxlayer-proxy] agent stdio error", error);
+  };
+
+  constructor(opts: CmuxLayerProxyOptions = {}) {
+    this.socketPath =
+      opts.socketPath ??
+      process.env.CMUXLAYER_DAEMON_SOCKET ??
+      DEFAULT_SOCKET_PATH;
+    this.input = opts.input ?? process.stdin;
+    this.output = opts.output ?? process.stdout;
+    this.connect = opts.connect ?? ((path) => net.createConnection(path));
+    this.initialBackoffMs =
+      opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+    this.maxBackoffMs = opts.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+    this.reconnectJitterRatio =
+      opts.reconnectJitterRatio ?? DEFAULT_RECONNECT_JITTER_RATIO;
+    this.random = opts.random ?? Math.random;
+    this.requestTimeoutMs =
+      opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.maxBufferedRequests =
+      opts.maxBufferedRequests ?? DEFAULT_MAX_BUFFERED_REQUESTS;
+    this.onReconnectDelay = opts.onReconnectDelay;
+    this.logger = opts.logger ?? console;
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.input.on("data", this.onAgentData);
+    this.input.on("error", this.onAgentError);
+    this.ensureConnecting();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+    this.running = false;
+    this.input.off("data", this.onAgentData);
+    this.input.off("error", this.onAgentError);
+    this.agentReadBuffer.clear();
+    this.clearReconnectTimer();
+    this.disconnectDaemon();
+    for (const pending of this.pendingRequests.values()) {
+      clearTimeout(pending.timeout);
+    }
+    this.pendingRequests.clear();
+    this.queue.length = 0;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  private processAgentBuffer(): void {
+    while (this.running) {
+      try {
+        const message = this.agentReadBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        this.handleAgentMessage(message);
+      } catch (error) {
+        this.logger.error(
+          "[cmuxlayer-proxy] failed to parse agent frame",
+          error,
+        );
+      }
+    }
+  }
+
+  private handleAgentMessage(message: JSONRPCMessage): void {
+    if (isJsonRpcRequest(message)) {
+      if (message.method === "initialize") {
+        this.initializeRequest = cloneMessage(message);
+      }
+      this.enqueueRequest(message);
+      return;
+    }
+
+    if (
+      isJsonRpcNotification(message) &&
+      message.method === "notifications/initialized"
+    ) {
+      this.initializedNotification = cloneMessage(message);
+    }
+
+    this.queue.push({
+      message: cloneMessage(message),
+      sequence: this.nextSequence++,
+    });
+    void this.flushQueue();
+  }
+
+  private enqueueRequest(message: JsonRpcRequest): void {
+    if (!this.daemonReady && this.bufferedRequestCount() >= this.maxBufferedRequests) {
+      void this.sendAgentError(
+        message.id,
+        "cmuxlayer daemon request buffer is full while reconnecting",
+      );
+      return;
+    }
+
+    const key = requestKey(message.id);
+    this.expiredRequestKeys.delete(key);
+    const pending: PendingRequest = {
+      id: message.id,
+      message: cloneMessage(message),
+      sequence: this.nextSequence++,
+      requestKey: key,
+      sent: false,
+      timeout: setTimeout(() => {
+        this.failPendingRequest(
+          key,
+          "cmuxlayer daemon temporarily offline or request timed out while retrying",
+        );
+      }, this.requestTimeoutMs),
+    };
+    this.pendingRequests.set(key, pending);
+    this.queue.push(pending);
+    void this.flushQueue();
+  }
+
+  private bufferedRequestCount(): number {
+    return this.queue.filter((queued) => queued.requestKey).length;
+  }
+
+  private ensureConnecting(): void {
+    if (!this.running || this.connecting || this.daemonSocket) {
+      return;
+    }
+    this.connecting = true;
+    void this.reconnectLoop();
+  }
+
+  private async reconnectLoop(): Promise<void> {
+    while (this.running && !this.daemonSocket) {
+      try {
+        const socket = await this.openDaemonSocket();
+        this.connecting = false;
+        this.attachDaemonSocket(socket);
+        return;
+      } catch {
+        const attempt = this.reconnectAttempt++;
+        const delayMs = computeReconnectDelay(attempt, {
+          initialBackoffMs: this.initialBackoffMs,
+          maxBackoffMs: this.maxBackoffMs,
+          jitterRatio: this.reconnectJitterRatio,
+          random: this.random,
+        });
+        this.onReconnectDelay?.(delayMs, attempt);
+        await this.delay(delayMs);
+      }
+    }
+    this.connecting = false;
+  }
+
+  private openDaemonSocket(): Promise<net.Socket> {
+    const socket = this.connect(this.socketPath);
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        socket.off("connect", onConnect);
+        socket.off("error", onError);
+      };
+      const settle = (error?: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        if (error) {
+          socket.destroy();
+          reject(error);
+          return;
+        }
+        resolve(socket);
+      };
+      const onConnect = () => settle();
+      const onError = (error: Error) => settle(error);
+      socket.once("connect", onConnect);
+      socket.once("error", onError);
+    });
+  }
+
+  private attachDaemonSocket(socket: net.Socket): void {
+    if (!this.running) {
+      socket.destroy();
+      return;
+    }
+    this.daemonSocket = socket;
+    this.daemonReadBuffer = new ReadBuffer();
+    this.reconnectAttempt = 0;
+    socket.on("data", this.onDaemonData);
+    socket.on("error", this.onDaemonError);
+    socket.on("close", this.onDaemonClose);
+
+    if (
+      this.initializeResultDelivered &&
+      this.initializeRequest
+    ) {
+      this.replayInitialize();
+      return;
+    }
+
+    this.daemonReady = true;
+    void this.flushQueue();
+  }
+
+  private readonly onDaemonData = (chunk: Buffer) => {
+    if (!this.daemonReadBuffer) {
+      return;
+    }
+    this.daemonReadBuffer.append(chunk);
+    while (this.running) {
+      try {
+        const message = this.daemonReadBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        this.handleDaemonMessage(message);
+      } catch (error) {
+        this.logger.error(
+          "[cmuxlayer-proxy] failed to parse daemon frame",
+          error,
+        );
+      }
+    }
+  };
+
+  private readonly onDaemonError = () => {};
+
+  private readonly onDaemonClose = () => {
+    this.handleDaemonDrop();
+  };
+
+  private handleDaemonMessage(message: JSONRPCMessage): void {
+    if (this.replayingInitialize && this.isInitializeResponse(message)) {
+      this.replayingInitialize = false;
+      void this.sendInitializedThenFlush();
+      return;
+    }
+
+    if (isJsonRpcResponse(message)) {
+      const key = requestKey(message.id);
+      const pending = this.pendingRequests.get(key);
+      if (!pending) {
+        if (this.expiredRequestKeys.has(key)) {
+          return;
+        }
+        void this.writeAgent(message);
+        return;
+      }
+      clearTimeout(pending.timeout);
+      this.pendingRequests.delete(key);
+      this.expiredRequestKeys.delete(key);
+      if (this.initializeRequest && key === requestKey(this.initializeRequest.id)) {
+        this.initializeResultDelivered = true;
+      }
+      void this.writeAgent(message);
+      return;
+    }
+
+    void this.writeAgent(message);
+  }
+
+  private isInitializeResponse(message: JSONRPCMessage): boolean {
+    return (
+      isJsonRpcResponse(message) &&
+      this.initializeRequest !== null &&
+      requestKey(message.id) === requestKey(this.initializeRequest.id)
+    );
+  }
+
+  private replayInitialize(): void {
+    if (!this.daemonSocket || !this.initializeRequest) {
+      this.handleDaemonDrop();
+      return;
+    }
+    this.daemonReady = false;
+    this.replayingInitialize = true;
+    void writeMessage(this.daemonSocket, this.initializeRequest).catch(() => {
+      this.handleDaemonDrop();
+    });
+  }
+
+  private async sendInitializedThenFlush(): Promise<void> {
+    if (!this.daemonSocket) {
+      this.handleDaemonDrop();
+      return;
+    }
+    if (this.initializedNotification) {
+      this.removeQueuedInitializedNotifications();
+      try {
+        await writeMessage(this.daemonSocket, this.initializedNotification);
+      } catch {
+        this.handleDaemonDrop();
+        return;
+      }
+    }
+    this.daemonReady = true;
+    await this.flushQueue();
+  }
+
+  private removeQueuedInitializedNotifications(): void {
+    for (let index = this.queue.length - 1; index >= 0; index -= 1) {
+      const queued = this.queue[index];
+      if (
+        isJsonRpcNotification(queued.message) &&
+        queued.message.method === "notifications/initialized"
+      ) {
+        this.queue.splice(index, 1);
+      }
+    }
+  }
+
+  private async flushQueue(): Promise<void> {
+    if (this.flushing || !this.running || !this.daemonReady || !this.daemonSocket) {
+      return;
+    }
+    this.flushing = true;
+    try {
+      while (
+        this.running &&
+        this.daemonReady &&
+        this.daemonSocket &&
+        this.queue.length > 0
+      ) {
+        const queued = this.queue.shift();
+        if (!queued) {
+          continue;
+        }
+        const pending = queued.requestKey
+          ? this.pendingRequests.get(queued.requestKey)
+          : undefined;
+        if (queued.requestKey && !pending) {
+          continue;
+        }
+        if (pending) {
+          pending.sent = true;
+        }
+        try {
+          await writeMessage(this.daemonSocket, queued.message);
+        } catch {
+          if (pending) {
+            pending.sent = false;
+          }
+          this.queue.unshift(queued);
+          this.handleDaemonDrop();
+          return;
+        }
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  private handleDaemonDrop(): void {
+    if (!this.daemonSocket && !this.daemonReadBuffer) {
+      this.ensureConnecting();
+      return;
+    }
+    this.disconnectDaemon();
+    this.daemonReady = false;
+    this.replayingInitialize = false;
+    this.requeueSentRequests();
+    this.enforceBufferCap();
+    this.ensureConnecting();
+  }
+
+  private disconnectDaemon(): void {
+    const socket = this.daemonSocket;
+    if (socket) {
+      socket.off("data", this.onDaemonData);
+      socket.off("error", this.onDaemonError);
+      socket.off("close", this.onDaemonClose);
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+    }
+    this.daemonSocket = null;
+    this.daemonReadBuffer?.clear();
+    this.daemonReadBuffer = null;
+  }
+
+  private requeueSentRequests(): void {
+    const queued = new Set(this.queue);
+    for (const pending of this.pendingRequests.values()) {
+      if (!pending.sent || queued.has(pending)) {
+        continue;
+      }
+      pending.sent = false;
+      this.queue.push(pending);
+    }
+    this.queue.sort((left, right) => left.sequence - right.sequence);
+  }
+
+  private failPendingRequest(key: string, message: string): void {
+    const pending = this.pendingRequests.get(key);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingRequests.delete(key);
+    this.expiredRequestKeys.add(key);
+    const index = this.queue.findIndex((queued) => queued.requestKey === key);
+    if (index >= 0) {
+      this.queue.splice(index, 1);
+    }
+    void this.sendAgentError(pending.id, message);
+  }
+
+  private enforceBufferCap(): void {
+    const queuedRequests = this.queue
+      .filter((queued) => queued.requestKey)
+      .sort((left, right) => left.sequence - right.sequence);
+    for (const queued of queuedRequests.slice(this.maxBufferedRequests)) {
+      if (!queued.requestKey) {
+        continue;
+      }
+      this.failPendingRequest(
+        queued.requestKey,
+        "cmuxlayer daemon request buffer is full while reconnecting",
+      );
+    }
+  }
+
+  private sendAgentError(id: RequestId, message: string): Promise<void> {
+    return this.writeAgent({
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: PROXY_ERROR_CODE,
+        message,
+      },
+    });
+  }
+
+  private async writeAgent(message: JSONRPCMessage): Promise<void> {
+    try {
+      await writeMessage(this.output, message);
+    } catch (error) {
+      this.logger.error("[cmuxlayer-proxy] failed to write agent frame", error);
+    }
+  }
+
+  private delay(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.reconnectTimerResolve = resolve;
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        this.reconnectTimerResolve = null;
+        resolve();
+      }, delayMs);
+    });
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectTimerResolve?.();
+    this.reconnectTimerResolve = null;
+  }
+}
+
+export async function runProxy(
+  opts: CmuxLayerProxyOptions = {},
+): Promise<CmuxLayerProxy> {
+  const proxy = new CmuxLayerProxy(opts);
+  proxy.start();
+  return proxy;
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  runProxy().catch((error) => {
+    console.error("[cmuxlayer-proxy] fatal", error);
+    process.exit(1);
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -101,7 +101,9 @@ function isJsonRpcNotification(
   );
 }
 
-function isJsonRpcResponse(message: JSONRPCMessage): message is JsonRpcResponse {
+function isJsonRpcResponse(
+  message: JSONRPCMessage,
+): message is JsonRpcResponse {
   return (
     typeof message === "object" &&
     message !== null &&
@@ -119,14 +121,19 @@ function cloneMessage<T extends JSONRPCMessage>(message: T): T {
 }
 
 function writeMessage(
-  stream: Pick<Writable, "write" | "once" | "off">,
+  stream: Pick<Writable, "write" | "once" | "off"> &
+    Partial<Pick<Writable, "destroyed" | "writableEnded">>,
   message: JSONRPCMessage,
 ): Promise<void> {
+  if (stream.destroyed || stream.writableEnded) {
+    return Promise.reject(new Error("stream is closed"));
+  }
   const payload = serializeMessage(message);
   return new Promise((resolve, reject) => {
     let settled = false;
     const onError = (error: Error) => settle(error);
-    const onClose = () => settle(new Error("stream closed before write completed"));
+    const onClose = () =>
+      settle(new Error("stream closed before write completed"));
     const cleanup = () => {
       stream.off("error", onError);
       stream.off("close", onClose);
@@ -165,7 +172,10 @@ export class CmuxLayerProxy {
   private readonly random: () => number;
   private readonly requestTimeoutMs: number;
   private readonly maxBufferedRequests: number;
-  private readonly onReconnectDelay?: (delayMs: number, attempt: number) => void;
+  private readonly onReconnectDelay?: (
+    delayMs: number,
+    attempt: number,
+  ) => void;
   private readonly logger: Pick<Console, "error">;
 
   private readonly agentReadBuffer = new ReadBuffer();
@@ -204,14 +214,12 @@ export class CmuxLayerProxy {
     this.input = opts.input ?? process.stdin;
     this.output = opts.output ?? process.stdout;
     this.connect = opts.connect ?? ((path) => net.createConnection(path));
-    this.initialBackoffMs =
-      opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+    this.initialBackoffMs = opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
     this.maxBackoffMs = opts.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
     this.reconnectJitterRatio =
       opts.reconnectJitterRatio ?? DEFAULT_RECONNECT_JITTER_RATIO;
     this.random = opts.random ?? Math.random;
-    this.requestTimeoutMs =
-      opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.maxBufferedRequests =
       opts.maxBufferedRequests ?? DEFAULT_MAX_BUFFERED_REQUESTS;
     this.onReconnectDelay = opts.onReconnectDelay;
@@ -286,11 +294,24 @@ export class CmuxLayerProxy {
       message: cloneMessage(message),
       sequence: this.nextSequence++,
     });
+    this.kickConnectionIfIdle();
     void this.flushQueue();
   }
 
   private enqueueRequest(message: JsonRpcRequest): void {
-    if (!this.daemonReady && this.bufferedRequestCount() >= this.maxBufferedRequests) {
+    const key = requestKey(message.id);
+    if (this.pendingRequests.has(key)) {
+      void this.sendAgentError(
+        message.id,
+        "duplicate JSON-RPC request id is already pending",
+      );
+      return;
+    }
+
+    if (
+      !this.daemonReady &&
+      this.bufferedRequestCount() >= this.maxBufferedRequests
+    ) {
       void this.sendAgentError(
         message.id,
         "cmuxlayer daemon request buffer is full while reconnecting",
@@ -298,7 +319,6 @@ export class CmuxLayerProxy {
       return;
     }
 
-    const key = requestKey(message.id);
     this.expiredRequestKeys.delete(key);
     const pending: PendingRequest = {
       id: message.id,
@@ -315,6 +335,7 @@ export class CmuxLayerProxy {
     };
     this.pendingRequests.set(key, pending);
     this.queue.push(pending);
+    this.kickConnectionIfIdle();
     void this.flushQueue();
   }
 
@@ -328,6 +349,22 @@ export class CmuxLayerProxy {
     }
     this.connecting = true;
     void this.reconnectLoop();
+  }
+
+  // Resume connecting after we went quiescent (e.g. the daemon rejected the
+  // replayed initialize). No-ops while connected, connecting, or a reconnect
+  // is already scheduled, so it only fires when the proxy is fully idle.
+  private kickConnectionIfIdle(): void {
+    if (
+      !this.running ||
+      this.daemonSocket ||
+      this.connecting ||
+      this.reconnectTimer
+    ) {
+      return;
+    }
+    this.reconnectAttempt = 0;
+    this.ensureConnecting();
   }
 
   private async reconnectLoop(): Promise<void> {
@@ -387,20 +424,21 @@ export class CmuxLayerProxy {
     }
     this.daemonSocket = socket;
     this.daemonReadBuffer = new ReadBuffer();
-    this.reconnectAttempt = 0;
     socket.on("data", this.onDaemonData);
     socket.on("error", this.onDaemonError);
     socket.on("close", this.onDaemonClose);
+    socket.resume();
 
     if (
-      this.initializeResultDelivered &&
-      this.initializeRequest
+      this.initializeRequest &&
+      !this.pendingRequests.has(requestKey(this.initializeRequest.id))
     ) {
       this.replayInitialize();
       return;
     }
 
     this.daemonReady = true;
+    this.reconnectAttempt = 0;
     void this.flushQueue();
   }
 
@@ -409,9 +447,13 @@ export class CmuxLayerProxy {
       return;
     }
     this.daemonReadBuffer.append(chunk);
-    while (this.running) {
+    // handleDaemonMessage may disconnect the daemon mid-loop (e.g. on a rejected
+    // initialize replay), which nulls daemonReadBuffer — re-check it each pass so
+    // we don't dereference null and spin forever logging TypeErrors.
+    while (this.running && this.daemonReadBuffer) {
+      const buffer = this.daemonReadBuffer;
       try {
-        const message = this.daemonReadBuffer.readMessage();
+        const message = buffer.readMessage();
         if (message === null) {
           break;
         }
@@ -421,11 +463,14 @@ export class CmuxLayerProxy {
           "[cmuxlayer-proxy] failed to parse daemon frame",
           error,
         );
+        break;
       }
     }
   };
 
-  private readonly onDaemonError = () => {};
+  private readonly onDaemonError = () => {
+    // Swallow socket errors; the following "close" event drives reconnection.
+  };
 
   private readonly onDaemonClose = () => {
     this.handleDaemonDrop();
@@ -434,6 +479,18 @@ export class CmuxLayerProxy {
   private handleDaemonMessage(message: JSONRPCMessage): void {
     if (this.replayingInitialize && this.isInitializeResponse(message)) {
       this.replayingInitialize = false;
+      if ("error" in message) {
+        this.failAllPendingRequests(
+          "cmuxlayer daemon initialize replay failed while reconnecting",
+        );
+        // A replayed initialize that the daemon *answers with an error* is a
+        // protocol rejection (e.g. handshake/version mismatch), not a transport
+        // drop. Reconnecting-and-replaying immediately would hammer the daemon
+        // in a tight loop (a connection storm), so go quiescent here and only
+        // reconnect when fresh agent traffic arrives — see kickConnectionIfIdle.
+        this.disconnectDaemon();
+        return;
+      }
       void this.sendInitializedThenFlush();
       return;
     }
@@ -451,7 +508,10 @@ export class CmuxLayerProxy {
       clearTimeout(pending.timeout);
       this.pendingRequests.delete(key);
       this.expiredRequestKeys.delete(key);
-      if (this.initializeRequest && key === requestKey(this.initializeRequest.id)) {
+      if (
+        this.initializeRequest &&
+        key === requestKey(this.initializeRequest.id)
+      ) {
         this.initializeResultDelivered = true;
       }
       void this.writeAgent(message);
@@ -496,6 +556,7 @@ export class CmuxLayerProxy {
       }
     }
     this.daemonReady = true;
+    this.reconnectAttempt = 0;
     await this.flushQueue();
   }
 
@@ -512,7 +573,12 @@ export class CmuxLayerProxy {
   }
 
   private async flushQueue(): Promise<void> {
-    if (this.flushing || !this.running || !this.daemonReady || !this.daemonSocket) {
+    if (
+      this.flushing ||
+      !this.running ||
+      !this.daemonReady ||
+      !this.daemonSocket
+    ) {
       return;
     }
     this.flushing = true;
@@ -554,7 +620,7 @@ export class CmuxLayerProxy {
 
   private handleDaemonDrop(): void {
     if (!this.daemonSocket && !this.daemonReadBuffer) {
-      this.ensureConnecting();
+      this.reconnectAfterDelay();
       return;
     }
     this.disconnectDaemon();
@@ -562,7 +628,28 @@ export class CmuxLayerProxy {
     this.replayingInitialize = false;
     this.requeueSentRequests();
     this.enforceBufferCap();
-    this.ensureConnecting();
+    this.reconnectAfterDelay();
+  }
+
+  private reconnectAfterDelay(): void {
+    if (!this.running || this.connecting || this.daemonSocket) {
+      return;
+    }
+    const attempt = this.reconnectAttempt++;
+    const delayMs = computeReconnectDelay(attempt, {
+      initialBackoffMs: this.initialBackoffMs,
+      maxBackoffMs: this.maxBackoffMs,
+      jitterRatio: this.reconnectJitterRatio,
+      random: this.random,
+    });
+    this.onReconnectDelay?.(delayMs, attempt);
+    this.connecting = true;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectTimerResolve = null;
+      this.connecting = false;
+      this.ensureConnecting();
+    }, delayMs);
   }
 
   private disconnectDaemon(): void {
@@ -622,6 +709,12 @@ export class CmuxLayerProxy {
     }
   }
 
+  private failAllPendingRequests(message: string): void {
+    for (const key of [...this.pendingRequests.keys()]) {
+      this.failPendingRequest(key, message);
+    }
+  }
+
   private sendAgentError(id: RequestId, message: string): Promise<void> {
     return this.writeAgent({
       jsonrpc: "2.0",
@@ -671,8 +764,7 @@ export async function runProxy(
 }
 
 const isMain =
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
   runProxy().catch((error) => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -13,10 +13,7 @@ import type {
   JSONRPCMessage,
   JSONRPCRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import {
-  CmuxLayerProxy,
-  computeReconnectDelay,
-} from "../src/proxy.js";
+import { CmuxLayerProxy, computeReconnectDelay } from "../src/proxy.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-proxy-test");
 
@@ -28,10 +25,7 @@ function writeFrame(stream: NodeJS.WritableStream, message: JSONRPCMessage) {
   stream.write(serializeMessage(message));
 }
 
-function waitFor(
-  predicate: () => boolean,
-  timeoutMs = 1_000,
-): Promise<void> {
+function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
   return new Promise((resolve, reject) => {
     const startedAt = Date.now();
     const tick = () => {
@@ -122,10 +116,18 @@ class FakeDaemon {
   private server: net.Server | null = null;
   private readonly events = new EventEmitter();
   private readonly sockets = new Set<net.Socket>();
+  private readonly held: Array<{
+    socket: net.Socket;
+    message: JSONRPCMessage;
+  }> = [];
 
   constructor(
     private readonly path: string,
-    private readonly opts: { holdMethods?: Set<string> } = {},
+    private readonly opts: {
+      holdMethods?: Set<string>;
+      initializeError?: boolean;
+      closeAfterInitializeError?: boolean;
+    } = {},
   ) {}
 
   async start(): Promise<void> {
@@ -155,12 +157,28 @@ class FakeDaemon {
     rmSync(this.path, { force: true });
   }
 
+  releaseHeld(method: string): void {
+    for (let index = this.held.length - 1; index >= 0; index -= 1) {
+      const held = this.held[index];
+      if (
+        typeof held.message === "object" &&
+        held.message !== null &&
+        "method" in held.message &&
+        held.message.method === method
+      ) {
+        this.held.splice(index, 1);
+        this.respond(held.socket, held.message, { ignoreHold: true });
+      }
+    }
+  }
+
   waitForMessage(
     connectionIndex: number,
     predicate: (message: JSONRPCMessage) => boolean,
     timeoutMs = 1_000,
   ): Promise<JSONRPCMessage> {
-    const existing = this.connections[connectionIndex]?.messages.find(predicate);
+    const existing =
+      this.connections[connectionIndex]?.messages.find(predicate);
     if (existing) {
       return Promise.resolve(existing);
     }
@@ -189,7 +207,9 @@ class FakeDaemon {
     const connectionIndex = this.connections.push(connection) - 1;
     const readBuffer = new ReadBuffer();
     this.sockets.add(socket);
-    socket.on("close", () => this.sockets.delete(socket));
+    socket.on("close", () => {
+      this.sockets.delete(socket);
+    });
     socket.on("error", () => {});
     socket.on("data", (chunk) => {
       readBuffer.append(chunk);
@@ -205,7 +225,11 @@ class FakeDaemon {
     });
   }
 
-  private respond(socket: net.Socket, message: JSONRPCMessage) {
+  private respond(
+    socket: net.Socket,
+    message: JSONRPCMessage,
+    opts: { ignoreHold?: boolean } = {},
+  ) {
     if (
       typeof message !== "object" ||
       message === null ||
@@ -214,10 +238,27 @@ class FakeDaemon {
     ) {
       return;
     }
-    if (this.opts.holdMethods?.has(message.method)) {
+    if (!opts.ignoreHold && this.opts.holdMethods?.has(message.method)) {
+      this.held.push({ socket, message });
       return;
     }
     if (message.method === "initialize") {
+      if (this.opts.initializeError) {
+        const payload = serializeMessage({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32000,
+            message: "initialize rejected by fake daemon",
+          },
+        });
+        if (this.opts.closeAfterInitializeError) {
+          socket.end(payload);
+          return;
+        }
+        socket.write(payload);
+        return;
+      }
       writeFrame(socket, {
         jsonrpc: "2.0",
         id: message.id,
@@ -257,7 +298,10 @@ describe("CmuxLayerProxy", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
   });
 
-  function createProxy(path: string, opts: Partial<ConstructorParameters<typeof CmuxLayerProxy>[0]> = {}) {
+  function createProxy(
+    path: string,
+    opts: Partial<ConstructorParameters<typeof CmuxLayerProxy>[0]> = {},
+  ) {
     const input = new PassThrough();
     const output = new PassThrough();
     const collector = createCollector(output);
@@ -289,15 +333,22 @@ describe("CmuxLayerProxy", () => {
     writeFrame(input, notification("notifications/initialized"));
     writeFrame(input, request(2, "tools/list"));
 
-    await expect(collector.waitForMessage(isResponseFor(1))).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(1)),
+    ).resolves.toMatchObject({
       id: 1,
       result: { serverInfo: { name: "fake-daemon" } },
     });
-    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(2)),
+    ).resolves.toMatchObject({
       id: 2,
       result: { tools: [expect.objectContaining({ name: "list_surfaces" })] },
     });
-    await daemon.waitForMessage(0, (message) => "method" in message && message.method === "tools/list");
+    await daemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
   });
 
   it("replays initialize on daemon restart and completes buffered in-flight requests", async () => {
@@ -314,7 +365,10 @@ describe("CmuxLayerProxy", () => {
     await collector.waitForMessage(isResponseFor(1));
     writeFrame(input, notification("notifications/initialized"));
     writeFrame(input, request(2, "tools/list"));
-    await firstDaemon.waitForMessage(0, (message) => "method" in message && message.method === "tools/list");
+    await firstDaemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
     await firstDaemon.stop();
     daemons.splice(daemons.indexOf(firstDaemon), 1);
 
@@ -322,7 +376,9 @@ describe("CmuxLayerProxy", () => {
     daemons.push(secondDaemon);
     await secondDaemon.start();
 
-    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(2)),
+    ).resolves.toMatchObject({
       id: 2,
       result: { tools: expect.any(Array) },
     });
@@ -332,7 +388,61 @@ describe("CmuxLayerProxy", () => {
         .filter((message) => "method" in message)
         .map((message) => message.method),
     ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
-    expect(collector.messages.filter((message) => "id" in message && message.id === 1)).toHaveLength(1);
+    expect(
+      collector.messages.filter(
+        (message) => "id" in message && message.id === 1,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("rejects duplicate request ids without replacing the original pending request", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("duplicate-id");
+    const daemon = new FakeDaemon(path, {
+      holdMethods: new Set(["tools/list"]),
+    });
+    daemons.push(daemon);
+    await daemon.start();
+    const { input, collector } = createProxy(path, { requestTimeoutMs: 1_000 });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+    await daemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
+
+    writeFrame(input, request(2, "read_screen"));
+
+    await expect(
+      collector.waitForMessage(
+        (message) =>
+          isResponseFor(2)(message) &&
+          "error" in message &&
+          /duplicate/i.test(message.error.message),
+      ),
+    ).resolves.toMatchObject({
+      id: 2,
+      error: expect.objectContaining({
+        code: -32001,
+      }),
+    });
+
+    daemon.releaseHeld("tools/list");
+
+    await expect(
+      collector.waitForMessage(
+        (message) =>
+          isResponseFor(2)(message) &&
+          "result" in message &&
+          Array.isArray(message.result.tools),
+      ),
+    ).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
   });
 
   it("replays initialize if the daemon restarts before initialized notification is cached", async () => {
@@ -358,7 +468,9 @@ describe("CmuxLayerProxy", () => {
     writeFrame(input, notification("notifications/initialized"));
     writeFrame(input, request(2, "tools/list"));
 
-    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(2)),
+    ).resolves.toMatchObject({
       id: 2,
       result: { tools: expect.any(Array) },
     });
@@ -367,7 +479,110 @@ describe("CmuxLayerProxy", () => {
         .filter((message) => "method" in message)
         .map((message) => message.method),
     ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
-    expect(collector.messages.filter((message) => "id" in message && message.id === 1)).toHaveLength(1);
+    expect(
+      collector.messages.filter(
+        (message) => "id" in message && message.id === 1,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does not flush queued RPCs when replayed initialize returns an error", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("replay-init-error");
+    const firstDaemon = new FakeDaemon(path, {
+      holdMethods: new Set(["tools/list"]),
+    });
+    daemons.push(firstDaemon);
+    await firstDaemon.start();
+    const { input, collector } = createProxy(path, {
+      requestTimeoutMs: 500,
+      initialBackoffMs: 5,
+      maxBackoffMs: 10,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+    await firstDaemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
+    await firstDaemon.stop();
+    daemons.splice(daemons.indexOf(firstDaemon), 1);
+
+    const secondDaemon = new FakeDaemon(path, {
+      initializeError: true,
+      closeAfterInitializeError: true,
+    });
+    daemons.push(secondDaemon);
+    await secondDaemon.start();
+    await secondDaemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "initialize",
+    );
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 500),
+    ).resolves.toMatchObject({
+      id: 2,
+      error: expect.objectContaining({
+        code: -32001,
+        message: expect.stringMatching(/initialize replay/i),
+      }),
+    });
+
+    expect(
+      secondDaemon.connections.flatMap((connection) =>
+        connection.messages
+          .filter((message) => "method" in message)
+          .map((message) => message.method),
+      ),
+    ).not.toContain("tools/list");
+  });
+
+  it("replays initialize before queued RPCs after the original initialize timed out", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("init-timeout-replay");
+    const { input, collector } = createProxy(path, {
+      requestTimeoutMs: 50,
+      initialBackoffMs: 5,
+      maxBackoffMs: 10,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    writeFrame(input, notification("notifications/initialized"));
+
+    // No daemon is listening, so the original initialize times out and the agent
+    // gets a keyed error (it is not re-sent — see the outage-timeout test).
+    await expect(
+      collector.waitForMessage(isResponseFor(1), 500),
+    ).resolves.toMatchObject({
+      id: 1,
+      error: expect.objectContaining({
+        code: -32001,
+      }),
+    });
+
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    // The agent retries once the daemon is back. The proxy must replay the
+    // cached initialize (and initialized) before forwarding this request, even
+    // though the original initialize already "completed" with a timeout error.
+    writeFrame(input, request(2, "tools/list"));
+
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 1_000),
+    ).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
+    expect(
+      daemon.connections[0].messages
+        .filter((message) => "method" in message)
+        .map((message) => message.method),
+    ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
   });
 
   it("computes exponential reconnect backoff with jitter", () => {
@@ -381,7 +596,9 @@ describe("CmuxLayerProxy", () => {
     );
 
     expect(delays).toEqual([125, 250, 500, 800]);
-    expect(delays.every((delay, index) => index === 0 || delay > delays[index - 1])).toBe(true);
+    expect(
+      delays.every((delay, index) => index === 0 || delay > delays[index - 1]),
+    ).toBe(true);
   });
 
   it("returns a JSON-RPC error when buffered requests exceed the cap", async () => {
@@ -405,7 +622,9 @@ describe("CmuxLayerProxy", () => {
     writeFrame(input, request(2, "tools/list"));
     writeFrame(input, request(3, "tools/list"));
 
-    await expect(collector.waitForMessage(isResponseFor(3))).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(3)),
+    ).resolves.toMatchObject({
       id: 3,
       error: expect.objectContaining({
         code: -32001,
@@ -430,7 +649,9 @@ describe("CmuxLayerProxy", () => {
 
     writeFrame(input, request(2, "tools/list"));
 
-    await expect(collector.waitForMessage(isResponseFor(2), 500)).resolves.toMatchObject({
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 500),
+    ).resolves.toMatchObject({
       id: 2,
       error: expect.objectContaining({
         code: -32001,

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,466 @@
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type {
+  JSONRPCMessage,
+  JSONRPCRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  CmuxLayerProxy,
+  computeReconnectDelay,
+} from "../src/proxy.js";
+
+const TEST_ROOT = join(tmpdir(), "cmuxlayer-proxy-test");
+
+function socketPath(name: string): string {
+  return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);
+}
+
+function writeFrame(stream: NodeJS.WritableStream, message: JSONRPCMessage) {
+  stream.write(serializeMessage(message));
+}
+
+function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error("timed out waiting for condition"));
+        return;
+      }
+      setTimeout(tick, 5);
+    };
+    tick();
+  });
+}
+
+function createCollector(stream: NodeJS.ReadableStream) {
+  const messages: JSONRPCMessage[] = [];
+  const events = new EventEmitter();
+  const readBuffer = new ReadBuffer();
+  stream.on("data", (chunk: Buffer) => {
+    readBuffer.append(chunk);
+    while (true) {
+      const message = readBuffer.readMessage();
+      if (message === null) {
+        break;
+      }
+      messages.push(message);
+      events.emit("message", message);
+    }
+  });
+
+  const waitForMessage = (
+    predicate: (message: JSONRPCMessage) => boolean,
+    timeoutMs = 1_000,
+  ): Promise<JSONRPCMessage> => {
+    const existing = messages.find(predicate);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        events.off("message", onMessage);
+        reject(new Error("timed out waiting for message"));
+      }, timeoutMs);
+      const onMessage = (message: JSONRPCMessage) => {
+        if (!predicate(message)) {
+          return;
+        }
+        clearTimeout(timeout);
+        events.off("message", onMessage);
+        resolve(message);
+      };
+      events.on("message", onMessage);
+    });
+  };
+
+  return { messages, waitForMessage };
+}
+
+function request(
+  id: number,
+  method: string,
+  params: Record<string, unknown> = {},
+): JSONRPCRequest {
+  return { jsonrpc: "2.0", id, method, params };
+}
+
+function notification(method: string, params: Record<string, unknown> = {}) {
+  return { jsonrpc: "2.0" as const, method, params };
+}
+
+function isResponseFor(id: number) {
+  return (message: JSONRPCMessage) =>
+    typeof message === "object" &&
+    message !== null &&
+    "id" in message &&
+    message.id === id &&
+    ("result" in message || "error" in message);
+}
+
+class FakeDaemon {
+  readonly connections: Array<{
+    socket: net.Socket;
+    messages: JSONRPCMessage[];
+  }> = [];
+  private server: net.Server | null = null;
+  private readonly events = new EventEmitter();
+  private readonly sockets = new Set<net.Socket>();
+
+  constructor(
+    private readonly path: string,
+    private readonly opts: { holdMethods?: Set<string> } = {},
+  ) {}
+
+  async start(): Promise<void> {
+    rmSync(this.path, { force: true });
+    this.server = net.createServer((socket) => this.accept(socket));
+    await new Promise<void>((resolve, reject) => {
+      this.server?.once("error", reject);
+      this.server?.listen(this.path, () => {
+        this.server?.off("error", reject);
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    for (const socket of this.sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(() => resolve());
+    });
+    this.server = null;
+    rmSync(this.path, { force: true });
+  }
+
+  waitForMessage(
+    connectionIndex: number,
+    predicate: (message: JSONRPCMessage) => boolean,
+    timeoutMs = 1_000,
+  ): Promise<JSONRPCMessage> {
+    const existing = this.connections[connectionIndex]?.messages.find(predicate);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.events.off("message", onMessage);
+        reject(new Error("timed out waiting for daemon message"));
+      }, timeoutMs);
+      const onMessage = (payload: {
+        index: number;
+        message: JSONRPCMessage;
+      }) => {
+        if (payload.index !== connectionIndex || !predicate(payload.message)) {
+          return;
+        }
+        clearTimeout(timeout);
+        this.events.off("message", onMessage);
+        resolve(payload.message);
+      };
+      this.events.on("message", onMessage);
+    });
+  }
+
+  private accept(socket: net.Socket) {
+    const connection = { socket, messages: [] as JSONRPCMessage[] };
+    const connectionIndex = this.connections.push(connection) - 1;
+    const readBuffer = new ReadBuffer();
+    this.sockets.add(socket);
+    socket.on("close", () => this.sockets.delete(socket));
+    socket.on("error", () => {});
+    socket.on("data", (chunk) => {
+      readBuffer.append(chunk);
+      while (true) {
+        const message = readBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        connection.messages.push(message);
+        this.events.emit("message", { index: connectionIndex, message });
+        this.respond(socket, message);
+      }
+    });
+  }
+
+  private respond(socket: net.Socket, message: JSONRPCMessage) {
+    if (
+      typeof message !== "object" ||
+      message === null ||
+      !("id" in message) ||
+      !("method" in message)
+    ) {
+      return;
+    }
+    if (this.opts.holdMethods?.has(message.method)) {
+      return;
+    }
+    if (message.method === "initialize") {
+      writeFrame(socket, {
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          serverInfo: { name: "fake-daemon", version: "0.1.0" },
+        },
+      });
+      return;
+    }
+    if (message.method === "tools/list") {
+      writeFrame(socket, {
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          tools: [{ name: "list_surfaces", inputSchema: { type: "object" } }],
+        },
+      });
+      return;
+    }
+    writeFrame(socket, {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { ok: true },
+    });
+  }
+}
+
+describe("CmuxLayerProxy", () => {
+  const daemons: FakeDaemon[] = [];
+  const proxies: CmuxLayerProxy[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(proxies.splice(0).map((proxy) => proxy.stop()));
+    await Promise.allSettled(daemons.splice(0).map((daemon) => daemon.stop()));
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  function createProxy(path: string, opts: Partial<ConstructorParameters<typeof CmuxLayerProxy>[0]> = {}) {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const collector = createCollector(output);
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      reconnectJitterRatio: 0,
+      requestTimeoutMs: 500,
+      maxBufferedRequests: 8,
+      ...opts,
+    });
+    proxies.push(proxy);
+    proxy.start();
+    return { input, output, collector, proxy };
+  }
+
+  it("forwards initialize and tools/list over the daemon socket", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("happy");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    const { input, collector } = createProxy(path);
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+
+    await expect(collector.waitForMessage(isResponseFor(1))).resolves.toMatchObject({
+      id: 1,
+      result: { serverInfo: { name: "fake-daemon" } },
+    });
+    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+      id: 2,
+      result: { tools: [expect.objectContaining({ name: "list_surfaces" })] },
+    });
+    await daemon.waitForMessage(0, (message) => "method" in message && message.method === "tools/list");
+  });
+
+  it("replays initialize on daemon restart and completes buffered in-flight requests", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("restart");
+    const firstDaemon = new FakeDaemon(path, {
+      holdMethods: new Set(["tools/list"]),
+    });
+    daemons.push(firstDaemon);
+    await firstDaemon.start();
+    const { input, collector } = createProxy(path, { requestTimeoutMs: 1_000 });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+    await firstDaemon.waitForMessage(0, (message) => "method" in message && message.method === "tools/list");
+    await firstDaemon.stop();
+    daemons.splice(daemons.indexOf(firstDaemon), 1);
+
+    const secondDaemon = new FakeDaemon(path);
+    daemons.push(secondDaemon);
+    await secondDaemon.start();
+
+    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
+    await waitFor(() => secondDaemon.connections[0]?.messages.length >= 3);
+    expect(
+      secondDaemon.connections[0].messages
+        .filter((message) => "method" in message)
+        .map((message) => message.method),
+    ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+    expect(collector.messages.filter((message) => "id" in message && message.id === 1)).toHaveLength(1);
+  });
+
+  it("replays initialize if the daemon restarts before initialized notification is cached", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("restart-before-initialized");
+    const firstDaemon = new FakeDaemon(path);
+    daemons.push(firstDaemon);
+    await firstDaemon.start();
+    const { input, collector } = createProxy(path, { requestTimeoutMs: 1_000 });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    await firstDaemon.stop();
+    daemons.splice(daemons.indexOf(firstDaemon), 1);
+
+    const secondDaemon = new FakeDaemon(path);
+    daemons.push(secondDaemon);
+    await secondDaemon.start();
+    await secondDaemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "initialize",
+    );
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+
+    await expect(collector.waitForMessage(isResponseFor(2))).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
+    expect(
+      secondDaemon.connections[0].messages
+        .filter((message) => "method" in message)
+        .map((message) => message.method),
+    ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+    expect(collector.messages.filter((message) => "id" in message && message.id === 1)).toHaveLength(1);
+  });
+
+  it("computes exponential reconnect backoff with jitter", () => {
+    const delays = [0, 1, 2, 3].map((attempt) =>
+      computeReconnectDelay(attempt, {
+        initialBackoffMs: 100,
+        maxBackoffMs: 800,
+        jitterRatio: 0.5,
+        random: () => 0.5,
+      }),
+    );
+
+    expect(delays).toEqual([125, 250, 500, 800]);
+    expect(delays.every((delay, index) => index === 0 || delay > delays[index - 1])).toBe(true);
+  });
+
+  it("returns a JSON-RPC error when buffered requests exceed the cap", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("cap");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    const { input, collector } = createProxy(path, {
+      maxBufferedRequests: 1,
+      requestTimeoutMs: 1_000,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    await daemon.stop();
+    daemons.splice(daemons.indexOf(daemon), 1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    writeFrame(input, request(2, "tools/list"));
+    writeFrame(input, request(3, "tools/list"));
+
+    await expect(collector.waitForMessage(isResponseFor(3))).resolves.toMatchObject({
+      id: 3,
+      error: expect.objectContaining({
+        code: -32001,
+        message: expect.stringMatching(/buffer/i),
+      }),
+    });
+  });
+
+  it("returns a keyed JSON-RPC error when an outage exceeds request timeout", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("timeout");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    const { input, collector } = createProxy(path, { requestTimeoutMs: 30 });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    await daemon.stop();
+    daemons.splice(daemons.indexOf(daemon), 1);
+
+    writeFrame(input, request(2, "tools/list"));
+
+    await expect(collector.waitForMessage(isResponseFor(2), 500)).resolves.toMatchObject({
+      id: 2,
+      error: expect.objectContaining({
+        code: -32001,
+        message: expect.stringMatching(/offline|timeout|retry/i),
+      }),
+    });
+  });
+
+  it("keeps agent stdio open while the daemon is offline", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("stdio-open");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    const { input, output, collector, proxy } = createProxy(path, {
+      requestTimeoutMs: 200,
+    });
+    let outputEnded = false;
+    output.on("end", () => {
+      outputEnded = true;
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    await daemon.stop();
+    daemons.splice(daemons.indexOf(daemon), 1);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(outputEnded).toBe(false);
+    expect(input.destroyed).toBe(false);
+    expect(proxy.isRunning()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/proxy.ts`, an agent-facing stdio to daemon unix-socket raw JSON-RPC relay.
- Keep agent stdio alive across daemon drops, auto-redial with capped exponential backoff and jitter, replay cached `initialize` plus `notifications/initialized`, and swallow duplicate replay initialize results.
- Buffer and replay in-flight/offline requests in id/order, cap buffered requests, and return keyed JSON-RPC errors on buffer overflow or request timeout.
- Add `proxy` script and `cmuxlayer-proxy` bin for the later P2-4 rollout. No `.mcp.json` files touched.

## Tests
- `bunx vitest run tests/proxy.test.ts`
- `bun run typecheck && bun run test` (604 tests)
- `bun run test` again (604 tests)
- `bun run build`
- Real daemon/proxy restart smoke: start `dist/daemon.js`, route raw MCP through `dist/proxy.js`, kill/restart daemon, confirm buffered `tools/list` completes through the same proxy process (`P2-2 SMOKE PASS`, 31 tools).
- Push hook full suite passed (604 tests).

## Review Notes
- `cr review --plain` before commit reported one minor finding on unrelated untracked `claude.scratchpad.md`; it is not part of this PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-lived transport on the MCP path with non-trivial reconnect and handshake replay; behavior is heavily tested but mistakes could affect agent sessions during daemon restarts.
> 
> **Overview**
> Adds a **reconnecting MCP proxy** so agents can keep a single stdio session while talking to the cmuxlayer daemon over a Unix socket. **`src/proxy.ts`** introduces `CmuxLayerProxy`, which forwards JSON-RPC both ways, redials with capped exponential backoff and jitter, and on reconnect replays cached **`initialize`** plus **`notifications/initialized`** before flushing a sequenced queue of in-flight work. It keeps agent stdio open during outages, caps buffered requests, rejects duplicate pending IDs, returns JSON-RPC errors (code **`-32001`**) on buffer overflow or per-request timeout, and goes quiescent after a rejected initialize replay to avoid reconnect storms.
> 
> **Packaging:** **`package.json`** adds the **`cmuxlayer-proxy`** CLI and **`npm run proxy`**. **`site/next.config.ts`** pins Turbopack’s root to **`site/`** so Next’s **`proxy.ts`** file convention does not pick up the new MCP proxy at repo **`src/proxy.ts`**. **`tests/proxy.test.ts`** covers happy path, daemon restarts, handshake edge cases, and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13f4ddcfa9e6c247d1b86e21acc6ad28a723e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reconnecting JSON-RPC daemon proxy with request buffering and initialize replay
> - Introduces `CmuxLayerProxy` in [src/proxy.ts](https://github.com/EtanHey/cmuxlayer/pull/126/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2), a stateful proxy that bridges agent stdio to a daemon Unix socket over JSON-RPC.
> - Reconnects to the daemon using exponential backoff with jitter; buffers pending requests while offline up to a configurable `maxBufferedRequests` limit.
> - Replays the `initialize` request and `notifications/initialized` after each reconnect before forwarding queued RPCs; requeues sent-but-unanswered requests on daemon drops.
> - Enforces per-request timeouts, returning a JSON-RPC error (`-32001`) on expiry, and rejects duplicate request IDs immediately.
> - Exposes a `cmuxlayer-proxy` CLI binary and a `proxy` npm script; adds a Vitest suite covering forwarding, replay, timeout, buffer cap, and reconnect backoff scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f13f4dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->