### PR TITLE
fix(layout): don't collapse columns on zero-area pane frames (geometry hardening)

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -3,7 +3,11 @@ import type { AgentRecord, AgentRole, CliType } from "./agent-types.js";
 import { extractPrefix } from "./naming.js";
 
 export type AgentSpawnPlacement =
-  | { kind: "split"; direction: "left" | "right" | "up" | "down"; pane?: string }
+  | {
+      kind: "split";
+      direction: "left" | "right" | "up" | "down";
+      pane?: string;
+    }
   | { kind: "surface"; pane: string };
 
 export interface SurfaceClosePolicy {
@@ -107,7 +111,17 @@ function roleForSurface(
 }
 
 export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
-  const useGeometry = panes.every((pane) => pane.pixel_frame);
+  // A pixel_frame is only usable for column detection when it has real area.
+  // cmux reports {x:0, width:0, ...} for panes in a workspace it isn't
+  // currently rendering (background/unfocused workspaces), and that frame is
+  // truthy — so a naive `pane.pixel_frame` check would treat every pane as
+  // sharing x:0, collapse them into a single column, and silently disable the
+  // left-vs-right (lead-vs-worker) docking logic. Require non-zero width on
+  // every pane before trusting geometry; otherwise fall back to pane.index,
+  // which is monotonic left-to-right and always present.
+  const useGeometry = panes.every(
+    (pane) => pane.pixel_frame && pane.pixel_frame.width > 0,
+  );
   const sortedGroups = [
     ...new Map(
       [...panes]
@@ -305,9 +319,9 @@ export function canInferAgentRole(input: {
 }): boolean {
   return Boolean(
     input.role ||
-      roleFromLauncherLabel(input.launcherName) ||
-      roleFromLauncherLabel(input.title) ||
-      roleFromCli(input.cli),
+    roleFromLauncherLabel(input.launcherName) ||
+    roleFromLauncherLabel(input.title) ||
+    roleFromCli(input.cli),
   );
 }
 
@@ -443,9 +457,7 @@ export function chooseAgentSpawnPlacement(
 
   if (role === "orchestrator") {
     const leftLeadPane =
-      leftPane && !isWorkerMajorityPane(leftPane)
-        ? leftPane
-        : undefined;
+      leftPane && !isWorkerMajorityPane(leftPane) ? leftPane : undefined;
     const orchestratorPane =
       leftLeadPane ??
       leftmostByColumn(layouts.filter(isDedicatedOrchestratorPane));
@@ -612,11 +624,10 @@ export function chooseSurfaceClosePolicy(
   workerSurfaceIds: ReadonlySet<string>,
   surfaceId: string,
 ): SurfaceClosePolicy {
-  const layout = describePaneLayouts(
-    panes,
-    paneSurfaces,
-    { ...emptyRoleSurfaceIds(), worker: new Set(workerSurfaceIds) },
-  ).find((candidate) =>
+  const layout = describePaneLayouts(panes, paneSurfaces, {
+    ...emptyRoleSurfaceIds(),
+    worker: new Set(workerSurfaceIds),
+  }).find((candidate) =>
     candidate.surfaces.some((surface) => surface.ref === surfaceId),
   );
 

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -144,14 +144,25 @@ describe("layout policy", () => {
     expect(columns.get("pane:geometric-left")).toBe(2);
   });
 
+  it("does not collapse columns when cmux reports zero-area frames for an unfocused workspace", () => {
+    // cmux reports {x:0, width:0} for every pane in a workspace it is not
+    // currently rendering. A naive truthy check on pixel_frame would treat all
+    // panes as sharing x:0 and collapse them into one column, disabling
+    // left-vs-right (lead-vs-worker) docking. Geometry must be ignored here so
+    // index ordering keeps the columns distinct.
+    const columns = deriveColumnIndex([
+      makePane("pane:left", 0, [], { x: 0, y: 0, width: 0, height: 0 }),
+      makePane("pane:right", 1, [], { x: 0, y: 0, width: 0, height: 0 }),
+    ]);
+
+    expect(columns.get("pane:left")).toBe(0);
+    expect(columns.get("pane:right")).toBe(1);
+  });
+
   it("infers default role from repoGolem launcher names", () => {
-    expect(inferAgentRole({ launcherName: "orcClaude" })).toBe(
-      "orchestrator",
-    );
+    expect(inferAgentRole({ launcherName: "orcClaude" })).toBe("orchestrator");
     expect(inferAgentRole({ launcherName: "cmuxlayerCodex" })).toBe("worker");
-    expect(inferAgentRole({ launcherName: "brainlayerCursor" })).toBe(
-      "worker",
-    );
+    expect(inferAgentRole({ launcherName: "brainlayerCursor" })).toBe("worker");
   });
 
   it("uses the final launcher marker when repo names contain role words", () => {
@@ -486,9 +497,7 @@ describe("layout policy", () => {
   });
 
   it("docks workers into launcher-title Codex panes without registry state", () => {
-    const panes = [
-      makePane("pane:worker", 0, ["surface:cmuxlayer-worker"]),
-    ];
+    const panes = [makePane("pane:worker", 0, ["surface:cmuxlayer-worker"])];
     const paneSurfaces = [
       makeTitledPaneSurfaces("pane:worker", [
         {
@@ -742,7 +751,10 @@ describe("layout policy", () => {
       makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
     ];
     const paneSurfaces = [
-      makePaneSurfaces("pane:left", ["surface:interactive", "surface:worker-1"]),
+      makePaneSurfaces("pane:left", [
+        "surface:interactive",
+        "surface:worker-1",
+      ]),
     ];
 
     const placement = chooseAgentSpawnPlacement(
@@ -943,7 +955,10 @@ describe("layout policy", () => {
 
   it("docks into a clean right-column pane when an unknown worker contaminates the left pane", () => {
     const panes = [
-      makePane("pane:left", 0, ["surface:interactive", "surface:unknown-worker"]),
+      makePane("pane:left", 0, [
+        "surface:interactive",
+        "surface:unknown-worker",
+      ]),
       makePane("pane:right", 1, ["surface:notes"]),
     ];
     const paneSurfaces = [
@@ -1049,7 +1064,10 @@ describe("layout policy", () => {
     ];
     const paneSurfaces = [
       makePaneSurfaces("pane:left", ["surface:orchestrator"]),
-      makePaneSurfaces("pane:right", ["surface:unknown-worker", "surface:shell"]),
+      makePaneSurfaces("pane:right", [
+        "surface:unknown-worker",
+        "surface:shell",
+      ]),
     ];
 
     const placement = chooseAgentSpawnPlacement(
@@ -1250,7 +1268,10 @@ describe("layout policy", () => {
       makePane("pane:left", 0, ["surface:interactive", "surface:worker-1"]),
     ];
     const paneSurfaces = [
-      makePaneSurfaces("pane:left", ["surface:interactive", "surface:worker-1"]),
+      makePaneSurfaces("pane:left", [
+        "surface:interactive",
+        "surface:worker-1",
+      ]),
     ];
 
     const policy = chooseSurfaceClosePolicy(


### PR DESCRIPTION
## What

`deriveColumnIndex` decides left-vs-right pane columns (the basis for **leads-left / workers-right** placement). It trusted **any truthy `pixel_frame`**.

The current cmux app reports `{x:0, width:0}` for every pane in a workspace it is **not actively rendering** (background/unfocused workspaces). That zero-area frame is still truthy, so every pane mapped to the same `x:0` group → **all panes collapsed into one column** → `columnCount === 1` → the right-column docking logic never fired. Role-based placement silently degraded whenever it queried an unfocused workspace.

## Fix

Require **non-zero width on every pane** before trusting geometry; otherwise fall back to `pane.index` ordering (monotonic left-to-right, always present). Focused workspaces (real width) are unaffected — this only changes the previously-broken zero-area case.

## Evidence

- New test reproduces the collapse — **fails pre-fix** (`pane:right` → column 0 instead of 1), passes post-fix.
- `783` tests green; typecheck clean.
- Live-confirmed: a focused cmux workspace reports real geometry (left x=216, right x=972); an **unfocused** one reports `{x:0, width:0}` for all panes.

## Scope — read this

This is **hardening**, not the whole regression story. Root-cause investigation (posted to the gen16 channel) found the cmuxlayer placement *logic* is correct and fully tested; the primary driver of the reported leads-left/workers-right regression **and** the S4 MCP handshake failures is operational: the fleet's cmux MCP is launched from **live working-tree source** (`bun run src/index.ts`, per `~/.golems/config.yaml`), coupling placement behavior + server startup health to uncommitted edits in this repo. That needs an operational fix (pin to a stable build) which is outside this PR. This change makes the placement core robust regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to layout geometry gating with a targeted test; focused workspaces unchanged and no auth or data paths touched.
> 
> **Overview**
> **`deriveColumnIndex`** no longer treats any truthy `pixel_frame` as valid geometry. It only uses x-position grouping when **every pane has `pixel_frame.width > 0`**; otherwise it falls back to **`pane.index`** for left-to-right columns.
> 
> That closes a bug where cmux reports **`{ x: 0, width: 0 }`** for panes in unfocused/background workspaces: all panes were grouped at `x:0`, **`columnCount` became 1**, and lead-left / worker-right spawn docking stopped applying for those layouts. Focused workspaces with real widths behave as before.
> 
> A regression test asserts two zero-area panes stay in columns **0** and **1** via index ordering. Remaining diff is mostly formatting in layout-policy and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74124c2eea5784cee31fc64d99ae34d8dbda6704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix column collapse in `deriveColumnIndex` when panes report zero-area pixel frames
> When a workspace is unfocused, the compositor (cmux) can report zero-width pixel frames. Previously, `deriveColumnIndex` treated any truthy `pixel_frame` as valid geometry, grouping all zero-width panes into a single column. Now it requires `pixel_frame.width > 0`; otherwise it falls back to pane index ordering. A new test in [layout-policy.test.ts](https://github.com/EtanHey/cmuxlayer/pull/154/files#diff-e19c3e332b3c61ccd559c1ee6439bd622460ecc6ccdf1e21371201e49a48dfd4) asserts the fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74124c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pane layout rendering to correctly maintain separate columns for panes with zero-area geometry, preventing unintended column collapse in certain workspace states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->