### PR TITLE
fix: back off idle agent sweeps

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -110,7 +110,10 @@ export type AgentLifecycleEvent = "spawned" | "done" | "errored";
 
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
-const SWEEP_INTERVAL_MS = 1000;
+const WAIT_FOR_SWEEP_INTERVAL_MS = 1000;
+const DEFAULT_SWEEP_ACTIVE_INTERVAL_MS = 5_000;
+const DEFAULT_SWEEP_IDLE_INTERVAL_MS = 15_000;
+const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
@@ -138,6 +141,18 @@ interface SidebarStatusSnapshot {
   workspaceId: string | null;
 }
 
+export interface SweepTimingOptions {
+  activeIntervalMs: number;
+  idleIntervalMs: number;
+  idleAfterSweeps: number;
+}
+
+type SweepTimingInput = number | Partial<SweepTimingOptions>;
+
+interface SweepAgentContext {
+  screen?: Promise<CmuxReadScreenResult>;
+}
+
 function autoArchiveEnabledByEnv(): boolean {
   return !["0", "false", "off", "no"].includes(
     (process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE ?? "").toLowerCase(),
@@ -146,6 +161,62 @@ function autoArchiveEnabledByEnv(): boolean {
 
 function tailScreenLines(text: string, lines: number): string {
   return text.split(/\r?\n/).slice(-lines).join("\n");
+}
+
+function parseNonNegativeInteger(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parsePositiveInteger(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveSweepTiming(
+  env: NodeJS.ProcessEnv = process.env,
+  input?: SweepTimingInput,
+): SweepTimingOptions {
+  if (typeof input === "number") {
+    return {
+      activeIntervalMs: input,
+      idleIntervalMs: input,
+      idleAfterSweeps: Number.POSITIVE_INFINITY,
+    };
+  }
+
+  const activeIntervalMs =
+    input?.activeIntervalMs ??
+    parsePositiveInteger(
+      env.CMUXLAYER_SWEEP_INTERVAL_MS,
+      DEFAULT_SWEEP_ACTIVE_INTERVAL_MS,
+    );
+  const idleIntervalMs =
+    input?.idleIntervalMs ??
+    parsePositiveInteger(
+      env.CMUXLAYER_SWEEP_IDLE_INTERVAL_MS,
+      DEFAULT_SWEEP_IDLE_INTERVAL_MS,
+    );
+  const idleAfterSweeps =
+    input?.idleAfterSweeps ??
+    parseNonNegativeInteger(
+      env.CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS,
+      DEFAULT_SWEEP_IDLE_AFTER_SWEEPS,
+    );
+
+  return {
+    activeIntervalMs,
+    idleIntervalMs,
+    idleAfterSweeps,
+  };
 }
 
 function taskDoneAutoArchiveMs(): number {
@@ -398,7 +469,10 @@ export class AgentEngine {
   ) => RoleSurfaceIds;
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
   private sessionIdentityResolver: SessionIdentityResolver;
-  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private sweepTimer: ReturnType<typeof setTimeout> | null = null;
+  private sweepTiming: SweepTimingOptions | null = null;
+  private lastSweepSignature: string | null = null;
+  private unchangedSweepCount = 0;
   /** agentId → last-pushed status target/value */
   private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
   private progressSnapshot: string | null = null;
@@ -483,7 +557,7 @@ export class AgentEngine {
   ): Promise<AgentRecord> {
     if (!this.requiresOutputDoneEvidence(targetState)) return agent;
     if (TERMINAL_STATES.has(agent.state)) return agent;
-    return (await this.maybeMarkTaskDone(agent)).agent;
+    return (await this.maybeMarkTaskDone(agent, {})).agent;
   }
 
   private async createAgentSurface(
@@ -672,7 +746,20 @@ export class AgentEngine {
     return updated;
   }
 
-  private async maybeCaptureBootSessionId(agent: AgentRecord): Promise<AgentRecord> {
+  private readSweepScreen(
+    agent: AgentRecord,
+    ctx: SweepAgentContext,
+  ): Promise<CmuxReadScreenResult> {
+    ctx.screen ??= this.client.readScreen(agent.surface_id, {
+      lines: BOOT_SESSION_CAPTURE_LINES,
+    });
+    return ctx.screen;
+  }
+
+  private async maybeCaptureBootSessionId(
+    agent: AgentRecord,
+    ctx: SweepAgentContext,
+  ): Promise<AgentRecord> {
     if (agent.cli_session_id || !this.isBootCaptureWindowOpen(agent)) {
       return agent;
     }
@@ -687,9 +774,7 @@ export class AgentEngine {
     }
 
     try {
-      const screen = await this.client.readScreen(agent.surface_id, {
-        lines: BOOT_SESSION_CAPTURE_LINES,
-      });
+      const screen = await this.readSweepScreen(agent, ctx);
       const sessionId = extractSessionId(screen.text);
       if (!sessionId) {
         return agent;
@@ -704,7 +789,10 @@ export class AgentEngine {
     }
   }
 
-  private async maybeMarkBootReady(agent: AgentRecord): Promise<AgentRecord> {
+  private async maybeMarkBootReady(
+    agent: AgentRecord,
+    ctx: SweepAgentContext,
+  ): Promise<AgentRecord> {
     if (agent.state !== "booting") {
       this.readyPatternMatches.delete(agent.agent_id);
       return agent;
@@ -734,9 +822,7 @@ export class AgentEngine {
     }
 
     try {
-      const screen = await this.client.readScreen(agent.surface_id, {
-        lines: BOOT_SESSION_CAPTURE_LINES,
-      });
+      const screen = await this.readSweepScreen(agent, ctx);
       const match = matchReadyPattern(agent.cli, screen.text);
       if (!match.matched) {
         this.readyPatternMatches.delete(agent.agent_id);
@@ -760,13 +846,12 @@ export class AgentEngine {
 
   private async maybeMarkTaskDone(
     agent: AgentRecord,
+    ctx: SweepAgentContext,
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
     if (TERMINAL_STATES.has(agent.state)) return { agent };
 
     try {
-      const screen = await this.client.readScreen(agent.surface_id, {
-        lines: BOOT_SESSION_CAPTURE_LINES,
-      });
+      const screen = await this.readSweepScreen(agent, ctx);
       if (!this.hasOutputDoneEvidence(screen.text)) {
         if (agent.task_done_candidate_at) {
           const updated = this.stateMgr.updateRecord(agent.agent_id, {
@@ -993,9 +1078,16 @@ export class AgentEngine {
     const done = agents.filter((a) => a.state === "done").length;
 
     for (const originalAgent of agents) {
-      const capturedAgent = await this.maybeCaptureBootSessionId(originalAgent);
-      const readyAgent = await this.maybeMarkBootReady(capturedAgent);
-      const taskDoneResult = await this.maybeMarkTaskDone(readyAgent);
+      const sweepCtx: SweepAgentContext = {};
+      const capturedAgent = await this.maybeCaptureBootSessionId(
+        originalAgent,
+        sweepCtx,
+      );
+      const readyAgent = await this.maybeMarkBootReady(capturedAgent, sweepCtx);
+      const taskDoneResult = await this.maybeMarkTaskDone(
+        readyAgent,
+        sweepCtx,
+      );
       const agent = taskDoneResult.agent;
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
@@ -1174,16 +1266,72 @@ export class AgentEngine {
     await this.syncSidebar();
   }
 
+  private sweepStateSignature(): string {
+    return this.registry
+      .list()
+      .map((agent) =>
+        [
+          agent.agent_id,
+          agent.surface_id,
+          agent.workspace_id ?? "",
+          agent.state,
+          agent.updated_at,
+          agent.cli_session_id ?? "",
+          agent.task_done_candidate_at ?? "",
+          agent.quality ?? "",
+        ].join(":"),
+      )
+      .sort()
+      .join("|");
+  }
+
+  private recordSweepStability(): void {
+    const signature = this.sweepStateSignature();
+    if (this.lastSweepSignature !== null && signature === this.lastSweepSignature) {
+      this.unchangedSweepCount += 1;
+    } else {
+      this.unchangedSweepCount = 0;
+    }
+    this.lastSweepSignature = signature;
+  }
+
+  private nextSweepIntervalMs(): number {
+    const timing = this.sweepTiming ?? resolveSweepTiming();
+    return this.unchangedSweepCount >= timing.idleAfterSweeps
+      ? timing.idleIntervalMs
+      : timing.activeIntervalMs;
+  }
+
   /**
    * Start the reconciliation sweep on an interval.
    */
-  startSweep(intervalMs: number = 5000): void {
+  startSweep(timingInput?: SweepTimingInput): void {
     if (this.sweepTimer) return;
-    this.sweepTimer = setInterval(() => {
-      this.runSweep().catch((e) => {
+    this.sweepTiming = resolveSweepTiming(process.env, timingInput);
+    this.unchangedSweepCount = 0;
+    this.lastSweepSignature = null;
+
+    const runAndSchedule = async () => {
+      this.sweepTimer = null;
+      try {
+        await this.runSweep();
+      } catch (e) {
         console.error("[cmux-mcp] sweep failed (will retry):", e);
-      });
-    }, intervalMs);
+      } finally {
+        this.recordSweepStability();
+        if (this.sweepTiming) {
+          this.sweepTimer = setTimeout(
+            runAndSchedule,
+            this.nextSweepIntervalMs(),
+          );
+        }
+      }
+    };
+
+    this.sweepTimer = setTimeout(
+      runAndSchedule,
+      this.sweepTiming.activeIntervalMs,
+    );
   }
 
   /**
@@ -1191,9 +1339,12 @@ export class AgentEngine {
    */
   dispose(): void {
     if (this.sweepTimer) {
-      clearInterval(this.sweepTimer);
+      clearTimeout(this.sweepTimer);
       this.sweepTimer = null;
     }
+    this.sweepTiming = null;
+    this.lastSweepSignature = null;
+    this.unchangedSweepCount = 0;
   }
 
   /**
@@ -1432,7 +1583,7 @@ export class AgentEngine {
               current.error ?? `Agent entered terminal state: ${current.state}`,
           });
         }
-      }, SWEEP_INTERVAL_MS);
+      }, WAIT_FOR_SWEEP_INTERVAL_MS);
     });
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -163,6 +163,14 @@ function tailScreenLines(text: string, lines: number): string {
   return text.split(/\r?\n/).slice(-lines).join("\n");
 }
 
+function screenTextSignature(text: string): string {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
+  }
+  return `${text.length}:${hash.toString(16)}`;
+}
+
 function parseNonNegativeInteger(
   raw: string | undefined,
   fallback: number,
@@ -188,8 +196,14 @@ export function resolveSweepTiming(
   if (typeof input === "number") {
     return {
       activeIntervalMs: input,
-      idleIntervalMs: input,
-      idleAfterSweeps: Number.POSITIVE_INFINITY,
+      idleIntervalMs: parsePositiveInteger(
+        env.CMUXLAYER_SWEEP_IDLE_INTERVAL_MS,
+        DEFAULT_SWEEP_IDLE_INTERVAL_MS,
+      ),
+      idleAfterSweeps: parseNonNegativeInteger(
+        env.CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS,
+        DEFAULT_SWEEP_IDLE_AFTER_SWEEPS,
+      ),
     };
   }
 
@@ -473,6 +487,7 @@ export class AgentEngine {
   private sweepTiming: SweepTimingOptions | null = null;
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
+  private currentSweepScreenSignatures = new Map<string, string>();
   /** agentId → last-pushed status target/value */
   private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
   private progressSnapshot: string | null = null;
@@ -750,9 +765,17 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<CmuxReadScreenResult> {
-    ctx.screen ??= this.client.readScreen(agent.surface_id, {
-      lines: BOOT_SESSION_CAPTURE_LINES,
-    });
+    ctx.screen ??= this.client
+      .readScreen(agent.surface_id, {
+        lines: BOOT_SESSION_CAPTURE_LINES,
+      })
+      .then((screen) => {
+        this.currentSweepScreenSignatures.set(
+          agent.agent_id,
+          `${agent.surface_id}:${screenTextSignature(screen.text)}`,
+        );
+        return screen;
+      });
     return ctx.screen;
   }
 
@@ -1246,6 +1269,7 @@ export class AgentEngine {
    * previous cmux sessions whose surface refs may have been recycled.
    */
   async runSweep(): Promise<void> {
+    this.currentSweepScreenSignatures = new Map();
     await this.registry.reconcile();
     await this.recoverCrashedAgents();
 
@@ -1267,7 +1291,7 @@ export class AgentEngine {
   }
 
   private sweepStateSignature(): string {
-    return this.registry
+    const agentSignature = this.registry
       .list()
       .map((agent) =>
         [
@@ -1283,6 +1307,11 @@ export class AgentEngine {
       )
       .sort()
       .join("|");
+    const screenSignature = [...this.currentSweepScreenSignatures.entries()]
+      .map(([agentId, signature]) => `${agentId}:${signature}`)
+      .sort()
+      .join("|");
+    return `${agentSignature}::screens:${screenSignature}`;
   }
 
   private recordSweepStability(): void {
@@ -1306,7 +1335,7 @@ export class AgentEngine {
    * Start the reconciliation sweep on an interval.
    */
   startSweep(timingInput?: SweepTimingInput): void {
-    if (this.sweepTimer) return;
+    if (this.sweepTiming) return;
     this.sweepTiming = resolveSweepTiming(process.env, timingInput);
     this.unchangedSweepCount = 0;
     this.lastSweepSignature = null;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -3,7 +3,7 @@ import { basename, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
-import { AgentEngine } from "./agent-engine.js";
+import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { StateManager } from "./state-manager.js";
 import { parseScreen } from "./screen-parser.js";
@@ -169,7 +169,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
   async initialize(): Promise<void> {
     await this.registry.reconstitute();
     this.engine.enableStartupPurge();
-    this.engine.startSweep(5000);
+    this.engine.startSweep(resolveSweepTiming());
   }
 
   dispose(): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
   AgentEngine,
+  resolveSweepTiming,
   type AgentLifecycleEvent,
   type SessionIdentityResolver,
   type SpawnAgentParams,
@@ -3264,7 +3265,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .catch((e) =>
           console.error("[cmux-mcp] registry reconstitution failed:", e),
         );
-      engine.startSweep(5000);
+      engine.startSweep(resolveSweepTiming());
     }
 
     // 11. spawn_agent

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -14,6 +14,7 @@ import {
   buildLaunchCommand,
   buildResumeCommand,
   extractSessionId,
+  resolveSweepTiming,
 } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
@@ -2042,6 +2043,33 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
+    it("reuses one tail read for boot capture, readiness, task done, and context checks in a sweep", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-reuse",
+          state: "booting",
+          surface_id: "surface:reuse",
+          cli: "codex",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:reuse")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:reuse",
+        text: "codex> ",
+        lines: 80,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
+      expect(mockClient.readScreen).toHaveBeenCalledWith("surface:reuse", {
+        lines: 80,
+      });
+      expect(engine.getAgentState("agent-boot-reuse")?.state).toBe("ready");
+    });
+
     it("does not promote booting agents while boot prompt delivery is pending", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -2120,6 +2148,58 @@ To continue this session, run codex resume ${sessionId}`,
       await expect(
         engine.waitFor("nonexistent", "ready", 1000),
       ).rejects.toThrow(/not found/);
+    });
+  });
+
+  describe("startSweep", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("backs off to the idle interval after unchanged sweeps", async () => {
+      const sweep = vi.spyOn(engine, "runSweep").mockResolvedValue(undefined);
+
+      engine.startSweep({
+        activeIntervalMs: 50,
+        idleIntervalMs: 150,
+        idleAfterSweeps: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sweep).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(3);
+    });
+
+    it("resolves sweep timing from environment with idle defaults", () => {
+      expect(
+        resolveSweepTiming({
+          CMUXLAYER_SWEEP_INTERVAL_MS: "7000",
+          CMUXLAYER_SWEEP_IDLE_INTERVAL_MS: "25000",
+          CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS: "4",
+        }),
+      ).toEqual({
+        activeIntervalMs: 7000,
+        idleIntervalMs: 25000,
+        idleAfterSweeps: 4,
+      });
+
+      expect(resolveSweepTiming({})).toEqual({
+        activeIntervalMs: 5000,
+        idleIntervalMs: 15000,
+        idleAfterSweeps: 3,
+      });
     });
   });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2182,6 +2182,75 @@ To continue this session, run codex resume ${sessionId}`,
       expect(sweep).toHaveBeenCalledTimes(3);
     });
 
+    it("keeps the active cadence while screen output changes", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-active-output",
+          state: "ready",
+          surface_id: "surface:active-output",
+          cli: "codex",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:active-output")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          surface: "surface:active-output",
+          text: "Working 1",
+          lines: 80,
+          scrollback_used: false,
+        })
+        .mockResolvedValueOnce({
+          surface: "surface:active-output",
+          text: "Working 2",
+          lines: 80,
+          scrollback_used: false,
+        })
+        .mockResolvedValue({
+          surface: "surface:active-output",
+          text: "Working 3",
+          lines: 80,
+          scrollback_used: false,
+        });
+      await engine.getRegistry().reconstitute();
+
+      engine.startSweep({
+        activeIntervalMs: 50,
+        idleIntervalMs: 150,
+        idleAfterSweeps: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not start a second loop while a sweep is running", async () => {
+      let finishSweep: (() => void) | null = null;
+      const sweep = vi
+        .spyOn(engine, "runSweep")
+        .mockImplementation(
+          () =>
+            new Promise<void>((resolve) => {
+              finishSweep = resolve;
+            }),
+        );
+
+      engine.startSweep({ activeIntervalMs: 50 });
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(1);
+
+      engine.startSweep({ activeIntervalMs: 50 });
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(1);
+
+      finishSweep?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sweep).toHaveBeenCalledTimes(2);
+    });
+
     it("resolves sweep timing from environment with idle defaults", () => {
       expect(
         resolveSweepTiming({
@@ -2197,6 +2266,12 @@ To continue this session, run codex resume ${sessionId}`,
 
       expect(resolveSweepTiming({})).toEqual({
         activeIntervalMs: 5000,
+        idleIntervalMs: 15000,
+        idleAfterSweeps: 3,
+      });
+
+      expect(resolveSweepTiming({}, 2500)).toEqual({
+        activeIntervalMs: 2500,
         idleIntervalMs: 15000,
         idleAfterSweeps: 3,
       });


### PR DESCRIPTION
## Summary
- add configurable adaptive agent sweep timing
- keep active sweep cadence at 5s by default and back off unchanged idle sweeps to 15s by default
- support CMUXLAYER_SWEEP_INTERVAL_MS, CMUXLAYER_SWEEP_IDLE_INTERVAL_MS, and CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS
- reuse one 80-line tail read per agent sweep across boot capture, readiness, TASK_DONE, and context checks when those checks overlap

## Verification
- bun run typecheck
- bun run build
- bun run test
- pre-push hook: run_tests.sh (race fixture, terminal state regression, full Vitest 44 files / 758 tests)

## Context
Implements PR-3 from the 2026-06-07 cmux leak redteam verdict. This does not redesign sweep architecture or add a daemon aggregator; it only makes idle sweeps cheaper and removes redundant readScreen calls while preserving active behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how often agent state and terminal evidence are polled, which could delay boot-ready, task-done, and sidebar updates when idle backoff is active; behavior is covered by new tests and defaults preserve prior active cadence.
> 
> **Overview**
> **Agent reconciliation sweeps** no longer run on a fixed 5s `setInterval`. Scheduling uses recursive `setTimeout` with **adaptive cadence**: default **5s active** polling steps down to **15s idle** after **3** consecutive sweeps where agent registry fields and per-agent screen signatures are unchanged. Changing terminal output keeps the active interval.
> 
> **Configuration** is centralized in exported `resolveSweepTiming()` (env: `CMUXLAYER_SWEEP_INTERVAL_MS`, `CMUXLAYER_SWEEP_IDLE_INTERVAL_MS`, `CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS`, or partial options / legacy numeric active interval). **`server.ts`** and **`app-server-runtime.ts`** call `startSweep(resolveSweepTiming())` instead of hardcoded `5000`.
> 
> **Per-sweep screen reads** are memoized via `SweepAgentContext`: boot session capture, boot-ready promotion, and task-done checks share one 80-line `readScreen` per agent when they overlap in `syncSidebar`. `dispose()` clears timeout state and stability counters; overlapping sweeps are not started while one is in flight.
> 
> Tests cover single-read reuse, idle backoff, stable-vs-changing output, env parsing, and no double loop during an in-flight sweep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761704791998af4c533f783ec173c055d2d94268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Back off agent sweep cadence to idle interval after consecutive unchanged sweeps
> - Replaces the fixed `setInterval` sweep loop in `AgentEngine.startSweep` with an adaptive `setTimeout` loop that slows to an idle interval (default 15s) after a configurable number of unchanged sweeps (default 3), and returns to active cadence (default 5s) when state changes are detected.
> - Adds `sweepStateSignature` and `recordSweepStability` to track sweep stability based on agent records and screen content, and `nextSweepIntervalMs` to select the correct interval per cycle.
> - Adds `resolveSweepTiming` to derive timing from environment variables (`CMUXLAYER_SWEEP_INTERVAL_MS`, `CMUXLAYER_SWEEP_IDLE_INTERVAL_MS`, `CMUXLAYER_SWEEP_IDLE_AFTER_SWEEPS`) or caller input; both [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/147/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/147/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now use this instead of a hardcoded 5000ms value.
> - Adds `AgentEngine.readSweepScreen` to deduplicate `readScreen` calls within a sweep — boot capture, readiness checks, and task-done detection all share one read per agent per sweep cycle via `SweepAgentContext`.
> - Behavioral Change: `AgentEngine.dispose` now calls `clearTimeout` instead of `clearInterval` and resets sweep tracking state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7617047.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->