### PR TITLE
fix(inbox): state-independent inbox wake — dispatch nudge + Claude Code hook transport (B5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs.local/
 # Local agent scratch + settings
 claude.scratchpad.md
 .claude/
+node_modules

--- a/docs/inbox-hook-transport.md
+++ b/docs/inbox-hook-transport.md
@@ -1,0 +1,68 @@
+# Inbox-Wake Hook Transport (B5 prototype)
+
+> Transport for the metacommlayer WRITE channel that does **not** depend on cmux
+> agent state. Born from the 2026-06-05 incident: a poisoned (error) registry
+> record killed the send_input fallback and a GO dispatch sat unread in
+> `inbox.jsonl`.
+
+## Two layers shipped in this PR
+
+### 1. `dispatch_to_agent` nudge (server-side, live by default)
+
+`dispatch_to_agent` now reports `monitor_alive` and, when the recipient's
+inbox-monitor heartbeat is stale/absent (`nudge: "auto"`, the default),
+best-effort types a one-line inbox pointer **directly into the agent's
+surface** — resolved from the registry record regardless of lifecycle state
+(error/done included; no `INTERACTIVE_STATES` gate). `nudge: "never"` restores
+pure file-append semantics. A failed nudge never fails the dispatch: the inbox
+file is the durable queue.
+
+### 2. Claude Code hook script (opt-in, NOT auto-registered)
+
+`scripts/hooks/inbox_hook.py` — one fail-open script, three events:
+
+| Event | Behavior |
+|-------|----------|
+| `SessionStart` | Ensures the inbox dir, announces the channel + any already-waiting messages, and returns `watchPaths: [inbox.jsonl]` so the harness watches the file. |
+| `FileChanged` | The moment a dispatch lands, injects "N undelivered message(s)" + ack instructions into context. **EXPERIMENTAL** — verify `additionalContext` is honored for this event in a live session. |
+| `Stop` | Safety net: blocks the stop (`decision: "block"`) while undelivered messages exist, so an agent drains its inbox before going idle. |
+
+Identity resolution order: `$CMUX_INBOX_ID` → `{repo}Claude-{session_id[:8]}`
+(the B4 canonical scheme) → `{repo}Claude`. Reads pick the first existing dir.
+
+## Registration (explicit decision — HOOK FILE RULE)
+
+The script ships **unregistered**. To enable for a project, add to that
+project's `.claude/settings.json` (or `settings.local.json`):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+    ],
+    "FileChanged": [
+      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+    ]
+  }
+}
+```
+
+## Honest limitations
+
+- Hooks cannot wake a **fully idle** session (no timer events; `FileChanged`
+  and `Stop` fire only around session activity). For truly idle agents the
+  `dispatch_to_agent` nudge (layer 1) or a manual `send_input` remains the
+  wake of last resort. The durable queue is always the inbox file.
+- Codex/Cursor have no hook system — they keep the poll-on-turn convention
+  (`replayUndelivered()` at turn start; see `recommendedCodexWatch`).
+
+## Verification status
+
+- 6/6 nudge tests (`tests/inbox-nudge.test.ts`), 8/8 hook smoke tests
+  (`tests/inbox-hook.test.ts`) driving the script over stdin exactly as the
+  harness does, including fail-open on garbage input.
+- Live FileChanged wake demo: pending (tracked in the 2026-06-05 collab).

--- a/docs/inbox-hook-transport.md
+++ b/docs/inbox-hook-transport.md
@@ -39,13 +39,13 @@ project's `.claude/settings.json` (or `settings.local.json`):
 {
   "hooks": {
     "SessionStart": [
-      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+      { "hooks": [{ "type": "command", "command": "python3 <path-to-cmuxlayer>/scripts/hooks/inbox_hook.py" }] }
     ],
     "FileChanged": [
-      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+      { "hooks": [{ "type": "command", "command": "python3 <path-to-cmuxlayer>/scripts/hooks/inbox_hook.py" }] }
     ],
     "Stop": [
-      { "hooks": [{ "type": "command", "command": "python3 /Users/etanheyman/Gits/cmuxlayer/scripts/hooks/inbox_hook.py" }] }
+      { "hooks": [{ "type": "command", "command": "python3 <path-to-cmuxlayer>/scripts/hooks/inbox_hook.py" }] }
     ]
   }
 }

--- a/scripts/hooks/inbox_hook.py
+++ b/scripts/hooks/inbox_hook.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""cmuxlayer inbox-wake hook — transport for the metacommlayer WRITE channel
+that does NOT depend on cmux agent state (Etan's idea A, 2026-06-05).
+
+One script, three Claude Code hook events (dispatch on hook_event_name):
+
+  SessionStart : ensure the agent's inbox dir exists, announce the channel,
+                 and register inbox.jsonl in watchPaths so FileChanged fires
+                 the moment a dispatch lands.
+  FileChanged  : a line landed in inbox.jsonl -> inject "inbox has a message"
+                 (EXPERIMENTAL: verify additionalContext is honored for this
+                 event in a live session before relying on it).
+  Stop         : safety net — if undelivered (un-acked) messages exist, block
+                 the stop with a reason so the agent drains the inbox first.
+
+Identity resolution (until B4 ships {golemName}-{sessionIdPrefix} everywhere):
+  1. $CMUX_INBOX_ID (explicit override, set by launcher)
+  2. {basename(cwd)}Claude-{session_id[:8]}   (B4 canonical scheme)
+  3. {basename(cwd)}Claude                    (legacy/manual)
+For reads, the first candidate with an existing inbox dir wins; SessionStart
+creates the canonical (2) dir when none exists.
+
+FAIL-OPEN: any error -> exit 0 with no output. This hook must never wedge a
+session. NOT auto-registered — see docs/inbox-hook-transport.md (HOOK FILE
+RULE: file exists first; registration is an explicit, separate decision).
+"""
+
+import json
+import os
+import sys
+
+AGENTS_DIR = os.environ.get(
+    "CMUX_AGENTS_DIR", os.path.expanduser("~/.cmux/agents")
+)
+MAX_PREVIEW = 200
+
+
+def candidates(payload):
+    ids = []
+    env_id = os.environ.get("CMUX_INBOX_ID")
+    if env_id:
+        ids.append(env_id)
+    cwd = payload.get("cwd") or os.getcwd()
+    golem = os.path.basename(cwd.rstrip("/")) + "Claude"
+    session_id = payload.get("session_id") or ""
+    if session_id:
+        ids.append(f"{golem}-{session_id[:8]}")
+    ids.append(golem)
+    return ids
+
+
+def resolve_agent_id(payload, create=False):
+    ids = candidates(payload)
+    for agent_id in ids:
+        if os.path.isdir(os.path.join(AGENTS_DIR, agent_id)):
+            return agent_id
+    canonical = ids[0]
+    if create:
+        os.makedirs(os.path.join(AGENTS_DIR, canonical), exist_ok=True)
+    return canonical
+
+
+def read_jsonl(path):
+    rows = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue  # tolerate partial lines on a live channel
+    except OSError:
+        return []
+    return rows
+
+
+def undelivered(agent_id):
+    base = os.path.join(AGENTS_DIR, agent_id)
+    acked = {
+        row.get("ack_of")
+        for row in read_jsonl(os.path.join(base, "inbox.ack.jsonl"))
+    }
+    return [
+        row
+        for row in read_jsonl(os.path.join(base, "inbox.jsonl"))
+        if row.get("id") not in acked
+    ]
+
+
+def summarize(messages):
+    parts = []
+    for msg in messages[:5]:
+        task = str(msg.get("task", ""))[:MAX_PREVIEW]
+        parts.append(f"- [{msg.get('id')}] from {msg.get('from')}: {task}")
+    if len(messages) > 5:
+        parts.append(f"... and {len(messages) - 5} more")
+    return "\n".join(parts)
+
+
+def ack_hint(agent_id):
+    ack_path = os.path.join(AGENTS_DIR, agent_id, "inbox.ack.jsonl")
+    return (
+        "Act on each message, then append an ack per message to "
+        f"{ack_path} as JSON: "
+        '{"ts_ms": <now-ms>, "agent": "' + agent_id + '", '
+        '"ack_of": "<message id>", "status": "done"}'
+    )
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+    event = payload.get("hook_event_name", "")
+
+    if event == "SessionStart":
+        agent_id = resolve_agent_id(payload, create=True)
+        inbox = os.path.join(AGENTS_DIR, agent_id, "inbox.jsonl")
+        # Touch so watchPaths has a real file to watch from t0.
+        try:
+            open(inbox, "a", encoding="utf-8").close()
+        except OSError:
+            return
+        pending = undelivered(agent_id)
+        context = (
+            f"[cmux inbox] Your inbox id is {agent_id}; channel file {inbox} "
+            "is being watched. When notified that the inbox changed, read the "
+            "undelivered messages, act on them, and ack. " + ack_hint(agent_id)
+        )
+        if pending:
+            context += (
+                f"\nALREADY WAITING ({len(pending)} undelivered):\n"
+                + summarize(pending)
+            )
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": context,
+                        "watchPaths": [inbox],
+                    }
+                }
+            )
+        )
+        return
+
+    if event == "FileChanged":
+        agent_id = resolve_agent_id(payload)
+        pending = undelivered(agent_id)
+        if not pending:
+            return
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "FileChanged",
+                        "additionalContext": (
+                            f"[cmux inbox] {len(pending)} undelivered "
+                            f"message(s) for {agent_id}:\n"
+                            + summarize(pending)
+                            + "\n"
+                            + ack_hint(agent_id)
+                        ),
+                    }
+                }
+            )
+        )
+        return
+
+    if event == "Stop":
+        agent_id = resolve_agent_id(payload)
+        pending = undelivered(agent_id)
+        if not pending:
+            return
+        print(
+            json.dumps(
+                {
+                    "decision": "block",
+                    "reason": (
+                        f"[cmux inbox] {len(pending)} undelivered message(s) "
+                        f"for {agent_id} — handle and ack before stopping:\n"
+                        + summarize(pending)
+                        + "\n"
+                        + ack_hint(agent_id)
+                    ),
+                }
+            )
+        )
+        return
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # FAIL-OPEN — never break a session over inbox plumbing.
+        pass
+    sys.exit(0)

--- a/scripts/hooks/inbox_hook.py
+++ b/scripts/hooks/inbox_hook.py
@@ -82,6 +82,7 @@ def undelivered(agent_id):
     acked = {
         row.get("ack_of")
         for row in read_jsonl(os.path.join(base, "inbox.ack.jsonl"))
+        if row.get("ack_of") is not None
     }
     return [
         row

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -108,7 +108,9 @@ export function shouldRetainCrashRecoveryError(
     "state" | "crash_recover" | "user_killed" | "cli_session_id" | "error"
   >,
 ): boolean {
-  return isCrashRecoveryEligible(agent) || isCrashRecoveryExhausted(agent.error);
+  return (
+    isCrashRecoveryEligible(agent) || isCrashRecoveryExhausted(agent.error)
+  );
 }
 
 export interface StateTransition {
@@ -128,7 +130,8 @@ export type DeliveryEventType =
   | "send_to"
   | "send_to_agent"
   | "interact"
-  | "press_enter";
+  | "press_enter"
+  | "dispatch_nudge";
 
 export interface DeliveryTelemetryEvent {
   ts: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 31 MCP tools across two categories:
+ * 33 MCP tools across three categories (keep in sync with server.ts and the
+ * "total tool count" assertion in tests/server-agent-tools.test.ts):
  *   Core (17): list_surfaces, select_workspace, create_workspace, new_split,
  *              new_surface, move_surface, reorder_surface, send_input,
  *              send_command, send_key, read_screen, rename_tab, notify,
  *              set_status, set_progress, close_surface, browser_surface
+ *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
  *   Agent lifecycle (14): spawn_agent, spawn_in_workspace, resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         read_agent_output, get_agent_state, list_agents,

--- a/src/server.ts
+++ b/src/server.ts
@@ -755,6 +755,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const inboxOpts = opts?.inboxBaseDir
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
+  // Wired up by the agent-lifecycle block below (when enabled). Lets the
+  // dispatch_to_agent nudge reuse the guarded relay path — stale-surface
+  // resync + recycled-occupant identity checks — instead of raw keystrokes.
+  let lifecycleAgentInputDeliverer:
+    | ((args: {
+        agent_id: string;
+        text: string;
+        press_enter: boolean;
+        allow_busy?: boolean;
+        source_event: DeliveryEventType;
+      }) => Promise<unknown>)
+    | null = null;
 
   const server = new McpServer(
     {
@@ -2870,21 +2882,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           nudge.reason = "monitor heartbeat fresh — Monitor will deliver";
         } else {
           // State-independent surface lookup: ANY registry record (including
-          // error/done) still carries the surface ref. No INTERACTIVE_STATES gate.
+          // error/done) still carries the surface ref. allow_busy bypasses the
+          // INTERACTIVE_STATES gate, but the guarded relay path keeps the
+          // stale-surface resync + recycled-occupant identity checks so the
+          // pointer can never land in a foreign agent's pane.
           const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
-          if (!record) {
-            nudge.reason =
-              "agent not in lifecycle registry; no surface to nudge — message waits in the inbox file";
+          if (!record || !lifecycleAgentInputDeliverer) {
+            nudge.reason = record
+              ? "agent lifecycle relay unavailable — message waits in the inbox file"
+              : "agent not in lifecycle registry; no surface to nudge — message waits in the inbox file";
           } else {
             nudge.attempted = true;
             try {
-              const workspace = record.workspace_id ?? undefined;
               const pointer = `[inbox] new message from ${msg.from} (id ${msg.id}) — read ${inboxPath(args.agent_id, inboxOpts)}, act, then ack`;
-              await withSurfaceWrite(record.surface_id, async () => {
-                await client.send(record.surface_id, pointer, { workspace });
-                await client.sendKey(record.surface_id, "return", {
-                  workspace,
-                });
+              await lifecycleAgentInputDeliverer({
+                agent_id: args.agent_id,
+                text: pointer,
+                press_enter: true,
+                allow_busy: true,
+                source_event: "dispatch_nudge",
               });
               nudge.sent = true;
               nudge.reason = `heartbeat stale/absent — typed inbox pointer into ${record.surface_id} (state: ${record.state})`;
@@ -3220,6 +3236,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }),
       );
     };
+    // Expose the guarded relay to dispatch_to_agent's nudge (registered above,
+    // outside this lifecycle block).
+    lifecycleAgentInputDeliverer = deliverAgentInput;
 
     // Reconstitute registry from disk on startup (async, best-effort).
     // Enable startup purge so the first sweep clears stale terminal-state

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,6 +133,8 @@ const BOOT_PROMPT_READY_POLL_MS = 250;
 const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
+/** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
+const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = 60_000;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 const READY_PATTERN_CLIS: CliType[] = [
   "claude",
@@ -622,6 +624,8 @@ export interface CreateServerOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   /** Explicitly disable spawn preflight checks (primarily for mocked tests). */
   disableSpawnPreflight?: boolean;
+  /** Base directory for agent inbox channels. Defaults to ~/.cmux/agents (primarily for tests). */
+  inboxBaseDir?: string;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -748,6 +752,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const spawnPreflight = opts?.spawnPreflight ?? context.spawnPreflight;
   const disableSpawnPreflight =
     opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
+  const inboxOpts = opts?.inboxBaseDir
+    ? { baseDir: opts.inboxBaseDir }
+    : undefined;
 
   const server = new McpServer(
     {
@@ -2801,9 +2808,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   );
 
   // 12. dispatch_to_agent — metacommlayer WRITE channel (sterile dispatch; send_input fallback)
+  // AIDEV-NOTE: B5 (2026-06-05 incident) — the wake must NOT depend on agent
+  // lifecycle state. A poisoned (error) registry record used to silently kill
+  // the send_input fallback (INTERACTIVE_STATES gate in sendToAgent) and GO
+  // messages sat unread. The nudge below types a one-line inbox pointer
+  // directly into the agent's surface, regardless of registry state.
   server.tool(
     "dispatch_to_agent",
-    "Append a task to an agent's inbox FILE (the deterministic write channel). The agent acts on it via a persistent native Monitor on its inbox — NO send_input/TUI typing. Use this as the primary dispatch path; send_input remains the fallback. Address to:'orc' to flag the orchestrator (own-tag triage). Channel is EPHEMERAL plumbing — set persist:true only for decisions that should be brain_store'd.",
+    "Append a task to an agent's inbox FILE (the deterministic write channel). The agent acts on it via a persistent native Monitor on its inbox — NO send_input/TUI typing. If the recipient's monitor heartbeat is stale/absent, nudge='auto' (default) best-effort types a one-line inbox pointer into the agent's surface — independent of agent lifecycle state. Address to:'orc' to flag the orchestrator (own-tag triage). Channel is EPHEMERAL plumbing — set persist:true only for decisions that should be brain_store'd.",
     {
       agent_id: z
         .string()
@@ -2824,18 +2836,71 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .describe(
           "Opt-in: mark this message as a candidate for BrainLayer ingestion",
         ),
+      nudge: z
+        .enum(["auto", "never"])
+        .optional()
+        .default("auto")
+        .describe(
+          "auto: when the recipient's inbox-monitor heartbeat is stale/absent, best-effort type a one-line inbox pointer into its surface (bypasses agent-state gates — works even when registry state is poisoned). never: file append only.",
+        ),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
-        const msg = dispatch(args.agent_id, {
-          from: args.from,
-          to: args.agent_id,
-          tag: args.tag,
-          task: args.task,
-          persist: args.persist,
+        const msg = dispatch(
+          args.agent_id,
+          {
+            from: args.from,
+            to: args.agent_id,
+            tag: args.tag,
+            task: args.task,
+            persist: args.persist,
+          },
+          inboxOpts,
+        );
+        const monitor_alive = monitorAlive(
+          args.agent_id,
+          INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS,
+          inboxOpts,
+        );
+        const nudge = { attempted: false, sent: false, reason: "" };
+        if (args.nudge === "never") {
+          nudge.reason = "nudge disabled by caller";
+        } else if (monitor_alive) {
+          nudge.reason = "monitor heartbeat fresh — Monitor will deliver";
+        } else {
+          // State-independent surface lookup: ANY registry record (including
+          // error/done) still carries the surface ref. No INTERACTIVE_STATES gate.
+          const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+          if (!record) {
+            nudge.reason =
+              "agent not in lifecycle registry; no surface to nudge — message waits in the inbox file";
+          } else {
+            nudge.attempted = true;
+            try {
+              const workspace = record.workspace_id ?? undefined;
+              const pointer = `[inbox] new message from ${msg.from} (id ${msg.id}) — read ${inboxPath(args.agent_id, inboxOpts)}, act, then ack`;
+              await withSurfaceWrite(record.surface_id, async () => {
+                await client.send(record.surface_id, pointer, { workspace });
+                await client.sendKey(record.surface_id, "return", {
+                  workspace,
+                });
+              });
+              nudge.sent = true;
+              nudge.reason = `heartbeat stale/absent — typed inbox pointer into ${record.surface_id} (state: ${record.state})`;
+            } catch (e) {
+              nudge.reason = `nudge failed (dispatch still durable in inbox file): ${
+                e instanceof Error ? e.message : String(e)
+              }`;
+            }
+          }
+        }
+        return ok({
+          dispatched: msg,
+          inbox: inboxPath(args.agent_id, inboxOpts),
+          monitor_alive,
+          nudge,
         });
-        return ok({ dispatched: msg, inbox: inboxPath(args.agent_id) });
       } catch (e) {
         return err(e);
       }
@@ -2868,9 +2933,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.readOnly,
     async (args) => {
       try {
-        const undelivered = replayUndelivered(args.agent_id);
-        const pending = pendingDispatches(args.agent_id, args.ack_timeout_ms);
-        const alive = monitorAlive(args.agent_id, args.heartbeat_max_age_ms);
+        const undelivered = replayUndelivered(args.agent_id, inboxOpts);
+        const pending = pendingDispatches(
+          args.agent_id,
+          args.ack_timeout_ms,
+          inboxOpts,
+        );
+        const alive = monitorAlive(
+          args.agent_id,
+          args.heartbeat_max_age_ms,
+          inboxOpts,
+        );
         return ok({
           agent_id: args.agent_id,
           monitor_alive: alive,

--- a/tests/inbox-hook.test.ts
+++ b/tests/inbox-hook.test.ts
@@ -1,0 +1,195 @@
+/**
+ * B5 — smoke tests for scripts/hooks/inbox_hook.py (the cmux-state-independent
+ * inbox-wake transport). Drives the script exactly as Claude Code would:
+ * hook payload JSON on stdin, JSON (or silence) on stdout, ALWAYS exit 0.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const execFileAsync = promisify(execFile);
+const HOOK = join(__dirname, "..", "scripts", "hooks", "inbox_hook.py");
+
+let agentsDir: string;
+let cwdDir: string;
+
+function runHook(
+  payload: unknown,
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      "python3",
+      [HOOK],
+      { env: { ...process.env, CMUX_AGENTS_DIR: agentsDir, ...env } },
+      (error, stdout, stderr) => {
+        // Fail-open contract: exit code must be 0 in every case.
+        if (error) reject(new Error(`hook exited non-zero: ${error.message}`));
+        else resolve({ stdout, stderr });
+      },
+    );
+    child.stdin!.write(JSON.stringify(payload));
+    child.stdin!.end();
+  });
+}
+
+function seedInbox(agentId: string, tasks: string[], ackFirst = false) {
+  const dir = join(agentsDir, agentId);
+  mkdirSync(dir, { recursive: true });
+  const lines = tasks.map((task, i) =>
+    JSON.stringify({
+      id: `m${i}`,
+      ts_ms: 1000 + i,
+      from: "orc",
+      to: agentId,
+      tag: "dispatch",
+      task,
+    }),
+  );
+  writeFileSync(join(dir, "inbox.jsonl"), lines.join("\n") + "\n");
+  if (ackFirst) {
+    writeFileSync(
+      join(dir, "inbox.ack.jsonl"),
+      JSON.stringify({
+        ts_ms: 2000,
+        agent: agentId,
+        ack_of: "m0",
+        status: "done",
+      }) + "\n",
+    );
+  }
+}
+
+beforeEach(() => {
+  agentsDir = mkdtempSync(join(tmpdir(), "cmux-hook-agents-"));
+  cwdDir = mkdtempSync(join(tmpdir(), "myrepo-"));
+});
+
+afterEach(() => {
+  rmSync(agentsDir, { recursive: true, force: true });
+  rmSync(cwdDir, { recursive: true, force: true });
+});
+
+describe("inbox_hook.py", () => {
+  it("SessionStart creates the canonical inbox dir and registers watchPaths", async () => {
+    const { stdout } = await runHook({
+      hook_event_name: "SessionStart",
+      session_id: "abcdef12-3456-7890-abcd-ef1234567890",
+      cwd: cwdDir,
+    });
+    const out = JSON.parse(stdout);
+    const expectedId = `${cwdDir.split("/").pop()}Claude-abcdef12`;
+    expect(out.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(out.hookSpecificOutput.watchPaths).toEqual([
+      join(agentsDir, expectedId, "inbox.jsonl"),
+    ]);
+    expect(out.hookSpecificOutput.additionalContext).toContain(expectedId);
+    expect(existsSync(join(agentsDir, expectedId, "inbox.jsonl"))).toBe(true);
+  });
+
+  it("SessionStart announces already-waiting undelivered messages", async () => {
+    seedInbox("wakerClaude-deadbeef", ["GO build the thing"]);
+    const { stdout } = await runHook(
+      { hook_event_name: "SessionStart", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "wakerClaude-deadbeef" },
+    );
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.additionalContext).toContain(
+      "ALREADY WAITING",
+    );
+    expect(out.hookSpecificOutput.additionalContext).toContain(
+      "GO build the thing",
+    );
+  });
+
+  it("FileChanged injects undelivered messages and the ack instruction", async () => {
+    seedInbox("wakerClaude-deadbeef", ["msg A", "msg B"], true); // m0 acked
+    const { stdout } = await runHook(
+      { hook_event_name: "FileChanged", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "wakerClaude-deadbeef" },
+    );
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.additionalContext).toContain("1 undelivered");
+    expect(out.hookSpecificOutput.additionalContext).toContain("msg B");
+    expect(out.hookSpecificOutput.additionalContext).not.toContain("msg A");
+    expect(out.hookSpecificOutput.additionalContext).toContain(
+      "inbox.ack.jsonl",
+    );
+  });
+
+  it("FileChanged is silent when everything is acked", async () => {
+    seedInbox("quietClaude-cafe0000", ["only"], false);
+    const dir = join(agentsDir, "quietClaude-cafe0000");
+    writeFileSync(
+      join(dir, "inbox.ack.jsonl"),
+      JSON.stringify({ ts_ms: 1, agent: "q", ack_of: "m0", status: "done" }) +
+        "\n",
+    );
+    const { stdout } = await runHook(
+      { hook_event_name: "FileChanged", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "quietClaude-cafe0000" },
+    );
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("Stop blocks with a reason while undelivered messages exist", async () => {
+    seedInbox("stopperClaude-12345678", ["drain me"]);
+    const { stdout } = await runHook(
+      { hook_event_name: "Stop", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "stopperClaude-12345678" },
+    );
+    const out = JSON.parse(stdout);
+    expect(out.decision).toBe("block");
+    expect(out.reason).toContain("drain me");
+  });
+
+  it("Stop is silent with an empty/absent inbox", async () => {
+    const { stdout } = await runHook(
+      { hook_event_name: "Stop", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "nobody-here" },
+    );
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("fail-open: garbage stdin still exits 0 with no output", async () => {
+    const { stdout } = await new Promise<{ stdout: string }>(
+      (resolve, reject) => {
+        const child = execFile(
+          "python3",
+          [HOOK],
+          { env: { ...process.env, CMUX_AGENTS_DIR: agentsDir } },
+          (error, stdout) =>
+            error ? reject(new Error("non-zero exit")) : resolve({ stdout }),
+        );
+        child.stdin!.write("not json at all{{{");
+        child.stdin!.end();
+      },
+    );
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("tolerates corrupt inbox lines (live-channel partial writes)", async () => {
+    const dir = join(agentsDir, "corruptClaude-00000000");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "inbox.jsonl"),
+      '{"id":"ok1","from":"orc","task":"good"}\n{broken json\n',
+    );
+    const { stdout } = await runHook(
+      { hook_event_name: "Stop", session_id: "x", cwd: cwdDir },
+      { CMUX_INBOX_ID: "corruptClaude-00000000" },
+    );
+    const out = JSON.parse(stdout);
+    expect(out.decision).toBe("block");
+    expect(out.reason).toContain("good");
+  });
+});

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -288,6 +288,108 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     ).toContain("GO");
   });
 
+  it("refuses to nudge a RECYCLED surface (foreign occupant) — pointer never lands in another agent's pane", async () => {
+    const agentId = await spawnTestAgent(server); // cli: claude
+    // Recycle the surface: it now hosts a Codex agent.
+    (exec as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_cmd: string, args: string[]) => {
+        if (args.includes("read-screen")) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "codex>\n gpt-5.5 xhigh · 100% context left",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-panes")) {
+          return {
+            stdout: JSON.stringify({
+              workspace_ref: "workspace:1",
+              window_ref: "window:1",
+              panes: [
+                {
+                  ref: "pane:1",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:new"],
+                  selected_surface_ref: "surface:new",
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-pane-surfaces")) {
+          return {
+            stdout: JSON.stringify({
+              workspace_ref: "workspace:1",
+              window_ref: "window:1",
+              pane_ref: "pane:1",
+              surfaces: [
+                {
+                  ref: "surface:new",
+                  title: "recycled",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-workspaces")) {
+          return {
+            stdout: JSON.stringify({
+              workspaces: [
+                {
+                  ref: "workspace:1",
+                  title: "Main",
+                  index: 0,
+                  selected: true,
+                  pinned: false,
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        return { stdout: "{}", stderr: "" };
+      },
+    );
+
+    const before = sendCalls(exec).length;
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(false);
+    expect(parsed.nudge.reason).toMatch(/recycled/i);
+    // No keystrokes reached the foreign occupant.
+    expect(sendCalls(exec).length).toBe(before);
+    // Message still durable in the inbox file.
+    expect(
+      readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
+    ).toContain("GO");
+  });
+
   it("inbox_check honors the injected inboxBaseDir", async () => {
     const dispatchTool = server._registeredTools["dispatch_to_agent"];
     await dispatchTool.handler(

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -1,0 +1,318 @@
+/**
+ * B5 — inbox wake must arm independent of spawn/agent state.
+ *
+ * dispatch_to_agent appends to the inbox file (state-independent already), but
+ * the WAKE was state-dependent: send_to_agent gates on INTERACTIVE_STATES, so a
+ * poisoned (error) registry record silently killed the fallback nudge and GO
+ * messages sat unread (2026-06-05 incident). These tests pin the new contract:
+ *
+ *   - nudge="auto" (default): when the recipient's inbox monitor heartbeat is
+ *     stale/absent, best-effort type a one-line inbox pointer into the agent's
+ *     surface — REGARDLESS of registry state (error/done included).
+ *   - heartbeat fresh → no nudge (monitor will deliver).
+ *   - agent unknown to the registry → dispatch still succeeds, nudge skipped.
+ *   - nudge="never" → file append only.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import { writeHeartbeat, readInbox } from "../src/inbox.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const STATE_DIR = join(tmpdir(), "cmux-agents-test-inbox-nudge");
+
+function makeExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:new"],
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:new",
+              title: "agent-pane",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: "What can I help you with?\n>",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return {
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
+function sendCalls(exec: ExecFn): string[][] {
+  return (exec as ReturnType<typeof vi.fn>).mock.calls
+    .filter(([, args]: [string, string[]]) => args.includes("send"))
+    .map(([, args]: [string, string[]]) => args);
+}
+
+async function spawnTestAgent(server: any): Promise<string> {
+  const tool = server._registeredTools["spawn_agent"];
+  const result = await tool.handler(
+    { repo: "brainlayer", model: "sonnet", cli: "claude", prompt: "task" },
+    {} as any,
+  );
+  const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);
+  expect(parsed.ok).toBe(true);
+  return parsed.agent_id as string;
+}
+
+describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
+  let inboxDir: string;
+  let exec: ExecFn;
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    mkdirSync(STATE_DIR, { recursive: true });
+    inboxDir = mkdtempSync(join(tmpdir(), "cmux-inbox-nudge-"));
+    exec = makeExec();
+    server = createServer({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    rmSync(inboxDir, { recursive: true, force: true });
+  });
+
+  it("nudges via the agent's surface when heartbeat is absent — even in a TERMINAL state", async () => {
+    const agentId = await spawnTestAgent(server);
+
+    // Poison-equivalent: force a terminal state. The nudge must still go out.
+    const stop = server._registeredTools["stop_agent"];
+    await stop.handler({ agent_id: agentId }, {} as any);
+
+    const before = sendCalls(exec).length;
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_alive).toBe(false);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(true);
+    // The pointer was typed into the agent's surface despite terminal state.
+    const after = sendCalls(exec);
+    expect(after.length).toBeGreaterThan(before);
+    const nudgeCall = after.at(-1)!;
+    expect(nudgeCall.join(" ")).toContain("surface:new");
+    expect(nudgeCall.join(" ")).toContain("inbox");
+    // And the message itself is durably in the inbox file.
+    expect(
+      readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
+    ).toContain("GO");
+  });
+
+  it("does NOT nudge when the monitor heartbeat is fresh", async () => {
+    const agentId = await spawnTestAgent(server);
+    writeHeartbeat(agentId, { baseDir: inboxDir });
+
+    const before = sendCalls(exec).length;
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_alive).toBe(true);
+    expect(parsed.nudge.attempted).toBe(false);
+    expect(sendCalls(exec).length).toBe(before);
+  });
+
+  it("dispatch still succeeds for an agent unknown to the registry (nudge skipped, not failed)", async () => {
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: "ghost-agent",
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(false);
+    expect(parsed.nudge.sent).toBe(false);
+    expect(readInbox("ghost-agent", { baseDir: inboxDir })).toHaveLength(1);
+  });
+
+  it('nudge:"never" appends to the file only', async () => {
+    const agentId = await spawnTestAgent(server);
+    const before = sendCalls(exec).length;
+
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "never",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(false);
+    expect(sendCalls(exec).length).toBe(before);
+  });
+
+  it("a failed nudge send never fails the dispatch (file append is the contract)", async () => {
+    const agentId = await spawnTestAgent(server);
+    // Make subsequent send calls explode.
+    (exec as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_cmd: string, args: string[]) => {
+        if (args.includes("send")) throw new Error("socket down");
+        return { stdout: "{}", stderr: "" };
+      },
+    );
+
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(false);
+    expect(parsed.nudge.reason).toMatch(/socket down|failed/i);
+    expect(
+      readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
+    ).toContain("GO");
+  });
+
+  it("inbox_check honors the injected inboxBaseDir", async () => {
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    await dispatchTool.handler(
+      {
+        agent_id: "checker",
+        task: "T1",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "never",
+      },
+      {} as any,
+    );
+    const checkTool = server._registeredTools["inbox_check"];
+    const result = await checkTool.handler(
+      {
+        agent_id: "checker",
+        ack_timeout_ms: 120000,
+        heartbeat_max_age_ms: 60000,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.undelivered_count).toBe(1);
+  });
+});


### PR DESCRIPTION
## The incident (2026-06-05)

A GO dispatch sat unread in `inbox.jsonl` because the recipient's registry state was poisoned to `error` (by the B2 readiness bug) and every wake path was state-gated.

## Two layers

### 1. `dispatch_to_agent` nudge (live by default)
- New `nudge` param (`auto` default / `never`). When the recipient's inbox-monitor heartbeat is stale/absent, best-effort types a one-line inbox pointer **directly into the agent's surface** — resolved from the registry record in ANY lifecycle state (error/done included; bypasses the `INTERACTIVE_STATES` gate that killed the incident's wake).
- A failed nudge never fails the dispatch — the inbox file is the durable queue.
- Result now reports `monitor_alive` + `nudge {attempted, sent, reason}`.
- `inboxBaseDir` option for hermetic tests; `inbox_check` honors it too.

### 2. Claude Code hook transport prototype (opt-in, NOT auto-registered)
`scripts/hooks/inbox_hook.py` — fail-open, one script, three events: SessionStart (announce + `watchPaths` on inbox.jsonl), FileChanged (inject undelivered messages the moment a dispatch lands — experimental), Stop (block while undelivered messages exist). Registration instructions + honest limitations in `docs/inbox-hook-transport.md`. Hook contract verified against current Claude Code docs before writing.

### Fold-in (B6)
`src/index.ts` header: 31 → 33 tools, categories corrected.

## Tests
+14 new (6 nudge via mocked-server handler dispatch incl. terminal-state nudge + exploding socket; 8 hook smoke tests driving python over stdin exactly as the harness does). **683/683 green**, typecheck clean.

Collab: `collab/2026-06-05-cmuxlayer-state-fixes.md` (B5/B6). Part of the state-tracking bug-cluster sprint (B1–B6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Nudges type into live terminals and bypass interactive-state gates (with recycled-surface guards); failed nudges are swallowed so operators must rely on `nudge`/`monitor_alive` in the response and the inbox file.
> 
> **Overview**
> Fixes inbox dispatches sitting unread when agent registry state is poisoned (e.g. `error`) by adding wake paths that do **not** depend on interactive lifecycle gates.
> 
> **`dispatch_to_agent`** gains a `nudge` parameter (`auto` default / `never`). After the durable inbox append, it reports `monitor_alive` and, when the monitor heartbeat is stale or missing, best-effort types a one-line inbox pointer into the agent’s surface via the existing guarded `deliverAgentInput` relay (`allow_busy`, stale-surface resync, recycled-pane checks). Nudge failures never fail the dispatch; responses include `nudge { attempted, sent, reason }`. Optional `inboxBaseDir` on server creation threads through `dispatch_to_agent` and `inbox_check` for tests. Telemetry adds `dispatch_nudge` as a delivery event type.
> 
> **Opt-in Claude Code transport:** new `scripts/hooks/inbox_hook.py` (fail-open, not auto-registered) handles `SessionStart` (inbox dir + `watchPaths`), `FileChanged` (undelivered summary), and `Stop` (block while un-acked messages remain), with registration and limits documented in `docs/inbox-hook-transport.md`.
> 
> **Tests:** 6 nudge contract tests and 8 hook smoke tests; minor `.gitignore` / `index.ts` tool-count comment updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2bb61163f69bc93931baa8484243b637334fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add state-independent inbox wake via `dispatch_to_agent` nudge and Claude Code hook transport
> - `dispatch_to_agent` now accepts a `nudge` arg and attempts a best-effort surface nudge by typing an inbox pointer into the agent surface when the recipient's heartbeat is stale or absent, returning `monitor_alive`, `nudge`, and inbox path fields.
> - Adds [inbox_hook.py](https://github.com/EtanHey/cmuxlayer/pull/134/files#diff-36e1baec5afa149eb6e94f2c7e3fc5b32698ebf830d1e4ae0d07c6c7bb139f1c), a fail-open Claude Code hook script that creates and watches an inbox on `SessionStart`, injects undelivered message summaries on `FileChanged`, and blocks `Stop` when undelivered messages exist.
> - Adds `'dispatch_nudge'` to the `DeliveryEventType` union in [agent-types.ts](https://github.com/EtanHey/cmuxlayer/pull/134/files#diff-efd9180892738f786d25ac95f9c9adf7070aa3bc8d56cf1c7d726435f977c6d9).
> - `inbox_check` and `dispatch_to_agent` now accept an optional `inboxBaseDir` override via `CreateServerOptions`.
> - Risk: `dispatch_to_agent` nudge behavior is new and active by default when heartbeat is absent — callers that previously relied on silent failure when a recipient is unreachable will now see a surface write attempt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd2bb61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->