### PR TITLE
fix: require output evidence for wait_for done

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -446,12 +446,51 @@ export class AgentEngine {
     return this.registry;
   }
 
-  private hasTrailingTaskDoneSignal(text: string): boolean {
-    const lines = text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
-    return lines.at(-1) === "TASK_DONE";
+  private hasOutputDoneEvidence(text: string): boolean {
+    const parsed = parseScreen(text);
+    return parsed.status === "done" && parsed.done_signal !== null;
+  }
+
+  private requiresOutputDoneEvidence(targetState: AgentState): boolean {
+    return targetState === "done";
+  }
+
+  private hasRecordedOutputDoneEvidence(agent: AgentRecord): boolean {
+    return !!agent.task_done_detected_at;
+  }
+
+  private async hasCurrentOutputDoneEvidence(
+    agent: AgentRecord,
+  ): Promise<boolean> {
+    try {
+      const screen = await this.client.readScreen(agent.surface_id, {
+        lines: BOOT_SESSION_CAPTURE_LINES,
+      });
+      return this.hasOutputDoneEvidence(screen.text);
+    } catch {
+      return false;
+    }
+  }
+
+  private async hasTargetStateEvidence(
+    agent: AgentRecord,
+    targetState: AgentState,
+  ): Promise<boolean> {
+    if (agent.state !== targetState) return false;
+    if (!this.requiresOutputDoneEvidence(targetState)) return true;
+    return (
+      this.hasRecordedOutputDoneEvidence(agent) ||
+      (await this.hasCurrentOutputDoneEvidence(agent))
+    );
+  }
+
+  private async refreshTargetStateEvidence(
+    agent: AgentRecord,
+    targetState: AgentState,
+  ): Promise<AgentRecord> {
+    if (!this.requiresOutputDoneEvidence(targetState)) return agent;
+    if (TERMINAL_STATES.has(agent.state)) return agent;
+    return (await this.maybeMarkTaskDone(agent)).agent;
   }
 
   private async createAgentSurface(
@@ -660,18 +699,18 @@ export class AgentEngine {
 
   private async maybeMarkTaskDone(
     agent: AgentRecord,
+    opts?: { allowBootPromptPending?: boolean },
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
     if (TERMINAL_STATES.has(agent.state)) return { agent };
-    if (agent.cli !== "codex" || inferRecordRole(agent) !== "worker") {
+    if (agent.boot_prompt_pending && opts?.allowBootPromptPending !== true) {
       return { agent };
     }
-    if (agent.boot_prompt_pending) return { agent };
 
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
       });
-      if (!this.hasTrailingTaskDoneSignal(screen.text)) {
+      if (!this.hasOutputDoneEvidence(screen.text)) {
         if (agent.task_done_candidate_at) {
           const updated = this.stateMgr.updateRecord(agent.agent_id, {
             task_done_candidate_at: null,
@@ -1233,8 +1272,8 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    // Retroactive check — already in target state?
-    if (initial.state === targetState) {
+    // Retroactive check — already in target state with required output evidence?
+    if (await this.hasTargetStateEvidence(initial, targetState)) {
       return {
         matched: true,
         state: initial.state,
@@ -1288,7 +1327,7 @@ export class AgentEngine {
 
         // Re-read from disk (another process may have updated)
         await this.registry.reconcile();
-        const current = this.registry.get(agentId);
+        let current = this.registry.get(agentId);
         if (!current) {
           clearInterval(checkInterval);
           resolve({
@@ -1302,7 +1341,9 @@ export class AgentEngine {
           return;
         }
 
-        if (current.state === targetState) {
+        current = await this.refreshTargetStateEvidence(current, targetState);
+
+        if (await this.hasTargetStateEvidence(current, targetState)) {
           clearInterval(checkInterval);
           resolve({
             matched: true,

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -157,7 +157,7 @@ export interface WaitResult {
  */
 export const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   creating: ["booting", "error"],
-  booting: ["ready", "error"],
+  booting: ["ready", "done", "error"],
   ready: ["working", "done", "error"],
   working: ["idle", "done", "error"],
   idle: ["working", "done", "error"],

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -97,7 +97,8 @@ export function inferContextWindow(
 }
 
 const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
-const DONE_SIGNAL_RE = /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)\b/;
+const DONE_SIGNAL_LINE_RE =
+  /^\s*([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)(?:\s+\S{1,16})?\s*$/;
 const CLAUDE_COUNTER_RE = /^\s*CLAUDE_COUNTER:\s*(\d+)\s*$/m;
 const RESPONSE_BLOCK_RE = /---RESPONSE_START---\s*(.*?)\s*---RESPONSE_END---/s;
 const TOKEN_USAGE_RE = /Token usage:\s*total=([0-9][0-9,]*)/i;
@@ -147,13 +148,14 @@ const CURSOR_STATUS_PCT_RE =
 const CURSOR_FOLLOWUP_RE = /→\s*Add a follow-up/i;
 const CURSOR_STOP_RE = /ctrl\+c to stop/i;
 const CURSOR_SESSION_COMPLETE_RE =
-  /\b(?:Task completed|Generation complete|All edits applied|Session complete)\b/i;
+  /^\s*(?:Task completed|Generation complete|All edits applied|Session complete)\s*$/i;
 const CURSOR_CHECKMARK_DONE_RE =
-  /(?:^|\n)\s*[✓✔]\s*(?:Done|Complete|Completed)\b/i;
+  /^\s*[✓✔]\s*(?:Done|Complete|Completed)\s*[.!]?\s*$/i;
 const CURSOR_MODEL_LINE_RE = /^\s*Model:\s*(.+)$/im;
 const CURSOR_USING_LINE_RE = /^\s*Using\s*:?\s*(.+)$/im;
 const CURSOR_MODEL_INLINE_RE =
   /\b(claude-[0-9][0-9a-z.-]*|gpt-[0-9][0-9a-z.-]*(?:\s+(?:high|low|mini))?|gemini-[0-9][0-9a-z.-]*)\b/i;
+const RULE_LINE_RE = /^[\s─-╿▀-▟\-=_~·•—–]+$/;
 
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_RE, "");
@@ -239,13 +241,31 @@ function parseTokenCount(text: string): number | null {
 }
 
 function parseDoneSignal(text: string): string | null {
-  const explicitDoneSignal = text.match(DONE_SIGNAL_RE)?.[1];
-  if (explicitDoneSignal) {
-    return explicitDoneSignal;
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const explicitDoneSignal = line.match(DONE_SIGNAL_LINE_RE)?.[1];
+    if (explicitDoneSignal) {
+      return explicitDoneSignal;
+    }
+
+    const claudeCounter = line.match(CLAUDE_COUNTER_RE)?.[1];
+    if (claudeCounter) {
+      return `CLAUDE_COUNTER:${claudeCounter}`;
+    }
+
+    if (isDoneSignalTailChromeLine(line)) {
+      continue;
+    }
+
+    break;
   }
 
-  const claudeCounter = text.match(CLAUDE_COUNTER_RE)?.[1];
-  return claudeCounter ? `CLAUDE_COUNTER:${claudeCounter}` : null;
+  return null;
 }
 
 function trimBlankEdges(lines: string[]): string[] {
@@ -429,9 +449,37 @@ function parseCursorModel(text: string): string | null {
 }
 
 function parseCursorDoneSignal(text: string): string | null {
-  if (CURSOR_SESSION_COMPLETE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
-  if (CURSOR_CHECKMARK_DONE_RE.test(text)) return "CURSOR_SESSION_COMPLETE";
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (CURSOR_SESSION_COMPLETE_RE.test(line)) return "CURSOR_SESSION_COMPLETE";
+    if (CURSOR_CHECKMARK_DONE_RE.test(line)) return "CURSOR_SESSION_COMPLETE";
+    if (isDoneSignalTailChromeLine(line)) continue;
+    break;
+  }
+
   return null;
+}
+
+function isDoneSignalTailChromeLine(line: string): boolean {
+  return (
+    RULE_LINE_RE.test(line) ||
+    TOKEN_USAGE_RE.test(line) ||
+    TOKENS_RE.test(line) ||
+    /^🤖\s/.test(line) ||
+    /^⎇\s/.test(line) ||
+    /^\s*(?:❯|>>>|\$|>)\s*$/.test(line) ||
+    /bypass permissions on/i.test(line) ||
+    CURSOR_MODE_BAR_RE.test(line) ||
+    CURSOR_FOLLOWUP_RE.test(line) ||
+    CURSOR_STOP_RE.test(line) ||
+    CURSOR_STATUS_PCT_RE.test(line) ||
+    CURSOR_HEX_IDLE_RE.test(line)
+  );
 }
 
 function inferStatus(
@@ -587,7 +635,6 @@ export function parseScreen(text: string): ParsedScreenResult {
 // adding signal: box-drawing rule/separator lines and per-harness status-bar art. Returns
 // the last `maxLines` of meaningful content. The structured fields (status/tokens/ctx/response)
 // already carry the real signal; this is only for a compact human-readable screen preview.
-const RULE_LINE_RE = /^[\s─-╿▀-▟\-=_~·•—–]+$/;
 const CHROME_LINE_RES: RegExp[] = [
   /🤖|💰|⏱/, // model/cost/timer status line
   /esc to interrupt/i,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1387,6 +1387,275 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       expect(result.agent?.session_id).toBeNull();
     });
 
+    it("does not resolve done for a Codex worker from registry state without TASK_DONE output", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-registry-done",
+            state: "done",
+            surface_id: "surface:worker-registry-done",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-registry-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-registry-done",
+          text: "gpt-5.4\nWorking (1m 02s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-registry-done", "done", 2_500);
+        await vi.advanceTimersByTimeAsync(3_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("done");
+        expect(mockClient.readScreen).toHaveBeenCalledWith(
+          "surface:worker-registry-done",
+          { lines: 80 },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve done from Codex resume text without an explicit done signal", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-codex-resume",
+            state: "done",
+            surface_id: "surface:worker-codex-resume",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-codex-resume")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-codex-resume",
+          text: [
+            "gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer",
+            "To continue this session, run codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-codex-resume", "done", 2_500);
+        await vi.advanceTimersByTimeAsync(3_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("done");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves done for a Codex worker after TASK_DONE output evidence is confirmed", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-output-done",
+            state: "ready",
+            surface_id: "surface:worker-output-done",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-output-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-output-done",
+          text: "gpt-5.4\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-output-done", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(6_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("sweep");
+        expect(result.state).toBe("done");
+        expect(engine.getAgentState("worker-output-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: expect.any(String),
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve done from a Claude completion banner without an explicit done signal", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "claude-banner-only",
+            state: "ready",
+            surface_id: "surface:claude-banner-only",
+            cli: "claude",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-banner-only")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-banner-only",
+          text: [
+            "Claude Code",
+            "⏺ Completed successfully",
+            "Preparing a follow-up response now.",
+            "🤖 Sonnet 4.6 | 💰 $0.10",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("claude-banner-only", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("claude-banner-only");
+        expect(agent?.state).toBe("ready");
+        expect(agent?.task_done_candidate_at ?? null).toBeNull();
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve done from boot prompt echo while prompt delivery is pending", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-pending-prompt",
+            state: "booting",
+            surface_id: "surface:worker-pending-prompt",
+            cli: "codex",
+            role: "worker",
+            boot_prompt_pending: true,
+            updated_at: new Date().toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-pending-prompt")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-pending-prompt",
+          text: "TASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-pending-prompt", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("worker-pending-prompt");
+        expect(agent?.state).toBe("booting");
+        expect(agent?.boot_prompt_pending).toBe(true);
+        expect(agent?.task_done_candidate_at ?? null).toBeNull();
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve done from Cursor checkmark progress lines", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cursor-progress-line",
+            state: "ready",
+            surface_id: "surface:cursor-progress-line",
+            cli: "cursor",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:cursor-progress-line")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:cursor-progress-line",
+          text: [
+            "Auto · 45% · 0 files edited",
+            "✓ Done reading src/server.ts",
+            "",
+            "⬡ Idle  1.2k tokens",
+            "/ commands · @ files · ! shell · ctrl+r to review edits",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("cursor-progress-line", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("cursor-progress-line");
+        expect(agent?.state).toBe("ready");
+        expect(agent?.task_done_candidate_at ?? null).toBeNull();
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves done for a non-Codex worker after trailing done output evidence is confirmed", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "claude-output-done",
+            state: "booting",
+            surface_id: "surface:claude-output-done",
+            cli: "claude",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-output-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-output-done",
+          text: "Implemented the requested fix.\nR2_WORKER_DONE 5",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("claude-output-done", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("sweep");
+        expect(result.state).toBe("done");
+        expect(engine.getAgentState("claude-output-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: expect.any(String),
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("returns error result when agent is in error state", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -12,8 +12,8 @@ describe("VALID_TRANSITIONS", () => {
     expect(VALID_TRANSITIONS.creating).toEqual(["booting", "error"]);
   });
 
-  it("booting can go to ready or error", () => {
-    expect(VALID_TRANSITIONS.booting).toEqual(["ready", "error"]);
+  it("booting can go to ready, done, or error", () => {
+    expect(VALID_TRANSITIONS.booting).toEqual(["ready", "done", "error"]);
   });
 
   it("ready can go to working, done, or error", () => {
@@ -41,6 +41,7 @@ describe("isValidTransition", () => {
   it("allows valid forward transitions", () => {
     expect(isValidTransition("creating", "booting")).toBe(true);
     expect(isValidTransition("booting", "ready")).toBe(true);
+    expect(isValidTransition("booting", "done")).toBe(true);
     expect(isValidTransition("ready", "working")).toBe(true);
     expect(isValidTransition("working", "done")).toBe(true);
     expect(isValidTransition("working", "idle")).toBe(true);

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -178,6 +178,42 @@ Working (2m 06s • esc to interrupt)
     expect(parsed.context_pct).toBe(13);
   });
 
+  it("does not treat echoed done instructions as a done signal while the agent is working", () => {
+    const parsed = parseScreen(`
+When the task is complete, print R2_WORKER_DONE on its own line.
+
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+Working (1m 02s • esc to interrupt)
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).toBe("working");
+  });
+
+  it("accepts one short trailing argument on a standalone done signal", () => {
+    const parsed = parseScreen(`
+Judge complete.
+R2_WORKER_DONE 5
+`);
+
+    expect(parsed.done_signal).toBe("R2_WORKER_DONE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("does not treat echoed numbered done instructions as a done signal", () => {
+    const parsed = parseScreen(`
+When the task is complete, print R2_WORKER_DONE 5.
+
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+Working (1m 02s • esc to interrupt)
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).toBe("working");
+  });
+
   it("parses Gemini-style output from explicit Gemini CLI markers", () => {
     const parsed = parseScreen(`
 Gemini CLI
@@ -285,6 +321,34 @@ Task completed
     expect(parsed.agent_type).toBe("cursor");
     expect(parsed.done_signal).toBe("CURSOR_SESSION_COMPLETE");
     expect(parsed.status).toBe("done");
+  });
+
+  it("detects exact Cursor checkmark completion as done_signal and status done", () => {
+    const parsed = parseScreen(`
+Auto · 90% · 2 files edited
+✓ Done
+
+⬡ Idle  1.2k tokens
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.done_signal).toBe("CURSOR_SESSION_COMPLETE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("does not treat Cursor checkmark progress lines as session completion", () => {
+    const parsed = parseScreen(`
+Auto · 45% · 0 files edited
+✓ Done reading src/server.ts
+
+⬡ Idle  1.2k tokens
+/ commands · @ files · ! shell · ctrl+r to review edits
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).toBe("idle");
   });
 
   it("detects Cursor via follow-up prompt and ctrl+c without mode bar", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1155,9 +1155,13 @@ describe("agent lifecycle tool handlers", () => {
     const engine = (server as any)._registeredTools["interact"]._engine;
     const stateMgr = engine["stateMgr"];
 
-    stateMgr.transition(agentId, "ready");
+    if (stateMgr.readState(agentId)?.state !== "ready") {
+      stateMgr.transition(agentId, "ready");
+    }
     stateMgr.transition(agentId, "done");
-    const doneState = stateMgr.readState(agentId);
+    const doneState = stateMgr.updateRecord(agentId, {
+      task_done_detected_at: "2026-06-05T17:20:00.000Z",
+    });
     if (!doneState) {
       throw new Error("Expected done state to exist");
     }


### PR DESCRIPTION
## Summary
- Gate `waitFor(done)` on output evidence instead of registry state alone.
- Let `wait_for` confirm trailing done evidence for non-Codex agents and completion directly from `booting`.
- Prevent echoed done instructions from being parsed as completion while an agent is still working.

## Test plan
- `npm run typecheck`
- `TMPDIR=/tmp npm test`
- push hook with `TMPDIR=/tmp` ran race fixtures plus full Vitest suite

## Notes
- `cr review --plain` could not run pre-commit because the CodeRabbit CLI review limit was reached; requesting CodeRabbit review on this PR.
- `node_modules` is an untracked symlink in this worktree and was not staged or committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestration completion semantics: callers that set `done` without terminal evidence will see timeouts, but the new rules reduce premature “done” from misleading screen text.
> 
> **Overview**
> **`waitFor('done')` no longer trusts registry state alone.** It now needs parsed terminal proof (`status === 'done'` and a non-null `done_signal`), either from `task_done_detected_at` or a live `readScreen` during the wait loop. The poll path calls `maybeMarkTaskDone` so agents can move to `done` (including from `booting`) when trailing output matches.
> 
> **Done-signal parsing is stricter.** `parseDoneSignal` and Cursor completion detection scan from the bottom of the screen, skip status/chrome lines, and only accept standalone `*_DONE` lines (optional one short arg). Echoed instructions like “print R2_WORKER_DONE” in prompts, Codex resume banners, Claude “Completed” banners, and Cursor “✓ Done reading …” progress lines no longer count as completion.
> 
> **`maybeMarkTaskDone` applies to all CLIs/roles** (not only Codex workers), still blocked while `boot_prompt_pending` is set. **`booting → done`** is added to allowed transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0d6174b8d0a081c3cc578dd1cae0fb2401caf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require output done-signal evidence before resolving `waitFor` done state
> - `waitFor('done')` now requires a parser-detected done signal in the screen output, not just an agent state match; both immediate and polled checks enforce this via `hasTargetStateEvidence`.
> - `parseDoneSignal` and `parseCursorDoneSignal` in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/137/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) are rewritten to scan trailing non-chrome lines only, preventing echoed instructions or progress lines (e.g. `✓ Done reading ...`) from being misclassified as completion.
> - `maybeMarkTaskDone` skips marking done while `boot_prompt_pending` is true and replaces the old `TASK_DONE` text check with the new parser-based `hasOutputDoneEvidence`.
> - `VALID_TRANSITIONS` is updated to allow `booting → done` to support agents that complete during boot.
> - Behavioral Change: agents that previously resolved `done` on state match alone (or on echoed TASK_DONE text) will no longer resolve until the parser confirms a trailing done signal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b0d617.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->