### PR TITLE
fix: tolerate contaminated lead pane for orchestrator tabs

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -181,6 +181,11 @@ function isWorkerDockPane(layout: PaneLayout): boolean {
   );
 }
 
+function isWorkerMajorityPane(layout: PaneLayout): boolean {
+  const nonWorkerCount = layout.surfaces.length - layout.workerCount;
+  return layout.workerCount > 0 && layout.workerCount > nonWorkerCount;
+}
+
 function isNonLeadWorkerZonePane(
   layout: PaneLayout,
   leftPane: PaneLayout | undefined,
@@ -427,7 +432,7 @@ export function chooseAgentSpawnPlacement(
 
   if (role === "orchestrator") {
     const leftLeadPane =
-      leftPane && leftPane.workerCount === 0
+      leftPane && !isWorkerMajorityPane(leftPane)
         ? leftPane
         : undefined;
     const orchestratorPane =

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -292,6 +292,199 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
   });
 
+  it("places orchestrators in pane:1 for the live lead-pane fixture with one IC record", () => {
+    const panes = [
+      makePane(
+        "pane:1",
+        0,
+        [
+          "surface:cmux-lead",
+          "surface:voicelayer-lead",
+          "surface:brainlayer-lead",
+          "surface:orchestrator-lead",
+        ],
+        {
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 900,
+        },
+      ),
+      makePane("pane:5", 1, ["surface:worker-1", "surface:worker-2"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:1", [
+        {
+          ref: "surface:cmux-lead",
+          title: "cmuxlayerClaude-LEAD",
+        },
+        {
+          ref: "surface:voicelayer-lead",
+          title: "voicelayerClaude-LEAD",
+        },
+        {
+          ref: "surface:brainlayer-lead",
+          title: "brainlayerClaude-LEAD",
+        },
+        {
+          ref: "surface:orchestrator-lead",
+          title: "orchestratorClaude-LEAD",
+        },
+      ]),
+      makeTitledPaneSurfaces("pane:5", [
+        {
+          ref: "surface:worker-1",
+          title: "cmuxlayerCodex W-B1",
+        },
+        {
+          ref: "surface:worker-2",
+          title: "cmuxlayerCursor W-B2",
+        },
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(["surface:voicelayer-lead"]),
+        worker: new Set(),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:1" });
+  });
+
+  it("places orchestrators in the left-column lead pane despite a stray worker record", () => {
+    const panes = [
+      makePane(
+        "pane:left",
+        0,
+        ["surface:cmux-lead", "surface:stale-worker", "surface:shell"],
+        {
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 900,
+        },
+      ),
+      makePane("pane:right", 1, ["surface:actual-worker"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:left", [
+        {
+          ref: "surface:cmux-lead",
+          title: "cmuxlayerClaude-LEAD",
+        },
+        {
+          ref: "surface:stale-worker",
+          title: "voicelayerClaude-LEAD",
+        },
+        {
+          ref: "surface:shell",
+          title: "manual shell",
+        },
+      ]),
+      makeTitledPaneSurfaces("pane:right", [
+        {
+          ref: "surface:actual-worker",
+          title: "cmuxlayerCodex W-B1",
+        },
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(),
+        worker: new Set(["surface:stale-worker"]),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
+  });
+
+  it("splits orchestrators left when the leftmost pane is worker-majority despite a stale IC record", () => {
+    const panes = [
+      makePane(
+        "pane:left-workers",
+        0,
+        [
+          "surface:worker-1",
+          "surface:worker-2",
+          "surface:worker-3",
+          "surface:stale-ic",
+        ],
+        {
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 900,
+        },
+      ),
+      makePane("pane:right-workers", 1, ["surface:worker-4"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:left-workers", [
+        {
+          ref: "surface:worker-1",
+          title: "cmuxlayerCodex W-B1",
+        },
+        {
+          ref: "surface:worker-2",
+          title: "cmuxlayerCodex W-B2",
+        },
+        {
+          ref: "surface:worker-3",
+          title: "cmuxlayerCursor W-B3",
+        },
+        {
+          ref: "surface:stale-ic",
+          title: "cmuxlayerCodex W-B4",
+        },
+      ]),
+      makeTitledPaneSurfaces("pane:right-workers", [
+        {
+          ref: "surface:worker-4",
+          title: "cmuxlayerCodex W-B5",
+        },
+      ]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(["surface:stale-ic"]),
+        worker: new Set(),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "split", direction: "left" });
+  });
+
   it("docks workers into launcher-title Codex panes without registry state", () => {
     const panes = [
       makePane("pane:worker", 0, ["surface:cmuxlayer-worker"]),


### PR DESCRIPTION
## Summary
- Keep `new_split(role=orchestrator)` tabbing into the left-column lead pane unless that pane is a worker dock / worker-majority pane.
- Add the exact live fixture: `pane:1` left with four Claude lead-titled tabs, one stale `ic` registry role; `pane:5` right with worker tabs; orchestrator placement returns `{ kind: \"surface\", pane: \"pane:1\" }`.
- Add a current-main regression guard for stray worker records in the left lead pane so a mis-roled worker record no longer forces a third split.

## Test plan
- `cr review --plain` — no findings
- `TMPDIR=/tmp npm test` — 44 files / 712 tests passed
- `npm run typecheck`
- `npm run build`
- pre-push hook with `TMPDIR=/tmp git push -u origin HEAD` — bun regressions passed and vitest 44 files / 712 tests passed

## Notes
- The default macOS temp dir path is too long for the daemon/proxy Unix socket tests; running the same hook with `TMPDIR=/tmp` avoids unrelated `listen/connect EINVAL` socket-path failures without bypassing hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to spawn placement heuristics in layout-policy with broad test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> **Orchestrator spawn placement** no longer treats the left-column lead pane as ineligible just because the registry lists a worker (or other stray role) on one of its tabs. It now skips the left pane only when that pane is **worker-majority** (`isWorkerMajorityPane`), matching the idea that a real worker dock column should not absorb new orchestrator tabs.
> 
> Concretely, `chooseAgentSpawnPlacement` for `role: "orchestrator"` uses `!isWorkerMajorityPane(leftPane)` instead of requiring `workerCount === 0` on the leftmost pane. Lead panes with multiple Claude lead tabs plus a misclassified IC/worker record still tab into the left pane; a left column that is mostly workers still gets a **split left** for a new orchestrator.
> 
> Tests cover the live two-column fixture, a stray worker record in the lead pane, and worker-majority left column with a stale IC record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdeec98db9926d03ad0842c7452f70d33ad693c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix orchestrator placement to tolerate contaminated lead panes with stray worker records
> - Adds `isWorkerMajorityPane` helper in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/139/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) that returns true only when workers outnumber non-worker surfaces in a pane.
> - Changes the lead-pane eligibility check in `chooseAgentSpawnPlacement` from `workerCount === 0` to `!isWorkerMajorityPane`, so a pane with a single stray worker record is still treated as a lead pane.
> - When the leftmost pane is worker-majority (even with a stale IC record), the function now falls back to a left split as before.
> - Behavioral Change: orchestrators can now be placed in a pane that contains a non-majority stray worker, rather than being forced to split left in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdeec98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->