### PR TITLE
feat: add cmux RAM observability

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB="${CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB:-${CMUX_MEM_WATCHDOG_THRESHOLD_GB:-5}}"
+CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB="${CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB:-${CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB:-${CMUX_MEM_WATCHDOG_THRESHOLD_GB:-5}}}"
 CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB="${CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB:-12}"
 CMUX_MEM_WATCHDOG_LOG_DIR="${CMUX_MEM_WATCHDOG_LOG_DIR:-$HOME/Library/Logs/cmux-watchdog}"
 CMUX_MEM_WATCHDOG_NOTIFY_URL="${CMUX_MEM_WATCHDOG_NOTIFY_URL:-http://localhost:3847/notify}"
@@ -77,26 +77,53 @@ get_cmux_pid() {
   return 1
 }
 
-aggregate_cmux_rss_bytes() {
-  local total_kb=0
+parse_phys_footprint_bytes() {
+  local output="$1"
+  local value
+
+  value="$(printf '%s\n' "$output" | awk '
+    /phys_footprint:/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phys_footprint:") {
+          print $(i + 1) $(i + 2)
+          exit
+        }
+      }
+    }')"
+
+  bytes_from_human "$value"
+}
+
+cmux_footprint_bytes_for_pid() {
+  local pid="$1"
+  local output
+
+  if [[ -n "${CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE:-}" ]]; then
+    output="$(awk -v pid="$pid" '$1 == pid { $1 = ""; sub(/^ /, ""); print }' "$CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE")"
+  elif [[ -n "${CMUX_MEM_WATCHDOG_PS_FIXTURE:-}" ]]; then
+    output="$(awk -v pid="$pid" '$1 == pid { print "phys_footprint: " $2 "K" }' "$CMUX_MEM_WATCHDOG_PS_FIXTURE")"
+  else
+    output="$(footprint -p "$pid" 2>/dev/null || true)"
+  fi
+
+  parse_phys_footprint_bytes "$output"
+}
+
+aggregate_cmux_footprint_bytes() {
+  local total_bytes=0
   local pid
-  local rss
+  local footprint_bytes
   local pids
 
   pids="$(pgrep -f 'cmux\.app/Contents/MacOS/cmux|/Applications/cmux\.app/Contents/Resources/bin/bun' 2>/dev/null || true)"
   for pid in $pids; do
-    if [[ -n "${CMUX_MEM_WATCHDOG_PS_FIXTURE:-}" ]]; then
-      rss="$(awk -v pid="$pid" '$1 == pid { print $2 }' "$CMUX_MEM_WATCHDOG_PS_FIXTURE")"
-    else
-      rss="$(ps -p "$pid" -o rss= 2>/dev/null | tr -d ' ')"
-    fi
-
-    if [[ -n "$rss" ]]; then
-      total_kb=$((total_kb + rss))
+    footprint_bytes="$(cmux_footprint_bytes_for_pid "$pid")"
+    if [[ -n "$footprint_bytes" ]]; then
+      total_bytes=$((total_bytes + footprint_bytes))
     fi
   done
 
-  echo $((total_kb * 1024))
+  echo "$total_bytes"
 }
 
 vmstat_compressor_bytes() {
@@ -122,24 +149,24 @@ snapshot_path() {
 
 capture_process_snapshot() {
   local pid="$1"
-  local cmux_rss_bytes="$2"
+  local cmux_footprint_bytes="$2"
   local vmstat_compressor_bytes_value="$3"
   local tripped="$4"
   local path="$5"
-  local cmux_rss_gb
+  local cmux_footprint_gb
   local compressor_gb
 
-  cmux_rss_gb="$(bytes_to_gb "$cmux_rss_bytes")"
+  cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
 
   mkdir -p "$CMUX_MEM_WATCHDOG_LOG_DIR"
   {
     printf 'timestamp=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
     printf 'pid=%s\n' "$pid"
-    printf 'rss_threshold_gb=%s\n' "$CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB"
+    printf 'footprint_threshold_gb=%s\n' "$CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB"
     printf 'compressor_threshold_gb=%s\n' "$CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB"
-    printf 'cmux_rss_bytes=%s\n' "$cmux_rss_bytes"
-    printf 'cmux_rss_gb=%s\n' "$cmux_rss_gb"
+    printf 'cmux_footprint_bytes=%s\n' "$cmux_footprint_bytes"
+    printf 'cmux_footprint_gb=%s\n' "$cmux_footprint_gb"
     printf 'vmstat_compressor_bytes=%s\n' "$vmstat_compressor_bytes_value"
     printf 'vmstat_compressor_gb=%s\n' "$compressor_gb"
     printf 'breached_signals=%s\n' "$tripped"
@@ -152,18 +179,18 @@ capture_process_snapshot() {
 
 brain_store_breach() {
   local pid="$1"
-  local cmux_rss_bytes="$2"
+  local cmux_footprint_bytes="$2"
   local vmstat_compressor_bytes_value="$3"
   local snapshot="$4"
   local processes="$5"
   local tripped="$6"
-  local cmux_rss_gb
+  local cmux_footprint_gb
   local compressor_gb
   local content
 
-  cmux_rss_gb="$(bytes_to_gb "$cmux_rss_bytes")"
+  cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
-  content="cmux watchdog threshold breach. WHAT: cmux pid $pid crossed signal(s): $tripped. WHY: dual-memory checks found $cmux_rss_gb GB RSS and $compressor_gb GB compressed memory. Details: cmux_rss_gb=$cmux_rss_gb rss_threshold_gb=$CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB vm_compressor_gb=$compressor_gb compressor_threshold_gb=$CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB snapshot=$snapshot processes=$processes"
+  content="cmux watchdog threshold breach. WHAT: cmux pid $pid crossed signal(s): $tripped. WHY: dual-memory checks found $cmux_footprint_gb GB phys_footprint and $compressor_gb GB compressed memory. Details: cmux_footprint_gb=$cmux_footprint_gb footprint_threshold_gb=$CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB vm_compressor_gb=$compressor_gb compressor_threshold_gb=$CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB snapshot=$snapshot processes=$processes"
 
   if [[ ! -S "$CMUX_MEM_WATCHDOG_BRAINBAR_SOCK" ]]; then
     log "brainbar socket missing at $CMUX_MEM_WATCHDOG_BRAINBAR_SOCK"
@@ -179,18 +206,18 @@ brain_store_breach() {
 notify_breach() {
   local pid="$1"
   local tripped="$2"
-  local cmux_rss_bytes="$3"
+  local cmux_footprint_bytes="$3"
   local vmstat_compressor_bytes_value="$4"
   local snapshot="$5"
-  local cmux_rss_gb
+  local cmux_footprint_gb
   local compressor_gb
 
-  cmux_rss_gb="$(bytes_to_gb "$cmux_rss_bytes")"
+  cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
 
   jq -cn \
     --arg title "cmux watchdog" \
-    --arg body "cmux hit $cmux_rss_gb GB RSS / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Terminating." \
+    --arg body "cmux hit $cmux_footprint_gb GB phys_footprint / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Terminating." \
     --arg source "$CMUX_MEM_WATCHDOG_SOURCE" \
     --arg priority "$CMUX_MEM_WATCHDOG_PRIORITY" \
     '{title:$title,body:$body,source:$source,priority:$priority}' \
@@ -210,27 +237,27 @@ terminate_cmux() {
 
 handle_breach() {
   local pid="$1"
-  local cmux_rss_bytes="$2"
+  local cmux_footprint_bytes="$2"
   local vmstat_compressor_bytes_value="$3"
   local tripped="$4"
   local snapshot
   local processes
 
-  log "cmux process $pid breached memory thresholds: $tripped (rss_bytes=$cmux_rss_bytes, vmstat_compressor_bytes=$vmstat_compressor_bytes_value)"
+  log "cmux process $pid breached memory thresholds: $tripped (footprint_bytes=$cmux_footprint_bytes, vmstat_compressor_bytes=$vmstat_compressor_bytes_value)"
 
   snapshot="$(snapshot_path)"
-  capture_process_snapshot "$pid" "$cmux_rss_bytes" "$vmstat_compressor_bytes_value" "$tripped" "$snapshot"
+  capture_process_snapshot "$pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$tripped" "$snapshot"
   processes="$(pgrep -lf cmux | tr '\n' ';' | sed 's/;$/\n/' || true)"
-  brain_store_breach "$pid" "$cmux_rss_bytes" "$vmstat_compressor_bytes_value" "$snapshot" "$processes" "$tripped"
-  notify_breach "$pid" "$tripped" "$cmux_rss_bytes" "$vmstat_compressor_bytes_value" "$snapshot"
+  brain_store_breach "$pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot" "$processes" "$tripped"
+  notify_breach "$pid" "$tripped" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot"
   terminate_cmux "$pid"
 }
 
 run_once() {
   local cmux_pid
-  local cmux_rss_bytes
+  local cmux_footprint_bytes
   local vmstat_compressor_bytes_value
-  local rss_threshold_bytes
+  local footprint_threshold_bytes
   local compressor_threshold_bytes
   local tripped
 
@@ -239,14 +266,14 @@ run_once() {
     return 0
   fi
 
-  cmux_rss_bytes="$(aggregate_cmux_rss_bytes)"
+  cmux_footprint_bytes="$(aggregate_cmux_footprint_bytes)"
   vmstat_compressor_bytes_value="$(vmstat_compressor_bytes)"
-  rss_threshold_bytes="$(threshold_bytes "$CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB")"
+  footprint_threshold_bytes="$(threshold_bytes "$CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB")"
   compressor_threshold_bytes="$(threshold_bytes "$CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB")"
 
   tripped=""
-  if (( cmux_rss_bytes > rss_threshold_bytes )); then
-    tripped="rss"
+  if (( cmux_footprint_bytes > footprint_threshold_bytes )); then
+    tripped="footprint"
   fi
 
   if (( vmstat_compressor_bytes_value > compressor_threshold_bytes )); then
@@ -258,7 +285,7 @@ run_once() {
   fi
 
   if [[ -n "$tripped" ]]; then
-    handle_breach "$cmux_pid" "$cmux_rss_bytes" "$vmstat_compressor_bytes_value" "$tripped"
+    handle_breach "$cmux_pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$tripped"
   fi
 }
 

--- a/launchd/cmux-memory-watchdog/launchd/com.golems.cmux-memory-watchdog.plist
+++ b/launchd/cmux-memory-watchdog/launchd/com.golems.cmux-memory-watchdog.plist
@@ -12,7 +12,7 @@
 
   <key>EnvironmentVariables</key>
   <dict>
-    <key>CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB</key>
+    <key>CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB</key>
     <string>5</string>
     <key>CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB</key>
     <string>12</string>

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -64,6 +64,13 @@ printf ' 4242  1000  16384   12345   0.0  01:00:00 /Applications/cmux.app/Conten
 EOF
   chmod +x "$root_dir/bin/ps"
 
+  cat >"$root_dir/bin/footprint" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'phys_footprint: 256.00 MB (peak 512.00 MB)\\n'
+EOF
+  chmod +x "$root_dir/bin/footprint"
+
   cat >"$root_dir/bin/pgrep" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -94,7 +101,7 @@ run_case() {
   local name="$1"
   local expect_breach="$2"
   local expected_signals="$3"
-  local ps_fixture="$4"
+  local footprint_fixture="$4"
   local vmstat_fixture="$5"
   local pgrep_cmux="$6"
   local pgrep_pids="$7"
@@ -105,21 +112,21 @@ run_case() {
   mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
   seed_fake_commands "$root_dir" "$log_dir"
 
-  printf '%s' "$ps_fixture" >"$root_dir/fixtures/ps.fixture"
+  printf '%s' "$footprint_fixture" >"$root_dir/fixtures/footprint.fixture"
   printf '%s' "$vmstat_fixture" >"$root_dir/fixtures/vmstat.fixture"
 
   export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
-  export CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB=5
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB=5
   export CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB=12
   export CMUX_MEM_WATCHDOG_LOG_DIR="$log_dir"
   export CMUX_MEM_WATCHDOG_KILL_BIN="$root_dir/bin/kill"
-  export CMUX_MEM_WATCHDOG_PS_FIXTURE="$root_dir/fixtures/ps.fixture"
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
   export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
   export CMUX_MEM_WATCHDOG_PGREP_CMUX="$pgrep_cmux"
   export CMUX_MEM_WATCHDOG_PGREP_CMUXPIDS="$pgrep_pids"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck source=../bin/cmux-memory-watchdog.sh
+  # shellcheck disable=SC1090
   source "$SCRIPT_PATH"
   run_once
 
@@ -127,7 +134,7 @@ run_case() {
     assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
     assert_file_contains "$log_dir/kill.log" "-TERM 4242"
     assert_file_contains "$log_dir/kill.log" "-KILL 4242"
-    snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '*.log' | head -n 1)"
+    snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
     if [[ -n "$expected_signals" ]]; then
       assert_file_contains "$snapshot" "breached_signals=$expected_signals"
     fi
@@ -142,35 +149,35 @@ run_case() {
 
 run_case "no breach when both below threshold" \
   0 "" \
-  $'4242 1024\n5001 512\n' \
+  $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
   $'Pages occupied by compressor: 1048576.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
-run_case "breach when rss above threshold" \
-  1 "rss" \
-  $'4242 4194304\n5001 2097152\n' \
+run_case "breach when footprint above threshold" \
+  1 "footprint" \
+  $'4242 phys_footprint: 9.5 GB (peak 25 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
   $'Pages occupied by compressor: 1048576.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "breach when compressor above threshold" \
   1 "compressor" \
-  $'4242 1024\n5001 512\n' \
+  $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
   $'Pages occupied by compressor: 3145729.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "breach when both above threshold" \
-  1 "rss,compressor" \
-  $'4242 3145728\n5001 3145728\n' \
+  1 "footprint,compressor" \
+  $'4242 phys_footprint: 3 GB (peak 4 GB)\n5001 phys_footprint: 3 GB (peak 4 GB)\n' \
   $'Pages occupied by compressor: 4194305.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "no cmux pid exits cleanly" \
   0 "" \
-  $'4242 1024\n5001 1024\n' \
+  $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 1024 MB (peak 2 GB)\n' \
   $'Pages occupied by compressor: 4194305.\n' \
   "" \
   ""

--- a/launchd/cmux-ram-sampler/README.md
+++ b/launchd/cmux-ram-sampler/README.md
@@ -1,0 +1,73 @@
+# cmux RAM Sampler
+
+Samples the stable and nightly cmux app processes with `phys_footprint`, the same
+per-process memory metric Activity Monitor reports. This catches compressed and
+swapped resident memory that `ps -o rss=` does not include.
+
+## What it records
+
+Every run resolves PIDs by bundle path:
+
+- `stable`: `/Applications/cmux.app/Contents/MacOS/cmux`
+- `nightly`: `/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux`
+
+It appends JSONL rows to:
+
+```bash
+~/Library/Logs/cmux-ram-sampler/samples.jsonl
+```
+
+Each row includes:
+
+- timestamp
+- instance name
+- pid
+- `phys_footprint_mb`
+- `phys_footprint_peak_mb`
+- swap used/free from `sysctl vm.swapusage`
+- compressor pages from `vm_stat`
+
+## Prediction
+
+The sampler reads only the trailing window from the JSONL log, estimates the
+per-instance leak rate in MB/min, and projects ETA to the danger threshold.
+Defaults:
+
+- danger footprint: `20` GB
+- danger swap free: `2` GB
+- warning lead time: `30` minutes
+- regression window: `12` samples
+
+Warnings are logged to stderr and sent best-effort to:
+
+```bash
+http://localhost:3847/notify
+```
+
+Notification failures are non-fatal.
+
+## Environment knobs
+
+- `CMUX_RAM_SAMPLER_LOG_DIR`
+- `CMUX_RAM_SAMPLER_SAMPLE_FILE`
+- `CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB`
+- `CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB`
+- `CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES`
+- `CMUX_RAM_SAMPLER_WINDOW_SAMPLES`
+- `CMUX_RAM_SAMPLER_NOTIFY_URL`
+- `CMUX_RAM_SAMPLER_STABLE_PATH`
+- `CMUX_RAM_SAMPLER_NIGHTLY_PATH`
+
+## Arm
+
+Do not arm this from automation. Etan-gated arm command:
+
+```bash
+launchctl load /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+```
+
+## Test
+
+```bash
+bash launchd/cmux-ram-sampler/tests/run-tests.sh
+```

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CMUX_RAM_SAMPLER_LOG_DIR="${CMUX_RAM_SAMPLER_LOG_DIR:-$HOME/Library/Logs/cmux-ram-sampler}"
+CMUX_RAM_SAMPLER_SAMPLE_FILE="${CMUX_RAM_SAMPLER_SAMPLE_FILE:-$CMUX_RAM_SAMPLER_LOG_DIR/samples.jsonl}"
+CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB="${CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB:-20}"
+CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB="${CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB:-2}"
+CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES="${CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES:-30}"
+CMUX_RAM_SAMPLER_WINDOW_SAMPLES="${CMUX_RAM_SAMPLER_WINDOW_SAMPLES:-12}"
+CMUX_RAM_SAMPLER_NOTIFY_URL="${CMUX_RAM_SAMPLER_NOTIFY_URL:-http://localhost:3847/notify}"
+CMUX_RAM_SAMPLER_SOURCE="${CMUX_RAM_SAMPLER_SOURCE:-alerts}"
+CMUX_RAM_SAMPLER_PRIORITY="${CMUX_RAM_SAMPLER_PRIORITY:-high}"
+
+CMUX_RAM_SAMPLER_STABLE_PATH="${CMUX_RAM_SAMPLER_STABLE_PATH:-/Applications/cmux.app/Contents/MacOS/cmux}"
+CMUX_RAM_SAMPLER_NIGHTLY_PATH="${CMUX_RAM_SAMPLER_NIGHTLY_PATH:-/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux}"
+
+log() {
+  printf '[cmux-ram-sampler] %s\n' "$*" >&2
+}
+
+bytes_from_human() {
+  local value="$1"
+  local trimmed number unit exponent
+  trimmed="$(printf '%s' "$value" | tr -d '[:space:],')"
+  if [[ -z "$trimmed" || "$trimmed" == "-" || "$trimmed" == "0" ]]; then
+    echo 0
+    return
+  fi
+
+  if [[ "$trimmed" =~ ^([0-9]+([.][0-9]+)?)([KMGTP]?) ]]; then
+    number="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[3]}"
+  else
+    echo 0
+    return
+  fi
+
+  exponent=0
+  case "$unit" in
+    K) exponent=1 ;;
+    M) exponent=2 ;;
+    G) exponent=3 ;;
+    T) exponent=4 ;;
+    P) exponent=5 ;;
+  esac
+
+  awk -v number="$number" -v exponent="$exponent" '
+    function power(base, exponent_value,   out, i) {
+      out = 1
+      for (i = 0; i < exponent_value; i++) out *= base
+      return out
+    }
+    BEGIN { printf "%.0f\n", number * power(1024, exponent) }'
+}
+
+bytes_to_mb() {
+  local bytes="$1"
+  awk -v bytes="$bytes" 'BEGIN { printf "%.0f\n", bytes / (1024 * 1024) }'
+}
+
+gb_to_mb() {
+  local gb="$1"
+  awk -v gb="$gb" 'BEGIN { printf "%.0f\n", gb * 1024 }'
+}
+
+timestamp_to_epoch() {
+  local ts="$1"
+  if date -j -f '%Y-%m-%dT%H:%M:%S%z' "$ts" '+%s' 2>/dev/null; then
+    return
+  fi
+  date -d "$ts" '+%s' 2>/dev/null || echo 0
+}
+
+pid_for_path() {
+  local app_path="$1"
+  pgrep -f "$app_path" 2>/dev/null | head -n 1 || true
+}
+
+footprint_output_for_pid() {
+  local pid="$1"
+  if [[ -n "${CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE:-}" ]]; then
+    awk -v pid="$pid" '$1 == pid { $1 = ""; sub(/^ /, ""); print }' "$CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE"
+    return
+  fi
+
+  footprint -p "$pid" 2>/dev/null || true
+}
+
+parse_footprint_mb() {
+  local output="$1"
+  local value
+  value="$(printf '%s\n' "$output" | awk '
+    /phys_footprint:/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phys_footprint:") {
+          print $(i + 1) $(i + 2)
+          exit
+        }
+      }
+    }')"
+  bytes_to_mb "$(bytes_from_human "$value")"
+}
+
+parse_footprint_peak_mb() {
+  local output="$1"
+  local value
+  value="$(printf '%s\n' "$output" | awk '
+    /phys_footprint:/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "(peak") {
+          unit = $(i + 2)
+          gsub(/[)]/, "", unit)
+          print $(i + 1) unit
+          exit
+        }
+      }
+    }')"
+  bytes_to_mb "$(bytes_from_human "$value")"
+}
+
+swap_usage_output() {
+  if [[ -n "${CMUX_RAM_SAMPLER_SWAP_FIXTURE:-}" ]]; then
+    cat "$CMUX_RAM_SAMPLER_SWAP_FIXTURE"
+    return
+  fi
+  sysctl vm.swapusage 2>/dev/null || true
+}
+
+swap_used_mb() {
+  swap_usage_output | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "used") {
+          value = $(i + 2)
+          gsub(/,/, "", value)
+          print value
+          exit
+        }
+      }
+    }' | while read -r value; do bytes_to_mb "$(bytes_from_human "$value")"; done
+}
+
+swap_free_mb() {
+  swap_usage_output | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "free") {
+          value = $(i + 2)
+          gsub(/,/, "", value)
+          print value
+          exit
+        }
+      }
+    }' | while read -r value; do bytes_to_mb "$(bytes_from_human "$value")"; done
+}
+
+vmstat_compressor_mb() {
+  local output pages
+  if [[ -n "${CMUX_RAM_SAMPLER_VMSTAT_FIXTURE:-}" ]]; then
+    output="$(cat "$CMUX_RAM_SAMPLER_VMSTAT_FIXTURE")"
+  else
+    output="$(vm_stat 2>/dev/null || true)"
+  fi
+  pages="$(printf '%s\n' "$output" | awk '/Pages occupied by compressor/ {gsub(/\./,"",$NF); print $NF}')"
+  pages="${pages:-0}"
+  bytes_to_mb "$((pages * 4096))"
+}
+
+json_number_field() {
+  local line="$1"
+  local key="$2"
+  printf '%s\n' "$line" | awk -v key="$key" '
+    {
+      pattern = "\"" key "\":[0-9]+"
+      if (match($0, pattern)) {
+        value = substr($0, RSTART + length(key) + 3, RLENGTH - length(key) - 3)
+        print value
+      }
+    }'
+}
+
+json_string_field() {
+  local line="$1"
+  local key="$2"
+  printf '%s\n' "$line" | awk -v key="$key" '
+    {
+      pattern = "\"" key "\":\"[^\"]+\""
+      if (match($0, pattern)) {
+        value = substr($0, RSTART + length(key) + 4, RLENGTH - length(key) - 4)
+        gsub(/"$/, "", value)
+        print value
+      }
+    }'
+}
+
+predict_eta_minutes() {
+  local sample_file="$1"
+  local instance="$2"
+  local danger_footprint_mb="$3"
+  local window_samples="$4"
+  local rows line ts footprint_mb first_epoch="" first_mb="" last_epoch="" last_mb="" count=0
+  local slope eta
+
+  [[ -f "$sample_file" ]] || return 1
+  rows="$(grep -F "\"instance\":\"$instance\"" "$sample_file" | tail -n "$window_samples" || true)"
+  [[ -n "$rows" ]] || return 1
+
+  while IFS= read -r line; do
+    ts="$(json_string_field "$line" ts)"
+    footprint_mb="$(json_number_field "$line" phys_footprint_mb)"
+    [[ -n "$ts" && -n "$footprint_mb" ]] || continue
+    if [[ -z "$first_epoch" ]]; then
+      first_epoch="$(timestamp_to_epoch "$ts")"
+      first_mb="$footprint_mb"
+    fi
+    last_epoch="$(timestamp_to_epoch "$ts")"
+    last_mb="$footprint_mb"
+    count=$((count + 1))
+  done <<<"$rows"
+
+  if (( count < 2 || last_epoch <= first_epoch || last_mb >= danger_footprint_mb )); then
+    return 1
+  fi
+
+  slope="$(awk -v first_mb="$first_mb" -v last_mb="$last_mb" -v minutes="$(((last_epoch - first_epoch) / 60))" \
+    'BEGIN { if (minutes <= 0) print 0; else printf "%.6f\n", (last_mb - first_mb) / minutes }')"
+  if ! awk -v slope="$slope" 'BEGIN { exit !(slope > 0) }'; then
+    return 1
+  fi
+
+  eta="$(awk -v current="$last_mb" -v danger="$danger_footprint_mb" -v slope="$slope" \
+    'BEGIN { printf "%.0f\n", (danger - current) / slope }')"
+  printf '%s\n' "$eta"
+}
+
+append_sample() {
+  local ts="$1"
+  local instance="$2"
+  local pid="$3"
+  local footprint_mb="$4"
+  local peak_mb="$5"
+  local swap_used="$6"
+  local swap_free="$7"
+  local compressor="$8"
+
+  mkdir -p "$CMUX_RAM_SAMPLER_LOG_DIR"
+  jq -cn \
+    --arg ts "$ts" \
+    --arg instance "$instance" \
+    --argjson pid "$pid" \
+    --argjson footprint "$footprint_mb" \
+    --argjson peak "$peak_mb" \
+    --argjson swap_used "$swap_used" \
+    --argjson swap_free "$swap_free" \
+    --argjson compressor "$compressor" \
+    '{ts:$ts,instance:$instance,pid:$pid,phys_footprint_mb:$footprint,phys_footprint_peak_mb:$peak,swap_used_mb:$swap_used,swap_free_mb:$swap_free,compressor_mb:$compressor}' \
+    >>"$CMUX_RAM_SAMPLER_SAMPLE_FILE"
+}
+
+notify_warning() {
+  local instance="$1"
+  local pid="$2"
+  local footprint_mb="$3"
+  local eta_minutes="$4"
+  local swap_free="$5"
+
+  jq -cn \
+    --arg title "cmux RAM sampler" \
+    --arg body "$instance pid $pid phys_footprint=${footprint_mb} MB; projected danger ETA=${eta_minutes} min; swap_free=${swap_free} MB" \
+    --arg source "$CMUX_RAM_SAMPLER_SOURCE" \
+    --arg priority "$CMUX_RAM_SAMPLER_PRIORITY" \
+    '{title:$title,body:$body,source:$source,priority:$priority}' \
+    | curl -sS -X POST "$CMUX_RAM_SAMPLER_NOTIFY_URL" \
+      -H 'Content-Type: application/json' \
+      --data-binary @- >/dev/null 2>&1 || true
+}
+
+sample_instance() {
+  local instance="$1"
+  local app_path="$2"
+  local ts="$3"
+  local swap_used="$4"
+  local swap_free="$5"
+  local compressor="$6"
+  local danger_footprint_mb="$7"
+  local pid output footprint_mb peak_mb eta_minutes=""
+
+  pid="$(pid_for_path "$app_path")"
+  if [[ -z "$pid" ]]; then
+    log "$instance not running at $app_path; skipping"
+    return 0
+  fi
+
+  output="$(footprint_output_for_pid "$pid")"
+  footprint_mb="$(parse_footprint_mb "$output")"
+  peak_mb="$(parse_footprint_peak_mb "$output")"
+  append_sample "$ts" "$instance" "$pid" "$footprint_mb" "$peak_mb" "$swap_used" "$swap_free" "$compressor"
+
+  eta_minutes="$(predict_eta_minutes "$CMUX_RAM_SAMPLER_SAMPLE_FILE" "$instance" "$danger_footprint_mb" "$CMUX_RAM_SAMPLER_WINDOW_SAMPLES" || true)"
+  if [[ -n "$eta_minutes" && "$eta_minutes" -lt "$CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES" ]]; then
+    log "$instance pid $pid projected to reach $CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB GB phys_footprint in ${eta_minutes}m"
+    notify_warning "$instance" "$pid" "$footprint_mb" "$eta_minutes" "$swap_free"
+  elif [[ "$swap_free" -lt "$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB")" ]]; then
+    log "$instance pid $pid sampled with low swap_free=${swap_free}MB"
+    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free"
+  fi
+}
+
+run_once() {
+  local ts swap_used swap_free compressor danger_footprint_mb
+  ts="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  swap_used="$(swap_used_mb)"
+  swap_free="$(swap_free_mb)"
+  compressor="$(vmstat_compressor_mb)"
+  danger_footprint_mb="$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB")"
+
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$danger_footprint_mb"
+  sample_instance nightly "$CMUX_RAM_SAMPLER_NIGHTLY_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$danger_footprint_mb"
+}
+
+if [[ "${CMUX_RAM_SAMPLER_SOURCE_ONLY:-0}" != "1" ]]; then
+  run_once
+fi

