### PR TITLE
fix(engine): stop_agent resolves aliased agent ids like every other tool (F4)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1480,7 +1480,11 @@ export class AgentEngine {
   }
 
   resolveAgentRoute(agentId: string): AgentRoute {
-    return resolvePublicAgentRoute(this.listAgents(), agentId);
+    const agent = this.registry.get(agentId);
+    if (!agent) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    return resolvePublicAgentRoute(this.listAgents(), agent.agent_id);
   }
 
   /**
@@ -1491,7 +1495,9 @@ export class AgentEngine {
     force?: boolean,
     opts?: { userInitiated?: boolean },
   ): Promise<void> {
-    const agent = this.registry.get(agentId);
+    const route = this.resolveAgentRoute(agentId);
+    const canonicalAgentId = route.agent_id;
+    const agent = this.registry.get(canonicalAgentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -1500,10 +1506,10 @@ export class AgentEngine {
 
     if (TERMINAL_STATES.has(agent.state)) {
       if (agent.state === "error" && userInitiated && agent.user_killed !== true) {
-        const marked = this.stateMgr.updateRecord(agentId, {
+        const marked = this.stateMgr.updateRecord(canonicalAgentId, {
           user_killed: true,
         });
-        this.registry.set(agentId, marked);
+        this.registry.set(canonicalAgentId, marked);
       }
       return; // Already stopped
     }
@@ -1516,31 +1522,31 @@ export class AgentEngine {
       }
     } else {
       // Graceful: send Ctrl+C
-      await this.client.sendKey(agent.surface_id, "c-c", {
-        workspace: agent.workspace_id ?? undefined,
+      await this.client.sendKey(route.surface_id, "c-c", {
+        workspace: route.workspace_id ?? undefined,
       });
     }
 
-    const current = this.registry.get(agentId) ?? agent;
+    const current = this.registry.get(canonicalAgentId) ?? agent;
     let marked = current;
     if ((current.user_killed ?? false) !== userInitiated) {
-      marked = this.stateMgr.updateRecord(agentId, {
+      marked = this.stateMgr.updateRecord(canonicalAgentId, {
         user_killed: userInitiated,
       });
-      this.registry.set(agentId, marked);
+      this.registry.set(canonicalAgentId, marked);
     }
 
     // Transition to done
     try {
-      const updated = this.stateMgr.transition(agentId, "done");
-      this.registry.set(agentId, updated);
+      const updated = this.stateMgr.transition(canonicalAgentId, "done");
+      this.registry.set(canonicalAgentId, updated);
     } catch {
       // If transition to done fails (e.g. from error state), try error
       try {
-        const updated = this.stateMgr.transition(agentId, "error", {
+        const updated = this.stateMgr.transition(canonicalAgentId, "error", {
           error: "Force stopped",
         });
-        this.registry.set(agentId, updated);
+        this.registry.set(canonicalAgentId, updated);
       } catch {
         // State is already terminal — that's fine
       }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1226,12 +1226,12 @@ export class AgentEngine {
       if (parent.spawn_depth >= MAX_SPAWN_DEPTH) {
         throw new Error(`Max spawn depth exceeded: ${MAX_SPAWN_DEPTH}`);
       }
-      const children = this.registry.getChildren(params.parent_agent_id);
+      const children = this.registry.getChildren(parent.agent_id);
       if (children.length >= MAX_CHILDREN) {
         throw new Error(`Max children exceeded: ${MAX_CHILDREN}`);
       }
       spawnDepth = parent.spawn_depth + 1;
-      parentAgentId = params.parent_agent_id;
+      parentAgentId = parent.agent_id;
       parentAgent = parent;
     }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -145,6 +145,32 @@ export class AgentRegistry {
     return current;
   }
 
+  private aliasesResolvingTo(agentId: string): string[] {
+    const aliases: string[] = [];
+    for (const [alias, target] of this.aliases) {
+      if (
+        alias === agentId ||
+        target === agentId ||
+        this.resolveAlias(alias) === agentId
+      ) {
+        aliases.push(alias);
+      }
+    }
+    return aliases;
+  }
+
+  private deleteAgentAndAliases(agentId: string): string {
+    const resolved = this.resolveAlias(agentId);
+    const aliases = this.aliasesResolvingTo(resolved);
+    this.agents.delete(resolved);
+    this.aliases.delete(agentId);
+    this.aliases.delete(resolved);
+    for (const alias of aliases) {
+      this.aliases.delete(alias);
+    }
+    return resolved;
+  }
+
   get(agentId: string): AgentRecord | null {
     return this.agents.get(this.resolveAlias(agentId)) ?? null;
   }
@@ -187,8 +213,8 @@ export class AgentRegistry {
         !discoveredEntry.read_error &&
         !discoveredEntry.has_agent
       ) {
-        this.agents.delete(record.agent_id);
-        this.stateMgr.removeState(record.agent_id);
+        const removedAgentId = this.deleteAgentAndAliases(record.agent_id);
+        this.stateMgr.removeState(removedAgentId);
         continue;
       }
 
@@ -362,14 +388,7 @@ export class AgentRegistry {
   }
 
   remove(agentId: string): void {
-    const resolved = this.resolveAlias(agentId);
-    this.agents.delete(resolved);
-    this.aliases.delete(agentId);
-    for (const [alias, target] of this.aliases) {
-      if (target === resolved) {
-        this.aliases.delete(alias);
-      }
-    }
+    this.deleteAgentAndAliases(agentId);
   }
 
   private evictMissingStateAgent(agentId: string): boolean {
@@ -377,8 +396,8 @@ export class AgentRegistry {
       return false;
     }
 
-    this.agents.delete(agentId);
-    this.stateMgr.removeState(agentId);
+    const removedAgentId = this.deleteAgentAndAliases(agentId);
+    this.stateMgr.removeState(removedAgentId);
     return true;
   }
 
@@ -426,8 +445,8 @@ export class AgentRegistry {
         // Best-effort transition before eviction.
       }
 
-      this.agents.delete(id);
-      this.stateMgr.removeState(id);
+      const removedAgentId = this.deleteAgentAndAliases(id);
+      this.stateMgr.removeState(removedAgentId);
     }
   }
 
@@ -452,9 +471,9 @@ export class AgentRegistry {
         continue;
       }
       if (TERMINAL_STATES.has(agent.state)) {
-        this.agents.delete(id);
-        this.stateMgr.removeState(id);
-        purgedIds.push(id);
+        const removedAgentId = this.deleteAgentAndAliases(id);
+        this.stateMgr.removeState(removedAgentId);
+        purgedIds.push(removedAgentId);
       }
     }
 
@@ -479,8 +498,8 @@ export class AgentRegistry {
         TERMINAL_STATES.has(agent.state) &&
         !liveSurfaceRefs.has(agent.surface_id)
       ) {
-        this.agents.delete(id);
-        this.stateMgr.removeState(id);
+        const removedAgentId = this.deleteAgentAndAliases(id);
+        this.stateMgr.removeState(removedAgentId);
         purged++;
       }
     }
@@ -504,6 +523,10 @@ export class AgentRegistry {
   getSubtree(rootId: string): AgentRecord[] {
     const result: AgentRecord[] = [];
     const visited = new Set<string>();
+    const root = this.get(rootId);
+    if (!root) {
+      return result;
+    }
     const collect = (id: string) => {
       if (visited.has(id)) return; // Prevent cycles from corrupted state
       visited.add(id);
@@ -514,7 +537,7 @@ export class AgentRegistry {
       const agent = this.agents.get(id);
       if (agent) result.push(agent);
     };
-    collect(rootId);
+    collect(root.agent_id);
     return result;
   }
 }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -511,8 +511,17 @@ export class AgentRegistry {
    * Get direct children of parentId.
    */
   getChildren(parentId: string): AgentRecord[] {
+    const parentIds = new Set<string>([parentId]);
+    const parent = this.get(parentId);
+    if (parent) {
+      parentIds.add(parent.agent_id);
+      for (const alias of this.aliasesResolvingTo(parent.agent_id)) {
+        parentIds.add(alias);
+      }
+    }
+
     return [...this.agents.values()].filter(
-      (a) => a.parent_agent_id === parentId,
+      (a) => a.parent_agent_id !== null && parentIds.has(a.parent_agent_id),
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4218,9 +4218,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         try {
           const merged = await registry.listMerged(discovery);
           const agents = args.parent_agent_id
-            ? merged.filter(
-                (agent) => agent.parent_agent_id === args.parent_agent_id,
-              )
+            ? (() => {
+                const childIds = new Set(
+                  registry
+                    .getChildren(args.parent_agent_id)
+                    .map((agent) => agent.agent_id),
+                );
+                return merged.filter((agent) => childIds.has(agent.agent_id));
+              })()
             : merged.filter((agent) => agent.parent_agent_id === null);
 
           const SCREEN_TIMEOUT = 3000;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2216,6 +2216,34 @@ To continue this session, run codex resume ${sessionId}`,
       expect(state!.state).toBe("done");
     });
 
+    it("resolves provisional agent aliases before stopping", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-pending",
+          state: "working",
+          surface_id: "surface:42",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+      const renamed = stateMgr.renameState("agent-pending", "agent-final");
+      engine.getRegistry().rename("agent-pending", "agent-final", renamed);
+
+      await engine.stopAgent("agent-pending");
+
+      expect(mockClient.sendKey).toHaveBeenCalledWith(
+        "surface:42",
+        "c-c",
+        expect.anything(),
+      );
+      expect(stateMgr.readState("agent-final")).toMatchObject({
+        agent_id: "agent-final",
+        state: "done",
+        user_killed: true,
+      });
+      expect(stateMgr.readState("agent-pending")).toBeNull();
+    });
+
     it("force stop kills the process when pid is available", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-hierarchy.test.ts
+++ b/tests/agent-hierarchy.test.ts
@@ -332,6 +332,36 @@ describe("Agent Hierarchy", () => {
       stopAgent.mockRestore();
     });
 
+    it("cascadeKill resolves aliases before collecting the subtree", async () => {
+      const stoppedOrder: string[] = [];
+      const stopAgent = vi
+        .spyOn(engine, "stopAgent")
+        .mockImplementation(async (agentId) => {
+          stoppedOrder.push(agentId);
+        });
+
+      stateMgr.writeState(
+        makeRecord({ agent_id: "root-pending", surface_id: "s:1" }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "child1",
+          surface_id: "s:2",
+          parent_agent_id: "root-pending",
+          spawn_depth: 1,
+        }),
+      );
+      liveSurfaces = [makeSurface("s:1"), makeSurface("s:2")];
+      await engine.getRegistry().reconstitute();
+      const renamed = stateMgr.renameState("root-pending", "root-final");
+      engine.getRegistry().rename("root-pending", "root-final", renamed);
+
+      await engine.cascadeKill("root-pending");
+
+      expect(stoppedOrder).toEqual(["child1", "root-final"]);
+      stopAgent.mockRestore();
+    });
+
     it("cascadeKill continues if one child stop fails", async () => {
       let callCount = 0;
       const stopAgent = vi

--- a/tests/agent-hierarchy.test.ts
+++ b/tests/agent-hierarchy.test.ts
@@ -362,6 +362,35 @@ describe("Agent Hierarchy", () => {
       stopAgent.mockRestore();
     });
 
+    it("cascadeKill includes children spawned through a finalized parent's pending alias", async () => {
+      stateMgr.writeState(
+        makeRecord({ agent_id: "root-pending", surface_id: "s:1" }),
+      );
+      liveSurfaces = [makeSurface("s:1")];
+      await engine.getRegistry().reconstitute();
+      const renamed = stateMgr.renameState("root-pending", "root-final");
+      engine.getRegistry().rename("root-pending", "root-final", renamed);
+
+      const child = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Fix gap F",
+        parent_agent_id: "root-pending",
+      });
+      const stoppedOrder: string[] = [];
+      const stopAgent = vi
+        .spyOn(engine, "stopAgent")
+        .mockImplementation(async (agentId) => {
+          stoppedOrder.push(agentId);
+        });
+
+      await engine.cascadeKill("root-pending");
+
+      expect(stoppedOrder).toEqual([child.agent_id, "root-final"]);
+      stopAgent.mockRestore();
+    });
+
     it("cascadeKill continues if one child stop fails", async () => {
       let callCount = 0;
       const stopAgent = vi

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -307,5 +307,37 @@ describe("AgentRegistry", () => {
       expect(purged).toBe(1);
       expect(registry.get("stale-recovery-error")).toBeNull();
     });
+
+    it("clears aliases that point at purged finalized agents", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-pending",
+          state: "done",
+          surface_id: "surface:gone",
+        }),
+      );
+
+      const surfaceProvider = async () => [] as CmuxSurface[];
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+      const renamed = stateMgr.renameState("agent-pending", "agent-final");
+      registry.rename("agent-pending", "agent-final", renamed);
+
+      const purged = await registry.purgeTerminal();
+      registry.set(
+        "agent-pending",
+        makeRecord({
+          agent_id: "agent-pending",
+          state: "working",
+          surface_id: "surface:new",
+        }),
+      );
+
+      expect(purged).toBe(1);
+      expect(registry.get("agent-pending")).toMatchObject({
+        agent_id: "agent-pending",
+        surface_id: "surface:new",
+      });
+    });
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1385,6 +1385,49 @@ describe("agent lifecycle tool handlers", () => {
     expect(data.parent_agent_id).toBe(parentId);
   });
 
+  it("my_agents resolves finalized parents through their pending aliases", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const myAgents = (server as any)._registeredTools["my_agents"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const parentResult = await spawn.handler(
+      {
+        repo: "orchestrator",
+        model: "opus",
+        cli: "claude",
+        prompt: "orchestrate",
+      },
+      {} as any,
+    );
+    const pendingParentId = parentResult.structuredContent.agent_id;
+    const finalParentId = "orchestratorClaude-session1";
+    const renamed = engine.stateMgr.renameState(pendingParentId, finalParentId);
+    engine
+      .getRegistry()
+      .rename(pendingParentId, finalParentId, renamed);
+
+    await spawn.handler(
+      {
+        repo: "voicelayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "fix",
+        parent_agent_id: pendingParentId,
+      },
+      {} as any,
+    );
+
+    const result = await myAgents.handler(
+      { parent_agent_id: pendingParentId },
+      {} as any,
+    );
+    const data = result.structuredContent;
+    expect(data.count).toBe(1);
+    expect(data.agents[0].repo).toBe("voicelayer");
+    expect(data.parent_agent_id).toBe(pendingParentId);
+  });
+
   it("my_agents returns empty array for nonexistent parent (orphan-safe)", async () => {
     const server = createLifecycleServer(mockExec);
     const myAgents = (server as any)._registeredTools["my_agents"];

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -72,6 +72,13 @@ function createV2Server(exec: ExecFn) {
   });
 }
 
+function finalizeAgentAlias(server: any, pendingId: string, finalId: string) {
+  const engine = server._registeredTools["interact"]._engine;
+  const renamed = engine.stateMgr.renameState(pendingId, finalId);
+  engine.getRegistry().rename(pendingId, finalId, renamed);
+  return engine;
+}
+
 describe("V2 tool registration", () => {
   it("registers interact and kill tools", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
@@ -232,6 +239,30 @@ describe("interact — agent resolution", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
   });
+
+  it("send resolves a finalized agent through its pending alias", async () => {
+    const spawnResult = await callTool(server, "spawn_agent", {
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+    });
+    const pendingId = parseResult(spawnResult).agent_id;
+    const finalId = "brainlayerClaude-session1";
+    const engine = finalizeAgentAlias(server, pendingId, finalId);
+    const registry = engine.getRegistry();
+    const agent = registry.get(pendingId);
+    registry.set(finalId, { ...agent, state: "ready" });
+
+    const result = await callTool(server, "interact", {
+      agent: pendingId,
+      action: "send",
+      text: "fix gap F",
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(pendingId);
+  });
 });
 
 describe("kill — scoped targets", () => {
@@ -263,6 +294,24 @@ describe("kill — scoped targets", () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.killed).toContain(agentId);
+  });
+
+  it("kill resolves a finalized agent through its pending alias", async () => {
+    const spawn = await callTool(server, "spawn_agent", {
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+    });
+    const pendingId = parseResult(spawn).agent_id;
+    finalizeAgentAlias(server, pendingId, "brainlayerClaude-session1");
+
+    const result = await callTool(server, "kill", {
+      target: pendingId,
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.killed).toContain(pendingId);
   });
 
   it("kill multiple agents by array", async () => {


### PR DESCRIPTION
## Summary
- resolve public agent routes through the alias-aware registry path before building route data
- make stopAgent mutate canonical state IDs while still accepting pending aliases
- make registry purge/removal paths clear aliases pointing at deleted finalized records
- cover cascadeKill, interact(send), and kill alias behavior at the engine/server boundaries

## Test plan
- [x] RED: `bun run test tests/agent-engine.test.ts tests/agent-hierarchy.test.ts tests/agent-registry.test.ts` failed before the registry cleanup fix for cascadeKill alias traversal and purge alias cleanup
- [x] `bun run test tests/agent-engine.test.ts tests/agent-hierarchy.test.ts tests/agent-registry.test.ts tests/v2-interact-kill.test.ts`
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] pre-push hook (`scripts/run_tests.sh`) passed race fixtures + full Vitest

## Notes
- CodeRabbit CLI local pre-commit review was attempted with `cr review --plain`; it returned review-limit reached and produced no findings.
- The active local Codex/Claude MCP config points cmux to `/Users/etanheyman/Gits/cmuxlayer/dist/index.js`, not this worktree's rebuilt dist, so no branch-specific live MCP session gate is claimed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent stop/kill, subtree traversal, and registry eviction paths; behavior change is scoped and heavily tested but affects core orchestration.
> 
> **Overview**
> **Agent lifecycle tools now treat pending and finalized agent IDs as the same handle**, fixing cases where an agent was renamed after session capture but callers still used the provisional ID.
> 
> `stopAgent` resolves routes through the alias-aware registry before sending Ctrl+C and updating state, matching `send_to` / `interact`. `resolveAgentRoute` fails fast when the ID is unknown, then routes using the **canonical** `agent_id`. Spawn parent checks and child limits use the resolved parent record.
> 
> **Registry cleanup and hierarchy** walk alias maps: removing or purging an agent clears every alias pointing at it (so a stale pending ID cannot resurrect a ghost). `getChildren` and `getSubtree` match children registered under a parent's provisional ID, which fixes `cascadeKill` and **`my_agents`** when filtering by a pending parent alias.
> 
> Tests cover stop, kill, interact send, cascade kill, purge, and `my_agents` with rename flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981c72be4319c276666ae9d68664cbe0188ff951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `stopAgent` and related agent tools to resolve aliased/provisional agent IDs
> - `AgentEngine.stopAgent` now resolves the canonical agent ID via `resolveAgentRoute` before sending Ctrl+C, updating state, or writing to the registry, matching the behavior of other agent tools.
> - `AgentEngine.resolveAgentRoute` resolves aliases to canonical IDs and throws on unknown IDs instead of silently operating on stale or provisional IDs.
> - `AgentRegistry` gains a `deleteAgentAndAliases` helper used across `remove`, `reconcileSurfaces`, `evictMissingStateAgent`, `purgeAllTerminal`, and `purgeTerminal` to ensure alias entries are cleaned up alongside agent records.
> - `AgentRegistry.getChildren` and `getSubtree` are now alias-aware, so children spawned under a provisional parent ID are correctly discovered when the parent is later finalized.
> - The `my_agents` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/143/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) uses `registry.getChildren` for alias-aware child filtering when a `parent_agent_id` is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 981c72b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->