### PR TITLE
feat(spawn): team-spawn + worktree tools + control-health + auto-focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,13 @@ docs.local/
 # Local agent scratch + settings
 claude.scratchpad.md
 .claude/
+
+# graphify knowledge graph output (local build artifact)
+graphify-out/
 node_modules
+
+# git worktrees (e.g. isolated PR branches)
+.worktrees/
+
+# local collab/scratch notes
+collab/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cmuxLayer
 
-**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 33 MCP tools that give AI agents programmatic control over terminal workspaces.
+**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that: 35 MCP tools that give AI agents programmatic control over terminal workspaces.
 
 <p align="center">
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
@@ -8,8 +8,8 @@
 
 [![install](https://img.shields.io/badge/install-npm%20install%20--g%20cmuxlayer-22c55e)](https://github.com/EtanHey/cmuxlayer#quick-start)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP-33%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-669%20passing-brightgreen.svg)](#testing)
+[![MCP Tools](https://img.shields.io/badge/MCP-35%20tools-green.svg)](https://modelcontextprotocol.io)
+[![Tests](https://img.shields.io/badge/tests-798%20passing-brightgreen.svg)](#testing)
 
 ## Quick Start
 
@@ -54,7 +54,7 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer exposes 33 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
+Under the hood, cmuxLayer exposes 35 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
 ## Agent Routing Workflow
 
@@ -62,26 +62,27 @@ For managed agents, use the agent-first path: `list_agents` to find the target, 
 
 See [Agent Routing and Handling Workflow](docs/agent-routing-and-handling.md) for the full operator playbook, including stuck surface recovery and safe `/mcp` menu reconnects.
 
-## MCP Tools (33)
+## MCP Tools (35)
 
 All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
 
-**Terminal control** — `list_surfaces` `select_workspace` `create_workspace` `new_split` `new_surface` `move_surface` `reorder_surface` `send_input` `send_command` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
+**Terminal control** — `list_surfaces` `control_health` `select_workspace` `create_workspace` `new_split` `new_surface` `move_surface` `reorder_surface` `send_input` `send_command` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
 
-**Agent lifecycle** — `spawn_agent` `spawn_in_workspace` `resync_agents` `send_to` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
+**Agent lifecycle** — `spawn_agent` `new_worktree_split` `spawn_in_workspace` `resync_agents` `send_to` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
 
 **Metacomm (agent inbox)** — `dispatch_to_agent` `inbox_check`
 
 **Workspace state** — `list_agents` `my_agents` `get_agent_state` `read_agent_output` `notify` `set_status` `set_progress`
 
 <details>
-<summary>Full tool reference (33 tools)</summary>
+<summary>Full tool reference (35 tools)</summary>
 
-### Read-only (7)
+### Read-only (8)
 
 | Tool | What it does |
 |------|-------------|
 | `list_surfaces` | List all surfaces across workspaces |
+| `control_health` | Report socket, binary, process, and job-control diagnostics |
 | `read_screen` | Read terminal output with parsed agent status |
 | `get_agent_state` | Full state of a tracked agent |
 | `list_agents` | All agents, with optional filters |
@@ -89,7 +90,7 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `read_agent_output` | Structured output between delimiter markers |
 | `inbox_check` | Inspect an agent's inbox channel: pending messages, monitor liveness, stale dispatches |
 
-### Mutating (23)
+### Mutating (24)
 
 | Tool | What it does |
 |------|-------------|
@@ -108,6 +109,7 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `set_progress` | Set progress indicator (0.0-1.0) |
 | `browser_surface` | Interact with browser surfaces |
 | `spawn_agent` | Spawn a CLI agent and return an `agent_id` for routing |
+| `new_worktree_split` | Create or reuse a git worktree and spawn a worker there |
 | `spawn_in_workspace` | Create a workspace and spawn a multi-agent team into a clean grid |
 | `resync_agents` | Re-sync the agent registry from live surfaces |
 | `dispatch_to_agent` | Append a task to an agent's inbox file (deterministic write channel) |
@@ -173,7 +175,7 @@ cmuxLayer auto-discovers the cmux socket (macOS: `~/Library/Application Support/
 ## Testing
 
 ```bash
-bun run test        # 669 tests via vitest
+bun run test        # 798 tests via vitest
 npm run typecheck   # Type checking
 ```
 

--- a/docs/plans/2026-06-13-worktree-spawn-design.md
+++ b/docs/plans/2026-06-13-worktree-spawn-design.md
@@ -1,0 +1,56 @@
+# Worktree Spawn Design
+
+**Goal:** Let leads spawn workers into fresh or reused git worktrees from cmuxlayer while preserving the existing cmux role layout and inherited MCP setup by default.
+
+**Approved default:** Worktree workers inherit the parent/default MCP setup unless the caller chooses a narrower profile.
+
+## Tool Contract
+
+`spawn_agent` accepts:
+
+```ts
+worktree?: boolean | {
+  create?: boolean;
+  reuse?: boolean;
+  name?: string;
+  path?: string;
+  branch?: string;
+  base?: string;
+};
+mcp_profile?: "inherit" | "sterile" | "skill_eval" | {
+  include?: string[];
+  exclude?: string[];
+};
+```
+
+`new_worktree_split` is a convenience wrapper for one worker. It uses the same fields, defaults `role` to `worker`, and returns the same spawn metadata plus worktree metadata.
+
+## Architecture
+
+Worktree creation lives in a small helper module instead of `server.ts`. The helper validates repo/name/path input, creates or reuses a git worktree under `~/Gits/<repo>.wt/<name>` by default, and returns the launch cwd.
+
+`AgentEngine.spawnAgent` receives the resolved `cwd` and `mcp_profile`, but keeps the current cmux surface placement code. Workers still go right, orchestrators/domain leads still go left. Only the command sent into the new terminal changes: launcher commands are prefixed with `cd <worktree> && ...` and MCP profile env is exported for launchers to consume.
+
+## MCP Profiles
+
+- `inherit`: default. No sterile filtering. Sets `CMUXLAYER_MCP_PROFILE=inherit`.
+- `sterile`: sets `CMUXLAYER_MCP_PROFILE=sterile`.
+- `skill_eval`: sets `CMUXLAYER_MCP_PROFILE=skill_eval`.
+- custom include/exclude: sets `CMUXLAYER_MCP_PROFILE=custom`, `CMUXLAYER_MCP_INCLUDE`, and `CMUXLAYER_MCP_EXCLUDE`.
+
+This deliberately avoids raw config passing. Launchers can map these profile hints to their own Codex/Claude config behavior.
+
+## Safety
+
+- No cmux restart.
+- No destructive git operations.
+- Existing worktrees are reused only when `reuse` is true.
+- User-supplied paths must be absolute and must stay under `~/Gits` unless explicitly allowed later.
+- `node_modules` is symlinked from the main checkout when present and absent in the worktree, because prior cmuxlayer worker incidents showed this is required for seamless local tests. The symlink is never committed.
+
+## Tests
+
+- Worktree helper creates the expected `git worktree add -b ... <path> <base>` command.
+- Existing worktree reuse skips creation.
+- `spawn_agent({ worktree: true })` launches from the worktree cwd, preserves worker role placement, and defaults to `mcp_profile: "inherit"`.
+- Custom MCP profiles are converted to env hints without exposing raw config.

--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -62,21 +62,30 @@ threshold_bytes() {
 
 get_cmux_pid() {
   local pid
-  pid="$(pgrep -x cmux 2>/dev/null | head -n 1 || true)"
+  pid="$(ps_cmux_pids | awk 'NF && found == "" { found = $1 } END { if (found != "") print found }')"
   if [[ -n "$pid" ]]; then
     printf '%s\n' "$pid"
     return 0
   fi
 
-  # cmux[^/]*\.app matches BOTH the stable bundle (cmux.app) and the nightly
-  # bundle (cmux NIGHTLY.app); the old cmux\.app pattern missed nightly entirely.
-  pid="$(pgrep -f 'cmux[^/]*\.app/Contents/MacOS/cmux' 2>/dev/null | head -n 1 || true)"
+  pid="$(pgrep -x cmux 2>/dev/null | awk 'NF && found == "" { found = $1 } END { if (found != "") print found }' || true)"
   if [[ -n "$pid" ]]; then
     printf '%s\n' "$pid"
     return 0
   fi
 
   return 1
+}
+
+ps_cmux_pids() {
+  ps -ww -axo pid=,command= 2>/dev/null | awk '
+    {
+      pid = $1
+      command = $0
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", command)
+      if (command ~ /^\/Applications\/cmux[^\/]*\.app\/Contents\/MacOS\/cmux([[:space:]]|$)/) print pid
+      else if (command ~ /^\/Applications\/cmux[^\/]*\.app\/Contents\/Resources\/bin\/bun([[:space:]]|$)/) print pid
+    }'
 }
 
 parse_phys_footprint_bytes() {
@@ -119,8 +128,9 @@ aggregate_cmux_footprint_bytes() {
 
   # Match BOTH cmux bundles (stable cmux.app + nightly "cmux NIGHTLY.app") so
   # the watchdog covers whichever instance(s) are running — including when only
-  # nightly is up. The old cmux\.app pattern silently skipped nightly.
-  pids="$(pgrep -f 'cmux[^/]*\.app/Contents/MacOS/cmux|cmux[^/]*\.app/Contents/Resources/bin/bun' 2>/dev/null || true)"
+  # nightly is up. Use ps as the primary source: broad pgrep -f can match the
+  # transient pgrep command itself on macOS.
+  pids="$({ ps_cmux_pids || true; pgrep -x cmux 2>/dev/null || true; } | awk 'NF && !seen[$1]++ { print $1 }')"
   for pid in $pids; do
     footprint_bytes="$(cmux_footprint_bytes_for_pid "$pid")"
     if [[ -n "$footprint_bytes" ]]; then

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -97,6 +97,65 @@ EOF
   chmod +x "$root_dir/bin/pgrep"
 }
 
+seed_ps_fallback_commands() {
+  local root_dir="$1"
+  local log_dir="$2"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/socat" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/socat.log"
+EOF
+  chmod +x "$root_dir/bin/socat"
+
+  cat >"$root_dir/bin/sleep" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/sleep.log"
+EOF
+  chmod +x "$root_dir/bin/sleep"
+
+  cat >"$root_dir/bin/kill" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/kill.log"
+EOF
+  chmod +x "$root_dir/bin/kill"
+
+  cat >"$root_dir/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "$root_dir/bin/pgrep"
+
+  cat >"$root_dir/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${*: -1}" == "pid=,command=" ]]; then
+  printf '4242 /Applications/cmux NIGHTLY.app/Contents/MacOS/cmux\n'
+  exit 0
+fi
+printf '   PID  PPID   RSS      VSZ  %%CPU ELAPSED COMMAND\n'
+printf ' 4242  1000  16384   12345   0.0  01:00:00 /Applications/cmux NIGHTLY.app/Contents/MacOS/cmux\n'
+EOF
+  chmod +x "$root_dir/bin/ps"
+
+  cat >"$root_dir/bin/footprint" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'phys_footprint: 6.00 GB (peak 8.00 GB)\\n'
+EOF
+  chmod +x "$root_dir/bin/footprint"
+}
+
 run_case() {
   local name="$1"
   local expect_breach="$2"
@@ -191,24 +250,62 @@ run_matcher_coverage() {
   script="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/cmux-memory-watchdog.sh"
   local stable="/Applications/cmux.app/Contents/MacOS/cmux"
   local nightly="/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux"
-  local broadened='cmux[^/]*\.app/Contents/MacOS/cmux'
+  local broadened='^/Applications/cmux[^/]*\.app/Contents/MacOS/cmux([[:space:]]|$)'
 
   printf '%s' "$stable" | grep -qE "$broadened" \
     || { printf 'FAIL: matcher misses STABLE bundle\n'; exit 1; }
   printf '%s' "$nightly" | grep -qE "$broadened" \
     || { printf 'FAIL: matcher misses NIGHTLY bundle\n'; exit 1; }
 
-  # The production script must use the broadened form in both discovery sites.
-  local broad_count
-  broad_count="$(grep -cE "pgrep -f 'cmux\[\^/\]\*\\\\\.app/Contents/MacOS/cmux" "$script" || true)"
-  [[ "$broad_count" -ge 2 ]] \
-    || { printf 'FAIL: expected >=2 broadened pgrep matchers in script, found %s\n' "$broad_count"; exit 1; }
+  # The production script must use the ps fallback matcher because broad
+  # pgrep -f can match its own transient pgrep command on macOS.
+  grep -q 'ps_cmux_pids()' "$script" \
+    || { printf 'FAIL: missing ps_cmux_pids fallback\n'; exit 1; }
+  grep -qE 'Contents.*MacOS.*cmux' "$script" \
+    || { printf 'FAIL: missing cmux app-path matcher in script\n'; exit 1; }
 
-  # Regression guard: the narrow stable-only matcher must be gone.
-  if grep -qE "pgrep -f 'cmux\\\\\.app/Contents/MacOS/cmux'" "$script"; then
-    printf 'FAIL: narrow cmux.app matcher regressed (would miss nightly)\n'; exit 1
+  # Regression guard: broad pgrep -f app matching must stay gone.
+  if grep -qE "pgrep -f 'cmux" "$script"; then
+    printf 'FAIL: broad pgrep app matcher regressed (can match itself)\n'; exit 1
   fi
 
   printf 'PASS: matcher covers both cmux bundles (stable + nightly)\n'
 }
 run_matcher_coverage
+
+run_ps_fallback_case() {
+  local root_dir log_dir snapshot
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_ps_fallback_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 6 GB (peak 8 GB)
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Pages occupied by compressor: 1048576.
+EOF
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB=5
+  export CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB=12
+  export CMUX_MEM_WATCHDOG_LOG_DIR="$log_dir"
+  export CMUX_MEM_WATCHDOG_KILL_BIN="$root_dir/bin/kill"
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  run_once
+
+  assert_file_contains "$log_dir/kill.log" "-TERM 4242"
+  snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
+  assert_file_contains "$snapshot" "breached_signals=footprint"
+
+  printf 'PASS: watchdog falls back to ps command discovery when pgrep misses GUI apps\n'
+  rm -rf "$root_dir"
+}
+
+run_ps_fallback_case

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -73,7 +73,24 @@ timestamp_to_epoch() {
 
 pid_for_path() {
   local app_path="$1"
-  pgrep -f "$app_path" 2>/dev/null | head -n 1 || true
+  local pid
+
+  pid="$(pgrep -f "$app_path" 2>/dev/null | awk 'NF && found == "" { found = $1 } END { if (found != "") print found }' || true)"
+  if [[ -n "$pid" ]]; then
+    printf '%s\n' "$pid"
+    return
+  fi
+
+  ps -ww -axo pid=,command= 2>/dev/null | awk -v app_path="$app_path" '
+    {
+      pid = $1
+      command = $0
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", command)
+      if (found == "" && index(command, app_path) == 1) found = pid
+    }
+    END {
+      if (found != "") print found
+    }'
 }
 
 footprint_output_for_pid() {

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -49,6 +49,33 @@ EOF
   chmod +x "$root_dir/bin/pgrep"
 }
 
+seed_ps_fallback_commands() {
+  local root_dir="$1"
+  local log_dir="$2"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "$root_dir/bin/pgrep"
+
+  cat >"$root_dir/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '4242 /Applications/cmux.app/Contents/MacOS/cmux\n'
+printf '5151 /Applications/cmux NIGHTLY.app/Contents/MacOS/cmux\n'
+EOF
+  chmod +x "$root_dir/bin/ps"
+}
+
 run_prediction_case() {
   local root_dir log_dir eta
   root_dir="$(mktemp -d)"
@@ -93,6 +120,7 @@ EOF
 
   export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
   export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
   export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
   export CMUX_RAM_SAMPLER_SWAP_FIXTURE="$root_dir/fixtures/swap.fixture"
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
@@ -116,5 +144,47 @@ EOF
   rm -rf "$root_dir"
 }
 
+run_ps_fallback_sampling_case() {
+  local root_dir log_dir sample_file line_count
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_ps_fallback_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+5151 phys_footprint: 2048 MB (peak 4096 MB)
+EOF
+  cat >"$root_dir/fixtures/swap.fixture" <<'EOF'
+vm.swapusage: total = 8192.00M  used = 6144.00M  free = 1024.00M  (encrypted)
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Pages occupied by compressor: 262144.
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_SWAP_FIXTURE="$root_dir/fixtures/swap.fixture"
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  run_once
+
+  sample_file="$log_dir/samples.jsonl"
+  line_count="$(wc -l <"$sample_file" | tr -d ' ')"
+  assert_eq "2" "$line_count"
+  assert_file_contains "$sample_file" '"instance":"stable"'
+  assert_file_contains "$sample_file" '"instance":"nightly"'
+  assert_file_contains "$sample_file" '"swap_free_mb":1024'
+
+  printf 'PASS: sampler falls back to ps command discovery when pgrep misses GUI apps\n'
+  rm -rf "$root_dir"
+}
+
 run_prediction_case
 run_sampling_case
+run_ps_fallback_sampling_case

--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -6,6 +6,10 @@ import type { CliType } from "./agent-types.js";
 export const AGENT_ENV =
   "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
 
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 export function sanitizeRepoName(repo: string): string {
   const safeRepo = repo.replace(/[^a-zA-Z0-9._-]/g, "");
   if (!safeRepo || safeRepo !== repo || safeRepo === "." || safeRepo === "..") {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3,17 +3,17 @@
  * These 7 functions are the engine that MCP tools (and later the 2-tool facade) drive.
  */
 
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
 import {
   AGENT_ENV,
   buildResumeCommand,
   sanitizeRepoName,
+  shellQuote,
 } from "./agent-command.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
 import {
@@ -73,6 +73,10 @@ export interface SpawnAgentParams {
   prompt: string;
   boot_prompt_pending?: boolean;
   workspace?: string;
+  cwd?: string;
+  mcp_env?: string;
+  mcp_profile_label?: string;
+  worktree_branch?: string;
   parent_agent_id?: string;
   role?: AgentRole;
   auto_archive_on_done?: boolean;
@@ -85,6 +89,8 @@ export interface SpawnAgentResult {
   surface_id: string;
   workspace_id?: string;
   state: AgentState;
+  cwd?: string;
+  mcp_env?: string;
 }
 
 export interface CapturedSessionIdentity {
@@ -148,8 +154,6 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`chatid:\\s*(${SESSION_ID_PATTERN})`, "i"),
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
-const execFileAsync = promisify(execFile);
-
 const JSONL_HARNESSES = new Set<CliType>(["claude", "codex", "cursor"]);
 
 export { buildResumeCommand } from "./agent-command.js";
@@ -449,24 +453,27 @@ export function buildLaunchCommand(
   // for a launcher CLI it overrides the naive `${repo}${Suffix}` guess so
   // hyphen-stripped registrations launch correctly. Ignored for gemini/kiro.
   launcherName?: string,
+  opts?: { cwd?: string; envPrefix?: string },
 ): string {
   const safeRepo = sanitizeRepoName(repo);
   const modelFlag = resolveModelFlag(cli, model);
   const launcherModelArgs = modelFlag ? ` -m ${modelFlag}` : "";
   const rawModelArgs = modelFlag ? ` --model ${modelFlag}` : "";
+  const cdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
+  const envPrefix = opts?.envPrefix ? `${opts.envPrefix} ` : "";
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry
-      return `${launcherName ?? `${safeRepo}Claude`} -s${launcherModelArgs}`;
+      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Claude`} -s${launcherModelArgs}`;
     case "codex":
-      return `${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}`;
+      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}`;
     case "gemini":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini${rawModelArgs}`;
+      return `${cdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} gemini${rawModelArgs}`;
     case "kiro":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli${rawModelArgs}`;
+      return `${cdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} kiro-cli${rawModelArgs}`;
     case "cursor":
       // repoGolem launcher - requires registration via golem-powers.
-      return `${launcherName ?? `${safeRepo}Cursor`} -s${launcherModelArgs}`;
+      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Cursor`} -s${launcherModelArgs}`;
   }
 }
 
@@ -484,6 +491,12 @@ export function extractSessionId(text: string): string | null {
 }
 
 export type LauncherSuffix = "Claude" | "Codex" | "Cursor";
+
+const REPO_LAUNCHER_ALIASES: Record<string, string[]> = {
+  // The orchestrator checkout lives at ~/Gits/orchestrator, but the
+  // repoGolem registry key is `orc`, so the launchers are orcClaude/Codex/Cursor.
+  orchestrator: ["orc"],
+};
 
 /**
  * Ordered, de-duplicated launcher-name candidates for a repo + suffix.
@@ -505,9 +518,12 @@ export function launcherNameCandidates(
   suffix: LauncherSuffix,
 ): string[] {
   const safeRepo = sanitizeRepoName(repo);
-  const verbatim = `${safeRepo}${suffix}`;
-  const stripped = `${safeRepo.replace(/-/g, "").toLowerCase()}${suffix}`;
-  return stripped === verbatim ? [verbatim] : [verbatim, stripped];
+  const prefixes = [
+    safeRepo,
+    safeRepo.replace(/-/g, "").toLowerCase(),
+    ...(REPO_LAUNCHER_ALIASES[safeRepo] ?? []),
+  ];
+  return [...new Set(prefixes)].map((prefix) => `${prefix}${suffix}`);
 }
 
 /** Returns true when a launcher function/command resolves in the login shell. */
@@ -517,12 +533,43 @@ const shellLauncherProbe: LauncherProbe = async (launcher) => {
   const shell = process.env.SHELL || "/bin/zsh";
   const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
   try {
-    await execFileAsync(shell, ["-ilc", probe]);
+    await runDetachedShellProbe(shell, probe);
     return true;
   } catch {
     return false;
   }
 };
+
+function runDetachedShellProbe(shell: string, probe: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(shell, ["-ilc", probe], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error("launcher probe timed out"));
+    }, 5_000);
+
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `launcher probe exited with ${code ?? `signal ${signal ?? "unknown"}`}`,
+        ),
+      );
+    });
+  });
+}
 
 /**
  * Resolve the actual launcher function name by probing candidate forms in
@@ -1659,6 +1706,10 @@ export class AgentEngine {
       respawn_attempts: 0,
       user_killed: false,
       boot_prompt_pending: params.boot_prompt_pending ?? false,
+      launch_cwd: params.cwd ?? null,
+      mcp_profile: params.mcp_profile_label ?? null,
+      worktree_path: params.cwd ?? null,
+      worktree_branch: params.worktree_branch ?? null,
     };
     this.stateMgr.writeState(record);
     this.registry.set(agentId, record);
@@ -1669,6 +1720,7 @@ export class AgentEngine {
       params.repo,
       params.model,
       preflight?.launcherName,
+      { cwd: params.cwd, envPrefix: params.mcp_env },
     );
     try {
       await this.sendLaunchCommand(surface.surface, surface.workspace, launchCmd);
@@ -1691,6 +1743,8 @@ export class AgentEngine {
       surface_id: surface.surface,
       workspace_id: surface.workspace,
       state: "booting",
+      cwd: params.cwd,
+      mcp_env: params.mcp_env,
     };
   }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -88,7 +88,14 @@ export class AgentRegistry {
   }
 
   private async reconcileSurfaces(): Promise<void> {
-    const surfaces = await this.surfaceProvider();
+    let surfaces: CmuxSurface[];
+    try {
+      surfaces = await this.surfaceProvider();
+    } catch {
+      // Treat enumeration failures as "unknown", not "zero surfaces". A transient
+      // socket/listing failure must not mark every active agent as disappeared.
+      return;
+    }
     const liveSurfaceRefs = new Set(surfaces.map((s) => s.ref));
 
     // Phase 1: Mark agents with disappeared surfaces as error

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -54,6 +54,11 @@ export interface AgentRecord {
   user_killed?: boolean;
   // Boot prompt delivery guard
   boot_prompt_pending?: boolean;
+  // Launch context for worktree/profile-aware spawns
+  launch_cwd?: string | null;
+  mcp_profile?: string | null;
+  worktree_path?: string | null;
+  worktree_branch?: string | null;
 }
 
 export interface MergedAgent extends AgentRecord {
@@ -147,7 +152,21 @@ export interface DeliveryTelemetryEvent {
   retry_count: number;
 }
 
-export type EventLogEntry = StateTransition | DeliveryTelemetryEvent;
+export interface ControlHealthTelemetryEvent {
+  ts: string;
+  event_type: "control_health";
+  selected_socket_path: string | null;
+  production_socket_path: string | null;
+  nightly_socket_path: string | null;
+  cmux_binary: string | null;
+  warnings: string[];
+  snapshot: unknown;
+}
+
+export type EventLogEntry =
+  | StateTransition
+  | DeliveryTelemetryEvent
+  | ControlHealthTelemetryEvent;
 
 export interface WaitResult {
   matched: boolean;

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -26,8 +26,6 @@ export interface ExecFn {
   (cmd: string, args: string[]): Promise<{ stdout: string; stderr: string }>;
 }
 
-const defaultExec: ExecFn = (cmd, args) => execFileAsync(cmd, args);
-
 interface CmuxIdentifyResult {
   caller?: {
     workspace_ref?: string;
@@ -42,17 +40,27 @@ interface CmuxIdentifyResult {
 }
 
 export class CmuxClient {
-  private exec: ExecFn;
+  private exec?: ExecFn;
   private bin: string;
+  private env?: NodeJS.ProcessEnv;
 
-  constructor(opts?: { exec?: ExecFn; bin?: string }) {
-    this.exec = opts?.exec ?? defaultExec;
+  constructor(opts?: { exec?: ExecFn; bin?: string; env?: NodeJS.ProcessEnv }) {
+    this.exec = opts?.exec;
     this.bin = opts?.bin ?? "cmux";
+    this.env = opts?.env;
+  }
+
+  setEnv(env: NodeJS.ProcessEnv | undefined): void {
+    this.env = env;
   }
 
   private async run(args: string[]): Promise<string> {
     try {
-      const { stdout } = await this.exec(this.bin, ["--json", ...args]);
+      const { stdout } = this.exec
+        ? await this.exec(this.bin, ["--json", ...args])
+        : await execFileAsync(this.bin, ["--json", ...args], {
+            ...(this.env ? { env: this.env } : {}),
+          });
       return stdout;
     } catch (error) {
       throw this.normalizeCliError(args, error);
@@ -417,8 +425,8 @@ export class CmuxClient {
   async createWorkspace(
     title: string,
   ): Promise<{ workspace: string; title: string }> {
-    const raw = await this.run(["new-workspace", "--title", title]);
-    const parsed = this.parse<Record<string, unknown>>(raw, "new-workspace");
+    const raw = await this.run(["workspace", "create", "--name", title]);
+    const parsed = this.parse<Record<string, unknown>>(raw, "workspace create");
     return {
       workspace:
         (parsed.workspace_ref as string) ?? (parsed.workspace as string) ?? "",

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -20,7 +20,7 @@ import type {
   CmuxSendOptions,
   CmuxStatusEntry,
 } from "./types.js";
-import type { CmuxClient } from "./cmux-client.js";
+import { CmuxClient } from "./cmux-client.js";
 import { normalizeKeyName } from "./key-names.js";
 import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
@@ -81,6 +81,7 @@ export class CmuxSocketClient {
     this.cliFallback = opts?.cliFallback;
     this.maxInFlight = opts?.maxInFlight;
     this.socketPathResolver = opts?.socketPathResolver;
+    this.syncCliFallbackSocketEnv();
     this.transport = new CmuxPersistentSocket({
       socketPath: this.socketPath,
       timeoutMs: this.timeoutMs,
@@ -189,11 +190,21 @@ export class CmuxSocketClient {
     this.transport.disconnect();
     this.socketPath = socketPath;
     this.password = this.authPassword;
+    this.syncCliFallbackSocketEnv();
     this.transport = new CmuxPersistentSocket({
       socketPath: this.socketPath,
       timeoutMs: this.timeoutMs,
       maxInFlight: this.maxInFlight,
     });
+  }
+
+  private syncCliFallbackSocketEnv(): void {
+    if (this.cliFallback instanceof CmuxClient) {
+      this.cliFallback.setEnv({
+        ...process.env,
+        CMUX_SOCKET_PATH: this.socketPath,
+      });
+    }
   }
 
   private async reconnectTransport(originalError: unknown): Promise<void> {
@@ -300,6 +311,16 @@ export class CmuxSocketClient {
     return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
   }
 
+  private async resolveSelectedSurface(opts?: {
+    workspace?: string;
+  }): Promise<string | undefined> {
+    const paneSurfaces = await this.listPaneSurfaces({
+      workspace: opts?.workspace,
+    });
+    const surfaces = paneSurfaces.surfaces ?? [];
+    return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
+  }
+
   async newSplit(
     direction: string,
     opts?: {
@@ -359,7 +380,7 @@ export class CmuxSocketClient {
             workspace: opts.workspace,
             pane: opts.pane,
           })
-        : undefined);
+        : await this.resolveSelectedSurface({ workspace: opts?.workspace }));
     // AIDEV-NOTE(2026-06-01): keep socket terminal splits aligned with the CLI
     // workaround for the cmux app `new-split --panel <pane>` regression. Raw CLI
     // reproduces "Surface not found"; `new-surface --pane` is unaffected.
@@ -367,7 +388,7 @@ export class CmuxSocketClient {
 
     try {
       const result = await this.call<Record<string, unknown>>(
-        "pane.split",
+        "surface.split",
         params,
       );
       return this.mapSplitResult(result, "terminal");

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -1,0 +1,555 @@
+import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface ControlHealthExecResult {
+  stdout: string;
+  stderr?: string;
+}
+
+export type ControlHealthExecFile = (
+  file: string,
+  args: string[],
+) => Promise<ControlHealthExecResult>;
+
+export interface ControlHealthOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  tmpDir?: string;
+  pid?: number;
+  ppid?: number;
+  cwd?: string;
+  client?: unknown;
+  execFile?: ControlHealthExecFile;
+  readFile?: typeof readFile;
+  stat?: typeof stat;
+  access?: typeof access;
+  now?: () => Date;
+}
+
+export interface PathStatus {
+  path: string;
+  exists: boolean;
+  kind?: "file" | "directory" | "socket" | "other";
+  mtime_ms?: number;
+  size?: number;
+  mode_octal?: string;
+  error?: string;
+}
+
+export interface MarkerStatus extends PathStatus {
+  label: string;
+  value?: string;
+}
+
+export interface ExecutableStatus extends PathStatus {
+  first_line?: string;
+  mentions_prod_app?: boolean;
+  mentions_nightly_app?: boolean;
+  mentions_last_cli_path?: boolean;
+}
+
+export interface CmuxInstanceHealth {
+  axis: "production" | "nightly";
+  app_bundle_path: string;
+  app_binary_path: string;
+  marker_files: MarkerStatus[];
+  socket_path: string | null;
+  socket_status: PathStatus | null;
+  processes: Array<{ pid: number | null; command: string }>;
+}
+
+export interface ControlHealth {
+  generated_at: string;
+  current_process: {
+    pid: number;
+    ppid: number;
+    cwd: string;
+    stdin_is_tty: boolean;
+    env: Record<string, string | null>;
+    path_entries: string[];
+    cmux_resolution: ExecutableStatus[];
+    ps?: string;
+    ps_error?: string;
+  };
+  selected_transport: {
+    client_class: string | null;
+    current_socket_path?: string;
+  };
+  cmux_instances: {
+    production: CmuxInstanceHealth;
+    nightly: CmuxInstanceHealth;
+  };
+  warnings: string[];
+}
+
+const ENV_KEYS = [
+  "CMUX_SOCKET_PATH",
+  "CMUX_BUNDLED_CLI_PATH",
+  "CMUX_BUNDLE_ID",
+  "CMUX_WORKSPACE_ID",
+  "CMUX_SURFACE_ID",
+  "CMUX_TAB_ID",
+  "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+  "CMUX_SOCKET_PASSWORD",
+  "PATH",
+] as const;
+
+function defaultExecFile(
+  file: string,
+  args: string[],
+): Promise<ControlHealthExecResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      { timeout: 1500, maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          const err = error as Error & { stdout?: string; stderr?: string };
+          err.stdout = typeof stdout === "string" ? stdout : String(stdout);
+          err.stderr = typeof stderr === "string" ? stderr : String(stderr);
+          reject(err);
+          return;
+        }
+
+        resolve({
+          stdout: typeof stdout === "string" ? stdout : String(stdout),
+          stderr: typeof stderr === "string" ? stderr : String(stderr),
+        });
+      },
+    );
+  });
+}
+
+function cleanText(value: string): string {
+  return value.replace(/\0/g, "").trim();
+}
+
+function redactEnvValue(key: string, value: string | undefined): string | null {
+  if (value === undefined) return null;
+  if (/PASSWORD|TOKEN|SECRET/i.test(key)) {
+    return value.length > 0 ? "<set>" : "";
+  }
+  return value;
+}
+
+async function inspectPath(
+  path: string,
+  statFn: typeof stat,
+): Promise<PathStatus> {
+  try {
+    const stats = await statFn(path);
+    const kind = stats.isSocket()
+      ? "socket"
+      : stats.isFile()
+        ? "file"
+        : stats.isDirectory()
+          ? "directory"
+          : "other";
+    return {
+      path,
+      exists: true,
+      kind,
+      mtime_ms: stats.mtimeMs,
+      size: stats.size,
+      mode_octal: `0${(stats.mode & 0o777).toString(8)}`,
+    };
+  } catch (error) {
+    return {
+      path,
+      exists: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readMarker(
+  label: string,
+  path: string,
+  deps: Pick<Required<ControlHealthOptions>, "readFile" | "stat">,
+): Promise<MarkerStatus> {
+  const status = await inspectPath(path, deps.stat);
+  if (!status.exists) {
+    return { ...status, label };
+  }
+
+  try {
+    const raw = await deps.readFile(path, "utf8");
+    const value = cleanText(raw);
+    return { ...status, label, value: value.length > 0 ? value : undefined };
+  } catch (error) {
+    return {
+      ...status,
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function splitPathEntries(pathValue: string | undefined): string[] {
+  return (pathValue ?? "")
+    .split(":")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+async function inspectExecutable(
+  path: string,
+  deps: Pick<
+    Required<ControlHealthOptions>,
+    "readFile" | "stat" | "access"
+  >,
+): Promise<ExecutableStatus | null> {
+  try {
+    await deps.access(path, fsConstants.X_OK);
+  } catch {
+    return null;
+  }
+
+  const status = await inspectPath(path, deps.stat);
+  let firstLine: string | undefined;
+  let sample = "";
+  try {
+    const raw = await deps.readFile(path);
+    sample = raw.subarray(0, 4096).toString("utf8");
+    if (!sample.includes("\0")) {
+      firstLine = sample.split(/\r?\n/, 1)[0]?.slice(0, 240);
+    }
+  } catch {
+    // Executable metadata is still useful when the file cannot be sampled.
+  }
+
+  return {
+    ...status,
+    first_line: firstLine,
+    mentions_prod_app: sample.includes("/Applications/cmux.app"),
+    mentions_nightly_app: sample.includes("/Applications/cmux NIGHTLY.app"),
+    mentions_last_cli_path: sample.includes("/tmp/cmux-last-cli-path"),
+  };
+}
+
+async function resolveExecutables(
+  command: string,
+  pathEntries: string[],
+  deps: Pick<
+    Required<ControlHealthOptions>,
+    "readFile" | "stat" | "access"
+  >,
+): Promise<ExecutableStatus[]> {
+  const seen = new Set<string>();
+  const found: ExecutableStatus[] = [];
+
+  for (const entry of pathEntries) {
+    const candidate = join(entry, command);
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    const inspected = await inspectExecutable(candidate, deps);
+    if (inspected) found.push(inspected);
+  }
+
+  return found;
+}
+
+async function runOptional(
+  execFileFn: ControlHealthExecFile,
+  file: string,
+  args: string[],
+): Promise<{ stdout?: string; error?: string }> {
+  try {
+    const result = await execFileFn(file, args);
+    return { stdout: result.stdout.trim() };
+  } catch (error) {
+    const err = error as Error & { stdout?: string; stderr?: string };
+    const detail = [err.message, err.stderr?.trim(), err.stdout?.trim()]
+      .filter((part): part is string => Boolean(part))
+      .join(": ");
+    return { error: detail || String(error) };
+  }
+}
+
+function parsePgrepOutput(
+  output: string | undefined,
+): Array<{ pid: number | null; command: string }> {
+  if (!output) return [];
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(.*)$/);
+      return {
+        pid: match ? Number(match[1]) : null,
+        command: match ? match[2] : line,
+      };
+    });
+}
+
+function selectSocketPath(markers: MarkerStatus[], fallback: string): string {
+  return markers.find((marker) => marker.value)?.value ?? fallback;
+}
+
+function describeClient(client: unknown): ControlHealth["selected_transport"] {
+  const record =
+    client && typeof client === "object"
+      ? (client as Record<string, unknown>)
+      : null;
+  const currentSocketPath =
+    record && typeof record.currentSocketPath === "function"
+      ? (record.currentSocketPath as () => unknown).call(client)
+      : undefined;
+
+  return {
+    client_class:
+      client && typeof client === "object"
+        ? (client as { constructor?: { name?: string } }).constructor?.name ??
+          null
+        : null,
+    ...(typeof currentSocketPath === "string"
+      ? { current_socket_path: currentSocketPath }
+      : {}),
+  };
+}
+
+function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
+  const warnings: string[] = [];
+  const envSocket = health.current_process.env.CMUX_SOCKET_PATH;
+  const bundledCli = health.current_process.env.CMUX_BUNDLED_CLI_PATH;
+  const firstCmux = health.current_process.cmux_resolution[0];
+  const nightlySocket = health.cmux_instances.nightly.socket_path;
+  const prodSocket = health.cmux_instances.production.socket_path;
+
+  if (
+    envSocket &&
+    nightlySocket &&
+    envSocket === nightlySocket &&
+    firstCmux?.mentions_prod_app &&
+    !firstCmux.mentions_nightly_app
+  ) {
+    warnings.push(
+      "CMUX_SOCKET_PATH points at Nightly, but the first cmux executable resolves through a prod app shim/binary.",
+    );
+  }
+
+  if (
+    bundledCli?.includes("cmux NIGHTLY.app") &&
+    firstCmux &&
+    !firstCmux.path.includes("cmux NIGHTLY.app") &&
+    !firstCmux.mentions_nightly_app
+  ) {
+    warnings.push(
+      "CMUX_BUNDLED_CLI_PATH is Nightly, but PATH resolves cmux somewhere else first.",
+    );
+  }
+
+  if (
+    health.selected_transport.current_socket_path &&
+    envSocket &&
+    health.selected_transport.current_socket_path !== envSocket
+  ) {
+    warnings.push(
+      "cmuxlayer selected socket path differs from process CMUX_SOCKET_PATH.",
+    );
+  }
+
+  if (
+    prodSocket &&
+    nightlySocket &&
+    prodSocket !== nightlySocket &&
+    health.selected_transport.current_socket_path === prodSocket &&
+    envSocket === nightlySocket
+  ) {
+    warnings.push(
+      "cmuxlayer is attached to the production socket while the process env points at Nightly.",
+    );
+  }
+
+  return warnings;
+}
+
+export async function collectControlHealth(
+  opts: ControlHealthOptions = {},
+): Promise<ControlHealth> {
+  const env = opts.env ?? process.env;
+  const homeDir = opts.homeDir ?? homedir();
+  const tmpDir = opts.tmpDir ?? "/tmp";
+  const deps = {
+    execFile: opts.execFile ?? defaultExecFile,
+    readFile: opts.readFile ?? readFile,
+    stat: opts.stat ?? stat,
+    access: opts.access ?? access,
+  };
+  const stateDir = join(homeDir, ".local", "state", "cmux");
+  const uid =
+    typeof process.getuid === "function" ? process.getuid() : undefined;
+  const prodDefaultSocket =
+    uid === undefined
+      ? join(stateDir, "cmux.sock")
+      : join(stateDir, `cmux-${uid}.sock`);
+  const nightlyDefaultSocket = join(tmpDir, "cmux-nightly.sock");
+  const pathEntries = splitPathEntries(env.PATH);
+
+  const [prodMarkers, nightlyMarkers, cmuxResolution, processList, ps] =
+    await Promise.all([
+      Promise.all([
+        readMarker("state_last_socket", join(stateDir, "last-socket-path"), deps),
+        readMarker(
+          "tmp_last_socket",
+          join(tmpDir, "cmux-last-socket-path"),
+          deps,
+        ),
+      ]),
+      Promise.all([
+        readMarker(
+          "state_nightly_last_socket",
+          join(stateDir, "nightly-last-socket-path"),
+          deps,
+        ),
+        readMarker(
+          "tmp_nightly_last_socket",
+          join(tmpDir, "cmux-nightly-last-socket-path"),
+          deps,
+        ),
+      ]),
+      resolveExecutables("cmux", pathEntries, deps),
+      runOptional(deps.execFile, "ps", [
+        "ax",
+        "-o",
+        "pid=",
+        "-o",
+        "command=",
+      ]),
+      runOptional(deps.execFile, "ps", [
+        "-o",
+        "pid=",
+        "-o",
+        "ppid=",
+        "-o",
+        "pgid=",
+        "-o",
+        "tpgid=",
+        "-o",
+        "stat=",
+        "-o",
+        "tty=",
+        "-o",
+        "command=",
+        "-p",
+        String(opts.pid ?? process.pid),
+      ]),
+    ]);
+
+  const prodSocket = selectSocketPath(prodMarkers, prodDefaultSocket);
+  const nightlySocket = selectSocketPath(nightlyMarkers, nightlyDefaultSocket);
+  const allProcesses = parsePgrepOutput(processList.stdout).filter((proc) =>
+    /\/Applications\/cmux|cmux NIGHTLY|cmux\.app/.test(proc.command),
+  );
+  const envSnapshot = Object.fromEntries(
+    ENV_KEYS.map((key) => [key, redactEnvValue(key, env[key])]),
+  ) as Record<string, string | null>;
+
+  const base: Omit<ControlHealth, "warnings"> = {
+    generated_at: (opts.now ?? (() => new Date()))().toISOString(),
+    current_process: {
+      pid: opts.pid ?? process.pid,
+      ppid: opts.ppid ?? process.ppid,
+      cwd: opts.cwd ?? process.cwd(),
+      stdin_is_tty: process.stdin.isTTY === true,
+      env: envSnapshot,
+      path_entries: pathEntries,
+      cmux_resolution: cmuxResolution,
+      ...(ps.stdout ? { ps: ps.stdout } : {}),
+      ...(ps.error ? { ps_error: ps.error } : {}),
+    },
+    selected_transport: describeClient(opts.client),
+    cmux_instances: {
+      production: {
+        axis: "production",
+        app_bundle_path: "/Applications/cmux.app",
+        app_binary_path: "/Applications/cmux.app/Contents/MacOS/cmux",
+        marker_files: prodMarkers,
+        socket_path: prodSocket,
+        socket_status: await inspectPath(prodSocket, deps.stat),
+        processes: allProcesses.filter(
+          (proc) =>
+            proc.command.includes("/Applications/cmux.app") &&
+            !proc.command.includes("cmux NIGHTLY.app"),
+        ),
+      },
+      nightly: {
+        axis: "nightly",
+        app_bundle_path: "/Applications/cmux NIGHTLY.app",
+        app_binary_path: "/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux",
+        marker_files: nightlyMarkers,
+        socket_path: nightlySocket,
+        socket_status: await inspectPath(nightlySocket, deps.stat),
+        processes: allProcesses.filter((proc) =>
+          proc.command.includes("cmux NIGHTLY.app"),
+        ),
+      },
+    },
+  };
+
+  return { ...base, warnings: buildWarnings(base) };
+}
+
+function formatInstance(instance: CmuxInstanceHealth): string[] {
+  const processSummary =
+    instance.processes.length > 0
+      ? instance.processes
+          .map((proc) => (proc.pid === null ? "unknown" : String(proc.pid)))
+          .join(", ")
+      : "none detected";
+  const socket = instance.socket_status;
+  const socketSummary = socket
+    ? `${socket.path} (${socket.exists ? socket.kind : "missing"})`
+    : "none";
+  return [
+    `${instance.axis}:`,
+    `  socket: ${socketSummary}`,
+    `  app: ${instance.app_binary_path}`,
+    `  pids: ${processSummary}`,
+  ];
+}
+
+export function formatControlHealth(health: ControlHealth): string {
+  const lines = [
+    "cmuxlayer control_health",
+    `generated_at: ${health.generated_at}`,
+    `transport: ${health.selected_transport.client_class ?? "unknown"}${
+      health.selected_transport.current_socket_path
+        ? ` (${health.selected_transport.current_socket_path})`
+        : ""
+    }`,
+    `env CMUX_SOCKET_PATH: ${health.current_process.env.CMUX_SOCKET_PATH ?? "unset"}`,
+    `env CMUX_BUNDLED_CLI_PATH: ${health.current_process.env.CMUX_BUNDLED_CLI_PATH ?? "unset"}`,
+    "cmux resolution:",
+    ...health.current_process.cmux_resolution
+      .slice(0, 5)
+      .map((entry, index) => {
+        const flags = [
+          entry.mentions_prod_app ? "prod-app" : null,
+          entry.mentions_nightly_app ? "nightly-app" : null,
+          entry.mentions_last_cli_path ? "last-cli-path" : null,
+        ]
+          .filter((value): value is string => Boolean(value))
+          .join(", ");
+        return `  ${index + 1}. ${entry.path}${flags ? ` [${flags}]` : ""}`;
+      }),
+    ...formatInstance(health.cmux_instances.production),
+    ...formatInstance(health.cmux_instances.nightly),
+  ];
+
+  if (health.current_process.cmux_resolution.length === 0) {
+    lines.push("  none");
+  }
+
+  if (health.warnings.length > 0) {
+    lines.push("warnings:");
+    lines.push(...health.warnings.map((warning) => `  - ${warning}`));
+  }
+
+  return lines.join("\n");
+}

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -7,6 +7,7 @@
 import { appendFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type {
+  ControlHealthTelemetryEvent,
   DeliveryTelemetryEvent,
   EventLogEntry,
   StateTransition,
@@ -25,6 +26,10 @@ export class EventLog {
   }
 
   appendDelivery(event: DeliveryTelemetryEvent): void {
+    this.appendEntry(event);
+  }
+
+  appendControlHealth(event: ControlHealthTelemetryEvent): void {
     this.appendEntry(event);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,18 +3,20 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 33 MCP tools across three categories (keep in sync with server.ts and the
+ * 35 MCP tools across three categories (keep in sync with server.ts and the
  * "total tool count" assertion in tests/server-agent-tools.test.ts):
- *   Core (17): list_surfaces, select_workspace, create_workspace, new_split,
- *              new_surface, move_surface, reorder_surface, send_input,
- *              send_command, send_key, read_screen, rename_tab, notify,
- *              set_status, set_progress, close_surface, browser_surface
+ *   Core (18): list_surfaces, control_health, select_workspace,
+ *              create_workspace, new_split, new_surface, move_surface,
+ *              reorder_surface, send_input, send_command, send_key,
+ *              read_screen, rename_tab, notify, set_status, set_progress,
+ *              close_surface, browser_surface
  *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
- *   Agent lifecycle (14): spawn_agent, spawn_in_workspace, resync_agents,
+ *   Agent lifecycle (13): spawn_agent, new_worktree_split, spawn_in_workspace,
+ *                         resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         read_agent_output, get_agent_state, list_agents,
- *                         my_agents, wait_for, wait_for_all, stop_agent,
- *                         kill, interact
+ *                         my_agents, wait_for, wait_for_all, stop_agent
+ *   V2 agent controls (2): kill, interact
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -6,7 +6,11 @@
 import type { ControlMode, IntentMode } from "./types.js";
 
 /** Tools that only read state — always allowed */
