### PR TITLE
fix: keep orchestrator spawns in the left lead pane

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -263,8 +263,12 @@ export function isAgentRoleInferenceError(
 function roleFromLauncherLabel(label: string | undefined): AgentRole | null {
   if (!label) return null;
   const launcher = extractPrefix(label);
-  if (/Claude(?:$|[^a-z0-9])/i.test(launcher)) return "orchestrator";
-  if (/(Codex|Cursor)(?:$|[^a-z0-9])/i.test(launcher)) return "worker";
+  const matches = [
+    ...launcher.matchAll(/(Claude|Codex|Cursor)(?=$|[^a-z0-9])/gi),
+  ];
+  const marker = matches.at(-1)?.[1]?.toLowerCase();
+  if (marker === "claude") return "orchestrator";
+  if (marker === "codex" || marker === "cursor") return "worker";
   return null;
 }
 

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -71,18 +71,15 @@ function describePaneLayouts(
 
   return panes.map((pane) => {
     const surfaces = groupsByPane.get(pane.ref) ?? [];
-    const orchestratorCount = surfaces.filter((surface) =>
-      roleSurfaceIds.orchestrator.has(surface.ref),
+    const roles = surfaces.map((surface) =>
+      roleForSurface(surface, roleSurfaceIds),
+    );
+    const orchestratorCount = roles.filter(
+      (role) => role === "orchestrator",
     ).length;
-    const icCount = surfaces.filter((surface) =>
-      roleSurfaceIds.ic.has(surface.ref),
-    ).length;
-    const workerCount = surfaces.filter((surface) =>
-      roleSurfaceIds.worker.has(surface.ref),
-    ).length;
-    const unknownCount = surfaces.filter((surface) =>
-      roleSurfaceIds.unknown?.has(surface.ref),
-    ).length;
+    const icCount = roles.filter((role) => role === "ic").length;
+    const workerCount = roles.filter((role) => role === "worker").length;
+    const unknownCount = roles.filter((role) => role === "unknown").length;
     const roleCount = orchestratorCount + icCount + workerCount;
     return {
       pane,
@@ -95,6 +92,18 @@ function describePaneLayouts(
       nonRoleCount: surfaces.length - roleCount,
     };
   });
+}
+
+function roleForSurface(
+  surface: CmuxPaneSurfaces["surfaces"][number],
+  roleSurfaceIds: RoleSurfaceIds,
+): AgentRole | "unknown" | null {
+  if (roleSurfaceIds.orchestrator.has(surface.ref)) return "orchestrator";
+  if (roleSurfaceIds.ic.has(surface.ref)) return "ic";
+  if (roleSurfaceIds.worker.has(surface.ref)) return "worker";
+  if (roleSurfaceIds.unknown?.has(surface.ref)) return "unknown";
+  if (surface.type === "terminal") return roleFromLauncherLabel(surface.title);
+  return null;
 }
 
 export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
@@ -254,8 +263,8 @@ export function isAgentRoleInferenceError(
 function roleFromLauncherLabel(label: string | undefined): AgentRole | null {
   if (!label) return null;
   const launcher = extractPrefix(label);
-  if (/Claude$/i.test(launcher)) return "orchestrator";
-  if (/(Codex|Cursor)$/i.test(launcher)) return "worker";
+  if (/Claude(?:$|[^a-z0-9])/i.test(launcher)) return "orchestrator";
+  if (/(Codex|Cursor)(?:$|[^a-z0-9])/i.test(launcher)) return "worker";
   return null;
 }
 
@@ -413,11 +422,13 @@ export function chooseAgentSpawnPlacement(
   }
 
   if (role === "orchestrator") {
-    const orchestratorPane =
-      leftmostByColumn(layouts.filter(isDedicatedOrchestratorPane)) ??
-      (leftPane && leftPane.icCount === 0 && leftPane.workerCount === 0
+    const leftLeadPane =
+      leftPane && leftPane.workerCount === 0
         ? leftPane
-        : undefined);
+        : undefined;
+    const orchestratorPane =
+      leftLeadPane ??
+      leftmostByColumn(layouts.filter(isDedicatedOrchestratorPane));
     return orchestratorPane
       ? { kind: "surface", pane: orchestratorPane.pane.ref }
       : { kind: "split", direction: "left" };

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -35,6 +35,20 @@ function makeSurface(ref: string, index: number): CmuxSurface {
   };
 }
 
+function makeTitledSurface(
+  ref: string,
+  index: number,
+  title: string,
+): CmuxSurface {
+  return {
+    ref,
+    title,
+    type: "terminal",
+    index,
+    selected: index === 0,
+  };
+}
+
 function makePaneSurfaces(
   pane: string,
   surfaceRefs: string[],
@@ -44,6 +58,20 @@ function makePaneSurfaces(
     window_ref: "window:1",
     pane_ref: pane,
     surfaces: surfaceRefs.map((ref, index) => makeSurface(ref, index)),
+  };
+}
+
+function makeTitledPaneSurfaces(
+  pane: string,
+  surfaces: Array<{ ref: string; title: string }>,
+): CmuxPaneSurfaces {
+  return {
+    workspace_ref: "ws:1",
+    window_ref: "window:1",
+    pane_ref: pane,
+    surfaces: surfaces.map((surface, index) =>
+      makeTitledSurface(surface.ref, index, surface.title),
+    ),
   };
 }
 
@@ -175,6 +203,111 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
+  });
+
+  it("places orchestrators as tabs in the left-column lead pane", () => {
+    const panes = [
+      makePane("pane:left", 1, ["surface:lead-shell"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+      makePane("pane:right-orc", 0, ["surface:orchestrator"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:lead-shell"]),
+      makePaneSurfaces("pane:right-orc", ["surface:orchestrator"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
+  });
+
+  it("places orchestrators in the left-column lead pane despite a stale IC record", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:voicelayer-lead"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+      makePane("pane:right", 1, ["surface:cmuxlayer-worker"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:left", [
+        {
+          ref: "surface:voicelayer-lead",
+          title: "voicelayerClaude-LEAD",
+        },
+      ]),
+      makeTitledPaneSurfaces("pane:right", [
+        {
+          ref: "surface:cmuxlayer-worker",
+          title: "cmuxlayerCodex W-B1",
+        },
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(["surface:voicelayer-lead"]),
+        worker: new Set(),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
+  });
+
+  it("docks workers into launcher-title Codex panes without registry state", () => {
+    const panes = [
+      makePane("pane:worker", 0, ["surface:cmuxlayer-worker"]),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:worker", [
+        {
+          ref: "surface:cmuxlayer-worker",
+          title: "cmuxlayerCodex W-B1",
+        },
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:worker" });
   });
 
   it("places the first IC in the right column above existing workers", () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -154,6 +154,15 @@ describe("layout policy", () => {
     );
   });
 
+  it("uses the final launcher marker when repo names contain role words", () => {
+    expect(inferAgentRole({ launcherName: "myClaude-toolsCodex" })).toBe(
+      "worker",
+    );
+    expect(inferAgentRole({ launcherName: "myCodex-toolsClaude" })).toBe(
+      "orchestrator",
+    );
+  });
+
   it("lets an explicit role override launcher inference", () => {
     expect(
       inferAgentRole({ launcherName: "skillcreatorClaude", role: "ic" }),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2689,6 +2689,150 @@ describe("tool handler integration", () => {
     expect(parsed.direction).toBeNull();
   });
 
+  it("new_split with role=orchestrator tabs into the left lead pane despite stale IC state", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-orchestrator-stale-ic");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "opus-voicelayer-1780659054-nsnv",
+      surface_id: "surface:voicelayer-lead",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "voicelayer",
+      model: "opus",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "stale lead record",
+      pid: null,
+      version: 1,
+      created_at: "2026-06-05T17:00:00.000Z",
+      updated_at: "2026-06-05T17:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      role: "ic",
+    });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 1,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:voicelayer-lead"],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:cmuxlayer-worker"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces:
+              pane === "pane:left"
+                ? [
+                    {
+                      ref: "surface:voicelayer-lead",
+                      title: "voicelayerClaude-LEAD",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : [
+                    {
+                      ref: "surface:cmuxlayer-worker",
+                      title: "cmuxlayerCodex W-B1",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:new-orchestrator",
+            pane: "pane:left",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:unexpected-split",
+            pane: "pane:third",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", role: "orchestrator", workspace: "workspace:1" },
+      {} as any,
+    );
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-surface", "--pane", "pane:left"]),
+    );
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["new-split", "left"]),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:new-orchestrator");
+    expect(parsed.role).toBe("orchestrator");
+    expect(parsed.placement).toBe("surface");
+    expect(parsed.direction).toBeNull();
+  });
+
   it("new_split with role=worker partitions unfiltered surface lists by pane membership", async () => {
     const stateDir = join(CHANNEL_TEST_DIR, "new-split-unfiltered-surfaces");
     rmSync(stateDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- classify terminal surfaces by launcher-style tab titles when lifecycle registry state does not know their role
- keep `new_split(role=orchestrator)` as a tab in the left-column lead pane, even when a stale IC record contaminates that pane
- add layout-policy and server-tool regressions for the B1 live repro (`voicelayerClaude-LEAD` stale IC + `cmuxlayerCodex W-B1` worker title)

## Test plan
- [x] `npm test -- tests/layout-policy.test.ts` (RED first: 2 expected failures before implementation; GREEN: 39 passed)
- [x] `npm test -- tests/layout-policy.test.ts tests/server.test.ts` (119 passed)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (42 files, 673 tests passed)
- [x] pre-push hook (`scripts/run_tests.sh`) passed during `git push`

## Review notes
- `cr review --plain` was attempted before commit but the CodeRabbit CLI returned `Review limit reached`; requesting bot review on the PR.
- `node_modules` is an untracked symlink in this worktree and was not staged or committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn placement and role counting used by new_split and agent spawns; behavior is localized but affects multi-pane layout in production workspaces.
> 
> **Overview**
> Fixes **orchestrator** and **worker** spawn placement when lifecycle registry roles are missing or stale (e.g. a lead tab still recorded as IC).
> 
> **`layout-policy.ts`** adds **`roleForSurface`**, which counts pane roles from registry IDs first, then infers **terminal** roles from tab titles via **`roleFromLauncherLabel`**. Pane layout stats and worker docking now honor titles like `cmuxlayerCodex W-B1` even with empty registry sets.
> 
> **`roleFromLauncherLabel`** no longer requires `Claude`/`Codex`/`Cursor` at the end of the string; it uses the **last** marker with a word boundary so compound names (`myClaude-toolsCodex`) and suffixes (`-LEAD`, ` W-B1`) resolve correctly.
> 
> For **`role=orchestrator`**, **`chooseAgentSpawnPlacement`** prefers the **left-column lead pane** when it has **no workers** (IC presence no longer blocks it), then falls back to a dedicated orchestrator-only pane. **`new_split(role=orchestrator)`** should tab into that lead pane via **`new-surface`** instead of opening a stray split.
> 
> Regressions cover layout-policy cases and a **`server.test`** **`new_split`** path for stale IC + titled lead/worker panes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd9d647294928f73ca6deaedfff582431b0d472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix orchestrator spawns to prefer the left lead pane over dedicated orchestrator panes
> - Updates `chooseAgentSpawnPlacement` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/135/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to place orchestrator tabs in the leftmost pane with no workers, even if IC surfaces are present, falling back to a dedicated orchestrator pane only afterward.
> - Adds a `roleForSurface` helper that classifies surfaces by checking `roleSurfaceIds` sets first, then falling back to launcher-title inference for terminal surfaces when registry state is missing.
> - Updates `roleFromLauncherLabel` to match the last occurrence of a role marker ('Claude', 'Codex', 'Cursor') in a label rather than requiring it at the end, fixing role detection for compound names.
> - Behavioral Change: orchestrators that previously targeted a dedicated orchestrator pane will now land in the left lead pane if it has no workers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fd9d64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->