### PR TITLE
fix(engine): resolve pending agent ids consistently across spawn finalization, stop, and evidence transitions (G1)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -16,7 +16,6 @@ import {
 } from "./agent-command.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import {
-  resolveAgentRoute as resolvePublicAgentRoute,
   toPublicAgent,
 } from "./agent-facade.js";
 import type {
@@ -762,12 +761,8 @@ export class AgentEngine {
 
   private async maybeMarkTaskDone(
     agent: AgentRecord,
-    opts?: { allowBootPromptPending?: boolean },
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
     if (TERMINAL_STATES.has(agent.state)) return { agent };
-    if (agent.boot_prompt_pending && opts?.allowBootPromptPending !== true) {
-      return { agent };
-    }
 
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
@@ -799,6 +794,7 @@ export class AgentEngine {
       const marked = this.stateMgr.updateRecord(agent.agent_id, {
         task_done_candidate_at: null,
         task_done_detected_at: new Date().toISOString(),
+        ...(agent.boot_prompt_pending ? { boot_prompt_pending: false } : {}),
       });
       this.registry.set(agent.agent_id, marked);
       const updated = this.stateMgr.transition(agent.agent_id, "done");
@@ -1484,7 +1480,17 @@ export class AgentEngine {
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
-    return resolvePublicAgentRoute(this.listAgents(), agent.agent_id);
+    const resumeCommand = agent.cli_session_id
+      ? buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id)
+      : undefined;
+    return {
+      agent_id: agent.agent_id,
+      surface_id: agent.surface_id,
+      workspace_id: agent.workspace_id ?? null,
+      state: agent.state,
+      session_id: agent.cli_session_id,
+      ...(resumeCommand ? { resume_command: resumeCommand } : {}),
+    };
   }
 
   /**

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -45,11 +45,46 @@ export class StateManager {
     return this.eventLog;
   }
 
+  private stateFilePath(dirName: string): string {
+    return join(this.baseDir, dirName, "state.json");
+  }
+
+  private readStateFromDir(dirName: string): AgentRecord | null {
+    const stateFile = this.stateFilePath(dirName);
+    if (!existsSync(stateFile)) return null;
+    try {
+      return JSON.parse(readFileSync(stateFile, "utf-8")) as AgentRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  private resolveStateDir(agentId: string): string | null {
+    if (existsSync(this.stateFilePath(agentId))) {
+      return agentId;
+    }
+    if (!existsSync(this.baseDir)) {
+      return null;
+    }
+
+    const entries = readdirSync(this.baseDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === agentId) continue;
+      const record = this.readStateFromDir(entry.name);
+      if (record?.agent_id === agentId) {
+        return entry.name;
+      }
+    }
+
+    return null;
+  }
+
   writeState(record: AgentRecord): void {
     const agentDir = join(this.baseDir, record.agent_id);
     mkdirSync(agentDir, { recursive: true });
 
-    const stateFile = join(agentDir, "state.json");
+    const stateFile = this.stateFilePath(record.agent_id);
     const tmpFile = join(agentDir, "state.json.tmp");
 
     writeFileSync(tmpFile, JSON.stringify(record, null, 2), "utf-8");
@@ -68,13 +103,8 @@ export class StateManager {
   }
 
   readState(agentId: string): AgentRecord | null {
-    const stateFile = join(this.baseDir, agentId, "state.json");
-    if (!existsSync(stateFile)) return null;
-    try {
-      return JSON.parse(readFileSync(stateFile, "utf-8")) as AgentRecord;
-    } catch {
-      return null;
-    }
+    const dirName = this.resolveStateDir(agentId);
+    return dirName ? this.readStateFromDir(dirName) : null;
   }
 
   transition(
@@ -84,7 +114,8 @@ export class StateManager {
       Pick<AgentRecord, "error" | "pid" | "cli_session_id" | "cli_session_path">
     >,
   ): AgentRecord {
-    const current = this.readState(agentId);
+    const dirName = this.resolveStateDir(agentId);
+    const current = dirName ? this.readStateFromDir(dirName) : null;
     if (!current) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -106,8 +137,8 @@ export class StateManager {
         : {}),
     };
 
-    const agentDir = join(this.baseDir, agentId);
-    const stateFile = join(agentDir, "state.json");
+    const agentDir = join(this.baseDir, dirName!);
+    const stateFile = this.stateFilePath(dirName!);
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
@@ -131,7 +162,8 @@ export class StateManager {
    * Update arbitrary non-state fields on an agent record without transition validation.
    */
   updateRecord(agentId: string, fields: AgentRecordPatch): AgentRecord {
-    const current = this.readState(agentId);
+    const dirName = this.resolveStateDir(agentId);
+    const current = dirName ? this.readStateFromDir(dirName) : null;
     if (!current) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -143,8 +175,8 @@ export class StateManager {
       updated_at: new Date().toISOString(),
     };
 
-    const agentDir = join(this.baseDir, agentId);
-    const stateFile = join(agentDir, "state.json");
+    const agentDir = join(this.baseDir, dirName!);
+    const stateFile = this.stateFilePath(dirName!);
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
@@ -172,7 +204,8 @@ export class StateManager {
       return current;
     }
 
-    const current = this.readState(agentId);
+    const dirName = this.resolveStateDir(agentId);
+    const current = dirName ? this.readStateFromDir(dirName) : null;
     if (!current) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -189,12 +222,12 @@ export class StateManager {
 
     const newAgentDir = join(this.baseDir, newAgentId);
     mkdirSync(newAgentDir, { recursive: true });
-    const stateFile = join(newAgentDir, "state.json");
+    const stateFile = this.stateFilePath(newAgentId);
     const tmpFile = join(newAgentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
 
-    rmSync(join(this.baseDir, agentId), { recursive: true, force: true });
+    rmSync(join(this.baseDir, dirName!), { recursive: true, force: true });
 
     this.eventLog.append({
       ts: updated.updated_at,
@@ -222,21 +255,24 @@ export class StateManager {
     const records: AgentRecord[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const record = this.readState(entry.name);
+      const record = this.readStateFromDir(entry.name);
       if (record) records.push(record);
     }
     return records;
   }
 
   removeState(agentId: string): void {
-    const agentDir = join(this.baseDir, agentId);
-    if (!existsSync(agentDir)) return;
+    const dirName = this.resolveStateDir(agentId);
+    if (!dirName) return;
+
+    const agentDir = join(this.baseDir, dirName);
+    const current = this.readStateFromDir(dirName);
 
     this.eventLog.append({
       ts: new Date().toISOString(),
       agent_id: agentId,
       event: "removed",
-      from_state: this.readState(agentId)?.state ?? null,
+      from_state: current?.state ?? null,
       to_state: "done" as AgentState,
       surface_id: null,
       source: "removeState",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5,7 +5,7 @@ vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -1767,7 +1767,13 @@ To continue this session, run codex resume ${sessionId}`,
         liveSurfaces = [makeSurface("surface:worker-pending-prompt")];
         (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
           surface: "surface:worker-pending-prompt",
-          text: "TASK_DONE",
+          text: [
+            "gpt-5.4 xhigh · 64% left · ~/Gits/cmuxlayer",
+            "→ Implement the fix. When complete, print exactly:",
+            "TASK_DONE",
+            "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
+            "Working (1m 02s • esc to interrupt)",
+          ].join("\n"),
           lines: 20,
           scrollback_used: false,
         });
@@ -1784,6 +1790,54 @@ To continue this session, run codex resume ${sessionId}`,
         expect(agent?.boot_prompt_pending).toBe(true);
         expect(agent?.task_done_candidate_at ?? null).toBeNull();
         expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves Cursor done evidence when boot prompt pending is stale", async () => {
+      vi.useFakeTimers();
+      try {
+        const agentId = "cmuxlayerCursor-pending-1780696860-r2fu";
+        const candidateAt = new Date("2026-06-05T22:01:10.000Z");
+        vi.setSystemTime(new Date(candidateAt.getTime() + 5_001));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: agentId,
+            state: "booting",
+            surface_id: "surface:cursor-pending",
+            repo: "cmuxlayer",
+            model: "",
+            cli: "cursor",
+            role: "worker",
+            boot_prompt_pending: true,
+            task_done_candidate_at: candidateAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:cursor-pending")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:cursor-pending",
+          text: readFileSync(
+            new URL("./fixtures/cursor-2026-06-04-task-done.txt", import.meta.url),
+            "utf8",
+          ),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(agentId, "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("evidence");
+        expect(result.state).toBe("done");
+        expect(engine.getAgentState(agentId)).toMatchObject({
+          state: "done",
+          boot_prompt_pending: false,
+          task_done_detected_at: expect.any(String),
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -2242,6 +2296,52 @@ To continue this session, run codex resume ${sessionId}`,
         user_killed: true,
       });
       expect(stateMgr.readState("agent-pending")).toBeNull();
+    });
+
+    it("stops a never-renamed pending agent whose state directory is noncanonical", async () => {
+      const agentId = "cmuxlayerCursor-pending-1780696860-r2fu";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "booting",
+          surface_id: "surface:cursor-pending",
+          repo: "cmuxlayer",
+          model: "",
+          cli: "cursor",
+          role: "worker",
+          boot_prompt_pending: true,
+        }),
+      );
+      renameSync(
+        join(TEST_DIR, agentId),
+        join(TEST_DIR, `legacy-${agentId}`),
+      );
+      expect(existsSync(join(TEST_DIR, agentId, "state.json"))).toBe(false);
+      liveSurfaces = [makeSurface("surface:cursor-pending")];
+      await engine.getRegistry().reconstitute();
+
+      expect(engine.getAgentState(agentId)).toMatchObject({
+        agent_id: agentId,
+        state: "booting",
+      });
+
+      await engine.stopAgent(agentId);
+
+      expect(mockClient.sendKey).toHaveBeenCalledWith(
+        "surface:cursor-pending",
+        "c-c",
+        expect.anything(),
+      );
+      expect(engine.getAgentState(agentId)).toMatchObject({
+        agent_id: agentId,
+        state: "done",
+        user_killed: true,
+      });
+      expect(stateMgr.readState(agentId)).toMatchObject({
+        agent_id: agentId,
+        state: "done",
+        user_killed: true,
+      });
     });
 
     it("force stop kills the process when pid is available", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3,7 +3,13 @@
  * Tests tool registration and handler dispatch with mocked cmux client.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -125,6 +131,18 @@ function createLifecycleServer(exec: ExecFn) {
     disableSpawnPreflight: true,
     sessionIdentityResolver: () => null,
   });
+}
+
+function moveOnlyAgentStateDir(prefix: string) {
+  const entries = readdirSync(TEST_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name !== "events");
+  expect(entries).toHaveLength(1);
+  renameSync(
+    join(TEST_DIR, entries[0]),
+    join(TEST_DIR, `${prefix}-${entries[0]}`),
+  );
 }
 
 describe("agent lifecycle tool registration", () => {
@@ -279,6 +297,53 @@ describe("agent lifecycle tool handlers", () => {
         "return",
       ]),
     );
+  });
+
+  it("spawn_agent finalizes a pending Cursor prompt when the state directory is noncanonical", async () => {
+    let movedStateDir = false;
+    const baseExec = makeLifecycleExec();
+    mockExec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (
+        !movedStateDir &&
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "cmuxlayerCursor -s"
+      ) {
+        movedStateDir = true;
+        moveOnlyAgentStateDir("legacy");
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const stop = (server as any)._registeredTools["stop_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "",
+        cli: "cursor",
+        prompt: "Say VERIFY_OK and stop.",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toMatch(
+      /^cmuxlayerCursor-pending-\d+-[a-z0-9]+$/,
+    );
+    expect(parsed.state).toBe("ready");
+    expect(parsed.boot_prompt_delivered).toBe(true);
+
+    const stopResult = await stop.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const stopped =
+      stopResult.structuredContent ?? JSON.parse(stopResult.content[0].text);
+    expect(stopped.ok).toBe(true);
+    expect(stopped.state).toBe("done");
   });
 
   it("spawn_agent sends boot_prompt_path contents after readiness", async () => {


### PR DESCRIPTION
## Summary
- resolve agent state files by record `agent_id` when the directory key is noncanonical, so pending ids can still finalize, stop, and transition
- route agent operations directly from the registry-resolved record instead of a second public route lookup
- allow parser-confirmed `TASK_DONE` evidence to clear stale `boot_prompt_pending` and transition to done while preserving prompt-echo rejection coverage

## Test plan
- [x] RED: `bun run test tests/agent-engine.test.ts tests/server-agent-tools.test.ts` failed on the new pending-id regression cases before implementation
- [x] `bun run test tests/agent-engine.test.ts tests/server-agent-tools.test.ts`
- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `cr review --plain` (no findings)

## Notes
- Did not fold in a composer-clearing fix; the prompt echo concatenation is still worth a follow-up because clearing terminal composers safely needs a separate relay-level behavior decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core state persistence and done/stop routing for pending agents; behavior change is scoped and covered by new regression tests.
> 
> **Overview**
> Fixes agent lifecycle when on-disk state lives under a **directory name that no longer matches** the record’s `agent_id` (e.g. pending Cursor agents that never got renamed). **StateManager** now resolves state by scanning for `state.json` whose record `agent_id` matches, and uses that directory for read, transition, update, rename, and remove.
> 
> **AgentEngine** builds **agent routes** from the registry record directly (drops the facade list lookup), and **confirmed `TASK_DONE` evidence** can mark agents done even while `boot_prompt_pending` is set—clearing that flag on transition—without re-opening the prompt-echo false-positive path covered by tests.
> 
> Regression tests cover noncanonical dirs for **stop**, **spawn finalization**, and **Cursor done** detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e0f02a7cfc79cfb20a5b4603832cef3db7ce9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pending agent ID resolution across spawn finalization, stop, and evidence transitions
> - Updates [`StateManager`](https://github.com/EtanHey/cmuxlayer/pull/144/files#diff-48f5aae831d763ad62d5e44527c3e96d45cfccfa451f8f81674c26e9bb0448a8) to resolve agent state directories by scanning subdirectories for a matching `agent_id` in `state.json` when the canonical path (`baseDir/agentId`) does not exist. All state operations (`readState`, `transition`, `updateRecord`, `renameState`, `removeState`) now use this lookup.
> - Updates [`AgentEngine.maybeMarkTaskDone`](https://github.com/EtanHey/cmuxlayer/pull/144/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to mark agents as `done` even when `boot_prompt_pending` is true, clearing that flag in the same transition.
> - Behavioral Change: agents stored under noncanonical directory names are now fully visible and mutable to all state operations; previously they would fail silently or be skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80e0f02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->