-const READ_ONLY_TOOLS = new Set(["list_surfaces", "read_screen"]);
+const READ_ONLY_TOOLS = new Set([
+  "list_surfaces",
+  "control_health",
+  "read_screen",
+]);
 
 /** Tools that mutate state — blocked in manual mode */
 const MUTATING_TOOLS = new Set([

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,6 +83,17 @@ import { normalizeKeyName } from "./key-names.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
+import {
+  collectControlHealth,
+  formatControlHealth,
+  type ControlHealth,
+} from "./control-health.js";
+import {
+  formatMcpProfileEnv,
+  prepareWorktree,
+  type McpProfile,
+  type WorktreeExec,
+} from "./worktree.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -634,6 +645,13 @@ export interface CreateServerOptions {
   inboxBaseDir?: string;
   /** Override session identity lookup (primarily for mocked tests). */
   sessionIdentityResolver?: SessionIdentityResolver;
+  /** Override git worktree execution/home for tests. */
+  worktreeExec?: WorktreeExec;
+  worktreeHomeDir?: string;
+  /** Override control health collection (primarily for tests). */
+  controlHealthCollector?: () => Promise<ControlHealth>;
+  /** Periodic control health sample interval. Defaults to env or 60000ms; 0 disables. */
+  controlHealthIntervalMs?: number;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -660,7 +678,28 @@ export interface CmuxServerContext {
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
   lifecycleSweepEngine: AgentEngine | null;
+  controlHealthCollector?: () => Promise<ControlHealth>;
+  controlHealthIntervalMs: number;
+  controlHealthTimer: ReturnType<typeof setInterval> | null;
   dispose(): void;
+}
+
+const DEFAULT_CONTROL_HEALTH_INTERVAL_MS = 60_000;
+const MIN_CONTROL_HEALTH_INTERVAL_MS = 5_000;
+
+function resolveControlHealthIntervalMs(input?: number): number {
+  const raw =
+    input ??
+    (process.env.CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS
+      ? Number(process.env.CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS)
+      : DEFAULT_CONTROL_HEALTH_INTERVAL_MS);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return DEFAULT_CONTROL_HEALTH_INTERVAL_MS;
+  }
+  if (raw === 0) {
+    return 0;
+  }
+  return Math.max(MIN_CONTROL_HEALTH_INTERVAL_MS, Math.floor(raw));
 }
 
 export function createServerContext(
@@ -692,8 +731,17 @@ export function createServerContext(
     lifecycleStarted: false,
     lifecycleStartPromise: null,
     lifecycleSweepEngine: null,
+    controlHealthCollector: opts?.controlHealthCollector,
+    controlHealthIntervalMs: resolveControlHealthIntervalMs(
+      opts?.controlHealthIntervalMs,
+    ),
+    controlHealthTimer: null,
     dispose() {
       context.lifecycleSweepEngine?.dispose();
+      if (context.controlHealthTimer) {
+        clearInterval(context.controlHealthTimer);
+        context.controlHealthTimer = null;
+      }
       context.lifecycleSweepEngine = null;
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
@@ -765,6 +813,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const spawnPreflight = opts?.spawnPreflight ?? context.spawnPreflight;
   const disableSpawnPreflight =
     opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
+  const controlHealthCollector =
+    opts?.controlHealthCollector ?? context.controlHealthCollector;
   const inboxOpts = opts?.inboxBaseDir
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
@@ -904,6 +954,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  const worktreeArgSchema = z.union([
+    z.boolean(),
+    z.object({
+      create: z.boolean().optional(),
+      reuse: z.boolean().optional(),
+      name: z.string().optional(),
+      path: z.string().optional(),
+      branch: z.string().optional(),
+      base: z.string().optional(),
+    }),
+  ]);
+
+  const mcpProfileSchema = z.union([
+    z.enum(["inherit", "sterile", "skill_eval"]),
+    z.object({
+      include: z.array(z.string()).optional(),
+      exclude: z.array(z.string()).optional(),
+    }),
+  ]);
+
   const pruneCompletedDeliveryHistory = (surface: string) => {
     const latestDeliveryId = latestDeliveryBySurface.get(surface);
     for (const [deliveryId, record] of deliveries.entries()) {
@@ -1020,6 +1090,36 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ...event,
     });
   };
+
+  const appendControlHealthSnapshot = async (): Promise<ControlHealth> => {
+    const health = controlHealthCollector
+      ? await controlHealthCollector()
+      : await collectControlHealth({ client });
+    eventLog.appendControlHealth({
+      ts: health.generated_at,
+      event_type: "control_health",
+      selected_socket_path:
+        health.selected_transport.current_socket_path ?? null,
+      production_socket_path: health.cmux_instances.production.socket_path,
+      nightly_socket_path: health.cmux_instances.nightly.socket_path,
+      cmux_binary: health.current_process.cmux_resolution[0]?.path ?? null,
+      warnings: health.warnings,
+      snapshot: health,
+    });
+    return health;
+  };
+
+  if (
+    context.controlHealthIntervalMs > 0 &&
+    context.controlHealthTimer === null
+  ) {
+    context.controlHealthTimer = setInterval(() => {
+      appendControlHealthSnapshot().catch((error) => {
+        console.error("[cmux-mcp] control_health periodic sample failed:", error);
+      });
+    }, context.controlHealthIntervalMs);
+    context.controlHealthTimer.unref?.();
+  }
 
   const readParsedSurface = async (
     surface: string,
@@ -1710,6 +1810,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           responseWorkspaces as Array<{ ref: string; title?: string }>,
         );
         return okFormatted(formatted, data);
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "control_health",
+    "Report cmuxlayer control-path health: selected transport, prod/nightly socket markers, cmux binary resolution, process env, and job-control diagnostics.",
+    {},
+    ANNOTATIONS.readOnly,
+    async () => {
+      try {
+        const health = await appendControlHealthSnapshot();
+        return okFormatted(formatControlHealth(health), {
+          health,
+        });
       } catch (e) {
         return err(e);
       }
@@ -3000,38 +3117,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   if (!skipAgentLifecycle) {
     const surfaceProvider = async () => {
-      try {
-        const workspaces = await client.listWorkspaces();
-        const panesByWorkspace = await Promise.all(
-          workspaces.workspaces.map(async (ws) => ({
-            ref: ws.ref,
-            panes: await client.listPanes({ workspace: ws.ref }),
-          })),
-        );
-        const surfaceGroupsByWorkspace = await Promise.all(
-          panesByWorkspace.map(async ({ ref, panes }) => {
-            const rawGroups = await Promise.all(
-              panes.panes.map((p) =>
-                client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
-              ),
-            );
-            return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
-              workspace_ref: panes.workspace_ref ?? ref,
-              window_ref: panes.window_ref,
-            });
-          }),
-        );
-        const surfaceGroups = surfaceGroupsByWorkspace.flat();
-        return surfaceGroups.flatMap((group) =>
-          group.surfaces.map((surface) => ({
-            ...surface,
-            workspace_ref: group.workspace_ref,
-            pane_ref: group.pane_ref,
-          })),
-        );
-      } catch {
-        return [];
-      }
+      const workspaces = await client.listWorkspaces();
+      const panesByWorkspace = await Promise.all(
+        workspaces.workspaces.map(async (ws) => ({
+          ref: ws.ref,
+          panes: await client.listPanes({ workspace: ws.ref }),
+        })),
+      );
+      const surfaceGroupsByWorkspace = await Promise.all(
+        panesByWorkspace.map(async ({ ref, panes }) => {
+          const rawGroups = await Promise.all(
+            panes.panes.map((p) =>
+              client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
+            ),
+          );
+          return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+            workspace_ref: panes.workspace_ref ?? ref,
+            window_ref: panes.window_ref,
+          });
+        }),
+      );
+      const surfaceGroups = surfaceGroupsByWorkspace.flat();
+      return surfaceGroups.flatMap((group) =>
+        group.surfaces.map((surface) => ({
+          ...surface,
+          workspace_ref: group.workspace_ref,
+          pane_ref: group.pane_ref,
+        })),
+      );
     };
     const registry =
       context.lifecycleRegistry ?? new AgentRegistry(stateMgr, surfaceProvider);
@@ -3142,6 +3255,73 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
     context.lifecycleSweepEngine = engine;
 
+    const resolveSpawnRecord = (
+      agentId: string,
+      surfaceId: string,
+    ): AgentRecord | null => {
+      const diskDirect = stateMgr.readState(agentId);
+      if (diskDirect) {
+        registry.set(agentId, diskDirect);
+        return diskDirect;
+      }
+
+      const bySurface =
+        stateMgr.listStates().find((agent) => agent.surface_id === surfaceId) ??
+        registry.list().find((agent) => agent.surface_id === surfaceId) ??
+        null;
+      if (bySurface) {
+        registry.set(agentId, bySurface);
+        return bySurface;
+      }
+
+      const registryDirect = registry.get(agentId);
+      if (registryDirect) {
+        registry.set(agentId, registryDirect);
+      }
+      return registryDirect;
+    };
+
+    const canonicalizeSpawnResult = <T extends {
+      agent_id: string;
+      surface_id: string;
+    }>(
+      result: T,
+    ): AgentRecord | null => {
+      const record = resolveSpawnRecord(result.agent_id, result.surface_id);
+      if (record) {
+        result.agent_id = record.agent_id;
+      }
+      return record;
+    };
+
+    const prepareSpawnWorktree = async (
+      repo: string,
+      worktree: boolean | object | undefined,
+      mcpProfile: McpProfile | undefined,
+    ) => {
+      if (!worktree) {
+        return {
+          prepared: undefined,
+          mcpProfileLabel: undefined,
+          mcpEnv: undefined,
+        };
+      }
+
+      const profile = mcpProfile ?? "inherit";
+      const prepared = await prepareWorktree({
+        repo,
+        worktree: worktree as Parameters<typeof prepareWorktree>[0]["worktree"],
+        exec: opts?.worktreeExec,
+        homeGitsDir: opts?.worktreeHomeDir,
+      });
+      return {
+        prepared,
+        mcpProfileLabel:
+          typeof profile === "string" ? profile : "custom",
+        mcpEnv: formatMcpProfileEnv(profile),
+      };
+    };
+
     const deliverAgentInput = async (args: {
       agent_id: string;
       text: string;
@@ -3159,10 +3339,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // is unavailable (empty) so a transient listing failure never blocks a
       // healthy relay.
       const liveSurfaceRefs = async (): Promise<Set<string> | null> => {
-        const surfaces = await surfaceProvider();
-        return surfaces.length > 0
-          ? new Set(surfaces.map((surface) => surface.ref))
-          : null;
+        try {
+          const surfaces = await surfaceProvider();
+          return surfaces.length > 0
+            ? new Set(surfaces.map((surface) => surface.ref))
+            : null;
+        } catch {
+          return null;
+        }
       };
       const isPositivelyStale = (
         refs: Set<string> | null,
@@ -3317,6 +3501,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "Timeout in milliseconds waiting for the agent ready prompt",
           ),
         workspace: z.string().optional().describe("Target workspace ref"),
+        worktree: worktreeArgSchema
+          .optional()
+          .describe(
+            "When set, create or reuse a git worktree before launch. true uses ~/Gits/<repo>.wt/<generated-name>; object fields can set name, path, branch, base, create, and reuse.",
+          ),
+        mcp_profile: mcpProfileSchema
+          .optional()
+          .describe(
+            "MCP profile hint for worktree launches. Defaults to inherit. Use sterile/skill_eval or include/exclude lists for narrower evals.",
+          ),
         parent_agent_id: z
           .string()
           .optional()
@@ -3357,6 +3551,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await preflightBootPromptFile(bootPromptPath);
           }
 
+          const worktree = await prepareSpawnWorktree(
+            args.repo,
+            args.worktree,
+            args.mcp_profile as McpProfile | undefined,
+          );
+
           const result = await engine.spawnAgent({
             repo: args.repo,
             model: args.model,
@@ -3365,6 +3565,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             boot_prompt_pending:
               hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: args.workspace,
+            cwd: worktree.prepared?.path,
+            mcp_env: worktree.mcpEnv,
+            mcp_profile_label: worktree.mcpProfileLabel,
+            worktree_branch: worktree.prepared?.branch,
             parent_agent_id: args.parent_agent_id,
             role: args.role,
             auto_archive_on_done: args.auto_archive_on_done ?? true,
@@ -3387,8 +3591,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 timeout_ms: args.boot_prompt_timeout_ms,
               });
 
-              result.agent_id =
-                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
+              canonicalizeSpawnResult(result);
               if (bootPromptDelivery.prompt_text !== null) {
                 const updated = stateMgr.updateRecord(result.agent_id, {
                   task_summary: bootPromptDelivery.prompt_text,
@@ -3414,8 +3617,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           } catch (e) {
             const message = e instanceof Error ? e.message : String(e);
             try {
-              result.agent_id =
-                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
+              canonicalizeSpawnResult(result);
               let updated = stateMgr.updateRecord(result.agent_id, {
                 boot_prompt_pending: false,
               });
@@ -3463,6 +3665,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }),
             {
               ...result,
+              worktree: worktree.prepared,
+              mcp_profile: worktree.mcpProfileLabel,
               role:
                 engine.getAgentState(result.agent_id)?.role ??
                 inferAgentRole({
@@ -3470,6 +3674,103 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   cli: args.cli,
                   launcherName: launcherNameForCli(args.repo, args.cli),
                 }),
+              boot_prompt_delivered: Boolean(bootPromptDelivery),
+              boot_prompt_bytes: bootPromptDelivery?.bytes,
+            },
+          );
+        } catch (e) {
+          return err(e);
+        }
+      },
+    );
+
+    server.tool(
+      "new_worktree_split",
+      "Create or reuse a git worktree and spawn one worker agent into a right-side cmux split. Defaults to inherited MCPs and preserves the existing worker layout policy.",
+      {
+        repo: z.string().describe("Repository name"),
+        model: z.string().describe("Model name"),
+        cli: z
+          .enum(["claude", "codex", "gemini", "kiro", "cursor"])
+          .describe("CLI tool to launch"),
+        prompt: z.string().optional().describe("Optional boot prompt"),
+        boot_prompt_timeout_ms: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .default(BOOT_PROMPT_TIMEOUT_MS),
+        workspace: z.string().optional().describe("Target workspace ref"),
+        worktree: worktreeArgSchema
+          .optional()
+          .describe(
+            "Worktree options. Defaults to true, creating/reusing ~/Gits/<repo>.wt/<generated-name>.",
+          ),
+        mcp_profile: mcpProfileSchema
+          .optional()
+          .describe("MCP profile hint. Defaults to inherit."),
+        parent_agent_id: z.string().optional(),
+        auto_archive_on_done: z.boolean().optional().default(true),
+        crash_recover: z.boolean().optional().default(false),
+      },
+      ANNOTATIONS.mutating,
+      async (args) => {
+        try {
+          assertBootPromptMode(args.prompt, null);
+          const worktree = await prepareSpawnWorktree(
+            args.repo,
+            args.worktree ?? true,
+            args.mcp_profile as McpProfile | undefined,
+          );
+          const hasPrompt = hasInlinePrompt(args.prompt);
+          const result = await engine.spawnAgent({
+            repo: args.repo,
+            model: args.model,
+            cli: args.cli,
+            prompt: args.prompt ?? "",
+            boot_prompt_pending: hasPrompt,
+            workspace: args.workspace,
+            cwd: worktree.prepared?.path,
+            mcp_env: worktree.mcpEnv,
+            mcp_profile_label: worktree.mcpProfileLabel,
+            worktree_branch: worktree.prepared?.branch,
+            parent_agent_id: args.parent_agent_id,
+            role: "worker",
+            auto_archive_on_done: args.auto_archive_on_done ?? true,
+            crash_recover: args.crash_recover,
+          });
+
+          let bootPromptDelivery:
+            | Awaited<ReturnType<typeof deliverBootPrompt>>
+            | undefined;
+          if (hasPrompt) {
+            bootPromptDelivery = await deliverBootPrompt({
+              surface: result.surface_id,
+              workspace: result.workspace_id ?? args.workspace,
+              cli: args.cli,
+              prompt: args.prompt,
+              timeout_ms: args.boot_prompt_timeout_ms,
+            });
+            canonicalizeSpawnResult(result);
+            const updated = stateMgr.updateRecord(result.agent_id, {
+              task_summary: bootPromptDelivery.prompt_text ?? args.prompt ?? "",
+              boot_prompt_pending: false,
+            });
+            registry.set(result.agent_id, updated);
+          }
+
+          return okFormatted(
+            formatOk("new_worktree_split", {
+              agent_id: result.agent_id,
+              surface: result.surface_id,
+              worktree: worktree.prepared?.path ?? "",
+              mcp_profile: worktree.mcpProfileLabel ?? "inherit",
+            }),
+            {
+              ...result,
+              role: "worker",
+              worktree: worktree.prepared,
+              mcp_profile: worktree.mcpProfileLabel ?? "inherit",
               boot_prompt_delivered: Boolean(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
             },
@@ -3548,8 +3849,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 timeout_ms: BOOT_PROMPT_TIMEOUT_MS,
               });
 
-              result.agent_id =
-                registry.get(result.agent_id)?.agent_id ?? result.agent_id;
+              canonicalizeSpawnResult(result);
               const updated = stateMgr.updateRecord(result.agent_id, {
                 task_summary:
                   bootPromptDelivery.prompt_text ?? agent.prompt ?? "",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1115,7 +1115,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ) {
     context.controlHealthTimer = setInterval(() => {
       appendControlHealthSnapshot().catch((error) => {
-        console.error("[cmux-mcp] control_health periodic sample failed:", error);
+        console.error(
+          "[cmux-mcp] control_health periodic sample failed:",
+          error,
+        );
       });
     }, context.controlHealthIntervalMs);
     context.controlHealthTimer.unref?.();
@@ -1520,6 +1523,60 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         deliveredChars,
       );
     }
+  };
+
+  // ── Auto-focus discipline for split/pane creation ──────────────────
+  // cmux attaches a new split to the *currently focused* workspace. When a
+  // spawn targets a different workspace, we must focus it BEFORE creating the
+  // pane (otherwise the split lands in the wrong workspace — happy-camper's
+  // split failed for exactly this reason), then restore the prior focus AFTER
+  // the new terminal is fully rendered — but ONLY when a jump was needed.
+
+  /** Currently-focused workspace ref, or undefined if it can't be read. */
+  const currentFocusedWorkspace = async (): Promise<string | undefined> => {
+    try {
+      const { workspaces } = await client.listWorkspaces();
+      return workspaces.find((w) => w.selected)?.ref;
+    } catch {
+      return undefined;
+    }
+  };
+
+  /**
+   * Focus the target workspace before a split when it differs from the prior
+   * focus. Returns the prior focus ref IF a jump was performed (so the caller
+   * passes it to restoreFocusAfterRender), or null when no jump was needed.
+   */
+  const focusTargetBeforeSplit = async (
+    targetWorkspace: string | undefined,
+  ): Promise<string | null> => {
+    if (!targetWorkspace) return null;
+    const prior = await currentFocusedWorkspace();
+    if (!prior || prior === targetWorkspace) return null;
+    await client.selectWorkspace(targetWorkspace);
+    return prior;
+  };
+
+  /**
+   * Restore the prior focus AFTER the new terminal is fully rendered — only
+   * when a jump actually happened (priorFocus non-null). Waits for shell
+   * readiness so focus is not restored mid-render. Restores focus even if
+   * readiness times out (never strand focus on the wrong workspace).
+   */
+  const restoreFocusAfterRender = async (
+    priorFocus: string | null,
+    surface: string | undefined,
+    workspace: string | undefined,
+  ): Promise<void> => {
+    if (!priorFocus) return;
+    if (surface) {
+      try {
+        await waitForLaunchShellReady({ surface, workspace });
+      } catch {
+        // Readiness timed out — restore focus anyway rather than strand it.
+      }
+    }
+    await client.selectWorkspace(priorFocus);
   };
 
   const startBackgroundDelivery = (record: DeliveryRecord) => {
@@ -1935,6 +1992,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await preflightBootPromptFile(bootPromptPath);
         }
 
+        // Auto-focus only applies to workspace-targeted splits (no explicit
+        // pane/surface anchor). Captured right before creation, AFTER all
+        // validation, so a rejected request has no focus side effects.
+        let priorFocus: string | null = null;
         const shouldInferRole =
           Boolean(args.role) ||
           (!args.pane &&
@@ -1990,6 +2051,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               "focus=false is not supported when role-based new_split reuses an existing pane as a tab",
             );
           }
+          // Role-based placement has no explicit pane/surface (validated above),
+          // so it is always a workspace-targeted split — apply auto-focus.
+          priorFocus = await focusTargetBeforeSplit(targetWorkspace);
           result =
             placement.kind === "surface"
               ? await client.newSurface({
@@ -2007,6 +2071,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   focus: args.focus,
                 });
         } else {
+          // Only workspace-targeted splits need auto-focus; an explicit
+          // pane/surface anchor already pins the destination workspace.
+          if (!args.pane && !args.surface) {
+            priorFocus = await focusTargetBeforeSplit(targetWorkspace);
+          }
           result = await client.newSplit(args.direction, {
             workspace: targetWorkspace,
             surface: args.surface,
@@ -2040,6 +2109,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             timeout_ms: args.boot_prompt_timeout_ms,
           });
         }