--- a/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+++ b/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.golems.cmux-ram-sampler</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB</key>
+    <string>20</string>
+    <key>CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB</key>
+    <string>2</string>
+    <key>CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES</key>
+    <string>30</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <key>StandardOutPath</key>
+  <string>/Users/etanheyman/Library/Logs/cmux-ram-sampler/launchd.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/etanheyman/Library/Logs/cmux-ram-sampler/launchd.stderr.log</string>
+</dict>
+</plist>

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/bin/cmux-ram-sampler.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  [[ -f "$file" ]] || fail "missing file: $file"
+  grep -F -- "$needle" "$file" >/dev/null || fail "expected '$needle' in $file"
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+seed_fake_commands() {
+  local root_dir="$1"
+  local log_dir="$2"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/pgrep" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "-f" && "\${2:-}" == "/Applications/cmux.app/Contents/MacOS/cmux" ]]; then
+  printf '4242\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "-f" && "\${2:-}" == "/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux" ]]; then
+  printf '5151\n'
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$root_dir/bin/pgrep"
+}
+
+run_prediction_case() {
+  local root_dir log_dir eta
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$log_dir"
+
+  cat >"$log_dir/samples.jsonl" <<'EOF'
+{"ts":"2026-06-09T10:00:00+0000","instance":"stable","pid":4242,"phys_footprint_mb":1000,"phys_footprint_peak_mb":1100,"swap_used_mb":100,"swap_free_mb":4096,"compressor_mb":64}
+{"ts":"2026-06-09T10:05:00+0000","instance":"stable","pid":4242,"phys_footprint_mb":1250,"phys_footprint_peak_mb":1300,"swap_used_mb":100,"swap_free_mb":4096,"compressor_mb":64}
+{"ts":"2026-06-09T10:10:00+0000","instance":"stable","pid":4242,"phys_footprint_mb":1500,"phys_footprint_peak_mb":1600,"swap_used_mb":100,"swap_free_mb":4096,"compressor_mb":64}
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+
+  eta="$(predict_eta_minutes "$log_dir/samples.jsonl" stable 2500 12)"
+  assert_eq "20" "$eta"
+
+  unset CMUX_RAM_SAMPLER_SAMPLE_FILE
+  printf 'PASS: sampler predicts ETA from known 50 MB/min slope\n'
+  rm -rf "$root_dir"
+}
+
+run_sampling_case() {
+  local root_dir log_dir sample_file line_count
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 9.5 GB (peak 25 GB)
+5151 phys_footprint: 2048 MB (peak 4096 MB)
+EOF
+  cat >"$root_dir/fixtures/swap.fixture" <<'EOF'
+vm.swapusage: total = 8192.00M  used = 6144.00M  free = 2048.00M  (encrypted)
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Pages occupied by compressor: 262144.
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_SWAP_FIXTURE="$root_dir/fixtures/swap.fixture"
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  run_once
+
+  sample_file="$log_dir/samples.jsonl"
+  line_count="$(wc -l <"$sample_file" | tr -d ' ')"
+  assert_eq "2" "$line_count"
+  assert_file_contains "$sample_file" '"instance":"stable"'
+  assert_file_contains "$sample_file" '"phys_footprint_mb":9728'
+  assert_file_contains "$sample_file" '"phys_footprint_peak_mb":25600'
+  assert_file_contains "$sample_file" '"instance":"nightly"'
+  assert_file_contains "$sample_file" '"swap_free_mb":2048'
+  assert_file_contains "$sample_file" '"compressor_mb":1024'
+
+  printf 'PASS: sampler appends both cmux instance rows\n'
+  rm -rf "$root_dir"
+}
+
+run_prediction_case
+run_sampling_case

