### PR TITLE
fix: route Gemini agents through repoGolem launchers

### DIFF
--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -24,18 +24,19 @@ export function buildResumeCommand(
   cli: CliType,
   repo: string,
   sessionId: string,
+  launcherName?: string | null,
 ): string {
   const safeRepo = sanitizeRepoName(repo);
   switch (cli) {
     case "claude":
-      return `${safeRepo}Claude -s --resume ${sessionId}`;
+      return `${launcherName ?? `${safeRepo}Claude`} -s --resume ${sessionId}`;
     case "codex":
-      return `${safeRepo}Codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
+      return `${launcherName ?? `${safeRepo}Codex`} --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
     case "gemini":
-      return `${safeRepo}Gemini -s --resume ${sessionId}`;
+      return `${launcherName ?? `${safeRepo}Gemini`} -s --resume ${sessionId}`;
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
     case "cursor":
-      return `${safeRepo}Cursor -s --resume ${sessionId}`;
+      return `${launcherName ?? `${safeRepo}Cursor`} -s --resume ${sessionId}`;
   }
 }

--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -32,7 +32,7 @@ export function buildResumeCommand(
     case "codex":
       return `${safeRepo}Codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
     case "gemini":
-      return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} gemini --resume ${sessionId}`;
+      return `${safeRepo}Gemini -s --resume ${sessionId}`;
     case "kiro":
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
     case "cursor":

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1267,6 +1267,7 @@ export class AgentEngine {
           agent.cli,
           agent.repo,
           agent.cli_session_id!,
+          agent.launcher_name,
         );
         await this.sendLaunchCommand(
           surface.surface,
@@ -1704,6 +1705,7 @@ export class AgentEngine {
       cli: params.cli,
       cli_session_id: null,
       cli_session_path: null,
+      launcher_name: preflight?.launcherName ?? null,
       task_summary: params.prompt,
       pid: null,
       version: 1,
@@ -1954,7 +1956,12 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
     const resumeCommand = agent.cli_session_id
-      ? buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id)
+      ? buildResumeCommand(
+          agent.cli,
+          agent.repo,
+          agent.cli_session_id,
+          agent.launcher_name,
+        )
       : undefined;
     return {
       agent_id: agent.agent_id,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -16,9 +16,7 @@ import {
   shellQuote,
 } from "./agent-command.js";
 import { AgentRegistry, type AgentFilter } from "./agent-registry.js";
-import {
-  toPublicAgent,
-} from "./agent-facade.js";
+import { toPublicAgent } from "./agent-facade.js";
 import type {
   CmuxPane,
   CmuxPaneSurfaces,
@@ -146,10 +144,12 @@ const TASK_DONE_CONFIRMATION_MS = 5_000;
 const DONE_QUIESCENCE_MS = 1_500;
 const SESSION_ID_PATTERN =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-const SESSION_ID_RE =
-  new RegExp(`\\b${SESSION_ID_PATTERN}\\b`, "gi");
+const SESSION_ID_RE = new RegExp(`\\b${SESSION_ID_PATTERN}\\b`, "gi");
 const CONTEXTUAL_SESSION_ID_PATTERNS = [
-  new RegExp(`(?:codex\\s+resume|--resume(?:-id)?|resume-id)\\s+(${SESSION_ID_PATTERN})`, "i"),
+  new RegExp(
+    `(?:codex\\s+resume|--resume(?:-id)?|resume-id)\\s+(${SESSION_ID_PATTERN})`,
+    "i",
+  ),
   new RegExp(`session\\s+id:\\s*(${SESSION_ID_PATTERN})`, "i"),
   new RegExp(`chatid:\\s*(${SESSION_ID_PATTERN})`, "i"),
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
@@ -310,11 +310,7 @@ interface AgentEngineClient {
     surface: string,
     opts?: { workspace?: string; lines?: number; scrollback?: boolean },
   ): Promise<CmuxReadScreenResult>;
-  send(
-    surface: string,
-    text: string,
-    opts?: CmuxSendOptions,
-  ): Promise<void>;
+  send(surface: string, text: string, opts?: CmuxSendOptions): Promise<void>;
   sendKey(
     surface: string,
     key: string,
@@ -385,12 +381,13 @@ const LIFECYCLE_LOGS = {
  * Build the shell command that launches a CLI agent.
  * Repo name is sanitized to prevent command injection.
  *
- * For claude: uses repoGolem launchers (e.g. `voicelayerClaude -s`)
- * which handle cd, model, iTerm profile, MCP config, and contexts.
+ * For claude/codex/cursor/gemini: uses repoGolem launchers (e.g.
+ * `voicelayerClaude -s`, `golemsGemini -s`) which handle cd, model,
+ * iTerm profile, MCP config (brainlayer etc.), and contexts.
  * No `cd` prefix needed — the launcher does it.
  *
- * For gemini/kiro: uses `cd ~/Gits/<repo> && <cli>` since they
- * don't have launcher functions yet.
+ * For kiro: uses `cd ~/Gits/<repo> && kiro-cli` since it doesn't have
+ * a launcher function yet.
  */
 const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
   claude: {
@@ -451,7 +448,8 @@ export function buildLaunchCommand(
   model?: string,
   // Resolved launcher function name (from resolveLauncherName). When provided
   // for a launcher CLI it overrides the naive `${repo}${Suffix}` guess so
-  // hyphen-stripped registrations launch correctly. Ignored for gemini/kiro.
+  // hyphen-stripped registrations launch correctly. Honored for the launcher
+  // CLIs (claude/codex/cursor/gemini); ignored for kiro (raw cd+exec).
   launcherName?: string,
   opts?: { cwd?: string; envPrefix?: string },
 ): string {
@@ -468,7 +466,8 @@ export function buildLaunchCommand(
     case "codex":
       return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}`;
     case "gemini":
-      return `${cdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} gemini${rawModelArgs}`;
+      // repoGolem launcher (e.g. golemsGemini -s) wires antigravity + MCP.
+      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Gemini`} -s${launcherModelArgs}`;
     case "kiro":
       return `${cdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} kiro-cli${rawModelArgs}`;
     case "cursor":
@@ -490,7 +489,7 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
-export type LauncherSuffix = "Claude" | "Codex" | "Cursor";
+export type LauncherSuffix = "Claude" | "Codex" | "Cursor" | "Gemini";
 
 const REPO_LAUNCHER_ALIASES: Record<string, string[]> = {
   // The orchestrator checkout lives at ~/Gits/orchestrator, but the
@@ -592,7 +591,7 @@ export async function resolveLauncherName(
     `Launcher not found for repo "${repo}". Tried: ${candidates.join(", ")}. ` +
       `The repoGolem registry may strip hyphens (e.g. "agent-html-host" -> ` +
       `"agenthtmlhostCursor"). Register the launcher in golem-powers or use ` +
-      `cli="gemini"/"kiro" which use direct cd+exec paths.`,
+      `cli="kiro" which uses a direct cd+exec path.`,
   );
 }
 
@@ -676,6 +675,11 @@ export class AgentEngine {
             launcherName: await assertLauncherAvailable(params.repo, "Cursor"),
           };
         }
+        if (params.cli === "gemini") {
+          return {
+            launcherName: await assertLauncherAvailable(params.repo, "Gemini"),
+          };
+        }
       });
   }
 
@@ -739,7 +743,9 @@ export class AgentEngine {
     agent: AgentRecord,
     targetState: AgentState,
   ): Promise<boolean> {
-    return (await this.getTargetStateEvidenceSource(agent, targetState)) !== null;
+    return (
+      (await this.getTargetStateEvidenceSource(agent, targetState)) !== null
+    );
   }
 
   private async getTargetStateEvidenceSource(
@@ -749,10 +755,8 @@ export class AgentEngine {
     if (agent.state !== targetState) return null;
     if (!this.requiresOutputDoneEvidence(targetState)) return "state";
     if (this.hasGroundTruthDone(agent)) return "transcript";
-    return (
-      this.hasRecordedOutputDoneEvidence(agent) ||
+    return this.hasRecordedOutputDoneEvidence(agent) ||
       (await this.hasCurrentOutputDoneEvidence(agent))
-    )
       ? "screen"
       : null;
   }
@@ -827,7 +831,9 @@ export class AgentEngine {
               .map((agent) => agent.surface_id)
           : [],
       );
-      const parentRole = parentAgent ? inferRecordRoleOrNull(parentAgent) : null;
+      const parentRole = parentAgent
+        ? inferRecordRoleOrNull(parentAgent)
+        : null;
       const placement = chooseAgentSpawnPlacement(
         panes.panes,
         paneSurfaces,
@@ -1172,7 +1178,9 @@ export class AgentEngine {
       this.registry.set(agentId, failed);
     } catch (persistError) {
       const persistMessage =
-        persistError instanceof Error ? persistError.message : String(persistError);
+        persistError instanceof Error
+          ? persistError.message
+          : String(persistError);
       if (persistMessage.includes("Agent not found")) {
         this.registry.remove(agentId);
         await this.client.log(
@@ -1219,13 +1227,16 @@ export class AgentEngine {
         });
         this.registry.set(agent.agent_id, attempted);
 
-        const surface = await this.createAgentSurface(agent.workspace_id ?? undefined, {
-          role: inferRecordRole(agent),
-          parentAgent: agent.parent_agent_id
-            ? this.registry.get(agent.parent_agent_id)
-            : null,
-          repo: agent.repo,
-        });
+        const surface = await this.createAgentSurface(
+          agent.workspace_id ?? undefined,
+          {
+            role: inferRecordRole(agent),
+            parentAgent: agent.parent_agent_id
+              ? this.registry.get(agent.parent_agent_id)
+              : null,
+            repo: agent.repo,
+          },
+        );
         const creating = this.stateMgr.transition(agent.agent_id, "creating", {
           error: null,
           pid: null,
@@ -1314,10 +1325,7 @@ export class AgentEngine {
         sweepCtx,
       );
       const readyAgent = await this.maybeMarkBootReady(capturedAgent, sweepCtx);
-      const taskDoneResult = await this.maybeMarkTaskDone(
-        readyAgent,
-        sweepCtx,
-      );
+      const taskDoneResult = await this.maybeMarkTaskDone(readyAgent, sweepCtx);
       const agent = taskDoneResult.agent;
       const { agent_id: agentId, repo, state, surface_id } = agent;
       const statusValue =
@@ -1432,7 +1440,9 @@ export class AgentEngine {
     }
 
     // Clean up sidebar entries for agents that were purged from the registry
-    const currentAgentIds = new Set(this.registry.list().map((a) => a.agent_id));
+    const currentAgentIds = new Set(
+      this.registry.list().map((a) => a.agent_id),
+    );
     for (const [agentId, snapshot] of this.sidebarSnapshot) {
       if (!currentAgentIds.has(agentId)) {
         try {
@@ -1523,7 +1533,10 @@ export class AgentEngine {
 
   private recordSweepStability(): void {
     const signature = this.sweepStateSignature();
-    if (this.lastSweepSignature !== null && signature === this.lastSweepSignature) {
+    if (
+      this.lastSweepSignature !== null &&
+      signature === this.lastSweepSignature
+    ) {
       this.unchangedSweepCount += 1;
     } else {
       this.unchangedSweepCount = 0;
@@ -1596,7 +1609,8 @@ export class AgentEngine {
   }
 
   private async assertPostSpawnLiveness(agentId: string): Promise<void> {
-    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    const agent =
+      this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
     if (!agent || TERMINAL_STATES.has(agent.state)) {
       return;
     }
@@ -1613,7 +1627,8 @@ export class AgentEngine {
     const error = `Post-spawn liveness failed: ${reason}`;
 
     try {
-      const current = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+      const current =
+        this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
       if (current && !TERMINAL_STATES.has(current.state)) {
         const failed = this.stateMgr.transition(agentId, "error", { error });
         this.registry.set(agentId, failed);
@@ -1723,7 +1738,11 @@ export class AgentEngine {
       { cwd: params.cwd, envPrefix: params.mcp_env },
     );
     try {
-      await this.sendLaunchCommand(surface.surface, surface.workspace, launchCmd);
+      await this.sendLaunchCommand(
+        surface.surface,
+        surface.workspace,
+        launchCmd,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       try {
@@ -1790,8 +1809,7 @@ export class AgentEngine {
         matched: true,
         state: initial.state,
         elapsed: Date.now() - start,
-        source:
-          initialEvidence === "state" ? "immediate" : initialEvidence,
+        source: initialEvidence === "state" ? "immediate" : initialEvidence,
         agent: toPublicAgent(initial),
       };
     }
@@ -1966,7 +1984,11 @@ export class AgentEngine {
     const userInitiated = opts?.userInitiated ?? true;
 
     if (TERMINAL_STATES.has(agent.state)) {
-      if (agent.state === "error" && userInitiated && agent.user_killed !== true) {
+      if (
+        agent.state === "error" &&
+        userInitiated &&
+        agent.user_killed !== true
+      ) {
         const marked = this.stateMgr.updateRecord(canonicalAgentId, {
           user_killed: true,
         });

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -4,10 +4,15 @@ import { buildResumeCommand } from "./agent-command.js";
 export type AgentStatePayload = AgentRecord & { resume_command?: string };
 
 export function resumeCommandForAgent(
-  record: Pick<AgentRecord, "cli" | "repo" | "cli_session_id">,
+  record: Pick<AgentRecord, "cli" | "repo" | "cli_session_id" | "launcher_name">,
 ): string | undefined {
   return record.cli_session_id
-    ? buildResumeCommand(record.cli, record.repo, record.cli_session_id)
+    ? buildResumeCommand(
+        record.cli,
+        record.repo,
+        record.cli_session_id,
+        record.launcher_name,
+      )
     : undefined;
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -31,6 +31,7 @@ export interface AgentRecord {
   cli: CliType;
   cli_session_id: string | null;
   cli_session_path?: string | null;
+  launcher_name?: string | null;
   task_summary: string;
   pid: number | null;
   version: number;

--- a/src/format.ts
+++ b/src/format.ts
@@ -186,7 +186,7 @@ export function formatAgentState(agent: AgentRecord): string {
   if (agent.cli_session_id) {
     lines.push(`\u2502 session: ${agent.cli_session_id}`);
     lines.push(
-      `\u2502 resume: ${buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id)}`,
+      `\u2502 resume: ${buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id, agent.launcher_name)}`,
     );
   }
   if (agent.cli_session_path) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -29,14 +29,8 @@ import {
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
-import {
-  MAX_RESPAWN_ATTEMPTS,
-  type AgentRecord,
-} from "../src/agent-types.js";
-import {
-  SpawnGuard,
-  SpawnRateLimitedError,
-} from "../src/spawn-guard.js";
+import { MAX_RESPAWN_ATTEMPTS, type AgentRecord } from "../src/agent-types.js";
+import { SpawnGuard, SpawnRateLimitedError } from "../src/spawn-guard.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
@@ -347,9 +341,8 @@ describe("AgentEngine", () => {
         prompt: "Fix gap F",
       });
 
-      const [, launchCmd] = (
-        mockClient.send as ReturnType<typeof vi.fn>
-      ).mock.calls[0];
+      const [, launchCmd] = (mockClient.send as ReturnType<typeof vi.fn>).mock
+        .calls[0];
       expect(launchCmd).toBe("agenthtmlhostCursor -s");
 
       resolvingEngine.dispose();
@@ -395,7 +388,9 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
         workspace_ref: "ws:1",
         window_ref: "window:1",
         pane_ref: "pane:left",
@@ -430,7 +425,9 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
         workspace_ref: "workspace:red-team",
         window_ref: "window:1",
         pane_ref: "pane:left",
@@ -445,7 +442,9 @@ describe("AgentEngine", () => {
         workspace: "workspace:red-team",
       });
 
-      expect(mockClient.selectWorkspace).toHaveBeenCalledWith("workspace:red-team");
+      expect(mockClient.selectWorkspace).toHaveBeenCalledWith(
+        "workspace:red-team",
+      );
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
         pane: "pane:left",
         workspace: "workspace:red-team",
@@ -461,20 +460,22 @@ describe("AgentEngine", () => {
     });
 
     it("inherits the workspace whose current directory matches the target repo", async () => {
-      (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue({
-        workspaces: [
-          {
-            ref: "workspace:brainlayer",
-            title: "BrainLayer",
-            current_directory: "/Users/etanheyman/Gits/brainlayer",
-          },
-          {
-            ref: "workspace:voice",
-            title: "VoiceLayer",
-            current_directory: "/Users/etanheyman/Gits/voicelayer",
-          },
-        ],
-      });
+      (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue(
+        {
+          workspaces: [
+            {
+              ref: "workspace:brainlayer",
+              title: "BrainLayer",
+              current_directory: "/Users/etanheyman/Gits/brainlayer",
+            },
+            {
+              ref: "workspace:voice",
+              title: "VoiceLayer",
+              current_directory: "/Users/etanheyman/Gits/voicelayer",
+            },
+          ],
+        },
+      );
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
         panes: [
           {
@@ -486,7 +487,9 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
         workspace_ref: "workspace:voice",
         window_ref: "window:1",
         pane_ref: "pane:voice",
@@ -508,7 +511,9 @@ describe("AgentEngine", () => {
       });
 
       expect(result.workspace_id).toBe("workspace:voice");
-      expect(mockClient.selectWorkspace).toHaveBeenCalledWith("workspace:voice");
+      expect(mockClient.selectWorkspace).toHaveBeenCalledWith(
+        "workspace:voice",
+      );
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
         pane: "pane:voice",
         workspace: "workspace:voice",
@@ -535,17 +540,17 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
-        async ({ pane }: { pane?: string }) => ({
-          workspace_ref: "ws:1",
-          window_ref: "window:1",
-          pane_ref: pane ?? "pane:left",
-          surfaces:
-            pane === "pane:right"
-              ? [makeSurface("surface:interactive-right")]
-              : [makeSurface("surface:interactive-left")],
-        }),
-      );
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: pane ?? "pane:left",
+        surfaces:
+          pane === "pane:right"
+            ? [makeSurface("surface:interactive-right")]
+            : [makeSurface("surface:interactive-left")],
+      }));
 
       await engine.spawnAgent({
         repo: "brainlayer",
@@ -578,7 +583,10 @@ describe("AgentEngine", () => {
           surface_id: "surface:worker-2",
         }),
       );
-      liveSurfaces = [makeSurface("surface:worker-1"), makeSurface("surface:worker-2")];
+      liveSurfaces = [
+        makeSurface("surface:worker-1"),
+        makeSurface("surface:worker-2"),
+      ];
       await engine.getRegistry().reconstitute();
 
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -599,17 +607,17 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
-        async ({ pane }: { pane?: string }) => ({
-          workspace_ref: "ws:1",
-          window_ref: "window:1",
-          pane_ref: pane ?? "pane:left",
-          surfaces:
-            pane === "pane:right"
-              ? [makeSurface("surface:worker-1"), makeSurface("surface:worker-2")]
-              : [makeSurface("surface:interactive")],
-        }),
-      );
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: pane ?? "pane:left",
+        surfaces:
+          pane === "pane:right"
+            ? [makeSurface("surface:worker-1"), makeSurface("surface:worker-2")]
+            : [makeSurface("surface:interactive")],
+      }));
       (mockClient.newSurface as ReturnType<typeof vi.fn>).mockResolvedValue({
         workspace: "ws:1",
         surface: "surface:new",
@@ -655,7 +663,9 @@ describe("AgentEngine", () => {
       });
 
       expect(stateMgr.readState(result.agent_id)?.role).toBe("worker");
-      expect(stateMgr.readState(result.agent_id)?.auto_archive_on_done).toBeUndefined();
+      expect(
+        stateMgr.readState(result.agent_id)?.auto_archive_on_done,
+      ).toBeUndefined();
     });
 
     it("uses role panes created by new_split when placing spawned agents", async () => {
@@ -688,17 +698,17 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
-        async ({ pane }: { pane?: string }) => ({
-          workspace_ref: "ws:1",
-          window_ref: "window:1",
-          pane_ref: pane ?? "pane:left",
-          surfaces:
-            pane === "pane:right"
-              ? [makeSurface("surface:worker-shell")]
-              : [makeSurface("surface:orc")],
-        }),
-      );
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: pane ?? "pane:left",
+        surfaces:
+          pane === "pane:right"
+            ? [makeSurface("surface:worker-shell")]
+            : [makeSurface("surface:orc")],
+      }));
 
       await engine.spawnAgent({
         repo: "brainlayer",
@@ -754,7 +764,9 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
         workspace_ref: "ws:1",
         window_ref: "window:1",
         surfaces: [
@@ -866,17 +878,17 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockImplementation(
-        async ({ pane }: { pane?: string }) => ({
-          workspace_ref: "ws:1",
-          window_ref: "window:1",
-          pane_ref: pane ?? "pane:left",
-          surfaces:
-            pane === "pane:ic"
-              ? [makeSurface("surface:ic")]
-              : [makeSurface("surface:orc")],
-        }),
-      );
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: pane ?? "pane:left",
+        surfaces:
+          pane === "pane:ic"
+            ? [makeSurface("surface:ic")]
+            : [makeSurface("surface:orc")],
+      }));
 
       await engine.spawnAgent({
         repo: "brainlayer",
@@ -1103,7 +1115,9 @@ describe("AgentEngine", () => {
           { workspace: undefined },
         );
         expect(mockClient.setStatus).not.toHaveBeenCalled();
-        expect(engine.getAgentState("worker-archived-before-status")).toBeNull();
+        expect(
+          engine.getAgentState("worker-archived-before-status"),
+        ).toBeNull();
         expect(stateMgr.readState("worker-archived-before-status")).toBeNull();
 
         (mockClient.setStatus as ReturnType<typeof vi.fn>).mockClear();
@@ -1552,10 +1566,7 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
 
         expect(
           (mockClient.readScreen as ReturnType<typeof vi.fn>).mock.calls,
-        ).not.toContainEqual([
-          "surface:new",
-          { lines: 80, scrollback: true },
-        ]);
+        ).not.toContainEqual(["surface:new", { lines: 80, scrollback: true }]);
         expect(engine.getAgentState(result.agent_id)?.cli_session_id).toBe(
           sessionId,
         );
@@ -1584,7 +1595,9 @@ To continue this session, run codex resume ${sessionId}`,
       });
 
       const finalAgentId = "brainlayerCodex-019d9aa5";
-      expect(result.agent_id).toMatch(/^brainlayerCodex-pending-\d+-[a-z0-9]+$/);
+      expect(result.agent_id).toMatch(
+        /^brainlayerCodex-pending-\d+-[a-z0-9]+$/,
+      );
 
       await vi.advanceTimersByTimeAsync(1000);
 
@@ -1963,7 +1976,10 @@ To continue this session, run codex resume ${sessionId}`,
         (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
           surface: "surface:cursor-pending",
           text: readFileSync(
-            new URL("./fixtures/cursor-2026-06-04-task-done.txt", import.meta.url),
+            new URL(
+              "./fixtures/cursor-2026-06-04-task-done.txt",
+              import.meta.url,
+            ),
             "utf8",
           ),
           lines: 20,
@@ -2094,7 +2110,11 @@ To continue this session, run codex resume ${sessionId}`,
         });
         await engine.getRegistry().reconstitute();
 
-        const pending = engine.waitFor("worker-transcript-fresh", "done", 1_200);
+        const pending = engine.waitFor(
+          "worker-transcript-fresh",
+          "done",
+          1_200,
+        );
         await vi.advanceTimersByTimeAsync(2_000);
         const result = await pending;
 
@@ -2185,7 +2205,11 @@ To continue this session, run codex resume ${sessionId}`,
         await engine.getRegistry().reconstitute();
 
         liveSurfaces = [];
-        const pending = engine.waitFor("agent-surface-gone", "done", 25 * 60_000);
+        const pending = engine.waitFor(
+          "agent-surface-gone",
+          "done",
+          25 * 60_000,
+        );
         await vi.advanceTimersByTimeAsync(1_100);
         const result = await pending;
 
@@ -2451,14 +2475,12 @@ To continue this session, run codex resume ${sessionId}`,
 
     it("does not start a second loop while a sweep is running", async () => {
       let finishSweep: (() => void) | null = null;
-      const sweep = vi
-        .spyOn(engine, "runSweep")
-        .mockImplementation(
-          () =>
-            new Promise<void>((resolve) => {
-              finishSweep = resolve;
-            }),
-        );
+      const sweep = vi.spyOn(engine, "runSweep").mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSweep = resolve;
+          }),
+      );
 
       engine.startSweep({ activeIntervalMs: 50 });
       await vi.advanceTimersByTimeAsync(50);
@@ -2696,10 +2718,7 @@ To continue this session, run codex resume ${sessionId}`,
           boot_prompt_pending: true,
         }),
       );
-      renameSync(
-        join(TEST_DIR, agentId),
-        join(TEST_DIR, `legacy-${agentId}`),
-      );
+      renameSync(join(TEST_DIR, agentId), join(TEST_DIR, `legacy-${agentId}`));
       expect(existsSync(join(TEST_DIR, agentId, "state.json"))).toBe(false);
       liveSurfaces = [makeSurface("surface:cursor-pending")];
       await engine.getRegistry().reconstitute();
@@ -2921,16 +2940,20 @@ describe("buildLaunchCommand", () => {
     );
   });
 
-  it("uses cd + env vars + raw command for gemini", () => {
+  it("uses repoGolem launcher for gemini (no cd prefix, wires MCP)", () => {
     expect(buildLaunchCommand("gemini", "voicelayer")).toBe(
-      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini",
+      "voicelayerGemini -s",
+    );
+    expect(buildLaunchCommand("gemini", "golems")).toBe("golemsGemini -s");
+  });
+
+  it("adds safe -m model flags for the gemini launcher", () => {
+    expect(buildLaunchCommand("gemini", "voicelayer", "gemini-2.5-pro")).toBe(
+      "voicelayerGemini -s -m gemini-2.5-pro",
     );
   });
 
   it("adds safe --model flags for recognized raw CLI model aliases", () => {
-    expect(buildLaunchCommand("gemini", "voicelayer", "gemini-2.5-pro")).toBe(
-      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini --model gemini-2.5-pro",
-    );
     expect(buildLaunchCommand("kiro", "golems", "sonnet")).toBe(
       "cd ~/Gits/golems && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli --model sonnet",
     );
@@ -2967,11 +2990,20 @@ describe("buildLaunchCommand", () => {
     ).toBe("agenthtmlhostClaude -s -m sonnet");
   });
 
-  it("ignores a launcher override for non-launcher CLIs", () => {
+  it("honors an explicitly resolved launcher name for gemini", () => {
     expect(
-      buildLaunchCommand("gemini", "voicelayer", undefined, "ignoredGemini"),
-    ).toBe(
-      "cd ~/Gits/voicelayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini",
+      buildLaunchCommand(
+        "gemini",
+        "agent-html-host",
+        undefined,
+        "agenthtmlhostGemini",
+      ),
+    ).toBe("agenthtmlhostGemini -s");
+  });
+
+  it("ignores a launcher override for non-launcher CLIs (kiro)", () => {
+    expect(buildLaunchCommand("kiro", "golems", undefined, "ignoredKiro")).toBe(
+      "cd ~/Gits/golems && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli",
     );
   });
 
@@ -3013,9 +3045,15 @@ describe("buildLaunchCommand", () => {
     expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
   });
 
-  it("includes MCP_CONNECTION_NONBLOCKING=1 for non-Claude CLIs", () => {
-    const cmd = buildLaunchCommand("gemini", "voicelayer");
+  it("includes MCP_CONNECTION_NONBLOCKING=1 for raw cd+exec CLIs (kiro)", () => {
+    const cmd = buildLaunchCommand("kiro", "golems");
     expect(cmd).toContain("MCP_CONNECTION_NONBLOCKING=1");
+  });
+
+  it("does NOT include env vars for gemini (launcher handles them)", () => {
+    const cmd = buildLaunchCommand("gemini", "voicelayer");
+    expect(cmd).not.toContain("MCP_CONNECTION_NONBLOCKING");
+    expect(cmd).not.toContain("CLAUDE_CODE_NO_FLICKER");
   });
 
   it("does NOT include env vars for claude (launcher handles them)", () => {
@@ -3076,9 +3114,7 @@ describe("assertLauncherAvailable", () => {
 
     await expect(
       assertLauncherAvailable("skill-creator", "Cursor"),
-    ).rejects.toThrow(
-      /skill-creatorCursor.*skillcreatorCursor.*cli="gemini"\/"kiro"/s,
-    );
+    ).rejects.toThrow(/skill-creatorCursor.*skillcreatorCursor.*cli="kiro"/s);
   });
 });
 
@@ -3181,9 +3217,9 @@ describe("extractSessionId", () => {
     expect(
       extractSessionId(`request ${traceId}\nSession ID: ${sessionId}`),
     ).toBe(sessionId);
-    expect(
-      extractSessionId(`request ${traceId}\nchatId: ${sessionId}`),
-    ).toBe(sessionId);
+    expect(extractSessionId(`request ${traceId}\nchatId: ${sessionId}`)).toBe(
+      sessionId,
+    );
     expect(
       extractSessionId(`request ${traceId}\nResumable session: ${sessionId}`),
     ).toBe(sessionId);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3196,7 +3196,7 @@ describe("buildResumeCommand", () => {
       "brainlayerCursor -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("gemini", "brainlayer", sessionId)).toBe(
-      "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 gemini --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerGemini -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("kiro", "brainlayer", sessionId)).toBe(
       "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli chat --resume-id 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -335,7 +335,7 @@ describe("AgentEngine", () => {
         sessionIdentityResolver: () => null,
       });
 
-      await resolvingEngine.spawnAgent({
+      const result = await resolvingEngine.spawnAgent({
         repo: "agent-html-host",
         cli: "cursor",
         prompt: "Fix gap F",
@@ -344,6 +344,8 @@ describe("AgentEngine", () => {
       const [, launchCmd] = (mockClient.send as ReturnType<typeof vi.fn>).mock
         .calls[0];
       expect(launchCmd).toBe("agenthtmlhostCursor -s");
+      const state = resolvingEngine.getAgentState(result.agent_id);
+      expect(state?.launcher_name).toBe("agenthtmlhostCursor");
 
       resolvingEngine.dispose();
     });
@@ -1319,6 +1321,33 @@ describe("AgentEngine", () => {
       expect(recovered?.state).toBe("booting");
       expect(recovered?.surface_id).toBe("surface:new");
       expect(recovered?.respawn_attempts).toBe(1);
+    });
+
+    it("respawns launcher CLI agents with their resolved launcher name", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-crash",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "agent-html-host",
+          model: "gemini-2.5-pro",
+          cli: "gemini",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          launcher_name: "agenthtmlhostGemini",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        "surface:new",
+        "agenthtmlhostGemini -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        { workspace: "ws:1" },
+      );
     });
 
     it("does not respawn an errored agent the user intentionally stopped", async () => {
@@ -3197,6 +3226,16 @@ describe("buildResumeCommand", () => {
     );
     expect(buildResumeCommand("gemini", "brainlayer", sessionId)).toBe(
       "brainlayerGemini -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+    expect(
+      buildResumeCommand(
+        "gemini",
+        "agent-html-host",
+        sessionId,
+        "agenthtmlhostGemini",
+      ),
+    ).toBe(
+      "agenthtmlhostGemini -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(buildResumeCommand("kiro", "brainlayer", sessionId)).toBe(
       "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli chat --resume-id 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",


### PR DESCRIPTION
## Summary
- Route Gemini spawn commands through the repoGolem `${repo}Gemini -s` launcher so MCP/antigravity wiring comes from the launcher instead of raw `cd && gemini`.
- Route Gemini resume commands through the same repoGolem launcher path: `${repo}Gemini -s --resume <session>`.
- Update `buildResumeCommand` coverage for the resume path regression.

## Test plan
- [x] `bun run test tests/agent-engine.test.ts -t buildResumeCommand` — 1 passed, 122 skipped
- [x] `bun run test` — 46 files passed, 805 tests passed
- [x] `bun run typecheck` — exit 0
- [x] `bun run build` — exit 0
- [x] pre-push hook `run_tests.sh` — exit status 0; 805 tests passed
- [x] `coderabbit review --agent` — review_completed, findings: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawn and resume now depend on per-repo Gemini launchers being registered; misconfiguration fails at preflight instead of falling back to raw CLI, which affects MCP wiring and session continuity.
> 
> **Overview**
> **Gemini** spawn and resume no longer use `cd ~/Gits/... && gemini`; they follow the same **repoGolem launcher** pattern as Claude, Codex, and Cursor (`<repo>Gemini -s`, with `-m` for models on launch).
> 
> Spawn **preflight** now probes and requires a registered **Gemini** launcher, and **`launcher_name`** is stored on **`AgentRecord`** so resume commands, crash recovery, routes, and formatted output use the **resolved** launcher (e.g. hyphen-stripped `agenthtmlhostGemini`) instead of guessing from the repo string.
> 
> **`buildResumeCommand`** accepts an optional **`launcherName`** for launcher-based CLIs; **Kiro** stays on the raw `cd` + `kiro-cli` path. Tests cover launch/resume strings, preflight persistence, and crash-recovery resume with a stored launcher name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f628c481cedda1d7c48d32d5983fc0b0d68c9fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Gemini agents through repoGolem launchers instead of raw cd+exec
> - `buildLaunchCommand` and `buildResumeCommand` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/158/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) and [agent-command.ts](https://github.com/EtanHey/cmuxlayer/pull/158/files#diff-d26fa272a3c419f8e0ed94e8a437d2c6a56042b923263c8027937e2b4267e11d) now construct launcher-style commands for Gemini (e.g., `repoGemini -s [-m <model>]`) instead of `cd ~/Gits/<repo> && env && gemini`.
> - The `AgentEngine` preflight hook validates and captures the resolved launcher name for `cli === 'gemini'` via `assertLauncherAvailable`, storing it as `launcher_name` on the `AgentRecord`.
> - `launcher_name` is now persisted on `AgentRecord` and threaded through crash recovery, `resolveAgentRoute`, `resumeCommandForAgent`, and `formatAgentState` so all resume command surfaces reflect the correct launcher.
> - Both `buildLaunchCommand` and `buildResumeCommand` accept an optional `launcherName` override, honored for claude/codex/cursor/gemini and ignored for kiro.
> - Behavioral Change: Gemini agents now require a matching repoGolem launcher to be available at spawn time; the previous raw-exec path is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f628c48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini as a launcher-based CLI tool alongside existing tools.

* **Refactoring**
  * Updated Gemini command execution to use a standardized launcher approach, aligning with system architecture for other CLI tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->