### PR TITLE
fix: update readiness detection without poisoning state

### DIFF
--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -18,9 +18,17 @@ export interface PatternMatch {
   consecutive: number;
 }
 
+const CLAUDE_READY_RE =
+  /What can I help you with\?|╭─|(?=[\s\S]*(?:Claude Code|CLAUDE_COUNTER|bypass permissions on|🤖))(?=[\s\S]*(?:^|\n)\s*(?:>|❯)\s*$)/m;
+
+const CURSOR_ACTIVE_RE =
+  /(?:^|\n)\s*(?:⬢|⬡|•)?\s*(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating)(?:\.\.\.|…)?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens\b/i;
+const CURSOR_READY_RE =
+  /cursor>|⬡\s+Idle\b|→\s*Add a follow-up|\/ commands · @ files · ! shell|(?:^|\n)\s*(?:Auto|Agent)\s*·\s*\d+(?:\.\d+)?\s*%\s*·[^\n]*files? edited\b/i;
+
 export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
   claude: {
-    pattern: /What can I help you with\?|╭─/,
+    pattern: CLAUDE_READY_RE,
     confidence: "high",
     consecutive: 1,
   },
@@ -41,7 +49,7 @@ export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
     consecutive: 2,
   },
   cursor: {
-    pattern: /cursor>/,
+    pattern: CURSOR_READY_RE,
     confidence: "high",
     consecutive: 1,
   },
