### PR TITLE
fix: reject false-green empty surfaces

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -524,7 +524,7 @@ function screenHasReadyAgentIdentity(
     case "kiro":
       return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
     case "gemini":
-      return hasParsedAgentIdentity(parsed);
+      return false;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -482,7 +482,50 @@ function formatToolValidationError(
 function isSubmitVerifiedStatus(
   status: ParsedScreenResult["status"] | null | undefined,
 ): boolean {
-  return status === "working" || status === "thinking" || status === "done";
+  return status === "working" || status === "thinking";
+}
+
+function hasParsedAgentIdentity(
+  parsed: ParsedScreenResult | null | undefined,
+): boolean {
+  return Boolean(parsed && parsed.agent_type !== "unknown");
+}
+
+function screenHasAnyAgentIdentity(
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  return (
+    hasParsedAgentIdentity(parsed) ||
+    /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?|(?:^|\n)\s*(?:codex>|cursor>|kiro>)\s*$/im.test(
+      screenText,
+    )
+  );
+}
+
+function screenHasReadyAgentIdentity(
+  cli: CliType,
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  if (parsed.agent_type === cli) {
+    return true;
+  }
+
+  switch (cli) {
+    case "claude":
+      return /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
+        screenText,
+      );
+    case "codex":
+      return /(?:^|\n)\s*codex>\s*$/im.test(screenText);
+    case "cursor":
+      return /(?:^|\n)\s*(?:cursor>|Cursor Agent)\s*$/im.test(screenText);
+    case "kiro":
+      return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
+    case "gemini":
+      return hasParsedAgentIdentity(parsed);
+  }
 }
 
 function screenShowsPendingInput(
@@ -1201,10 +1244,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return { submit_verified: true, retry_count: retryCount };
       }
 
-      if (!screenShowsPendingInput(snapshot.text, opts.text)) {
+      if (
+        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+        !screenShowsPendingInput(snapshot.text, opts.text)
+      ) {
         // The submitted text is no longer echoed in the input box: the terminal
-        // accepted it and cleared the prompt, even if the agent has already
-        // settled back to idle. Treat that as a verified landing.
+        // accepted it and cleared the prompt on a parsed agent surface, even if
+        // the agent has already settled back to idle.
         return { submit_verified: true, retry_count: retryCount };
       }
 
@@ -1345,10 +1391,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           scrollback: false,
         });
         lastText = screen.text;
+        const parsed = parseScreen(screen.text);
 
         for (const candidate of candidates) {
           const match = matchReadyPattern(candidate, screen.text);
-          const count = match.matched
+          const ready =
+            match.matched &&
+            screenHasReadyAgentIdentity(candidate, screen.text, parsed);
+          const count = ready
             ? (consecutiveMatches.get(candidate) ?? 0) + 1
             : 0;
           consecutiveMatches.set(candidate, count);

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -58,6 +58,48 @@ describe("false-green empty surface protection", () => {
     );
   });
 
