### PR TITLE
fix(spawn): resolve launcher names by probing candidate forms (R-039)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -91,8 +91,19 @@ export type SessionIdentityResolver = (
   agent: AgentRecord,
 ) => CapturedSessionIdentity | string | null;
 
+/**
+ * Result of the spawn preflight. `launcherName` carries the launcher function
+ * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
+ * launches the form that actually registered, even when hyphens were stripped.
+ */
+export interface SpawnPreflightResult {
+  launcherName?: string;
+}
+
 export interface AgentEngineOptions {
-  spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
+  spawnPreflight?: (
+    params: SpawnAgentParams,
+  ) => Promise<SpawnPreflightResult | void>;
   spawnGuard?: SpawnGuard;
   sessionIdentityResolver?: SessionIdentityResolver;
   roleSurfaceIdsProvider?: (
@@ -416,6 +427,10 @@ export function buildLaunchCommand(
   cli: CliType,
   repo: string,
   model?: string,
+  // Resolved launcher function name (from resolveLauncherName). When provided
+  // for a launcher CLI it overrides the naive `${repo}${Suffix}` guess so
+  // hyphen-stripped registrations launch correctly. Ignored for gemini/kiro.
+  launcherName?: string,
 ): string {
   const safeRepo = sanitizeRepoName(repo);
   const modelFlag = resolveModelFlag(cli, model);
@@ -424,16 +439,16 @@ export function buildLaunchCommand(
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry
-      return `${safeRepo}Claude -s${launcherModelArgs}`;
+      return `${launcherName ?? `${safeRepo}Claude`} -s${launcherModelArgs}`;
     case "codex":
-      return `${safeRepo}Codex -s${launcherModelArgs}`;
+      return `${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}`;
     case "gemini":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini${rawModelArgs}`;
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli${rawModelArgs}`;
     case "cursor":
       // repoGolem launcher - requires registration via golem-powers.
-      return `${safeRepo}Cursor -s${launcherModelArgs}`;
+      return `${launcherName ?? `${safeRepo}Cursor`} -s${launcherModelArgs}`;
   }
 }
 
@@ -450,32 +465,91 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
-export async function assertLauncherAvailable(
+export type LauncherSuffix = "Claude" | "Codex" | "Cursor";
+
+/**
+ * Ordered, de-duplicated launcher-name candidates for a repo + suffix.
+ *
+ * The repoGolem registry emits launcher function names INCONSISTENTLY per repo
+ * (see ~/.config/ralphtools/golem-dispatch.zsh `_golem_register_wrappers`):
+ *   - the primary wrapper uses the lowercased, hyphen-stripped registry key
+ *     (`${(L)name}` -> `agenthtmlhostCursor`), and
+ *   - the P10 "hyphen-aware verbatim alias" is emitted ONLY for some repos
+ *     (`agent-html-hostCursor` exists for `maakaf-home`/`skill-creator` but
+ *     NOT for `agent-html-host`).
+ *
+ * cmuxlayer cannot know which form a given repo registered, so we generate
+ * both and probe in order. Candidate #1 preserves today's behavior (verbatim
+ * dir name); candidate #2 matches the registry's primary wrapper.
+ */
+export function launcherNameCandidates(
   repo: string,
-  suffix: "Claude" | "Codex" | "Cursor",
-): Promise<void> {
-  const launcher = `${sanitizeRepoName(repo)}${suffix}`;
+  suffix: LauncherSuffix,
+): string[] {
+  const safeRepo = sanitizeRepoName(repo);
+  const verbatim = `${safeRepo}${suffix}`;
+  const stripped = `${safeRepo.replace(/-/g, "").toLowerCase()}${suffix}`;
+  return stripped === verbatim ? [verbatim] : [verbatim, stripped];
+}
+
+/** Returns true when a launcher function/command resolves in the login shell. */
+export type LauncherProbe = (launcher: string) => Promise<boolean>;
+
+const shellLauncherProbe: LauncherProbe = async (launcher) => {
   const shell = process.env.SHELL || "/bin/zsh";
   const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
-
   try {
     await execFileAsync(shell, ["-ilc", probe]);
+    return true;
   } catch {
-    throw new Error(
-      `Launcher "${launcher}" not found. ` +
-        `For repo "${repo}" with hyphens the launcher strips hyphens ` +
-        `(e.g. "skill-creator" -> "skillcreatorCursor"). ` +
-        `Register the launcher in golem-powers or use cli="gemini"/"kiro" ` +
-        `which use direct cd+exec paths.`,
-    );
+    return false;
   }
+};
+
+/**
+ * Resolve the actual launcher function name by probing candidate forms in
+ * order. Returns the first candidate that resolves in the login shell; throws a
+ * clear registration error (listing every form tried) when none resolve. The
+ * probe is injectable for deterministic tests.
+ */
+export async function resolveLauncherName(
+  repo: string,
+  suffix: LauncherSuffix,
+  probe: LauncherProbe = shellLauncherProbe,
+): Promise<string> {
+  const candidates = launcherNameCandidates(repo, suffix);
+  for (const candidate of candidates) {
+    if (await probe(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Launcher not found for repo "${repo}". Tried: ${candidates.join(", ")}. ` +
+      `The repoGolem registry may strip hyphens (e.g. "agent-html-host" -> ` +
+      `"agenthtmlhostCursor"). Register the launcher in golem-powers or use ` +
+      `cli="gemini"/"kiro" which use direct cd+exec paths.`,
+  );
+}
+
+/**
+ * Validate that a launcher is registered and return its resolved name. Probes
+ * candidate forms so multi-hyphen repos that registered a stripped name resolve
+ * instead of failing on the naive verbatim guess.
+ */
+export async function assertLauncherAvailable(
+  repo: string,
+  suffix: LauncherSuffix,
+): Promise<string> {
+  return resolveLauncherName(repo, suffix);
 }
 
 export class AgentEngine {
   private stateMgr: StateManager;
   private registry: AgentRegistry;
   private client: AgentEngineClient;
-  private spawnPreflight: (params: SpawnAgentParams) => Promise<void>;
+  private spawnPreflight: (
+    params: SpawnAgentParams,
+  ) => Promise<SpawnPreflightResult | void>;
   private spawnGuard: SpawnGuard;
   private roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
@@ -513,13 +587,21 @@ export class AgentEngine {
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.spawnPreflight =
       opts?.spawnPreflight ??
-      (async (params) => {
+      (async (params): Promise<SpawnPreflightResult | void> => {
         if (params.cli === "claude") {
-          await assertLauncherAvailable(params.repo, "Claude");
-        } else if (params.cli === "codex") {
-          await assertLauncherAvailable(params.repo, "Codex");
-        } else if (params.cli === "cursor") {
-          await assertLauncherAvailable(params.repo, "Cursor");
+          return {
+            launcherName: await assertLauncherAvailable(params.repo, "Claude"),
+          };
+        }
+        if (params.cli === "codex") {
+          return {
+            launcherName: await assertLauncherAvailable(params.repo, "Codex"),
+          };
+        }
+        if (params.cli === "cursor") {
+          return {
+            launcherName: await assertLauncherAvailable(params.repo, "Cursor"),
+          };
         }
       });
   }
@@ -1412,7 +1494,7 @@ export class AgentEngine {
 
     this.spawnGuard.check(params.workspace);
 
-    await this.spawnPreflight(params);
+    const preflight = await this.spawnPreflight(params);
 
     // 1. Create cmux surface using the deterministic worker layout policy.
     const surface = await this.createAgentSurface(params.workspace, {
@@ -1455,7 +1537,12 @@ export class AgentEngine {
     this.registry.set(agentId, record);
 
     // 3. Send launch command
-    const launchCmd = buildLaunchCommand(params.cli, params.repo, params.model);
+    const launchCmd = buildLaunchCommand(
+      params.cli,
+      params.repo,
+      params.model,
+      preflight?.launcherName,
+    );
     try {
       await this.sendLaunchCommand(surface.surface, surface.workspace, launchCmd);
     } catch (error) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -14,6 +14,8 @@ import {
   buildLaunchCommand,
   buildResumeCommand,
   extractSessionId,
+  launcherNameCandidates,
+  resolveLauncherName,
   resolveSweepTiming,
 } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
@@ -215,6 +217,28 @@ describe("AgentEngine", () => {
       expect(surface).toBe("surface:new");
       expect(opts).toEqual({ workspace: "ws:1" });
       expect(launchCmd).toBe("brainlayerClaude -s -m sonnet");
+    });
+
+    it("launches with the launcher name resolved by preflight", async () => {
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      const resolvingEngine = new AgentEngine(stateMgr, registry, mockClient, {
+        // agent-html-host registered only as the hyphen-stripped form.
+        spawnPreflight: async () => ({ launcherName: "agenthtmlhostCursor" }),
+        sessionIdentityResolver: () => null,
+      });
+
+      await resolvingEngine.spawnAgent({
+        repo: "agent-html-host",
+        cli: "cursor",
+        prompt: "Fix gap F",
+      });
+
+      const [, launchCmd] = (
+        mockClient.send as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      expect(launchCmd).toBe("agenthtmlhostCursor -s");
+
+      resolvingEngine.dispose();
     });
 
     it("writes initial state file", async () => {
@@ -2725,6 +2749,33 @@ describe("buildLaunchCommand", () => {
     );
   });
 
+  it("uses an explicitly resolved launcher name for launcher CLIs", () => {
+    expect(
+      buildLaunchCommand(
+        "cursor",
+        "agent-html-host",
+        undefined,
+        "agenthtmlhostCursor",
+      ),
+    ).toBe("agenthtmlhostCursor -s");
+    expect(
+      buildLaunchCommand(
+        "claude",
+        "agent-html-host",
+        "sonnet",
+        "agenthtmlhostClaude",
+      ),
+    ).toBe("agenthtmlhostClaude -s -m sonnet");
+  });
+
+  it("ignores a launcher override for non-launcher CLIs", () => {
+    expect(
+      buildLaunchCommand("gemini", "voicelayer", undefined, "ignoredGemini"),
+    ).toBe(
+      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini",
+    );
+  });
+
   it("rejects invalid repo names", () => {
     expect(() => buildLaunchCommand("claude", "foo bar")).toThrow(
       /Invalid repo name/,
@@ -2785,14 +2836,14 @@ describe("assertLauncherAvailable", () => {
     vi.unstubAllEnvs();
   });
 
-  it("passes when the interactive shell probe returns 0", async () => {
+  it("resolves to the verbatim launcher name when the probe returns 0", async () => {
     execFileMock.mockImplementation((_cmd, _args, callback) => {
       callback(null, "", "");
     });
 
-    await expect(
-      assertLauncherAvailable("brainlayer", "Cursor"),
-    ).resolves.toBeUndefined();
+    await expect(assertLauncherAvailable("brainlayer", "Cursor")).resolves.toBe(
+      "brainlayerCursor",
+    );
 
     expect(execFileMock).toHaveBeenCalledWith(
       "/bin/zsh",
@@ -2804,7 +2855,23 @@ describe("assertLauncherAvailable", () => {
     );
   });
 
-  it("throws a clear launcher registration message when the probe fails", async () => {
+  it("falls back to the hyphen-stripped launcher when verbatim is unregistered", async () => {
+    // agent-html-host registered only as agenthtmlhostCursor (hyphens stripped).
+    execFileMock.mockImplementation((_cmd, args, callback) => {
+      const probe = String(args?.[1] ?? "");
+      if (probe.includes("agenthtmlhostCursor")) {
+        callback(null, "", "");
+      } else {
+        callback(new Error("missing launcher"), "", "");
+      }
+    });
+
+    await expect(
+      assertLauncherAvailable("agent-html-host", "Cursor"),
+    ).resolves.toBe("agenthtmlhostCursor");
+  });
+
+  it("throws listing every candidate when none resolve", async () => {
     execFileMock.mockImplementation((_cmd, _args, callback) => {
       callback(new Error("missing launcher"), "", "");
     });
@@ -2812,8 +2879,56 @@ describe("assertLauncherAvailable", () => {
     await expect(
       assertLauncherAvailable("skill-creator", "Cursor"),
     ).rejects.toThrow(
-      /Launcher "skill-creatorCursor" not found.*skillcreatorCursor.*cli="gemini"\/"kiro"/s,
+      /skill-creatorCursor.*skillcreatorCursor.*cli="gemini"\/"kiro"/s,
     );
+  });
+});
+
+describe("launcherNameCandidates", () => {
+  it("returns a single candidate for hyphenless repos", () => {
+    expect(launcherNameCandidates("brainlayer", "Cursor")).toEqual([
+      "brainlayerCursor",
+    ]);
+  });
+
+  it("adds the lowercased hyphen-stripped form for hyphenated repos", () => {
+    expect(launcherNameCandidates("agent-html-host", "Cursor")).toEqual([
+      "agent-html-hostCursor",
+      "agenthtmlhostCursor",
+    ]);
+  });
+
+  it("preserves the verbatim form even when it has hyphens", () => {
+    expect(launcherNameCandidates("maakaf-home", "Claude")).toEqual([
+      "maakaf-homeClaude",
+      "maakafhomeClaude",
+    ]);
+  });
+});
+
+describe("resolveLauncherName", () => {
+  it("returns the verbatim launcher when it resolves first", async () => {
+    const probe = vi.fn(async (name: string) => name === "maakaf-homeCursor");
+    await expect(
+      resolveLauncherName("maakaf-home", "Cursor", probe),
+    ).resolves.toBe("maakaf-homeCursor");
+    expect(probe).toHaveBeenCalledWith("maakaf-homeCursor");
+  });
+
+  it("probes the stripped form only after the verbatim form misses", async () => {
+    const probe = vi.fn(async (name: string) => name === "agenthtmlhostCursor");
+    await expect(
+      resolveLauncherName("agent-html-host", "Cursor", probe),
+    ).resolves.toBe("agenthtmlhostCursor");
+    expect(probe).toHaveBeenNthCalledWith(1, "agent-html-hostCursor");
+    expect(probe).toHaveBeenNthCalledWith(2, "agenthtmlhostCursor");
+  });
+
+  it("throws when no candidate resolves", async () => {
+    const probe = vi.fn(async () => false);
+    await expect(
+      resolveLauncherName("agent-html-host", "Cursor", probe),
+    ).rejects.toThrow(/agent-html-hostCursor.*agenthtmlhostCursor/s);
   });
 });
 


### PR DESCRIPTION
## R-039 — launcher-name resolution

### Problem
The repoGolem registry (`~/.config/ralphtools/golem-dispatch.zsh` `_golem_register_wrappers`) emits launcher function names **inconsistently per repo**:
- the **primary wrapper** uses the lowercased, hyphen-stripped registry key — `agent-html-host` → **`agenthtmlhostCursor`**
- the **P10 hyphen-aware verbatim alias** (`agent-html-hostCursor`) is emitted for *only some* repos (`maakaf-home`, `skill-creator`) but **not** `agent-html-host`.

cmuxlayer's `buildLaunchCommand`/`assertLauncherAvailable` guessed a **single naive form** (`${repo}${Suffix}`, hyphens preserved), so multi-hyphen repos that registered the stripped name failed launch with *"launcher not found"* (the gen-14 `agent-html-host → agent-html-hostCursor "not found"` symptom).

### Fix
Resolve the launcher by **probing ordered candidates** and using the first that exists in the login shell:
1. verbatim `${repo}${Suffix}` (preserves today's behavior)
2. lowercased, hyphen-stripped `${repo/-//}${Suffix}` (matches the registry's primary wrapper)

- `launcherNameCandidates(repo, suffix)` — pure, ordered, de-duped
- `resolveLauncherName(repo, suffix, probe?)` — injectable probe; throws listing **all** tried forms when none resolve
- `assertLauncherAvailable` now **returns the resolved name** (still throws when none found — backward compatible for void-ignorers)
- `buildLaunchCommand` gains an optional resolved `launcherName` (gemini/kiro unaffected)
- `SpawnPreflightResult.launcherName` threads the resolved name from preflight → `spawnAgent` → `buildLaunchCommand`, so the **correct form is launched**, with only one probe

### Tests
+10 tests (candidates / resolver fallback / probe ordering / preflight threading / command override). **770 total green.** `typecheck` + `build` clean. No unrelated formatting churn.

Part of the gen-15 spawn-hygiene mission (R-037/R-039/R-031/R-038).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the spawn launch path and runs shell probes during preflight; resume/crash-recovery still use naive `${repo}${Suffix}` names and are not updated in this PR.
> 
> **Overview**
> Fixes **"launcher not found"** spawns for hyphenated repos (e.g. `agent-html-host`) when golem registered only a **hyphen-stripped** wrapper like `agenthtmlhostCursor`.
> 
> **Launcher resolution:** Adds ordered candidates (verbatim `${repo}${Suffix}` first, then lowercased hyphen-stripped), **`resolveLauncherName`** with an injectable shell probe, and **`assertLauncherAvailable`** now **returns** the resolved name instead of only throwing.
> 
> **Spawn wiring:** **`SpawnPreflightResult.launcherName`** flows from default/custom preflight into **`spawnAgent` → `buildLaunchCommand`**, which accepts an optional override for launcher CLIs; gemini/kiro unchanged.
> 
> **Tests:** Coverage for candidate generation, probe fallback order, preflight threading, and explicit launcher overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817eb6b690345d51938ecb6a50d9523776f79264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve launcher names by probing candidate forms in `AgentEngine` spawn preflight
> - Adds `resolveLauncherName` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/149/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5), which generates candidate launcher names (verbatim and hyphen-stripped/lowercased) and probes each via the shell's `type`/`command -v`, returning the first that resolves.
> - Updates `assertLauncherAvailable` to return the resolved launcher name string instead of `void`, and throws a detailed error listing all candidates when none resolve.
> - Passes the preflight-resolved launcher name into `buildLaunchCommand` for `claude`/`codex`/`cursor` so the final shell command uses the correct wrapper name; `gemini`/`kiro` are unaffected.
> - Behavioral Change: launchers installed under a hyphen-stripped name (e.g. `claudeai` instead of `claude-ai`) now resolve successfully where they previously failed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 817eb6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and resolution of launcher names for agent spawning.
  * Added support for custom launcher name overrides.
  * Enhanced error messaging when launcher verification fails.

* **Tests**
  * Extended test coverage for launcher resolution and agent spawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->