### PR TITLE
feat(output-quality): self-describing read_screen column + send delivery identity (F7+F8)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -223,6 +223,10 @@ export function formatDelivery(
     model?: string | null;
     agent_type?: string | null;
     delivered: boolean;
+    // true => still in flight (e.g. background send); renders "delivering to"
+    // instead of the delivered/failed binary, so the line never contradicts a
+    // pending status.
+    pending?: boolean;
     submit_verified?: boolean | null;
   },
 ): string {
@@ -236,9 +240,14 @@ export function formatDelivery(
     (v): v is string => typeof v === "string" && v.length > 0,
   );
   const parens = meta.length > 0 ? ` (${meta.join(" \u00b7 ")})` : "";
-  const head = info.delivered
-    ? `delivered to ${label}${parens}`
-    : `delivery FAILED to ${label}${parens}`;
+  let head: string;
+  if (info.pending) {
+    head = `delivering to ${label}${parens}`;
+  } else if (info.delivered) {
+    head = `delivered to ${label}${parens}`;
+  } else {
+    head = `delivery FAILED to ${label}${parens}`;
+  }
   let submit = "";
   if (info.submit_verified === true) submit = " \u2713 submit_verified";
   else if (info.submit_verified === false)

--- a/src/format.ts
+++ b/src/format.ts
@@ -86,12 +86,19 @@ export function formatReadScreen(
   parsed: ParsedScreenResult,
   scrollbackUsed: boolean,
   lines: number,
+  column?: number | null,
+  columnCount?: number | null,
 ): string {
   const result: string[] = [];
 
-  // Header with surface info
+  // Header with surface info + a column hint (e.g. "col 1/2") so fleet sprawl
+  // is visible on every read. Omitted when geometry is unavailable.
   const titleStr = title ? ` "${truncate(title, 30)}"` : "";
-  result.push(`\u250c\u2500 ${surfaceRef}${titleStr}`);
+  const colStr =
+    typeof column === "number" && typeof columnCount === "number"
+      ? ` \u00b7 col ${column + 1}/${columnCount}`
+      : "";
+  result.push(`\u250c\u2500 ${surfaceRef}${titleStr}${colStr}`);
 
   // Parsed agent status line
   const statusParts: string[] = [];
@@ -202,6 +209,43 @@ export function formatOk(
     }
   }
   return `\u2714 ${action}${parts.length > 0 ? " \u2500 " + parts.join("  ") : ""}`;
+}
+
+// Phone-readable, self-describing line for input delivery (send_input /
+// send_command). Tells WHAT happened to WHICH agent on one line, e.g.:
+//   \u2714 send_command \u2500 delivered to BL-LEAD (s:95 \u00b7 Opus 4.8 \u00b7 claude) \u2713 submit_verified
+// Identity fields are best-effort; whatever is unknown is simply omitted.
+export function formatDelivery(
+  action: string,
+  info: {
+    surface: string;
+    title?: string | null;
+    model?: string | null;
+    agent_type?: string | null;
+    delivered: boolean;
+    submit_verified?: boolean | null;
+  },
+): string {
+  const hasTitle = typeof info.title === "string" && info.title.length > 0;
+  const label = hasTitle ? truncate(info.title as string, 30) : info.surface;
+  // When the label already IS the surface, don't repeat it inside the parens.
+  const metaSource = hasTitle
+    ? [info.surface, info.model, info.agent_type]
+    : [info.model, info.agent_type];
+  const meta = metaSource.filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  const parens = meta.length > 0 ? ` (${meta.join(" \u00b7 ")})` : "";
+  const head = info.delivered
+    ? `delivered to ${label}${parens}`
+    : `delivery FAILED to ${label}${parens}`;
+  let submit = "";
+  if (info.submit_verified === true) submit = " \u2713 submit_verified";
+  else if (info.submit_verified === false)
+    submit = " \u2717 submit not verified";
+  else if (info.submit_verified === null)
+    submit = " \u00b7 submit_verified=null (not attempted)";
+  return `\u2714 ${action} \u2500 ${head}${submit}`;
 }
 
 export function formatResync(diff: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2117,8 +2117,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             status: record.status,
           };
           return okFormatted(
-            formatDelivery("send_input", { ...identity, delivered: false }) +
-              ` (background ${record.delivery_id})`,
+            formatDelivery("send_input", {
+              ...identity,
+              delivered: false,
+              pending: true,
+            }) + ` (background ${record.delivery_id})`,
             data,
           );
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
   formatListAgents,
   formatAgentState,
   formatOk,
