### PR TITLE
fix: pass worktree cwd to launchers

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -899,6 +899,10 @@ export class AgentEngine {
   }
 
   private harnessCwdForAgent(agent: AgentRecord): string {
+    const launchCwd = agent.launch_cwd?.trim();
+    if (launchCwd) return launchCwd;
+    const worktreePath = agent.worktree_path?.trim();
+    if (worktreePath) return worktreePath;
     return join(homedir(), "Gits", agent.repo);
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -457,22 +457,23 @@ export function buildLaunchCommand(
   const modelFlag = resolveModelFlag(cli, model);
   const launcherModelArgs = modelFlag ? ` -m ${modelFlag}` : "";
   const rawModelArgs = modelFlag ? ` --model ${modelFlag}` : "";
-  const cdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
+  const launcherWorktreeArg = opts?.cwd ? ` -w ${shellQuote(opts.cwd)}` : "";
+  const rawCdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const envPrefix = opts?.envPrefix ? `${opts.envPrefix} ` : "";
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry
-      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Claude`} -s${launcherModelArgs}`;
+      return `${envPrefix}${launcherName ?? `${safeRepo}Claude`} -s${launcherModelArgs}${launcherWorktreeArg}`;
     case "codex":
-      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}`;
+      return `${envPrefix}${launcherName ?? `${safeRepo}Codex`} -s${launcherModelArgs}${launcherWorktreeArg}`;
     case "gemini":
       // repoGolem launcher (e.g. golemsGemini -s) wires antigravity + MCP.
-      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Gemini`} -s${launcherModelArgs}`;
+      return `${envPrefix}${launcherName ?? `${safeRepo}Gemini`} -s${launcherModelArgs}${launcherWorktreeArg}`;
     case "kiro":
-      return `${cdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} kiro-cli${rawModelArgs}`;
+      return `${rawCdPrefix || `cd ~/Gits/${safeRepo} && `}${envPrefix}${AGENT_ENV} kiro-cli${rawModelArgs}`;
     case "cursor":
       // repoGolem launcher - requires registration via golem-powers.
-      return `${cdPrefix}${envPrefix}${launcherName ?? `${safeRepo}Cursor`} -s${launcherModelArgs}`;
+      return `${envPrefix}${launcherName ?? `${safeRepo}Cursor`} -s${launcherModelArgs}${launcherWorktreeArg}`;
   }
 }
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1684,6 +1684,72 @@ To continue this session, run codex resume ${sessionId}`,
         "brainlayerCodex-019e942c",
       );
     });
+
+    it("uses the saved launch cwd when capturing worktree transcript sessions", async () => {
+      vi.setSystemTime(new Date("2026-06-19T05:00:30.000Z"));
+      const home = join(TEST_DIR, "home");
+      const worktreeCwd = join(
+        TEST_DIR,
+        "Gits",
+        "cmuxlayer.wt",
+        "skill-eval",
+      );
+      const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+      const sessionDir = join(home, ".codex", "sessions", "2026", "06", "19");
+      const sessionPath = join(sessionDir, "rollout-worktree.jsonl");
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        sessionPath,
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: sessionId,
+            cwd: worktreeCwd,
+          },
+        }),
+      );
+
+      vi.stubEnv("HOME", home);
+      try {
+        engine.dispose();
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        engine = new AgentEngine(stateMgr, registry, mockClient, {
+          spawnPreflight: async () => {},
+        });
+        liveSurfaces = [makeSurface("surface:new")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:new",
+          text: "codex> ",
+          lines: 80,
+          scrollback_used: true,
+        });
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-pending-worktree",
+            repo: "cmuxlayer",
+            model: "gpt-5.4",
+            cli: "codex",
+            surface_id: "surface:new",
+            state: "booting",
+            created_at: "2026-06-19T05:00:00.000Z",
+            updated_at: "2026-06-19T05:00:00.000Z",
+            launch_cwd: worktreeCwd,
+            worktree_path: worktreeCwd,
+          }),
+        );
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(engine.getAgentState("cmuxlayerCodex-019e942c")).toMatchObject({
+          agent_id: "cmuxlayerCodex-019e942c",
+          cli_session_id: sessionId,
+          cli_session_path: sessionPath,
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
   });
 
   describe("waitFor", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3000,6 +3000,40 @@ describe("buildLaunchCommand", () => {
     );
   });
 
