### PR TITLE
feat(metacomm): minimal write-channel — per-agent inbox dispatch (Monitor-driven, send_input fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,15 @@ bun run typecheck    # Type checking only
 
 ## Architecture
 
-### MCP Tools (29 total)
-- **29 registered tools**: terminal control, browser surface control, workspace state, and agent lifecycle orchestration.
+### MCP Tools (33 total)
+- **33 registered tools**: terminal control, browser surface control, workspace state, agent lifecycle orchestration, and the metacommlayer write channel (dispatch_to_agent, inbox_check).
 
 ### Key Source Files
 | File | Role |
 |------|------|
-| `server.ts` | MCP tool registration and handlers (all 29 tools) |
+| `server.ts` | MCP tool registration and handlers (all 33 tools) |
+| `harness-session.ts` | metacommlayer READ channel — real agent state (tokens/context/model) from harness transcript JSONL (see docs/harness-jsonl-field-map.md) |
+| `inbox.ts` | metacommlayer WRITE channel — per-agent inbox file dispatch + replay/ack/heartbeat (Monitor-driven, send_input fallback) |
 | `cmux-socket-client.ts` | Persistent Unix socket to cmux |
 | `cmux-client.ts` | CLI wrapper fallback |
 | `agent-engine.ts` | Agent lifecycle — spawn, monitor, quality tracking |

--- a/docs/metacommlayer-inbox.md
+++ b/docs/metacommlayer-inbox.md
@@ -1,0 +1,49 @@
+# metacommlayer WRITE channel — inbox dispatch (operations)
+
+> Sterile, deterministic dispatch that replaces `send_input`/TUI typing. Pairs with the READ
+> channel (`harness-session.ts`). Library: `src/inbox.ts`. MCP tools: `dispatch_to_agent`,
+> `inbox_check`. Spike proof: `orchestrator/docs.local/handoffs/2026-06-04/metacommlayer-write-channel-SPIKE-findings.md`.
+>
+> **`send_input` is KEPT as the fallback** — this channel is additive (belt-and-suspenders) until
+> proven in production. Fall back to `send_input` whenever `inbox_check` shows a wedged monitor.
+
+## Files (per agent, EPHEMERAL plumbing — NOT BrainLayer)
+- `~/.cmux/agents/<agent-id>/inbox.jsonl` — append-only dispatches.
+- `~/.cmux/agents/<agent-id>/inbox.ack.jsonl` — append-only ACKs.
+- `~/.cmux/agents/<agent-id>/monitor.heartbeat` — liveness.
+
+Do NOT auto-ingest these into BrainLayer. Only messages with `persist:true` are candidates for
+`brain_store`, at the caller's discretion. Keep the channel dir off any BrainLayer watch path.
+
+## orc / lead side (the write)
+- Dispatch: MCP `dispatch_to_agent { agent_id, task, from?, tag?, persist? }` (or append a line via
+  the `dispatch()` lib). One record: `{ id, ts_ms, from, to, tag, task, persist? }`.
+- **FM#4 — keep dispatch low-rate / batched** so the agent's Monitor doesn't trip its flood auto-stop.
+- **FM#3 — detect wedged agents:** `inbox_check { agent_id, ack_timeout_ms, heartbeat_max_age_ms }`
+  → `{ monitor_alive, undelivered, stale }`. Non-empty `stale` (un-acked past the timeout) or
+  `monitor_alive:false` ⇒ the channel is down → **fall back to `send_input`** for that agent.
+- Triage: when an agent needs orc, it dispatches to `to:"orc"`; orc's own inbox monitor + its
+  existing cron-tick loop catch it. No firehose, no separate buddy/local-model.
+
+## agent side (the read + act) — boot policy
+1. **On boot/arm:** `writeHeartbeat(self)`, then arm the native **Monitor** with
+   `recommendedMonitorCommand(self)` (= `tail -n0 -F .../inbox.jsonl`) using **`persistent:true`**
+   (FM#1 — a non-persistent monitor times out silently and misses dispatches).
+2. **Replay first (FM#2):** call `replayUndelivered(self)` and act on anything already queued —
+   `tail -n0` only catches appends *after* arming, so messages written while you were down are
+   recovered from the acked-id set, not a tail offset.
+3. **On each Monitor event:** read the new message, **act**, then `ack(self, msg.id, status)`
+   (ack also refreshes the heartbeat). Process `replayUndelivered` in order to avoid gaps.
+4. **FM#5 — policy:** Monitor events arrive as *system notifications*, not user input. The agent
+   MUST treat an inbox event as an actionable dispatch (this is the standing instruction), not
+   background noise.
+
+## Honest latency
+The file watch is sub-second; end-to-end latency = (time until the agent's current turn ends) +
+(one LLM turn). Idle agent ≈ seconds; busy agent = queued until free. Dispatch cadence ≈ turn
+cadence — fine for coordination, not for sub-second control.
+
+## Per-harness status
+- **Claude:** native Monitor ✅ (this build).
+- **Codex:** no native Monitor → background-bash `tail -f`/poll surfaces the line into the session (NEXT).
+- **Cursor:** TBD (bg-bash or TUI).

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -1,0 +1,239 @@
+// AIDEV-NOTE: metacommlayer WRITE channel — the sterile dispatch path that replaces send_input.
+// orc/lead appends a dispatch to a per-agent inbox FILE; the agent watches it with a persistent
+// native Monitor (`tail -n0 -F`) and acts WITHOUT any TUI typing. Pairs with the harness-JSONL
+// READ channel (harness-session.ts). Spike findings + design:
+// orchestrator/docs.local/handoffs/2026-06-04/metacommlayer-write-channel-SPIKE-findings.md
+//
+// This module is the deterministic plumbing. It bakes in the 5 spike failure-modes:
+//   FM#1 monitor liveness   → heartbeat + monitorAlive()
+//   FM#2 gap/replay         → replayUndelivered() works off the ACKED-id set (NOT post-arm tail),
+//                             so messages written while the monitor was down are still delivered.
+//   FM#3 wedged agent       → pendingDispatches() = orc-side ACK-timeout detector.
+//   FM#4 flood auto-stop    → low-rate is a caller convention; recommendedMonitorCommand emits
+//                             only inbox lines (no chatter).
+//   FM#5 dispatch policy    → events are system-notifications; the agent must be told to treat
+//                             inbox events as actionable dispatch (documented; not code).
+//
+// EPHEMERAL: the inbox/ack files are coordination plumbing, NOT memory. Do NOT auto-ingest them
+// into BrainLayer. Only messages explicitly tagged persist:true are candidates for brain_store,
+// and that is the caller's decision — this module never touches BrainLayer.
+//
+// send_input is KEPT as the fallback path — this channel is additive (belt-and-suspenders) until
+// proven in production.
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface InboxMessage {
+  id: string;
+  ts_ms: number;
+  from: string;
+  /** Recipient agent id (own-tag) or "orc". Each agent monitors only its own inbox. */
+  to: string;
+  tag: string;
+  task: string;
+  /** Opt-in: only persist:true messages are candidates for BrainLayer ingestion (caller's call). */
+  persist?: boolean;
+}
+
+export interface InboxAck {
+  ts_ms: number;
+  agent: string;
+  /** id of the message being acked. */
+  ack_of: string;
+  status: string;
+}
+
+export interface InboxOpts {
+  /** Base dir for agent channels. Default ~/.cmux/agents (override for tests). */
+  baseDir?: string;
+  /** Injectable clock for determinism (default Date.now). */
+  now?: () => number;
+}
+
+export interface DispatchInput {
+  from: string;
+  to?: string;
+  tag?: string;
+  task: string;
+  persist?: boolean;
+  /** Optional explicit id/timestamp (else generated). */
+  id?: string;
+  ts_ms?: number;
+}
+
+function baseDirOf(opts: InboxOpts | undefined): string {
+  return opts?.baseDir ?? join(homedir(), ".cmux", "agents");
+}
+
+function nowOf(opts: InboxOpts | undefined): number {
+  return (opts?.now ?? Date.now)();
+}
+
+export function agentDir(agentId: string, opts?: InboxOpts): string {
+  return join(baseDirOf(opts), agentId);
+}
+export function inboxPath(agentId: string, opts?: InboxOpts): string {
+  return join(agentDir(agentId, opts), "inbox.jsonl");
+}
+export function ackPath(agentId: string, opts?: InboxOpts): string {
+  return join(agentDir(agentId, opts), "inbox.ack.jsonl");
+}
+export function heartbeatPath(agentId: string, opts?: InboxOpts): string {
+  return join(agentDir(agentId, opts), "monitor.heartbeat");
+}
+
+function ensureDir(agentId: string, opts?: InboxOpts): void {
+  mkdirSync(agentDir(agentId, opts), { recursive: true });
+}
+
+function readJsonl<T>(path: string): T[] {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const out: T[] = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t) as T);
+    } catch {
+      // tolerate partial/corrupt lines — never throw on a live channel
+    }
+  }
+  return out;
+}
+
+let idCounter = 0;
+function genId(ts: number): string {
+  idCounter = (idCounter + 1) % 1_000_000;
+  return `${ts}-${idCounter.toString(36)}`;
+}
+
+/**
+ * Append a dispatch to an agent's inbox (the deterministic write). Returns the stored message.
+ * Atomic append (single writev) so a concurrent reader never sees a half line.
+ */
+export function dispatch(
+  agentId: string,
+  input: DispatchInput,
+  opts?: InboxOpts,
+): InboxMessage {
+  ensureDir(agentId, opts);
+  const ts = input.ts_ms ?? nowOf(opts);
+  const msg: InboxMessage = {
+    id: input.id ?? genId(ts),
+    ts_ms: ts,
+    from: input.from,
+    to: input.to ?? agentId,
+    tag: input.tag ?? "dispatch",
+    task: input.task,
+    ...(input.persist ? { persist: true } : {}),
+  };
+  appendFileSync(inboxPath(agentId, opts), JSON.stringify(msg) + "\n");
+  return msg;
+}
+
+export function readInbox(agentId: string, opts?: InboxOpts): InboxMessage[] {
+  return readJsonl<InboxMessage>(inboxPath(agentId, opts));
+}
+
+export function readAcks(agentId: string, opts?: InboxOpts): InboxAck[] {
+  return readJsonl<InboxAck>(ackPath(agentId, opts));
+}
+
+/** Set of message ids that have been acked. */
+export function ackedIds(agentId: string, opts?: InboxOpts): Set<string> {
+  return new Set(readAcks(agentId, opts).map((a) => a.ack_of));
+}
+
+/**
+ * FM#2 — messages not yet acked, in file (oldest-first) order. Works off the ACKED-id set, not a
+ * post-arm tail offset, so dispatches written while the monitor was down are STILL replayed on
+ * (re)arm. The agent calls this on startup/arm and after each Monitor event, then acts in order.
+ */
+export function replayUndelivered(
+  agentId: string,
+  opts?: InboxOpts,
+): InboxMessage[] {
+  const acked = ackedIds(agentId, opts);
+  return readInbox(agentId, opts).filter((m) => !acked.has(m.id));
+}
+
+/** Append an ACK (deterministic delivery confirmation) and refresh the liveness heartbeat. */
+export function ack(
+  agentId: string,
+  ackOf: string,
+  status: string,
+  opts?: InboxOpts,
+): InboxAck {
+  ensureDir(agentId, opts);
+  const record: InboxAck = {
+    ts_ms: nowOf(opts),
+    agent: agentId,
+    ack_of: ackOf,
+    status,
+  };
+  appendFileSync(ackPath(agentId, opts), JSON.stringify(record) + "\n");
+  writeHeartbeat(agentId, opts);
+  return record;
+}
+
+/**
+ * FM#3 — orc-side ACK-timeout: undelivered dispatches older than timeoutMs. A non-empty result
+ * for a healthy-looking agent means it's wedged / its monitor is dead → fall back to send_input.
+ */
+export function pendingDispatches(
+  agentId: string,
+  timeoutMs: number,
+  opts?: InboxOpts,
+): InboxMessage[] {
+  const cutoff = nowOf(opts) - timeoutMs;
+  return replayUndelivered(agentId, opts).filter((m) => m.ts_ms <= cutoff);
+}
+
+/** FM#1 — heartbeat the agent's monitor writes (on arm + each act) to prove liveness. */
+export function writeHeartbeat(agentId: string, opts?: InboxOpts): number {
+  ensureDir(agentId, opts);
+  const ts = nowOf(opts);
+  appendFileSync(heartbeatPath(agentId, opts), `${ts}\n`);
+  return ts;
+}
+
+/**
+ * FM#1 — is the monitor heartbeat fresh within maxAgeMs? false → treat the channel as down.
+ * Reads the last written heartbeat timestamp (not file mtime) so it's consistent with the
+ * injectable clock and reflects when the agent actually heartbeated.
+ */
+export function monitorAlive(
+  agentId: string,
+  maxAgeMs: number,
+  opts?: InboxOpts,
+): boolean {
+  let raw: string;
+  try {
+    raw = readFileSync(heartbeatPath(agentId, opts), "utf8");
+  } catch {
+    return false;
+  }
+  const last = raw.trim().split("\n").filter(Boolean).pop();
+  const ts = last ? Number.parseInt(last, 10) : NaN;
+  if (!Number.isFinite(ts)) return false;
+  return nowOf(opts) - ts <= maxAgeMs;
+}
+
+/**
+ * The shell command an agent arms via the native Monitor tool (persistent:true). Emits one stdout
+ * line per new inbox message (each becomes a Monitor event). Only inbox lines are emitted — no
+ * chatter — to avoid Monitor's flood auto-stop (FM#4). Heartbeat (FM#1) is written by the agent
+ * via writeHeartbeat() on arm + each act, not by this command (keeps the event stream clean).
+ */
+export function recommendedMonitorCommand(
+  agentId: string,
+  opts?: InboxOpts,
+): string {
+  return `tail -n0 -F ${inboxPath(agentId, opts)}`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,13 @@ import {
   parseScreen,
 } from "./screen-parser.js";
 import {
+  dispatch,
+  inboxPath,
+  monitorAlive,
+  pendingDispatches,
+  replayUndelivered,
+} from "./inbox.js";
+import {
   applyHarnessState,
   harnessJsonlEnabled,
   loadHarnessSession,
@@ -2787,6 +2794,91 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         // browser_surface actions map to cmux browser-surface subcommands
         const data = { action: args.action, surface: args.surface, result };
         return okFormatted(formatOk("browser_surface", data), data);
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 12. dispatch_to_agent — metacommlayer WRITE channel (sterile dispatch; send_input fallback)
+  server.tool(
+    "dispatch_to_agent",
+    "Append a task to an agent's inbox FILE (the deterministic write channel). The agent acts on it via a persistent native Monitor on its inbox — NO send_input/TUI typing. Use this as the primary dispatch path; send_input remains the fallback. Address to:'orc' to flag the orchestrator (own-tag triage). Channel is EPHEMERAL plumbing — set persist:true only for decisions that should be brain_store'd.",
+    {
+      agent_id: z
+        .string()
+        .describe(
+          "Recipient agent id (its inbox is ~/.cmux/agents/<id>/inbox.jsonl)",
+        ),
+      task: z.string().describe("The dispatch payload / instruction"),
+      from: z.string().optional().default("orc").describe("Sender id"),
+      tag: z
+        .string()
+        .optional()
+        .default("dispatch")
+        .describe("Routing/semantics tag"),
+      persist: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Opt-in: mark this message as a candidate for BrainLayer ingestion",
+        ),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const msg = dispatch(args.agent_id, {
+          from: args.from,
+          to: args.agent_id,
+          tag: args.tag,
+          task: args.task,
+          persist: args.persist,
+        });
+        return ok({ dispatched: msg, inbox: inboxPath(args.agent_id) });
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  // 13. inbox_check — orc-side liveness/delivery view of an agent's write channel
+  server.tool(
+    "inbox_check",
+    "Inspect an agent's inbox channel: undelivered (un-acked) messages, monitor liveness (heartbeat freshness), and stale dispatches past the ACK-timeout. A non-empty 'pending' for a live-looking agent means its monitor is wedged → fall back to send_input. Read-only.",
+    {
+      agent_id: z.string().describe("Agent id to inspect"),
+      ack_timeout_ms: z
+        .number()
+        .int()
+        .min(1000)
+        .optional()
+        .default(120000)
+        .describe("Treat un-acked dispatches older than this as stale/wedged"),
+      heartbeat_max_age_ms: z
+        .number()
+        .int()
+        .min(1000)
+        .optional()
+        .default(60000)
+        .describe(
+          "Monitor is considered alive if it heartbeated within this window",
+        ),
+    },
+    ANNOTATIONS.readOnly,
+    async (args) => {
+      try {
+        const undelivered = replayUndelivered(args.agent_id);
+        const pending = pendingDispatches(args.agent_id, args.ack_timeout_ms);
+        const alive = monitorAlive(args.agent_id, args.heartbeat_max_age_ms);
+        return ok({
+          agent_id: args.agent_id,
+          monitor_alive: alive,
+          undelivered_count: undelivered.length,
+          undelivered,
+          stale_count: pending.length,
+          stale: pending,
+        });
       } catch (e) {
         return err(e);
       }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -7,10 +7,7 @@ import { join } from "node:path";
 import net from "node:net";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
-import {
-  CmuxLayerDaemon,
-  SocketJsonRpcTransport,
-} from "../src/daemon.js";
+import { CmuxLayerDaemon, SocketJsonRpcTransport } from "../src/daemon.js";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 
@@ -203,7 +200,10 @@ async function listen(server: net.Server, path: string): Promise<void> {
   });
 }
 
-async function rawToolsList(path: string, timeoutMs = 500): Promise<{
+async function rawToolsList(
+  path: string,
+  timeoutMs = 500,
+): Promise<{
   server?: string;
   toolCount?: number;
 }> {
@@ -212,7 +212,9 @@ async function rawToolsList(path: string, timeoutMs = 500): Promise<{
     let buffer = "";
     const timeout = setTimeout(() => {
       socket.destroy();
-      reject(new Error(`timed out waiting for tools/list after ${timeoutMs}ms`));
+      reject(
+        new Error(`timed out waiting for tools/list after ${timeoutMs}ms`),
+      );
     }, timeoutMs);
     const send = (message: Record<string, unknown>) => {
       socket.write(`${JSON.stringify(message)}\n`);
@@ -351,7 +353,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.start();
 
     await expect(rawToolsList(path, 100)).resolves.toMatchObject({
-      toolCount: 17,
+      toolCount: 19,
     });
 
     await daemon.shutdown();
@@ -388,8 +390,9 @@ describe("CmuxLayerDaemon", () => {
     const observed = deferred<Record<string, unknown>>();
     const server = net.createServer(async (socket) => {
       const transport = new SocketJsonRpcTransport(socket);
-      (transport as any).onRequestObserved = (message: Record<string, unknown>) =>
-        observed.resolve(message);
+      (transport as any).onRequestObserved = (
+        message: Record<string, unknown>,
+      ) => observed.resolve(message);
       transport.onmessage = () => {};
       await transport.start();
       transport.onmessage = () => {};
@@ -742,8 +745,14 @@ describe("CmuxLayerDaemon", () => {
       drainTimeoutMs: 500,
       serverFactory: (connectionListener) =>
         net.createServer((socket) => {
-          const originalWrite = socket.write.bind(socket) as typeof socket.write;
-          socket.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
+          const originalWrite = socket.write.bind(
+            socket,
+          ) as typeof socket.write;
+          socket.write = ((
+            chunk: any,
+            encodingOrCallback?: any,
+            callback?: any,
+          ) => {
             const payload = Buffer.isBuffer(chunk)
               ? chunk.toString("utf8")
               : String(chunk);

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ack,
+  ackedIds,
+  dispatch,
+  inboxPath,
+  monitorAlive,
+  pendingDispatches,
+  readInbox,
+  recommendedMonitorCommand,
+  replayUndelivered,
+  writeHeartbeat,
+} from "../src/inbox.js";
+
+const baseDir = mkdtempSync(join(tmpdir(), "cmux-inbox-"));
+let clock = 1_000_000;
+const opts = { baseDir, now: () => clock };
+
+afterAll(() => rmSync(baseDir, { recursive: true, force: true }));
+
+describe("inbox write-channel", () => {
+  it("dispatch appends a message with defaults (to=agent, tag=dispatch) and id", () => {
+    const m = dispatch("a1", { from: "orc", task: "do X" }, opts);
+    expect(m.to).toBe("a1");
+    expect(m.tag).toBe("dispatch");
+    expect(m.id).toBeTruthy();
+    expect(m.ts_ms).toBe(1_000_000);
+    const all = readInbox("a1", opts);
+    expect(all).toHaveLength(1);
+    expect(all[0].task).toBe("do X");
+  });
+
+  it("FM#2 replayUndelivered returns un-acked messages oldest-first; ack removes them", () => {
+    const id1 = dispatch("a2", { from: "orc", task: "t1", id: "m1" }, opts).id;
+    dispatch("a2", { from: "orc", task: "t2", id: "m2" }, opts);
+    expect(replayUndelivered("a2", opts).map((m) => m.id)).toEqual([
+      "m1",
+      "m2",
+    ]);
+    ack("a2", id1, "done", opts);
+    expect(replayUndelivered("a2", opts).map((m) => m.id)).toEqual(["m2"]);
+    expect(ackedIds("a2", opts).has("m1")).toBe(true);
+  });
+
+  it("FM#2 replay survives a 'monitor was down' gap (acted-set, not tail offset)", () => {
+    // 3 dispatched, only the middle acked → the other two still replay (incl. the first,
+    // which would be lost by a naive post-arm tail).
+    dispatch("a3", { from: "orc", task: "t1", id: "g1" }, opts);
+    dispatch("a3", { from: "orc", task: "t2", id: "g2" }, opts);
+    dispatch("a3", { from: "orc", task: "t3", id: "g3" }, opts);
+    ack("a3", "g2", "done", opts);
+    expect(replayUndelivered("a3", opts).map((m) => m.id)).toEqual([
+      "g1",
+      "g3",
+    ]);
+  });
+
+  it("FM#3 pendingDispatches flags un-acked messages older than the ack-timeout", () => {
+    clock = 5_000;
+    dispatch("a4", { from: "orc", task: "old", id: "old1" }, opts);
+    clock = 5_500;
+    dispatch("a4", { from: "orc", task: "recent", id: "recent1" }, opts);
+    clock = 10_500; // old1 is 5500ms old, recent1 is 5000ms old
+    const stale = pendingDispatches("a4", 5_200, opts);
+    expect(stale.map((m) => m.id)).toEqual(["old1"]);
+    // once acked, no longer pending
+    ack("a4", "old1", "done", opts);
+    expect(pendingDispatches("a4", 5_200, opts)).toHaveLength(0);
+  });
+
+  it("FM#1 heartbeat + monitorAlive freshness gate", () => {
+    clock = 20_000;
+    writeHeartbeat("a5", opts);
+    clock = 20_500;
+    expect(monitorAlive("a5", 1_000, opts)).toBe(true);
+    clock = 22_000; // 2000ms since heartbeat
+    expect(monitorAlive("a5", 1_000, opts)).toBe(false);
+  });
+
+  it("FM#1 monitorAlive is false when no heartbeat exists", () => {
+    expect(monitorAlive("never-armed", 1_000, opts)).toBe(false);
+  });
+
+  it("ack writes a heartbeat (acting proves liveness)", () => {
+    clock = 30_000;
+    dispatch("a6", { from: "orc", task: "t", id: "h1" }, opts);
+    ack("a6", "h1", "done", opts);
+    clock = 30_200;
+    expect(monitorAlive("a6", 1_000, opts)).toBe(true);
+  });
+
+  it("persist flag is preserved only when true (ingestion is opt-in)", () => {
+    const persisted = dispatch(
+      "a7",
+      { from: "orc", task: "decision", persist: true },
+      opts,
+    );
+    const ephemeral = dispatch("a7", { from: "orc", task: "routine" }, opts);
+    expect(persisted.persist).toBe(true);
+    expect(ephemeral.persist).toBeUndefined();
+  });
+
+  it("readers tolerate blank / corrupt lines without throwing", () => {
+    const path = inboxPath("a8", opts);
+    dispatch("a8", { from: "orc", task: "ok", id: "ok1" }, opts);
+    // append junk directly
+    appendFileSync(path, "\nnot json\n\n");
+    const all = readInbox("a8", opts);
+    expect(all.map((m) => m.id)).toEqual(["ok1"]);
+  });
+
+  it("recommendedMonitorCommand tails the agent's inbox (events only, no chatter)", () => {
+    const cmd = recommendedMonitorCommand("a9", opts);
+    expect(cmd).toBe(`tail -n0 -F ${inboxPath("a9", opts)}`);
+  });
+});

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -37,6 +37,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "list_agents",
     "my_agents",
     "read_agent_output",
+    "inbox_check",
   ];
 
   const DESTRUCTIVE_TOOLS = ["kill", "close_surface", "stop_agent"];
@@ -64,6 +65,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "wait_for",
     "wait_for_all",
     "interact",
+    "dispatch_to_agent",
   ];
 
   let tools: Record<string, { annotations?: Record<string, unknown> }>;
@@ -81,9 +83,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 31 tools have annotations", () => {
+  it("all 33 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(31);
+    expect(toolNames.length).toBe(33);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -155,11 +155,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 31 (17 low-level + 12 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 33 (19 low-level + 12 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(31);
+    expect(Object.keys(registeredTools)).toHaveLength(33);
   });
 });
 
@@ -254,23 +254,28 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:new",
-    ]));
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:new",
-      "fix prompt delivery",
-    ]));
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send-key",
-      "--surface",
-      "surface:new",
-      "return",
-    ]));
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:new"]),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        "fix prompt delivery",
+      ]),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send-key",
+        "--surface",
+        "surface:new",
+        "return",
+      ]),
+    );
   });
 
   it("spawn_agent sends boot_prompt_path contents after readiness", async () => {
@@ -292,12 +297,15 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(mockExec).toHaveBeenCalledWith("cmux", expect.arrayContaining([
-      "send",
-      "--surface",
-      "surface:new",
-      "file prompt body",
-    ]));
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        "file prompt body",
+      ]),
+    );
   });
 
   it("spawn_agent retries Enter when the launcher command remains pending at the shell", async () => {
@@ -380,8 +388,8 @@ describe("agent lifecycle tool handlers", () => {
               lastSentText === ""
                 ? "$ "
                 : launcherReturnCount < 2
-                ? "$ voicelayerCodex -s"
-                : "codex> ",
+                  ? "$ voicelayerCodex -s"
+                  : "codex> ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -518,10 +526,7 @@ describe("agent lifecycle tool handlers", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text:
-              lastSentText === ""
-                ? "$ "
-                : "$ voicelayerCodex -s\ncodex> ",
+            text: lastSentText === "" ? "$ " : "$ voicelayerCodex -s\ncodex> ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -1011,7 +1016,9 @@ describe("agent lifecycle tool handlers", () => {
     const sendKeyCalls = mockExec.mock.calls.filter(
       ([, args]) => Array.isArray(args) && args.includes("send-key"),
     );
-    const deliveredText = setBufferCalls.map(([, args]) => args.at(-1)).join("");
+    const deliveredText = setBufferCalls
+      .map(([, args]) => args.at(-1))
+      .join("");
 
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -27,6 +27,8 @@ const EXPECTED_TOOLS = [
   "set_progress",
   "close_surface",
   "browser_surface",
+  "dispatch_to_agent",
+  "inbox_check",
 ] as const;
 
 const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
@@ -73,7 +75,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 17 core tools", () => {
+  it("registers all 19 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -84,14 +84,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 31 (17 low-level + 12 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 33 (19 low-level + 12 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(31);
+    expect(count).toBe(33);
   });
 });
 


### PR DESCRIPTION
The deterministic **WRITE channel** proven in the spike: orc/lead appends a task to an agent's **inbox file**; the agent watches it with a persistent native **Monitor** and acts **without `send_input`/TUI typing**. Pairs with the harness-JSONL **READ** channel (#128) → together = the metacommlayer.

**`send_input` is KEPT as the fallback** — this channel is additive (belt-and-suspenders) until proven in production.

## All 5 spike failure-modes addressed up front
- **FM#1 monitor liveness** — `writeHeartbeat()` + `monitorAlive()`; agents arm Monitor with `persistent:true` (no silent timeout-miss).
- **FM#2 gap/replay** — `replayUndelivered()` works off the **acked-id set**, not a post-arm tail offset → dispatches written while the monitor was down are still delivered on re-arm.
- **FM#3 wedged agent** — `pendingDispatches()` = orc-side **ACK-timeout**; `inbox_check` surfaces it → caller falls back to `send_input`.
- **FM#4 flood** — dispatch is low-rate by convention; the monitor command emits inbox lines only.
- **FM#5 policy** — documented: agents must treat inbox events (system notifications) as actionable dispatch.

## Changes
- **`src/inbox.ts`** — `dispatch` / `readInbox` / `replayUndelivered` / `ack` / `pendingDispatches` / `writeHeartbeat` / `monitorAlive` / `recommendedMonitorCommand`. Ephemeral plumbing — **never touches BrainLayer**; `persist:true` is an opt-in ingestion hint only.
- **`server.ts`** — `dispatch_to_agent` (mutating) + `inbox_check` (readOnly) MCP tools. Total tools 31 → **33**.
- **`docs/metacommlayer-inbox.md`** — operations, agent boot policy, fallback rules.
- **tests** — `inbox.test.ts` (10, deterministic injected clock + temp dir) covering all 5 FMs; updated tool-count assertions. **667 tests pass.**

## Triage (simplified per Etan)
own-tag monitor per agent + agents address `to:"orc"` on important messages → orc's existing cron-tick loop catches them. No local-model "buddy".

## Channel files (ephemeral, NOT BrainLayer)
`~/.cmux/agents/<id>/inbox.jsonl` + `inbox.ack.jsonl` + `monitor.heartbeat`.

Next: Codex via bg-bash `tail`; Cursor TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New coordination path writes under the user home and changes how orcs dispatch work; delivery still depends on agents arming monitors correctly, with send_input as fallback.
> 
> **Overview**
> Adds the metacommlayer **WRITE channel**: orchestrators can append tasks to per-agent JSONL inboxes under `~/.cmux/agents/<id>/` instead of relying on TUI `send_input`, while **`send_input` stays the fallback** when monitors look wedged.
> 
> **`src/inbox.ts`** implements dispatch, ack/replay (`replayUndelivered` by acked-id set, not tail offset), heartbeat liveness, stale pending detection, and `recommendedMonitorCommand` (`tail -n0 -F`). **`server.ts`** exposes **`dispatch_to_agent`** (mutating) and **`inbox_check`** (read-only liveness/undelivered/stale view). Core MCP tool count rises **17 → 19** (33 with agent lifecycle).
> 
> **`docs/metacommlayer-inbox.md`** documents boot policy, FM#1–5 handling, and ephemeral plumbing (no auto BrainLayer ingest; optional `persist:true`). **`tests/inbox.test.ts`** covers the failure modes; existing suites update tool counts and annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6310fa55c3b46bf8db6149878530a6dedb2635b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-agent inbox dispatch write channel with `dispatch_to_agent` and `inbox_check` MCP tools
> - Adds [src/inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/131/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) implementing a file-based WRITE channel: messages are appended as JSONL to a per-agent `inbox.jsonl`, with ack tracking, heartbeat liveness, and replay of undelivered messages.
> - Registers two new MCP tools in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/131/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): `dispatch_to_agent` (mutating, writes a structured message to an agent's inbox) and `inbox_check` (read-only, returns monitor liveness, undelivered messages, and stale dispatches).
> - Agent-side boot policy relies on a Monitor-driven `tail -n0 -F` of the inbox file, with `replayUndelivered` as a fallback for catching missed messages after downtime.
> - Increases total registered tool count from 31 to 33; test files updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6310fa5. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->