+  formatDelivery,
   formatResync,
 } from "./format.js";
 import { inferContextWindow, parseScreen } from "./screen-parser.js";
@@ -116,7 +117,13 @@ const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
-const READY_PATTERN_CLIS: CliType[] = ["claude", "codex", "gemini", "kiro", "cursor"];
+const READY_PATTERN_CLIS: CliType[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "kiro",
+  "cursor",
+];
 const SendToArgsSchema = z.object({
   agent_id: z.string(),
   text: z.string(),
@@ -423,8 +430,10 @@ function isRetryableDeliveryError(error: unknown): boolean {
   return /socket|connection_|connection closed|timeout/i.test(message);
 }
 
-
-function formatToolValidationError(toolName: string, error: z.ZodError): string {
+function formatToolValidationError(
+  toolName: string,
+  error: z.ZodError,
+): string {
   const details = error.issues
     .map((issue) => {
       const path = issue.path.length > 0 ? issue.path.join(".") : "input";
@@ -440,7 +449,10 @@ function isSubmitVerifiedStatus(
   return status === "working" || status === "thinking" || status === "done";
 }
 
-function screenShowsPendingInput(screenText: string, submittedText: string): boolean {
+function screenShowsPendingInput(
+  screenText: string,
+  submittedText: string,
+): boolean {
   const trimmed = submittedText.trim();
   if (!trimmed) {
     return false;
@@ -453,7 +465,10 @@ function screenShowsPendingInput(screenText: string, submittedText: string): boo
 function computeEnterDelayMs(bytes: number, chunkCount: number): number {
   const extraChunks = Math.max(0, chunkCount - 1);
   const longPayloadPenalty = bytes >= SEND_INPUT_CHUNK_THRESHOLD ? 100 : 0;
-  return Math.min(250, SEND_INPUT_ENTER_DELAY_MS + extraChunks * 50 + longPayloadPenalty);
+  return Math.min(
+    250,
+    SEND_INPUT_ENTER_DELAY_MS + extraChunks * 50 + longPayloadPenalty,
+  );
 }
 
 function pickLatestSurfaceModel(
@@ -474,6 +489,37 @@ function pickLatestSurfaceModel(
   });
 
   return matches[0]?.model ?? null;
+}
+
+export interface TargetIdentity {
+  surface: string;
+  title?: string;
+  model?: string;
+  agent_type?: string;
+}
+
+// Best-effort, CHEAP target-agent identity for delivery responses (send_input /
+// send_command). Sourced from the in-memory state cache only — no extra socket
+// round-trip / read_screen per send. Unknown fields are omitted.
+function resolveTargetIdentity(
+  stateMgr: StateManager,
+  surfaceRef: string,
+): TargetIdentity {
+  const identity: TargetIdentity = { surface: surfaceRef };
+  const matches = stateMgr
+    .listStates()
+    .filter((record) => record.surface_id === surfaceRef)
+    .sort((a, b) => {
+      if (b.version !== a.version) return b.version - a.version;
+      return (
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      );
+    });
+  const record = matches[0];
+  if (record?.task_summary) identity.title = record.task_summary;
+  if (record?.model) identity.model = record.model;
+  if (record?.cli) identity.agent_type = record.cli;
+  return identity;
 }
 
 function enrichParsedScreen(
@@ -1155,7 +1201,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         lastText = screen.text;
         if (
           matchesShellPrompt(screen.text) ||
-          READY_PATTERN_CLIS.some((cli) => matchReadyPattern(cli, screen.text).matched)
+          READY_PATTERN_CLIS.some(
+            (cli) => matchReadyPattern(cli, screen.text).matched,
+          )
         ) {
           return;
         }
@@ -1194,8 +1242,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         });
         lastText = screen.text;
         if (
-          READY_PATTERN_CLIS.some((cli) =>
-            matchReadyPattern(cli, screen.text).matched,
+          READY_PATTERN_CLIS.some(
+            (cli) => matchReadyPattern(cli, screen.text).matched,
           )
         ) {
           return;
@@ -1350,6 +1398,62 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     return null;
+  };
+
+  // Resolve a surface's 0-based column + the workspace column_count using the
+  // SAME reliable post-F5 logic as list_surfaces: derive columns from pane
+  // geometry, then attribute the surface to its pane by membership (pane_id),
+  // NOT the unfiltered surface.list. Best-effort: returns nulls on any failure
+  // so callers (e.g. read_screen) never break when geometry is unavailable.
+  const resolveSurfaceColumn = async (
+    surfaceRef: string,
+    workspace?: string,
+  ): Promise<{ column: number | null; column_count: number | null }> => {
+    try {
+      const workspaceRefs = workspace
+        ? [workspace]
+        : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+
+      for (const workspaceRef of workspaceRefs) {
+        const panes = await client.listPanes({ workspace: workspaceRef });
+        if (!panes.panes || panes.panes.length === 0) {
+          continue;
+        }
+        const columnIndex = deriveColumnIndex(panes.panes);
+        const columnCount = new Set(columnIndex.values()).size;
+        const rawGroups = await Promise.all(
+          panes.panes.map(async (pane) => {
+            const group = await client.listPaneSurfaces({
+              workspace: workspaceRef,
+              pane: pane.ref,
+            });
+            return {
+              ...group,
+              workspace_ref: group.workspace_ref ?? workspaceRef,
+              pane_ref: group.pane_ref ?? pane.ref,
+            };
+          }),
+        );
+        const partitioned = partitionPaneSurfacesByMembership(
+          panes.panes,
+          rawGroups,
+          {
+            workspace_ref: panes.workspace_ref ?? workspaceRef,
+            window_ref: panes.window_ref,
+          },
+        );
+        for (const group of partitioned) {
+          if (group.surfaces.some((surface) => surface.ref === surfaceRef)) {
+            const column = columnIndex.get(group.pane_ref);
+            return { column: column ?? null, column_count: columnCount };
+          }
+        }
+      }
+    } catch {
+      return { column: null, column_count: null };
+    }
+
+    return { column: null, column_count: null };
   };
 
   // 1. list_surfaces
@@ -1614,10 +1718,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         const targetWorkspace =
           args.workspace ??
-          (await resolveWorkspaceForRepo(inferRepoFromLauncherTitle(args.title)));
+          (await resolveWorkspaceForRepo(
+            inferRepoFromLauncherTitle(args.title),
+          ));
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
-            throw new Error("boot_prompt_path is only supported for terminal surfaces");
+            throw new Error(
+              "boot_prompt_path is only supported for terminal surfaces",
+            );
           }
           await preflightBootPromptFile(bootPromptPath);
         }
@@ -1803,7 +1911,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
-            throw new Error("boot_prompt_path is only supported for terminal surfaces");
+            throw new Error(
+              "boot_prompt_path is only supported for terminal surfaces",
+            );
           }
           await preflightBootPromptFile(bootPromptPath);
         }
@@ -1892,13 +2002,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           index: args.index,
           focus: args.focus,
         });
-        const data = { ...result };
+        // F8: slim, phone-readable confirmation — drop the verbose passthrough.
+        const data = {
+          surface: result.surface,
+          pane: result.pane,
+          workspace: result.workspace,
+        };
+        const dest = result.pane ?? result.workspace ?? "destination";
         return okFormatted(
-          formatOk("move_surface", {
-            surface: result.surface,
-            pane: result.pane,
-            workspace: result.workspace,
-          }),
+          `✔ move_surface ─ moved ${result.surface} → ${dest}`,
           data,
         );
       } catch (e) {
@@ -1965,9 +2077,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .boolean()
         .optional()
         .default(false)
-        .describe(
-          "Press return once after all chunks have landed.",
-        ),
+        .describe("Press return once after all chunks have landed."),
       rename_to_task: z
         .string()
         .optional()
@@ -1999,12 +2109,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           startBackgroundDelivery(record);
 
+          const identity = resolveTargetIdentity(stateMgr, args.surface);
           const data = {
-            surface: args.surface,
+            ...identity,
+            delivered: false,
             delivery_id: record.delivery_id,
             status: record.status,
           };
-          return okFormatted(formatOk("send_input", data), data);
+          return okFormatted(
+            formatDelivery("send_input", { ...identity, delivered: false }) +
+              ` (background ${record.delivery_id})`,
+            data,
+          );
         }
 
         await withSurfaceWrite(args.surface, async () => {
@@ -2019,8 +2135,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
         });
 
-        const data = { surface: args.surface };
-        return okFormatted(formatOk("send_input", data), data);
+        const identity = resolveTargetIdentity(stateMgr, args.surface);
+        const data = { ...identity, delivered: true };
+        return okFormatted(
+          formatDelivery("send_input", { ...identity, delivered: true }),
+          data,
+        );
       } catch (e) {
         if (e instanceof DeliveryError) {
           return err(e, { failed_chunk: e.failed_chunk ?? null });
@@ -2086,8 +2206,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: true,
             source_event: "send_command",
-            verify_submit:
-              sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD,
+            verify_submit: sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD,
           }),
         );
 
