### PR TITLE
fix: resolve live cmux socket path durably

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -5,14 +5,14 @@
 
 import * as net from "node:net";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
-import {
-  CmuxSocketClient,
-  type CmuxSocketClientOptions,
-} from "./cmux-socket-client.js";
-import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
+import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
+import { CmuxSocketClient } from "./cmux-socket-client.js";
+import { cmuxSocketPathCandidates } from "./cmux-socket-path.js";
 
 export interface CreateCmuxClientOptions {
   socketPath?: string;
+  /** Override cmux state dir for tests or nonstandard installs */
+  socketStateDir?: string;
   /** CLI exec function (for testing) */
   exec?: ExecFn;
   /** CLI binary name */
@@ -21,6 +21,8 @@ export interface CreateCmuxClientOptions {
   timeoutMs?: number;
   /** Password for socket access mode "password" */
   password?: string;
+  /** Boot transport logger; defaults to console */
+  logger?: Pick<Console, "error">;
 }
 
 /**
@@ -45,6 +47,55 @@ function probeSocket(path: string, timeoutMs = 1000): Promise<boolean> {
   });
 }
 
+async function resolveSocketPath(
+  opts?: Pick<
+    CreateCmuxClientOptions,
+    "socketPath" | "socketStateDir" | "timeoutMs" | "password"
+  >,
+): Promise<string | null> {
+  for (const candidate of candidateSocketPaths(opts)) {
+    if (await probeUsableSocket(candidate, opts)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function candidateSocketPaths(
+  opts?: Pick<CreateCmuxClientOptions, "socketPath" | "socketStateDir">,
+): string[] {
+  return opts?.socketPath
+    ? [opts.socketPath]
+    : cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
+}
+
+async function probeUsableSocket(
+  socketPath: string,
+  opts?: Pick<CreateCmuxClientOptions, "timeoutMs" | "password">,
+): Promise<boolean> {
+  if (!(await probeSocket(socketPath, opts?.timeoutMs))) {
+    return false;
+  }
+
+  const transport = new CmuxPersistentSocket({
+    socketPath,
+    timeoutMs: opts?.timeoutMs,
+  });
+
+  try {
+    if (opts?.password) {
+      await transport.call("auth.login", { password: opts.password });
+    }
+    const result = await transport.call<{ pong: boolean }>("system.ping");
+    return result.pong === true;
+  } catch {
+    return false;
+  } finally {
+    transport.disconnect();
+  }
+}
+
 /**
  * Create the best available cmux client.
  * Tries socket first (0.2ms per op), falls back to CLI (287ms per op).
@@ -52,29 +103,32 @@ function probeSocket(path: string, timeoutMs = 1000): Promise<boolean> {
 export async function createCmuxClient(
   opts?: CreateCmuxClientOptions,
 ): Promise<CmuxClient | CmuxSocketClient> {
-  const socketPath =
-    opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
-
-  const socketAvailable = await probeSocket(socketPath, opts?.timeoutMs);
-
+  const logger = opts?.logger ?? console;
   const cliFallback = new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
 
-  if (socketAvailable) {
+  for (const socketPath of candidateSocketPaths(opts)) {
+    if (!(await probeUsableSocket(socketPath, opts))) {
+      continue;
+    }
+
     const client = new CmuxSocketClient({
       socketPath,
       timeoutMs: opts?.timeoutMs,
       password: opts?.password,
       cliFallback,
+      socketPathResolver: () => resolveSocketPath(opts),
     });
     // Verify socket actually works (catches auth failures)
     try {
       await client.ping();
+      logger.error("[cmuxlayer] transport selected: socket");
       return client;
     } catch {
       // Socket reachable but not usable (auth required, protocol mismatch, etc.)
-      // Fall through to CLI
+      // Try the next candidate before falling through to CLI.
     }
   }
 
+  logger.error("[cmuxlayer] transport selected: cli");
   return cliFallback;
 }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -31,6 +31,15 @@ export { CmuxSocketError } from "./cmux-socket-error.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
+const RETRY_SAFE_V2_METHODS = new Set([
+  "system.ping",
+  "system.identify",
+  "workspace.list",
+  "surface.list",
+  "pane.list",
+  "surface.read_text",
+  "status.list",
+]);
 
 interface V1RawArg {
   raw: string;
@@ -46,6 +55,8 @@ export interface CmuxSocketClientOptions {
   password?: string;
   /** CLI client fallback for V2 methods not supported by the daemon */
   cliFallback?: CmuxClient;
+  /** Re-resolve a live socket when the current path stops accepting requests */
+  socketPathResolver?: () => Promise<string | null>;
 }
 
 // ── The Client ─────────────────────────────────────────────────────────
