### PR TITLE
test(layout): assert two-way invariant (no third column) on zero-area frames

### DIFF
--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -144,19 +144,41 @@ describe("layout policy", () => {
     expect(columns.get("pane:geometric-left")).toBe(2);
   });
 
-  it("does not collapse columns when cmux reports zero-area frames for an unfocused workspace", () => {
-    // cmux reports {x:0, width:0} for every pane in a workspace it is not
-    // currently rendering. A naive truthy check on pixel_frame would treat all
-    // panes as sharing x:0 and collapse them into one column, disabling
-    // left-vs-right (lead-vs-worker) docking. Geometry must be ignored here so
-    // index ordering keeps the columns distinct.
-    const columns = deriveColumnIndex([
-      makePane("pane:left", 0, [], { x: 0, y: 0, width: 0, height: 0 }),
-      makePane("pane:right", 1, [], { x: 0, y: 0, width: 0, height: 0 }),
-    ]);
+  it("stays two-way (worker docks right, never a third column) when an unfocused workspace reports zero-area frames", () => {
+    // THE invariant: cmux geometry is two-way — a LEFT lead column and a RIGHT
+    // worker column, never three. cmux reports {x:0, width:0} for every pane in
+    // a workspace it is not currently rendering. If that zero geometry collapses
+    // the two columns into one, the lead's next worker splits RIGHT off the lead
+    // pane and a THIRD column appears. Ignoring zero-area frames keeps the
+    // columns distinct, so the worker docks into the existing right column.
+    const zero = { x: 0, y: 0, width: 0, height: 0 };
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"], zero),
+      makePane("pane:right", 1, [], zero),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", []),
+    ];
 
-    expect(columns.get("pane:left")).toBe(0);
-    expect(columns.get("pane:right")).toBe(1);
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+      },
+    );
+
+    // Docks into the existing right column (two-way). The regression is
+    // { kind: "split", direction: "right", pane: "pane:left" } — a third column.
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
   it("infers default role from repoGolem launcher names", () => {


### PR DESCRIPTION
## Why

Etan flagged the geometry test shipped in #154 as terrible — and it was. It asserted `deriveColumnIndex` returns sequential column indices: low-level trivia that says nothing about the actual rule.

**The invariant:** cmux geometry is **two-way** — a LEFT lead column and a RIGHT worker column, **never three**. (Standing complaint, recurring since 2026-05-01.)

## What

Replaces the weak `deriveColumnIndex` test with a placement-level test that drives `chooseAgentSpawnPlacement` directly:
- Layout: lead-left + an existing right column, both panes reporting `{x:0, width:0}` (an **unfocused** workspace — cmux only computes geometry for the visible one).
- Asserts the lead's next worker **docks into the existing right column** (`{kind:"surface", pane:"pane:right"}`) rather than **splitting a third column** off the lead pane (`{kind:"split", direction:"right", pane:"pane:left"}`).

## Proven meaningful

- Against pre-#154 code → **FAILS** with exactly the third-column split.
- With the #154 zero-frame guard → docks right (two-way).
- 45 layout tests green.

This locks the two-way invariant at the level that matters (placement), not column-indexing trivia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no runtime changes; it strengthens regression coverage for layout placement.
> 
> **Overview**
> Replaces a **column-index-only** test with one that exercises **`chooseAgentSpawnPlacement`** end-to-end for the **two-way layout** rule (lead left, worker right—never a third column).
> 
> The scenario models an **unfocused workspace** where cmux reports **`{x:0, width:0}`** on every pane. The test spawns an orchestrator’s **worker** and expects **`{ kind: "surface", pane: "pane:right" }`** (dock into the existing right column), not a **right split off the lead** that would open a third column. Comments document that failure mode as the regression target tied to ignoring zero-area frames in column detection.
> 
> **Test-only change**—no production code in this diff; it locks behavior that **`deriveColumnIndex`**’s zero-width guard is meant to preserve at the placement layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2cb74c3cc885c47c3286f876d32615b4648407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert two-way invariant for `chooseAgentSpawnPlacement` on zero-area frames
> Replaces a `deriveColumnIndex`-based test with one that validates `chooseAgentSpawnPlacement` directly. The new test constructs two panes with zero-area geometry and asserts that a worker docks into the existing right pane (`{ kind: "surface", pane: "pane:right" }`) rather than splitting left and creating a third column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b2cb74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->