### PR TITLE
fix(wait_for): resolve on trailing done evidence; widen task-done detection; ignore prompt echo (B3)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1413,7 +1413,9 @@ export class AgentEngine {
             matched: true,
             state: current.state,
             elapsed,
-            source: "sweep",
+            source: this.requiresOutputDoneEvidence(targetState)
+              ? "evidence"
+              : "sweep",
             agent: toPublicAgent(current),
           });
           return;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -153,7 +153,7 @@ export interface WaitResult {
   matched: boolean;
   state: AgentState;
   elapsed: number;
-  source: "immediate" | "poll" | "sweep" | "watch" | "timeout";
+  source: "immediate" | "poll" | "sweep" | "watch" | "evidence" | "timeout";
   agent: PublicAgent | null;
   error?: string;
 }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -250,6 +250,9 @@ function parseDoneSignal(text: string): string | null {
     const line = lines[i];
     const explicitDoneSignal = line.match(DONE_SIGNAL_LINE_RE)?.[1];
     if (explicitDoneSignal) {
+      if (isUnsafeDoneSignalContext(lines, i)) {
+        return null;
+      }
       return explicitDoneSignal;
     }
 
@@ -266,6 +269,44 @@ function parseDoneSignal(text: string): string | null {
   }
 
   return null;
+}
+
+function isUnsafeDoneSignalContext(lines: string[], index: number): boolean {
+  const immediateTail = lines.slice(Math.max(0, index - 3), index);
+  const immediateText = immediateTail.join("\n");
+
+  if (
+    CODEX_WORKING_RE.test(immediateText) ||
+    CLAUDE_WORKING_LINE_RE.test(immediateText) ||
+    THINKING_RE.test(immediateText) ||
+    CURSOR_HEX_RUNNING_RE.test(immediateText) ||
+    GEMINI_WORKING_RE.test(immediateText)
+  ) {
+    return true;
+  }
+
+  return immediateTail.some((line) => isEchoedPromptContextLine(line));
+}
+
+function isEchoedPromptContextLine(line: string): boolean {
+  const hasDoneToken = /\b[A-Z][A-Z0-9_]*_DONE\b/.test(line);
+  const hasInstructionVerb = /\b(?:print|emit|write|respond)\b/i.test(line);
+
+  if (
+    /^\s*(?:→|>|[│┃║])\s+/.test(line) ||
+    /^\s*(?:╭|╰|┌|└|├|┬|┴|┼)/.test(line)
+  ) {
+    return true;
+  }
+
+  return (
+    (hasInstructionVerb && hasDoneToken) ||
+    (/\bwhen\b.*\bcomplete\b/i.test(line) &&
+      (hasInstructionVerb || hasDoneToken || /\bdone signal\b/i.test(line))) ||
+    (/\bon its own line\b/i.test(line) &&
+      (hasInstructionVerb || hasDoneToken || /\bdone signal\b/i.test(line))) ||
+    (/\bdone signal\b/i.test(line) && (hasInstructionVerb || hasDoneToken))
+  );
 }
 
 function trimBlankEdges(lines: string[]): string[] {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -806,6 +806,51 @@ describe("AgentEngine", () => {
       }
     });
 