+        await restoreFocusAfterRender(
+          priorFocus,
+          result.surface,
+          result.workspace || targetWorkspace,
+        );
         const data: Record<string, unknown> = { ...result };
         data.placement = actualPlacement;
         data.direction = actualDirection;
@@ -3281,10 +3355,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return registryDirect;
     };
 
-    const canonicalizeSpawnResult = <T extends {
-      agent_id: string;
-      surface_id: string;
-    }>(
+    const canonicalizeSpawnResult = <
+      T extends {
+        agent_id: string;
+        surface_id: string;
+      },
+    >(
       result: T,
     ): AgentRecord | null => {
       const record = resolveSpawnRecord(result.agent_id, result.surface_id);
@@ -3316,8 +3392,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       });
       return {
         prepared,
-        mcpProfileLabel:
-          typeof profile === "string" ? profile : "custom",
+        mcpProfileLabel: typeof profile === "string" ? profile : "custom",
         mcpEnv: formatMcpProfileEnv(profile),
       };
     };
@@ -3717,6 +3792,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           assertBootPromptMode(args.prompt, null);
+          const priorFocus = await focusTargetBeforeSplit(args.workspace);
           const worktree = await prepareSpawnWorktree(
             args.repo,
             args.worktree ?? true,
@@ -3758,6 +3834,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
             registry.set(result.agent_id, updated);
           }