+  it("does not deliver a Gemini boot prompt to a different agent prompt", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const promptPath = join(TEST_DIR, "boot.md");
+    writeFileSync(promptPath, "boot prompt", "utf8");
+
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "Claude Code\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerGemini -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 300,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Timed out");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
+  });
+
   it("does not verify a cleared long command on a non-agent shell prompt", async () => {
     const longCommand = `echo ${"x".repeat(520)}`;
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-false-green-empty-surface");
+
+function parseToolResult(result: any): Record<string, any> {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+describe("false-green empty surface protection", () => {
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("does not deliver a Gemini boot prompt to a bare shell prompt", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const promptPath = join(TEST_DIR, "boot.md");
+    writeFileSync(promptPath, "boot prompt", "utf8");
+
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "\n>\n",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerGemini -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 300,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Timed out");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
+  });
+
+  it("does not verify a cleared long command on a non-agent shell prompt", async () => {
+    const longCommand = `echo ${"x".repeat(520)}`;
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "\n$\n",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      { surface: "surface:2", command: longCommand },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Enter submit could not be verified");
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -943,6 +943,7 @@ describe("agent lifecycle tool handlers", () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
     let launchSent = false;
+    let readCountAfterLaunch = 0;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("send")) {
         launchSent = true;
@@ -954,10 +955,18 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
       }
       if (args.includes("read-screen")) {
+        if (launchSent) {
+          readCountAfterLaunch += 1;
+        }
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text: launchSent ? "$ waiting" : "$ ",
+            text:
+              !launchSent || readCountAfterLaunch === 1
+                ? "$ "
+                : readCountAfterLaunch === 2
+                  ? "codex> "
+                  : "$ waiting",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -323,7 +323,7 @@ describe("tool handler integration", () => {
       sendKey: vi.fn().mockResolvedValue(undefined),
       readScreen: vi.fn().mockResolvedValue({
         surface: "surface:1",
-        text: "$ ",
+        text: "Claude Code\n>",
         lines: 1,
         scrollback_used: false,
       }),
@@ -1834,7 +1834,10 @@ describe("tool handler integration", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
-            text: reads === 1 ? "booting\n>" : "ready\n>",
+            text:
+              reads === 1
+                ? "Gemini CLI\nbooting\n>"
+                : "Gemini CLI\nready\n>",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -48,7 +48,7 @@ function makeWorkspaceClient() {
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({
       surface: "surface:1",
-      text: "$ ",
+      text: "Claude Code\n>",
       lines: 1,
       scrollback_used: false,
     }),


### PR DESCRIPTION
## Summary
- require positive agent identity before boot-prompt readiness can accept a matched ready pattern
- stop treating `done` and cleared input on non-agent shell prompts as submit verification success
- add false-green regressions for bare Gemini `>` and cleared long commands on shell prompts

## Test plan
- RED: `bun run test tests/false-green-empty-surface.test.ts` failed with 2 failed tests before the fix (`expected true to be false`)
- GREEN: `bun run test tests/false-green-empty-surface.test.ts tests/server.test.ts tests/server-agent-tools.test.ts tests/pattern-registry.test.ts tests/spawn-workspace.test.ts` -> 5 files passed, 157 tests passed
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit`
- pre-push `bun run test` -> 47 files passed, 810 tests passed
- local CodeRabbit before commit -> `findings:0`; second post-fixture attempt hit free OSS `rate_limit` with wait time `1 minute and 44 seconds`

## Notes
- Stacked PR 1/4 for gen17 CX-1.
- Do not merge; lead/orc owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delivery and boot-prompt readiness paths; legitimate slow boots or idle agents after submit may time out or fail verification more often, though behavior on confirmed agent surfaces should stay the same.
> 
> **Overview**
> **Prevents false-green success** when terminal screens look “ready” but are only bare shells or the wrong agent—boot prompts and long-command submit checks now require evidence of a real agent surface.
> 
> Boot-prompt polling in `waitForBootPromptReady` still uses CLI ready patterns, but a match only counts when **`screenHasReadyAgentIdentity`** confirms the expected CLI (parsed `agent_type` or CLI-specific markers). **Gemini** never satisfies identity via regex alone (`screenHasReadyAgentIdentity` returns false), so a lone `>` prompt no longer triggers boot-prompt delivery.
> 
> **Enter submit verification** no longer treats **`done`** as verified; only **`working`** and **`thinking`** do. Cleared input counts as verified only when **`screenHasAnyAgentIdentity`** is true and the submitted text is no longer echoed—plain `$` / `%` shells no longer get **`ok: true`** for unverified long commands.
> 
> New regressions in `tests/false-green-empty-surface.test.ts`; existing tests updated so mocked screens include agent identity where the stricter contract applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946fc32744a6ae17275b991cfd6c468c40c5b4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject false-green submit verifications and agent readiness on bare or mismatched shell prompts
> - `isSubmitVerifiedStatus` no longer treats `'done'` as verified; only `'working'` and `'thinking'` count.
> - Submit verification after input clearing now requires the screen to show an agent identity via the new `screenHasAnyAgentIdentity` helper, preventing false positives on bare shell prompts.
> - Agent readiness polling now requires both a matched ready pattern and a CLI-specific identity match via `screenHasReadyAgentIdentity`, preventing delivery to the wrong agent (e.g. a Claude Code prompt when targeting Gemini).
> - New tests in [false-green-empty-surface.test.ts](https://github.com/EtanHey/cmuxlayer/pull/164/files#diff-b7859db89dc39454aedb4833638b4299190b539ba63c873267f48f26812f9310) cover bare shell, wrong-agent, and cleared-command scenarios.
> - Behavioral Change: existing screens that previously passed verification with a `'done'` status or a clear input box on a non-agent prompt will no longer be considered ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 946fc32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->