### PR TITLE
feat: centralize spawn model policy

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -63,10 +63,15 @@ import {
   type Harness,
   type HarnessSessionWithMeta,
 } from "./harness-session.js";
+import {
+  resolveLaunchModelFlag,
+  resolveSpawnModelPolicy,
+  type SpawnModelPolicy,
+} from "./model-policy.js";
 
 export interface SpawnAgentParams {
   repo: string;
-  model: string;
+  model?: string;
   cli: CliType;
   prompt: string;
   boot_prompt_pending?: boolean;
@@ -87,6 +92,10 @@ export interface SpawnAgentResult {
   surface_id: string;
   workspace_id?: string;
   state: AgentState;
+  model?: string;
+  requested_model?: string;
+  warnings?: string[];
+  model_policy?: SpawnModelPolicy;
   cwd?: string;
   mcp_env?: string;
 }
@@ -389,66 +398,6 @@ const LIFECYCLE_LOGS = {
  * For kiro: uses `cd ~/Gits/<repo> && kiro-cli` since it doesn't have
  * a launcher function yet.
  */
-const MODEL_FLAG_ALIASES: Record<CliType, Record<string, string>> = {
-  claude: {
-    opus: "opus",
-    sonnet: "sonnet",
-    haiku: "haiku",
-  },
-  codex: {
-    "gpt-5": "gpt-5",
-    "gpt-5-codex": "gpt-5-codex",
-    "gpt-5.3": "gpt-5.3",
-    "gpt-5.3-codex": "gpt-5.3-codex",
-    "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
-    "gpt-5.4": "gpt-5.4",
-    "gpt-5.4-mini": "gpt-5.4-mini",
-    "gpt-5.5": "gpt-5.5",
-    "gpt-5.5-mini": "gpt-5.5-mini",
-  },
-  cursor: {
-    codex: "gpt-5",
-    "gpt-5": "gpt-5",
-    "gpt-5.2-codex-high": "gpt-5.2-codex-high",
-    "gpt-5.2-codex-xhigh": "gpt-5.2-codex-xhigh",
-    sonnet: "sonnet-4",
-    "sonnet-4": "sonnet-4",
-    "sonnet-4-thinking": "sonnet-4-thinking",
-  },
-  gemini: {
-    pro: "Gemini 3.1 Pro (High)",
-    "pro-high": "Gemini 3.1 Pro (High)",
-    "gemini-2.5-pro": "gemini-2.5-pro",
-    "gemini-2.5-flash": "gemini-2.5-flash",
-    "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-    "gemini-3.1-pro": "gemini-3.1-pro",
-  },
-  kiro: {
-    opus: "opus",
-    sonnet: "sonnet",
-    haiku: "haiku",
-  },
-};
-
-function resolveModelFlag(cli: CliType, model?: string): string | null {
-  const normalized = model?.trim().toLowerCase();
-  if (!normalized) {
-    return null;
-  }
-
-  const aliases = MODEL_FLAG_ALIASES[cli];
-  if (!Object.prototype.hasOwnProperty.call(aliases, normalized)) {
-    return null;
-  }
-
-  const mapped = aliases[normalized];
-  if (typeof mapped !== "string" || !mapped) {
-    return null;
-  }
-
-  return mapped;
-}
-
 function formatModelArg(modelFlag: string): string {
   return isSafeShellToken(modelFlag) ? modelFlag : shellQuote(modelFlag);
 }
@@ -462,10 +411,12 @@ export function buildLaunchCommand(
   // hyphen-stripped registrations launch correctly. Honored for the launcher
   // CLIs (claude/codex/cursor/gemini); ignored for kiro (raw cd+exec).
   launcherName?: string,
-  opts?: { cwd?: string; envPrefix?: string },
+  opts?: { cwd?: string; envPrefix?: string; allowModelOverride?: boolean },
 ): string {
   const safeRepo = sanitizeRepoName(repo);
-  const modelFlag = resolveModelFlag(cli, model);
+  const modelFlag = resolveLaunchModelFlag(cli, model, {
+    allowModelOverride: opts?.allowModelOverride,
+  });
   const formattedModelFlag = modelFlag ? formatModelArg(modelFlag) : null;
   const launcherModelArgs = formattedModelFlag ? ` -m ${formattedModelFlag}` : "";
   const rawModelArgs = formattedModelFlag
@@ -1672,22 +1623,27 @@ export class AgentEngine {
    * Does NOT wait for ready state.
    */
   async spawnAgent(params: SpawnAgentParams): Promise<SpawnAgentResult> {
-    const agentId = generateAgentId(params.cli, params.repo);
+    const modelPolicy = resolveSpawnModelPolicy(params.cli, params.model);
+    const spawnParams: SpawnAgentParams = {
+      ...params,
+      model: modelPolicy.effective_model,
+    };
+    const agentId = generateAgentId(spawnParams.cli, spawnParams.repo);
 
     // Resolve parent hierarchy
     let spawnDepth = 0;
     let parentAgentId: string | null = null;
     let parentAgent: AgentRecord | null = null;
     const role = inferAgentRole({
-      role: params.role,
-      cli: params.cli,
-      launcherName: launcherNameForCli(params.repo, params.cli),
+      role: spawnParams.role,
+      cli: spawnParams.cli,
+      launcherName: launcherNameForCli(spawnParams.repo, spawnParams.cli),
     });
 
-    if (params.parent_agent_id) {
-      const parent = this.registry.get(params.parent_agent_id);
+    if (spawnParams.parent_agent_id) {
+      const parent = this.registry.get(spawnParams.parent_agent_id);
       if (!parent) {
-        throw new Error(`Parent agent not found: ${params.parent_agent_id}`);
+        throw new Error(`Parent agent not found: ${spawnParams.parent_agent_id}`);
       }
       if (parent.spawn_depth >= MAX_SPAWN_DEPTH) {
         throw new Error(`Max spawn depth exceeded: ${MAX_SPAWN_DEPTH}`);
@@ -1701,15 +1657,15 @@ export class AgentEngine {
       parentAgent = parent;
     }
 
-    this.spawnGuard.check(params.workspace);
+    this.spawnGuard.check(spawnParams.workspace);
 
-    const preflight = await this.spawnPreflight(params);
+    const preflight = await this.spawnPreflight(spawnParams);
 
     // 1. Create cmux surface using the deterministic worker layout policy.
-    const surface = await this.createAgentSurface(params.workspace, {
+    const surface = await this.createAgentSurface(spawnParams.workspace, {
       role,
       parentAgent,
-      repo: params.repo,
+      repo: spawnParams.repo,
     });
 
     // 2. Write initial state (creating → booting)
@@ -1719,13 +1675,13 @@ export class AgentEngine {
       surface_id: surface.surface,
       workspace_id: surface.workspace,
       state: "booting",
-      repo: params.repo,
-      model: params.model,
-      cli: params.cli,
+      repo: spawnParams.repo,
+      model: spawnParams.model ?? modelPolicy.effective_model,
+      cli: spawnParams.cli,
       cli_session_id: null,
       cli_session_path: null,
       launcher_name: preflight?.launcherName ?? null,
-      task_summary: params.prompt,
+      task_summary: spawnParams.prompt,
       pid: null,
       version: 1,
       created_at: now,
@@ -1734,29 +1690,33 @@ export class AgentEngine {
       parent_agent_id: parentAgentId,
       spawn_depth: spawnDepth,
       role,
-      auto_archive_on_done: params.auto_archive_on_done,
+      auto_archive_on_done: spawnParams.auto_archive_on_done,
       deletion_intent: false,
       quality: "unknown",
-      max_cost_per_agent: params.max_cost_per_agent ?? null,
-      crash_recover: params.crash_recover ?? false,
+      max_cost_per_agent: spawnParams.max_cost_per_agent ?? null,
+      crash_recover: spawnParams.crash_recover ?? false,
       respawn_attempts: 0,
       user_killed: false,
-      boot_prompt_pending: params.boot_prompt_pending ?? false,
-      launch_cwd: params.cwd ?? null,
-      mcp_profile: params.mcp_profile_label ?? null,
-      worktree_path: params.cwd ?? null,
-      worktree_branch: params.worktree_branch ?? null,
+      boot_prompt_pending: spawnParams.boot_prompt_pending ?? false,
+      launch_cwd: spawnParams.cwd ?? null,
+      mcp_profile: spawnParams.mcp_profile_label ?? null,
+      worktree_path: spawnParams.cwd ?? null,
+      worktree_branch: spawnParams.worktree_branch ?? null,
     };
     this.stateMgr.writeState(record);
     this.registry.set(agentId, record);
 
     // 3. Send launch command
     const launchCmd = buildLaunchCommand(
-      params.cli,
-      params.repo,
-      params.model,
+      spawnParams.cli,
+      spawnParams.repo,
+      modelPolicy.launcher_model ?? undefined,
       preflight?.launcherName,
-      { cwd: params.cwd, envPrefix: params.mcp_env },
+      {
+        cwd: spawnParams.cwd,
+        envPrefix: spawnParams.mcp_env,
+        allowModelOverride: modelPolicy.override_allowed,
+      },
     );
     try {
       await this.sendLaunchCommand(
@@ -1783,8 +1743,12 @@ export class AgentEngine {
       surface_id: surface.surface,
       workspace_id: surface.workspace,
       state: "booting",
-      cwd: params.cwd,
-      mcp_env: params.mcp_env,
+      model: modelPolicy.effective_model,
+      requested_model: modelPolicy.requested_model,
+      warnings: modelPolicy.warnings,
+      model_policy: modelPolicy,
+      cwd: spawnParams.cwd,
+      mcp_env: spawnParams.mcp_env,
     };
   }
 

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,0 +1,206 @@
+import type { CliType } from "./agent-types.js";
+
+export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
+
+export interface CliModelPolicyContract {
+  defaultModel: string;
+  allowModelOverrideByDefault: boolean;
+  forbiddenModelPatterns: string[];
+  modelAliases: Record<string, string>;
+}
+
+export interface SpawnModelPolicy {
+  cli: CliType;
+  requested_model: string;
+  effective_model: string;
+  launcher_model: string | null;
+  coerced: boolean;
+  warnings: string[];
+  override_env: typeof MODEL_OVERRIDE_ENV;
+  override_allowed: boolean;
+}
+
+export const MODEL_POLICY_CONTRACT: {
+  version: 1;
+  escapeEnv: typeof MODEL_OVERRIDE_ENV;
+  cli: Record<CliType, CliModelPolicyContract>;
+} = {
+  version: 1,
+  escapeEnv: MODEL_OVERRIDE_ENV,
+  cli: {
+    cursor: {
+      defaultModel: "auto",
+      allowModelOverrideByDefault: false,
+      forbiddenModelPatterns: ["^claude-", "sonnet", "opus", "haiku"],
+      modelAliases: {},
+    },
+    gemini: {
+      // repoGolem owns Antigravity alias-to-canonical resolution. Keep cmux on
+      // the short launcher token so canonical model renames cannot drift here.
+      defaultModel: "pro",
+      allowModelOverrideByDefault: true,
+      forbiddenModelPatterns: [],
+      modelAliases: {
+        pro: "pro",
+        "pro-high": "pro-high",
+        "pro-low": "pro-low",
+        flash: "flash",
+        "flash-high": "flash-high",
+        "flash-med": "flash-med",
+        "flash-medium": "flash-medium",
+        "flash-low": "flash-low",
+        "gemini-2.5-pro": "gemini-2.5-pro",
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-3.1-pro": "gemini-3.1-pro",
+      },
+    },
+    codex: {
+      defaultModel: "codex",
+      allowModelOverrideByDefault: true,
+      forbiddenModelPatterns: [],
+      modelAliases: {
+        "gpt-5": "gpt-5",
+        "gpt-5-codex": "gpt-5-codex",
+        "gpt-5.3": "gpt-5.3",
+        "gpt-5.3-codex": "gpt-5.3-codex",
+        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+        "gpt-5.4": "gpt-5.4",
+        "gpt-5.4-mini": "gpt-5.4-mini",
+        "gpt-5.5": "gpt-5.5",
+        "gpt-5.5-mini": "gpt-5.5-mini",
+      },
+    },
+    claude: {
+      defaultModel: "opus-4-8[1m]",
+      allowModelOverrideByDefault: true,
+      forbiddenModelPatterns: [],
+      modelAliases: {
+        opus: "opus",
+        sonnet: "sonnet",
+        haiku: "haiku",
+      },
+    },
+    kiro: {
+      defaultModel: "opus",
+      allowModelOverrideByDefault: true,
+      forbiddenModelPatterns: [],
+      modelAliases: {
+        opus: "opus",
+        sonnet: "sonnet",
+        haiku: "haiku",
+      },
+    },
+  },
+};
+
+function envFlagEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function normalizeModelKey(model: string): string {
+  return model.trim().toLowerCase();
+}
+
+function modelMatchesDefault(cli: CliType, model: string): boolean {
+  const contract = MODEL_POLICY_CONTRACT.cli[cli];
+  const normalized = normalizeModelKey(model);
+  const defaultModel = normalizeModelKey(contract.defaultModel);
+  return (
+    normalized === defaultModel ||
+    normalizeModelKey(resolveModelAlias(cli, model)) === defaultModel
+  );
+}
+
+function forbiddenModelFamily(cli: CliType, model: string): string {
+  const contract = MODEL_POLICY_CONTRACT.cli[cli];
+  for (const pattern of contract.forbiddenModelPatterns) {
+    if (new RegExp(pattern, "i").test(model)) return "Claude model";
+  }
+  return "non-default model";
+}
+
+function ownModelAlias(cli: CliType, normalized: string): string | null {
+  const aliases = MODEL_POLICY_CONTRACT.cli[cli].modelAliases;
+  if (!Object.prototype.hasOwnProperty.call(aliases, normalized)) return null;
+
+  const alias = aliases[normalized];
+  return typeof alias === "string" && alias ? alias : null;
+}
+
+export function resolveModelAlias(cli: CliType, model: string): string {
+  const trimmed = model.trim();
+  const normalized = normalizeModelKey(trimmed);
+  return ownModelAlias(cli, normalized) ?? trimmed;
+}
+
+export function resolveLaunchModelFlag(
+  cli: CliType,
+  model: string | undefined,
+  opts?: { allowModelOverride?: boolean },
+): string | null {
+  const requested = model?.trim();
+  if (!requested) return null;
+
+  if (cli === "cursor") {
+    if (modelMatchesDefault(cli, requested)) return null;
+    return opts?.allowModelOverride ? requested : null;
+  }
+
+  const alias = ownModelAlias(cli, normalizeModelKey(requested));
+  return alias ?? null;
+}
+
+export function resolveSpawnModelPolicy(
+  cli: CliType,
+  model?: string,
+  env: Record<string, string | undefined> = process.env,
+): SpawnModelPolicy {
+  const contract = MODEL_POLICY_CONTRACT.cli[cli];
+  const requestedModel = model?.trim() ?? "";
+  const requestedWasOmitted = requestedModel.length === 0;
+  const overrideAllowed = envFlagEnabled(env[MODEL_OVERRIDE_ENV]);
+  const defaultModel = contract.defaultModel;
+  const requestedOrDefault = requestedWasOmitted ? defaultModel : requestedModel;
+  const resolvedRequested = resolveModelAlias(cli, requestedOrDefault);
+
+  if (
+    !requestedWasOmitted &&
+    !contract.allowModelOverrideByDefault &&
+    !overrideAllowed &&
+    !modelMatchesDefault(cli, requestedModel)
+  ) {
+    const effectiveModel = resolveModelAlias(cli, defaultModel);
+    const family = forbiddenModelFamily(cli, requestedModel);
+    const warning =
+      `WARNING: ${cli.toUpperCase()} MODEL POLICY: requested ${family} "${requestedModel}" ` +
+      `was coerced to "${effectiveModel}". ${cli} agents must use ${effectiveModel} ` +
+      `unless ${MODEL_OVERRIDE_ENV}=1 is set.`;
+
+    return {
+      cli,
+      requested_model: requestedModel,
+      effective_model: effectiveModel,
+      launcher_model: null,
+      coerced: true,
+      warnings: [warning],
+      override_env: MODEL_OVERRIDE_ENV,
+      override_allowed: false,
+    };
+  }
+
+  return {
+    cli,
+    requested_model: requestedModel,
+    effective_model: resolvedRequested,
+    launcher_model:
+      requestedWasOmitted || modelMatchesDefault(cli, resolvedRequested)
+        ? null
+        : resolvedRequested,
+    coerced: false,
+    warnings: [],
+    override_env: MODEL_OVERRIDE_ENV,
+    override_allowed: overrideAllowed,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3549,6 +3549,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("Repository name (e.g. 'brainlayer', 'golems')"),
         model: z
           .string()
+          .optional()
           .describe("Model name (e.g. 'sonnet', 'codex', 'opus')"),
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])
@@ -3727,7 +3728,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("spawn_agent", {
               agent_id: result.agent_id,
               repo: args.repo,
-              model: args.model,
+              model: result.model ?? args.model,
+              requested_model: result.requested_model,
+              warning:
+                result.warnings && result.warnings.length > 0
+                  ? result.warnings.join(" | ")
+                  : undefined,
               surface: result.surface_id,
               role:
                 engine.getAgentState(result.agent_id)?.role ??

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3013,8 +3013,13 @@ describe("buildLaunchCommand", () => {
       "brainlayerCodex -s",
     );
     expect(buildLaunchCommand("cursor", "cmuxlayer", "sonnet")).toBe(
-      "cmuxlayerCursor -s -m sonnet-4",
+      "cmuxlayerCursor -s",
     );
+    expect(
+      buildLaunchCommand("cursor", "cmuxlayer", "sonnet", undefined, {
+        allowModelOverride: true,
+      }),
+    ).toBe("cmuxlayerCursor -s -m sonnet");
   });
 
   it("preserves launcher defaults when model is omitted", () => {
@@ -3050,7 +3055,7 @@ describe("buildLaunchCommand", () => {
       "voicelayerGemini -s -m gemini-2.5-pro",
     );
     expect(buildLaunchCommand("gemini", "golems", "pro")).toBe(
-      "golemsGemini -s -m 'Gemini 3.1 Pro (High)'",
+      "golemsGemini -s -m pro",
     );
   });
 

--- a/tests/model-policy.test.ts
+++ b/tests/model-policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  MODEL_OVERRIDE_ENV,
+  MODEL_POLICY_CONTRACT,
+  resolveModelAlias,
+  resolveSpawnModelPolicy,
+} from "../src/model-policy.js";
+
+describe("model policy contract", () => {
+  it("declares per-CLI defaults and override rules", () => {
+    expect(MODEL_POLICY_CONTRACT.cli.cursor).toMatchObject({
+      defaultModel: "auto",
+      allowModelOverrideByDefault: false,
+    });
+    expect(MODEL_POLICY_CONTRACT.cli.gemini.defaultModel).toBe("pro");
+    expect(MODEL_POLICY_CONTRACT.cli.claude.defaultModel).toBe(
+      "opus-4-8[1m]",
+    );
+    expect(MODEL_POLICY_CONTRACT.cli.codex.defaultModel).toBe("codex");
+  });
+
+  it("coerces Cursor model overrides to auto unless the escape env is enabled", () => {
+    const coerced = resolveSpawnModelPolicy("cursor", "sonnet", {});
+
+    expect(coerced.effective_model).toBe("auto");
+    expect(coerced.launcher_model).toBeNull();
+    expect(coerced.coerced).toBe(true);
+    expect(coerced.warnings[0]).toContain("CURSOR MODEL POLICY");
+    expect(coerced.warnings[0]).toContain("sonnet");
+
+    const escaped = resolveSpawnModelPolicy("cursor", "sonnet", {
+      [MODEL_OVERRIDE_ENV]: "1",
+    });
+
+    expect(escaped.effective_model).toBe("sonnet");
+    expect(escaped.launcher_model).toBe("sonnet");
+    expect(escaped.coerced).toBe(false);
+    expect(escaped.override_allowed).toBe(true);
+  });
+
+  it("resolves omitted models to per-CLI defaults without pinning launcher args", () => {
+    expect(resolveSpawnModelPolicy("cursor", undefined, {}).effective_model).toBe(
+      "auto",
+    );
+    expect(resolveSpawnModelPolicy("claude", undefined, {}).effective_model).toBe(
+      "opus-4-8[1m]",
+    );
+    expect(resolveSpawnModelPolicy("gemini", undefined, {}).effective_model).toBe(
+      "pro",
+    );
+    expect(resolveSpawnModelPolicy("codex", undefined, {}).effective_model).toBe(
+      "codex",
+    );
+
+    expect(resolveSpawnModelPolicy("gemini", undefined, {}).launcher_model).toBeNull();
+  });
+
+  it("passes Gemini aliases through for repoGolem canonical resolution", () => {
+    expect(resolveModelAlias("gemini", "pro")).toBe("pro");
+    expect(resolveModelAlias("gemini", "pro-high")).toBe("pro-high");
+    expect(resolveModelAlias("gemini", "gemini-2.5-pro")).toBe(
+      "gemini-2.5-pro",
+    );
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -254,6 +254,39 @@ describe("agent lifecycle tool handlers", () => {
     expect(persisted.auto_archive_on_done).toBe(true);
   });
 
+  it("spawn_agent accepts an omitted model and resolves the CLI default", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        cli: "claude",
+        prompt: "fix gap F",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.model).toBe("opus-4-8[1m]");
+    expect(parsed.requested_model).toBe("");
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "brainlayerClaude -s"]),
+    );
+
+    const stateTool = (server as any)._registeredTools["get_agent_state"];
+    const stateResult = await stateTool.handler(
+      { agent_id: parsed.agent_id },
+      {} as any,
+    );
+    const persisted =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(persisted.model).toBe("opus-4-8[1m]");
+  });
+
   it("spawn_agent accepts explicit role and returns persisted role", async () => {
     const server = createLifecycleServer(mockExec);
     const tool = (server as any)._registeredTools["spawn_agent"];


### PR DESCRIPTION
## Summary
- Adds a cmuxlayer-local `src/model-policy.ts` contract table with per-CLI defaults, override policy, forbidden model patterns, and launch aliases.
- Makes `spawn_agent.model` optional and resolves omitted models to the per-CLI default for state/result reporting while preserving the no-pin launch rule by omitting `-m` when the model is omitted/default.
- Enforces Cursor's default-Auto policy locally: non-default Cursor model requests coerce to `auto` unless `REPOGOLEM_ALLOW_MODEL=1` is set.
- Incorporates lead steering for Gemini: cmux no longer duplicates repoGolem's Antigravity canonical strings; it passes short tokens such as `pro` through and lets repoGolem resolve them.

## TDD / Verification
- RED: `bun run test tests/model-policy.test.ts tests/server-agent-tools.test.ts` failed as expected: `tests/model-policy.test.ts` could not import missing `../src/model-policy.js`, and omitted-model spawn returned `undefined` instead of `opus-4-8[1m]`.
- GREEN: `bun run test tests/model-policy.test.ts tests/server-agent-tools.test.ts tests/agent-engine.test.ts` passed: `Test Files  3 passed (3)`, `Tests  174 passed (174)`.
- Typecheck: `bun run typecheck` exited 0 with `tsc -p tsconfig.json --noEmit`.
- Pre-commit CodeRabbit: rate-limited before findings (`Rate limit exceeded`, wait time `4 minutes and 9 seconds`), so committed on fresh local verification per PR-loop guidance.
- Push hook/full suite: `Test Files  47 passed (47)`, `Tests  813 passed (813)`, `run_tests.sh finished with exit status 0`.

## Stack
- Base PR: #162 (`gen17-cx2-opus-1m`)
- Root PR: #160 (`gen17-cx2-gemini-alias`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which model actually launches (especially Cursor coercion and Gemini alias behavior) and affects all agent spawns; mitigated by tests and an explicit env escape hatch.
> 
> **Overview**
> Introduces **`src/model-policy.ts`** as the single place for per-CLI defaults, alias maps, launch `-m` behavior, and override rules (including **`REPOGOLEM_ALLOW_MODEL`**).
> 
> **`spawn_agent.model`** is now optional; omitted requests resolve to each CLI’s default for persisted state and API responses, while launch commands still **omit `-m`** when the effective model is the default so repoGolem launcher defaults stay unpinned.
> 
> **Cursor** non-default model requests (e.g. Claude-family names) are **coerced to `auto`** with a warning unless the override env is set; **`buildLaunchCommand`** no longer inlines the old alias table and delegates to **`resolveLaunchModelFlag`**. **Gemini** passes short tokens like `pro` through instead of hard-coded Antigravity display strings.
> 
> **`spawnAgent`** applies policy before spawn, stores the effective model, and returns **`model`**, **`requested_model`**, **`warnings`**, and **`model_policy`**; the MCP **`spawn_agent`** tool surfaces these (including a combined warning string).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e73467c2e256f8894de550a11b3805947a6ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize spawn model policy with per-CLI resolution, coercion, and override rules
> - Adds [src/model-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/163/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d) to centralize model resolution: per-CLI defaults, alias maps, coercion rules, and an environment variable escape hatch (`REPOGOLEM_ALLOW_MODEL`).
> - Cursor defaults to `auto` and rejects model overrides unless `REPOGOLEM_ALLOW_MODEL` is set; the `-m` flag is omitted for default models. Gemini uses short aliases.
> - `spawnAgent` now accepts omitted `model`, applies the policy to derive the effective model, and returns `model`, `requested_model`, `warnings`, and `model_policy` in its result.
> - `resolveModelMax` in [src/screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/163/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) returns a 1M context window for Claude Opus 4.6–4.8 and Sonnet 4.6 without requiring a `(1M` marker in the screen footer.
> - Behavioral Change: Cursor no longer passes `-m` for the default model; unsafe/unrecognized model strings are shell-quoted or omitted rather than forwarded raw.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91e7346.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->