### PR TITLE
fix: align Gemini pro launcher alias

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -436,8 +436,13 @@ function resolveModelFlag(cli: CliType, model?: string): string | null {
     return null;
   }
 
-  const mapped = MODEL_FLAG_ALIASES[cli][normalized];
-  if (!mapped) {
+  const aliases = MODEL_FLAG_ALIASES[cli];
+  if (!Object.prototype.hasOwnProperty.call(aliases, normalized)) {
+    return null;
+  }
+
+  const mapped = aliases[normalized];
+  if (typeof mapped !== "string" || !mapped) {
     return null;
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -416,6 +416,8 @@ const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
     "sonnet-4-thinking": "sonnet-4-thinking",
   },
   gemini: {
+    pro: "Gemini 3.1 Pro (High)",
+    "pro-high": "Gemini 3.1 Pro (High)",
     "gemini-2.5-pro": "gemini-2.5-pro",
     "gemini-2.5-flash": "gemini-2.5-flash",
     "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
@@ -430,16 +432,20 @@ const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
 
 function resolveModelFlag(cli: CliType, model?: string): string | null {
   const normalized = model?.trim().toLowerCase();
-  if (!normalized || !isSafeShellToken(normalized)) {
+  if (!normalized) {
     return null;
   }
 
   const mapped = MODEL_FLAG_ALIASES[cli][normalized];
-  if (!mapped || !isSafeShellToken(mapped)) {
+  if (!mapped) {
     return null;
   }
 
   return mapped;
+}
+
+function formatModelArg(modelFlag: string): string {
+  return isSafeShellToken(modelFlag) ? modelFlag : shellQuote(modelFlag);
 }
 
 export function buildLaunchCommand(
@@ -455,8 +461,11 @@ export function buildLaunchCommand(
 ): string {
   const safeRepo = sanitizeRepoName(repo);
   const modelFlag = resolveModelFlag(cli, model);
-  const launcherModelArgs = modelFlag ? ` -m ${modelFlag}` : "";
-  const rawModelArgs = modelFlag ? ` --model ${modelFlag}` : "";
+  const formattedModelFlag = modelFlag ? formatModelArg(modelFlag) : null;
+  const launcherModelArgs = formattedModelFlag ? ` -m ${formattedModelFlag}` : "";
+  const rawModelArgs = formattedModelFlag
+    ? ` --model ${formattedModelFlag}`
+    : "";
   const launcherWorktreeArg = opts?.cwd ? ` -w ${shellQuote(opts.cwd)}` : "";
   const rawCdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const envPrefix = opts?.envPrefix ? `${opts.envPrefix} ` : "";

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3033,6 +3033,9 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("codex", "brainlayer", "codex;rm-rf")).toBe(
       "brainlayerCodex -s",
     );
+    expect(buildLaunchCommand("gemini", "golems", "constructor")).toBe(
+      "golemsGemini -s",
+    );
   });
 
   it("uses repoGolem launcher for gemini (no cd prefix, wires MCP)", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3046,6 +3046,9 @@ describe("buildLaunchCommand", () => {
     expect(buildLaunchCommand("gemini", "voicelayer", "gemini-2.5-pro")).toBe(
       "voicelayerGemini -s -m gemini-2.5-pro",
     );
+    expect(buildLaunchCommand("gemini", "golems", "pro")).toBe(
+      "golemsGemini -s -m 'Gemini 3.1 Pro (High)'",
+    );
   });
 
   it("adds safe --model flags for recognized raw CLI model aliases", () => {


### PR DESCRIPTION
## Summary
- Maps Gemini `pro` and `pro-high` launch aliases to repoGolem's current Antigravity default model string: `Gemini 3.1 Pro (High)`.
- Quotes non-token model strings when building launcher commands, while preserving existing safe-token flags such as `gemini-2.5-pro`.

## TDD / Verification
- RED: `bun run test tests/agent-engine.test.ts` failed as expected with `1 failed | 123 passed`; failure: expected `golemsGemini -s -m 'Gemini 3.1 Pro (High)'`, received `golemsGemini -s`.
- GREEN: `bun run test tests/agent-engine.test.ts` passed: `Test Files  1 passed (1)`, `Tests  124 passed (124)`.
- Typecheck: `bun run typecheck` exited 0 with `tsc -p tsconfig.json --noEmit`.
- Pre-commit CodeRabbit: `findings: 0`.
- Push hook/full suite: `Test Files  46 passed (46)`, `Tests  806 passed (806)`, `run_tests.sh finished with exit status 0`.

## Notes
- Source of truth checked: `/Users/etanheyman/Gits/golems/scripts/repogolem/golem-dispatch.zsh` maps `pro|pro-high` to `Gemini 3.1 Pro (High)`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how spawn launch shell commands are built; risk is mitigated by whitelist-only aliases and quoting for non-token mapped values.
> 
> **Overview**
> **Gemini `pro` / `pro-high`** now map to repoGolem’s **`Gemini 3.1 Pro (High)`** string and show up on launcher commands as **`-m 'Gemini 3.1 Pro (High)'`** instead of being dropped.
> 
> **Model flag handling** in `buildLaunchCommand` / `resolveModelFlag` is tightened: alias lookup uses **`hasOwnProperty`** so inputs like **`constructor`** are ignored, and a new **`formatModelArg`** **shell-quotes** mapped values that aren’t simple tokens while leaving safe aliases (e.g. `gemini-2.5-pro`) unquoted. Unrecognized or unsafe *user* model strings are still omitted with no `-m` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930a52d3a3ab408b1f9f77ddebf28de874bf34a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Gemini `pro` and `pro-high` model aliases to pass shell-quoted model flags
> - Adds `pro` and `pro-high` entries to `MODEL_FLAG_ALIASES` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/160/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5), both mapping to `'Gemini 3.1 Pro (High)'`.
> - Extracts a new `formatModelArg` function that shell-quotes model flags containing spaces or special characters, replacing the previous approach of omitting them when `isSafeShellToken` failed.
> - `resolveModelFlag` now only checks alias presence (no `isSafeShellToken` gate), returning `null` for unrecognized inputs including prototype-inherited keys like `'constructor'`.
> - Behavioral Change: recognized aliases whose mapped value is not a safe shell token (e.g. `'Gemini 3.1 Pro (High)'`) now produce a `-m`/`--model` argument with a quoted value instead of being silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 930a52d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Gemini model alias support to include "pro" and "pro-high" shortcuts, mapping to the Gemini 3.1 Pro (High) model

* **Improvements**
  * Enhanced model parameter safety in command execution with improved shell argument escaping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->