### PR TITLE
mcp descriptions: role geometry (leads LEFT/workers RIGHT) + @-mention file-picker trap

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1932,7 +1932,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 2. new_split
   server.tool(
     "new_split",
-    "Create a new split pane (terminal or browser). For terminal panes that boot an agent, boot_prompt_path can deliver a file prompt after the agent reaches a ready prompt.",
+    "Create a new split pane (terminal or browser). PLACEMENT IS BY ROLE, NOT BY HAND: pass `role` (or let it infer from the launcher title) and the layout policy enforces the two-column invariant — leads/orchestrators land in the LEFT column, workers land in the RIGHT column, and extra workers dock as tabs in the rightmost worker pane (never a third column). Workspace-targeted splits auto-focus the target before splitting and restore your prior focus after the new pane renders, so you do not hand-run focus-pane around splits. For terminal panes that boot an agent, boot_prompt_path can deliver a file prompt after the agent reaches a ready prompt.",
     {
       direction: z
         .enum(["left", "right", "up", "down"])
@@ -1951,7 +1951,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .enum(["orchestrator", "ic", "worker"])
         .optional()
         .describe(
-          "Optional agent role used for deterministic placement. Defaults from title launcher suffix: *Claude=orchestrator, *Codex/*Cursor=worker.",
+          "Agent role drives deterministic column placement: orchestrator/ic → LEFT column (leads, the Claude that coordinates), worker → RIGHT column (Codex/Cursor that implement/gather). Defaults from title launcher suffix: *Claude=orchestrator, *Codex/*Cursor=worker. Pass this instead of trying to control left/right via direction.",
         ),
       focus: z
         .boolean()
@@ -2333,7 +2333,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 6. send_input
   server.tool(
     "send_input",
-    "Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxLayer resolves the current backing surface. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
+    "Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxLayer resolves the current backing surface. WARNING — DO NOT include a bare `@word` (e.g. `@narration-lead`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats `@` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (`narration-lead:`) for pane-to-pane addressing; reserve `@<name>` for collab-file posts where monitors match it. If a literal `@` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
     {
       surface: z.string().describe("Target surface ref"),
       text: z.string().describe("Text to send"),
@@ -2435,7 +2435,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 7. send_command
   server.tool(
     "send_command",
-    "Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command. For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path reads a prompt file after the launcher reaches readiness and submits it; passing boot_prompt_path for plain shell commands is rejected.",
+    "Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command. WARNING — never include a bare `@word` in text destined for an interactive agent composer: it fires the receiver's file-reference picker and corrupts delivery (use the bare name; `@<name>` belongs in collab files, not pane keystrokes). For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path reads a prompt file after the launcher reaches readiness and submits it; passing boot_prompt_path for plain shell commands is rejected.",
     {
       surface: z.string().describe("Target surface ref"),
       command: z


### PR DESCRIPTION
## Why
Companion to golems#517. Agents kept getting confused about cmux geometry and kept mangling pane sends with `@`-mentions (2026-06-14). Description-strings only, **no logic changes**.

## What
- **`new_split`** — top description + `role` describe now state: orchestrator/ic → **LEFT** column (leads), worker → **RIGHT** column (Codex/Cursor); auto-focus is handled; pass `role` instead of hand-managing left/right.
- **`send_input` / `send_command`** — warn that a bare `@word` in text bound for an interactive agent composer fires the receiver's file-reference picker and **silently corrupts delivery** (`ok:true` won't report it); use bare names for pane sends, reserve `@<name>` for collab files.

## Verification
- `tsc --noEmit` clean (exit 0).
- `git diff --stat`: 1 file, 4 insertions / 4 deletions — all description strings.

## Notes for @cmuxlayer-lead
- Builds on your PR #156 (team-tools + auto-focus, already on main) — zero overlap with the auto-focus logic; the descriptions now document the behavior your PR shipped.
- Needs **merge + dist-rebuild-from-main** to go live (you own dist). Posted a heads-up in the gen16 collab channel before touching these strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only MCP tool description strings change; no behavioral, security, or data-path code is modified.
> 
> **Overview**
> **Documentation-only** updates to MCP tool strings in `src/server.ts` — no runtime or layout logic changes.
> 
> **`new_split`** — The main description and the `role` parameter now spell out that placement is **role-driven**, not manual left/right via `direction`: orchestrator/ic → **LEFT** (leads), worker → **RIGHT** (Codex/Cursor), extra workers tab into the rightmost worker pane (no third column). They also document workspace auto-focus before/after splits so callers should pass `role` instead of hand-managing geometry.
> 
> **`send_input` / `send_command`** — Both add a **WARNING** that bare `@word` text sent to interactive agent composers (Claude Code / Codex / Cursor) triggers the receiver’s file-reference picker, silently corrupts delivery while still returning `ok: true`, and should be avoided: use bare names for pane addressing, reserve `@<name>` for collab files, or deliver via a file when a literal `@` is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd517b1def4e6700b21b24913d7d0adbc4ac14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update MCP tool descriptions with role-based split geometry and @-mention file-picker warning
> - Updates the `new_split` tool description to clarify that orchestrator/IC roles go in the left column and workers in the right, and that callers should pass `role` rather than explicit split direction to control placement.
> - Adds a warning to both `send_input` and `send_command` descriptions that bare `@word` sequences in composer-bound text trigger a file-reference picker, corrupting delivery; advises using bare names or file-based delivery instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cd517b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->