### PR TITLE
fix(layout): workers dock into the right column structurally — never a new column (F3)

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -186,6 +186,12 @@ function isWorkerMajorityPane(layout: PaneLayout): boolean {
   return layout.workerCount > 0 && layout.workerCount > nonWorkerCount;
 }
 
+function isLeadMajorityPane(layout: PaneLayout): boolean {
+  const leadCount = layout.orchestratorCount + layout.icCount;
+  const nonLeadCount = layout.surfaces.length - leadCount;
+  return leadCount > 0 && leadCount > nonLeadCount;
+}
+
 function isNonLeadWorkerZonePane(
   layout: PaneLayout,
   leftPane: PaneLayout | undefined,
@@ -395,15 +401,13 @@ export function collectRoleSurfaceIds(
 
 /**
  * Deterministic worker placement:
- * - first worker creates the right split
- * - subsequent workers become tabs in the rightmost worker-owned pane — a
- *   worker-majority pane, which tolerates a stray non-role tab (a setup shell
- *   or dashboard) so a populated workers pane never sprouts a redundant pane
- * - under sparse roles, the rightmost non-lead pane seeds the worker zone so
- *   reconnect/manual panes do not fall back to focus-relative center splits
- * - a lone worker sharing a pane with an interactive/non-role surface is still
- *   treated as invalid and repaired with a fresh right split, preserving the
- *   left-interactive/right-worker invariant
+ * - in a single-column layout, the first worker creates the right split
+ * - once at least two columns exist, workers become tabs in the rightmost
+ *   non-lead-owned pane; worker-dock and worker-zone predicates only order
+ *   which right-column pane wins
+ * - if every right-column pane is lead-owned, split within that column instead
+ *   of creating another column
+ * - single-column layouts may still split right to seed the worker column
  */
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
@@ -429,6 +433,13 @@ export function chooseAgentSpawnPlacement(
   if (layouts.length === 0) {
     return { kind: "split", direction: "right" };
   }
+
+  const columnValues = [...new Set(columnByPane.values())];
+  const columnCount = columnValues.length;
+  const rightmostColumn = Math.max(...columnValues);
+  const rightmostColumnPanes = layouts.filter(
+    (layout) => columnByPane.get(layout.pane.ref) === rightmostColumn,
+  );
 
   if (role === "orchestrator") {
     const leftLeadPane =
@@ -460,6 +471,36 @@ export function chooseAgentSpawnPlacement(
       };
     }
     return { kind: "split", direction: "right" };
+  }
+
+  if (columnCount >= 2) {
+    const nonLeadRightColumnPanes = rightmostColumnPanes.filter(
+      (layout) => !isLeadMajorityPane(layout),
+    );
+    const structuralWorkerPane =
+      rightmostByColumn(nonLeadRightColumnPanes.filter(isWorkerDockPane)) ??
+      rightmostByColumn(
+        nonLeadRightColumnPanes.filter((layout) =>
+          isNonLeadWorkerZonePane(layout, leftPane),
+        ),
+      ) ??
+      rightmostByColumn(
+        nonLeadRightColumnPanes.filter(isSparseWorkerZoneSeedPane),
+      ) ??
+      rightmostByColumn(nonLeadRightColumnPanes);
+
+    if (structuralWorkerPane) {
+      return { kind: "surface", pane: structuralWorkerPane.pane.ref };
+    }
+
+    const leadOwnedRightPane = rightmostByColumn(rightmostColumnPanes);
+    if (leadOwnedRightPane) {
+      return {
+        kind: "split",
+        direction: "down",
+        pane: leadOwnedRightPane.pane.ref,
+      };
+    }
   }
 
   if (context.parentRole === "ic") {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -573,7 +573,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("keeps a parent IC's first child local even when an unrelated worker zone exists", () => {
+  it("docks a parent IC's first child into the rightmost worker column when one exists", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -602,9 +602,8 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "down",
-      pane: "pane:ic",
+      kind: "surface",
+      pane: "pane:other-workers",
     });
   });
 
@@ -642,7 +641,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("splits the first child worker to the right of its parent orchestrator pane", () => {
+  it("docks the first child worker into an existing right-column non-lead pane", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"]),
       makePane("pane:notes", 1, ["surface:notes"]),
@@ -669,13 +668,12 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "right",
-      pane: "pane:lead",
+      kind: "surface",
+      pane: "pane:notes",
     });
   });
 
-  it("keeps a parent orchestrator's first child local even when an unrelated worker zone exists", () => {
+  it("docks a parent orchestrator's first child into the rightmost worker column when one exists", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"]),
       makePane("pane:other-workers", 1, ["surface:worker-1"]),
@@ -702,9 +700,8 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "right",
-      pane: "pane:lead",
+      kind: "surface",
+      pane: "pane:other-workers",
     });
   });
 
