### PR TITLE
fix: default sweep reads to tail output

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -689,7 +689,6 @@ export class AgentEngine {
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
-        scrollback: true,
       });
       const sessionId = extractSessionId(screen.text);
       if (!sessionId) {

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -257,7 +257,6 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     const screen = await this.client.readScreen(route.surface_id, {
       workspace: route.workspace_id ?? undefined,
       lines: 40,
-      scrollback: true,
     });
     const text = typeof screen === "string" ? screen : (screen.text ?? "");
     const parsed = parseScreen(text);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3893,6 +3893,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default(200)
           .describe("Number of screen lines to scan (default: 200)"),
+        scrollback: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Scan full scrollback instead of only the current terminal tail. Default: false.",
+          ),
         workspace: z.string().optional().describe("Target workspace ref"),
       },
       ANNOTATIONS.readOnly,
@@ -3900,8 +3907,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         try {
           const opts: Record<string, unknown> = {
             lines: args.lines,
-            scrollback: true,
           };
+          if (args.scrollback) opts.scrollback = true;
           if (args.workspace) opts.workspace = args.workspace;
 
           const raw = await client.readScreen(args.surface, opts);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1411,6 +1411,12 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
 
         await vi.advanceTimersByTimeAsync(1000);
 
+        expect(
+          (mockClient.readScreen as ReturnType<typeof vi.fn>).mock.calls,
+        ).not.toContainEqual([
+          "surface:new",
+          { lines: 80, scrollback: true },
+        ]);
         expect(engine.getAgentState(result.agent_id)?.cli_session_id).toBe(
           sessionId,
         );

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -88,7 +88,6 @@ describe("CmuxAppServerRuntime", () => {
     expect(client.readScreen).toHaveBeenCalledWith("surface:1", {
       workspace: "workspace:app",
       lines: 40,
-      scrollback: true,
     });
 
     runtime.dispose();

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -376,6 +376,49 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
+  it("read_agent_output scans bounded tail lines by default", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["read_agent_output"];
+
+    const result = await tool.handler(
+      { surface: "surface:new", tag: "OUTPUT", lines: 80 },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.found).toBe(false);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "read-screen",
+        "--surface",
+        "surface:new",
+        "--lines",
+        "80",
+      ]),
+    );
+    const readCalls = (mockExec as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("read-screen"),
+    );
+    expect(readCalls.at(-1)?.[1]).not.toContain("--scrollback");
+  });
+
+  it("read_agent_output can opt into full scrollback", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["read_agent_output"];
+
+    await tool.handler(
+      { surface: "surface:new", tag: "OUTPUT", lines: 80, scrollback: true },
+      {} as any,
+    );
+
+    const readCalls = (mockExec as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("read-screen"),
+    );
+    expect(readCalls.at(-1)?.[1]).toContain("--scrollback");
+  });
+
   it("spawn_agent retries Enter when the launcher command remains pending at the shell", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");


### PR DESCRIPTION
## Summary
- remove full scrollback from boot session capture and app-server runtime screen snapshots
- make read_agent_output scan bounded tail lines by default
- add explicit read_agent_output scrollback opt-in for callers that need full history

## Verification
- bun run typecheck
- bun run build
- bun run test
- pre-push hook: run_tests.sh (race fixture, terminal state regression, full Vitest 44 files / 755 tests)

## Context
Implements PR-2 from the 2026-06-07 cmux leak redteam verdict: keep scrollback only where callers semantically opt into full history, reducing fleet-scale JSON payload volume through the upstream cmux retention leak.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default `read_agent_output` may miss delimiter markers that scrolled out of the tail unless callers set `scrollback: true`; boot session ID capture relies on tail-only reads within the line window.
> 
> **Overview**
> **Reduces cmux read-screen payload size** by no longer forcing full scrollback on high-frequency paths.
> 
> **Agent sweep and app-server snapshots** now call `readScreen` with only a `lines` cap (boot session capture, runtime screen reads). **MCP `read_agent_output`** adds a `scrollback` argument defaulting to `false` and passes `--scrollback` to cmux only when `scrollback: true`, so delimiter scanning uses the terminal tail by default.
> 
> Tests assert sweep boot capture does not use scrollback and cover default vs opt-in behavior for `read_agent_output`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f77b82d8a5b710305481d8edda0b4cec2830b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `read_agent_output` sweep reads to tail output instead of full scrollback
> - The `read_agent_output` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/146/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) no longer unconditionally passes `scrollback: true` to `cmux read-screen`; it now reads only the bounded tail (last N lines) by default.
> - A new optional boolean `scrollback` argument (default `false`) is added to the tool schema, allowing callers to explicitly opt into full scrollback when needed.
> - Boot banner session capture in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/146/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) and bridge screen reads in [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/146/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) also drop `scrollback: true`, aligning all sweep reads with the new default.
> - Behavioral Change: any existing caller relying on `read_agent_output` returning full scrollback history will now receive only the tail unless they pass `scrollback: true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f77b82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->