+    it("marks TASK_DONE for any cli and role without using the auto-archive gate", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(doneAt);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "claude-ic-done",
+            state: "ready",
+            surface_id: "surface:claude-ic-done",
+            cli: "claude",
+            role: "ic",
+            auto_archive_on_done: true,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-ic-done")];
+        await engine.getRegistry().reconstitute();
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-ic-done",
+          text: "Claude Code\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+
+        await engine.runSweep();
+        expect(engine.getAgentState("claude-ic-done")).toMatchObject({
+          state: "ready",
+          task_done_candidate_at: doneAt.toISOString(),
+        });
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 5_001));
+        await engine.runSweep();
+        expect(engine.getAgentState("claude-ic-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: expect.any(String),
+        });
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 5_001 + 31 * 60_000));
+        await engine.runSweep();
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("prefers TASK_DONE auto-archive milliseconds over minutes when both env vars are set", async () => {
       const previousMs = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
       const previousMinutes =
@@ -1570,12 +1615,95 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("sweep");
+        expect(result.source).toBe("evidence");
         expect(result.state).toBe("done");
         expect(engine.getAgentState("worker-output-done")).toMatchObject({
           state: "done",
           task_done_detected_at: expect.any(String),
         });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves a working agent with trailing TASK_DONE within two sweep ticks after confirmation", async () => {
+      vi.useFakeTimers();
+      try {
+        const candidateAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(candidateAt.getTime() + 5_001));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "incident-working-done",
+            state: "working",
+            surface_id: "surface:incident-working-done",
+            cli: "codex",
+            role: "worker",
+            task_done_candidate_at: candidateAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:incident-working-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:incident-working-done",
+          text: "gpt-5.4\nImplemented the fix.\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "incident-working-done",
+          "done",
+          25 * 60_000,
+        );
+        await vi.advanceTimersByTimeAsync(1_100);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("evidence");
+        expect(result.state).toBe("done");
+        expect(result.elapsed).toBeLessThan(2_000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve done when TASK_DONE appears only in an echoed instruction box with an active spinner", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "incident-echo-active",
+            state: "working",
+            surface_id: "surface:incident-echo-active",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:incident-echo-active")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:incident-echo-active",
+          text: [
+            "gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer",
+            "→ Implement the fix. When complete, print exactly:",
+            "TASK_DONE",
+            "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
+            "Working (1m 02s • esc to interrupt)",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("incident-echo-active", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("incident-echo-active");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_candidate_at ?? null).toBeNull();
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
       } finally {
         vi.useRealTimers();
       }
@@ -1729,7 +1857,7 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("sweep");
+        expect(result.source).toBe("evidence");
         expect(result.state).toBe("done");
         expect(engine.getAgentState("claude-output-done")).toMatchObject({
           state: "done",
@@ -1756,6 +1884,37 @@ To continue this session, run codex resume ${sessionId}`,
       expect(result.state).toBe("error");
       expect(result.agent?.agent_id).toBe("agent-err");
       expect(result.agent?.state).toBe("error");
+    });
+
+    it("fails fast when reconcile detects the waited agent surface disappeared", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-surface-gone",
+            state: "ready",
+            surface_id: "surface:gone-during-wait",
+            cli: "claude",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:gone-during-wait")];
+        await engine.getRegistry().reconstitute();
+
+        liveSurfaces = [];
+        const pending = engine.waitFor("agent-surface-gone", "done", 25 * 60_000);
+        await vi.advanceTimersByTimeAsync(1_100);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.state).toBe("error");
+        expect(result.source).toBe("sweep");
+        expect(result.elapsed).toBeLessThan(25 * 60_000);
+        expect(result.error).toContain(
+          "Surface surface:gone-during-wait disappeared",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("times out when target state is never reached", async () => {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -2,7 +2,6 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
 import { EventEmitter, once } from "node:events";
@@ -11,7 +10,7 @@ import { CmuxLayerDaemon, SocketJsonRpcTransport } from "../src/daemon.js";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 
-const TEST_ROOT = join(tmpdir(), "cmuxlayer-daemon-test");
+const TEST_ROOT = join("/tmp", "cmuxlayer-daemon-test");
 
 function socketPath(name: string): string {
   return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -2,7 +2,6 @@ import net from "node:net";
 import { EventEmitter } from "node:events";
 import { rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -15,7 +14,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { CmuxLayerProxy, computeReconnectDelay } from "../src/proxy.js";
 
-const TEST_ROOT = join(tmpdir(), "cmuxlayer-proxy-test");
+const TEST_ROOT = join("/tmp", "cmuxlayer-proxy-test");
 
 function socketPath(name: string): string {
   return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -214,6 +214,58 @@ Working (1m 02s • esc to interrupt)
     expect(parsed.status).toBe("working");
   });
 
+  it("does not treat a standalone done token inside a Codex echoed prompt box as output", () => {
+    const parsed = parseScreen(`
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+→ Implement the fix. When complete, print exactly:
+TASK_DONE
+▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).not.toBe("done");
+  });
+
+  it("accepts a real trailing done token after an echoed prompt box and output", () => {
+    const parsed = parseScreen(`
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+→ Implement the fix. When complete, print exactly:
+TASK_DONE
+▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+Implemented the fix.
+TASK_DONE
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBe("TASK_DONE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("accepts a real trailing done token after ordinary output mentioning done signal", () => {
+    const parsed = parseScreen(`
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+Updated the done signal parser edge case.
+TASK_DONE
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBe("TASK_DONE");
+    expect(parsed.status).toBe("done");
+  });
+
+  it("does not treat a done token as output while the current tail is still working", () => {
+    const parsed = parseScreen(`
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+Working (1m 02s • esc to interrupt)
+TASK_DONE
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).toBe("working");
+  });
+
   it("parses Gemini-style output from explicit Gemini CLI markers", () => {
     const parsed = parseScreen(`
 Gemini CLI


### PR DESCRIPTION
## Summary
- Return wait_for(done) matches from output evidence as source:\"evidence\" instead of source:\"sweep\".
- Harden done-signal parsing so echoed prompt/composer regions and active thinking tails do not count as completion.
- Add regression coverage for numbered done signals, any-cli/any-role TASK_DONE confirmation, stale surface fast-fail, and the incident shape where registry state stays working but the screen tail prints TASK_DONE.
- Stabilize local socket tests by using /tmp for Unix socket roots so exact bun run test works on macOS.

## Test plan
- [x] bun run test — 44 files / 707 tests passed
- [x] bun run typecheck
- [x] git diff --check
- [x] push hook run_tests.sh — 44 files / 707 tests passed

Local CodeRabbit CLI note: cr review --plain returned \"Review limit reached\" before commit; GitHub PR reviewer gate will be used before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration-critical completion detection and waitFor semantics; false negatives are possible if legitimate done tokens resemble echoed prompt context.
> 
> **Overview**
> **Hardens task-done detection** so `waitFor(..., "done")` and sweeps no longer treat echoed instructions or in-progress UI as real completion.
> 
> `parseDoneSignal` now rejects trailing `*_DONE` tokens when nearby lines look like **echoed prompt/composer boxes** (arrow/box-drawing prefixes, “when complete / print TASK_DONE” wording) or when **working/spinner tails** (Codex “Working…”, Claude/Cursor/Gemini activity lines) sit above the token. Real output after an echoed box still counts as done.
> 
> **`waitFor` reporting:** successful `done` matches driven by screen output evidence use `WaitResult.source: "evidence"` instead of `"sweep"`; the type union adds `"evidence"`.
> 
> **Tests** cover echo+spinner false positives, fast evidence resolution for agents still marked `working`, any-cli/any-role `TASK_DONE` confirmation without auto-archive, and reconcile **fail-fast** when the waited surface vanishes. Daemon/proxy tests pin Unix socket roots under **`/tmp`** for macOS stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256b47528db36eb280314842e7b891171fd2717a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `waitFor` to resolve on trailing done evidence and ignore echoed prompt signals
> - `parseDoneSignal` in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/140/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) now suppresses done signals that appear only inside echoed instruction/prompt boxes or while an active working/spinner tail is present, using two new helpers: `isUnsafeDoneSignalContext` and `isEchoedPromptContextLine`.
> - `AgentEngine.waitFor` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/140/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) sets `WaitResult.source` to `"evidence"` (instead of always `"sweep"`) when the target state requires output-done evidence; the `"evidence"` literal is added to the `WaitResult` type in [agent-types.ts](https://github.com/EtanHey/cmuxlayer/pull/140/files#diff-efd9180892738f786d25ac95f9c9adf7070aa3bc8d56cf1c7d726435f977c6d9).
> - New tests cover: trailing `TASK_DONE` resolving with source `"evidence"`, ignoring `TASK_DONE` inside an echoed instruction box with an active spinner, and fast-fail when the agent surface disappears during wait.
> - Behavioral Change: agents that previously resolved on a `TASK_DONE` token echoed back inside a prompt/instruction box will no longer resolve until a real trailing done signal appears.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 256b475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of task completion signals to prevent false positives triggered by echoed prompts, AI working states, and in-progress indicators.

* **New Features**
  * Enhanced task completion reporting with more precise identification and classification of what triggered the completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->