### PR TITLE
fix(read_screen): lean output by default — strip chrome, response once, raw opt-in

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -582,3 +582,44 @@ export function parseScreen(text: string): ParsedScreenResult {
 
   return result;
 }
+
+// AIDEV-NOTE: read_screen leanness — strip the terminal chrome that bloats output without
+// adding signal: box-drawing rule/separator lines and per-harness status-bar art. Returns
+// the last `maxLines` of meaningful content. The structured fields (status/tokens/ctx/response)
+// already carry the real signal; this is only for a compact human-readable screen preview.
+const RULE_LINE_RE = /^[\s─-╿▀-▟\-=_~·•—–]+$/;
+const CHROME_LINE_RES: RegExp[] = [
+  /🤖|💰|⏱/, // model/cost/timer status line
+  /esc to interrupt/i,
+  /bypass permissions on/i,
+  /\d+%\s+left\b/i, // Codex context footer
+  /(?:^|\s)(?:Auto|Agent)\s*·\s*\d/i, // Cursor status strip
+  /→\s*Add a follow-up/i,
+  /ctrl\+c to stop/i,
+  /ctrl\+r to review edits/i,
+  /\/ commands · @ files/i,
+  /^[⬡⬢✻✢✳✶●⏺]\s/, // spinner/status glyphs at line start
+];
+
+/**
+ * Compact, de-chromed screen preview: drops box-drawing rule lines and status-bar art,
+ * collapses blank runs, and returns the last `maxLines` meaningful lines. Used by read_screen
+ * for a lean default view (full raw text is available via raw=true).
+ */
+export function cleanScreenText(text: string, maxLines = 8): string {
+  const out: string[] = [];
+  for (const rawLine of normalizeText(text).split("\n")) {
+    const line = rawLine.replace(/\s+$/, "");
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (out.length > 0 && out[out.length - 1] !== "") out.push("");
+      continue;
+    }
+    if (RULE_LINE_RE.test(trimmed)) continue;
+    if (CHROME_LINE_RES.some((re) => re.test(trimmed))) continue;
+    out.push(line);
+  }
+  while (out.length > 0 && out[0] === "") out.shift();
+  while (out.length > 0 && out[out.length - 1] === "") out.pop();
+  return out.slice(-maxLines).join("\n");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,7 +39,11 @@ import {
   formatDelivery,
   formatResync,
 } from "./format.js";
