### PR TITLE
fix: use session-backed agent identity

### DIFF
--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -1,0 +1,37 @@
+import type { CliType } from "./agent-types.js";
+
+// Env vars for headless/spawned agent sessions:
+// - MCP_CONNECTION_NONBLOCKING: skip MCP connection wait (Claude Code 2.1.90+)
+// - CLAUDE_CODE_NO_FLICKER: stable alt-screen rendering for terminal parsing
+export const AGENT_ENV =
+  "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
+
+export function sanitizeRepoName(repo: string): string {
+  const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
+  if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {
+    throw new Error(
+      `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed. "." and ".." are not permitted.`,
+    );
+  }
+  return safeRepo;
+}
+
+export function buildResumeCommand(
+  cli: CliType,
+  repo: string,
+  sessionId: string,
+): string {
+  const safeRepo = sanitizeRepoName(repo);
+  switch (cli) {
+    case "claude":
+      return `${safeRepo}Claude -s --resume ${sessionId}`;
+    case "codex":
+      return `${safeRepo}Codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
+    case "gemini":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini --resume ${sessionId}`;
+    case "kiro":
+      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
+    case "cursor":
+      return `${safeRepo}Cursor -s --resume ${sessionId}`;
+  }
+}

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4,6 +4,8 @@
  */
 
 import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
@@ -50,6 +52,10 @@ import { matchReadyPattern } from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { SpawnGuard } from "./spawn-guard.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
+import {
+  findLatestHarnessSessionIdentity,
+  type Harness,
+} from "./harness-session.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -72,9 +78,19 @@ export interface SpawnAgentResult {
   state: AgentState;
 }
 
+export interface CapturedSessionIdentity {
+  session_id: string;
+  path?: string | null;
+}
+
+export type SessionIdentityResolver = (
+  agent: AgentRecord,
+) => CapturedSessionIdentity | string | null;
+
 export interface AgentEngineOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   spawnGuard?: SpawnGuard;
+  sessionIdentityResolver?: SessionIdentityResolver;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -107,6 +123,8 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
 const execFileAsync = promisify(execFile);
