### PR TITLE
fix: register launcher agents before dispatch nudge

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -117,6 +117,8 @@ const MODEL_EMOJI_RE =
 // Last resort: 🤖 + bare model family name (for narrow panes where version is cut off)
 const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
+const CLAUDE_PERMISSION_APPROVAL_RE =
+  /allow for this session|do you want to allow|\[y\/n\]/i;
 const CODEX_HEADER_RE =
   /^\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)(?:\s*[·•]\s*[^\n]*)?\s*$/m;
 const CODEX_CONTEXT_LEFT_RE =
@@ -216,7 +218,10 @@ function detectAgentType(text: string): ParsedScreenAgentType {
     "---RESPONSE_START---",
     "Claude Code",
   ];
-  if (claudeMarkers.some((marker) => text.includes(marker))) {
+  if (
+    claudeMarkers.some((marker) => text.includes(marker)) ||
+    CLAUDE_PERMISSION_APPROVAL_RE.test(text)
+  ) {
     return "claude";
   }
   if (
@@ -446,6 +451,7 @@ function parseErrors(text: string): string[] {
     "permission denied",
     "permission prompt",
     "do you want to allow",
+    "allow for this session",
     "[y/n]",
   ];
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -780,6 +780,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         source_event: DeliveryEventType;
       }) => Promise<unknown>)
     | null = null;
+  let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
 
   const server = new McpServer(
     {
@@ -2899,7 +2900,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // INTERACTIVE_STATES gate, but the guarded relay path keeps the
           // stale-surface resync + recycled-occupant identity checks so the
           // pointer can never land in a foreign agent's pane.
-          const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+          let record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+          if (!record) {
+            try {
+              await lifecycleEnsureRegistered?.();
+              record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+            } catch {
+              // Best-effort only: dispatch has already appended the durable inbox message.
+            }
+          }
           if (!record || !lifecycleAgentInputDeliverer) {
             nudge.reason = record
               ? "agent lifecycle relay unavailable — message waits in the inbox file"
@@ -3031,6 +3040,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       listSurfaces: surfaceProvider,
       readScreen: (surface, opts) => client.readScreen(surface, opts),
     });
+    lifecycleEnsureRegistered = async () => {
+      await registry.listMerged(discovery, { force: true });
+    };
     const notifyLifecycleEvent = async (
       event: AgentLifecycleEvent,
       agent: AgentRecord,

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -23,7 +23,10 @@ import type { ExecFn } from "../src/cmux-client.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-inbox-nudge");
 
-function makeExec(): ExecFn {
+function makeExec(
+  screenText = "What can I help you with?\n>",
+  surfaceTitle = "agent-pane",
+): ExecFn {
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("list-workspaces")) {
       return {
@@ -69,7 +72,7 @@ function makeExec(): ExecFn {
           surfaces: [
             {
               ref: "surface:new",
-              title: "agent-pane",
+              title: surfaceTitle,
               type: "terminal",
               index: 0,
               selected: true,
@@ -83,7 +86,7 @@ function makeExec(): ExecFn {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: "What can I help you with?\n>",
+          text: screenText,
           lines: 20,
           scrollback_used: false,
         }),
@@ -228,6 +231,52 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     expect(parsed.nudge.attempted).toBe(false);
     expect(parsed.nudge.sent).toBe(false);
     expect(readInbox("ghost-agent", { baseDir: inboxDir })).toHaveLength(1);
+  });
+
+  it("discovers and registers a launcher-spawned Claude agent before nudging", async () => {
+    exec = makeExec(
+      [
+        "Do you want to allow this command?",
+        "",
+        "❯ 1. Allow for this session",
+        "  2. Allow once",
+        "  3. Deny",
+        "",
+        "[y/n]",
+      ].join("\n"),
+      "agenthtmlhostClaude",
+    );
+    server = createServer({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+    });
+
+    const agentId = "auto-claude-surface-new";
+    const before = sendCalls(exec).length;
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(true);
+    expect(sendCalls(exec).length).toBeGreaterThan(before);
+    expect(
+      readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
+    ).toContain("GO");
   });
 
   it('nudge:"never" appends to the file only', async () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -56,6 +56,22 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.status).toBe("working");
   });
 
+  it("recognizes Claude permission approval dialogs as Claude", () => {
+    const parsed = parseScreen(`
+Do you want to allow this command?
+
+❯ 1. Allow for this session
+  2. Allow once
+  3. Deny
+
+[y/n]
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("frozen");
+    expect(parsed.errors).toContain("permission_prompt");
+  });
+
   it("extracts model from no-cost status line (production format)", () => {
     const parsed = parseScreen(`
 ✻ Working…


### PR DESCRIPTION
## Summary
- Recognize Claude permission approval dialogs (`Allow for this session` / `[y/n]` modal chrome) as Claude screens so discovery can create auto lifecycle records for launcher-spawned agents.
- Add a best-effort discovery/register pass before `dispatch_to_agent` gives up on a missing lifecycle record, then reuse the guarded lifecycle relay for the inbox pointer.
- Scope note: `.mcp.json` provisioning is already handled by the repoGolem launcher that cmuxlayer invokes; this PR only fixes cmuxlayer-side recognition/registration for dispatch nudging.

## Test plan
- [x] TDD red: `bun run test tests/screen-parser.test.ts tests/inbox-nudge.test.ts` failed before implementation (`unknown` parser type; nudge skipped).
- [x] Focused: `bun run test tests/screen-parser.test.ts tests/inbox-nudge.test.ts` -> 77 passed.
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` -> 44 files, 780 tests passed.
- [x] CodeRabbit pre-commit review completed with 0 findings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the dispatch nudge path and screen-based agent classification; misclassification could affect routing, though inbox writes remain durable and registration is best-effort only.
> 
> **Overview**
> **Launcher-spawned Claude panes** often show permission approval UI instead of usual Claude markers, so discovery never registered them and `dispatch_to_agent` could not nudge. The screen parser now treats that modal chrome as Claude (`detectAgentType`) and flags **`permission_prompt`** (including **Allow for this session**).
> 
> When **`dispatch_to_agent`** needs an inbox pointer nudge but the agent is **not in the lifecycle registry**, it runs a **best-effort forced discovery/register** pass (`registry.listMerged` with `force: true`) before giving up; durable inbox append is unchanged if registration still fails.
> 
> Tests cover permission-dialog parsing and nudging a discovered launcher agent (`auto-claude-surface-new`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe427c9df5af1776ecde388107e762aa3189b67d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register launcher agents before dispatch nudge in `dispatch_to_agent`
> - When `dispatch_to_agent` evaluates a nudge and finds no registry record for the target agent, it now calls `lifecycleEnsureRegistered()` (a forced `registry.listMerged` discovery) before deciding whether to nudge, allowing launcher-spawned agents to be discovered on demand.
> - Extends Claude detection in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/151/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to recognize permission approval dialogs (e.g. 'allow for this session', '[y/n]') as agent type `claude` with a `permission_prompt` error.
> - Adds test coverage in [inbox-nudge.test.ts](https://github.com/EtanHey/cmuxlayer/pull/151/files#diff-7bd986c46b6cbccd155247c8a3227e4211a482bec9349641502016dd8c625935) for the discovery-before-nudge path and in [screen-parser.test.ts](https://github.com/EtanHey/cmuxlayer/pull/151/files#diff-f9e39ca6ad69e6b5b1b6052b007496bda3425ccaf48a0f8699ec099e39b8e2e4) for permission dialog detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fe427c9. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->