### PR TITLE
fix: assert post-spawn agent liveness

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -99,6 +99,7 @@ export type SessionIdentityResolver = (
 export interface AgentEngineOptions {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   spawnGuard?: SpawnGuard;
+  postSpawnLivenessMs?: number;
   sessionIdentityResolver?: SessionIdentityResolver;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
@@ -120,6 +121,7 @@ const DEFAULT_SWEEP_ACTIVE_INTERVAL_MS = 5_000;
 const DEFAULT_SWEEP_IDLE_INTERVAL_MS = 15_000;
 const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
+const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
 const TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS = 30 * 60_000;
@@ -493,6 +495,7 @@ export class AgentEngine {
   private client: AgentEngineClient;
   private spawnPreflight: (params: SpawnAgentParams) => Promise<void>;
   private spawnGuard: SpawnGuard;
+  private postSpawnLivenessMs: number;
   private roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -500,6 +503,7 @@ export class AgentEngine {
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
   private sessionIdentityResolver: SessionIdentityResolver;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
+  private postSpawnLivenessTimers = new Set<ReturnType<typeof setTimeout>>();
   private sweepTiming: SweepTimingOptions | null = null;
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
@@ -527,6 +531,12 @@ export class AgentEngine {
       opts?.sessionIdentityResolver ??
       ((agent) => this.findTranscriptSessionIdentity(agent));
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
+    this.postSpawnLivenessMs =
+      opts?.postSpawnLivenessMs ??
+      parseNonNegativeInteger(
+        process.env.CMUXLAYER_POST_SPAWN_LIVENESS_MS,
+        DEFAULT_POST_SPAWN_LIVENESS_MS,
+      );
     this.spawnPreflight =
       opts?.spawnPreflight ??
       (async (params) => {
@@ -1439,9 +1449,58 @@ export class AgentEngine {
       clearTimeout(this.sweepTimer);
       this.sweepTimer = null;
     }
+    for (const timer of this.postSpawnLivenessTimers) {
+      clearTimeout(timer);
+    }
+    this.postSpawnLivenessTimers.clear();
     this.sweepTiming = null;
     this.lastSweepSignature = null;
     this.unchangedSweepCount = 0;
+  }
+
+  private schedulePostSpawnLivenessAssertion(agentId: string): void {
+    const timer = setTimeout(() => {
+      this.postSpawnLivenessTimers.delete(timer);
+      void this.assertPostSpawnLiveness(agentId);
+    }, this.postSpawnLivenessMs);
+    this.postSpawnLivenessTimers.add(timer);
+  }
+
+  private async assertPostSpawnLiveness(agentId: string): Promise<void> {
+    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    if (!agent || TERMINAL_STATES.has(agent.state)) {
+      return;
+    }
+
+    const registered = this.registry.get(agentId) !== null;
+    const surfaceLive = await this.registry.hasLiveSurface(agent.surface_id);
+    if (registered && surfaceLive) {
+      return;
+    }
+
+    const reason = registered
+      ? `surface ${agent.surface_id} is not live`
+      : `agent ${agentId} is not registered`;
+    const error = `Post-spawn liveness failed: ${reason}`;
+
+    try {
+      const current = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+      if (current && !TERMINAL_STATES.has(current.state)) {
+        const failed = this.stateMgr.transition(agentId, "error", { error });
+        this.registry.set(agentId, failed);
+      }
+    } catch {
+      // Best-effort liveness assertion; still attempt surface cleanup below.
+    }
+
+    try {
+      await this.client.closeSurface(agent.surface_id, {
+        workspace: agent.workspace_id ?? undefined,
+        collapsePane: true,
+      });
+    } catch {
+      // Best-effort zombie cleanup.
+    }
   }
 
   /**
@@ -1538,6 +1597,7 @@ export class AgentEngine {
       }
       throw error;
     }
+    this.schedulePostSpawnLivenessAssertion(agentId);
 
     return {
       agent_id: agentId,

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -189,6 +189,11 @@ export class AgentRegistry {
     return results;
   }
 
+  async hasLiveSurface(surfaceId: string): Promise<boolean> {
+    const surfaces = await this.surfaceProvider();
+    return surfaces.some((surface) => surface.ref === surfaceId);
+  }
+
   async listMerged(
     discovery: AgentDiscovery,
     opts?: { filter?: AgentFilter; force?: boolean },

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -232,6 +232,75 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).toHaveBeenCalled();
     });
 
+    it("marks a post-launch disappeared surface as error and attempts cleanup", async () => {
+      vi.useFakeTimers();
+      try {
+        engine.dispose();
+        engine = new AgentEngine(
+          stateMgr,
+          new AgentRegistry(stateMgr, async () => liveSurfaces),
+          mockClient,
+          {
+            spawnPreflight: async () => {},
+            postSpawnLivenessMs: 0,
+          },
+        );
+
+        const result = await engine.spawnAgent({
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "Fix gap F",
+        });
+
+        expect(stateMgr.readState(result.agent_id)?.state).toBe("booting");
+
+        await vi.runOnlyPendingTimersAsync();
+
+        expect(stateMgr.readState(result.agent_id)).toMatchObject({
+          state: "error",
+          error: "Post-spawn liveness failed: surface surface:new is not live",
+        });
+        expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:new", {
+          workspace: "ws:1",
+          collapsePane: true,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps a healthy post-launch surface booting", async () => {
+      vi.useFakeTimers();
+      try {
+        liveSurfaces = [makeSurface("surface:new")];
+        engine.dispose();
+        engine = new AgentEngine(
+          stateMgr,
+          new AgentRegistry(stateMgr, async () => liveSurfaces),
+          mockClient,
+          {
+            spawnPreflight: async () => {},
+            postSpawnLivenessMs: 0,
+          },
+        );
+
+        const result = await engine.spawnAgent({
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "Fix gap F",
+        });
+
+        await vi.runOnlyPendingTimersAsync();
+
+        expect(stateMgr.readState(result.agent_id)?.state).toBe("booting");
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("launches Claude via repoGolem launcher with requested model tier", async () => {
       await engine.spawnAgent({
         repo: "brainlayer",


### PR DESCRIPTION
## Summary
- Add a bounded post-spawn liveness assertion after `spawnAgent` sends the launcher command.
- Mark the agent `error` and best-effort close the surface when the registered agent loses its surface or is no longer in the registry.
- Keep the assertion window injectable via `postSpawnLivenessMs` / `CMUXLAYER_POST_SPAWN_LIVENESS_MS` so tests do not sleep.

## Test plan
- [x] TDD red: `bun run test tests/agent-engine.test.ts` failed before implementation for the new behavior.
- [x] Focused: `bun run test tests/agent-engine.test.ts` -> 108 passed.
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` -> 44 files, 770 tests passed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn lifecycle and can force error state and close surfaces shortly after launch; behavior is bounded and best-effort but affects all new spawns.
> 
> **Overview**
> Adds a **bounded post-spawn liveness check** right after a successful launch in `spawnAgent`. A timer (default **5s**, overridable via `postSpawnLivenessMs` or `CMUXLAYER_POST_SPAWN_LIVENESS_MS`) verifies the agent is still registered and its cmux surface is still live via new `AgentRegistry.hasLiveSurface`.
> 
> If either check fails, the agent is transitioned to **`error`** with a `Post-spawn liveness failed: …` message and the engine **best-effort closes** the surface with `collapsePane: true`. Timers are cleared in `dispose()`. Tests cover the failure path (vanished surface) and the happy path (surface stays booting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736ff8a3036a7ab6169c9e213e758bcc848e72b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert post-spawn agent liveness and transition to error if surface is not live
> - After a successful agent spawn, `AgentEngine` schedules a liveness check (default 5s, configurable via `postSpawnLivenessMs` or `CMUXLAYER_POST_SPAWN_LIVENESS_MS`) using the new `schedulePostSpawnLivenessAssertion` method in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/150/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5).
> - If the agent is no longer registered or its surface is not live at check time, `assertPostSpawnLiveness` transitions the agent to error state and calls `client.closeSurface` with `collapsePane: true`.
> - `AgentRegistry` gains a new `hasLiveSurface(surfaceId)` method in [agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/150/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) to support the liveness check.
> - Pending liveness timers are cleared on `dispose()` to prevent stale callbacks.
> - Behavioral Change: newly spawned agents that lose their surface within the liveness window will now automatically be marked as errored and have their pane closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 736ff8a. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->