+
+          await restoreFocusAfterRender(
+            priorFocus,
+            result.surface_id,
+            result.workspace_id ?? args.workspace,
+          );
 
           return okFormatted(
             formatOk("new_worktree_split", {
@@ -3818,6 +3900,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             throw new Error("create_workspace returned an empty workspace ref");
           }
 
+          const priorFocus = await focusTargetBeforeSplit(workspace);
+          // Always focus the target so agents spawn into it; harmless when the
+          // workspace was just created (and is already selected) or already
+          // focused. priorFocus drives the focus-back only when a jump happened.
           await client.selectWorkspace(workspace);
 
           const spawnedAgents: Array<{
@@ -3874,6 +3960,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               cli: agent.cli,
             });
           }
+
+          const lastSurface =
+            spawnedAgents[spawnedAgents.length - 1]?.surface_id;
+          await restoreFocusAfterRender(priorFocus, lastSurface, workspace);
 
           return okFormatted(
             formatOk("spawn_in_workspace", {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,0 +1,213 @@
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { sanitizeRepoName, shellQuote } from "./agent-command.js";
+
+const execFileAsync = promisify(execFile);
+
+export type WorktreeExec = (
+  cmd: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }>;
+
+export type McpProfile =
+  | "inherit"
+  | "sterile"
+  | "skill_eval"
+  | {
+      include?: string[];
+      exclude?: string[];
+    };
+
+export interface WorktreeRequest {
+  create?: boolean;
+  reuse?: boolean;
+  name?: string;
+  path?: string;
+  branch?: string;
+  base?: string;
+}
+
+export interface PrepareWorktreeInput {
+  repo: string;
+  repoRoot?: string;
+  homeGitsDir?: string;
+  worktree?: boolean | WorktreeRequest;
+  exec?: WorktreeExec;
+}
+
+export interface PreparedWorktree {
+  path: string;
+  name: string;
+  branch: string;
+  base: string;
+  created: boolean;
+  reused: boolean;
+  node_modules_linked: boolean;
+}
+
+function defaultExec(cmd: string, args: string[]) {
+  return execFileAsync(cmd, args);
+}
+
+function safeName(input: string): string {
+  const normalized = input
+    .trim()
+    .replace(/[^A-Za-z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/-+/g, "-")
+    .replace(/^[-/.]+|[-/.]+$/g, "");
+  if (!normalized || normalized.includes("..")) {
+    throw new Error(`Invalid worktree name: "${input}"`);
+  }
+  return normalized;
+}
+
+function assertInside(root: string, path: string): void {
+  const resolvedRoot = resolve(root);
+  const resolvedPath = resolve(path);
+  const rel = relative(resolvedRoot, resolvedPath);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`Worktree path ${path} must be inside ${root}`);
+  }
+}
+
+function normalizeWorktreeRequest(
+  repo: string,
+  request: boolean | WorktreeRequest | undefined,
+): Required<Pick<WorktreeRequest, "create" | "reuse" | "base">> &
+  Omit<WorktreeRequest, "create" | "reuse" | "base"> & { name: string } {
+  const spec: WorktreeRequest =
+    request === true || request === false || request === undefined ? {} : request;
+  const name = safeName(spec.name ?? `${repo}-worker-${Date.now()}`);
+  return {
+    create: spec.create ?? true,
+    reuse: spec.reuse ?? true,
+    base: spec.base ?? "HEAD",
+    name,
+    ...(spec.path ? { path: spec.path } : {}),
+    ...(spec.branch ? { branch: spec.branch } : {}),
+  };
+}
+
+function validateMcpList(values: string[] | undefined, field: string): string[] {
+  if (!values) return [];
+  return values.map((value) => {
+    if (!/^[A-Za-z0-9_.-]+$/.test(value)) {
+      throw new Error(`Invalid MCP ${field} entry: "${value}"`);
+    }
+    return value;
+  });
+}
+
+export function formatMcpProfileEnv(profile?: McpProfile): string {
+  if (!profile || profile === "inherit") {
+    return "CMUXLAYER_MCP_PROFILE=inherit";
+  }
+  if (profile === "sterile" || profile === "skill_eval") {
+    return `CMUXLAYER_MCP_PROFILE=${profile}`;
+  }
+
+  const include = validateMcpList(profile.include, "include");
+  const exclude = validateMcpList(profile.exclude, "exclude");
+  const env = ["CMUXLAYER_MCP_PROFILE=custom"];
+  if (include.length > 0) {
+    env.push(`CMUXLAYER_MCP_INCLUDE=${include.join(",")}`);
+  }
+  if (exclude.length > 0) {
+    env.push(`CMUXLAYER_MCP_EXCLUDE=${exclude.join(",")}`);
+  }
+  return env.join(" ");
+}
+
+function linkNodeModules(repoRoot: string, worktreePath: string): boolean {
+  const source = join(repoRoot, "node_modules");
+  const target = join(worktreePath, "node_modules");
+  if (!existsSync(source) || existsSync(target)) {
+    return false;
+  }
+  symlinkSync(source, target, "dir");
+  return true;
+}
+
+async function assertExistingWorktree(path: string, exec: WorktreeExec) {
+  const result = await exec("git", [
+    "-C",
+    path,
+    "rev-parse",
+    "--is-inside-work-tree",
+  ]);
+  if (result.stdout.trim() !== "true") {
+    throw new Error(`Existing path is not a git worktree: ${path}`);
+  }
+}
+
+export async function prepareWorktree(
+  input: PrepareWorktreeInput,
+): Promise<PreparedWorktree> {
+  const repo = sanitizeRepoName(input.repo);
+  const homeGitsDir = resolve(input.homeGitsDir ?? join(homedir(), "Gits"));
+  const repoRoot = resolve(input.repoRoot ?? join(homeGitsDir, repo));
+  assertInside(homeGitsDir, repoRoot);
+
+  const spec = normalizeWorktreeRequest(repo, input.worktree);
+  const worktreePath = spec.path
+    ? resolve(spec.path)
+    : join(homeGitsDir, `${repo}.wt`, spec.name);
+  assertInside(homeGitsDir, worktreePath);
+
+  const exec = input.exec ?? defaultExec;
+  if (existsSync(worktreePath)) {
+    if (!spec.reuse) {
+      throw new Error(`Worktree already exists: ${worktreePath}`);
+    }
+    const stat = lstatSync(worktreePath);
+    if (!stat.isDirectory()) {
+      throw new Error(`Worktree path exists but is not a directory: ${worktreePath}`);
+    }
+    await assertExistingWorktree(worktreePath, exec);
+    return {
+      path: worktreePath,
+      name: basename(worktreePath),
+      branch: spec.branch ?? `cmuxlayer/${spec.name}`,
+      base: spec.base,
+      created: false,
+      reused: true,
+      node_modules_linked: linkNodeModules(repoRoot, worktreePath),
+    };
+  }
+
+  if (!spec.create) {
+    throw new Error(`Worktree does not exist: ${worktreePath}`);
+  }
+
+  mkdirSync(dirname(worktreePath), { recursive: true });
+  const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+  await exec("git", [
+    "-C",
+    repoRoot,
+    "worktree",
+    "add",
+    "-b",
+    branch,
+    worktreePath,
+    spec.base,
+  ]);
+
+  return {
+    path: worktreePath,
+    name: basename(worktreePath),
+    branch,
+    base: spec.base,
+    created: true,
+    reused: false,
+    node_modules_linked: linkNodeModules(repoRoot, worktreePath),
+  };
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-const execFileMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
-  execFile: execFileMock,
+  spawn: spawnMock,
 }));
 
 import {
@@ -40,6 +40,22 @@ import {
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
+
+function mockSpawnExit(code: number): {
+  kill: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+} {
+  const child = {
+    kill: vi.fn(),
+    once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      if (event === "exit") {
+        queueMicrotask(() => callback(code, null));
+      }
+      return child;
+    }),
+  };
+  return child;
+}
 
 function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
   return {
@@ -145,10 +161,8 @@ describe("AgentEngine", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
-    execFileMock.mockReset();
-    execFileMock.mockImplementation((_cmd, _args, callback) => {
-      callback(new Error("missing launcher"), "", "");
-    });
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => mockSpawnExit(1));
     stateMgr = new StateManager(TEST_DIR);
     mockClient = makeMockClient();
     liveSurfaces = [];
@@ -3013,7 +3027,7 @@ describe("buildLaunchCommand", () => {
 
 describe("assertLauncherAvailable", () => {
   beforeEach(() => {
-    execFileMock.mockReset();
+    spawnMock.mockReset();
     vi.stubEnv("SHELL", "/bin/zsh");
   });
 
@@ -3022,33 +3036,34 @@ describe("assertLauncherAvailable", () => {
   });
 
   it("resolves to the verbatim launcher name when the probe returns 0", async () => {
-    execFileMock.mockImplementation((_cmd, _args, callback) => {
-      callback(null, "", "");
-    });
+    spawnMock.mockImplementation(() => mockSpawnExit(0));
 
     await expect(assertLauncherAvailable("brainlayer", "Cursor")).resolves.toBe(
       "brainlayerCursor",
     );
 
-    expect(execFileMock).toHaveBeenCalledWith(
+    expect(spawnMock).toHaveBeenCalledWith(
       "/bin/zsh",
       [
         "-ilc",
         "type brainlayerCursor >/dev/null 2>&1 || command -v brainlayerCursor >/dev/null 2>&1",
       ],
-      expect.any(Function),
+      {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+      },
     );
   });
 
   it("falls back to the hyphen-stripped launcher when verbatim is unregistered", async () => {
     // agent-html-host registered only as agenthtmlhostCursor (hyphens stripped).
-    execFileMock.mockImplementation((_cmd, args, callback) => {
+    spawnMock.mockImplementation((_cmd, args) => {
       const probe = String(args?.[1] ?? "");
       if (probe.includes("agenthtmlhostCursor")) {
-        callback(null, "", "");
-      } else {
-        callback(new Error("missing launcher"), "", "");
+        return mockSpawnExit(0);
       }
+      return mockSpawnExit(1);
     });
 
     await expect(
@@ -3057,9 +3072,7 @@ describe("assertLauncherAvailable", () => {
   });
 
   it("throws listing every candidate when none resolve", async () => {
-    execFileMock.mockImplementation((_cmd, _args, callback) => {
-      callback(new Error("missing launcher"), "", "");
-    });
+    spawnMock.mockImplementation(() => mockSpawnExit(1));
 
     await expect(
       assertLauncherAvailable("skill-creator", "Cursor"),
@@ -3073,6 +3086,13 @@ describe("launcherNameCandidates", () => {
   it("returns a single candidate for hyphenless repos", () => {
     expect(launcherNameCandidates("brainlayer", "Cursor")).toEqual([
       "brainlayerCursor",
+    ]);
+  });
+
+  it("includes the repoGolem orc alias for orchestrator", () => {
+    expect(launcherNameCandidates("orchestrator", "Cursor")).toEqual([
+      "orchestratorCursor",
+      "orcCursor",
     ]);
   });
 
@@ -3107,6 +3127,15 @@ describe("resolveLauncherName", () => {
     ).resolves.toBe("agenthtmlhostCursor");
     expect(probe).toHaveBeenNthCalledWith(1, "agent-html-hostCursor");
     expect(probe).toHaveBeenNthCalledWith(2, "agenthtmlhostCursor");
+  });
+
+  it("falls back to the orc launcher alias for the orchestrator repo", async () => {
+    const probe = vi.fn(async (name: string) => name === "orcCursor");
+    await expect(
+      resolveLauncherName("orchestrator", "Cursor", probe),
+    ).resolves.toBe("orcCursor");
+    expect(probe).toHaveBeenNthCalledWith(1, "orchestratorCursor");
+    expect(probe).toHaveBeenNthCalledWith(2, "orcCursor");
   });
 
   it("throws when no candidate resolves", async () => {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -221,6 +221,33 @@ describe("AgentRegistry", () => {
       expect(agent!.error).toContain("disappeared");
     });
 
+    it("does not mark agents disappeared when surface enumeration fails", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-live",
+          surface_id: "surface:1",
+          state: "working",
+        }),
+      );
+
+      let shouldThrow = false;
+      const surfaceProvider = async () => {
+        if (shouldThrow) {
+          throw new Error("socket unavailable");
+        }
+        return [makeSurface("surface:1")];
+      };
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+
+      shouldThrow = true;
+      await registry.reconcile();
+
+      const agent = registry.get("agent-live");
+      expect(agent!.state).toBe("working");
+      expect(agent!.error).toBeNull();
+    });
+
     it("picks up new state files created by other processes", async () => {
       const surfaceProvider = async () => [makeSurface("surface:new")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -36,6 +36,26 @@ describe("CmuxClient.listWorkspaces", () => {
   });
 });
 
+describe("CmuxClient.createWorkspace", () => {
+  it("uses the current workspace create --name CLI shape", async () => {
+    const { client, exec } = mockClient({
+      workspace_ref: "workspace:7",
+      title: "red-team",
+    });
+
+    const result = await client.createWorkspace("red-team");
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "workspace",
+      "create",
+      "--name",
+      "red-team",
+    ]);
+    expect(result).toEqual({ workspace: "workspace:7", title: "red-team" });
+  });
+});
+
 describe("CmuxClient.listPaneSurfaces", () => {
   it("calls with workspace flag when provided", async () => {
     const data = {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -80,7 +80,7 @@ const MOCK_RESPONSES: Record<string, unknown> = {
     text: "$ echo hello\nhello\n$",
     lines: 3,
   },
-  "pane.split": {
+  "surface.split": {
     workspace_ref: "workspace:1",
     surface_ref: "surface:2",
     pane_ref: "pane:2",
@@ -470,6 +470,14 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
   it("newSplit creates a surface and returns refs", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
     const result = await client.newSplit("right", { workspace: "workspace:1" });
+    expect(lastV2Request).toEqual({
+      method: "surface.split",
+      params: {
+        direction: "right",
+        workspace_id: "workspace:1",
+        surface_id: "surface:1",
+      },
+    });
     expect(result).toHaveProperty("workspace");
     expect(result).toHaveProperty("surface");
     expect(result).toHaveProperty("pane");
@@ -486,7 +494,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     });
 
     expect(lastV2Request).toEqual({
-      method: "pane.split",
+      method: "surface.split",
       params: {
         direction: "right",
         workspace_id: "workspace:1",
@@ -513,7 +521,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
       });
 
       expect(lastV2Request).toEqual({
-        method: "pane.split",
+        method: "surface.split",
         params: {
           direction: "right",
           workspace_id: "workspace:1",
@@ -757,9 +765,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
     } as unknown as CmuxClient;
   }
 
-  it("newSplit falls back to CLI when pane.split returns method_not_found", async () => {
-    const saved = MOCK_RESPONSES["pane.split"];
-    delete MOCK_RESPONSES["pane.split"];
+  it("newSplit falls back to CLI when surface.split returns method_not_found", async () => {
+    const saved = MOCK_RESPONSES["surface.split"];
+    delete MOCK_RESPONSES["surface.split"];
     try {
       const client = new CmuxSocketClient({
         socketPath: MOCK_SOCKET_PATH,
@@ -772,7 +780,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
       expect(cliCalls[0].method).toBe("newSplit");
       expect(result.surface).toBe("surface:cli");
     } finally {
-      MOCK_RESPONSES["pane.split"] = saved;
+      MOCK_RESPONSES["surface.split"] = saved;
     }
   });
 
@@ -887,15 +895,15 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
   });
 
   it("newSplit throws when no CLI fallback and method_not_found", async () => {
-    const saved = MOCK_RESPONSES["pane.split"];
-    delete MOCK_RESPONSES["pane.split"];
+    const saved = MOCK_RESPONSES["surface.split"];
+    delete MOCK_RESPONSES["surface.split"];
     try {
       const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
       await expect(
         client.newSplit("right", { workspace: "workspace:1" }),
       ).rejects.toThrow("method_not_found");
     } finally {
-      MOCK_RESPONSES["pane.split"] = saved;
+      MOCK_RESPONSES["surface.split"] = saved;
     }
   });
 
@@ -913,7 +921,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
   });
 
   it("uses V2 when method is available (no fallback triggered)", async () => {
-    // pane.split IS in MOCK_RESPONSES — V2 should work directly
+    // surface.split IS in MOCK_RESPONSES — V2 should work directly
     const client = new CmuxSocketClient({
       socketPath: MOCK_SOCKET_PATH,
       cliFallback: createMockCli(),
@@ -970,6 +978,43 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
       } else {
         process.env.CMUX_SOCKET_PATH = savedEnv;
       }
+      await stopSocketServer(server, liveSocketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("binds CLI fallback calls to the selected socket path", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
+    const liveSocketPath = join(stateDir, "cmux-live.sock");
+    const fakeCmux = join(stateDir, "cmux-fake");
+    fs.writeFileSync(
+      fakeCmux,
+      [
+        "#!/bin/sh",
+        `if [ "$CMUX_SOCKET_PATH" != "${liveSocketPath}" ]; then`,
+        '  echo "wrong socket: $CMUX_SOCKET_PATH" >&2',
+        "  exit 42",
+        "fi",
+        'printf \'{"workspace_ref":"workspace:1","surface_ref":"surface:cli","pane_ref":"pane:1","type":"terminal"}\\n\'',
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.chmodSync(fakeCmux, 0o755);
+    const server = await startSocketServer(liveSocketPath);
+
+    try {
+      const client = await createCmuxClient({
+        socketPath: liveSocketPath,
+        bin: fakeCmux,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      const result = await (client as CmuxSocketClient).newSurface({
+        pane: "pane:1",
+        workspace: "workspace:1",
+      });
+      expect(result.surface).toBe("surface:cli");
+    } finally {
       await stopSocketServer(server, liveSocketPath);
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  collectControlHealth,
+  formatControlHealth,
+} from "../src/control-health.js";
+import { createServer, createServerContext } from "../src/server.js";
+import type { ControlHealth } from "../src/control-health.js";
+
+const TEST_ROOT = join(tmpdir(), "cmuxlayer-control-health-test");
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("control health", () => {
+  it("reports prod/nightly sockets and warns on Nightly env with prod-resolving cmux", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home");
+    const tmp = join(TEST_ROOT, "tmp");
+    const bin = join(TEST_ROOT, "bin");
+    const stateDir = join(home, ".local", "state", "cmux");
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    mkdirSync(bin, { recursive: true });
+
+    const prodSocket = join(stateDir, "cmux-501.sock");
+    const nightlySocket = join(tmp, "cmux-nightly.sock");
+    writeFileSync(join(stateDir, "last-socket-path"), `${prodSocket}\n`);
+    writeFileSync(join(stateDir, "nightly-last-socket-path"), `${nightlySocket}\n`);
+    writeFileSync(join(tmp, "cmux-last-socket-path"), `${prodSocket}\n`);
+    writeFileSync(join(tmp, "cmux-nightly-last-socket-path"), `${nightlySocket}\n`);
+    writeFileSync(prodSocket, "");
+    writeFileSync(nightlySocket, "");
+
+    const cmuxShim = join(bin, "cmux");
+    writeFileSync(
+      cmuxShim,
+      [
+        "#!/usr/bin/env bash",
+        'CLI_FILE="/tmp/cmux-last-cli-path"',
+        'exec "/Applications/cmux.app/Contents/Resources/bin/cmux" "$@"',
+        "",
+      ].join("\n"),
+    );
+    chmodSync(cmuxShim, 0o755);
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      pid: 123,
+      ppid: 1,
+      cwd: TEST_ROOT,
+      env: {
+        PATH: bin,
+        CMUX_SOCKET_PATH: nightlySocket,
+        CMUX_BUNDLED_CLI_PATH:
+          "/Applications/cmux NIGHTLY.app/Contents/Resources/bin/cmux",
+        CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly",
+        CMUX_SOCKET_PASSWORD: "secret",
+      },
+      client: {
+        constructor: { name: "CmuxSocketClient" },
+        currentSocketPath: () => nightlySocket,
+      },
+      execFile: async (file, args) => {
+        if (
+          file === "ps" &&
+          args.join(" ") === "ax -o pid= -o command="
+        ) {
+          expect(args).toEqual([
+            "ax",
+            "-o",
+            "pid=",
+            "-o",
+            "command=",
+          ]);
+          return {
+            stdout: [
+              "100 /Applications/Other.app/Contents/MacOS/cmux-helper",
+              "59547 /Applications/cmux.app/Contents/MacOS/cmux",
+              "83734 /Applications/cmux NIGHTLY.app/Contents/MacOS/cmux",
+            ].join("\n"),
+          };
+        }
+        if (file === "ps") {
+          return { stdout: "123 1 123 123 S+ ttys001 node server.js" };
+        }
+        throw new Error(`unexpected execFile: ${file}`);
+      },
+      now: () => new Date("2026-06-13T12:00:00.000Z"),
+    });
+
+    expect(health.cmux_instances.production.socket_path).toBe(prodSocket);
+    expect(health.cmux_instances.nightly.socket_path).toBe(nightlySocket);
+    expect(health.cmux_instances.production.processes).toHaveLength(1);
+    expect(health.cmux_instances.nightly.processes).toHaveLength(1);
+    expect(health.current_process.cmux_resolution[0]).toMatchObject({
+      path: cmuxShim,
+      mentions_prod_app: true,
+      mentions_last_cli_path: true,
+    });
+    expect(health.current_process.env.CMUX_SOCKET_PASSWORD).toBe("<set>");
+    expect(health.warnings).toContain(
+      "CMUX_SOCKET_PATH points at Nightly, but the first cmux executable resolves through a prod app shim/binary.",
+    );
+    expect(health.warnings).toContain(
+      "CMUX_BUNDLED_CLI_PATH is Nightly, but PATH resolves cmux somewhere else first.",
+    );
+    expect(formatControlHealth(health)).toContain("cmuxlayer control_health");
+
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("control_health tool appends prod and Nightly snapshot data to events.jsonl", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const prodSocket = "/Users/etanheyman/.local/state/cmux/cmux-501.sock";
+    const nightlySocket = "/tmp/cmux-nightly.sock";
+    const health = {
+      generated_at: "2026-06-13T13:00:00.000Z",
+      current_process: {
+        pid: 123,
+        ppid: 1,
+        cwd: TEST_ROOT,
+        stdin_is_tty: false,
+        env: { CMUX_SOCKET_PATH: nightlySocket, PATH: "/bin" },
+        path_entries: ["/bin"],
+        cmux_resolution: [{ path: "/Applications/cmux NIGHTLY.app/bin/cmux", exists: true }],
+      },
+      selected_transport: {
+        client_class: "CmuxSocketClient",
+        current_socket_path: nightlySocket,
+      },
+      cmux_instances: {
+        production: {
+          axis: "production",
+          app_bundle_path: "/Applications/cmux.app",
+          app_binary_path: "/Applications/cmux.app/Contents/MacOS/cmux",
+          marker_files: [],
+          socket_path: prodSocket,
+          socket_status: null,
+          processes: [],
+        },
+        nightly: {
+          axis: "nightly",
+          app_bundle_path: "/Applications/cmux NIGHTLY.app",
+          app_binary_path: "/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux",
+          marker_files: [],
+          socket_path: nightlySocket,
+          socket_status: null,
+          processes: [],
+        },
+      },
+      warnings: ["sample warning"],
+    } satisfies ControlHealth;
+    const server = createServer({
+      stateDir: TEST_ROOT,
+      skipAgentLifecycle: true,
+      controlHealthCollector: async () => health,
+    });
+    const tool = (server as any)._registeredTools["control_health"];
+
+    const result = await tool.handler({}, {} as any);
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.health.selected_transport.current_socket_path).toBe(
+      nightlySocket,
+    );
+    const lines = readFileSync(join(TEST_ROOT, "events.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      event_type: "control_health",
+      selected_socket_path: nightlySocket,
+      production_socket_path: prodSocket,
+      nightly_socket_path: nightlySocket,
+      cmux_binary: "/Applications/cmux NIGHTLY.app/bin/cmux",
+      warnings: ["sample warning"],
+    });
+    expect(lines[0].snapshot.cmux_instances.production.socket_path).toBe(
+      prodSocket,
+    );
+    expect(lines[0].snapshot.cmux_instances.nightly.socket_path).toBe(
+      nightlySocket,
+    );
+  });
+
+  it("periodically appends control health snapshots without tool invocation", async () => {
+    vi.useFakeTimers();
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const prodSocket = "/Users/etanheyman/.local/state/cmux/cmux-501.sock";
+    const nightlySocket = "/tmp/cmux-nightly.sock";
+    let count = 0;
+    const makeHealth = (): ControlHealth => {
+      count += 1;
+      return {
+        generated_at: `2026-06-13T13:00:0${count}.000Z`,
+        current_process: {
+          pid: 123,
+          ppid: 1,
+          cwd: TEST_ROOT,
+          stdin_is_tty: false,
+          env: { PATH: "/bin" },
+          path_entries: ["/bin"],
+          cmux_resolution: [{ path: "/usr/local/bin/cmux", exists: true }],
+        },
+        selected_transport: {
+          client_class: "CmuxSocketClient",
+          current_socket_path: count % 2 === 0 ? prodSocket : nightlySocket,
+        },
+        cmux_instances: {
+          production: {
+            axis: "production",
+            app_bundle_path: "/Applications/cmux.app",
+            app_binary_path: "/Applications/cmux.app/Contents/MacOS/cmux",
+            marker_files: [],
+            socket_path: prodSocket,
+            socket_status: null,
+            processes: [],
+          },
+          nightly: {
+            axis: "nightly",
+            app_bundle_path: "/Applications/cmux NIGHTLY.app",
+            app_binary_path:
+              "/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux",
+            marker_files: [],
+            socket_path: nightlySocket,
+            socket_status: null,
+            processes: [],
+          },
+        },
+        warnings: [],
+      };
+    };
+    const context = createServerContext({
+      stateDir: TEST_ROOT,
+      skipAgentLifecycle: true,
+      controlHealthCollector: async () => makeHealth(),
+      controlHealthIntervalMs: 5_000,
+    });
+
+    createServer({ context });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    context.dispose();
+    const lines = readFileSync(join(TEST_ROOT, "events.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(lines.map((line) => line.event_type)).toEqual([
+      "control_health",
+      "control_health",
+    ]);
+    expect(lines.map((line) => line.selected_socket_path)).toEqual([
+      nightlySocket,
+      prodSocket,
+    ]);
+  });
+});

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -352,7 +352,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.start();
 
     await expect(rawToolsList(path, 100)).resolves.toMatchObject({
-      toolCount: 19,
+      toolCount: 20,
     });
 
     await daemon.shutdown();

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -32,6 +32,7 @@ function makeMockExec(): ExecFn {
 describe("B1: ToolAnnotations on all tools", () => {
   const READONLY_TOOLS = [
     "list_surfaces",
+    "control_health",
     "read_screen",
     "get_agent_state",
     "list_agents",
@@ -83,9 +84,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 33 tools have annotations", () => {
+  it("all 35 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(33);
+    expect(toolNames.length).toBe(35);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   mkdirSync,
+  readFileSync,
   readdirSync,
   renameSync,
   rmSync,
@@ -14,11 +15,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
+import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 
 const AGENT_TOOLS = [
   "spawn_agent",
+  "new_worktree_split",
   "spawn_in_workspace",
   "resync_agents",
   "send_to",
@@ -145,8 +148,33 @@ function moveOnlyAgentStateDir(prefix: string) {
   );
 }
 
+function renameOnlyAgentStateToSession(sessionId: string): string {
+  const entries = readdirSync(TEST_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name !== "events");
+  expect(entries).toHaveLength(1);
+
+  const statePath = join(TEST_DIR, entries[0], "state.json");
+  const current = JSON.parse(readFileSync(statePath, "utf8")) as AgentRecord;
+  const finalAgentId = generateAgentId(current.cli, current.repo, sessionId);
+  const updated: AgentRecord = {
+    ...current,
+    agent_id: finalAgentId,
+    cli_session_id: sessionId,
+    version: current.version + 1,
+    updated_at: new Date().toISOString(),
+  };
+
+  const finalDir = join(TEST_DIR, finalAgentId);
+  mkdirSync(finalDir, { recursive: true });
+  writeFileSync(join(finalDir, "state.json"), JSON.stringify(updated, null, 2));
+  rmSync(join(TEST_DIR, entries[0]), { recursive: true, force: true });
+  return finalAgentId;
+}
+
 describe("agent lifecycle tool registration", () => {
-  it("registers all 12 agent lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 13 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -174,11 +202,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 33 (19 low-level + 12 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 35 (20 low-level + 13 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(33);
+    expect(Object.keys(registeredTools)).toHaveLength(35);
   });
 });
 
@@ -295,6 +323,169 @@ describe("agent lifecycle tool handlers", () => {
         "--surface",
         "surface:new",
         "return",
+      ]),
+    );
+  });
+
+  it("spawn_agent canonicalizes the agent id after session capture renames pending state", async () => {
+    const sessionId = "019ec0e6-1111-2222-3333-444455556666";
+    let finalAgentId: string | null = null;
+    let renamed = false;
+    const baseExec = makeLifecycleExec();
+    mockExec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (
+        !renamed &&
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "probe renamed state"
+      ) {
+        renamed = true;
+        finalAgentId = renameOnlyAgentStateToSession(sessionId);
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "probe renamed state",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent_id).toBe(finalAgentId);
+    expect(parsed.agent_id).toBe("cmuxlayerCodex-019ec0e6");
+    expect(parsed.boot_prompt_delivered).toBe(true);
+
+    const stateTool = (server as any)._registeredTools["get_agent_state"];
+    const stateResult = await stateTool.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const persisted =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(persisted.boot_prompt_pending).toBe(false);
+    expect(persisted.task_summary).toBe("probe renamed state");
+  });
+
+  it("spawn_agent with worktree launches from the worktree and inherits MCPs by default", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "cmuxlayer");
+    mkdirSync(repoRoot, { recursive: true });
+    const worktreeExec = vi.fn().mockImplementation(async () => {
+      mkdirSync(join(gitsDir, "cmuxlayer.wt", "skill-eval"), {
+        recursive: true,
+      });
+      return { stdout: "", stderr: "" };
+    });
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        role: "worker",
+        worktree: {
+          name: "skill eval",
+          branch: "fix/skill-eval",
+          base: "origin/main",
+        },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const worktreePath = join(gitsDir, "cmuxlayer.wt", "skill-eval");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.worktree).toMatchObject({
+      path: worktreePath,
+      branch: "fix/skill-eval",
+      created: true,
+      reused: false,
+    });
+    expect(parsed.mcp_profile).toBe("inherit");
+    expect(worktreeExec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      "fix/skill-eval",
+      worktreePath,
+      "origin/main",
+    ]);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        `cd '${worktreePath}' && CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s`,
+      ]),
+    );
+  });
+
+  it("new_worktree_split launches a worker with the requested MCP profile", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "cmuxlayer");
+    mkdirSync(repoRoot, { recursive: true });
+    const worktreeExec = vi.fn().mockImplementation(async () => {
+      mkdirSync(join(gitsDir, "cmuxlayer.wt", "sterile-worker"), {
+        recursive: true,
+      });
+      return { stdout: "", stderr: "" };
+    });
+    const server = createServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["new_worktree_split"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        worktree: { name: "sterile worker" },
+        mcp_profile: "sterile",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const worktreePath = join(gitsDir, "cmuxlayer.wt", "sterile-worker");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.role).toBe("worker");
+    expect(parsed.mcp_profile).toBe("sterile");
+    expect(parsed.worktree.path).toBe(worktreePath);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        `cd '${worktreePath}' && CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s`,
       ]),
     );
   });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -240,9 +240,7 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(parsed.agent_id).toMatch(
-      /^brainlayerClaude-pending-\d+-[a-z0-9]+$/,
-    );
+    expect(parsed.agent_id).toMatch(/^brainlayerClaude-pending-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
 
@@ -521,9 +519,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.agent_id).toMatch(
-      /^cmuxlayerCursor-pending-\d+-[a-z0-9]+$/,
-    );
+    expect(parsed.agent_id).toMatch(/^cmuxlayerCursor-pending-\d+-[a-z0-9]+$/);
     expect(parsed.state).toBe("ready");
     expect(parsed.boot_prompt_delivered).toBe(true);
 
@@ -1702,9 +1698,7 @@ describe("agent lifecycle tool handlers", () => {
     const pendingParentId = parentResult.structuredContent.agent_id;
     const finalParentId = "orchestratorClaude-session1";
     const renamed = engine.stateMgr.renameState(pendingParentId, finalParentId);
-    engine
-      .getRegistry()
-      .rename(pendingParentId, finalParentId, renamed);
+    engine.getRegistry().rename(pendingParentId, finalParentId, renamed);
 
     await spawn.handler(
       {
@@ -1785,5 +1779,144 @@ describe("agent lifecycle tool handlers", () => {
       resume_command:
         "voicelayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
+  });
+});
+
+describe("auto-focus discipline (focus target before split, restore after render)", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  // Builds an exec mock that records every call, reports `selectedWorkspace` as
+  // the focused one, and returns a non-ready screen for the first `notReadyFor`
+  // read-screen polls before reporting ready.
+  function makeFocusExec(opts: {
+    selectedWorkspace: string;
+    notReadyFor?: number;
+  }): { exec: ExecFn; calls: string[][]; readScreenCount: () => number } {
+    const calls: string[][] = [];
+    let readScreens = 0;
+    const exec = vi.fn(async (_cmd: string, args: string[]) => {
+      calls.push(args);
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "One",
+                index: 0,
+                selected: opts.selectedWorkspace === "workspace:1",
+                pinned: false,
+              },
+              {
+                ref: "workspace:2",
+                title: "Two",
+                index: 1,
+                selected: opts.selectedWorkspace === "workspace:2",
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("read-screen")) {
+        readScreens++;
+        const notReady = (opts.notReadyFor ?? 0) >= readScreens;
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: notReady
+              ? "still booting up please wait"
+              : "What can I help you with?\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      // Default: split/surface creation result.
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:2",
+          surface: "surface:new",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    }) as unknown as ExecFn;
+    return { exec, calls, readScreenCount: () => readScreens };
+  }
+
+  const selectIdx = (calls: string[][], ws: string) =>
+    calls.findIndex((a) => a.includes("select-workspace") && a.includes(ws));
+  const firstReadScreenIdx = (calls: string[][]) =>
+    calls.findIndex((a) => a.includes("read-screen"));
+  const lastReadScreenIdx = (calls: string[][]) =>
+    calls.reduce((last, a, i) => (a.includes("read-screen") ? i : last), -1);
+
+  it("new_split focuses the target workspace before the split and restores prior focus after readiness when a jump is needed", async () => {
+    const { exec, calls } = makeFocusExec({ selectedWorkspace: "workspace:1" });
+    const server = createLifecycleServer(exec);
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      { direction: "right", workspace: "workspace:2", type: "terminal" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.surface).toBe("surface:new");
+
+    const focusTarget = selectIdx(calls, "workspace:2");
+    const restorePrior = selectIdx(calls, "workspace:1");
+    const readScreen = firstReadScreenIdx(calls);
+
+    // Target was focused BEFORE the prior focus was restored.
+    expect(focusTarget).toBeGreaterThanOrEqual(0);
+    expect(restorePrior).toBeGreaterThan(focusTarget);
+    // Readiness was awaited between the split and the focus-back.
+    expect(readScreen).toBeGreaterThan(focusTarget);
+    expect(readScreen).toBeLessThan(restorePrior);
+  });
+
+  it("new_split does NOT touch focus when the target is already the focused workspace", async () => {
+    const { exec, calls } = makeFocusExec({ selectedWorkspace: "workspace:2" });
+    const server = createLifecycleServer(exec);
+    const tool = (server as any)._registeredTools["new_split"];
+
+    await tool.handler(
+      { direction: "right", workspace: "workspace:2", type: "terminal" },
+      {} as any,
+    );
+
+    const selectCalls = calls.filter((a) => a.includes("select-workspace"));
+    expect(selectCalls).toHaveLength(0);
+  });
+
+  it("new_split waits for the new terminal to render before restoring focus", async () => {
+    const { exec, calls, readScreenCount } = makeFocusExec({
+      selectedWorkspace: "workspace:1",
+      notReadyFor: 2,
+    });
+    const server = createLifecycleServer(exec);
+    const tool = (server as any)._registeredTools["new_split"];
+
+    await tool.handler(
+      { direction: "right", workspace: "workspace:2", type: "terminal" },
+      {} as any,
+    );
+
+    // Polled until ready (2 not-ready + 1 ready) and only then restored focus.
+    expect(readScreenCount()).toBeGreaterThanOrEqual(3);
+    const restorePrior = selectIdx(calls, "workspace:1");
+    expect(restorePrior).toBeGreaterThan(lastReadScreenIdx(calls));
   });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -8,9 +8,10 @@ import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 
-// The 12 low-level tools from the design doc
+// Core low-level and metadata tools.
 const EXPECTED_TOOLS = [
   "list_surfaces",
+  "control_health",
   "select_workspace",
   "create_workspace",
   "new_split",
@@ -75,7 +76,7 @@ describe("createServer", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 19 core tools", () => {
+  it("registers all 20 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -91,14 +91,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 33 (19 low-level + 12 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 35 (20 low-level + 13 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(33);
+    expect(count).toBe(35);
   });
 });
 

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  formatMcpProfileEnv,
+  prepareWorktree,
+} from "../src/worktree.js";
+
+const TEST_ROOT = join(tmpdir(), "cmuxlayer-worktree-test");
+
+describe("worktree helpers", () => {
+  beforeEach(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(TEST_ROOT, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("creates a named git worktree with a deterministic default path", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: {
+        name: "skill eval",
+        branch: "fix/skill-eval",
+        base: "origin/main",
+      },
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      path: join(TEST_ROOT, "cmuxlayer.wt", "skill-eval"),
+      branch: "fix/skill-eval",
+      base: "origin/main",
+      created: true,
+      reused: false,
+    });
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      "fix/skill-eval",
+      join(TEST_ROOT, "cmuxlayer.wt", "skill-eval"),
+      "origin/main",
+    ]);
+  });
+
+  it("reuses an existing worktree when reuse is enabled", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "existing");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(worktreePath, { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "existing", reuse: true },
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      path: worktreePath,
+      created: false,
+      reused: true,
+    });
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      worktreePath,
+      "rev-parse",
+      "--is-inside-work-tree",
+    ]);
+    expect(exec).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["worktree", "add"]),
+    );
+  });
+
+  it("symlinks node_modules from the main checkout when present", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    mkdirSync(join(repoRoot, "node_modules"), { recursive: true });
+    const exec = vi.fn().mockImplementation(async () => {
+      const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "deps");
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "deps" },
+      exec,
+    });
+
+    expect(result.node_modules_linked).toBe(true);
+  });
+
+  it("rejects a path outside the allowed Gits root", async () => {
+    await expect(
+      prepareWorktree({
+        repo: "cmuxlayer",
+        repoRoot: join(TEST_ROOT, "repo"),
+        homeGitsDir: TEST_ROOT,
+        worktree: { path: "/tmp/outside" },
+        exec: vi.fn(),
+      }),
+    ).rejects.toThrow(/must be inside/);
+  });
+
+  it("formats MCP profile env hints without raw config passing", () => {
+    expect(formatMcpProfileEnv(undefined)).toBe(
+      "CMUXLAYER_MCP_PROFILE=inherit",
+    );
+    expect(formatMcpProfileEnv("sterile")).toBe(
+      "CMUXLAYER_MCP_PROFILE=sterile",
+    );
+    expect(
+      formatMcpProfileEnv({
+        include: ["cmux", "brainlayer"],
+        exclude: ["exa"],
+      }),
+    ).toBe(
+      "CMUXLAYER_MCP_PROFILE=custom CMUXLAYER_MCP_INCLUDE=cmux,brainlayer CMUXLAYER_MCP_EXCLUDE=exa",
+    );
+  });
+});


### PR DESCRIPTION
## What

Lands the **team-spawn / worktree** toolset that the live fleet dist was already built from, plus a **control-health** observability surface, and folds in the **auto-focus discipline** fix for cross-workspace spawns.

### New MCP tools / capabilities
- **`new_worktree_split`** — create/reuse a git worktree and spawn one worker agent into a right-side split (inherited MCPs by default, preserves worker layout policy).
- **`spawn_in_workspace`** — stand up a multi-agent team atomically as a clean 2-pane grid (commanders LEFT / workers RIGHT); handles workspace create/select/role-placement in one call.
- **`control_health`** (`src/control-health.ts`) — control-plane health/observability.
- **`src/worktree.ts`** — worktree preparation + MCP-profile resolution.

### Auto-focus discipline (commit `24e878a`) — the durable C1 fix
cmux attaches a new split to the **currently-focused** workspace, so spawning into a *different* workspace landed the pane in the wrong place (happy-camper's split failed for exactly this reason). Now, for workspace-targeted splits:
1. **Before** creating the pane → focus the target workspace (`focusTargetBeforeSplit`).
2. **After** the new terminal is fully rendered (`waitForLaunchShellReady`) → restore the previously-focused workspace — **only when a jump was actually needed** (`restoreFocusAfterRender`; no-op otherwise).

Applied to `new_split`, `new_worktree_split`, `spawn_in_workspace`. Skipped when an explicit `pane`/`surface` anchor is given (destination already pinned), and runs **after validation** so rejected requests have no focus side effects.

## Tests
- `bun run test` → **802 passed** (was 799; +3 auto-focus tests: focus-before-on-jump, no-touch-when-already-focused, waits-for-render-before-restore).
- `bun run typecheck` clean.

## Notes
- The live fleet dist was already built from this branch; merging makes `main` the single source of truth, after which dist is rebuilt from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span agent spawn (git worktrees, cross-workspace focus), cmux socket/CLI behavior, and agent registry reconciliation—important for orchestration correctness but bounded by tests and path/MCP env validation.
> 
> **Overview**
> Adds **team/worktree spawning** and **control-plane diagnostics**, plus fixes that keep splits and agent reconciliation reliable across workspaces and cmux builds.
> 
> **Worktree agents:** `spawn_agent` now accepts `worktree` and `mcp_profile`; **`new_worktree_split`** wraps one worker in a right-side split after create/reuse under `~/Gits/<repo>.wt/`. Launch commands get `cd <worktree>` and `CMUXLAYER_MCP_*` env hints (no raw MCP config). Agent records store launch cwd, profile, and worktree metadata.
> 
> **Observability:** Read-only **`control_health`** reports prod/nightly sockets, `cmux` binary resolution, env, and warnings; snapshots append to `events.jsonl` on demand and on a configurable interval.
> 
> **Auto-focus:** Workspace-targeted **`new_split`**, **`new_worktree_split`**, and **`spawn_in_workspace`** focus the target workspace before creating panes, wait for shell readiness, then restore the prior focus only when a jump was needed.
> 
> **Transport & lifecycle:** Socket splits use **`surface.split`** with a selected-surface anchor; CLI fallback gets **`CMUX_SOCKET_PATH`** synced to the active socket. **`create_workspace`** uses `workspace create --name`. Surface enumeration failures no longer mark all agents disappeared; spawn responses **canonicalize** agent IDs after pending→session renames.
> 
> **Ops scripts:** Memory watchdog and RAM sampler discover cmux PIDs via **`ps`** when broad **`pgrep -f`** misses GUI apps (stable + nightly bundles).
> 
> Docs/README bump MCP tools to **35** and tests to **798+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e878a697d048256b55782d6571c913beab0e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add team-spawn worktree tools, control_health diagnostics, and auto-focus discipline to agent spawning
> - Adds `new_worktree_split` tool and extends `spawn_agent` with `worktree`/`mcp_profile` args; [worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/156/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d) prepares or reuses git worktrees under a configured home directory, symlinks `node_modules`, and emits MCP profile env strings for the spawned agent's working context.
> - Adds `control_health` tool and periodic background sampling via [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/156/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d); collects socket paths, cmux binary resolution, process state, and environment into a structured snapshot appended to the event log.
> - Introduces auto-focus discipline in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/156/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): `new_split` and `spawn_in_workspace` focus the target workspace before split/spawn and restore prior focus after terminal readiness.
> - Hardens `AgentRegistry.reconcileSurfaces` to skip reconciliation (rather than marking agents as errored) when surface enumeration throws transiently.
> - Fixes cmux PID discovery in the memory watchdog and RAM sampler launchd scripts to prefer `ps`-based matching over broad `pgrep -f`, reducing false positives.
> - Risk: `CmuxClient.createWorkspace` now calls `workspace create --name` instead of `new-workspace --title`, which is a breaking CLI contract change for any external callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 24e878a. 16 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->