-import { inferContextWindow, parseScreen } from "./screen-parser.js";
+import {
+  cleanScreenText,
+  inferContextWindow,
+  parseScreen,
+} from "./screen-parser.js";
 import {
   applyHarnessState,
   harnessJsonlEnabled,
@@ -2325,7 +2329,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 9. read_screen
   server.tool(
     "read_screen",
-    "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors, plus delivery metadata for the current or most recent background send_input operation. Use parsed_only=true for monitoring (omits raw terminal content).",
+    "Read terminal screen with parsed agent status. Returns parsed fields: agent_type, status, model, token_count, context_pct (% used), context_window (max tokens), cost, done_signal, response, errors, plus delivery metadata. LEAN BY DEFAULT: the response is returned once (parsed.response); the raw terminal dump is NOT included — instead a compact, de-chromed screen_preview (box-drawing rules + status-bar art stripped) is included only when there is no parsed.response. Pass raw=true for the full untrimmed terminal content, or parsed_only=true for parsed fields alone (best for monitoring).",
     {
       surface: z.string().describe("Target surface ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
@@ -2347,7 +2351,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .default(false)
         .describe(
-          "If true, return only parsed fields (omit raw content). Best for agent monitoring.",
+          "If true, return only parsed fields (omit screen content). Best for agent monitoring.",
+        ),
+      raw: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, include the full untrimmed terminal content (separators, status-bar art, all lines). Default false returns a compact de-chromed screen_preview instead.",
         ),
     },
     ANNOTATIONS.readOnly,
@@ -2396,24 +2407,54 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return okFormatted(formatted, data);
         }
 
+        if (args.raw) {
+          // Full untrimmed terminal content on explicit request.
+          const data = {
+            surface: result.surface,
+            title: surface?.title ?? null,
+            column,
+            column_count,
+            lines: result.lines,
+            content: result.text,
+            scrollback_used: result.scrollback_used,
+            parsed,
+            delivery: getSurfaceDelivery(result.surface),
+          };
+          const formatted = formatReadScreen(
+            result.surface,
+            surface?.title ?? null,
+            result.text,
+            parsed,
+            result.scrollback_used,
+            result.lines,
+            column,
+            column_count,
+          );
+          return okFormatted(formatted, data);
+        }
+
+        // LEAN DEFAULT: response returned once (parsed.response); no raw dump. Show a
+        // compact de-chromed preview ONLY when there's no response, so non-agent panes
+        // (shell prompts, menus) still surface something without duplicating the response.
+        const screenPreview = parsed.response
+          ? null
+          : cleanScreenText(result.text, 12) || null;
         const data = {
           surface: result.surface,
           title: surface?.title ?? null,
           column,
           column_count,
-          lines: result.lines,
-          content: result.text,
-          scrollback_used: result.scrollback_used,
           parsed,
+          ...(screenPreview ? { screen_preview: screenPreview } : {}),
           delivery: getSurfaceDelivery(result.surface),
         };
         const formatted = formatReadScreen(
           result.surface,
           surface?.title ?? null,
-          result.text,
+          screenPreview,
           parsed,
-          result.scrollback_used,
-          result.lines,
+          false,
+          screenPreview ? screenPreview.split("\n").length : 0,
           column,
           column_count,
         );

--- a/tests/clean-screen.test.ts
+++ b/tests/clean-screen.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { cleanScreenText } from "../src/screen-parser.js";
+
+describe("cleanScreenText (read_screen leanness)", () => {
+  it("drops box-drawing rule/separator lines, keeps real content", () => {
+    const input = [
+      "────────────────────────",
+      "Real output line one",
+      "═══════════ • ═══════════",
+      "Real output line two",
+      "----------",
+    ].join("\n");
+    expect(cleanScreenText(input)).toBe(
+      "Real output line one\nReal output line two",
+    );
+  });
+
+  it("strips the agent status-bar art (🤖 model · cost, spinner, esc to interrupt)", () => {
+    const input = [
+      "Did the work",
+      "✻ Working… Reticulating",
+      "  esc to interrupt",
+      "🤖 Sonnet 4.6 | 💰 $1.25 | ⏱️  2m",
+    ].join("\n");
+    expect(cleanScreenText(input)).toBe("Did the work");
+  });
+
+  it("strips Codex '% left' footer and Cursor status strip + prompts", () => {
+    const codex = "answer text\ngpt-5.5 xhigh · 60% left · ~/x";
+    expect(cleanScreenText(codex)).toBe("answer text");
+    const cursor = [
+      "cursor answer",
+      "Auto · 22% · 3 files edited",
+      "→ Add a follow-up",
+      "ctrl+c to stop",
+    ].join("\n");
+    expect(cleanScreenText(cursor)).toBe("cursor answer");
+  });
+
+  it("collapses blank runs and trims edges", () => {
+    const input = "\n\nfirst\n\n\n\nsecond\n\n";
+    expect(cleanScreenText(input)).toBe("first\n\nsecond");
+  });
+
+  it("returns only the last maxLines meaningful lines", () => {
+    const input = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join(
+      "\n",
+    );
+    const out = cleanScreenText(input, 3).split("\n");
+    expect(out).toEqual(["line 18", "line 19", "line 20"]);
+  });
+
+  it("strips ANSI escapes before cleaning", () => {
+    const input = "[32mGreen output[0m\n──────";
+    expect(cleanScreenText(input)).toBe("Green output");
+  });
+
+  it("empty / all-chrome input → empty string", () => {
+    expect(cleanScreenText("")).toBe("");
+    expect(cleanScreenText("─────\n🤖 model\n  esc to interrupt")).toBe("");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1050,7 +1050,10 @@ describe("tool handler integration", () => {
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(parsed.content).toContain("hello");
+    // LEAN DEFAULT: response returned once (parsed.response); NOT duplicated in a raw
+    // content dump, and no screen_preview when there's a response.
+    expect(parsed.content).toBeUndefined();
+    expect(parsed.screen_preview).toBeUndefined();
     expect(parsed.parsed).toMatchObject({
       agent_type: "claude",
       status: "done",
@@ -1060,6 +1063,15 @@ describe("tool handler integration", () => {
       model: "Sonnet 4.6",
       cost: 1.25,
     });
+
+    // raw=true returns the full untrimmed terminal content.
+    const rawResult = await tool.handler(
+      { surface: "surface:1", raw: true },
+      {} as any,
+    );
+    const rawParsed =
+      rawResult.structuredContent ?? JSON.parse(rawResult.content[0].text);
+    expect(rawParsed.content).toContain("hello");
   });
 
   it("read_screen parsed_only includes the tab title and recovers model context from agent state", async () => {
@@ -1404,7 +1416,9 @@ describe("tool handler integration", () => {
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(data.column).toBeNull();
     expect(data.column_count).toBeNull();
-    expect(data.content).toBe("screen content\n");
+    // Lean default: no parsed.response → cleaned screen_preview carries the content.
+    expect(data.content).toBeUndefined();
+    expect(data.screen_preview).toBe("screen content");
     expect(result.content[0].text).not.toContain("col ");
   });
 


### PR DESCRIPTION
## The problem (Etan, with screenshot)
`read_screen` was way too verbose — it dumped (a) box-drawing separator/rule lines (`─────`), (b) raw escaped `\n` literals, (c) the full status-bar art, AND (d) **duplicated the entire response** in both the raw `content` field and `parsed.response`.

## The fix — lean by default
- **`screen-parser.ts`** — new `cleanScreenText()`: strips box-drawing rule/separator lines and per-harness status-bar art (`🤖 model · cost`, spinner glyphs, `esc to interrupt`, Codex `% left`, Cursor `Auto · X%` / follow-up / `ctrl+c`), collapses blank runs, returns the last N meaningful lines.
- **`server.ts` `read_screen`**:
  - **DEFAULT (lean):** no raw `content` dump. The response is returned **once** via `parsed.response`. A compact de-chromed `screen_preview` is included **only when there is no `parsed.response`** (so shell prompts / menus still surface something) — never duplicating the response.
  - **`raw=true`:** full untrimmed terminal content (separators + status art + all lines), as before.
  - **`parsed_only=true`:** unchanged (parsed fields only).

## Tests
- `clean-screen.test.ts` (7) — rule-line stripping, status-art stripping (Claude/Codex/Cursor), blank collapsing, last-N, ANSI, all-chrome→empty.
- Updated `read_screen` contract tests: lean default (no `content`, no dup), `screen_preview` when no response, `raw=true` returns full content.
- **651 tests pass**, typecheck clean.

This is PR#2 of the output-quality family (PR#1 #128 = real per-model context window from harness JSONL). Independent of the harness-JSONL default-on flip (#129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default response shape drops `content` unless `raw=true`, which can break callers that assumed the old verbose dump; behavior change is intentional and opt-in recovery exists.
> 
> **Overview**
> **read_screen** default responses are slimmed down so MCP clients stop getting huge, duplicated terminal noise.
> 
> A new **`cleanScreenText`** helper strips box-drawing rules, harness status-bar lines (Claude/Codex/Cursor chrome), collapses blank runs, and keeps only the last N meaningful lines (12 in the handler). **Default path:** omits **`content`** entirely; agent answers appear once in **`parsed.response`**. **`screen_preview`** is added only when there is no parsed response (shells/menus). **`raw=true`** brings back full **`content`** plus line/scrollback metadata; **`parsed_only`** is unchanged aside from wording.
> 
> Tool docs and **`formatReadScreen`** wiring follow the new shapes; tests cover **`cleanScreenText`** and the updated **`read_screen`** contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb642489be948ef26461c0659a687a3822ddf60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip terminal chrome from `read_screen` output by default and add `raw` opt-in flag
> - By default, `read_screen` no longer returns a raw terminal content dump; it returns `parsed.response` once (inside `parsed`) and omits `content`, `lines`, and `scrollback_used`.
> - When no `parsed.response` exists, a compact `screen_preview` is included, generated by the new `cleanScreenText` utility in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/130/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) that strips box-drawing separators, status-bar art, and collapses blank lines, returning only the last N meaningful lines.
> - A new boolean `raw` argument (default `false`) restores the previous behavior, returning the full untrimmed terminal content.
> - Behavioral Change: existing callers relying on `content`, `lines`, or `scrollback_used` in the default response will no longer receive those fields unless they pass `raw=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fb6424.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->