### PR TITLE
fix: enforce cursor auto model in spawn layer

### DIFF
--- a/results/contract-spine-proposal.md
+++ b/results/contract-spine-proposal.md
@@ -1,0 +1,108 @@
+# Agent Contract Spine Proposal
+
+Status: proposal after cmux runtime hotfix
+Owner: codex-modelguard
+Date: 2026-06-18
+
+## Problem
+
+The Cursor model contract was encoded in the repoGolem shell launcher, but the
+actual cmux MCP spawn path can bypass that shell-level refusal by generating a
+launcher command with `-m/--model` before repoGolem receives control.
+
+The immediate bug was:
+
+- caller invokes `spawn_agent({ cli: "cursor", model: "sonnet" })`
+- cmuxlayer builds a Cursor launcher command with a hardcoded model flag
+- repoGolem's shell guard is in the wrong layer for this direct MCP path
+
+## Hotfix Shipped In cmuxlayer
+
+cmuxlayer now normalizes spawn models inside `AgentEngine.spawnAgent` before:
+
+- preflight
+- state persistence
+- launcher command construction
+- MCP result formatting
+
+Runtime rule:
+
+- Cursor default is always `auto`.
+- Cursor requests for Claude-family models (`sonnet`, `opus`, `haiku`,
+  `claude-*`) are coerced to `auto`.
+- Cursor requests for any other non-default model are also coerced to `auto`.
+- The only escape hatch is `REPOGOLEM_ALLOW_MODEL=1`.
+- Coercions return a loud warning in the spawn result and formatted text.
+
+This kills the recurring runtime leak tonight, including calls through
+`spawn_agent`, `new_worktree_split`, `spawn_in_workspace`, and direct
+`AgentEngine.spawnAgent` users.
+
+## Required Spine
+
+Long-term policy must live in one source of truth, not in both:
+
+- `golems/scripts/repogolem/golem-dispatch.zsh`
+- `cmuxlayer/src/model-policy.ts`
+
+Recommended home: `controllayer`, because it is the control-plane spine rather
+than a single launcher or a single MCP server.
+
+Suggested package shape:
+
+```text
+controllayer/
+  packages/agent-contract/
+    agent-contract.json
+    src/index.ts
+    bin/agent-contract
+```
+
+`agent-contract.json` is the canonical data:
+
+```json
+{
+  "version": 1,
+  "escapeEnv": "REPOGOLEM_ALLOW_MODEL",
+  "cli": {
+    "cursor": {
+      "defaultModel": "auto",
+      "allowModelOverrideByDefault": false,
+      "forbiddenModelPatterns": ["^claude-", "sonnet", "opus", "haiku"]
+    }
+  }
+}
+```
+
+Consumers:
+
+- cmuxlayer imports the TypeScript API and calls
+  `resolveSpawnModelPolicy(cli, requestedModel, env)` before building launcher
+  commands.
+- repoGolem shell calls `agent-contract resolve --cli cursor --model "$model"`
+  or reads the JSON through `jq` for the same policy decision.
+- future UI/control tools read the same policy for form defaults and validation.
+
+## Migration Plan
+
+1. Create the controllayer contract package with JSON policy plus TypeScript and
+   CLI adapters.
+2. Add unit tests in controllayer for Cursor `sonnet`, `opus`, `haiku`,
+   `claude-*`, blank, `auto`, and `REPOGOLEM_ALLOW_MODEL=1`.
+3. Update cmuxlayer to depend on the contract package instead of local
+   `src/model-policy.ts`.
+4. Update repoGolem `golem-dispatch.zsh` to call the same contract package or
+   read the same JSON, replacing duplicated shell logic.
+5. Add a drift test that fails if cmuxlayer and repoGolem do not both reference
+   the same contract version.
+
+## Tonight Scope Decision
+
+Full extraction crosses at least three repos (`controllayer`, `golems`,
+`cmuxlayer`) and requires packaging plus shell integration verification. That is
+too large for the immediate recurring-bug PR.
+
+This PR should ship the runtime cmux guard now, with this proposal as the
+tracked follow-up design. The next PR should move the exact policy from
+`cmuxlayer/src/model-policy.ts` into the controllayer spine and make repoGolem
+consume it.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -63,6 +63,11 @@ import {
   type Harness,
   type HarnessSessionWithMeta,
 } from "./harness-session.js";
