### PR TITLE
feat: monitor boot orchestrator spawns

### DIFF
--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -94,6 +94,13 @@ function ensureDir(agentId: string, opts?: InboxOpts): void {
   mkdirSync(agentDir(agentId, opts), { recursive: true });
 }
 
+export function ensureInboxFile(agentId: string, opts?: InboxOpts): string {
+  ensureDir(agentId, opts);
+  const path = inboxPath(agentId, opts);
+  appendFileSync(path, "");
+  return path;
+}
+
 function readJsonl<T>(path: string): T[] {
   let raw: string;
   try {
@@ -242,6 +249,24 @@ export function readLastHeartbeat(
   return last ? parseHeartbeatLine(last) : null;
 }
 
+function readLastAgentHeartbeat(
+  agentId: string,
+  opts?: InboxOpts,
+): MonitorHeartbeat | null {
+  let raw: string;
+  try {
+    raw = readFileSync(heartbeatPath(agentId, opts), "utf8");
+  } catch {
+    return null;
+  }
+  const lines = raw.trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const heartbeat = parseHeartbeatLine(lines[i] ?? "");
+    if (heartbeat?.source === "agent") return heartbeat;
+  }
+  return null;
+}
+
 /**
  * FM#1 — is the monitor heartbeat fresh within maxAgeMs? false → treat the channel as down.
  * Reads the last written heartbeat timestamp (not file mtime) so it's consistent with the
@@ -252,8 +277,8 @@ export function monitorAlive(
   maxAgeMs: number,
   opts?: InboxOpts,
 ): boolean {
-  const heartbeat = readLastHeartbeat(agentId, opts);
-  if (!heartbeat || heartbeat.source === "server_boot") return false;
+  const heartbeat = readLastAgentHeartbeat(agentId, opts);
+  if (!heartbeat) return false;
   return nowOf(opts) - heartbeat.ts_ms <= maxAgeMs;
 }
 

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -51,6 +51,13 @@ export interface InboxOpts {
   now?: () => number;
 }
 
+export type MonitorHeartbeatSource = "agent" | "server_boot";
+
+export interface MonitorHeartbeat {
+  ts_ms: number;
+  source: MonitorHeartbeatSource;
+}
+
 export interface DispatchInput {
   from: string;
   to?: string;
@@ -105,6 +112,16 @@ function readJsonl<T>(path: string): T[] {
     }
   }
   return out;
+}
+
+function parseHeartbeatLine(line: string): MonitorHeartbeat | null {
+  const [tsText, sourceText] = line.trim().split(/\s+/, 2);
+  const ts = Number.parseInt(tsText ?? "", 10);
+  if (!Number.isFinite(ts)) return null;
+  return {
+    ts_ms: ts,
+    source: sourceText === "server_boot" ? "server_boot" : "agent",
+  };
 }
 
 let idCounter = 0;
@@ -195,12 +212,34 @@ export function pendingDispatches(
   return replayUndelivered(agentId, opts).filter((m) => m.ts_ms <= cutoff);
 }
 
-/** FM#1 — heartbeat the agent's monitor writes (on arm + each act) to prove liveness. */
-export function writeHeartbeat(agentId: string, opts?: InboxOpts): number {
+/**
+ * FM#1 — heartbeat the agent's monitor writes (on arm + each act) to prove liveness.
+ * Server boot markers share the file for auditability, but do not satisfy monitorAlive().
+ */
+export function writeHeartbeat(
+  agentId: string,
+  opts?: InboxOpts,
+  source: MonitorHeartbeatSource = "agent",
+): number {
   ensureDir(agentId, opts);
   const ts = nowOf(opts);
-  appendFileSync(heartbeatPath(agentId, opts), `${ts}\n`);
+  const sourceSuffix = source === "agent" ? "" : ` ${source}`;
+  appendFileSync(heartbeatPath(agentId, opts), `${ts}${sourceSuffix}\n`);
   return ts;
+}
+
+export function readLastHeartbeat(
+  agentId: string,
+  opts?: InboxOpts,
+): MonitorHeartbeat | null {
+  let raw: string;
+  try {
+    raw = readFileSync(heartbeatPath(agentId, opts), "utf8");
+  } catch {
+    return null;
+  }
+  const last = raw.trim().split("\n").filter(Boolean).pop();
+  return last ? parseHeartbeatLine(last) : null;
 }
 
 /**
@@ -213,16 +252,9 @@ export function monitorAlive(
   maxAgeMs: number,
   opts?: InboxOpts,
 ): boolean {
-  let raw: string;
-  try {
-    raw = readFileSync(heartbeatPath(agentId, opts), "utf8");
-  } catch {
-    return false;
-  }
-  const last = raw.trim().split("\n").filter(Boolean).pop();
-  const ts = last ? Number.parseInt(last, 10) : NaN;
-  if (!Number.isFinite(ts)) return false;
-  return nowOf(opts) - ts <= maxAgeMs;
+  const heartbeat = readLastHeartbeat(agentId, opts);
+  if (!heartbeat || heartbeat.source === "server_boot") return false;
+  return nowOf(opts) - heartbeat.ts_ms <= maxAgeMs;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -3993,6 +3993,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface_id: string;
             repo: string;
             cli: CliType;
+            role: AgentRole;
+            monitor_boot?: MonitorBootResult;
           }> = [];
 
           for (const agent of args.agents) {
@@ -4035,11 +4037,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
 
+            const role =
+              engine.getAgentState(result.agent_id)?.role ??
+              inferAgentRole({
+                role: agent.role,
+                cli: agent.cli,
+                launcherName: launcherNameForCli(agent.repo, agent.cli),
+              });
+            const monitorBoot =
+              role === "orchestrator"
+                ? ensureMonitorBoot(result.agent_id)
+                : undefined;
+
             spawnedAgents.push({
               agent_id: result.agent_id,
               surface_id: result.surface_id,
               repo: agent.repo,
               cli: agent.cli,
+              role,
+              monitor_boot: monitorBoot,
             });
           }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -545,6 +545,7 @@ function screenShowsPendingInput(
 
 type MonitorBootResult = {
   heartbeat_written: true;
+  heartbeat_source: "server_boot";
   monitor_command: string;
 };
 
@@ -869,9 +870,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
   const ensureMonitorBoot = (agentId: string): MonitorBootResult => {
-    writeHeartbeat(agentId, inboxOpts);
+    writeHeartbeat(agentId, inboxOpts, "server_boot");
     return {
       heartbeat_written: true,
+      heartbeat_source: "server_boot",
       monitor_command: recommendedMonitorCommand(agentId, inboxOpts),
     };
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -524,7 +524,7 @@ function screenHasReadyAgentIdentity(
     case "kiro":
       return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
     case "gemini":
-      return hasParsedAgentIdentity(parsed);
+      return false;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -482,7 +482,50 @@ function formatToolValidationError(
 function isSubmitVerifiedStatus(
   status: ParsedScreenResult["status"] | null | undefined,
 ): boolean {
-  return status === "working" || status === "thinking" || status === "done";
+  return status === "working" || status === "thinking";
+}
+
+function hasParsedAgentIdentity(
+  parsed: ParsedScreenResult | null | undefined,
+): boolean {
+  return Boolean(parsed && parsed.agent_type !== "unknown");
+}
+
+function screenHasAnyAgentIdentity(
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  return (
+    hasParsedAgentIdentity(parsed) ||
+    /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?|(?:^|\n)\s*(?:codex>|cursor>|kiro>)\s*$/im.test(
+      screenText,
+    )
+  );
+}
+
+function screenHasReadyAgentIdentity(
+  cli: CliType,
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  if (parsed.agent_type === cli) {
+    return true;
+  }
+
+  switch (cli) {
+    case "claude":
+      return /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
+        screenText,
+      );
+    case "codex":
+      return /(?:^|\n)\s*codex>\s*$/im.test(screenText);
+    case "cursor":
+      return /(?:^|\n)\s*(?:cursor>|Cursor Agent)\s*$/im.test(screenText);
+    case "kiro":
+      return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
+    case "gemini":
+      return hasParsedAgentIdentity(parsed);
+  }
 }
 
 function screenShowsPendingInput(
@@ -1201,10 +1244,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return { submit_verified: true, retry_count: retryCount };
       }
 
-      if (!screenShowsPendingInput(snapshot.text, opts.text)) {
+      if (
+        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+        !screenShowsPendingInput(snapshot.text, opts.text)
+      ) {
         // The submitted text is no longer echoed in the input box: the terminal
-        // accepted it and cleared the prompt, even if the agent has already
-        // settled back to idle. Treat that as a verified landing.
+        // accepted it and cleared the prompt on a parsed agent surface, even if
+        // the agent has already settled back to idle.
         return { submit_verified: true, retry_count: retryCount };
       }
 
@@ -1345,10 +1391,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           scrollback: false,
         });
         lastText = screen.text;
+        const parsed = parseScreen(screen.text);
 
         for (const candidate of candidates) {
           const match = matchReadyPattern(candidate, screen.text);
-          const count = match.matched
+          const ready =
+            match.matched &&
+            screenHasReadyAgentIdentity(candidate, screen.text, parsed);
+          const count = ready
             ? (consecutiveMatches.get(candidate) ?? 0) + 1
             : 0;
           consecutiveMatches.set(candidate, count);

--- a/src/server.ts
+++ b/src/server.ts
@@ -544,9 +544,10 @@ function screenShowsPendingInput(
 }
 
 type MonitorBootResult = {
-  heartbeat_written: true;
+  heartbeat_written: boolean;
   heartbeat_source: "server_boot";
   monitor_command: string;
+  error?: string;
 };
 
 function computeEnterDelayMs(bytes: number, chunkCount: number): number {
@@ -870,12 +871,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
   const ensureMonitorBoot = (agentId: string): MonitorBootResult => {
-    writeHeartbeat(agentId, inboxOpts, "server_boot");
-    return {
-      heartbeat_written: true,
-      heartbeat_source: "server_boot",
-      monitor_command: recommendedMonitorCommand(agentId, inboxOpts),
-    };
+    let monitorCommand = "";
+    try {
+      monitorCommand = recommendedMonitorCommand(agentId, inboxOpts);
+      writeHeartbeat(agentId, inboxOpts, "server_boot");
+      return {
+        heartbeat_written: true,
+        heartbeat_source: "server_boot",
+        monitor_command: monitorCommand,
+      };
+    } catch (e) {
+      return {
+        heartbeat_written: false,
+        heartbeat_source: "server_boot",
+        monitor_command: monitorCommand,
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
   };
   // Wired up by the agent-lifecycle block below (when enabled). Lets the
   // dispatch_to_agent nudge reuse the guarded relay path — stale-surface

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,9 @@ import {
   inboxPath,
   monitorAlive,
   pendingDispatches,
+  recommendedMonitorCommand,
   replayUndelivered,
+  writeHeartbeat,
 } from "./inbox.js";
 import {
   applyHarnessState,
@@ -541,6 +543,11 @@ function screenShowsPendingInput(
   return screenText.includes(tail);
 }
 
+type MonitorBootResult = {
+  heartbeat_written: true;
+  monitor_command: string;
+};
+
 function computeEnterDelayMs(bytes: number, chunkCount: number): number {
   const extraChunks = Math.max(0, chunkCount - 1);
   const longPayloadPenalty = bytes >= SEND_INPUT_CHUNK_THRESHOLD ? 100 : 0;
@@ -861,6 +868,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const inboxOpts = opts?.inboxBaseDir
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
+  const ensureMonitorBoot = (agentId: string): MonitorBootResult => {
+    writeHeartbeat(agentId, inboxOpts);
+    return {
+      heartbeat_written: true,
+      monitor_command: recommendedMonitorCommand(agentId, inboxOpts),
+    };
+  };
   // Wired up by the agent-lifecycle block below (when enabled). Lets the
   // dispatch_to_agent nudge reuse the guarded relay path — stale-surface
   // resync + recycled-occupant identity checks — instead of raw keystrokes.
@@ -3773,32 +3787,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return err(e, extra);
           }
 
+          const role =
+            engine.getAgentState(result.agent_id)?.role ??
+            inferAgentRole({
+              role: args.role,
+              cli: args.cli,
+              launcherName: launcherNameForCli(args.repo, args.cli),
+            });
+          const monitorBoot =
+            role === "orchestrator"
+              ? ensureMonitorBoot(result.agent_id)
+              : undefined;
+
           return okFormatted(
             formatOk("spawn_agent", {
               agent_id: result.agent_id,
               repo: args.repo,
               model: args.model,
               surface: result.surface_id,
-              role:
-                engine.getAgentState(result.agent_id)?.role ??
-                inferAgentRole({
-                  role: args.role,
-                  cli: args.cli,
-                  launcherName: launcherNameForCli(args.repo, args.cli),
-                }),
+              role,
+              monitor_boot: monitorBoot,
               boot_prompt_delivered: Boolean(bootPromptDelivery),
             }),
             {
               ...result,
               worktree: worktree.prepared,
               mcp_profile: worktree.mcpProfileLabel,
-              role:
-                engine.getAgentState(result.agent_id)?.role ??
-                inferAgentRole({
-                  role: args.role,
-                  cli: args.cli,
-                  launcherName: launcherNameForCli(args.repo, args.cli),
-                }),
+              role,
+              monitor_boot: monitorBoot,
               boot_prompt_delivered: Boolean(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
             },

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ import {
 } from "./screen-parser.js";
 import {
   dispatch,
+  ensureInboxFile,
   inboxPath,
   monitorAlive,
   pendingDispatches,
@@ -874,6 +875,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let monitorCommand = "";
     try {
       monitorCommand = recommendedMonitorCommand(agentId, inboxOpts);
+      ensureInboxFile(agentId, inboxOpts);
       writeHeartbeat(agentId, inboxOpts, "server_boot");
       return {
         heartbeat_written: true,

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -58,6 +58,48 @@ describe("false-green empty surface protection", () => {
     );
   });
 
+  it("does not deliver a Gemini boot prompt to a different agent prompt", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const promptPath = join(TEST_DIR, "boot.md");
+    writeFileSync(promptPath, "boot prompt", "utf8");
+
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "Claude Code\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerGemini -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 300,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Timed out");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
+  });
+
   it("does not verify a cleared long command on a non-agent shell prompt", async () => {
     const longCommand = `echo ${"x".repeat(520)}`;
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-false-green-empty-surface");
+
+function parseToolResult(result: any): Record<string, any> {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+describe("false-green empty surface protection", () => {
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("does not deliver a Gemini boot prompt to a bare shell prompt", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const promptPath = join(TEST_DIR, "boot.md");
+    writeFileSync(promptPath, "boot prompt", "utf8");
+
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "\n>\n",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerGemini -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 300,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Timed out");
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+    );
+  });
+
+  it("does not verify a cleared long command on a non-agent shell prompt", async () => {
+    const longCommand = `echo ${"x".repeat(520)}`;
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "\n$\n",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      { surface: "surface:2", command: longCommand },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Enter submit could not be verified");
+  });
+});

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -115,7 +115,13 @@ function sendCalls(exec: ExecFn): string[][] {
 async function spawnTestAgent(server: any): Promise<string> {
   const tool = server._registeredTools["spawn_agent"];
   const result = await tool.handler(
-    { repo: "brainlayer", model: "sonnet", cli: "claude", prompt: "task" },
+    {
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+      role: "ic",
+      prompt: "task",
+    },
     {} as any,
   );
   const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -10,6 +10,7 @@ import {
   monitorAlive,
   pendingDispatches,
   readInbox,
+  readLastHeartbeat,
   recommendedCodexWatch,
   recommendedMonitorCommand,
   replayUndelivered,
@@ -84,6 +85,24 @@ describe("inbox write-channel", () => {
 
   it("FM#1 monitorAlive is false when no heartbeat exists", () => {
     expect(monitorAlive("never-armed", 1_000, opts)).toBe(false);
+  });
+
+  it("FM#1 server boot markers do not prove monitor liveness", () => {
+    clock = 25_000;
+    writeHeartbeat("a5-boot", opts, "server_boot");
+    clock = 25_200;
+    expect(readLastHeartbeat("a5-boot", opts)).toEqual({
+      ts_ms: 25_000,
+      source: "server_boot",
+    });
+    expect(monitorAlive("a5-boot", 1_000, opts)).toBe(false);
+
+    writeHeartbeat("a5-boot", opts);
+    expect(readLastHeartbeat("a5-boot", opts)).toEqual({
+      ts_ms: 25_200,
+      source: "agent",
+    });
+    expect(monitorAlive("a5-boot", 1_000, opts)).toBe(true);
   });
 
   it("ack writes a heartbeat (acting proves liveness)", () => {

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -105,6 +105,18 @@ describe("inbox write-channel", () => {
     expect(monitorAlive("a5-boot", 1_000, opts)).toBe(true);
   });
 
+  it("FM#1 server boot markers do not mask an agent heartbeat", () => {
+    clock = 27_000;
+    writeHeartbeat("a5-mask", opts);
+    clock = 27_100;
+    writeHeartbeat("a5-mask", opts, "server_boot");
+    expect(readLastHeartbeat("a5-mask", opts)).toEqual({
+      ts_ms: 27_100,
+      source: "server_boot",
+    });
+    expect(monitorAlive("a5-mask", 1_000, opts)).toBe(true);
+  });
+
   it("ack writes a heartbeat (acting proves liveness)", () => {
     clock = 30_000;
     dispatch("a6", { from: "orc", task: "t", id: "h1" }, opts);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -943,6 +943,7 @@ describe("agent lifecycle tool handlers", () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
     let launchSent = false;
+    let readCountAfterLaunch = 0;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("send")) {
         launchSent = true;
@@ -954,10 +955,18 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
       }
       if (args.includes("read-screen")) {
+        if (launchSent) {
+          readCountAfterLaunch += 1;
+        }
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text: launchSent ? "$ waiting" : "$ ",
+            text:
+              !launchSent || readCountAfterLaunch === 1
+                ? "$ "
+                : readCountAfterLaunch === 2
+                  ? "codex> "
+                  : "$ waiting",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -323,7 +323,7 @@ describe("tool handler integration", () => {
       sendKey: vi.fn().mockResolvedValue(undefined),
       readScreen: vi.fn().mockResolvedValue({
         surface: "surface:1",
-        text: "$ ",
+        text: "Claude Code\n>",
         lines: 1,
         scrollback_used: false,
       }),
@@ -1834,7 +1834,10 @@ describe("tool handler integration", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
-            text: reads === 1 ? "booting\n>" : "ready\n>",
+            text:
+              reads === 1
+                ? "Gemini CLI\nbooting\n>"
+                : "Gemini CLI\nready\n>",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
-import { monitorAlive, readInbox } from "../src/inbox.js";
+import { inboxPath, monitorAlive, readInbox } from "../src/inbox.js";
 
 const STATE_DIR = join(tmpdir(), "cmuxlayer-spawn-monitor-boot-state");
 
@@ -142,6 +148,9 @@ describe("spawn monitor boot", () => {
       monitor_command: expect.stringContaining(parsed.agent_id),
     });
     expect(parsed.monitor_boot.monitor_command).toContain("tail -n0 -F");
+    expect(existsSync(inboxPath(parsed.agent_id, { baseDir: inboxDir }))).toBe(
+      true,
+    );
     expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
       false,
     );

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import { monitorAlive, readInbox } from "../src/inbox.js";
+
+const STATE_DIR = join(tmpdir(), "cmuxlayer-spawn-monitor-boot-state");
+
+function makeExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:new"],
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:new",
+              title: "agent-pane",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: "Claude Code\n>",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return {
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
+function parseToolResult(result: any): Record<string, any> {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+function sendCalls(exec: ExecFn): string[][] {
+  return (exec as ReturnType<typeof vi.fn>).mock.calls
+    .filter(([, args]: [string, string[]]) => args.includes("send"))
+    .map(([, args]: [string, string[]]) => args);
+}
+
+describe("spawn monitor boot", () => {
+  let inboxDir: string;
+  let exec: ExecFn;
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    mkdirSync(STATE_DIR, { recursive: true });
+    inboxDir = mkdtempSync(join(tmpdir(), "cmux-monitor-boot-"));
+    exec = makeExec();
+    server = createServer({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    rmSync(inboxDir, { recursive: true, force: true });
+  });
+
+  it("returns monitor boot metadata and writes a heartbeat for orchestrators", async () => {
+    const spawn = server._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        role: "orchestrator",
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_boot).toEqual({
+      heartbeat_written: true,
+      monitor_command: expect.stringContaining(parsed.agent_id),
+    });
+    expect(parsed.monitor_boot.monitor_command).toContain("tail -n0 -F");
+    expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
+      true,
+    );
+  });
+
+  it("does not monitor-boot worker spawns", async () => {
+    const spawn = server._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_boot).toBeUndefined();
+    expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
+      false,
+    );
+  });
+
+  it("dispatch sees monitor boot heartbeat before the first orchestrator task", async () => {
+    const spawn = server._registeredTools["spawn_agent"];
+    const dispatch = server._registeredTools["dispatch_to_agent"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        role: "orchestrator",
+      },
+      {} as any,
+    );
+    const agentId = parseToolResult(spawnResult).agent_id as string;
+    const beforeDispatchSendCount = sendCalls(exec).length;
+
+    const result = await dispatch.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_alive).toBe(true);
+    expect(parsed.nudge.attempted).toBe(false);
+    expect(sendCalls(exec)).toHaveLength(beforeDispatchSendCount);
+    expect(readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task)).toEqual(
+      ["GO"],
+    );
+  });
+});

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -166,6 +166,45 @@ describe("spawn monitor boot", () => {
     expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
       false,
     );
+  });
+
+  it("does not fail orchestrator spawn when monitor boot cannot write", async () => {
+    const blockedInboxBase = join(
+      tmpdir(),
+      `cmux-monitor-boot-blocked-${process.pid}-${Date.now()}`,
+    );
+    writeFileSync(blockedInboxBase, "not a directory");
+    const blockedExec = makeExec();
+    const blockedServer = createServer({
+      exec: blockedExec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: blockedInboxBase,
+    });
+
+    try {
+      const spawn = blockedServer._registeredTools["spawn_agent"];
+      const result = await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "sonnet",
+          cli: "claude",
+          role: "orchestrator",
+        },
+        {} as any,
+      );
+
+      const parsed = parseToolResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.monitor_boot).toEqual({
+        heartbeat_written: false,
+        heartbeat_source: "server_boot",
+        monitor_command: expect.stringContaining(parsed.agent_id),
+        error: expect.stringContaining("ENOTDIR"),
+      });
+    } finally {
+      rmSync(blockedInboxBase, { force: true });
+    }
   });
 
   it("nudges the first orchestrator dispatch until the agent heartbeats", async () => {

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -121,7 +121,7 @@ describe("spawn monitor boot", () => {
     rmSync(inboxDir, { recursive: true, force: true });
   });
 
-  it("returns monitor boot metadata and writes a heartbeat for orchestrators", async () => {
+  it("returns monitor boot metadata without marking the monitor alive", async () => {
     const spawn = server._registeredTools["spawn_agent"];
 
     const result = await spawn.handler(
@@ -138,11 +138,12 @@ describe("spawn monitor boot", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.monitor_boot).toEqual({
       heartbeat_written: true,
+      heartbeat_source: "server_boot",
       monitor_command: expect.stringContaining(parsed.agent_id),
     });
     expect(parsed.monitor_boot.monitor_command).toContain("tail -n0 -F");
     expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
-      true,
+      false,
     );
   });
 
@@ -167,7 +168,7 @@ describe("spawn monitor boot", () => {
     );
   });
 
-  it("dispatch sees monitor boot heartbeat before the first orchestrator task", async () => {
+  it("nudges the first orchestrator dispatch until the agent heartbeats", async () => {
     const spawn = server._registeredTools["spawn_agent"];
     const dispatch = server._registeredTools["dispatch_to_agent"];
 
@@ -196,9 +197,10 @@ describe("spawn monitor boot", () => {
 
     const parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
-    expect(parsed.monitor_alive).toBe(true);
-    expect(parsed.nudge.attempted).toBe(false);
-    expect(sendCalls(exec)).toHaveLength(beforeDispatchSendCount);
+    expect(parsed.monitor_alive).toBe(false);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(true);
+    expect(sendCalls(exec)).toHaveLength(beforeDispatchSendCount + 1);
     expect(readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task)).toEqual(
       ["GO"],
     );

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
+import { inboxPath, monitorAlive } from "../src/inbox.js";
 
 const TEST_DIR = join(tmpdir(), "cmuxlayer-spawn-workspace-test");
 
@@ -95,10 +96,12 @@ describe("workspace spawn tools", () => {
 
   it("spawn_in_workspace spawns agents into the created workspace", async () => {
     const client = makeWorkspaceClient();
+    const inboxDir = join(TEST_DIR, "inbox");
     const server = createServer({
       client: client as any,
       stateDir: TEST_DIR,
       disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
     });
     const tool = (server as any)._registeredTools["spawn_in_workspace"];
 
@@ -121,6 +124,11 @@ describe("workspace spawn tools", () => {
         surface_id: "surface:1",
         repo: "brainlayer",
         cli: "claude",
+        monitor_boot: {
+          heartbeat_written: true,
+          heartbeat_source: "server_boot",
+          monitor_command: expect.any(String),
+        },
       }),
       expect.objectContaining({
         surface_id: "surface:2",
@@ -128,6 +136,13 @@ describe("workspace spawn tools", () => {
         cli: "codex",
       }),
     ]);
+    expect(parsed.agents[1].monitor_boot).toBeUndefined();
+    expect(
+      existsSync(inboxPath(parsed.agents[0].agent_id, { baseDir: inboxDir })),
+    ).toBe(true);
+    expect(
+      monitorAlive(parsed.agents[0].agent_id, 1_000, { baseDir: inboxDir }),
+    ).toBe(false);
     expect(client.createWorkspace).toHaveBeenCalledTimes(1);
     expect(client.newSplit).toHaveBeenCalledTimes(2);
     expect(

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -48,7 +48,7 @@ function makeWorkspaceClient() {
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({
       surface: "surface:1",
-      text: "$ ",
+      text: "Claude Code\n>",
       lines: 1,
       scrollback_used: false,
     }),


### PR DESCRIPTION
## Summary
- add monitor boot metadata for orchestrator-role `spawn_agent` responses
- write an inbox heartbeat and expose the recommended persistent Monitor command at spawn time
- keep worker/IC spawns out of monitor boot so existing nudge fallback coverage remains valid

## Test plan
- RED: `bun run test tests/spawn-monitor-boot.test.ts` failed with missing `monitor_boot` and `monitor_alive:false` on orchestrator dispatch
- GREEN: `bun run test tests/spawn-monitor-boot.test.ts tests/inbox-nudge.test.ts tests/inbox.test.ts tests/server-agent-tools.test.ts tests/server.test.ts` -> 5 files passed, 148 tests passed
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit`
- pre-push `bun run test` -> 48 files passed, 814 tests passed
- local CodeRabbit CLI was rate-limited for this branch (`waitTime: 6 minutes and 31 seconds`)

## Notes
- Stacked PR 2/4 for gen17 CX-1.
- Base is PR1 branch `gen17-cx1-false-green`.
- Do not merge; lead/orc owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbox liveness semantics and adds orchestrator-only spawn response fields; misclassification of role or heartbeat parsing could affect dispatch nudge behavior until the agent heartbeats.
> 
> **Overview**
> Orchestrator spawns now **prepare the inbox monitor channel at boot** and expose setup metadata in spawn responses, while **worker/IC spawns stay unchanged**.
> 
> **Inbox heartbeats** gain an optional `source` (`agent` vs `server_boot`). Server boot lines are written for audit but **`monitorAlive` only considers the latest `agent` heartbeat**, so a boot marker no longer suppresses `dispatch_to_agent` nudges or looks like a live monitor. New helpers create the inbox file and parse/read the last heartbeat line.
> 
> **`spawn_agent` and `spawn_in_workspace`** call monitor boot only when the resolved role is **orchestrator**: ensure inbox exists, append a `server_boot` heartbeat, and return **`monitor_boot`** (recommended `tail -n0 -F` command, write success/failure). Boot failures are reported in metadata and **do not fail the spawn**.
> 
> Tests cover boot vs agent liveness, orchestrator-only boot, non-fatal write errors, first-dispatch nudge when only `server_boot` exists, and workspace spawn shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c628cd9d5a6ebdb9c6f28244b3b11a6a0f10924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track monitor boot orchestrator spawns with `server_boot` heartbeats
> - When `spawn_agent` or `spawn_in_workspace` spawns an orchestrator role, the server now writes a `server_boot` heartbeat to the agent's inbox and returns `monitor_boot` metadata (recommended monitor command, inbox path) in the response.
> - Adds `readLastHeartbeat` and `readLastAgentHeartbeat` to [src/inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/166/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d); `monitorAlive` now scans backwards for the last agent-sourced heartbeat, ignoring `server_boot` markers.
> - Boot readiness and enter-submit verification in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/166/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now require a recognizable agent identity on screen, preventing false-positives on bare shell prompts.
> - Behavioral Change: `isSubmitVerifiedStatus` no longer treats `done` as a verified status; enter-submit polling continues until an agent identity is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c628cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->