### PR TITLE
feat(context): default-ON harness-JSONL agent state + validation

### DIFF
--- a/docs/harness-jsonl-field-map.md
+++ b/docs/harness-jsonl-field-map.md
@@ -4,6 +4,12 @@
 > Both readers MUST agree on where each number lives per harness. Change this doc in lockstep with either reader.
 > Every path below was verified against on-disk JSONL on 2026-06-04 — do **not** add a field without verifying it exists.
 
+## Enablement
+**DEFAULT-ON** as of 2026-06-04 (validated: 647 tests + 4 live Codex sessions correct).
+Strictly additive — the JSONL overlay only fires when a session transcript resolves; otherwise
+the screen-parser stands. Opt out with `CMUXLAYER_HARNESS_JSONL=0`. The resolver honors
+`CODEX_HOME` and (for tests) `CMUXLAYER_HARNESS_HOME`.
+
 ## Why this exists
 cmuxlayer reads the harness transcript JSONL (not the rendered terminal) to report real agent
 state: tokens used, context window, model, last response, last tool, done. Phoenix ingest reads

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -404,9 +404,13 @@ export function loadHarnessSession(
   return readHarnessSessionFromFile(harness, path);
 }
 
-/** True when JSONL-derived agent state is enabled (flag-gated; screen-parser is the fallback). */
+/**
+ * True when JSONL-derived agent state is enabled. DEFAULT-ON (validated 2026-06-04: 647
+ * tests + 4 live Codex sessions correct; strictly additive — overlay only fires when a
+ * session JSONL resolves, else screen-parser stands). Opt OUT with CMUXLAYER_HARNESS_JSONL=0.
+ */
 export function harnessJsonlEnabled(): boolean {
-  return process.env.CMUXLAYER_HARNESS_JSONL === "1";
+  return process.env.CMUXLAYER_HARNESS_JSONL !== "0";
 }
 
 /** Context/usage fields an overlay can fill. ParsedScreenResult satisfies this. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -522,7 +522,14 @@ function resolveHarnessStateForSurface(
   const cli = record?.cli as Harness | undefined;
   const sessionId = record?.cli_session_id ?? null;
   if (!cli || !sessionId || !JSONL_HARNESSES.has(cli)) return null;
-  return loadHarnessSession(cli, sessionId);
+  // Honor CODEX_HOME (already used by app-server-bridge) and a test-only home override.
+  const opts = {
+    ...(process.env.CMUXLAYER_HARNESS_HOME
+      ? { home: process.env.CMUXLAYER_HARNESS_HOME }
+      : {}),
+    ...(process.env.CODEX_HOME ? { codexHome: process.env.CODEX_HOME } : {}),
+  };
+  return loadHarnessSession(cli, sessionId, opts);
 }
 
 export interface TargetIdentity {

--- a/tests/harness-jsonl-validation.test.ts
+++ b/tests/harness-jsonl-validation.test.ts
@@ -1,0 +1,194 @@
+// VALIDATION (gates the default-on decision for #128): with CMUXLAYER_HARNESS_JSONL=1,
+// read_screen must report the REAL per-harness context window from the transcript JSONL —
+// Codex 258400 (NOT 1M), Claude the table window, Cursor cleanly falling back to its TUI strip.
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import { StateManager } from "../src/state-manager.js";
+
+const FIX = join(__dirname, "fixtures", "harness");
+
+function record(
+  agent_id: string,
+  surface_id: string,
+  cli: string,
+  sid: string,
+  model: string,
+) {
+  return {
+    agent_id,
+    surface_id,
+    state: "idle" as const,
+    repo: "x",
+    model,
+    cli: cli as never,
+    cli_session_id: sid,
+    task_summary: "validate",
+    pid: null,
+    version: 1,
+    created_at: "2026-06-04T00:00:00Z",
+    updated_at: "2026-06-04T00:00:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown" as const,
+    max_cost_per_agent: null,
+  };
+}
+
+describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () => {
+  const home = mkdtempSync(join(tmpdir(), "cmux-validate-home-"));
+  const stateDir = mkdtempSync(join(tmpdir(), "cmux-validate-state-"));
+  const prevFlag = process.env.CMUXLAYER_HARNESS_JSONL;
+  const prevHome = process.env.CMUXLAYER_HARNESS_HOME;
+
+  beforeAll(() => {
+    // Place the verified fixtures where findHarnessSessionPath resolves them by sessionId.
+    mkdirSync(join(home, ".codex", "sessions", "2026", "06", "04"), {
+      recursive: true,
+    });
+    cpSync(
+      join(FIX, "codex.jsonl"),
+      join(
+        home,
+        ".codex",
+        "sessions",
+        "2026",
+        "06",
+        "04",
+        "rollout-2026-06-04T22-46-15-vsid-codex.jsonl",
+      ),
+    );
+    mkdirSync(join(home, ".claude", "projects", "-x"), { recursive: true });
+    cpSync(
+      join(FIX, "claude.jsonl"),
+      join(home, ".claude", "projects", "-x", "vsid-claude.jsonl"),
+    );
+    mkdirSync(
+      join(
+        home,
+        ".cursor",
+        "projects",
+        "x",
+        "agent-transcripts",
+        "vsid-cursor",
+      ),
+      { recursive: true },
+    );
+    cpSync(
+      join(FIX, "cursor.jsonl"),
+      join(
+        home,
+        ".cursor",
+        "projects",
+        "x",
+        "agent-transcripts",
+        "vsid-cursor",
+        "vsid-cursor.jsonl",
+      ),
+    );
+
+    const sm = new StateManager(stateDir);
+    sm.writeState(
+      record("a-codex", "surface:1", "codex", "vsid-codex", "gpt-5.5"),
+    );
+    sm.writeState(
+      record(
+        "a-claude",
+        "surface:2",
+        "claude",
+        "vsid-claude",
+        "claude-opus-4-8",
+      ),
+    );
+    sm.writeState(
+      record("a-cursor", "surface:3", "cursor", "vsid-cursor", "cursor"),
+    );
+
+    process.env.CMUXLAYER_HARNESS_JSONL = "1";
+    process.env.CMUXLAYER_HARNESS_HOME = home;
+  });
+
+  afterAll(() => {
+    if (prevFlag === undefined) delete process.env.CMUXLAYER_HARNESS_JSONL;
+    else process.env.CMUXLAYER_HARNESS_JSONL = prevFlag;
+    if (prevHome === undefined) delete process.env.CMUXLAYER_HARNESS_HOME;
+    else process.env.CMUXLAYER_HARNESS_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  const screens: Record<string, string> = {
+    "surface:1":
+      "gpt-5.5 xhigh · 60% left · ~/x\nWorking (2m 00s • esc to interrupt)",
+    "surface:2": "Token usage: total=40,000\nCLAUDE_COUNTER: 7",
+    "surface:3":
+      "Auto · 22% · 3 files edited\n→ Add a follow-up\nctrl+c to stop",
+  };
+
+  function makeTool() {
+    const mockClient = {
+      // Real client signature: readScreen(surfaceRef, opts) — surface is positional.
+      readScreen: async (surface: string) => ({
+        surface,
+        text: screens[surface],
+        lines: 20,
+        scrollback_used: false,
+      }),
+      listWorkspaces: async () => ({ workspaces: [{ ref: "workspace:1" }] }),
+      listPanes: async () => ({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: async ({}: any) => ({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          { ref: "surface:1", title: "codex", type: "terminal", index: 0 },
+          { ref: "surface:2", title: "claude", type: "terminal", index: 1 },
+          { ref: "surface:3", title: "cursor", type: "terminal", index: 2 },
+        ],
+      }),
+    } as any;
+    const server = createServer({
+      client: mockClient,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    return (server as any)._registeredTools["read_screen"];
+  }
+
+  const callParsed = async (surface: string) => {
+    const tool = makeTool();
+    const res = await tool.handler({ surface, parsed_only: true }, {} as any);
+    return (res.structuredContent ?? JSON.parse(res.content[0].text)).parsed;
+  };
+
+  it("Codex: real in-JSONL window 258400 (NOT 1M)", async () => {
+    const p = await callParsed("surface:1");
+    expect(p.agent_type).toBe("codex");
+    expect(p.context_window).toBe(258400);
+    expect(p.context_window).not.toBe(1_000_000);
+    expect(p.token_count).toBe(108569);
+    expect(p.context_pct).toBe(42);
+  });
+
+  it("Claude: table window (opus-4-8 → 1M) from JSONL usage tail", async () => {
+    const p = await callParsed("surface:2");
+    expect(p.context_window).toBe(1_000_000);
+    expect(p.token_count).toBe(82000);
+    expect(p.context_pct).toBe(8);
+  });
+
+  it("Cursor: clean TUI-strip fallback (JSONL has no tokens/window)", async () => {
+    const p = await callParsed("surface:3");
+    expect(p.agent_type).toBe("cursor");
+    expect(p.context_pct).toBe(22); // from "Auto · 22%" strip, NOT overwritten
+    expect(p.context_window).toBeNull();
+  });
+});

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -10,10 +10,31 @@ import {
   findHarnessSessionPath,
   loadHarnessSession,
   applyHarnessState,
+  harnessJsonlEnabled,
 } from "../src/harness-session.js";
 
 const FIX = join(__dirname, "fixtures", "harness");
 const read = (name: string) => readFileSync(join(FIX, name), "utf8");
+
+describe("harnessJsonlEnabled (default-ON, opt-out with =0)", () => {
+  const prev = process.env.CMUXLAYER_HARNESS_JSONL;
+  afterAll(() => {
+    if (prev === undefined) delete process.env.CMUXLAYER_HARNESS_JSONL;
+    else process.env.CMUXLAYER_HARNESS_JSONL = prev;
+  });
+  it("defaults ON when unset", () => {
+    delete process.env.CMUXLAYER_HARNESS_JSONL;
+    expect(harnessJsonlEnabled()).toBe(true);
+  });
+  it("stays ON for =1", () => {
+    process.env.CMUXLAYER_HARNESS_JSONL = "1";
+    expect(harnessJsonlEnabled()).toBe(true);
+  });
+  it("opts OUT only for =0", () => {
+    process.env.CMUXLAYER_HARNESS_JSONL = "0";
+    expect(harnessJsonlEnabled()).toBe(false);
+  });
+});
 
 describe("parseHarnessSession", () => {
   it("Claude: tokens from last usage tail, window from model table (NOT in JSONL)", () => {


### PR DESCRIPTION
Flips the #128 harness-JSONL overlay **default-ON** after conclusive validation. Kept as a small, isolated, reversible PR.

## Why now
Validation of #128 was conclusive:
- **Deterministic test** through the real `read_screen` handler (all 3 harnesses): Codex → **258400** (not 1M), Claude(opus-4-8) → 1M table window, Cursor → clean TUI-strip fallback (window null, pct from `Auto · X%`).
- **Live**: 4 real on-disk Codex `gpt-5.5` sessions all report window **258400** with real fill (23/93/86/49%). Under the old code the **93%-full** session (239,767 tok) showed **~24%** "plenty of room" — exactly the monitoring corruption Etan flagged.

## Why default-on is safe
- **Strictly additive**: the JSONL overlay only fires when a session transcript resolves; otherwise the screen-parser stands unchanged.
- **Reversible**: opt out with `CMUXLAYER_HARNESS_JSONL=0`.

## Changes
- `harness-session.ts`: `harnessJsonlEnabled()` defaults `true` (opt-out `=0`).
- `server.ts`: `resolveHarnessStateForSurface` honors `CODEX_HOME` + `CMUXLAYER_HARNESS_HOME` (test-only home override) so the load path is injectable.
- `docs/harness-jsonl-field-map.md`: enablement note.
- tests: `harness-jsonl-validation.test.ts` (flag-on end-to-end, 3 harnesses) + default-on/opt-out unit tests.

**650 tests pass**, typecheck clean. Closes Etan's context-window correction with proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change affects agent monitoring context fields whenever JSONL resolves; mitigated by screen-parser fallback when transcripts are missing and explicit opt-out via `CMUXLAYER_HARNESS_JSONL=0`.
> 
> **Overview**
> Makes the harness transcript **JSONL overlay default-on** for live context/token reporting in `read_screen` (and related paths), after validation that it fixes wrong Codex context windows (e.g. **258400** vs a misleading **1M** / ~24% vs ~93% fill).
> 
> **`harnessJsonlEnabled()`** now returns true unless `CMUXLAYER_HARNESS_JSONL=0`; unset or `=1` stays enabled. **`resolveHarnessStateForSurface`** forwards **`CODEX_HOME`** and test-only **`CMUXLAYER_HARNESS_HOME`** into **`loadHarnessSession`** so transcript resolution matches real installs and injectable fixtures.
> 
> Docs add an **Enablement** note (default-on, opt-out, home overrides). New **`harness-jsonl-validation.test.ts`** exercises the real **`read_screen`** handler for Codex, Claude, and Cursor; **`harness-session.test.ts`** covers the flag semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55c6c6ca47f748866c3cc67ee3b646f0deaf4585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch `harnessJsonlEnabled` to default-ON with opt-out via `CMUXLAYER_HARNESS_JSONL=0`
> - `harnessJsonlEnabled()` in [harness-session.ts](https://github.com/EtanHey/cmuxlayer/pull/129/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) now returns `true` when `CMUXLAYER_HARNESS_JSONL` is unset, and `false` only when it is set to `"0"`; previously it required `"1"` to activate.
> - `resolveHarnessStateForSurface` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/129/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now forwards `CMUXLAYER_HARNESS_HOME` and `CODEX_HOME` env vars to `loadHarnessSession` for correct path resolution.
> - Adds a vitest suite in [tests/harness-jsonl-validation.test.ts](https://github.com/EtanHey/cmuxlayer/pull/129/files#diff-45af95cd4fec82645ddd106669c651a598e9b12da2b6e2506ddfbbc253a0f180) covering JSONL overlay behavior for Codex, Claude, and Cursor harnesses, including fallback when tokens/window are absent.
> - Behavioral Change: any environment that previously left `CMUXLAYER_HARNESS_JSONL` unset will now have JSONL-derived agent state applied automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55c6c6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->