### PR TITLE
fix(parser): recognize Cursor Agent v2026.06 chrome — agent type, fresh-boot ready, done evidence (F1)

### DIFF
--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -25,8 +25,18 @@ const CLAUDE_ACTIVE_RE =
 
 const CURSOR_ACTIVE_RE =
   /(?:^|\n)[^\S\r\n]*(?:(?:[⠀-⣿]+|⬢|⬡|•)[^\S\r\n]*)?(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating|Thinking|Waiting)\b(?:\.\.\.|…)?(?:[^\S\r\n]+[0-9][0-9,]*(?:\.[0-9]+)?[km]?[^\S\r\n]+tokens\b|[^\S\r\n]*(?=\r?(?:\n|$)))/i;
-const CURSOR_READY_RE =
-  /cursor>|⬡\s+Idle\b|→\s*Add a follow-up|\/ commands · @ files · ! shell|(?:^|\n)\s*(?:Auto|Agent)\s*·\s*\d+(?:\.\d+)?\s*%\s*·[^\n]*files? edited\b/i;
+const CURSOR_READY_RE = new RegExp(
+  [
+    String.raw`cursor>`,
+    String.raw`⬡\s+Idle\b`,
+    String.raw`→\s*Add a follow-up`,
+    String.raw`\/ commands · @ files · ! shell`,
+    String.raw`(?:^|\n)\s*(?:Auto|Agent)\s*·\s*\d+(?:\.\d+)?\s*%\s*·[^\n]*files? edited\b`,
+    String.raw`(?=[\s\S]*(?:^|\n)\s*Cursor Agent\s*(?:\n|$))(?=[\s\S]*(?:^|\n)\s*(?:v20\d{2}\.\d{2}\.\d{2}-[a-f0-9]+|Use\s+\/plan to iterate\b|→\s+Plan, search, build anything|Auto(?:\s*·\s*\d+(?:\.\d+)?\s*%)?)\s*(?:\n|$))`,
+    String.raw`(?=[\s\S]*(?:^|\n)\s*→\s+Plan, search, build anything\s*(?:\n|$))(?=[\s\S]*(?:^|\n)\s*Auto(?:\s*·\s*\d+(?:\.\d+)?\s*%)?\s*(?:\n|$))`,
+  ].join("|"),
+  "i",
+);
 
 export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
   claude: {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -179,7 +179,7 @@ function normalizeText(text: string): string {
 function isCursorAgentScreen(text: string): boolean {
   if (CURSOR_MODE_BAR_RE.test(text)) return true;
   if (CURSOR_FOLLOWUP_RE.test(text) && CURSOR_STOP_RE.test(text)) return true;
-  if (CURSOR_STATUS_PCT_RE.test(text) && /files edited/i.test(text)) {
+  if (CURSOR_STATUS_PCT_RE.test(text) && /files? edited/i.test(text)) {
     return true;
   }
   if (
@@ -608,6 +608,7 @@ function hasCursorChromeContext(lines: string[]): boolean {
     CURSOR_AGENT_BANNER_RE.test(text) ||
     CURSOR_MODE_BAR_RE.test(text) ||
     CURSOR_FOLLOWUP_RE.test(text) ||
+    (CURSOR_STATUS_PCT_RE.test(text) && /files? edited/i.test(text)) ||
     (CURSOR_COMPOSER_RULE_RE.test(text) && CURSOR_COMPOSER_LINE_RE.test(text))
   );
 }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -135,6 +135,17 @@ const THINKING_RE =
   /(?:^|\n)\s*(?:(?:[✻✢✳✶]\s*)?thinking(?:\s+with\s+[a-z-]+\s+effort)?(?:\s*(?:\.{3,}|…))?|(?:Reticulating splines|Perambulating|Cooked|Crunched|Razzmatazzing|Schlepping|Nucleating|Seasoning)(?:\s*(?:\.{3,}|…))?|(?:⬡\s*)?(?:Running|Generating)(?:\s*(?:\.{3,}|…))?\s+[0-9][0-9,]*(?:\.[0-9]+)?[km]?\s+tokens)\s*$/im;
 
 /** Cursor Agent CLI — mode bar, hex status, context strip, follow-up prompt */
+const CURSOR_AGENT_BANNER_RE = /(?:^|\n)\s*Cursor Agent\s*(?:\n|$)/i;
+const CURSOR_VERSION_RE =
+  /(?:^|\n)\s*v20\d{2}\.\d{2}\.\d{2}-[a-f0-9]+\s*(?:\n|$)/i;
+const CURSOR_PLAN_HINT_RE = /\bUse\s+\/plan\s+to iterate\b/i;
+const CURSOR_COMPOSER_RULE_RE = /(?:^|\n)\s*[▄▀]{12,}\s*(?:\n|$)/;
+const CURSOR_COMPOSER_LINE_RE =
+  /(?:^|\n)\s*→\s+(?:Plan, search, build anything|[^\n]+)\s*(?:\n|$)/;
+const CURSOR_AUTO_FOOTER_RE =
+  /(?:^|\n)\s*Auto(?:\s*·\s*\d+(?:\.\d+)?\s*%)?(?:\s*·[^\n]*)?\s*(?:\n|$)/i;
+const CURSOR_CWD_FOOTER_RE =
+  /(?:^|\n)\s*(?:~|\/)[^\n]*\s+·\s+[^\n]+\s*(?:\n|$)/;
 const CURSOR_MODE_BAR_RE =
   /\/ commands · @ files · ! shell · ctrl\+r to review edits/i;
 const CURSOR_HEX_RUNNING_RE = /⬡\s+Running\.\.\./i;
@@ -174,6 +185,24 @@ function isCursorAgentScreen(text: string): boolean {
   if (
     (CURSOR_HEX_RUNNING_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) &&
     CURSOR_TOKEN_LINE_RE.test(text)
+  ) {
+    return true;
+  }
+  if (
+    CURSOR_AGENT_BANNER_RE.test(text) &&
+    (CURSOR_VERSION_RE.test(text) ||
+      CURSOR_PLAN_HINT_RE.test(text) ||
+      (CURSOR_COMPOSER_RULE_RE.test(text) &&
+        CURSOR_COMPOSER_LINE_RE.test(text)) ||
+      CURSOR_AUTO_FOOTER_RE.test(text))
+  ) {
+    return true;
+  }
+  if (
+    CURSOR_COMPOSER_RULE_RE.test(text) &&
+    CURSOR_COMPOSER_LINE_RE.test(text) &&
+    CURSOR_AUTO_FOOTER_RE.test(text) &&
+    CURSOR_CWD_FOOTER_RE.test(text)
   ) {
     return true;
   }
@@ -274,6 +303,10 @@ function parseDoneSignal(text: string): string | null {
 function isUnsafeDoneSignalContext(lines: string[], index: number): boolean {
   const immediateTail = lines.slice(Math.max(0, index - 3), index);
   const immediateText = immediateTail.join("\n");
+  const hasPostDoneCursorComposer = hasCursorComposerAfterDoneSignal(
+    lines,
+    index,
+  );
 
   if (
     CODEX_WORKING_RE.test(immediateText) ||
@@ -285,7 +318,9 @@ function isUnsafeDoneSignalContext(lines: string[], index: number): boolean {
     return true;
   }
 
-  return immediateTail.some((line) => isEchoedPromptContextLine(line));
+  return immediateTail.some((line) =>
+    isUnsafeDoneSignalContextLine(line, hasPostDoneCursorComposer),
+  );
 }
 
 function isEchoedPromptContextLine(line: string): boolean {
@@ -306,6 +341,41 @@ function isEchoedPromptContextLine(line: string): boolean {
     (/\bon its own line\b/i.test(line) &&
       (hasInstructionVerb || hasDoneToken || /\bdone signal\b/i.test(line))) ||
     (/\bdone signal\b/i.test(line) && (hasInstructionVerb || hasDoneToken))
+  );
+}
+
+function isUnsafeDoneSignalContextLine(
+  line: string,
+  hasPostDoneCursorComposer: boolean,
+): boolean {
+  if (!isEchoedPromptContextLine(line)) return false;
+
+  // Cursor v2026 can leave the submitted task text in the transcript above the
+  // real output line, then render a fresh composer below. That transcript line
+  // is safe; actual composer/box lines before a done token remain unsafe.
+  if (hasPostDoneCursorComposer && !isComposerLine(line)) {
+    return false;
+  }
+
+  return true;
+}
+
+function hasCursorComposerAfterDoneSignal(
+  lines: string[],
+  index: number,
+): boolean {
+  const tail = lines.slice(index + 1).join("\n");
+  return (
+    CURSOR_COMPOSER_RULE_RE.test(tail) &&
+    CURSOR_COMPOSER_LINE_RE.test(tail) &&
+    CURSOR_AUTO_FOOTER_RE.test(tail)
+  );
+}
+
+function isComposerLine(line: string): boolean {
+  return (
+    /^\s*(?:→|>|[│┃║])\s+/.test(line) ||
+    /^\s*(?:╭|╰|┌|└|├|┬|┴|┼)/.test(line)
   );
 }
 
@@ -519,6 +589,9 @@ function isDoneSignalTailChromeLine(line: string): boolean {
     CURSOR_FOLLOWUP_RE.test(line) ||
     CURSOR_STOP_RE.test(line) ||
     CURSOR_STATUS_PCT_RE.test(line) ||
+    CURSOR_AUTO_FOOTER_RE.test(line) ||
+    CURSOR_CWD_FOOTER_RE.test(line) ||
+    CURSOR_COMPOSER_LINE_RE.test(line) ||
     CURSOR_HEX_IDLE_RE.test(line)
   );
 }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -290,7 +290,7 @@ function parseDoneSignal(text: string): string | null {
       return `CLAUDE_COUNTER:${claudeCounter}`;
     }
 
-    if (isDoneSignalTailChromeLine(line)) {
+    if (isDoneSignalTailChromeLine(line, lines, i)) {
       continue;
     }
 
@@ -569,14 +569,20 @@ function parseCursorDoneSignal(text: string): string | null {
     const line = lines[i];
     if (CURSOR_SESSION_COMPLETE_RE.test(line)) return "CURSOR_SESSION_COMPLETE";
     if (CURSOR_CHECKMARK_DONE_RE.test(line)) return "CURSOR_SESSION_COMPLETE";
-    if (isDoneSignalTailChromeLine(line)) continue;
+    if (isDoneSignalTailChromeLine(line, lines, i)) continue;
     break;
   }
 
   return null;
 }
 
-function isDoneSignalTailChromeLine(line: string): boolean {
+function isDoneSignalTailChromeLine(
+  line: string,
+  lines: string[] = [line],
+  index = 0,
+): boolean {
+  const hasCursorContext = hasCursorChromeContext(lines);
+
   return (
     RULE_LINE_RE.test(line) ||
     TOKEN_USAGE_RE.test(line) ||
@@ -588,12 +594,32 @@ function isDoneSignalTailChromeLine(line: string): boolean {
     CURSOR_MODE_BAR_RE.test(line) ||
     CURSOR_FOLLOWUP_RE.test(line) ||
     CURSOR_STOP_RE.test(line) ||
-    CURSOR_STATUS_PCT_RE.test(line) ||
-    CURSOR_AUTO_FOOTER_RE.test(line) ||
-    CURSOR_CWD_FOOTER_RE.test(line) ||
-    CURSOR_COMPOSER_LINE_RE.test(line) ||
+    (hasCursorContext && CURSOR_STATUS_PCT_RE.test(line)) ||
+    (hasCursorContext && CURSOR_AUTO_FOOTER_RE.test(line)) ||
+    (hasCursorContext && CURSOR_CWD_FOOTER_RE.test(line)) ||
+    (hasCursorContext && isCursorComposerTailLine(line, lines, index)) ||
     CURSOR_HEX_IDLE_RE.test(line)
   );
+}
+
+function hasCursorChromeContext(lines: string[]): boolean {
+  const text = lines.join("\n");
+  return (
+    CURSOR_AGENT_BANNER_RE.test(text) ||
+    CURSOR_MODE_BAR_RE.test(text) ||
+    CURSOR_FOLLOWUP_RE.test(text) ||
+    (CURSOR_COMPOSER_RULE_RE.test(text) && CURSOR_COMPOSER_LINE_RE.test(text))
+  );
+}
+
+function isCursorComposerTailLine(
+  line: string,
+  lines: string[],
+  index: number,
+): boolean {
+  if (!CURSOR_COMPOSER_LINE_RE.test(line)) return false;
+  const tail = lines.slice(index).join("\n");
+  return CURSOR_COMPOSER_RULE_RE.test(tail) && CURSOR_AUTO_FOOTER_RE.test(tail);
 }
 
 function inferStatus(

--- a/tests/fixtures/cursor-2026-06-04-boot-ready.txt
+++ b/tests/fixtures/cursor-2026-06-04-boot-ready.txt
@@ -1,0 +1,10 @@
+  Cursor Agent
+  v2026.06.04-5fd875e
+  Use /plan to iterate on an implementation plan before code changes.
+
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Plan, search, build anything
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  Auto
+  ~/Gits/cmuxlayer · main

--- a/tests/fixtures/cursor-2026-06-04-task-done.txt
+++ b/tests/fixtures/cursor-2026-06-04-task-done.txt
@@ -1,0 +1,16 @@
+  Cursor Agent
+  v2026.06.04-5fd875e
+  Use /plan to iterate on an implementation plan before code changes.
+
+
+  Print exactly TASK_DONE on its own line, then stop. Do nothing else.
+
+
+  TASK_DONE
+
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Print exactly TASK_DONE on its own line, then stop. Do nothing else.
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  Auto · 19%
+  ~/Gits/cmuxlayer · main

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -1,9 +1,13 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import {
   CLI_READY_PATTERNS,
   matchReadyPattern,
   type PatternMatch,
 } from "../src/pattern-registry.js";
+
+const readFixture = (name: string) =>
+  readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
 
 describe("CLI_READY_PATTERNS", () => {
   it("has entries for all supported CLIs", () => {
@@ -228,6 +232,19 @@ ctrl+c to stop
 `,
     );
     expect(result.matched).toBe(true);
+  });
+
+  it("matches Cursor Agent v2026.06.04 fresh-boot ready chrome", () => {
+    const result = matchReadyPattern(
+      "cursor",
+      readFixture("cursor-2026-06-04-boot-ready.txt"),
+    );
+
+    expect(result).toEqual<PatternMatch>({
+      matched: true,
+      confidence: "high",
+      consecutive: 1,
+    });
   });
 
   it("does not match active Cursor generation as ready", () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -466,6 +466,19 @@ Using claude-sonnet-4-20250514
     expect(parsed.context_pct).toBe(19);
   });
 
+  it("parses Cursor TASK_DONE before a legacy status footer without mode chrome", () => {
+    const parsed = parseScreen(`
+Auto · 10% · 2 files edited
+TASK_DONE
+Auto · 10% · 2 files edited
+`);
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("done");
+    expect(parsed.done_signal).toBe("TASK_DONE");
+    expect(parsed.context_pct).toBe(10);
+  });
+
   it.each([
     ["Claude thinking indicator", "✶ thinking"],
     ["Claude high-effort thinking indicator", "thinking with high effort"],

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   parseScreen,
@@ -5,6 +6,9 @@ import {
   resolveModelMax,
   inferContextWindow,
 } from "../src/screen-parser.js";
+
+const readFixture = (name: string) =>
+  readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
 
 describe("parseScreen", () => {
   it("parses Claude-style output with response block and done signal", () => {
@@ -424,6 +428,30 @@ Using claude-sonnet-4-20250514
 
     expect(parsed.agent_type).toBe("cursor");
     expect(parsed.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("parses Cursor Agent v2026.06.04 fresh-boot ready chrome", () => {
+    const parsed = parseScreen(
+      readFixture("cursor-2026-06-04-boot-ready.txt"),
+    );
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.model).toBeNull();
+    expect(parsed.context_pct).toBeNull();
+  });
+
+  it("parses Cursor Agent v2026.06.04 standalone TASK_DONE output evidence", () => {
+    const parsed = parseScreen(
+      readFixture("cursor-2026-06-04-task-done.txt"),
+    );
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("done");
+    expect(parsed.done_signal).toBe("TASK_DONE");
+    expect(parsed.model).toBeNull();
+    expect(parsed.context_pct).toBe(19);
   });
 
   it.each([

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -258,6 +258,18 @@ TASK_DONE
     expect(parsed.status).toBe("done");
   });
 
+  it("does not revive stale done evidence when later output starts with an arrow", () => {
+    const parsed = parseScreen(`
+gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer
+TASK_DONE
+→ Later output from the agent
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.done_signal).toBeNull();
+    expect(parsed.status).not.toBe("done");
+  });
+
   it("does not treat a done token as output while the current tail is still working", () => {
     const parsed = parseScreen(`
 gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer


### PR DESCRIPTION
## Summary
- classify Cursor Agent v2026.06.04 boot/task screens as `cursor` using banner/version/composer/footer anchors
- match fresh-boot Cursor ready chrome with the `/plan` placeholder and bare `Auto` footer while preserving active suppression
- parse standalone `TASK_DONE` output above Cursor composer/footer chrome and retain echoed composer protection

## Test plan
- `bun run test tests/screen-parser.test.ts tests/pattern-registry.test.ts` → 93 tests passed
- `bun run test` → 44 test files, 732 tests passed
- `bun run typecheck` → passed
- `cr review --plain` → no findings after clarification commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal parsing used for agent idle/done orchestration; mistakes could cause false ready or missed done signals, but behavior is heavily fixture-tested.
> 
> **Overview**
> **Cursor Agent v2026.06** screens (banner, version, `/plan` hint, composer box, `Auto` / cwd footers) are now treated as **cursor** and as **idle/ready**, including fresh-boot layouts that no longer show the legacy follow-up or mode bar.
> 
> **Ready detection** expands `CURSOR_READY_RE` with lookaheads for the new boot and composer chrome while still blocking matches when generation/spinner activity is present.
> 
> **Done-signal parsing** skips new Cursor footer/composer lines only when the buffer actually looks like Cursor chrome, so bare `Auto · N%` footers do not hide a real `TASK_DONE`. When a done token is followed by a fresh composer, echoed task text above the token is no longer treated as unsafe prompt context; composer-shaped lines still are.
> 
> Fixtures and tests cover v2026.06.04 boot-ready and task-done captures plus a regression where trailing `→` output must not revive a stale done token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7052c86ba646e022d59b52b4d042aff025ffb14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix parser to recognize Cursor Agent v2026.06 boot chrome and done signal evidence
> - Adds regex constants for Cursor Agent v2026 UI elements (banner, version line, plan hint, composer rule/line, Auto footer, cwd footer) to [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/142/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) and [pattern-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/142/files#diff-1f1872f4b73cb466921af9511f51f36eab87d558851ccc6f9e68a0a552286b4a).
> - Extends `isCursorAgentScreen` to classify v2026 boot screens as Cursor agent type when banner+version/plan/composer/Auto chrome is present.
> - Fixes `isUnsafeDoneSignalContext` to allow a valid done token when the only preceding echoed line is a safe transcript line and a Cursor composer appears after the done token; true composer/box lines still block it.
> - Improves `isDoneSignalTailChromeLine` to gate status percentage and Auto/cwd footer filtering on detected Cursor chrome context, and to coherently filter composer tail blocks.
> - Adds fixture files for a v2026.06.04 boot-ready screen and a standalone `TASK_DONE` transcript with composer chrome, plus tests covering all new detection paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7052c86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->