### PR TITLE
fix(watchdog): match BOTH cmux bundles (stable + nightly)

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -68,7 +68,9 @@ get_cmux_pid() {
     return 0
   fi
 
-  pid="$(pgrep -f 'cmux\.app/Contents/MacOS/cmux' 2>/dev/null | head -n 1 || true)"
+  # cmux[^/]*\.app matches BOTH the stable bundle (cmux.app) and the nightly
+  # bundle (cmux NIGHTLY.app); the old cmux\.app pattern missed nightly entirely.
+  pid="$(pgrep -f 'cmux[^/]*\.app/Contents/MacOS/cmux' 2>/dev/null | head -n 1 || true)"
   if [[ -n "$pid" ]]; then
     printf '%s\n' "$pid"
     return 0
@@ -115,7 +117,10 @@ aggregate_cmux_footprint_bytes() {
   local footprint_bytes
   local pids
 
-  pids="$(pgrep -f 'cmux\.app/Contents/MacOS/cmux|/Applications/cmux\.app/Contents/Resources/bin/bun' 2>/dev/null || true)"
+  # Match BOTH cmux bundles (stable cmux.app + nightly "cmux NIGHTLY.app") so
+  # the watchdog covers whichever instance(s) are running — including when only
+  # nightly is up. The old cmux\.app pattern silently skipped nightly.
+  pids="$(pgrep -f 'cmux[^/]*\.app/Contents/MacOS/cmux|cmux[^/]*\.app/Contents/Resources/bin/bun' 2>/dev/null || true)"
   for pid in $pids; do
     footprint_bytes="$(cmux_footprint_bytes_for_pid "$pid")"
     if [[ -n "$footprint_bytes" ]]; then

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -181,3 +181,34 @@ run_case "no cmux pid exits cleanly" \
   $'Pages occupied by compressor: 4194305.\n' \
   "" \
   ""
+
+# Matcher coverage regression guard (2026-06-09): the PID matcher must catch
+# BOTH cmux bundles — stable "cmux.app" AND nightly "cmux NIGHTLY.app". The old
+# `cmux\.app` pattern silently skipped nightly, so a nightly-only fleet (the
+# common case while we run on nightly) went completely unwatched.
+run_matcher_coverage() {
+  local script
+  script="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/cmux-memory-watchdog.sh"
+  local stable="/Applications/cmux.app/Contents/MacOS/cmux"
+  local nightly="/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux"
+  local broadened='cmux[^/]*\.app/Contents/MacOS/cmux'
+
+  printf '%s' "$stable" | grep -qE "$broadened" \
+    || { printf 'FAIL: matcher misses STABLE bundle\n'; exit 1; }
+  printf '%s' "$nightly" | grep -qE "$broadened" \
+    || { printf 'FAIL: matcher misses NIGHTLY bundle\n'; exit 1; }
+
+  # The production script must use the broadened form in both discovery sites.
+  local broad_count
+  broad_count="$(grep -cE "pgrep -f 'cmux\[\^/\]\*\\\\\.app/Contents/MacOS/cmux" "$script" || true)"
+  [[ "$broad_count" -ge 2 ]] \
+    || { printf 'FAIL: expected >=2 broadened pgrep matchers in script, found %s\n' "$broad_count"; exit 1; }
+
+  # Regression guard: the narrow stable-only matcher must be gone.
+  if grep -qE "pgrep -f 'cmux\\\\\.app/Contents/MacOS/cmux'" "$script"; then
+    printf 'FAIL: narrow cmux.app matcher regressed (would miss nightly)\n'; exit 1
+  fi
+
+  printf 'PASS: matcher covers both cmux bundles (stable + nightly)\n'
+}
+run_matcher_coverage


### PR DESCRIPTION
## Problem (Etan armed the watchdog; it was blind)
Etan `launchctl load`-ed `com.golems.cmux-memory-watchdog`. But its PID matcher used `cmux\.app/Contents/MacOS/cmux`, which **cannot match the nightly bundle** `cmux NIGHTLY.app/Contents/MacOS/cmux`. With the fleet on nightly (stable closed), the watchdog matched **nothing** and skipped every check — armed but blind to the only running instance.

Verified live: only `cmux NIGHTLY.app` (PID 58922) is running; a manual run found no process and exited clean. Regex check confirms `cmux\.app` matches stable only, misses nightly.

## Fix
Broaden the matcher to `cmux[^/]*\.app/...` in **both** discovery sites (`get_cmux_pid` + `aggregate_cmux_footprint_bytes`) → covers stable, nightly, or both. Plus a **matcher-coverage regression test** asserting the pattern matches both bundles and guarding against the narrow form returning.

## Verified
- Regex matches both bundle paths (stable + nightly); old pattern misses nightly.
- Watchdog test suite green incl. new `matcher covers both cmux bundles` case.
- shellcheck clean.

## Scope note (for Etan's Q2/Q3)
- This is the **breach-alert** watchdog — it now SEES both instances and aggregates them for threshold-tripping.
- **Side-by-side per-instance time-series + ETA/predictionLayer feed = the `cmux-ram-sampler`** (added in #152, models stable+nightly separately, writes `samples.jsonl`, has `predict_eta_minutes` + telegram warn). It is **not yet armed** (`launchctl load`, Etan-gated). `/tmp/brainbar.sock` exists; the watchdog feeds it `brain_store` on breach. Full side-by-side/prediction wiring = arm the sampler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small regex change in a local launchd watchdog script; no auth or shared infra, but incorrect matching could still miss processes or affect breach termination behavior.
> 
> **Overview**
> The memory watchdog’s `pgrep` patterns were **stable-only** (`cmux\.app`), so a **nightly-only** install (`cmux NIGHTLY.app`) was never discovered and checks were skipped.
> 
> **PID discovery** in `get_cmux_pid` and **footprint aggregation** in `aggregate_cmux_footprint_bytes` now use `cmux[^/]*\.app/...`, matching stable and nightly bundle paths (main binary and bundled `bun`).
> 
> A **`run_matcher_coverage`** test asserts the regex hits both bundle paths, that the script has the broadened matcher in both sites, and that the old narrow pattern cannot regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0382ffc76c3ff4eea2c19729551f7016b863a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cmux memory watchdog to match both stable and nightly app bundles
> - Updates `pgrep` patterns in `get_cmux_pid` and `aggregate_cmux_footprint_bytes` in [cmux-memory-watchdog.sh](https://github.com/EtanHey/cmuxlayer/pull/153/files#diff-e67359a7bbbc7ad3ee4d8d37b25d23790c5567c97896c5fc3f9159f9ce0ac2ef) from `cmux\.app/...` to `cmux[^/]*\.app/...` to match both `cmux.app` and `cmux NIGHTLY.app`.
> - Removes the hardcoded `/Applications` prefix from the `bun` helper path pattern so processes are matched regardless of install location.
> - Adds a test in [tests/cmux-memory-watchdog.sh](https://github.com/EtanHey/cmuxlayer/pull/153/files#diff-da57b6fd4035e035947b69f57112359f90a86a1a770d0c3c11b0ee78030ab357) that asserts both bundle paths match the broadened regex and that the old narrow matcher is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0382ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->