### PR TITLE
feat: detect wait_for done from transcripts

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -58,7 +59,11 @@ import { SpawnGuard } from "./spawn-guard.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
   findLatestHarnessSessionIdentity,
+  harnessJsonlEnabled,
+  loadHarnessSessionWithMeta,
+  readHarnessSessionFromFile,
   type Harness,
+  type HarnessSessionWithMeta,
 } from "./harness-session.js";
 
 export interface SpawnAgentParams {
@@ -119,6 +124,7 @@ const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
 const TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS = 30 * 60_000;
 const TASK_DONE_CONFIRMATION_MS = 5_000;
+const DONE_QUIESCENCE_MS = 1_500;
 const SESSION_ID_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const SESSION_ID_RE =
@@ -153,6 +159,8 @@ interface SweepAgentContext {
   screen?: Promise<CmuxReadScreenResult>;
 }
 
+type TargetStateEvidenceSource = "state" | "transcript" | "screen";
+
 function autoArchiveEnabledByEnv(): boolean {
   return !["0", "false", "off", "no"].includes(
     (process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE ?? "").toLowerCase(),
@@ -169,6 +177,14 @@ function screenTextSignature(text: string): string {
     hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
   }
   return `${text.length}:${hash.toString(16)}`;
+}
+
+function safeMtimeMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
 }
 
 function parseNonNegativeInteger(
@@ -541,6 +557,32 @@ export class AgentEngine {
     return !!agent.task_done_detected_at;
   }
 
+  private loadGroundTruthSession(
+    agent: AgentRecord,
+  ): HarnessSessionWithMeta | null {
+    if (!harnessJsonlEnabled() || !JSONL_HARNESSES.has(agent.cli)) {
+      return null;
+    }
+    const harness = agent.cli as Harness;
+    if (agent.cli_session_path) {
+      const state = readHarnessSessionFromFile(harness, agent.cli_session_path);
+      const mtime_ms = safeMtimeMs(agent.cli_session_path);
+      return state && mtime_ms > 0
+        ? { state, path: agent.cli_session_path, mtime_ms }
+        : null;
+    }
+    if (agent.state === "booting") return null;
+    return agent.cli_session_id
+      ? loadHarnessSessionWithMeta(harness, agent.cli_session_id)
+      : null;
+  }
+
+  private hasGroundTruthDone(agent: AgentRecord): boolean {
+    const session = this.loadGroundTruthSession(agent);
+    if (!session?.state.done) return false;
+    return Date.now() - session.mtime_ms >= DONE_QUIESCENCE_MS;
+  }
+
   private async hasCurrentOutputDoneEvidence(
     agent: AgentRecord,
   ): Promise<boolean> {
@@ -558,12 +600,22 @@ export class AgentEngine {
     agent: AgentRecord,
     targetState: AgentState,
   ): Promise<boolean> {
-    if (agent.state !== targetState) return false;
-    if (!this.requiresOutputDoneEvidence(targetState)) return true;
+    return (await this.getTargetStateEvidenceSource(agent, targetState)) !== null;
+  }
+
+  private async getTargetStateEvidenceSource(
+    agent: AgentRecord,
+    targetState: AgentState,
+  ): Promise<TargetStateEvidenceSource | null> {
+    if (agent.state !== targetState) return null;
+    if (!this.requiresOutputDoneEvidence(targetState)) return "state";
+    if (this.hasGroundTruthDone(agent)) return "transcript";
     return (
       this.hasRecordedOutputDoneEvidence(agent) ||
       (await this.hasCurrentOutputDoneEvidence(agent))
-    );
+    )
+      ? "screen"
+      : null;
   }
 
   private async refreshTargetStateEvidence(
@@ -872,6 +924,22 @@ export class AgentEngine {
     ctx: SweepAgentContext,
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
     if (TERMINAL_STATES.has(agent.state)) return { agent };
+
+    if (this.hasGroundTruthDone(agent)) {
+      try {
+        const marked = this.stateMgr.updateRecord(agent.agent_id, {
+          task_done_candidate_at: null,
+          task_done_detected_at: new Date().toISOString(),
+          ...(agent.boot_prompt_pending ? { boot_prompt_pending: false } : {}),
+        });
+        this.registry.set(agent.agent_id, marked);
+        const updated = this.stateMgr.transition(agent.agent_id, "done");
+        this.registry.set(agent.agent_id, updated);
+        return { agent: updated };
+      } catch {
+        return { agent };
+      }
+    }
 
     try {
       const screen = await this.readSweepScreen(agent, ctx);
@@ -1511,13 +1579,18 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    // Retroactive check — already in target state with required output evidence?
-    if (await this.hasTargetStateEvidence(initial, targetState)) {
+    // Retroactive check — already in target state with required evidence?
+    const initialEvidence = await this.getTargetStateEvidenceSource(
+      initial,
+      targetState,
+    );
+    if (initialEvidence) {
       return {
         matched: true,
         state: initial.state,
         elapsed: Date.now() - start,
-        source: "immediate",
+        source:
+          initialEvidence === "state" ? "immediate" : initialEvidence,
         agent: toPublicAgent(initial),
       };
     }
@@ -1582,15 +1655,17 @@ export class AgentEngine {
 
         current = await this.refreshTargetStateEvidence(current, targetState);
 
-        if (await this.hasTargetStateEvidence(current, targetState)) {
+        const evidenceSource = await this.getTargetStateEvidenceSource(
+          current,
+          targetState,
+        );
+        if (evidenceSource) {
           clearInterval(checkInterval);
           resolve({
             matched: true,
             state: current.state,
             elapsed,
-            source: this.requiresOutputDoneEvidence(targetState)
-              ? "evidence"
-              : "sweep",
+            source: evidenceSource === "state" ? "sweep" : evidenceSource,
             agent: toPublicAgent(current),
           });
           return;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -153,7 +153,15 @@ export interface WaitResult {
   matched: boolean;
   state: AgentState;
   elapsed: number;
-  source: "immediate" | "poll" | "sweep" | "watch" | "evidence" | "timeout";
+  source:
+    | "immediate"
+    | "poll"
+    | "sweep"
+    | "watch"
+    | "evidence"
+    | "transcript"
+    | "screen"
+    | "timeout";
   agent: PublicAgent | null;
   error?: string;
 }

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -111,6 +111,89 @@ function lastContentTextAndTool(
   return { lastText, lastTool };
 }
 
+const CLAUDE_TRAILING_METADATA_TYPES = new Set([
+  "system",
+  "permission-mode",
+  "mode",
+  "last-prompt",
+  "bridge-session",
+  "custom-title",
+  "agent-name",
+  "pr-link",
+  "user",
+  "attachment",
+  "file-history-snapshot",
+  "queue-operation",
+  "agent-setting",
+  "worktree-state",
+]);
+
+function messageContent(ev: Record<string, unknown>): unknown[] {
+  const message = asRecord(ev.message);
+  return Array.isArray(message?.content) ? message.content : [];
+}
+
+function collectClaudeToolResults(ev: Record<string, unknown>): Set<string> {
+  const ids = new Set<string>();
+  for (const item of messageContent(ev)) {
+    const block = asRecord(item);
+    if (block?.type !== "tool_result") continue;
+    if (typeof block.tool_use_id === "string") ids.add(block.tool_use_id);
+  }
+  return ids;
+}
+
+function collectClaudeToolUses(message: Record<string, unknown>): {
+  ids: string[];
+  missingId: boolean;
+} {
+  const ids: string[] = [];
+  let missingId = false;
+  const content = Array.isArray(message.content) ? message.content : [];
+  for (const item of content) {
+    const block = asRecord(item);
+    if (block?.type !== "tool_use") continue;
+    if (typeof block.id === "string") ids.push(block.id);
+    else missingId = true;
+  }
+  return { ids, missingId };
+}
+
+function claudeDone(events: Record<string, unknown>[]): boolean {
+  const answeredToolUseIds = new Set<string>();
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const ev = events[i];
+    if (ev.type === "user" || ev.role === "user") {
+      for (const id of collectClaudeToolResults(ev)) {
+        answeredToolUseIds.add(id);
+      }
+      continue;
+    }
+
+    if (ev.type !== "assistant" && ev.role !== "assistant") {
+      const type = typeof ev.type === "string" ? ev.type : null;
+      if (type && CLAUDE_TRAILING_METADATA_TYPES.has(type)) continue;
+      continue;
+    }
+
+    const message = asRecord(ev.message);
+    if (!message) return false;
+    const stopReason =
+      typeof message.stop_reason === "string" ? message.stop_reason : null;
+    const toolUses = collectClaudeToolUses(message);
+    if (toolUses.missingId) return false;
+    const hasUnansweredTool = toolUses.ids.some(
+      (id) => !answeredToolUseIds.has(id),
+    );
+    if (hasUnansweredTool) return false;
+    if (stopReason === "end_turn" || stopReason === "stop_sequence") {
+      return true;
+    }
+    return stopReason === "tool_use" && toolUses.ids.length > 0;
+  }
+  return false;
+}
+
 function parseClaude(events: Record<string, unknown>[]): HarnessSessionState {
   let model: string | null = null;
   let tokensUsed: number | null = null;
@@ -138,7 +221,7 @@ function parseClaude(events: Record<string, unknown>[]): HarnessSessionState {
     context_pct: pct(tokensUsed, window),
     last_text: lastText,
     last_tool: lastTool,
-    done: false,
+    done: claudeDone(events),
   };
 }
 
@@ -193,6 +276,10 @@ function parseCodex(events: Record<string, unknown>[]): HarnessSessionState {
         done = true;
         break;
       }
+      case "task_started": {
+        done = false;
+        break;
+      }
     }
   }
   return {
@@ -218,6 +305,7 @@ function parseCursor(events: Record<string, unknown>[]): HarnessSessionState {
     context_pct: null,
     last_text: lastText,
     last_tool: lastTool,
+    // AIDEV-NOTE: Cursor done is screen-scrape-fallback-only until its JSONL has a reliable lifecycle marker.
     done: false,
   };
 }
@@ -316,6 +404,12 @@ export function readHarnessSessionFromFile(
     return null;
   }
   return parseHarnessSession(harness, content);
+}
+
+export interface HarnessSessionWithMeta {
+  state: HarnessSessionState;
+  path: string;
+  mtime_ms: number;
 }
 
 function safeReaddir(dir: string): string[] {
@@ -572,6 +666,27 @@ export function loadHarnessSession(
   }
   if (!path) return null;
   return readHarnessSessionFromFile(harness, path);
+}
+
+export function loadHarnessSessionWithMeta(
+  harness: Harness,
+  sessionId: string,
+  opts: ResolveOpts = {},
+): HarnessSessionWithMeta | null {
+  if (!sessionId) return null;
+  const cacheKey = `${harness}:${sessionId}`;
+  let path = sessionPathCache.get(cacheKey) ?? null;
+  if (path && !isFile(path)) path = null;
+  if (!path) {
+    path = findHarnessSessionPath(harness, sessionId, opts);
+    if (path) sessionPathCache.set(cacheKey, path);
+  }
+  if (!path) return null;
+  const state = readHarnessSessionFromFile(harness, path);
+  if (!state) return null;
+  const mtime_ms = mtimeMs(path);
+  if (mtime_ms <= 0) return null;
+  return { state, path, mtime_ms };
 }
 
 /**

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5,7 +5,15 @@ vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -101,6 +109,29 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
     user_killed: false,
     ...overrides,
   };
+}
+
+function writeCodexDoneTranscript(path: string): void {
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: "019eab06-57d6-72b1-b3a8-6cf98a30a3f6",
+          cwd: "/Users/etanheyman/Gits/cmuxlayer",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "task_complete",
+          turn_id: "019eab07-94c8-7610-be92-95610333aa91",
+          last_agent_message: "Implemented the fix.\n\nTASK_DONE",
+        },
+      }),
+    ].join("\n"),
+  );
 }
 
 describe("AgentEngine", () => {
@@ -1622,7 +1653,7 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("evidence");
+        expect(result.source).toBe("screen");
         expect(result.state).toBe("done");
         expect(engine.getAgentState("worker-output-done")).toMatchObject({
           state: "done",
@@ -1666,7 +1697,7 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("evidence");
+        expect(result.source).toBe("screen");
         expect(result.state).toBe("done");
         expect(result.elapsed).toBeLessThan(2_000);
       } finally {
@@ -1838,7 +1869,7 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("evidence");
+        expect(result.source).toBe("screen");
         expect(result.state).toBe("done");
         expect(engine.getAgentState(agentId)).toMatchObject({
           state: "done",
@@ -1918,9 +1949,94 @@ To continue this session, run codex resume ${sessionId}`,
         const result = await pending;
 
         expect(result.matched).toBe(true);
-        expect(result.source).toBe("evidence");
+        expect(result.source).toBe("screen");
         expect(result.state).toBe("done");
         expect(engine.getAgentState("claude-output-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: expect.any(String),
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve transcript done while the JSONL mtime is fresh", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-09T10:00:00.000Z");
+        vi.setSystemTime(now);
+        const transcript = join(TEST_DIR, "fresh-codex-done.jsonl");
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, now, now);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-fresh",
+            state: "working",
+            surface_id: "surface:worker-transcript-fresh",
+            cli: "codex",
+            role: "worker",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-fresh")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-transcript-fresh",
+          text: "gpt-5.4\nWorking (1m 02s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-transcript-fresh", "done", 1_200);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(engine.getAgentState("worker-transcript-fresh")?.state).toBe(
+          "working",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves done from stale transcript ground truth with no screen banner", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-09T10:00:00.000Z");
+        const stale = new Date(now.getTime() - 2_000);
+        vi.setSystemTime(now);
+        const transcript = join(TEST_DIR, "stale-codex-done.jsonl");
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, stale, stale);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-done",
+            state: "working",
+            surface_id: "surface:worker-transcript-done",
+            cli: "codex",
+            role: "worker",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-transcript-done",
+          text: "gpt-5.4\nWorked for 16m 44s\ncodex> ",
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("worker-transcript-done", "done", 7_000);
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("transcript");
+        expect(result.state).toBe("done");
+        expect(engine.getAgentState("worker-transcript-done")).toMatchObject({
           state: "done",
           task_done_detected_at: expect.any(String),
         });

--- a/tests/fixtures/harness/codex.jsonl
+++ b/tests/fixtures/harness/codex.jsonl
@@ -5,3 +5,4 @@
 {"type":"event","timestamp":"2026-06-04T22:47:00.000Z","payload":{"type":"function_call","name":"exec_command","call_id":"call_a","arguments":"{}"}}
 {"type":"event","timestamp":"2026-06-04T22:47:30.000Z","payload":{"type":"agent_message","message":"codex latest message","phase":"execute"}}
 {"type":"event","timestamp":"2026-06-04T22:48:00.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":107745,"cached_input_tokens":106368,"output_tokens":824,"reasoning_output_tokens":516,"total_tokens":108569},"total_token_usage":{"input_tokens":20265083,"output_tokens":87553,"total_tokens":20352636},"model_context_window":258400}}}
+{"type":"event_msg","timestamp":"2026-06-04T22:49:00.000Z","payload":{"type":"task_complete","turn_id":"019e942c-turn-1","last_agent_message":"codex latest message\n\nTASK_DONE","completed_at":1780613340,"duration_ms":60000}}

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,6 +18,7 @@ import {
   findLatestHarnessSessionIdentity,
   findHarnessSessionPath,
   loadHarnessSession,
+  loadHarnessSessionWithMeta,
   applyHarnessState,
   harnessJsonlEnabled,
 } from "../src/harness-session.js";
@@ -93,6 +95,116 @@ describe("parseHarnessSession", () => {
     expect(s.context_pct).toBeNull();
     expect(s.done).toBe(false);
   });
+
+  it("Claude: settled end_turn with trailing harness metadata is done", () => {
+    const s = parseHarnessSession(
+      "claude",
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-8",
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "TASK_DONE" }],
+          },
+        }),
+        JSON.stringify({ type: "system", content: "harness metadata" }),
+        JSON.stringify({ type: "last-prompt", prompt: "previous prompt" }),
+        JSON.stringify({ type: "mode", mode: "default" }),
+        JSON.stringify({ type: "permission-mode", mode: "acceptEdits" }),
+        JSON.stringify({ type: "pr-link", url: "https://example.invalid/pr" }),
+      ].join("\n"),
+    );
+
+    expect(s.done).toBe(true);
+  });
+
+  it("Claude: unanswered terminal tool_use is still in flight", () => {
+    const s = parseHarnessSession(
+      "claude",
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-8",
+            stop_reason: "tool_use",
+            content: [
+              { type: "text", text: "I will inspect the file." },
+              { type: "tool_use", id: "toolu_018xNv2zPGrCXaudR29Wsdef", name: "Read" },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "queue-operation", op: "append" }),
+        JSON.stringify({ type: "last-prompt", prompt: "continue" }),
+        JSON.stringify({ type: "agent-setting", name: "model" }),
+        JSON.stringify({ type: "mode", mode: "default" }),
+        JSON.stringify({ type: "permission-mode", mode: "acceptEdits" }),
+      ].join("\n"),
+    );
+
+    expect(s.done).toBe(false);
+  });
+
+  it("Claude: terminal tool_use is done once a later user tool_result answers it", () => {
+    const toolUseId = "toolu_019cdJd1eHLJHcwLgEHTUU2L";
+    const s = parseHarnessSession(
+      "claude",
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            model: "claude-opus-4-8",
+            stop_reason: "tool_use",
+            content: [
+              { type: "text", text: "Running the check." },
+              { type: "tool_use", id: toolUseId, name: "Bash" },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "attachment", name: "ctx" }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: toolUseId, content: "ok" },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "attachment", name: "more ctx" }),
+        JSON.stringify({ type: "last-prompt", prompt: "continue" }),
+        JSON.stringify({ type: "custom-title", title: "private-tmp" }),
+        JSON.stringify({ type: "agent-name", name: "cmuxlayerClaude" }),
+        JSON.stringify({ type: "mode", mode: "default" }),
+        JSON.stringify({ type: "permission-mode", mode: "acceptEdits" }),
+        JSON.stringify({ type: "bridge-session", id: "bridge" }),
+      ].join("\n"),
+    );
+
+    expect(s.done).toBe(true);
+  });
+
+  it("Codex: task_complete marks done", () => {
+    const s = parseHarnessSession("codex", read("codex.jsonl"));
+    expect(s.done).toBe(true);
+  });
+
+  it("Codex: later task_started resets stale task_complete done", () => {
+    const s = parseHarnessSession(
+      "codex",
+      [
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "task_complete", turn_id: "turn-1" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "task_started", turn_id: "turn-2" },
+        }),
+      ].join("\n"),
+    );
+
+    expect(s.done).toBe(false);
+  });
 });
 
 describe("modelContextWindow (Claude denominator + no-JSONL fallback)", () => {
@@ -163,6 +275,38 @@ describe("readHarnessSessionFromFile", () => {
   it("missing file → null (caller falls back to screen-parser)", () => {
     const s = readHarnessSessionFromFile("codex", join(FIX, "nope.jsonl"));
     expect(s).toBeNull();
+  });
+});
+
+describe("loadHarnessSessionWithMeta", () => {
+  it("returns parsed state with transcript mtime for quiescence checks", () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-harness-meta-"));
+    const root = join(home, ".codex", "sessions", "2026", "06", "09");
+    const path = join(root, "rollout-2026-06-09T09-16-20-sid-meta.jsonl");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "sid-meta", cwd: "/Users/e/Gits/cmuxlayer" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "task_complete", turn_id: "turn-1" },
+        }),
+      ].join("\n"),
+    );
+    const mtime = new Date("2026-06-09T10:00:00.000Z");
+    utimesSync(path, mtime, mtime);
+
+    try {
+      const meta = loadHarnessSessionWithMeta("codex", "sid-meta", { home });
+      expect(meta?.state.done).toBe(true);
+      expect(meta?.mtime_ms).toBe(mtime.getTime());
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Claude transcript done detection from the tail's unanswered `tool_use` set, including answered terminal `tool_use` and trailing harness metadata.
- Make Codex `done` reflect the last lifecycle event by resetting on later `task_started`.
- Promote `wait_for(done)` from quiescent transcript ground truth first, with screen-scrape preserved as fallback and labeled as `source: "screen"`.
- Add transcript mtime metadata and a 1500ms quiescence guard; `source: "transcript"` is returned for ground-truth done.

## P1 Scope
- Includes ground-truth done detection only.
- Does not add poll mode, pending, still_running, server schema changes, or wait_for_all mode changes.

## Eval Pack
- Baseline (screen-scrape only): focused RED tests failed as expected: `tests/harness-session.test.ts` had 4 failures for Claude done, Codex stale done, and metadata loading; `tests/agent-engine.test.ts` had 5 failures for screen source labels and transcript-done-with-no-banner.
- After (ground-truth-first): `waitFor(done)` resolves stale transcript completion with `matched:true` and `source:"transcript"`; screen fallback still resolves with `source:"screen"`.
- Delta: closes the leakfix class where `task_complete` is in JSONL but `TASK_DONE` scrolled off screen. No regressions found in full test/typecheck runs.

## Test Plan
- `bun run test` → 44 test files passed, 768 tests passed.
- `bun run typecheck` → `tsc -p tsconfig.json --noEmit` exited 0.
- Pre-push hook reran full tests and finished with exit status 0.

## Review Notes
- `coderabbit review --agent` was attempted pre-commit and hit a recoverable free-tier rate limit (`waitTime: 4 minutes and 8 seconds`). PR-level review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent lifecycle and wait_for completion semantics; mis-parsed JSONL or quiescence timing could mark done too early or late, though screen fallback and fresh-mtime guard limit exposure.
> 
> **Overview**
> **`wait_for(..., "done")` now prefers quiescent harness JSONL over terminal scraping**, so completion can be recognized when `task_complete` or Claude turn-end is in the transcript but `TASK_DONE` is no longer on screen.
> 
> **Transcript parsing** adds Claude `done` from the tail assistant turn (unanswered `tool_use`, trailing harness metadata), Codex `done` from the last `task_complete` / `task_started` lifecycle events, and **`loadHarnessSessionWithMeta`** (parsed state + file mtime). **`AgentEngine`** treats transcript `done` as ground truth only after **1500ms** since the JSONL mtime (`DONE_QUIESCENCE_MS`), marks agents done via **`maybeMarkTaskDone`** without a screen banner, and classifies wait sources as **`transcript`** vs **`screen`** (replacing the old **`evidence`** label for scrape-based completion).
> 
> Screen-based TASK_DONE confirmation remains the fallback when JSONL is disabled, missing, or still “fresh.” Cursor JSONL still does not drive `done`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3aae6bcf505e384cd0742c3e9e7aa0a7d8ba2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect `waitFor` done from JSONL harness transcripts in `AgentEngine`
> - Adds transcript-based done detection to `AgentEngine`: when a harness JSONL transcript has `state.done=true` and its file mtime is older than 1500ms (quiescence), the agent transitions to `done` without requiring screen evidence.
> - Adds `claudeDone` logic in [harness-session.ts](https://github.com/EtanHey/cmuxlayer/pull/148/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) to infer done state from Claude transcript events by checking `stop_reason` and matching tool use/result pairs; Codex `done` is now reset to `false` if a later `task_started` event follows a `task_complete`.
> - Adds `loadHarnessSessionWithMeta` to return transcript state alongside file path and mtime for quiescence checks.
> - Refactors `getTargetStateEvidenceSource` to return granular sources: `'state'`, `'transcript'`, or `'screen'`; `WaitResult.source` no longer returns the generic `'evidence'` value.
> - Behavioral Change: existing callers reading `WaitResult.source === 'evidence'` will no longer receive that value — screen-based evidence now returns `'screen'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e3aae6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->