--- a/launchd/cmux-ram-sampler/tests/run-tests.sh
+++ b/launchd/cmux-ram-sampler/tests/run-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/tests/cmux-ram-sampler.sh"


### PR DESCRIPTION
## Summary
- Fix cmux memory watchdog to threshold aggregate `phys_footprint` instead of RSS, with `CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE` for deterministic shell tests and backward-compatible RSS threshold env aliases.
- Add `launchd/cmux-ram-sampler`, a lightweight Bash sampler for stable and nightly cmux bundle paths that logs JSONL samples, computes trailing-window ETA, and sends best-effort early warnings.
- Add sampler README, launchd plist, shell tests, and a 9.5GB footprint fixture path that trips the watchdog.

## Test plan
- [x] `bash launchd/cmux-memory-watchdog/tests/run-tests.sh`
- [x] `bash launchd/cmux-ram-sampler/tests/run-tests.sh`
- [x] `shellcheck launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test` (44 files, 782 tests)
- [x] Push hook `run_tests.sh` (44 files, 782 tests)

## Launchd arm command
Do not run from automation. Etan-gated arm command:

```bash
launchctl load /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
```

## Review notes
- Pre-commit CodeRabbit CLI was attempted with a 180s timeout; it remained in `reviewing` and emitted no findings before timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Watchdog still terminates cmux on breach but may trip on different memory signals than RSS; mis-tuned thresholds or missing `footprint` could affect behavior. Sampler only logs and notifies—no process kills.
> 
> **Overview**
> **Memory watchdog** now breaches on aggregate **`phys_footprint`** (via `footprint -p`) instead of summed **`ps` RSS**, with **`CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB`** (plist updated; old RSS/threshold env names still fall through). Snapshots, notifications, brainbar text, and breach signals use **`footprint`** instead of **`rss`**. Tests mock **`footprint`** and **`CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE`**.
> 
> **New `cmux-ram-sampler`** launchd job samples stable and nightly cmux by bundle path, appends JSONL (`phys_footprint`, swap, compressor), estimates leak rate from a trailing window, and sends best-effort early warnings to the same notify URL. Includes README, plist (5‑minute interval), and shell tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d42e8990e68da8324575272686055d25e11f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cmux RAM sampler service and switch memory watchdog to phys_footprint
> - Adds a new `cmux-ram-sampler` launchd service ([cmux-ram-sampler.sh](https://github.com/EtanHey/cmuxlayer/pull/152/files#diff-8a20a2da4bb278f0b8f4b4be5abb9ab8140a99dafb5f8748d92e55ef3d93dfb9)) that samples `phys_footprint`, peak footprint, swap usage, and compressor memory every 5 minutes for both `stable` and `nightly` cmux instances, appending JSONL rows to a sample file.
> - Implements linear regression over a trailing sample window to predict time-to-danger in minutes; sends HTTP notifications when the projected ETA falls below a configured lead time or when swap free is critically low.
> - Switches the existing `cmux-memory-watchdog` from RSS to `phys_footprint` for breach detection, replacing `CMUX_MEM_WATCHDOG_RSS_THRESHOLD_GB` with `CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB` (default 5 GB) in both the script and its [plist](https://github.com/EtanHey/cmuxlayer/pull/152/files#diff-7324e84c85a7e70d17b755a0dac899caa1e1a5d48e148584de2a0c23930d3de9).
> - Both services support fixture environment variables for unit testing; test harnesses are added under each service's `tests/` directory.
> - Behavioral Change: watchdog breach detection now measures `phys_footprint` (via the `footprint` tool) rather than RSS; breach signals are labeled `footprint` instead of `rss`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9d42e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->