@@ -2104,15 +2223,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
         }
 
+        const identity = resolveTargetIdentity(stateMgr, args.surface);
         const data = {
-          surface: args.surface,
+          ...identity,
           command: sanitizedCommand,
+          delivered: true,
           retry_count: delivery.retry_count,
           submit_verified: delivery.submit_verified,
           boot_prompt_delivered: Boolean(bootPromptDelivery),
           boot_prompt_bytes: bootPromptDelivery?.bytes,
         };
-        return okFormatted(formatOk("send_command", data), data);
+        return okFormatted(
+          formatDelivery("send_command", {
+            ...identity,
+            delivered: true,
+            submit_verified: delivery.submit_verified,
+          }),
+          data,
+        );
       } catch (e) {
         if (e instanceof BootPromptTimeoutError) {
           return err(e, { last_10_lines: e.last_10_lines });
@@ -2196,11 +2324,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           result.text,
           pickLatestSurfaceModel(stateMgr, result.surface),
         );
+        // F7: surface column + workspace column_count so sprawl is visible on
+        // every read. Best-effort — omitted (null) if geometry is unavailable.
+        const { column, column_count } = await resolveSurfaceColumn(
+          result.surface,
+          args.workspace,
+        );
 
         if (args.parsed_only) {
           const data = {
             surface: result.surface,
             title: surface?.title ?? null,
+            column,
+            column_count,
             parsed,
             delivery: getSurfaceDelivery(result.surface),
           };
@@ -2211,6 +2347,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             parsed,
             false,
             0,
+            column,
+            column_count,
           );
           return okFormatted(formatted, data);
         }