+
+const JSONL_HARNESSES = new Set<CliType>(["claude", "codex", "cursor"]);
 
 interface SidebarStatusSnapshot {
   statusValue: string;
@@ -408,6 +426,7 @@ export class AgentEngine {
     workspace?: string,
   ) => RoleSurfaceIds;
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
+  private sessionIdentityResolver: SessionIdentityResolver;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   /** agentId → last-pushed status target/value */
   private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
@@ -428,6 +447,9 @@ export class AgentEngine {
     this.client = client;
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
+    this.sessionIdentityResolver =
+      opts?.sessionIdentityResolver ??
+      ((agent) => this.findTranscriptSessionIdentity(agent));
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.spawnPreflight =
       opts?.spawnPreflight ??
@@ -618,8 +640,78 @@ export class AgentEngine {
     return Date.now() - since <= BOOT_SESSION_CAPTURE_WINDOW_MS;
   }
 
+  private harnessCwdForAgent(agent: AgentRecord): string {
+    return join(homedir(), "Gits", agent.repo);
+  }
+
+  private findTranscriptSessionIdentity(
+    agent: AgentRecord,
+  ): CapturedSessionIdentity | null {
+    if (!JSONL_HARNESSES.has(agent.cli)) {
+      return null;
+    }
+
+    const createdAt = Date.parse(agent.created_at);
+    const sinceMs = Number.isNaN(createdAt) ? undefined : createdAt - 5_000;
+    const identity = findLatestHarnessSessionIdentity(
+      agent.cli as Harness,
+      this.harnessCwdForAgent(agent),
+      { sinceMs },
+    );
+    return identity
+      ? { session_id: identity.session_id, path: identity.path }
+      : null;
+  }
+
+  private normalizeCapturedSessionIdentity(
+    identity: CapturedSessionIdentity | string,
+  ): CapturedSessionIdentity {
+    if (typeof identity === "string") {
+      return { session_id: identity, path: null };
+    }
+    return { session_id: identity.session_id, path: identity.path ?? null };
+  }
+
+  private finalizeCapturedSession(
+    agent: AgentRecord,
+    capturedIdentity: CapturedSessionIdentity | string,
+  ): AgentRecord {
+    const identity = this.normalizeCapturedSessionIdentity(capturedIdentity);
+    let updated = this.stateMgr.updateRecord(agent.agent_id, {
+      cli_session_id: identity.session_id,
+      cli_session_path: identity.path,
+    });
+    this.registry.set(agent.agent_id, updated);
+
+    const finalAgentId = generateAgentId(
+      agent.cli,
+      agent.repo,
+      identity.session_id,
+    );
+    if (updated.agent_id === finalAgentId) {
+      return updated;
+    }
+    if (this.stateMgr.readState(finalAgentId)) {
+      return updated;
+    }
+
+    const previousAgentId = updated.agent_id;
+    updated = this.stateMgr.renameState(previousAgentId, finalAgentId);
+    this.registry.rename(previousAgentId, finalAgentId, updated);
+    return updated;
+  }
+
   private async maybeCaptureBootSessionId(agent: AgentRecord): Promise<AgentRecord> {
     if (agent.cli_session_id || !this.isBootCaptureWindowOpen(agent)) {
+      return agent;
+    }
+
+    try {
+      const transcriptSessionId = this.sessionIdentityResolver(agent);
+      if (transcriptSessionId) {
+        return this.finalizeCapturedSession(agent, transcriptSessionId);
+      }
+    } catch {
       return agent;
     }
 
@@ -633,11 +725,10 @@ export class AgentEngine {
         return agent;
       }
 
-      const updated = this.stateMgr.updateRecord(agent.agent_id, {
-        cli_session_id: sessionId,
+      return this.finalizeCapturedSession(agent, {
+        session_id: sessionId,
+        path: null,
       });
-      this.registry.set(agent.agent_id, updated);
-      return updated;
     } catch {
       return agent;
     }
@@ -1052,7 +1143,7 @@ export class AgentEngine {
     }
 
     // Clean up sidebar entries for agents that were purged from the registry
-    const currentAgentIds = new Set(agents.map((a) => a.agent_id));
+    const currentAgentIds = new Set(this.registry.list().map((a) => a.agent_id));
     for (const [agentId, snapshot] of this.sidebarSnapshot) {
       if (!currentAgentIds.has(agentId)) {
         try {
@@ -1143,7 +1234,7 @@ export class AgentEngine {
    * Does NOT wait for ready state.
    */
   async spawnAgent(params: SpawnAgentParams): Promise<SpawnAgentResult> {
-    const agentId = generateAgentId(params.model, params.repo);
+    const agentId = generateAgentId(params.cli, params.repo);
 
     // Resolve parent hierarchy
     let spawnDepth = 0;
@@ -1194,6 +1285,7 @@ export class AgentEngine {
       model: params.model,
       cli: params.cli,
       cli_session_id: null,
+      cli_session_path: null,
       task_summary: params.prompt,
       pid: null,
       version: 1,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -9,6 +9,11 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
+import {
+  AGENT_ENV,
+  buildResumeCommand,
+  sanitizeRepoName,
+} from "./agent-command.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import {
   resolveAgentRoute as resolvePublicAgentRoute,
@@ -125,6 +130,8 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
 const execFileAsync = promisify(execFile);
 
 const JSONL_HARNESSES = new Set<CliType>(["claude", "codex", "cursor"]);
+
+export { buildResumeCommand } from "./agent-command.js";
 
 interface SidebarStatusSnapshot {
   statusValue: string;
@@ -268,21 +275,6 @@ const LIFECYCLE_LOGS = {
  * For gemini/kiro: uses `cd ~/Gits/<repo> && <cli>` since they
  * don't have launcher functions yet.
  */
-// Env vars for headless/spawned agent sessions:
-// - MCP_CONNECTION_NONBLOCKING: skip MCP connection wait (Claude Code 2.1.90+)
-// - CLAUDE_CODE_NO_FLICKER: stable alt-screen rendering for terminal parsing
-const AGENT_ENV = "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
-
-function sanitizeRepoName(repo: string): string {
-  const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
-  if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {
-    throw new Error(
-      `Invalid repo name: "${repo}". Only alphanumeric, dots, hyphens, and underscores allowed. "." and ".." are not permitted.`,
-    );
-  }
-  return safeRepo;
-}
-
 const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
   claude: {
     opus: "opus",
@@ -358,26 +350,6 @@ export function buildLaunchCommand(
     case "cursor":
       // repoGolem launcher - requires registration via golem-powers.
       return `${safeRepo}Cursor -s${launcherModelArgs}`;
-  }
-}
-
-export function buildResumeCommand(
-  cli: CliType,
-  repo: string,
-  sessionId: string,
-): string {
-  const safeRepo = sanitizeRepoName(repo);
-  switch (cli) {
-    case "claude":
-      return `${safeRepo}Claude -s --resume ${sessionId}`;
-    case "codex":
-      return `${safeRepo}Codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
-    case "gemini":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini --resume ${sessionId}`;
-    case "kiro":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
-    case "cursor":
-      return `${safeRepo}Cursor -s --resume ${sessionId}`;
   }
 }
 

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -1,12 +1,33 @@
 import type { AgentRecord, AgentRoute, PublicAgent } from "./agent-types.js";
+import { buildResumeCommand } from "./agent-command.js";
+
+export type AgentStatePayload = AgentRecord & { resume_command?: string };
+
+export function resumeCommandForAgent(
+  record: Pick<AgentRecord, "cli" | "repo" | "cli_session_id">,
+): string | undefined {
+  return record.cli_session_id
+    ? buildResumeCommand(record.cli, record.repo, record.cli_session_id)
+    : undefined;
+}
 
 export function toPublicAgent(record: AgentRecord): PublicAgent {
+  const resumeCommand = resumeCommandForAgent(record);
   return {
     agent_id: record.agent_id,
     repo: record.repo,
     model: record.model,
     state: record.state,
     session_id: record.cli_session_id,
+    ...(resumeCommand ? { resume_command: resumeCommand } : {}),
+  };
+}
+
+export function toAgentStatePayload(record: AgentRecord): AgentStatePayload {
+  const resumeCommand = resumeCommandForAgent(record);
+  return {
+    ...record,
+    ...(resumeCommand ? { resume_command: resumeCommand } : {}),
   };
 }
 
@@ -16,12 +37,14 @@ export function buildRouteTable(
   const routes = new Map<string, AgentRoute>();
 
   for (const record of records) {
+    const resumeCommand = resumeCommandForAgent(record);
     const nextRoute: AgentRoute = {
       agent_id: record.agent_id,
       surface_id: record.surface_id,
       workspace_id: record.workspace_id ?? null,
       state: record.state,
       session_id: record.cli_session_id,
+      ...(resumeCommand ? { resume_command: resumeCommand } : {}),
     };
     const existing = routes.get(record.agent_id);
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -45,6 +45,7 @@ class AgentNotFoundError extends Error {
 
 export class AgentRegistry {
   private agents = new Map<string, AgentRecord>();
+  private aliases = new Map<string, string>();
   private stateMgr: StateManager;
   private surfaceProvider: SurfaceProvider;
 
@@ -59,6 +60,7 @@ export class AgentRegistry {
    */
   async reconstitute(): Promise<void> {
     this.agents.clear();
+    this.aliases.clear();
 
     const stateFiles = this.stateMgr.listStates();
     for (const record of stateFiles) {
@@ -133,8 +135,18 @@ export class AgentRegistry {
     }
   }
 
+  private resolveAlias(agentId: string): string {
+    let current = agentId;
+    const seen = new Set<string>();
+    while (this.aliases.has(current) && !seen.has(current)) {
+      seen.add(current);
+      current = this.aliases.get(current)!;
+    }
+    return current;
+  }
+
   get(agentId: string): AgentRecord | null {
-    return this.agents.get(agentId) ?? null;
+    return this.agents.get(this.resolveAlias(agentId)) ?? null;
   }
 
   list(filter?: AgentFilter): AgentRecord[] {
@@ -322,11 +334,42 @@ export class AgentRegistry {
    * write state through the StateManager and need to sync the registry.
    */
   set(agentId: string, record: AgentRecord): void {
-    this.agents.set(agentId, record);
+    const resolved = this.resolveAlias(agentId);
+    if (resolved !== agentId && record.agent_id === resolved) {
+      this.agents.set(resolved, record);
+      return;
+    }
+    if (agentId !== record.agent_id) {
+      this.aliases.set(agentId, record.agent_id);
+    }
+    this.agents.set(record.agent_id, record);
+  }
+
+  rename(oldAgentId: string, newAgentId: string, record: AgentRecord): void {
+    this.agents.delete(oldAgentId);
+    for (const [alias, target] of this.aliases) {
+      if (target === oldAgentId) {
+        this.aliases.set(alias, newAgentId);
+      }
+    }
+    for (const [id, agent] of this.agents) {
+      if (agent.parent_agent_id === oldAgentId) {
+        this.agents.set(id, { ...agent, parent_agent_id: newAgentId });
+      }
+    }
+    this.aliases.set(oldAgentId, newAgentId);
+    this.agents.set(newAgentId, record);
   }
 
   remove(agentId: string): void {
-    this.agents.delete(agentId);
+    const resolved = this.resolveAlias(agentId);
+    this.agents.delete(resolved);
+    this.aliases.delete(agentId);
+    for (const [alias, target] of this.aliases) {
+      if (target === resolved) {
+        this.aliases.delete(alias);
+      }
+    }
   }
 
   private evictMissingStateAgent(agentId: string): boolean {

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -30,6 +30,7 @@ export interface AgentRecord {
   model: string;
   cli: CliType;
   cli_session_id: string | null;
+  cli_session_path?: string | null;
   task_summary: string;
   pid: number | null;
   version: number;
@@ -204,9 +205,42 @@ export function parseContextPercent(text: string): number | null {
 /**
  * Generate a unique agent ID from components.
  */
-export function generateAgentId(model: string, repo: string): string {
+export const SESSION_ID_PREFIX_LENGTH = 8;
+
+const CLI_GOLEM_SUFFIX: Record<CliType, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+  kiro: "Kiro",
+  cursor: "Cursor",
+};
+
+function sanitizeAgentIdPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-");
+}
+
+export function golemNameForAgent(cli: CliType, repo: string): string {
+  const safeRepo = sanitizeAgentIdPart(repo).replace(/^-+|-+$/g, "");
+  return `${safeRepo || "agent"}${CLI_GOLEM_SUFFIX[cli]}`;
+}
+
+export function sessionIdPrefix(sessionId: string): string {
+  return sanitizeAgentIdPart(sessionId.trim().toLowerCase()).slice(
+    0,
+    SESSION_ID_PREFIX_LENGTH,
+  );
+}
+
+export function generateAgentId(
+  cli: CliType,
+  repo: string,
+  sessionId?: string | null,
+): string {
+  const golemName = golemNameForAgent(cli, repo);
+  if (sessionId) {
+    return `${golemName}-${sessionIdPrefix(sessionId)}`;
+  }
   const ts = Math.floor(Date.now() / 1000);
   const rand = Math.random().toString(36).slice(2, 6);
-  const slug = repo.replace(/[^a-zA-Z0-9-]/g, "-");
-  return `${model}-${slug}-${ts}-${rand}`;
+  return `${golemName}-pending-${ts}-${rand}`;
 }

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -67,6 +67,7 @@ export interface PublicAgent {
   model: string;
   state: AgentState;
   session_id: string | null;
+  resume_command?: string;
 }
 
 export interface AgentRoute {
@@ -75,6 +76,7 @@ export interface AgentRoute {
   workspace_id?: string | null;
   state: AgentState;
   session_id: string | null;
+  resume_command?: string;
 }
 
 export function hasRecoverableCrashError(error: string | null): boolean {

--- a/src/format.ts
+++ b/src/format.ts
@@ -185,6 +185,9 @@ export function formatAgentState(agent: AgentRecord): string {
   if (agent.cli_session_id) {
     lines.push(`\u2502 session: ${agent.cli_session_id}`);
   }
+  if (agent.cli_session_path) {
+    lines.push(`\u2502 transcript: ${agent.cli_session_path}`);
+  }
   if (agent.parent_agent_id) {
     lines.push(`\u2502 parent: ${agent.parent_agent_id}`);
   }

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentRecord, PublicAgent } from "./agent-types.js";
+import { buildResumeCommand } from "./agent-command.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 function truncate(text: string, maxLen: number = 60): string {
@@ -184,6 +185,9 @@ export function formatAgentState(agent: AgentRecord): string {
   lines.push(`\u2502 surface: ${agent.surface_id}  cli: ${agent.cli}`);
   if (agent.cli_session_id) {
     lines.push(`\u2502 session: ${agent.cli_session_id}`);
+    lines.push(
+      `\u2502 resume: ${buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id)}`,
+    );
   }
   if (agent.cli_session_path) {
     lines.push(`\u2502 transcript: ${agent.cli_session_path}`);

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -386,13 +386,13 @@ function parseCodexSessionMeta(
       if (obj.type !== "session_meta") continue;
       const payload = asRecord(obj.payload);
       const id = typeof payload?.id === "string" ? payload.id : null;
-      if (!id) return null;
+      if (!id) continue;
       return {
         session_id: id,
         cwd: typeof payload?.cwd === "string" ? payload.cwd : null,
       };
     } catch {
-      return null;
+      continue;
     }
   }
 

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -7,7 +7,7 @@
 // (its JSONL carries neither tokens nor window).
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 export type Harness = "claude" | "codex" | "cursor";
 
@@ -253,6 +253,18 @@ export interface ResolveOpts {
   codexHome?: string;
 }
 
+export interface HarnessSessionIdentity {
+  harness: Harness;
+  session_id: string;
+  cwd: string | null;
+  path: string;
+  mtime_ms: number;
+}
+
+export interface IdentityResolveOpts extends ResolveOpts {
+  sinceMs?: number;
+}
+
 /**
  * Resolve the JSONL path from a thread's cwd + sessionId.
  * Claude/Cursor are deterministic. Codex rollout filenames embed a timestamp, so the
@@ -319,6 +331,164 @@ function isFile(path: string): boolean {
     return statSync(path).isFile();
   } catch {
     return false;
+  }
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function mtimeMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function afterSince(path: string, sinceMs: number | undefined): boolean {
+  return sinceMs === undefined || mtimeMs(path) >= sinceMs;
+}
+
+function newestIdentity(
+  current: HarnessSessionIdentity | null,
+  candidate: HarnessSessionIdentity,
+): HarnessSessionIdentity {
+  return !current || candidate.mtime_ms > current.mtime_ms
+    ? candidate
+    : current;
+}
+
+function sessionIdFromJsonlName(path: string): string | null {
+  const name = basename(path);
+  return name.endsWith(".jsonl") ? name.slice(0, -".jsonl".length) : null;
+}
+
+function parseCodexSessionMeta(
+  path: string,
+): { session_id: string; cwd: string | null } | null {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      const obj = JSON.parse(line) as Record<string, unknown>;
+      if (obj.type !== "session_meta") continue;
+      const payload = asRecord(obj.payload);
+      const id = typeof payload?.id === "string" ? payload.id : null;
+      if (!id) return null;
+      return {
+        session_id: id,
+        cwd: typeof payload?.cwd === "string" ? payload.cwd : null,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the newest harness transcript identity for a cwd. This is the bootstrap
+ * path for resume: it discovers the real session id before callers already know
+ * that id.
+ */
+export function findLatestHarnessSessionIdentity(
+  harness: Harness,
+  cwd: string,
+  opts: IdentityResolveOpts = {},
+): HarnessSessionIdentity | null {
+  if (!cwd) return null;
+  const home = opts.home ?? homedir();
+
+  switch (harness) {
+    case "claude": {
+      const root = join(home, ".claude", "projects", encodeClaudeCwd(cwd));
+      let found: HarnessSessionIdentity | null = null;
+      for (const name of safeReaddir(root)) {
+        const path = join(root, name);
+        if (!name.endsWith(".jsonl") || !isFile(path) || !afterSince(path, opts.sinceMs)) {
+          continue;
+        }
+        const sessionId = sessionIdFromJsonlName(path);
+        if (!sessionId) continue;
+        found = newestIdentity(found, {
+          harness,
+          session_id: sessionId,
+          cwd,
+          path,
+          mtime_ms: mtimeMs(path),
+        });
+      }
+      return found;
+    }
+    case "cursor": {
+      const root = join(
+        home,
+        ".cursor",
+        "projects",
+        encodeCursorCwd(cwd),
+        "agent-transcripts",
+      );
+      let found: HarnessSessionIdentity | null = null;
+      for (const dir of safeReaddir(root)) {
+        const transcriptDir = join(root, dir);
+        if (!isDir(transcriptDir)) continue;
+        for (const name of safeReaddir(transcriptDir)) {
+          const path = join(transcriptDir, name);
+          if (!name.endsWith(".jsonl") || !isFile(path) || !afterSince(path, opts.sinceMs)) {
+            continue;
+          }
+          const sessionId = sessionIdFromJsonlName(path) ?? dir;
+          found = newestIdentity(found, {
+            harness,
+            session_id: sessionId,
+            cwd,
+            path,
+            mtime_ms: mtimeMs(path),
+          });
+        }
+      }
+      return found;
+    }
+    case "codex": {
+      const root = join(opts.codexHome ?? join(home, ".codex"), "sessions");
+      let found: HarnessSessionIdentity | null = null;
+      const walk = (dir: string, depth: number): void => {
+        for (const name of safeReaddir(dir)) {
+          const child = join(dir, name);
+          if (isFile(child) && name.endsWith(".jsonl")) {
+            if (!afterSince(child, opts.sinceMs)) continue;
+            const meta = parseCodexSessionMeta(child);
+            if (!meta || meta.cwd !== cwd) continue;
+            found = newestIdentity(found, {
+              harness,
+              session_id: meta.session_id,
+              cwd: meta.cwd,
+              path: child,
+              mtime_ms: mtimeMs(child),
+            });
+            continue;
+          }
+          if (depth > 0 && isDir(child)) {
+            walk(child, depth - 1);
+          }
+        }
+      };
+      walk(root, 4);
+      return found;
+    }
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,11 @@ import {
   type SpawnAgentParams,
 } from "./agent-engine.js";
 import { AgentDiscovery } from "./agent-discovery.js";
-import { toPublicAgent } from "./agent-facade.js";
+import {
+  resumeCommandForAgent,
+  toAgentStatePayload,
+  toPublicAgent,
+} from "./agent-facade.js";
 import type {
   AgentRecord,
   AgentRole,
@@ -3667,9 +3671,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
           const formatted = formatAgentState(state);
+          const payload = toAgentStatePayload(state);
           return okFormatted(
             formatted,
-            state as unknown as Record<string, unknown>,
+            payload as unknown as Record<string, unknown>,
           );
         } catch (e) {
           return err(e);
@@ -4240,12 +4245,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 // Surface may be closed, unavailable, or timed out
               }
 
+              const resumeCommand = resumeCommandForAgent(agent);
               return {
                 agent_id: agent.agent_id,
                 repo: agent.repo,
                 state: agent.state,
                 model: agent.model,
                 cli: agent.cli,
+                session_id: agent.cli_session_id,
+                ...(resumeCommand ? { resume_command: resumeCommand } : {}),
                 surface_id: agent.surface_id,
                 token_count: screenData?.token_count ?? null,
                 context_pct: screenData?.context_pct ?? null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { AgentRegistry } from "./agent-registry.js";
 import {
   AgentEngine,
   type AgentLifecycleEvent,
+  type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
 import { AgentDiscovery } from "./agent-discovery.js";
@@ -626,6 +627,8 @@ export interface CreateServerOptions {
   disableSpawnPreflight?: boolean;
   /** Base directory for agent inbox channels. Defaults to ~/.cmux/agents (primarily for tests). */
   inboxBaseDir?: string;
+  /** Override session identity lookup (primarily for mocked tests). */
+  sessionIdentityResolver?: SessionIdentityResolver;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -647,6 +650,7 @@ export interface CmuxServerContext {
   skipAgentLifecycle: boolean;
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   disableSpawnPreflight?: boolean;
+  sessionIdentityResolver?: SessionIdentityResolver;
   lifecycleRegistry: AgentRegistry | null;
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
@@ -678,6 +682,7 @@ export function createServerContext(
     skipAgentLifecycle: opts?.skipAgentLifecycle ?? false,
     spawnPreflight: opts?.spawnPreflight,
     disableSpawnPreflight: opts?.disableSpawnPreflight,
+    sessionIdentityResolver: opts?.sessionIdentityResolver,
     lifecycleRegistry: null,
     lifecycleStarted: false,
     lifecycleStartPromise: null,
@@ -730,6 +735,9 @@ function buildLifecycleChannelMeta(
   }
   if (agent.cli_session_id) {
     meta.cli_session_id = agent.cli_session_id;
+  }
+  if (agent.cli_session_path) {
+    meta.cli_session_path = agent.cli_session_path;
   }
 
   return meta;
@@ -3075,6 +3083,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           spawnPreflight:
             spawnPreflight ??
             (disableSpawnPreflight ? async () => {} : undefined),
+          sessionIdentityResolver: context.sessionIdentityResolver,
           roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
           launchCommandSender: async ({ surface, workspace, command }) => {
             const sanitizedCommand = sanitizeTerminalInput(command);
@@ -3361,6 +3370,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 timeout_ms: args.boot_prompt_timeout_ms,
               });
 
+              result.agent_id =
+                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
               if (bootPromptDelivery.prompt_text !== null) {
                 const updated = stateMgr.updateRecord(result.agent_id, {
                   task_summary: bootPromptDelivery.prompt_text,
@@ -3386,6 +3397,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           } catch (e) {
             const message = e instanceof Error ? e.message : String(e);
             try {
+              result.agent_id =
+                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
               let updated = stateMgr.updateRecord(result.agent_id, {
                 boot_prompt_pending: false,
               });
@@ -3514,6 +3527,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 timeout_ms: BOOT_PROMPT_TIMEOUT_MS,
               });
 
+              result.agent_id =
+                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
               const updated = stateMgr.updateRecord(result.agent_id, {
                 task_summary:
                   bootPromptDelivery.prompt_text ?? agent.prompt ?? "",

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -80,7 +80,9 @@ export class StateManager {
   transition(
     agentId: string,
     toState: AgentState,
-    extra?: Partial<Pick<AgentRecord, "error" | "pid" | "cli_session_id">>,
+    extra?: Partial<
+      Pick<AgentRecord, "error" | "pid" | "cli_session_id" | "cli_session_path">
+    >,
   ): AgentRecord {
     const current = this.readState(agentId);
     if (!current) {
@@ -98,6 +100,9 @@ export class StateManager {
       ...(extra?.pid !== undefined ? { pid: extra.pid } : {}),
       ...(extra?.cli_session_id !== undefined
         ? { cli_session_id: extra.cli_session_id }
+        : {}),
+      ...(extra?.cli_session_path !== undefined
+        ? { cli_session_path: extra.cli_session_path }
         : {}),
     };
 
@@ -158,6 +163,59 @@ export class StateManager {
     return updated;
   }
 
+  renameState(agentId: string, newAgentId: string): AgentRecord {
+    if (agentId === newAgentId) {
+      const current = this.readState(agentId);
+      if (!current) {
+        throw new Error(`Agent not found: ${agentId}`);
+      }
+      return current;
+    }
+
+    const current = this.readState(agentId);
+    if (!current) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    if (this.readState(newAgentId)) {
+      throw new Error(`Agent already exists: ${newAgentId}`);
+    }
+
+    const updated: AgentRecord = {
+      ...current,
+      agent_id: newAgentId,
+      version: current.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+
+    const newAgentDir = join(this.baseDir, newAgentId);
+    mkdirSync(newAgentDir, { recursive: true });
+    const stateFile = join(newAgentDir, "state.json");
+    const tmpFile = join(newAgentDir, "state.json.tmp");
+    writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
+    renameSync(tmpFile, stateFile);
+
+    rmSync(join(this.baseDir, agentId), { recursive: true, force: true });
+
+    this.eventLog.append({
+      ts: updated.updated_at,
+      agent_id: newAgentId,
+      event: "transition",
+      from_state: current.state,
+      to_state: current.state,
+      surface_id: updated.surface_id,
+      source: `renameState:${agentId}`,
+      error: null,
+    });
+
+    for (const child of this.listStates()) {
+      if (child.parent_agent_id === agentId) {
+        this.updateRecord(child.agent_id, { parent_agent_id: newAgentId });
+      }
+    }
+
+    return updated;
+  }
+
   listStates(): AgentRecord[] {
     if (!existsSync(this.baseDir)) return [];
     const entries = readdirSync(this.baseDir, { withFileTypes: true });
@@ -204,6 +262,7 @@ export class StateManager {
       model: discovered.model ?? "unknown",
       cli: discovered.cli === "unknown" ? "claude" : discovered.cli,
       cli_session_id: null,
+      cli_session_path: null,
       task_summary: "(auto-discovered)",
       pid: null,
       version: 1,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -122,6 +122,7 @@ describe("AgentEngine", () => {
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
     });
   });
 
@@ -180,7 +181,9 @@ describe("AgentEngine", () => {
         prompt: "Fix gap F",
       });
 
-      expect(result.agent_id).toMatch(/^sonnet-brainlayer-\d+-[a-z0-9]+$/);
+      expect(result.agent_id).toMatch(
+        /^brainlayerClaude-pending-\d+-[a-z0-9]+$/,
+      );
       expect(result.surface_id).toBe("surface:new");
       expect(result.state).toBe("booting");
     });
@@ -1368,6 +1371,87 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
         );
       },
     );
+
+    it("finalizes agent_id to golemName-session-prefix and aliases the provisional id", async () => {
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      liveSurfaces = [makeSurface("surface:new")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:new",
+        text: `gpt-5.4
+Working (12s • esc to interrupt)
+To continue this session, run codex resume ${sessionId}`,
+        lines: 80,
+        scrollback_used: true,
+      });
+
+      engine.startSweep(1000);
+
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+      });
+
+      const finalAgentId = "brainlayerCodex-019d9aa5";
+      expect(result.agent_id).toMatch(/^brainlayerCodex-pending-\d+-[a-z0-9]+$/);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: null,
+      });
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: null,
+      });
+      expect(stateMgr.readState(result.agent_id)).toBeNull();
+      expect(stateMgr.readState(finalAgentId)?.agent_id).toBe(finalAgentId);
+    });
+
+    it("captures the real session id from transcript metadata when the screen has no UUID", async () => {
+      const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+      const sessionPath =
+        "/Users/etanheyman/.codex/sessions/2026/06/05/rollout.jsonl";
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: (agent) =>
+          agent.cli === "codex" && agent.repo === "brainlayer"
+            ? { session_id: sessionId, path: sessionPath }
+            : null,
+      });
+      liveSurfaces = [makeSurface("surface:new")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:new",
+        text: "codex> ",
+        lines: 80,
+        scrollback_used: true,
+      });
+
+      engine.startSweep(1000);
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(engine.getAgentState("brainlayerCodex-019e942c")).toMatchObject({
+        agent_id: "brainlayerCodex-019e942c",
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+      });
+      expect(engine.getAgentState(result.agent_id)?.agent_id).toBe(
+        "brainlayerCodex-019e942c",
+      );
+    });
   });
 
   describe("waitFor", () => {

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -44,8 +44,21 @@ describe("agent facade projections", () => {
       model: "sonnet",
       state: "ready",
       session_id: "session-1",
+      resume_command: "brainlayerClaude -s --resume session-1",
     });
     expect((projected as any).surface_id).toBeUndefined();
+  });
+
+  it("omits resume_command when no session id has been captured", () => {
+    const projected = toPublicAgent(makeRecord({ cli_session_id: null }));
+
+    expect(projected).toEqual({
+      agent_id: "agent-1",
+      repo: "brainlayer",
+      model: "sonnet",
+      state: "ready",
+      session_id: null,
+    });
   });
 });
 
@@ -62,6 +75,7 @@ describe("agent route table", () => {
       workspace_id: "ws:1",
       state: "ready",
       session_id: "session-1",
+      resume_command: "brainlayerClaude -s --resume session-1",
     });
     expect(table.get("agent-2")?.surface_id).toBe("surface:2");
   });

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -96,21 +96,29 @@ describe("assertValidTransition", () => {
 });
 
 describe("generateAgentId", () => {
-  it("produces a model-repo-timestamp-rand pattern", () => {
-    const id = generateAgentId("codex", "brainlayer");
-    expect(id).toMatch(/^codex-brainlayer-\d+-[a-z0-9]+$/);
+  it("uses golemName-session-prefix when a real session id is known", () => {
+    const id = generateAgentId(
+      "codex",
+      "brainlayer",
+      "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(id).toBe("brainlayerCodex-019d9aa5");
   });
 
-  it("sanitizes repo names with special characters", () => {
-    const id = generateAgentId("claude", "my/weird repo");
-    expect(id).toMatch(/^claude-my-weird-repo-\d+-[a-z0-9]+$/);
+  it("keeps repoGolem launcher identity in the golemName prefix", () => {
+    const id = generateAgentId(
+      "claude",
+      "skill-creator",
+      "5b9f4f35-2942-4c8b-b1af-d89d4e36c95d",
+    );
+    expect(id).toBe("skill-creatorClaude-5b9f4f35");
   });
 
-  it("generates unique IDs for sequential calls within the same second", () => {
-    const id1 = generateAgentId("sonnet", "test");
-    const id2 = generateAgentId("sonnet", "test");
-    expect(id1).toMatch(/^sonnet-test-\d+-[a-z0-9]+$/);
-    expect(id2).toMatch(/^sonnet-test-\d+-[a-z0-9]+$/);
+  it("uses a golemName-pending fallback until session capture finishes", () => {
+    const id1 = generateAgentId("codex", "brainlayer");
+    const id2 = generateAgentId("codex", "brainlayer");
+    expect(id1).toMatch(/^brainlayerCodex-pending-\d+-[a-z0-9]+$/);
+    expect(id2).toMatch(/^brainlayerCodex-pending-\d+-[a-z0-9]+$/);
     // Random suffix should make them different even in the same second
     expect(id1).not.toBe(id2);
   });

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -1,5 +1,12 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -7,6 +14,7 @@ import {
   modelContextWindow,
   resolveSessionPath,
   readHarnessSessionFromFile,
+  findLatestHarnessSessionIdentity,
   findHarnessSessionPath,
   loadHarnessSession,
   applyHarnessState,
@@ -234,6 +242,60 @@ describe("findHarnessSessionPath / loadHarnessSession (resolve by sessionId, no 
 
   it("unknown sessionId → null", () => {
     expect(loadHarnessSession("claude", "does-not-exist", { home })).toBeNull();
+  });
+});
+
+describe("findLatestHarnessSessionIdentity (cwd → real session id)", () => {
+  const home = mkdtempSync(join(tmpdir(), "cmux-harness-identity-"));
+
+  mkdirSync(join(home, ".codex", "sessions", "2026", "06", "04"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(
+      home,
+      ".codex",
+      "sessions",
+      "2026",
+      "06",
+      "04",
+      "rollout-2026-06-04T21-00-00-old.jsonl",
+    ),
+    JSON.stringify({
+      type: "session_meta",
+      payload: {
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        cwd: "/Users/etanheyman/Gits/other",
+      },
+    }),
+  );
+  cpSync(
+    join(FIX, "codex.jsonl"),
+    join(
+      home,
+      ".codex",
+      "sessions",
+      "2026",
+      "06",
+      "04",
+      "rollout-2026-06-04T22-46-15-not-the-real-id.jsonl",
+    ),
+  );
+
+  afterAll(() => rmSync(home, { recursive: true, force: true }));
+
+  it("Codex: scans transcripts for matching cwd and returns payload.session_meta id", () => {
+    const identity = findLatestHarnessSessionIdentity(
+      "codex",
+      "/Users/etanheyman/Gits/brainlayer",
+      { home },
+    );
+
+    expect(identity).toMatchObject({
+      harness: "codex",
+      session_id: "019e942c-0dda-76f2-bbca-0ef6e484d1c9",
+    });
+    expect(identity?.path).toContain("not-the-real-id.jsonl");
   });
 });
 

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -297,6 +297,43 @@ describe("findLatestHarnessSessionIdentity (cwd → real session id)", () => {
     });
     expect(identity?.path).toContain("not-the-real-id.jsonl");
   });
+
+  it("Codex: skips malformed lines and session_meta entries missing ids", () => {
+    const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-bad-jsonl-"));
+    const root = join(localHome, ".codex", "sessions", "2026", "06", "05");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "rollout-2026-06-05T20-00-00-jsonl-noise.jsonl"),
+      [
+        "{not-json",
+        JSON.stringify({
+          type: "session_meta",
+          payload: { cwd: "/Users/etanheyman/Gits/brainlayer" },
+        }),
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+            cwd: "/Users/etanheyman/Gits/brainlayer",
+          },
+        }),
+      ].join("\n"),
+    );
+
+    try {
+      const identity = findLatestHarnessSessionIdentity(
+        "codex",
+        "/Users/etanheyman/Gits/brainlayer",
+        { home: localHome },
+      );
+
+      expect(identity?.session_id).toBe(
+        "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+      );
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("applyHarnessState (overlay; JSONL wins, screen is fallback)", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -123,6 +123,7 @@ function createLifecycleServer(exec: ExecFn) {
     exec,
     stateDir: TEST_DIR,
     disableSpawnPreflight: true,
+    sessionIdentityResolver: () => null,
   });
 }
 
@@ -193,7 +194,9 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(parsed.agent_id).toMatch(/^sonnet-brainlayer-\d+-[a-z0-9]+$/);
+    expect(parsed.agent_id).toMatch(
+      /^brainlayerClaude-pending-\d+-[a-z0-9]+$/,
+    );
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
 
@@ -1155,7 +1158,7 @@ describe("agent lifecycle tool handlers", () => {
     const engine = (server as any)._registeredTools["interact"]._engine;
     const stateMgr = engine["stateMgr"];
 
-    if (stateMgr.readState(agentId)?.state !== "ready") {
+    if (stateMgr.readState(agentId)?.state === "booting") {
       stateMgr.transition(agentId, "ready");
     }
     stateMgr.transition(agentId, "done");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -790,7 +790,43 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.count).toBe(1);
     expect(parsed.agents[0].repo).toBe("brainlayer");
     expect(parsed.agents[0].session_id).toBeNull();
+    expect(parsed.agents[0].resume_command).toBeUndefined();
     expect(parsed.agents[0].surface_id).toBeUndefined();
+  });
+
+  it("list_agents includes resume_command when a session id is captured", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const list = (server as any)._registeredTools["list_agents"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "task 1",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const stateMgr = engine["stateMgr"];
+    const updated = stateMgr.updateRecord(agentId, {
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    });
+    engine.getRegistry().set(agentId, updated);
+
+    const result = await list.handler({}, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.agents[0]).toMatchObject({
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      resume_command:
+        "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    });
   });
 
   it("get_agent_state returns full record", async () => {
@@ -817,6 +853,40 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.cli).toBe("codex");
+    expect(parsed.resume_command).toBeUndefined();
+  });
+
+  it("get_agent_state includes resume_command when a session id is captured", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "golems",
+        model: "codex",
+        cli: "codex",
+        prompt: "prune skills",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const stateMgr = engine["stateMgr"];
+    const updated = stateMgr.updateRecord(agentId, {
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    });
+    engine.getRegistry().set(agentId, updated);
+
+    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.resume_command).toBe(
+      "golemsCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
   });
 
   it("get_agent_state returns error for unknown agent", async () => {
@@ -1336,5 +1406,32 @@ describe("agent lifecycle tool handlers", () => {
     expect(agent).toHaveProperty("spawn_depth");
     expect(agent).toHaveProperty("created_at");
     expect(agent).toHaveProperty("quality");
+  });
+
+  it("my_agents includes resume_command when a session id is captured", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const myAgents = (server as any)._registeredTools["my_agents"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const spawnResult = await spawn.handler(
+      { repo: "voicelayer", model: "opus", cli: "claude", prompt: "fix tts" },
+      {} as any,
+    );
+    const agentId = spawnResult.structuredContent.agent_id;
+    const stateMgr = engine["stateMgr"];
+    const updated = stateMgr.updateRecord(agentId, {
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    });
+    engine.getRegistry().set(agentId, updated);
+
+    const result = await myAgents.handler({}, {} as any);
+    const agent = result.structuredContent.agents[0];
+
+    expect(agent).toMatchObject({
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      resume_command:
+        "voicelayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    });
   });
 });

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -16,6 +16,7 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
     model: "codex",
     cli: "codex",
     cli_session_id: null,
+    cli_session_path: null,
     task_summary: "Fix search gap F",
     pid: null,
     version: 0,
@@ -65,6 +66,7 @@ describe("StateManager", () => {
       expect(parsed.model).toBe(record.model);
       expect(parsed.cli).toBe(record.cli);
       expect(parsed.cli_session_id).toBeNull();
+      expect(parsed.cli_session_path).toBeNull();
       expect(parsed.version).toBe(0);
     });
 


### PR DESCRIPTION
## Summary
- generate cmux agent ids from repoGolem-style names, starting as `<golemName>-pending-*` and finalizing to `<golemName>-<sessionIdPrefix>` after real session capture
- capture Claude/Cursor/Codex transcript identities from harness JSONL metadata, persist `cli_session_id` + `cli_session_path`, and keep pending ids routable through registry aliases
- expose `resume_command` in public agent payloads (`get_agent_state`, `list_agents`, `my_agents`) when `cli_session_id` is set
- canonicalize post-spawn state writes after identity finalization and expose transcript path/resume command in agent state formatting

## Verification
- `npm test -- tests/agent-facade.test.ts tests/server-agent-tools.test.ts tests/harness-session.test.ts`
- `npm run typecheck`
- `npm run build`
- `TMPDIR=/tmp npm test` (44 files / 709 tests)
- pre-push hook with `TMPDIR=/tmp` (race fixtures + full Vitest)
- fresh Claude MCP live gate on cmux `surface:73` using this worktree `dist/index.js`: `LIVE_MCP_OK surfaces=30`

## Notes
- `harnessCwdForAgent` intentionally assumes `~/Gits/{repo}` for this PR; worktree spawns launched with `-w` can fall back to screen-grep session capture.
- pending-id aliases are in-memory; a pending id held across an MCP server restart will not resolve post-reconstitute, which is acceptable because finalization is expected inside the 30s boot window.
- Default push without `TMPDIR=/tmp` fails daemon/proxy Unix socket path-length tests under `/var/folders/...`; rerunning with `TMPDIR=/tmp` passes without bypassing hooks.