+import {
+  CURSOR_DEFAULT_MODEL,
+  resolveSpawnModelPolicy,
+  type SpawnModelPolicy,
+} from "./model-policy.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -87,6 +92,10 @@ export interface SpawnAgentResult {
   surface_id: string;
   workspace_id?: string;
   state: AgentState;
+  model?: string;
+  requested_model?: string;
+  warnings?: string[];
+  model_policy?: SpawnModelPolicy;
   cwd?: string;
   mcp_env?: string;
 }
@@ -407,13 +416,6 @@ const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
     "gpt-5.5-mini": "gpt-5.5-mini",
   },
   cursor: {
-    codex: "gpt-5",
-    "gpt-5": "gpt-5",
-    "gpt-5.2-codex-high": "gpt-5.2-codex-high",
-    "gpt-5.2-codex-xhigh": "gpt-5.2-codex-xhigh",
-    sonnet: "sonnet-4",
-    "sonnet-4": "sonnet-4",
-    "sonnet-4-thinking": "sonnet-4-thinking",
   },
   gemini: {
     "gemini-2.5-pro": "gemini-2.5-pro",
@@ -428,10 +430,21 @@ const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
   },
 };
 
-function resolveModelFlag(cli: CliType, model?: string): string | null {
+function resolveModelFlag(
+  cli: CliType,
+  model?: string,
+  opts?: { allowCursorModelOverride?: boolean },
+): string | null {
   const normalized = model?.trim().toLowerCase();
   if (!normalized || !isSafeShellToken(normalized)) {
     return null;
+  }
+
+  if (cli === "cursor") {
+    if (normalized === CURSOR_DEFAULT_MODEL) {
+      return null;
+    }
+    return opts?.allowCursorModelOverride ? normalized : null;
   }
 
   const mapped = MODEL_FLAG_ALIASES[cli][normalized];
@@ -451,10 +464,12 @@ export function buildLaunchCommand(
   // hyphen-stripped registrations launch correctly. Honored for the launcher
   // CLIs (claude/codex/cursor/gemini); ignored for kiro (raw cd+exec).
   launcherName?: string,
-  opts?: { cwd?: string; envPrefix?: string },
+  opts?: { cwd?: string; envPrefix?: string; allowModelOverride?: boolean },
 ): string {
   const safeRepo = sanitizeRepoName(repo);
-  const modelFlag = resolveModelFlag(cli, model);
+  const modelFlag = resolveModelFlag(cli, model, {
+    allowCursorModelOverride: opts?.allowModelOverride,
+  });
   const launcherModelArgs = modelFlag ? ` -m ${modelFlag}` : "";
   const rawModelArgs = modelFlag ? ` --model ${modelFlag}` : "";
   const cdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
@@ -1653,22 +1668,27 @@ export class AgentEngine {
    * Does NOT wait for ready state.
    */
   async spawnAgent(params: SpawnAgentParams): Promise<SpawnAgentResult> {
-    const agentId = generateAgentId(params.cli, params.repo);
+    const modelPolicy = resolveSpawnModelPolicy(params.cli, params.model ?? "");
+    const spawnParams: SpawnAgentParams = {
+      ...params,
+      model: modelPolicy.effective_model,
+    };
+    const agentId = generateAgentId(spawnParams.cli, spawnParams.repo);
 
     // Resolve parent hierarchy
     let spawnDepth = 0;
     let parentAgentId: string | null = null;
     let parentAgent: AgentRecord | null = null;
     const role = inferAgentRole({
-      role: params.role,
-      cli: params.cli,
-      launcherName: launcherNameForCli(params.repo, params.cli),
+      role: spawnParams.role,
+      cli: spawnParams.cli,
+      launcherName: launcherNameForCli(spawnParams.repo, spawnParams.cli),
     });
 
-    if (params.parent_agent_id) {
-      const parent = this.registry.get(params.parent_agent_id);
+    if (spawnParams.parent_agent_id) {
+      const parent = this.registry.get(spawnParams.parent_agent_id);
       if (!parent) {
-        throw new Error(`Parent agent not found: ${params.parent_agent_id}`);
+        throw new Error(`Parent agent not found: ${spawnParams.parent_agent_id}`);
       }
       if (parent.spawn_depth >= MAX_SPAWN_DEPTH) {
         throw new Error(`Max spawn depth exceeded: ${MAX_SPAWN_DEPTH}`);
@@ -1682,15 +1702,15 @@ export class AgentEngine {
       parentAgent = parent;
     }
 
-    this.spawnGuard.check(params.workspace);
+    this.spawnGuard.check(spawnParams.workspace);
 
-    const preflight = await this.spawnPreflight(params);
+    const preflight = await this.spawnPreflight(spawnParams);
 
     // 1. Create cmux surface using the deterministic worker layout policy.
-    const surface = await this.createAgentSurface(params.workspace, {
+    const surface = await this.createAgentSurface(spawnParams.workspace, {
       role,
       parentAgent,
-      repo: params.repo,
+      repo: spawnParams.repo,
     });
 
     // 2. Write initial state (creating → booting)
@@ -1700,13 +1720,13 @@ export class AgentEngine {
       surface_id: surface.surface,
       workspace_id: surface.workspace,
       state: "booting",
-      repo: params.repo,
-      model: params.model,
-      cli: params.cli,
+      repo: spawnParams.repo,
+      model: spawnParams.model,
+      cli: spawnParams.cli,
       cli_session_id: null,
       cli_session_path: null,
       launcher_name: preflight?.launcherName ?? null,
-      task_summary: params.prompt,
+      task_summary: spawnParams.prompt,
       pid: null,
       version: 1,
       created_at: now,
@@ -1715,29 +1735,33 @@ export class AgentEngine {
       parent_agent_id: parentAgentId,
       spawn_depth: spawnDepth,
       role,
-      auto_archive_on_done: params.auto_archive_on_done,
+      auto_archive_on_done: spawnParams.auto_archive_on_done,
       deletion_intent: false,
       quality: "unknown",
-      max_cost_per_agent: params.max_cost_per_agent ?? null,
-      crash_recover: params.crash_recover ?? false,
+      max_cost_per_agent: spawnParams.max_cost_per_agent ?? null,
+      crash_recover: spawnParams.crash_recover ?? false,
       respawn_attempts: 0,
       user_killed: false,
-      boot_prompt_pending: params.boot_prompt_pending ?? false,
-      launch_cwd: params.cwd ?? null,
-      mcp_profile: params.mcp_profile_label ?? null,
-      worktree_path: params.cwd ?? null,
-      worktree_branch: params.worktree_branch ?? null,
+      boot_prompt_pending: spawnParams.boot_prompt_pending ?? false,
+      launch_cwd: spawnParams.cwd ?? null,
+      mcp_profile: spawnParams.mcp_profile_label ?? null,
+      worktree_path: spawnParams.cwd ?? null,
+      worktree_branch: spawnParams.worktree_branch ?? null,
     };
     this.stateMgr.writeState(record);
     this.registry.set(agentId, record);
 
     // 3. Send launch command
     const launchCmd = buildLaunchCommand(
-      params.cli,
-      params.repo,
-      params.model,
+      spawnParams.cli,
+      spawnParams.repo,
+      spawnParams.model,
       preflight?.launcherName,
-      { cwd: params.cwd, envPrefix: params.mcp_env },
+      {
+        cwd: spawnParams.cwd,
+        envPrefix: spawnParams.mcp_env,
+        allowModelOverride: modelPolicy.override_allowed,
+      },
     );
     try {
       await this.sendLaunchCommand(
@@ -1764,8 +1788,12 @@ export class AgentEngine {
       surface_id: surface.surface,
       workspace_id: surface.workspace,
       state: "booting",
-      cwd: params.cwd,
-      mcp_env: params.mcp_env,
+      model: modelPolicy.effective_model,
+      requested_model: modelPolicy.requested_model,
+      warnings: modelPolicy.warnings,
+      model_policy: modelPolicy,
+      cwd: spawnParams.cwd,
+      mcp_env: spawnParams.mcp_env,
     };
   }
 

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,0 +1,101 @@
+import type { CliType } from "./agent-types.js";
+
+export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
+export const CURSOR_DEFAULT_MODEL = "auto";
+
+export interface SpawnModelPolicy {
+  cli: CliType;
+  requested_model: string;
+  effective_model: string;
+  coerced: boolean;
+  warnings: string[];
+  override_env: typeof MODEL_OVERRIDE_ENV;
+  override_allowed: boolean;
+}
+
+function envFlagEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+export function isClaudeModelName(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.startsWith("claude-") ||
+    normalized.includes("sonnet") ||
+    normalized.includes("opus") ||
+    normalized.includes("haiku")
+  );
+}
+
+export function resolveSpawnModelPolicy(
+  cli: CliType,
+  model: string,
+  env: NodeJS.ProcessEnv = process.env,
+): SpawnModelPolicy {
+  const requestedModel = model.trim();
+  const overrideAllowed = envFlagEnabled(env[MODEL_OVERRIDE_ENV]);
+
+  if (cli !== "cursor") {
+    return {
+      cli,
+      requested_model: requestedModel,
+      effective_model: requestedModel,
+      coerced: false,
+      warnings: [],
+      override_env: MODEL_OVERRIDE_ENV,
+      override_allowed: overrideAllowed,
+    };
+  }
+
+  if (
+    overrideAllowed &&
+    requestedModel &&
+    requestedModel.toLowerCase() !== CURSOR_DEFAULT_MODEL
+  ) {
+    return {
+      cli,
+      requested_model: requestedModel,
+      effective_model: requestedModel,
+      coerced: false,
+      warnings: [],
+      override_env: MODEL_OVERRIDE_ENV,
+      override_allowed: true,
+    };
+  }
+
+  const effectiveModel = CURSOR_DEFAULT_MODEL;
+  const requestedIsDefault =
+    !requestedModel || requestedModel.toLowerCase() === CURSOR_DEFAULT_MODEL;
+
+  if (requestedIsDefault) {
+    return {
+      cli,
+      requested_model: requestedModel,
+      effective_model: effectiveModel,
+      coerced: false,
+      warnings: [],
+      override_env: MODEL_OVERRIDE_ENV,
+      override_allowed: overrideAllowed,
+    };
+  }
+
+  const family = isClaudeModelName(requestedModel)
+    ? "Claude model"
+    : "non-default model";
+  const warning =
+    `WARNING: CURSOR MODEL POLICY: requested ${family} "${requestedModel}" ` +
+    `was coerced to "${effectiveModel}". Cursor agents must use Cursor Auto ` +
+    `unless ${MODEL_OVERRIDE_ENV}=1 is set.`;
+
+  return {
+    cli,
+    requested_model: requestedModel,
+    effective_model: effectiveModel,
+    coerced: true,
+    warnings: [warning],
+    override_env: MODEL_OVERRIDE_ENV,
+    override_allowed: false,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3727,7 +3727,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("spawn_agent", {
               agent_id: result.agent_id,
               repo: args.repo,
-              model: args.model,
+              model: result.model ?? args.model,
+              requested_model:
+                result.requested_model && result.requested_model !== result.model
+                  ? result.requested_model
+                  : undefined,
+              warning:
+                result.warnings && result.warnings.length > 0
+                  ? result.warnings.join(" | ")
+                  : undefined,
               surface: result.surface_id,
               role:
                 engine.getAgentState(result.agent_id)?.role ??
@@ -3845,6 +3853,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("new_worktree_split", {
               agent_id: result.agent_id,
               surface: result.surface_id,
+              model: result.model ?? args.model,
+              requested_model:
+                result.requested_model && result.requested_model !== result.model
+                  ? result.requested_model
+                  : undefined,
+              warning:
+                result.warnings && result.warnings.length > 0
+                  ? result.warnings.join(" | ")
+                  : undefined,
               worktree: worktree.prepared?.path ?? "",
               mcp_profile: worktree.mcpProfileLabel ?? "inherit",
             }),
@@ -3911,7 +3928,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface_id: string;
             repo: string;
             cli: CliType;
+            model?: string;
+            requested_model?: string;
+            warnings?: string[];
           }> = [];
+          const warnings: string[] = [];
 
           for (const agent of args.agents) {
             const hasPrompt = hasInlinePrompt(agent.prompt);
@@ -3958,7 +3979,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               surface_id: result.surface_id,
               repo: agent.repo,
               cli: agent.cli,
+              model: result.model,
+              requested_model: result.requested_model,
+              warnings: result.warnings,
             });
+            warnings.push(...(result.warnings ?? []));
           }
 
           const lastSurface =
@@ -3969,11 +3994,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("spawn_in_workspace", {
               workspace,
               agents: spawnedAgents.length,
+              warning:
+                warnings.length > 0 ? warnings.join(" | ") : undefined,
             }),
             {
               workspace,
               title: workspaceResult.title,
               agents: spawnedAgents,
+              warnings,
             },
           );
         } catch (e) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -242,6 +242,92 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).toHaveBeenCalled();
     });
 
+    it("coerces cursor Claude model requests to auto before launch", async () => {
+      const previousAllow = process.env.REPOGOLEM_ALLOW_MODEL;
+      delete process.env.REPOGOLEM_ALLOW_MODEL;
+
+      try {
+        const result = await engine.spawnAgent({
+          repo: "cmuxlayer",
+          model: "sonnet",
+          cli: "cursor",
+          prompt: "Fix cursor model policy",
+        });
+
+        expect(result.model).toBe("auto");
+        expect(result.requested_model).toBe("sonnet");
+        expect(result.warnings?.[0]).toContain("WARNING: CURSOR MODEL POLICY");
+        expect(result.warnings?.[0]).toContain("sonnet");
+        expect(result.warnings?.[0]).toContain("auto");
+        expect(mockClient.send).toHaveBeenCalledWith(
+          "surface:new",
+          "cmuxlayerCursor -s",
+          { workspace: "ws:1" },
+        );
+
+        const state = stateMgr.readState(result.agent_id);
+        expect(state?.model).toBe("auto");
+      } finally {
+        if (previousAllow === undefined) delete process.env.REPOGOLEM_ALLOW_MODEL;
+        else process.env.REPOGOLEM_ALLOW_MODEL = previousAllow;
+      }
+    });
+
+    it("allows cursor model overrides only with REPOGOLEM_ALLOW_MODEL", async () => {
+      const previousAllow = process.env.REPOGOLEM_ALLOW_MODEL;
+      process.env.REPOGOLEM_ALLOW_MODEL = "1";
+
+      try {
+        const result = await engine.spawnAgent({
+          repo: "cmuxlayer",
+          model: "sonnet",
+          cli: "cursor",
+          prompt: "Explicit override",
+        });
+
+        expect(result.model).toBe("sonnet");
+        expect(result.requested_model).toBe("sonnet");
+        expect(result.warnings).toEqual([]);
+        expect(mockClient.send).toHaveBeenCalledWith(
+          "surface:new",
+          "cmuxlayerCursor -s -m sonnet",
+          { workspace: "ws:1" },
+        );
+
+        const state = stateMgr.readState(result.agent_id);
+        expect(state?.model).toBe("sonnet");
+      } finally {
+        if (previousAllow === undefined) delete process.env.REPOGOLEM_ALLOW_MODEL;
+        else process.env.REPOGOLEM_ALLOW_MODEL = previousAllow;
+      }
+    });
+
+    it("coerces any cursor non-auto model without the override env", async () => {
+      const previousAllow = process.env.REPOGOLEM_ALLOW_MODEL;
+      delete process.env.REPOGOLEM_ALLOW_MODEL;
+
+      try {
+        const result = await engine.spawnAgent({
+          repo: "cmuxlayer",
+          model: "gpt-5",
+          cli: "cursor",
+          prompt: "Non-default override",
+        });
+
+        expect(result.model).toBe("auto");
+        expect(result.requested_model).toBe("gpt-5");
+        expect(result.warnings?.[0]).toContain("non-default model");
+        expect(mockClient.send).toHaveBeenCalledWith(
+          "surface:new",
+          "cmuxlayerCursor -s",
+          { workspace: "ws:1" },
+        );
+      } finally {
+        if (previousAllow === undefined) delete process.env.REPOGOLEM_ALLOW_MODEL;
+        else process.env.REPOGOLEM_ALLOW_MODEL = previousAllow;
+      }
+    });
+
     it("marks a post-launch disappeared surface as error and attempts cleanup", async () => {
       vi.useFakeTimers();
       try {
@@ -2946,9 +3032,17 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("codex", "brainlayer", "codex")).toBe(
       "brainlayerCodex -s",
     );
+  });
+
+  it("omits cursor model flags unless the explicit override is allowed", () => {
     expect(buildLaunchCommand("cursor", "cmuxlayer", "sonnet")).toBe(
-      "cmuxlayerCursor -s -m sonnet-4",
+      "cmuxlayerCursor -s",
     );
+    expect(
+      buildLaunchCommand("cursor", "cmuxlayer", "sonnet", undefined, {
+        allowModelOverride: true,
+      }),
+    ).toBe("cmuxlayerCursor -s -m sonnet");
   });
 
   it("preserves launcher defaults when model is omitted", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -254,6 +254,51 @@ describe("agent lifecycle tool handlers", () => {
     expect(persisted.auto_archive_on_done).toBe(true);
   });
 
+  it("spawn_agent coerces cursor Claude model requests to auto with a loud warning", async () => {
+    const previousAllow = process.env.REPOGOLEM_ALLOW_MODEL;
+    delete process.env.REPOGOLEM_ALLOW_MODEL;
+
+    try {
+      const server = createLifecycleServer(mockExec);
+      const tool = (server as any)._registeredTools["spawn_agent"];
+
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "sonnet",
+          cli: "cursor",
+        },
+        {} as any,
+      );
+
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.model).toBe("auto");
+      expect(parsed.requested_model).toBe("sonnet");
+      expect(parsed.warnings[0]).toContain("WARNING: CURSOR MODEL POLICY");
+      expect(parsed.warnings[0]).toContain("sonnet");
+      expect(parsed.warnings[0]).toContain("auto");
+      expect(result.content[0].text).toContain("WARNING: CURSOR MODEL POLICY");
+      expect(mockExec).toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["send", "cmuxlayerCursor -s"]),
+      );
+
+      const stateTool = (server as any)._registeredTools["get_agent_state"];
+      const stateResult = await stateTool.handler(
+        { agent_id: parsed.agent_id },
+        {} as any,
+      );
+      const persisted =
+        stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+      expect(persisted.model).toBe("auto");
+    } finally {
+      if (previousAllow === undefined) delete process.env.REPOGOLEM_ALLOW_MODEL;
+      else process.env.REPOGOLEM_ALLOW_MODEL = previousAllow;
+    }
+  });
+
   it("spawn_agent accepts explicit role and returns persisted role", async () => {
     const server = createLifecycleServer(mockExec);
     const tool = (server as any)._registeredTools["spawn_agent"];


### PR DESCRIPTION
## Summary
- Add a cmuxlayer spawn model policy so Cursor spawns default to `auto` and coerce Claude-family/non-default model requests unless `REPOGOLEM_ALLOW_MODEL=1` is set.
- Apply the effective model before preflight, state persistence, and launcher command construction, and surface loud warnings in spawn results.
- Remove hardcoded Cursor model aliasing from `buildLaunchCommand`; explicit override mode now passes the caller's exact safe token.
- Add `results/contract-spine-proposal.md` for the follow-up shared agent-contract spine across controllayer/repoGolem/cmuxlayer.

## Test plan
- [x] Red confirmed: `spawn_agent` Cursor+`sonnet` test initially failed with missing `model: auto`.
- [x] `timeout 180 coderabbit review --agent` completed with 1 minor finding, fixed in `new_worktree_split` model fallback.
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test tests/agent-engine.test.ts tests/server-agent-tools.test.ts tests/spawn-agent-preflight.test.ts` (175 passed)
- [x] `bun run test` (46 files, 811 passed)
- [x] Push hook reran `scripts/run_tests.sh` successfully, including full Vitest suite and regression replay tests.

## Runtime verification note
This touches MCP/spawn runtime code. The pr-loop daemon gate asks for a fresh Claude Code client session, but this task is explicitly CODEX ONLY due Claude usage limits. I did not launch Claude. Local MCP handler/engine integration tests and the repository push hook passed; orc should decide whether to run any additional live client verification before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP spawn runtime behavior and persisted agent model fields for all Cursor spawns; incorrect policy could block intended models or still leak wrong flags, though behavior is covered by engine and server tests.
> 
> **Overview**
> **Cursor spawns through cmux MCP no longer bypass repoGolem’s model contract** by injecting `-m` on the launcher. A new **`model-policy`** module resolves spawn model policy before preflight, persisted state, and launch command construction.
> 
> For **Cursor**, the effective model is **`auto`** unless **`REPOGOLEM_ALLOW_MODEL=1`**. Claude-family and other non-default requests are **coerced to `auto`** with explicit warnings on spawn results. **`buildLaunchCommand`** drops hardcoded Cursor aliases and only adds `-m` when override is allowed. MCP handlers for **`spawn_agent`**, **`new_worktree_split`**, and **`spawn_in_workspace`** return **`model`**, **`requested_model`**, and **`warning`** fields.
> 
> Adds **`results/contract-spine-proposal.md`** describing a follow-up shared **agent-contract** spine in controllayer (not implemented here). Tests cover coercion, override env, and server tool formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6965bfddb14610cec0423cdb1c5ab0387569db71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce cursor model coercion to 'auto' in agent spawn layer
> - Adds [`resolveSpawnModelPolicy`](https://github.com/EtanHey/cmuxlayer/pull/159/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d) to centralize cursor model policy: any non-`auto` model request is coerced to `auto` unless the `REPOGOLEM_ALLOW_MODEL` env var is set.
> - Removes cursor-specific model flag aliases from `MODEL_FLAG_ALIASES` and gates cursor `-m` flag inclusion in `buildLaunchCommand` behind a new `allowModelOverride` option.
> - `AgentEngine.spawnAgent` now applies the policy at spawn time and returns `effective_model`, `requested_model`, warnings, and `model_policy` in its result.
> - Server tool handlers (`spawn_agent`, `new_worktree_split`, `spawn_in_workspace`) surface policy warnings and effective model in formatted responses.
> - Behavioral Change: cursor spawns silently use `auto` by default; any model override requires explicitly setting `REPOGOLEM_ALLOW_MODEL`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6965bfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->