@@ -54,15 +65,22 @@ export class CmuxSocketClient {
   private socketPath: string;
   private timeoutMs: number;
   private password?: string;
+  private authPassword?: string;
   private cliFallback?: CmuxClient;
   private transport: CmuxPersistentSocket;
+  private maxInFlight?: number;
+  private socketPathResolver?: () => Promise<string | null>;
+  private reconnecting?: Promise<void>;
 
   constructor(opts?: CmuxSocketClientOptions) {
     this.socketPath =
       opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
     this.password = opts?.password;
+    this.authPassword = opts?.password;
     this.cliFallback = opts?.cliFallback;
+    this.maxInFlight = opts?.maxInFlight;
+    this.socketPathResolver = opts?.socketPathResolver;
     this.transport = new CmuxPersistentSocket({
       socketPath: this.socketPath,
       timeoutMs: this.timeoutMs,
@@ -89,7 +107,13 @@ export class CmuxSocketClient {
    * set_progress, log) only exist as V1 commands.
    */
   private sendV1(command: string): Promise<string> {
-    return this.transport.sendLine(command);
+    return this.withConnectionRetry(
+      async () => {
+        await this.ensureAuthenticated();
+        return this.transport.sendLine(command);
+      },
+      false,
+    );
   }
 
   private quoteV1Arg(arg: string): string {
@@ -120,11 +144,76 @@ export class CmuxSocketClient {
     method: string,
     params: Record<string, unknown> = {},
   ): Promise<T> {
-    if (this.password) {
-      await this.transport.call("auth.login", { password: this.password });
-      this.password = undefined;
+    return this.withConnectionRetry(
+      async () => {
+        await this.ensureAuthenticated();
+        return this.transport.call<T>(method, params);
+      },
+      RETRY_SAFE_V2_METHODS.has(method),
+    );
+  }
+
+  private async ensureAuthenticated(): Promise<void> {
+    if (!this.password) return;
+    await this.transport.call("auth.login", { password: this.password });
+    this.password = undefined;
+  }
+
+  private async withConnectionRetry<T>(
+    operation: () => Promise<T>,
+    retryOperation: boolean,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!this.shouldReprobe(error)) {
+        throw error;
+      }
+
+      await this.reconnectTransport(error);
+      if (!retryOperation) {
+        throw error;
+      }
+      return operation();
     }
-    return this.transport.call<T>(method, params);
+  }
+
+  private shouldReprobe(error: unknown): boolean {
+    return (
+      error instanceof CmuxSocketError &&
+      (error.code === "connection_error" || error.code === "connection_closed")
+    );
+  }
+
+  private replaceTransport(socketPath: string): void {
+    this.transport.disconnect();
+    this.socketPath = socketPath;
+    this.password = this.authPassword;
+    this.transport = new CmuxPersistentSocket({
+      socketPath: this.socketPath,
+      timeoutMs: this.timeoutMs,
+      maxInFlight: this.maxInFlight,
+    });
+  }
+
+  private async reconnectTransport(originalError: unknown): Promise<void> {
+    if (!this.reconnecting) {
+      this.reconnecting = (async () => {
+        const nextPath = await this.socketPathResolver?.();
+        if (!nextPath) {
+          throw originalError;
+        }
+        this.replaceTransport(nextPath);
+      })().finally(() => {
+        this.reconnecting = undefined;
+      });
+    }
+
+    return this.reconnecting;
+  }
+
+  currentSocketPath(): string {
+    return this.socketPath;
   }
 
   // ── Public API (mirrors CmuxClient interface) ──────────────────────

--- a/src/cmux-socket-path.ts
+++ b/src/cmux-socket-path.ts
@@ -1,10 +1,54 @@
+import * as fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export const DEFAULT_SOCKET_PATH = join(
-  homedir(),
-  "Library",
-  "Application Support",
-  "cmux",
-  "cmux.sock",
-);
+export function legacySocketPath(): string {
+  return join(homedir(), "Library", "Application Support", "cmux", "cmux.sock");
+}
+
+export function defaultStateDir(): string {
+  return join(homedir(), ".local", "state", "cmux");
+}
+
+export function stateSocketPath(stateDir = defaultStateDir()): string {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  return uid === null
+    ? join(stateDir, "cmux.sock")
+    : join(stateDir, `cmux-${uid}.sock`);
+}
+
+export function lastSocketPathFile(stateDir = defaultStateDir()): string {
+  return join(stateDir, "last-socket-path");
+}
+
+export interface CmuxSocketPathCandidateOptions {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}
+
+export function readLastSocketPath(stateDir = defaultStateDir()): string | null {
+  try {
+    const value = fs.readFileSync(lastSocketPathFile(stateDir), "utf-8").trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function cmuxSocketPathCandidates(
+  opts: CmuxSocketPathCandidateOptions = {},
+): string[] {
+  const env = opts.env ?? process.env;
+  const stateDir = opts.stateDir ?? defaultStateDir();
+  const candidates = [
+    env.CMUX_SOCKET_PATH,
+    readLastSocketPath(stateDir),
+    stateSocketPath(stateDir),
+    join(stateDir, "cmux.sock"),
+    legacySocketPath(),
+  ].filter((path): path is string => Boolean(path));
+
+  return [...new Set(candidates)];
+}
+
+export const DEFAULT_SOCKET_PATH = legacySocketPath();

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -7,9 +7,20 @@
  * 3. Error handling and connection lifecycle
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
 import * as net from "node:net";
 import * as fs from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
 import { CmuxClient } from "../src/cmux-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
@@ -93,6 +104,7 @@ const MOCK_RESPONSES: Record<string, unknown> = {
   "progress.clear": {},
   "notification.create": {},
   "surface.close": {},
+  "auth.login": {},
   "system.identify": {
     caller: {
       workspace_ref: "workspace:1",
@@ -106,8 +118,13 @@ let mockServer: net.Server;
 let lastV1Command = "";
 let lastV2Request: { method: string; params: Record<string, unknown> } | null =
   null;
+const mockEvents: Array<
+  | { type: "v1"; command: string }
+  | { type: "v2"; method: string; params: Record<string, unknown> }
+> = [];
 let connectionCount = 0;
 const activeConnections = new Set<net.Socket>();
+const helperServerConnections = new WeakMap<net.Server, Set<net.Socket>>();
 
 function startMockServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -135,6 +152,11 @@ function startMockServer(): Promise<void> {
             const req = JSON.parse(line);
             const method = req.method as string;
             lastV2Request = { method, params: req.params ?? {} };
+            mockEvents.push({
+              type: "v2",
+              method,
+              params: req.params ?? {},
+            });
             const result = MOCK_RESPONSES[method];
 
             if (result !== undefined) {
@@ -156,6 +178,7 @@ function startMockServer(): Promise<void> {
           } catch {
             // Not JSON — handle as V1 plain-text command
             lastV1Command = line;
+            mockEvents.push({ type: "v1", command: line });
             const cmd = line.split(" ")[0];
             if (
               cmd &&
@@ -201,6 +224,151 @@ function stopMockServer(): Promise<void> {
   });
 }
 
+function startSocketServer(socketPath: string): Promise<net.Server> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+
+          const req = JSON.parse(line);
+          conn.write(
+            JSON.stringify({
+              id: req.id,
+              ok: true,
+              result: { pong: true },
+            }) + "\n",
+          );
+        }
+      });
+    });
+    helperServerConnections.set(server, connections);
+
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function stopSocketServer(
+  server: net.Server,
+  socketPath: string,
+): Promise<void> {
+  return new Promise((resolve) => {
+    for (const conn of helperServerConnections.get(server) ?? []) {
+      conn.destroy();
+    }
+    server.close(() => {
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        /* ignore */
+      }
+      resolve();
+    });
+  });
+}
+
+function startCloseAfterMethodServer(
+  socketPath: string,
+  closeMethod: string,
+): Promise<{ server: net.Server; seenMethods: string[] }> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+
+    const seenMethods: string[] = [];
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+
+          const req = JSON.parse(line);
+          seenMethods.push(req.method);
+          if (req.method === closeMethod) {
+            conn.destroy();
+            continue;
+          }
+          conn.write(
+            JSON.stringify({
+              id: req.id,
+              ok: true,
+              result: { pong: true },
+            }) + "\n",
+          );
+        }
+      });
+    });
+    helperServerConnections.set(server, connections);
+
+    server.listen(socketPath, () => resolve({ server, seenMethods }));
+  });
+}
+
+function startProtocolErrorServer(socketPath: string): Promise<net.Server> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+
+          const req = JSON.parse(line);
+          conn.write(
+            JSON.stringify({
+              id: req.id,
+              ok: false,
+              error: {
+                code: "method_not_found",
+                message: "controlled protocol failure",
+              },
+            }) + "\n",
+          );
+        }
+      });
+    });
+    helperServerConnections.set(server, connections);
+
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
 // ── Shared lifecycle ───────────────────────────────────────────────────
 
 beforeAll(async () => {
@@ -220,6 +388,7 @@ afterAll(async () => {
 beforeEach(() => {
   lastV1Command = "";
   lastV2Request = null;
+  mockEvents.length = 0;
   connectionCount = 0;
 });
 
@@ -404,6 +573,25 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
       workspace: "workspace:1",
     });
     // No throw = success
+  });
+
+  it("authenticates before V1 commands when password is configured", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      password: "secret",
+    });
+
+    await client.setStatus("agent", "active", {
+      icon: "bolt",
+      workspace: "workspace:1",
+    });
+
+    expect(mockEvents).toEqual(
+      expect.arrayContaining([
+        { type: "v2", method: "auth.login", params: { password: "secret" } },
+        expect.objectContaining({ type: "v1", command: expect.stringContaining("set_status") }),
+      ]),
+    );
   });
 
   it("listStatus returns entries", async () => {
@@ -748,5 +936,266 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
     });
     // Should not be a CmuxSocketClient
     expect(client).not.toBeInstanceOf(CmuxSocketClient);