@@ -56,7 +64,9 @@ export function matchReadyPattern(
     return { matched: false, confidence: "low", consecutive: 1 };
   }
   return {
-    matched: entry.pattern.test(screenContent),
+    matched:
+      entry.pattern.test(screenContent) &&
+      (cli !== "cursor" || !CURSOR_ACTIVE_RE.test(screenContent)),
     confidence: entry.confidence,
     consecutive: entry.consecutive,
   };

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -20,9 +20,11 @@ export interface PatternMatch {
 
 const CLAUDE_READY_RE =
   /What can I help you with\?|╭─|(?=[\s\S]*(?:Claude Code|CLAUDE_COUNTER|bypass permissions on|🤖))(?=[\s\S]*(?:^|\n)\s*(?:>|❯)\s*$)/m;
+const CLAUDE_ACTIVE_RE =
+  /(?:^|\n)\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
 const CURSOR_ACTIVE_RE =
-  /(?:^|\n)\s*(?:⬢|⬡|•)?\s*(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating)(?:\.\.\.|…)?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens\b/i;
+  /(?:^|\n)\s*(?:[⠀-⣿]+|⬢|⬡|•)?\s*(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating|Thinking|Waiting)(?:\.\.\.|…)?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens\b/i;
 const CURSOR_READY_RE =
   /cursor>|⬡\s+Idle\b|→\s*Add a follow-up|\/ commands · @ files · ! shell|(?:^|\n)\s*(?:Auto|Agent)\s*·\s*\d+(?:\.\d+)?\s*%\s*·[^\n]*files? edited\b/i;
 
@@ -66,6 +68,7 @@ export function matchReadyPattern(
   return {
     matched:
       entry.pattern.test(screenContent) &&
+      (cli !== "claude" || !CLAUDE_ACTIVE_RE.test(screenContent)) &&
       (cli !== "cursor" || !CURSOR_ACTIVE_RE.test(screenContent)),
     confidence: entry.confidence,
     consecutive: entry.consecutive,

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -24,7 +24,7 @@ const CLAUDE_ACTIVE_RE =
   /(?:^|\n)\s*(?:[✻✢✳✶]|[⏺●])\s+(?:Thinking|Working|Running|Receiving|Preparing|Updating|Sending|Reading|Analyzing)\b/im;
 
 const CURSOR_ACTIVE_RE =
-  /(?:^|\n)\s*(?:[⠀-⣿]+|⬢|⬡|•)?\s*(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating|Thinking|Waiting)(?:\.\.\.|…)?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens\b/i;
+  /(?:^|\n)[^\S\r\n]*(?:(?:[⠀-⣿]+|⬢|⬡|•)[^\S\r\n]*)?(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating|Thinking|Waiting)\b(?:\.\.\.|…)?(?:[^\S\r\n]+[0-9][0-9,]*(?:\.[0-9]+)?[km]?[^\S\r\n]+tokens\b|[^\S\r\n]*(?=\r?(?:\n|$)))/i;
 const CURSOR_READY_RE =
   /cursor>|⬡\s+Idle\b|→\s*Add a follow-up|\/ commands · @ files · ! shell|(?:^|\n)\s*(?:Auto|Agent)\s*·\s*\d+(?:\.\d+)?\s*%\s*·[^\n]*files? edited\b/i;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3390,7 +3390,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 boot_prompt_pending: false,
               });
               registry.set(result.agent_id, updated);
-              if (updated.state !== "done" && updated.state !== "error") {
+              if (
+                !(e instanceof BootPromptTimeoutError) &&
+                updated.state !== "done" &&
+                updated.state !== "error"
+              ) {
                 updated = stateMgr.transition(result.agent_id, "error", {
                   error: `Boot prompt failed: ${message}`,
                 });

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -86,6 +86,21 @@ describe("matchReadyPattern", () => {
     expect(result.matched).toBe(false);
   });
 
+  it("does not match active Claude work even when a stale prompt remains visible", () => {
+    const result = matchReadyPattern(
+      "claude",
+      [
+        "Claude Code",
+        "✻ Working",
+        "  Reading src/server.ts",
+        "",
+        ">",
+        "CLAUDE_COUNTER:1",
+      ].join("\n"),
+    );
+    expect(result.matched).toBe(false);
+  });
+
   it("matches Codex ready prompt", () => {
     const result = matchReadyPattern("codex", "codex> ");
     expect(result.matched).toBe(true);
@@ -227,6 +242,18 @@ Auto · 22.5% · 4 files edited
 ctrl+c to stop
 
 / commands · @ files · ! shell · ctrl+r to review edits
+`,
+    );
+    expect(result.matched).toBe(false);
+  });
+
+  it("does not match live Cursor thinking chrome with braille spinner and Auto footer", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      `
+ ⠠⠛ Thinking  5.71k tokens
+    Tip: Use /debug to instrument and debug complex problems.
+  Auto · 20.5% · 4 files edited                    Auto-run
 `,
     );
     expect(result.matched).toBe(false);

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -54,6 +54,38 @@ describe("matchReadyPattern", () => {
     expect(result.matched).toBe(true);
   });
 
+  it("matches modern Claude idle prompt with status footer", () => {
+    const result = matchReadyPattern(
+      "claude",
+      [
+        "  Say \"go\" when you're ready and I'll start your timer.",
+        "",
+        "  CLAUDE_COUNTER: 186",
+        "",
+        "──────────────────────────────────────────────────────────────────────────",
+        "❯",
+        "──────────────────────────────────────────────────────────────────────────",
+        "  ⎇ master | +1273,-196 | 🔧 11                     418310 tokens",
+        "  🤖 …                              current: 2.1.81 · latest…",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+      ].join("\n"),
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches Claude Code prompt when the old welcome copy is absent", () => {
+    const result = matchReadyPattern(
+      "claude",
+      "Claude Code\n> \nCLAUDE_COUNTER:1\n",
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("does not match active Claude work as ready", () => {
+    const result = matchReadyPattern("claude", "Claude Code\n✻ Working\n");
+    expect(result.matched).toBe(false);
+  });
+
   it("matches Codex ready prompt", () => {
     const result = matchReadyPattern("codex", "codex> ");
     expect(result.matched).toBe(true);
@@ -146,6 +178,55 @@ gpt-5.5 xhigh · /workspaces/cmuxlayer
 › Find and fix a bug in @filename
 
 gpt-5.5 xhigh · ~/Gits/brainlayer
+`,
+    );
+    expect(result.matched).toBe(false);
+  });
+
+  it("matches Cursor idle status without the legacy cursor prompt", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      `
+Auto · 10% · 1 file edited
+Model: gpt-5.2 high
+
+⬡ Idle  12,450 tokens
+
+→ Add a follow-up
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("matches Cursor follow-up prompt without an Idle token line", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      `
+Auto · 22% · 3 files edited
+
+→ Add a follow-up
+ctrl+c to stop
+
+/ commands · @ files · ! shell · ctrl+r to review edits
+`,
+    );
+    expect(result.matched).toBe(true);
+  });
+
+  it("does not match active Cursor generation as ready", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      `
+Auto · 22.5% · 4 files edited
+
+⬡ Running...  3.3k tokens
+
+→ Add a follow-up
+ctrl+c to stop
+
+/ commands · @ files · ! shell · ctrl+r to review edits
 `,
     );
     expect(result.matched).toBe(false);

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -259,6 +259,17 @@ ctrl+c to stop
     expect(result.matched).toBe(false);
   });
 
+  it("does not match Cursor spinner work without a token count as ready", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      `
+ ⠸ Generating...
+  Auto · 20.5% · 4 files edited                    Auto-run
+`,
+    );
+    expect(result.matched).toBe(false);
+  });
+
   it("does not match unrelated output", () => {
     const result = matchReadyPattern("claude", "Installing dependencies...");
     expect(result.matched).toBe(false);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -641,7 +641,7 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
-  it("spawn_agent marks the agent errored when boot prompt delivery times out", async () => {
+  it("spawn_agent reports readiness timeout without poisoning agent state", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
     let launchSent = false;
@@ -696,6 +696,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.agent_id).toBeDefined();
     expect(parsed.surface_id).toBe("surface:new");
+    expect(parsed.last_10_lines).toContain("$ waiting");
 
     const stateResult = await getState.handler(
       { agent_id: parsed.agent_id },
@@ -703,9 +704,18 @@ describe("agent lifecycle tool handlers", () => {
     );
     const state =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
-    expect(state.state).toBe("error");
+    expect(state.state).toBe("booting");
     expect(state.boot_prompt_pending).toBe(false);
-    expect(state.error).toContain("Boot prompt failed");
+    expect(state.error).toBeNull();
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        "file prompt body",
+      ]),
+    );
   });
 
   it("spawn_agent persists crash_recover=true in agent state", async () => {


### PR DESCRIPTION
## Summary
- update Claude readiness detection for current prompt/status chrome, including bare prompt surfaces with Claude markers
- update Cursor readiness detection for current idle/follow-up/mode-bar chrome while rejecting active token-generation states
- keep spawned agents in booting state on readiness timeout instead of transitioning them to error, while preserving error transitions for actual boot prompt delivery failures

## Test plan
- [x] npm test -- tests/pattern-registry.test.ts tests/server-agent-tools.test.ts -- --runInBand
- [x] npm run typecheck
- [x] npm run build
- [x] TMPDIR=/tmp npm test
- [x] pre-push hook passed with TMPDIR=/tmp git push -u origin fix/b2-ready-patterns-no-poison
- [x] live MCP gate: fresh Claude Code process in cmux surface:63 used --strict-mcp-config pointing at this worktree's dist/index.js and returned LIVE_MCP_OK surfaces=24

## Notes
- Plain pre-push without TMPDIR=/tmp hit existing macOS Unix socket path-length failures in daemon/proxy tests; rerun with TMPDIR=/tmp executed the same hook with short socket paths and passed.
- Local cr review could not run because the CLI review limit was reached, so PR review is the reviewer gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent boot/readiness semantics used by spawn and boot-prompt polling; incorrect regex could delay prompts or mis-report idle, but scope is pattern matching and timeout error handling only.
> 
> **Overview**
> **Readiness detection** for Claude and Cursor is updated for current terminal chrome (status footers, follow-up prompts, markers like `CLAUDE_COUNTER`) instead of relying only on legacy strings such as `cursor>` or the old welcome line. **`matchReadyPattern`** now requires idle signals and **rejects** a match when **active-work** regexes fire (e.g. Claude “Working/Thinking”, Cursor spinners and token lines), so mid-task screens are not treated as ready.
> 
> **Spawn lifecycle:** when boot prompt delivery fails with **`BootPromptTimeoutError`**, the agent stays in **`booting`** with **`boot_prompt_pending` cleared** and no **`error`** transition; real delivery failures still move the agent to **`error`**. Tests cover the new patterns and the non-poisoning timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87baf32dffa2acf69e6e27d841fab53704bebd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix readiness detection to avoid false positives when Claude or Cursor is active
> - Adds `CLAUDE_ACTIVE_RE` and `CURSOR_ACTIVE_RE` regexes in [pattern-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/136/files#diff-1f1872f4b73cb466921af9511f51f36eab87d558851ccc6f9e68a0a552286b4a) to detect active work states (Thinking, Working, Running, etc.), and blocks ready matches when they are present.
> - Expands `CLAUDE_READY_RE` and `CURSOR_READY_RE` to recognize modern idle UI (status footers, `⬡ Idle`, `→ Add a follow-up`, etc.) without relying on legacy prompt text.
> - Fixes `createServer` boot prompt handling in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/136/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) so a `BootPromptTimeoutError` no longer transitions the agent to `error` state; agent stays in `booting`.
> - Behavioral Change: screens showing active work will no longer match as ready even if a stale idle prompt is visible elsewhere in the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d87baf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of CLI readiness detection for Claude and Cursor, preventing false positives when actively processing
  * Enhanced timeout handling during agent initialization to prevent incorrect state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->