+  it("passes cwd as -w to launcher CLIs while keeping kiro on cd", () => {
+    const cwd = "/Users/x/Gits/golems.wt/t";
+
+    expect(
+      buildLaunchCommand("claude", "golems", undefined, undefined, { cwd }),
+    ).toBe("golemsClaude -s -w '/Users/x/Gits/golems.wt/t'");
+    expect(
+      buildLaunchCommand("codex", "golems", undefined, undefined, { cwd }),
+    ).toBe("golemsCodex -s -w '/Users/x/Gits/golems.wt/t'");
+    expect(
+      buildLaunchCommand("cursor", "golems", undefined, undefined, { cwd }),
+    ).toBe("golemsCursor -s -w '/Users/x/Gits/golems.wt/t'");
+    expect(
+      buildLaunchCommand("gemini", "golems", undefined, undefined, { cwd }),
+    ).toBe("golemsGemini -s -w '/Users/x/Gits/golems.wt/t'");
+    expect(
+      buildLaunchCommand("claude", "golems", "sonnet", undefined, {
+        cwd: "/p/wt",
+      }),
+    ).toBe("golemsClaude -s -m sonnet -w '/p/wt'");
+    expect(
+      buildLaunchCommand("kiro", "golems", undefined, undefined, {
+        cwd: "/p/wt",
+      }),
+    ).toBe(
+      "cd '/p/wt' && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli",
+    );
+    expect(
+      buildLaunchCommand("claude", "golems", undefined, undefined, {
+        cwd: "/Users/x/Gits/worktree launch",
+      }),
+    ).toBe("golemsClaude -s -w '/Users/x/Gits/worktree launch'");
+  });
+
   it("uses an explicitly resolved launcher name for launcher CLIs", () => {
     expect(
       buildLaunchCommand(

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -434,7 +434,7 @@ describe("agent lifecycle tool handlers", () => {
         "send",
         "--surface",
         "surface:new",
-        `cd '${worktreePath}' && CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s`,
+        `CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
   });
@@ -483,7 +483,7 @@ describe("agent lifecycle tool handlers", () => {
         "send",
         "--surface",
         "surface:new",
-        `cd '${worktreePath}' && CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s`,
+        `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- Pass `opts.cwd` to repoGolem launcher CLIs as `-w <cwd>` instead of prefixing launcher commands with `cd <cwd> &&`.
- Preserve raw `cd` launch behavior for `kiro`, which does not use a repoGolem launcher.
- Update worktree launch tests and server-agent command expectations for the new `-w` contract.

## Test plan
- RED: `bun run test tests/agent-engine.test.ts` failed before implementation with expected `golemsClaude -s -w '/Users/x/Gits/golems.wt/t'` but received `cd '/Users/x/Gits/golems.wt/t' && golemsClaude -s`.
- GREEN: `bun run test tests/agent-engine.test.ts` passed: `Test Files  1 passed (1)` and `Tests  125 passed (125)`.
- `bun run typecheck` passed: `$ tsc -p tsconfig.json --noEmit` exited 0 with no diagnostics.
- Push hook full suite passed: `Test Files  46 passed (46)` and `Tests  807 passed (807)`.
- Local CodeRabbit gate: `review_completed`, `findings: 0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the launch contract for all worktree-backed agent spawns and session-id capture; misaligned launcher `-w` support would break worktree launches or leave agents on the wrong cwd.
> 
> **Overview**
> Worktree spawns for **claude/codex/cursor/gemini** no longer prefix launcher commands with `cd '<path>' &&`; the working directory is passed as **`-w '<path>'`** on the repoGolem launcher (model flags and MCP env prefixes unchanged). **kiro** still uses a `cd` prefix when `opts.cwd` is set.
> 
> Boot-time transcript session lookup now resolves harness CWD from **`launch_cwd`**, then **`worktree_path`**, before falling back to `~/Gits/<repo>`, so Codex sessions started in a worktree can be matched and finalized during sweep.
> 
> Tests and server-agent tool expectations were updated for the new launch string shape and for worktree transcript capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a782c347b71df6eafb15fee068ba7460696f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass worktree cwd as `-w` flag to launcher CLIs instead of `cd` prefix
> - Changes `buildLaunchCommand` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/161/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to pass `-w <cwd>` to claude, codex, gemini, and cursor launchers instead of prepending `cd <cwd> &&`; kiro continues to use the `cd` prefix.
> - Updates `AgentEngine.harnessCwdForAgent` to return `agent.launch_cwd` if set, then `agent.worktree_path`, falling back to the previous homedir-based path.
> - Behavioral Change: launcher commands no longer start with a shell `cd` for most launchers; any tooling that parses the raw command string will see a different format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06a782c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->