+  });
+
+  it("uses last-socket-path before legacy defaults when no env socket is set", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const liveSocketPath = join(stateDir, "cmux-live.sock");
+    fs.writeFileSync(
+      join(stateDir, "last-socket-path"),
+      `${liveSocketPath}\n`,
+      "utf-8",
+    );
+    const server = await startSocketServer(liveSocketPath);
+    const savedEnv = process.env.CMUX_SOCKET_PATH;
+    delete process.env.CMUX_SOCKET_PATH;
+    const logger = { error: vi.fn() };
+
+    try {
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        logger,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(logger.error).toHaveBeenCalledWith(
+        "[cmuxlayer] transport selected: socket",
+      );
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining(liveSocketPath),
+      );
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      await stopSocketServer(server, liveSocketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("probes the uid-suffixed state socket when last-socket-path is absent", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const uid =
+      typeof process.getuid === "function" ? process.getuid() : undefined;
+    const liveSocketPath = join(
+      stateDir,
+      uid === undefined ? "cmux.sock" : `cmux-${uid}.sock`,
+    );
+    const server = await startSocketServer(liveSocketPath);
+    const savedEnv = process.env.CMUX_SOCKET_PATH;
+    delete process.env.CMUX_SOCKET_PATH;
+
+    try {
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      await stopSocketServer(server, liveSocketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-probes candidate sockets after the selected socket fails", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const firstSocketPath = join(stateDir, "first.sock");
+    const secondSocketPath = join(stateDir, "second.sock");
+    fs.writeFileSync(
+      join(stateDir, "last-socket-path"),
+      `${firstSocketPath}\n`,
+      "utf-8",
+    );
+    const firstServer = await startSocketServer(firstSocketPath);
+    const savedEnv = process.env.CMUX_SOCKET_PATH;
+    delete process.env.CMUX_SOCKET_PATH;
+
+    let secondServer: net.Server | null = null;
+    try {
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+      });
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(await client.ping()).toBe(true);
+
+      await stopSocketServer(firstServer, firstSocketPath);
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${secondSocketPath}\n`,
+        "utf-8",
+      );
+      secondServer = await startSocketServer(secondSocketPath);
+
+      await expect(client.ping()).resolves.toBe(true);
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      if (secondServer) {
+        await stopSocketServer(secondServer, secondSocketPath);
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not replay mutating calls after re-probing a failed socket", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const firstSocketPath = join(stateDir, "first.sock");
+    const secondSocketPath = join(stateDir, "second.sock");
+    fs.writeFileSync(
+      join(stateDir, "last-socket-path"),
+      `${firstSocketPath}\n`,
+      "utf-8",
+    );
+    const first = await startCloseAfterMethodServer(
+      firstSocketPath,
+      "surface.send_text",
+    );
+    const savedEnv = process.env.CMUX_SOCKET_PATH;
+    delete process.env.CMUX_SOCKET_PATH;
+
+    let secondServer: net.Server | null = null;
+    try {
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+      });
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${secondSocketPath}\n`,
+        "utf-8",
+      );
+      secondServer = await startSocketServer(secondSocketPath);
+
+      await expect(
+        client.send("surface:1", "do-not-duplicate", {
+          workspace: "workspace:1",
+        }),
+      ).rejects.toThrow(/Socket closed unexpectedly|Socket error/i);
+      expect(first.seenMethods).toContain("surface.send_text");
+
+      await expect(client.ping()).resolves.toBe(true);
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      await stopSocketServer(first.server, firstSocketPath);
+      if (secondServer) {
+        await stopSocketServer(secondServer, secondSocketPath);
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not hop sockets after non-transport protocol errors", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const firstSocketPath = join(stateDir, "first.sock");
+    const secondSocketPath = join(stateDir, "second.sock");
+    const firstServer = await startProtocolErrorServer(firstSocketPath);
+    const secondServer = await startSocketServer(secondSocketPath);
+
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: firstSocketPath,
+        socketPathResolver: async () => secondSocketPath,
+      });
+
+      await expect(client.ping()).rejects.toThrow(/method_not_found/i);
+    } finally {
+      await stopSocketServer(firstServer, firstSocketPath);
+      await stopSocketServer(secondServer, secondSocketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips listening but unusable sockets during runtime re-resolution", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const firstSocketPath = join(stateDir, "first.sock");
+    const badSocketPath = join(stateDir, "bad.sock");
+    const uid =
+      typeof process.getuid === "function" ? process.getuid() : undefined;
+    const healthySocketPath = join(
+      stateDir,
+      uid === undefined ? "cmux.sock" : `cmux-${uid}.sock`,
+    );
+    fs.writeFileSync(
+      join(stateDir, "last-socket-path"),
+      `${firstSocketPath}\n`,
+      "utf-8",
+    );
+    const firstServer = await startSocketServer(firstSocketPath);
+    const savedEnv = process.env.CMUX_SOCKET_PATH;
+    delete process.env.CMUX_SOCKET_PATH;
+
+    let badServer: net.Server | null = null;
+    let healthyServer: net.Server | null = null;
+    try {
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+      });
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(await client.ping()).toBe(true);
+
+      await stopSocketServer(firstServer, firstSocketPath);
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${badSocketPath}\n`,
+        "utf-8",
+      );
+      badServer = await startProtocolErrorServer(badSocketPath);
+      healthyServer = await startSocketServer(healthySocketPath);
+
+      await expect(client.ping()).resolves.toBe(true);
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      if (badServer) await stopSocketServer(badServer, badSocketPath);
+      if (healthyServer) {
+        await stopSocketServer(healthyServer, healthySocketPath);
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent reconnects through one socket re-resolution", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const firstSocketPath = join(stateDir, "missing.sock");
+    const secondSocketPath = join(stateDir, "second.sock");
+    const secondServer = await startSocketServer(secondSocketPath);
+    let resolverCalls = 0;
+
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: firstSocketPath,
+        timeoutMs: 50,
+        socketPathResolver: async () => {
+          resolverCalls++;
+          return secondSocketPath;
+        },
+      });
+
+      await expect(Promise.all([client.ping(), client.ping()])).resolves.toEqual(
+        [true, true],
+      );
+      expect(resolverCalls).toBe(1);
+    } finally {
+      await stopSocketServer(secondServer, secondSocketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Resolve cmux socket candidates in durable order: explicit `CMUX_SOCKET_PATH`/option, `~/.local/state/cmux/last-socket-path`, uid-suffixed state socket, generic state socket, then legacy App Support socket.
- Keep CLI fallback only after candidate probes fail or reachable sockets fail the boot ping.
- Add boot transport logging so socket vs CLI selection is visible.
- Re-probe socket candidates on in-session connection failure and retry once on the newly selected socket.

## Test plan
- [x] `bun run test tests/cmux-socket-client.test.ts` — 44 passed
- [x] `bun run typecheck`
- [x] `bun run test` — 44 files, 748 passed
- [x] `bun run build`
- [x] Real socket smoke: selected `/Users/etanheyman/.local/state/cmux/cmux-501.sock`, returned `CmuxSocketClient`, `ping:true`
- [x] Push hook: `run_tests.sh` exit status 0; includes full Vitest suite and two bun regression tests

## Notes
- Local `coderabbit review --agent` was run with a 180s timeout. It timed out after emitting one minor finding against unrelated untracked `collab/2026-06-05-cmuxlayer-state-fixes.md`; no PR-1 source/test finding was returned before timeout.

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transport selection and reconnect behavior; mutating socket calls can fail mid-flight without automatic retry, so callers must handle connection errors.
> 
> **Overview**
> Socket client creation no longer assumes a single legacy App Support path. **`cmuxSocketPathCandidates`** builds a deduplicated priority list (`CMUX_SOCKET_PATH`, `last-socket-path`, UID-suffixed state socket, generic state socket, legacy path), and **`createCmuxClient`** walks it with **`probeUsableSocket`** (connect + optional auth + `system.ping`) before choosing the socket transport. Boot logs **`[cmuxlayer] transport selected: socket|cli`**, and **`socketStateDir`** supports tests/nonstandard installs.
> 
> **`CmuxSocketClient`** gains optional **`socketPathResolver`** for runtime recovery: on **`connection_error` / `connection_closed`**, it re-resolves a path, swaps transport, re-authenticates, and retries **only** methods in **`RETRY_SAFE_V2_METHODS`** (reads/lists/ping). V1 and mutating V2 calls fail without replay. Concurrent reconnects share one in-flight resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccf35dad419fefa085b2928975ec43490fc8ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic probing of multiple socket path candidates with fallback to CLI transport when unavailable
  * Added connection retry mechanism that re-resolves socket paths on connection failures
  * Added support for state directory configuration to customize socket discovery

* **Tests**
  * Expanded test coverage for socket selection and connection recovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve live cmux socket path durably with multi-candidate probing and reconnection
> - Adds `cmuxSocketPathCandidates` in [`src/cmux-socket-path.ts`](https://github.com/EtanHey/cmuxlayer/pull/145/files#diff-3ab0a18c172ea9124f5a550a90c4f60bf4da7a7fa77a0cbbfc44e23e626ded74) to build a prioritized list of socket path candidates from `CMUX_SOCKET_PATH` env, last-socket-path marker file, uid-suffixed state socket, and legacy path.
> - Adds `resolveSocketPath` and `probeUsableSocket` in [`src/cmux-client-factory.ts`](https://github.com/EtanHey/cmuxlayer/pull/145/files#diff-37e2c062823d882ca9c154692047152501d1bd813787b69cf13d4a1dbbcd1342) to select the first candidate that responds to auth and `system.ping`, falling back to CLI if all candidates fail.
> - Extends `CmuxSocketClient` in [`src/cmux-socket-client.ts`](https://github.com/EtanHey/cmuxlayer/pull/145/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) with `reconnectTransport` and `withConnectionRetry` so that on transport failure the client re-invokes `socketPathResolver` to find a new live socket and retries safe read-only methods.
> - Safe-to-retry V2 methods are enumerated in `RETRY_SAFE_V2_METHODS`; mutating or unlisted methods surface the original error without replay.
> - Behavioral Change: `CmuxSocketClient` now re-authenticates after reconnection and serializes concurrent reconnect attempts; callers may observe a reconnect delay on `connection_error` or `connection_closed` instead of an immediate failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cccf35d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->