@@ -2218,6 +2356,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const data = {
           surface: result.surface,
           title: surface?.title ?? null,
+          column,
+          column_count,
           lines: result.lines,
           content: result.text,
           scrollback_used: result.scrollback_used,
@@ -2231,6 +2371,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           parsed,
           result.scrollback_used,
           result.lines,
+          column,
+          column_count,
         );
         return okFormatted(formatted, data);
       } catch (e) {
@@ -2409,7 +2551,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             const panes = await client.listPanes({ workspace });
             const rawPaneSurfaces = await Promise.all(
               panes.panes.map(async (pane) => {
-                const ps = await client.listPaneSurfaces({ workspace, pane: pane.ref });
+                const ps = await client.listPaneSurfaces({
+                  workspace,
+                  pane: pane.ref,
+                });
                 return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
               }),
             );
@@ -2762,10 +2907,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const isForeign = (occ: typeof cachedOccupant): boolean =>
           Boolean(
             occ &&
-              occ.has_agent &&
-              !occ.read_error &&
-              occ.cli !== "unknown" &&
-              occ.cli !== expectedCli,
+            occ.has_agent &&
+            !occ.read_error &&
+            occ.cli !== "unknown" &&
+            occ.cli !== expectedCli,
           );
         if (isForeign(cachedOccupant)) {
           // Confirm against a FRESH scan before refusing. discovery.scan(false)
@@ -2867,7 +3012,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .positive()
           .optional()
           .default(BOOT_PROMPT_TIMEOUT_MS)
-          .describe("Timeout in milliseconds waiting for the agent ready prompt"),
+          .describe(
+            "Timeout in milliseconds waiting for the agent ready prompt",
+          ),
         workspace: z.string().optional().describe("Target workspace ref"),
         parent_agent_id: z
           .string()
@@ -2914,7 +3061,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             model: args.model,
             cli: args.cli,
             prompt: args.prompt ?? "",
-            boot_prompt_pending: hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
+            boot_prompt_pending:
+              hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: args.workspace,
             parent_agent_id: args.parent_agent_id,
             role: args.role,
@@ -3045,7 +3193,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         reuse_workspace: z
           .string()
           .optional()
-          .describe("Ref of an existing workspace to use instead of creating a new one"),
+          .describe(
+            "Ref of an existing workspace to use instead of creating a new one",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { formatDelivery } from "../src/format.js";
+
+describe("formatDelivery", () => {
+  it("renders a phone-readable delivered line with full identity", () => {
+    const line = formatDelivery("send_command", {
+      surface: "surface:95",
+      title: "BL-LEAD",
+      model: "Opus 4.8",
+      agent_type: "claude",
+      delivered: true,
+      submit_verified: true,
+    });
+    expect(line).toContain("delivered to BL-LEAD");
+    expect(line).toContain("surface:95");
+    expect(line).toContain("Opus 4.8");
+    expect(line).toContain("claude");
+    expect(line).toContain("✓ submit_verified");
+  });
+
+  it("does not repeat the surface when there is no title", () => {
+    const line = formatDelivery("send_input", {
+      surface: "surface:1",
+      model: "GPT-5.5",
+      agent_type: "codex",
+      delivered: true,
+    });
+    expect(line).toContain("delivered to surface:1 (GPT-5.5 · codex)");
+  });
+
+  it("omits unknown identity fields entirely", () => {
+    const line = formatDelivery("send_input", {
+      surface: "surface:1",
+      delivered: true,
+    });
+    expect(line).toBe("✔ send_input ─ delivered to surface:1");
+  });
+
+  it("renders 'delivering' (never FAILED) while a send is still in flight", () => {
+    const line = formatDelivery("send_input", {
+      surface: "surface:7",
+      delivered: false,
+      pending: true,
+    });
+    expect(line).toContain("delivering to surface:7");
+    expect(line).not.toContain("FAILED");
+  });
+
+  it("renders a clear failure line when delivery did not complete", () => {
+    const line = formatDelivery("send_input", {
+      surface: "surface:1",
+      delivered: false,
+    });
+    expect(line).toContain("delivery FAILED to surface:1");
+  });
+
+  it("flags an unverified submit and a not-attempted submit distinctly", () => {
+    expect(
+      formatDelivery("send_command", {
+        surface: "surface:1",
+        delivered: true,
+        submit_verified: false,
+      }),
+    ).toContain("✗ submit not verified");
+    expect(
+      formatDelivery("send_command", {
+        surface: "surface:1",
+        delivered: true,
+        submit_verified: null,
+      }),
+    ).toContain("submit_verified=null (not attempted)");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -346,7 +346,12 @@ describe("tool handler integration", () => {
       {
         workspace_title: "red-team",
         agents: [
-          { repo: "brainlayer", model: "sonnet", cli: "claude", role: "orchestrator" },
+          {
+            repo: "brainlayer",
+            model: "sonnet",
+            cli: "claude",
+            role: "orchestrator",
+          },
           { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
         ],
       },
@@ -670,7 +675,8 @@ describe("tool handler integration", () => {
 
     const verboseResult = await tool.handler({ verbose: true }, {} as any);
     const verbose =
-      verboseResult.structuredContent ?? JSON.parse(verboseResult.content[0].text);
+      verboseResult.structuredContent ??
+      JSON.parse(verboseResult.content[0].text);
 
     expect(verbose.column_count).toBe(2);
     expect(verbose.surfaces).toEqual([
@@ -777,7 +783,8 @@ describe("tool handler integration", () => {
     const tool = (server as any)._registeredTools["list_surfaces"];
 
     const result = await tool.handler({}, {} as any);
-    const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.surfaces).toEqual([
       expect.objectContaining({
@@ -1291,6 +1298,116 @@ describe("tool handler integration", () => {
     });
   });
 
+  it("read_screen reports the surface column + workspace column_count inline (F7)", async () => {
+    // Simulates the real cmux bug: surface.list is unfiltered (every per-pane
+    // query returns the WHOLE workspace list). The column must still be correct
+    // via pane_id membership, NOT first-seen attribution.
+    const fullList = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      surfaces: [
+        {
+          id: "surface-left-id",
+          pane_id: "pane-left-id",
+          ref: "surface:left",
+          title: "left",
+          type: "terminal",
+          index: 0,
+          selected: false,
+        },
+        {
+          id: "surface-right-id",
+          pane_id: "pane-right-id",
+          ref: "surface:right",
+          title: "rightAgent",
+          type: "terminal",
+          index: 1,
+          selected: true,
+        },
+      ],
+    };
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:right",
+        text: "right pane content\n",
+        lines: 20,
+        scrollback_used: false,
+      }),
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            id: "pane-left-id",
+            index: 0,
+            surface_refs: ["surface:left"],
+            surface_ids: ["surface-left-id"],
+            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+          },
+          {
+            ref: "pane:right",
+            id: "pane-right-id",
+            index: 1,
+            surface_refs: ["surface:right"],
+            surface_ids: ["surface-right-id"],
+            pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+          },
+        ],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue(fullList),
+    } as any;
+
+    const server = createServer({
+      client: mockClient,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["read_screen"];
+    const result = await tool.handler(
+      { surface: "surface:right", workspace: "workspace:1" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.column).toBe(1);
+    expect(data.column_count).toBe(2);
+    expect(result.content[0].text).toContain("col 2/2");
+  });
+
+  it("read_screen omits column when pane geometry is unavailable but still returns the screen (F7)", async () => {
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:1",
+        text: "screen content\n",
+        lines: 20,
+        scrollback_used: false,
+      }),
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),
+      // geometry unavailable: listPanes fails — column resolution must degrade.
+      listPanes: vi.fn().mockRejectedValue(new Error("no panes")),
+      listPaneSurfaces: vi.fn().mockRejectedValue(new Error("no surfaces")),
+    } as any;
+
+    const server = createServer({
+      client: mockClient,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["read_screen"];
+    const result = await tool.handler(
+      { surface: "surface:1", workspace: "workspace:1" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.column).toBeNull();
+    expect(data.column_count).toBeNull();
+    expect(data.content).toBe("screen content\n");
+    expect(result.content[0].text).not.toContain("col ");
+  });
+
   it("send_input handler calls cmux send", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
@@ -1365,6 +1482,151 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.surface).toBe("surface:6");
+  });
+
+  it("send_input returns delivered + cheap target identity from the state cache (F8)", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "bl-lead-1",
+      surface_id: "surface:95",
+      state: "idle",
+      repo: "brainlayer",
+      model: "Opus 4.8",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "BL-LEAD",
+      pid: null,
+      version: 1,
+      created_at: "2026-06-04T00:00:00Z",
+      updated_at: "2026-06-04T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const result = await tool.handler(
+      { surface: "surface:95", text: "hi" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.delivered).toBe(true);
+    expect(data.surface).toBe("surface:95");
+    expect(data.title).toBe("BL-LEAD");
+    expect(data.model).toBe("Opus 4.8");
+    expect(data.agent_type).toBe("claude");
+    expect(result.content[0].text).toContain("delivered to BL-LEAD");
+    expect(result.content[0].text).toContain("Opus 4.8");
+    expect(result.content[0].text).toContain("claude");
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("send_input degrades gracefully when no identity is cached (F8)", async () => {
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+    const result = await tool.handler(
+      { surface: "surface:unknown", text: "hi" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.delivered).toBe(true);
+    expect(data.surface).toBe("surface:unknown");
+    expect(data.title).toBeUndefined();
+    expect(data.model).toBeUndefined();
+    expect(data.agent_type).toBeUndefined();
+    expect(result.content[0].text).toContain("delivered to surface:unknown");
+  });
+
+  it("send_command returns delivered + identity + submit_verified (F8)", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-command");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "codex-1",
+      surface_id: "surface:6",
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "GPT-5.5",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "cmuxlayerCodex",
+      pid: null,
+      version: 1,
+      created_at: "2026-06-04T00:00:00Z",
+      updated_at: "2026-06-04T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_command"];
+    const result = await tool.handler(
+      { surface: "surface:6", command: "codex resume 123" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.delivered).toBe(true);
+    expect(data.surface).toBe("surface:6");
+    expect(data.title).toBe("cmuxlayerCodex");
+    expect(data.model).toBe("GPT-5.5");
+    expect(data.agent_type).toBe("codex");
+    expect("submit_verified" in data).toBe(true);
+    expect(result.content[0].text).toContain("delivered to cmuxlayerCodex");
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("move_surface returns a slim, phone-readable confirmation (F8)", async () => {
+    const mockExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        ok: true,
+        workspace: "workspace:1",
+        surface: "surface:102",
+        pane: "pane:1",
+        // verbose passthrough that should NOT leak into the slim response:
+        window_ref: "window:1",
+        surfaces: [{ ref: "surface:102" }],
+      }),
+      stderr: "",
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["move_surface"];
+    const result = await tool.handler(
+      { surface: "surface:102", pane: "pane:1" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(Object.keys(data).sort()).toEqual([
+      "ok",
+      "pane",
+      "surface",
+      "workspace",
+    ]);
+    expect(data.surface).toBe("surface:102");
+    expect(data.pane).toBe("pane:1");
+    expect(result.content[0].text).toContain("moved surface:102 → pane:1");
   });
 
   it("send_command rejects boot_prompt_path for non-launcher commands before sending", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1484,6 +1484,21 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:6");
   });
 
+  it("send_input background reads 'delivering' (not FAILED) while in flight (F8)", async () => {
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+    const result = await tool.handler(
+      { surface: "surface:7", text: "hi", background: true },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(data.status).toBe("delivering");
+    expect(typeof data.delivery_id).toBe("string");
+    expect(result.content[0].text).toContain("delivering to surface:7");
+    expect(result.content[0].text).not.toContain("FAILED");
+  });
+
   it("send_input returns delivered + cheap target identity from the state cache (F8)", async () => {
     const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input");
     rmSync(stateDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Makes cmux tool outputs informative + self-describing (Etan reads them on his phone). Today `send_input` returns a bare `{ok:true}` and `read_screen` gives no hint of fleet sprawl.

### F7 — `read_screen` reports column inline
- Adds the surface's 0-based `column` + workspace `column_count` to `read_screen` (structured fields + a `col N/M` hint in the formatted header).
- Uses the **same reliable post-F5 logic** as `list_surfaces`: `deriveColumnIndex` from pane geometry + `partitionPaneSurfacesByMembership` (attribute each surface to its pane by `pane_id`, **not** the unfiltered `surface.list`).
- Best-effort: `column`/`column_count` are `null` when geometry is unavailable — never breaks the screen read.

### F8 — `send_input`/`send_command` self-describe + `move_surface` slims
- `send_input` / `send_command` responses now carry `delivered` + best-effort **target identity** (`title`/`model`/`agent_type`) + (for `send_command`) `submit_verified`, with a phone-readable line:
  ```
  ✔ send_command ─ delivered to BL-LEAD (s:95 · Opus 4.8 · claude) ✓ submit_verified
  ```
- Identity is sourced **cheaply** from the in-memory state cache — no extra socket round-trip / `read_screen` per send. Unknown fields are omitted and never block delivery.
- `move_surface` trims its verbose passthrough to a slim `{ok, surface, pane, workspace}` + `moved <surface> → <dest>`.

## Tests
613 pass (+6): F7 column present / geometry-absent; F8 send_input identity + graceful-degradation, send_command identity + submit_verified, move_surface slim shape. typecheck + build clean.

## Deploy note
Like F4/F5, these become visible to Etan only once the **daemon+proxy rollout (P2-3/P2-4)** deploys — `read_screen`/`send_*` run in the per-agent MCP today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes structured and formatted MCP tool response shapes for read_screen and send/move tools; read_screen adds best-effort pane listing work that could add latency but is designed to fail open.
> 
> **Overview**
> Improves **cmux MCP tool output** so results are readable on a phone and show **which pane/agent** was affected without digging into raw JSON.
> 
> **F7 — `read_screen` column context:** Each read now includes **`column`** and **`column_count`** in structured output and a **`col N/M`** hint in the formatted header. Column is resolved with the same pane-geometry + membership logic as **`list_surfaces`** (not unfiltered surface lists). If geometry fails, fields stay **`null`** and the screen read still succeeds.
> 
> **F8 — delivery identity and slimmer confirmations:** New **`formatDelivery`** and **`resolveTargetIdentity`** (in-memory **`StateManager` only**, no extra **`read_screen`** per send) power one-line summaries for **`send_input`** and **`send_command`**: delivered vs delivering vs failed, optional title/model/agent_type, and **`submit_verified`** on commands. Background **`send_input`** uses **“delivering”** instead of implying failure. **`move_surface`** returns a trimmed payload and a short **`moved surface → dest`** line instead of verbose passthrough.
> 
> Tests cover **`formatDelivery`**, column present/absent on **`read_screen`**, and F8 behavior for send/move handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c6f4bde458c71c79095951bdc97c0f763625e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add column position to `read_screen` header and identity metadata to `send_input`/`send_command` output
> - `read_screen` now resolves the surface's zero-based column and workspace `column_count` from pane geometry, including both in structured response data and in the formatted header as `· col X/Y`; degrades gracefully when geometry is unavailable.
> - `send_input` and `send_command` responses now include a concise delivery line via the new `formatDelivery` function in [format.ts](https://github.com/EtanHey/cmuxlayer/pull/127/files#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36b), showing target identity (title, model, agent_type) and delivery state (`delivering to …`, `delivered to …`, or `delivery FAILED to …`).
> - `send_command` output also appends submit verification status (`✓ submit_verified`, `✗ submit not verified`, or `· submit_verified=null`).
> - `move_surface` structured data and text output are trimmed to a slim confirmation (`✔ move_surface ─ moved {surface} → {dest}`) instead of verbose passthrough fields.
> - Behavioral Change: `move_surface` tool response no longer includes full passthrough fields in structured data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39c6f4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->