### PR TITLE
feat(metacomm): Codex/Cursor watch — poll-on-turn (honest: no async wake-up without Monitor)

### DIFF
--- a/docs/metacommlayer-inbox.md
+++ b/docs/metacommlayer-inbox.md
@@ -44,6 +44,14 @@ The file watch is sub-second; end-to-end latency = (time until the agent's curre
 cadence — fine for coordination, not for sub-second control.
 
 ## Per-harness status
-- **Claude:** native Monitor ✅ (this build).
-- **Codex:** no native Monitor → background-bash `tail -f`/poll surfaces the line into the session (NEXT).
-- **Cursor:** TBD (bg-bash or TUI).
+- **Claude:** native Monitor ✅ — true async wake-up. `recommendedMonitorCommand()`, `persistent:true`.
+- **Codex:** **no native Monitor → no async wake-up.** Honest finding: the inbox FILE is already the
+  durable queue, so the load-bearing requirement is a **poll cadence**, NOT a bg-tail. Codex pattern =
+  **poll-on-turn**: at the start of each turn (e.g. each loop tick) call `replayUndelivered(self)`,
+  act, `ack()`. This reuses the universal lib with zero Codex-specific code. `recommendedCodexWatch()`
+  (bg-tail → `inbox.surfaced.log`) is OPTIONAL continuous capture only — it does NOT wake an idle
+  Codex. **Residual:** a truly-idle, non-looping Codex still needs a turn trigger; that one case is
+  where `send_input` (the kept fallback) remains required. Deterministic dispatch for a *looping*
+  Codex is fully covered (latency = next tick).
+- **Cursor:** same as Codex — no native async Monitor; poll-on-turn via `replayUndelivered`. TBD which
+  Cursor surface/loop drives the cadence.

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -237,3 +237,24 @@ export function recommendedMonitorCommand(
 ): string {
   return `tail -n0 -F ${inboxPath(agentId, opts)}`;
 }
+
+/** Continuous-capture log for harnesses without a native Monitor (Codex/Cursor). */
+export function surfacedLogPath(agentId: string, opts?: InboxOpts): string {
+  return join(agentDir(agentId, opts), "inbox.surfaced.log");
+}
+
+/**
+ * Codex/Cursor watch command (no native Monitor → no async wake-up). Background-tails the inbox
+ * into a surfaced log the agent re-reads each turn. IMPORTANT (honest limitation): this gives
+ * continuous CAPTURE, not async wake-up — Codex/Cursor only ACT when they take a turn. The durable
+ * queue is the inbox file itself, so the surfaced log is OPTIONAL; the load-bearing requirement is
+ * a POLL cadence: call replayUndelivered() at the start of each turn (e.g. each loop tick) and
+ * ack() what you handle. A truly-idle, non-looping Codex still needs something to trigger a turn —
+ * that residual is the one case where send_input (the kept fallback) is still required.
+ */
+export function recommendedCodexWatch(
+  agentId: string,
+  opts?: InboxOpts,
+): string {
+  return `tail -n0 -F ${inboxPath(agentId, opts)} >> ${surfacedLogPath(agentId, opts)}`;
+}

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -10,8 +10,10 @@ import {
   monitorAlive,
   pendingDispatches,
   readInbox,
+  recommendedCodexWatch,
   recommendedMonitorCommand,
   replayUndelivered,
+  surfacedLogPath,
   writeHeartbeat,
 } from "../src/inbox.js";
 
@@ -115,5 +117,20 @@ describe("inbox write-channel", () => {
   it("recommendedMonitorCommand tails the agent's inbox (events only, no chatter)", () => {
     const cmd = recommendedMonitorCommand("a9", opts);
     expect(cmd).toBe(`tail -n0 -F ${inboxPath("a9", opts)}`);
+  });
+
+  it("Codex watch: bg-tails the inbox into a surfaced log (capture; poll-on-turn to consume)", () => {
+    const cmd = recommendedCodexWatch("a10", opts);
+    expect(cmd).toBe(
+      `tail -n0 -F ${inboxPath("a10", opts)} >> ${surfacedLogPath("a10", opts)}`,
+    );
+  });
+
+  it("Codex consume path reuses the universal lib (replayUndelivered + ack, no harness code)", () => {
+    dispatch("a11", { from: "orc", task: "codex task", id: "c1" }, opts);
+    // poll-on-turn: read what's undelivered, act, ack — same primitives as Claude
+    expect(replayUndelivered("a11", opts).map((m) => m.id)).toEqual(["c1"]);
+    ack("a11", "c1", "done", opts);
+    expect(replayUndelivered("a11", opts)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Codex/Cursor side of the metacommlayer write-channel. **Honest finding from the spike:** Codex/Cursor have **no native Monitor → no async wake-up**. The inbox FILE is already the durable queue, so the load-bearing requirement is a **poll cadence**, not a bg-tail.

## Codex/Cursor pattern: poll-on-turn
Each turn (loop tick): `replayUndelivered(self)` → act → `ack()`. Reuses the universal `inbox.ts` lib with **zero harness-specific code**. Deterministic dispatch is fully covered for a **looping** Codex (latency = next tick).

**Residual (honest):** a truly-idle, non-looping Codex still needs *something* to trigger a turn — that one case is where `send_input` (the kept fallback) remains required. The bg-tail does NOT solve this (it captures, it doesn't wake).

## Changes
- `inbox.ts`: `recommendedCodexWatch()` — OPTIONAL bg-tail → `inbox.surfaced.log` for continuous capture (explicitly labeled NOT an async waker) + `surfacedLogPath()`.
- `docs/metacommlayer-inbox.md`: per-harness section rewritten with the honest limitation.
- tests: Codex watch command + poll-on-turn consume path. **669 tests pass.**

## Comparison
| Harness | Wake-up | Pattern |
|---|---|---|
| Claude | async (native Monitor) | Monitor event → act → ack |
| Codex | none | poll-on-turn (replayUndelivered each tick) → act → ack |
| Cursor | none | poll-on-turn (cadence TBD) |

Next: live-validate with a Codex worker (via launcher, **not** spawn_agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and small string-path helpers plus tests; no changes to dispatch, ack, or orchestration runtime behavior.
> 
> **Overview**
> Documents and implements the **Codex/Cursor** side of metacomm inbox dispatch when there is **no native Monitor** (no async wake-up). The durable queue stays **`inbox.jsonl`**; the required pattern is **poll-on-turn**: each loop tick call `replayUndelivered(self)` → act → `ack()`, reusing the same `inbox.ts` primitives as Claude with no harness-specific consume logic.
> 
> Adds **`surfacedLogPath()`** and **`recommendedCodexWatch()`** — a `tail -n0 -F` shell command that appends inbox lines to **`inbox.surfaced.log`** for optional continuous capture only (explicitly **not** an idle waker). Docs in **`metacommlayer-inbox.md`** expand per-harness guidance: Claude keeps Monitor + `recommendedMonitorCommand()`; Codex/Cursor poll-on-turn; **`send_input`** remains the fallback for a truly idle, non-looping Codex.
> 
> Tests assert the Codex watch command string and that poll-on-turn consume works via **`replayUndelivered` + `ack`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a9d06ad103d7aa78c14583f34cc089bd1d1852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `recommendedCodexWatch` and `surfacedLogPath` helpers for Codex/Cursor poll-on-turn inbox consumption
> - Adds `recommendedCodexWatch(agentId, opts?)` in [`src/inbox.ts`](https://github.com/EtanHey/cmuxlayer/pull/132/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) that returns a shell command to background-tail the inbox and append to a surfaced log file; this provides continuous capture only and does not wake an idle agent.
> - Adds `surfacedLogPath(agentId, opts?)` to return the path of the surfaced log file used by the watch command.
> - Documents that Codex and Cursor have no async wake-up mechanism; the intended consumption pattern is poll-on-turn using `replayUndelivered` + `ack`, with `send_input` required to wake a truly idle Codex agent.
> - Updates [`docs/metacommlayer-inbox.md`](https://github.com/EtanHey/cmuxlayer/pull/132/files#diff-1466c81b1f7178409e773f09bbc0ec3480cc3852849f641c5e6f0d72f5983708) to contrast Claude's native Monitor (`recommendedMonitorCommand()`, `persistent:true`) against Codex/Cursor's poll-on-turn approach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35a9d06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->