@@ -811,6 +808,88 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
+  it("docks a worker into the right column despite the live non-role-majority pane", () => {
+    const nonRoleSurfaces = Array.from({ length: 15 }, (_, index) => ({
+      ref: `surface:judge-${index + 1}`,
+      title:
+        index % 3 === 0
+          ? "Judge Worker"
+          : index % 3 === 1
+            ? "voicelayer"
+            : "Red Team Judge",
+    }));
+    const rightSurfaces = [
+      ...nonRoleSurfaces,
+      {
+        ref: "surface:worker",
+        title: "cmuxlayerCursor W-F3",
+      },
+    ];
+    const panes = [
+      makePane(
+        "pane:1",
+        0,
+        [
+          "surface:cmux-lead",
+          "surface:voicelayer-lead",
+          "surface:brainlayer-lead",
+          "surface:orchestrator-lead",
+        ],
+        {
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 900,
+        },
+      ),
+      makePane(
+        "pane:5",
+        1,
+        rightSurfaces.map((surface) => surface.ref),
+        {
+          x: 500,
+          y: 0,
+          width: 500,
+          height: 900,
+        },
+      ),
+    ];
+    const paneSurfaces = [
+      makeTitledPaneSurfaces("pane:1", [
+        {
+          ref: "surface:cmux-lead",
+          title: "cmuxlayerClaude-LEAD",
+        },
+        {
+          ref: "surface:voicelayer-lead",
+          title: "voicelayerClaude-LEAD",
+        },
+        {
+          ref: "surface:brainlayer-lead",
+          title: "brainlayerClaude-LEAD",
+        },
+        {
+          ref: "surface:orchestrator-lead",
+          title: "orchestratorClaude-LEAD",
+        },
+      ]),
+      makeTitledPaneSurfaces("pane:5", rightSurfaces),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:5" });
+  });
+
   it("still splits fresh when a lone worker shares a pane with one non-role surface", () => {
     // Guard the worker-majority rule against over-reach: a single worker tied
     // with a non-role surface is NOT a worker pane — split fresh (unchanged).
@@ -837,7 +916,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("repairs a mixed worker pane by splitting from the mixed pane even when another pane exists", () => {
+  it("docks into a clean right-column pane instead of repairing a mixed left worker pane", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
       makePane("pane:right", 1, ["surface:notes"]),
@@ -857,13 +936,12 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "right",
-      pane: "pane:left",
+      kind: "surface",
+      pane: "pane:right",
     });
   });
 
-  it("repairs a mixed unknown-agent pane instead of treating the layout as sparse", () => {
+  it("docks into a clean right-column pane when an unknown worker contaminates the left pane", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive", "surface:unknown-worker"]),
       makePane("pane:right", 1, ["surface:notes"]),
@@ -889,9 +967,8 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "right",
-      pane: "pane:left",
+      kind: "surface",
+      pane: "pane:right",
     });
   });
 
@@ -965,7 +1042,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
-  it("repairs a contaminated non-lead unknown worker zone instead of docking into it", () => {
+  it("docks into a contaminated right-column worker zone rather than creating a third column", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orchestrator"]),
       makePane("pane:right", 1, ["surface:unknown-worker", "surface:shell"]),
@@ -988,8 +1065,7 @@ describe("layout policy", () => {
     );
 
     expect(placement).toEqual({
-      kind: "split",
-      direction: "right",
+      kind: "surface",
       pane: "pane:right",
     });
   });


### PR DESCRIPTION
## Summary
- Make worker placement structural once a workspace has at least two columns: workers tab into a non-lead pane in the rightmost column instead of creating a new column.
- Keep worker-dock and worker-zone checks as ordering preferences inside the right column, with splits reserved for single-column layouts or all-lead right columns.
- Add the live F3 incident fixture: left lead pane plus right pane with 15 non-role Judge Worker-style tabs and one worker-titled tab.

## Test plan
- [x] RED: `bun run test tests/layout-policy.test.ts -t "docks a worker into the right column despite the live non-role-majority pane"` failed with `{ kind: "split", direction: "right", pane: "pane:5" }`
- [x] GREEN: `bun run test tests/layout-policy.test.ts -t "docks a worker into the right column despite the live non-role-majority pane"`
- [x] `bun run test tests/layout-policy.test.ts`
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `git diff --check`
- [x] `cr review --plain` (no findings)
- [x] pre-push hook via `TMPDIR=/tmp git push -u origin HEAD`

@coderabbitai learn: Worker placement in cmuxlayer is structural after the F3 live gate. In any layout with two or more columns, worker spawns should dock as tabs into a non-lead pane in the rightmost column, even when that pane is mostly non-role/manual tabs. Worker-majority and worker-zone predicates are ordering preferences within the right column, not prerequisites for avoiding a split. Creating another column is reserved for single-column layouts; if every right-column pane is lead-owned, split within that right column instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn placement for all workers and overrides several parent-child and mixed-pane repair paths; behavior is heavily covered by updated tests but still affects live workspace layout.
> 
> **Overview**
> **Worker spawn placement** now treats a two-or-more-column workspace as structurally fixed: new workers tab into a **non-lead pane in the rightmost column** instead of opening another column or splitting beside a parent lead pane.
> 
> The change adds **`isLeadMajorityPane`** and an early branch in **`chooseAgentSpawnPlacement`** that derives column count from pane geometry, filters the right column to panes that are not lead-majority, then picks a target using existing dock/zone/seed ordering (worker-dock → worker zone → sparse seed → any eligible pane). If every right-column pane is lead-owned, placement **splits down within that column** rather than adding a column. **Single-column** layouts still use the prior split-right behavior.
> 
> Tests are updated to expect **surface docking** (not local splits) when a right worker column already exists—including the **F3 fixture** where the right pane is mostly non-role tabs plus one worker—and when mixed or unknown workers contaminate the left pane but a clean right column is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69eb777423a5ecb03651abe32e08e1ad84800714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worker panes to dock into the rightmost column instead of creating a new column
> - In multi-column layouts, `chooseAgentSpawnPlacement` now finds the rightmost non-lead pane in the rightmost column and returns a surface placement into it, rather than splitting to create a new column.
> - Pane selection uses a priority order: `isWorkerDockPane`, `isNonLeadWorkerZonePane`, `isSparseWorkerZoneSeedPane`, then any non-lead pane in the rightmost column.
> - If all panes in the rightmost column are lead-owned, workers split downward within that column instead of splitting right.
> - Single-column layouts retain the existing behavior of splitting right to seed the worker column.
> - Behavioral Change: workers in multi-column layouts will dock into existing right-column panes rather than spawning into new columns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69eb777.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized workspace layout management by improving element placement logic. The system now more intelligently positions elements within existing panes, reducing unnecessary layout splits and creating more organized, efficient layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->