### PR TITLE
feat: add dry-run MCP orphan reaper

### DIFF
--- a/scripts/com.cmuxlayer.mcp-reaper.plist
+++ b/scripts/com.cmuxlayer.mcp-reaper.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  cmuxlayer MCP orphan reaper launchd template.
+
+  Install:
+    1. Run `bun run build` in the cmuxlayer checkout.
+    2. Copy this file to ~/Library/LaunchAgents/com.cmuxlayer.mcp-reaper.plist.
+    3. Edit ProgramArguments if the checkout is not /Users/etanheyman/Gits/cmuxlayer.
+    4. Load it with:
+       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cmuxlayer.mcp-reaper.plist
+
+  Safety:
+    REAPER_DRY_RUN defaults to 1 here and in the CLI. Set it to 0 only after
+    reviewing dry-run logs.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cmuxlayer.mcp-reaper</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/etanheyman/Gits/cmuxlayer/scripts/mcp-orphan-reaper.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>REAPER_DRY_RUN</key>
+    <string>1</string>
+    <key>REAPER_MIN_AGE_SECONDS</key>
+    <string>600</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/com.cmuxlayer.mcp-reaper.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/tmp/com.cmuxlayer.mcp-reaper.err.log</string>
+</dict>
+</plist>

--- a/scripts/com.cmuxlayer.mcp-reaper.plist
+++ b/scripts/com.cmuxlayer.mcp-reaper.plist
@@ -27,6 +27,8 @@
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>REAPER_DRY_RUN</key>
     <string>1</string>
     <key>REAPER_MIN_AGE_SECONDS</key>

--- a/scripts/mcp-orphan-reaper.sh
+++ b/scripts/mcp-orphan-reaper.sh
@@ -28,14 +28,27 @@
 
 set -euo pipefail
 
+launchd_safe_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+if [[ -n "${PATH:-}" ]]; then
+  export PATH="${launchd_safe_path}:${PATH}"
+else
+  export PATH="${launchd_safe_path}"
+fi
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(cd "${script_dir}/.." && pwd)"
 dist_cli="${repo_dir}/dist/mcp-reaper.js"
 src_cli="${repo_dir}/src/mcp-reaper.ts"
 local_tsx="${repo_dir}/node_modules/.bin/tsx"
+node_bin="$(command -v node || true)"
+
+if [[ -z "${node_bin}" ]]; then
+  printf '%s\n' "node is required but was not found on PATH: ${PATH}" >&2
+  exit 1
+fi
 
 if [[ -f "${dist_cli}" ]]; then
-  exec node "${dist_cli}" "$@"
+  exec "${node_bin}" "${dist_cli}" "$@"
 fi
 
 if [[ -x "${local_tsx}" ]]; then

--- a/scripts/mcp-orphan-reaper.sh
+++ b/scripts/mcp-orphan-reaper.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cmuxlayer MCP orphan reaper
+#
+# What it kills:
+#   Only node MCP server processes selected by src/mcp-reaper.ts where all gates
+#   pass: argv matches a tight MCP server pattern or allowlist, ppid == 1, and
+#   elapsed age >= REAPER_MIN_AGE_SECONDS (default 600).
+#
+# Dry-run default:
+#   This wrapper sends no signals unless you pass --execute or set
+#   REAPER_DRY_RUN=0. Dry-run logs what WOULD be killed.
+#
+# Usage:
+#   scripts/mcp-orphan-reaper.sh
+#   scripts/mcp-orphan-reaper.sh --execute
+#   REAPER_MIN_AGE_SECONDS=1800 REAPER_DRY_RUN=0 scripts/mcp-orphan-reaper.sh
+#
+# launchd install:
+#   1. Run `bun run build` so dist/mcp-reaper.js exists.
+#   2. Copy scripts/com.cmuxlayer.mcp-reaper.plist to ~/Library/LaunchAgents/.
+#   3. Edit the ProgramArguments path if this checkout is not
+#      /Users/etanheyman/Gits/cmuxlayer/scripts/mcp-orphan-reaper.sh.
+#   4. Run:
+#      launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cmuxlayer.mcp-reaper.plist
+#
+# This is a standalone process cleanup tool. It does not alter cmuxlayer agent
+# lifecycle or orphan-survival behavior.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "${script_dir}/.." && pwd)"
+dist_cli="${repo_dir}/dist/mcp-reaper.js"
+src_cli="${repo_dir}/src/mcp-reaper.ts"
+local_tsx="${repo_dir}/node_modules/.bin/tsx"
+
+if [[ -f "${dist_cli}" ]]; then
+  exec node "${dist_cli}" "$@"
+fi
+
+if [[ -x "${local_tsx}" ]]; then
+  exec "${local_tsx}" "${src_cli}" "$@"
+fi
+
+printf '%s\n' "dist/mcp-reaper.js is missing and node_modules/.bin/tsx is unavailable." >&2
+printf '%s\n' "Run bun install and bun run build before installing the launchd job." >&2
+exit 1

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -55,6 +55,16 @@ interface CliOptions {
   knownServerNames: readonly string[];
 }
 
+export interface SignalAttempt {
+  ok: boolean;
+  pid: number;
+  signal: NodeJS.Signals;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export type KillProcess = (pid: number, signal: NodeJS.Signals) => void;
+
 const DEFAULT_MIN_AGE_SECONDS = 600;
 const DEFAULT_GRACE_SECONDS = 10;
 const DEFAULT_LOG_FILE = `${homedir()}/.local/state/cmuxlayer/mcp-reaper.log`;
@@ -145,6 +155,40 @@ export function parseProcessLine(line: string): ProcessInfo | null {
   } catch {
     return null;
   }
+}
+
+export function signalProcessBatch(
+  processes: readonly ProcessInfo[],
+  signal: NodeJS.Signals,
+  killProcess: KillProcess = process.kill,
+): SignalAttempt[] {
+  return processes.map((proc) => {
+    try {
+      killProcess(proc.pid, signal);
+      return { ok: true, pid: proc.pid, signal };
+    } catch (error) {
+      return {
+        ok: false,
+        pid: proc.pid,
+        signal,
+        errorCode: signalErrorCode(error),
+        errorMessage:
+          error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+}
+
+function signalErrorCode(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return "UNKNOWN";
 }
 
 async function readProcessTable(): Promise<ProcessInfo[]> {
@@ -261,6 +305,20 @@ async function appendLogLine(logFile: string, line: string): Promise<void> {
   await appendFile(logFile, `${new Date().toISOString()} ${line}\n`);
 }
 
+async function logSignalFailures(
+  logFile: string,
+  attempts: readonly SignalAttempt[],
+): Promise<void> {
+  for (const attempt of attempts) {
+    if (attempt.ok) {
+      continue;
+    }
+    const line = `SIGNAL_FAILED signal=${attempt.signal} pid=${attempt.pid} code=${attempt.errorCode ?? "UNKNOWN"} message=${attempt.errorMessage ?? ""}`;
+    console.error(line);
+    await appendLogLine(logFile, line);
+  }
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
@@ -284,14 +342,16 @@ async function runReaper(opts: CliOptions): Promise<void> {
     const line = `${opts.dryRun ? "DRY_RUN would terminate" : "SIGTERM"} ${formatProcess(proc)}`;
     console.log(line);
     await appendLogLine(opts.logFile, line);
-    if (!opts.dryRun) {
-      process.kill(proc.pid, "SIGTERM");
-    }
   }
 
   if (opts.dryRun) {
     return;
   }
+
+  await logSignalFailures(
+    opts.logFile,
+    signalProcessBatch(reapable, "SIGTERM"),
+  );
 
   await sleep(opts.graceSeconds * 1000);
 
@@ -310,8 +370,11 @@ async function runReaper(opts: CliOptions): Promise<void> {
     const line = `SIGKILL ${formatProcess(proc)}`;
     console.log(line);
     await appendLogLine(opts.logFile, line);
-    process.kill(proc.pid, "SIGKILL");
   }
+  await logSignalFailures(
+    opts.logFile,
+    signalProcessBatch(killable, "SIGKILL"),
+  );
 }
 
 async function main(): Promise<void> {

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -282,7 +282,7 @@ function envDryRun(value: string | undefined): boolean {
   return !["0", "false", "no"].includes(value.trim().toLowerCase());
 }
 
-function parseCliOptions(argv: readonly string[]): CliOptions {
+export function parseCliOptions(argv: readonly string[]): CliOptions {
   let dryRun = envDryRun(process.env.REAPER_DRY_RUN);
   let minAgeSeconds = parseIntegerEnv(
     process.env.REAPER_MIN_AGE_SECONDS,
@@ -305,9 +305,15 @@ function parseCliOptions(argv: readonly string[]): CliOptions {
       dryRun = true;
     } else if (arg === "--min-age-seconds") {
       i += 1;
+      if (!argv[i]) {
+        throw new Error("--min-age-seconds requires a value");
+      }
       minAgeSeconds = parseIntegerEnv(argv[i], minAgeSeconds, arg);
     } else if (arg === "--grace-seconds") {
       i += 1;
+      if (!argv[i]) {
+        throw new Error("--grace-seconds requires a value");
+      }
       graceSeconds = parseIntegerEnv(argv[i], graceSeconds, arg);
     } else if (arg === "--log-file") {
       i += 1;

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * cmuxlayer MCP orphan reaper
+ *
+ * What it targets:
+ * - node processes whose argv matches a tight MCP server pattern or known MCP
+ *   server allowlist,
+ * - whose parent is pid 1,
+ * - whose elapsed age is at least REAPER_MIN_AGE_SECONDS, default 600 seconds.
+ *
+ * Dry-run is the default. With no flags, the reaper logs and prints what it
+ * would terminate, but sends no signals. To actually reap processes, pass
+ * --execute or set REAPER_DRY_RUN=0.
+ *
+ * Usage:
+ *   scripts/mcp-orphan-reaper.sh
+ *   scripts/mcp-orphan-reaper.sh --execute
+ *   REAPER_MIN_AGE_SECONDS=1800 REAPER_DRY_RUN=0 scripts/mcp-orphan-reaper.sh
+ *
+ * launchd:
+ *   Copy scripts/com.cmuxlayer.mcp-reaper.plist to ~/Library/LaunchAgents/,
+ *   edit the ProgramArguments path for this checkout, then run:
+ *   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cmuxlayer.mcp-reaper.plist
+ *
+ * This tool intentionally does not change cmuxlayer agent lifecycle semantics.
+ * It only considers already-orphaned MCP server child processes.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdir, appendFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+
+export interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  etimes: number;
+  command: string;
+}
+
+export interface SelectReapableOptions {
+  minAgeSeconds?: number;
+  knownServerNames?: readonly string[];
+}
+
+interface CliOptions {
+  dryRun: boolean;
+  graceSeconds: number;
+  logFile: string;
+  minAgeSeconds: number;
+  knownServerNames: readonly string[];
+}
+
+const DEFAULT_MIN_AGE_SECONDS = 600;
+const DEFAULT_GRACE_SECONDS = 10;
+const DEFAULT_LOG_FILE = `${homedir()}/.local/state/cmuxlayer/mcp-reaper.log`;
+const DEFAULT_KNOWN_SERVER_NAMES = [
+  "@modelcontextprotocol/server-",
+  "brainlayer-mcp",
+  "context7-mcp",
+  "mcp-server-daemon",
+  "voicelayer-mcp",
+  "whatsapp-mcp",
+] as const;
+
+export function selectReapablePids(
+  procList: readonly ProcessInfo[],
+  opts: SelectReapableOptions = {},
+): number[] {
+  const minAgeSeconds = opts.minAgeSeconds ?? DEFAULT_MIN_AGE_SECONDS;
+  const knownServerNames =
+    opts.knownServerNames ?? DEFAULT_KNOWN_SERVER_NAMES;
+
+  return procList
+    .filter((proc) => proc.ppid === 1)
+    .filter((proc) => proc.etimes >= minAgeSeconds)
+    .filter((proc) => isNodeCommand(proc.command))
+    .filter((proc) => isMcpServerCommand(proc.command, knownServerNames))
+    .map((proc) => proc.pid);
+}
+
+function isNodeCommand(command: string): boolean {
+  const executable = command.trim().split(/\s+/, 1)[0] ?? "";
+  return basename(executable) === "node";
+}
+
+function isMcpServerCommand(
+  command: string,
+  knownServerNames: readonly string[],
+): boolean {
+  if (/-mcp(?:$|[\s/._-])/i.test(command)) {
+    return true;
+  }
+
+  const lowered = command.toLowerCase();
+  return knownServerNames
+    .map((name) => name.trim().toLowerCase())
+    .filter((name) => name.length > 0 && name !== "mcp")
+    .some((name) => lowered.includes(name));
+}
+
+export function parseElapsedSeconds(etime: string): number {
+  const trimmed = etime.trim();
+  const dayParts = trimmed.split("-");
+  if (dayParts.length > 2) {
+    throw new Error(`Invalid ps etime value: ${etime}`);
+  }
+
+  const days = dayParts.length === 2 ? Number(dayParts[0]) : 0;
+  const timePart = dayParts[dayParts.length - 1];
+  const timeParts = timePart.split(":").map((part) => Number(part));
+  if (
+    !Number.isInteger(days) ||
+    days < 0 ||
+    ![2, 3].includes(timeParts.length) ||
+    timeParts.some((part) => !Number.isInteger(part) || part < 0)
+  ) {
+    throw new Error(`Invalid ps etime value: ${etime}`);
+  }
+
+  const [hours, minutes, seconds] =
+    timeParts.length === 3
+      ? timeParts
+      : [0, timeParts[0], timeParts[1]];
+  return days * 86400 + hours * 3600 + minutes * 60 + seconds;
+}
+
+export function parseProcessLine(line: string): ProcessInfo | null {
+  const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.+?)\s*$/);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    return {
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      etimes: parseElapsedSeconds(match[3]),
+      command: match[4],
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readProcessTable(): Promise<ProcessInfo[]> {
+  const { stdout } = await execFileAsync("ps", [
+    "-axo",
+    "pid=,ppid=,etime=,command=",
+  ]);
+  return stdout
+    .split("\n")
+    .map(parseProcessLine)
+    .filter((proc): proc is ProcessInfo => proc !== null);
+}
+
+function parseIntegerEnv(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${value}`);
+  }
+  return parsed;
+}
+
+function envDryRun(value: string | undefined): boolean {
+  if (value === undefined || value.trim() === "") {
+    return true;
+  }
+  return !["0", "false", "no"].includes(value.trim().toLowerCase());
+}
+
+function parseCliOptions(argv: readonly string[]): CliOptions {
+  let dryRun = envDryRun(process.env.REAPER_DRY_RUN);
+  let minAgeSeconds = parseIntegerEnv(
+    process.env.REAPER_MIN_AGE_SECONDS,
+    DEFAULT_MIN_AGE_SECONDS,
+    "REAPER_MIN_AGE_SECONDS",
+  );
+  let graceSeconds = parseIntegerEnv(
+    process.env.REAPER_GRACE_SECONDS,
+    DEFAULT_GRACE_SECONDS,
+    "REAPER_GRACE_SECONDS",
+  );
+  let logFile = process.env.REAPER_LOG_FILE ?? DEFAULT_LOG_FILE;
+  let knownServerNames: readonly string[] = DEFAULT_KNOWN_SERVER_NAMES;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--execute") {
+      dryRun = false;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--min-age-seconds") {
+      i += 1;
+      minAgeSeconds = parseIntegerEnv(argv[i], minAgeSeconds, arg);
+    } else if (arg === "--grace-seconds") {
+      i += 1;
+      graceSeconds = parseIntegerEnv(argv[i], graceSeconds, arg);
+    } else if (arg === "--log-file") {
+      i += 1;
+      if (!argv[i]) {
+        throw new Error("--log-file requires a path");
+      }
+      logFile = argv[i];
+    } else if (arg === "--known-server-name") {
+      i += 1;
+      if (!argv[i]) {
+        throw new Error("--known-server-name requires a value");
+      }
+      knownServerNames = [...knownServerNames, argv[i]];
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return {
+    dryRun,
+    graceSeconds,
+    knownServerNames,
+    logFile,
+    minAgeSeconds,
+  };
+}
+
+function printUsage(): void {
+  console.log(`cmuxlayer MCP orphan reaper
+
+Dry-run by default. Pass --execute or set REAPER_DRY_RUN=0 to send signals.
+
+Options:
+  --dry-run                 Force dry-run mode
+  --execute                 Send SIGTERM, then SIGKILL after grace if still safe
+  --min-age-seconds <n>     Minimum process age, default ${DEFAULT_MIN_AGE_SECONDS}
+  --grace-seconds <n>       Seconds between SIGTERM and SIGKILL, default ${DEFAULT_GRACE_SECONDS}
+  --log-file <path>         Log file, default ${DEFAULT_LOG_FILE}
+  --known-server-name <s>   Add a known MCP server name allowlist entry
+`);
+}
+
+function formatProcess(proc: ProcessInfo): string {
+  return `pid=${proc.pid} ppid=${proc.ppid} age=${proc.etimes}s argv=${proc.command}`;
+}
+
+async function appendLogLine(logFile: string, line: string): Promise<void> {
+  await mkdir(dirname(logFile), { recursive: true });
+  await appendFile(logFile, `${new Date().toISOString()} ${line}\n`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+async function runReaper(opts: CliOptions): Promise<void> {
+  const processes = await readProcessTable();
+  const reapablePids = new Set(
+    selectReapablePids(processes, {
+      knownServerNames: opts.knownServerNames,
+      minAgeSeconds: opts.minAgeSeconds,
+    }),
+  );
+  const reapable = processes.filter((proc) => reapablePids.has(proc.pid));
+
+  if (reapable.length === 0) {
+    console.log("No reapable ppid=1 idle node MCP orphans found.");
+    return;
+  }
+
+  for (const proc of reapable) {
+    const line = `${opts.dryRun ? "DRY_RUN would terminate" : "SIGTERM"} ${formatProcess(proc)}`;
+    console.log(line);
+    await appendLogLine(opts.logFile, line);
+    if (!opts.dryRun) {
+      process.kill(proc.pid, "SIGTERM");
+    }
+  }
+
+  if (opts.dryRun) {
+    return;
+  }
+
+  await sleep(opts.graceSeconds * 1000);
+
+  const afterGrace = await readProcessTable();
+  const stillReapablePids = new Set(
+    selectReapablePids(afterGrace, {
+      knownServerNames: opts.knownServerNames,
+      minAgeSeconds: opts.minAgeSeconds,
+    }),
+  );
+  const killable = afterGrace.filter(
+    (proc) => reapablePids.has(proc.pid) && stillReapablePids.has(proc.pid),
+  );
+
+  for (const proc of killable) {
+    const line = `SIGKILL ${formatProcess(proc)}`;
+    console.log(line);
+    await appendLogLine(opts.logFile, line);
+    process.kill(proc.pid, "SIGKILL");
+  }
+}
+
+async function main(): Promise<void> {
+  const opts = parseCliOptions(process.argv.slice(2));
+  await runReaper(opts);
+}
+
+const isMain =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isMain) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -40,6 +40,8 @@ export interface ProcessInfo {
   ppid: number;
   etimes: number;
   command: string;
+  launchdManaged?: boolean;
+  launchdLabel?: string;
 }
 
 export interface SelectReapableOptions {
@@ -90,6 +92,7 @@ export function selectReapablePids(
 
   return procList
     .filter((proc) => proc.ppid === 1)
+    .filter((proc) => proc.launchdManaged !== true)
     .filter((proc) => proc.etimes >= minAgeSeconds)
     .filter((proc) => isNodeCommand(proc.command))
     .filter((proc) => isMcpServerCommand(proc.command, knownServerNames))
@@ -163,6 +166,22 @@ export function parseProcessLine(line: string): ProcessInfo | null {
   }
 }
 
+export function parseLaunchdServicePids(output: string): Map<number, string> {
+  const services = new Map<number, string>();
+  for (const line of output.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+[-\d]+\s+([A-Za-z0-9_.-]+)\s*$/);
+    if (!match) {
+      continue;
+    }
+
+    const pid = Number(match[1]);
+    if (pid > 0) {
+      services.set(pid, match[2]);
+    }
+  }
+  return services;
+}
+
 export function signalProcessBatch(
   processes: readonly ProcessInfo[],
   signal: NodeJS.Signals,
@@ -202,10 +221,42 @@ async function readProcessTable(): Promise<ProcessInfo[]> {
     "-axo",
     "pid=,ppid=,etime=,command=",
   ]);
+  const launchdServices = await readLaunchdServicePids();
   return stdout
     .split("\n")
     .map(parseProcessLine)
-    .filter((proc): proc is ProcessInfo => proc !== null);
+    .filter((proc): proc is ProcessInfo => proc !== null)
+    .map((proc) => {
+      const launchdLabel = launchdServices.get(proc.pid);
+      if (!launchdLabel) {
+        return proc;
+      }
+      return {
+        ...proc,
+        launchdLabel,
+        launchdManaged: true,
+      };
+    });
+}
+
+async function readLaunchdServicePids(): Promise<Map<number, string>> {
+  const domains = ["system"];
+  if (typeof process.getuid === "function") {
+    domains.push(`gui/${process.getuid()}`);
+  }
+
+  const services = new Map<number, string>();
+  for (const domain of domains) {
+    try {
+      const { stdout } = await execFileAsync("launchctl", ["print", domain]);
+      for (const [pid, label] of parseLaunchdServicePids(stdout)) {
+        services.set(pid, label);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return services;
 }
 
 function parseIntegerEnv(

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -67,6 +67,12 @@ export interface SignalAttempt {
 
 export type KillProcess = (pid: number, signal: NodeJS.Signals) => void;
 
+export const PROCESS_TABLE_PS_ARGS = [
+  "-ww",
+  "-axo",
+  "pid=,ppid=,etime=,command=",
+] as const;
+
 const DEFAULT_MIN_AGE_SECONDS = 600;
 const DEFAULT_GRACE_SECONDS = 10;
 const DEFAULT_LOG_FILE = `${homedir()}/.local/state/cmuxlayer/mcp-reaper.log`;
@@ -217,10 +223,7 @@ function signalErrorCode(error: unknown): string {
 }
 
 async function readProcessTable(): Promise<ProcessInfo[]> {
-  const { stdout } = await execFileAsync("ps", [
-    "-axo",
-    "pid=,ppid=,etime=,command=",
-  ]);
+  const { stdout } = await execFileAsync("ps", [...PROCESS_TABLE_PS_ARGS]);
   const launchdServices = await readLaunchdServicePids();
   return stdout
     .split("\n")

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -76,6 +76,9 @@ const DEFAULT_KNOWN_SERVER_NAMES = [
   "voicelayer-mcp",
   "whatsapp-mcp",
 ] as const;
+const MCP_PACKAGE_NAME_PATTERN = /-mcp(?:$|[\s/._-])/i;
+const MCP_SERVER_ENTRYPOINT_PATTERN =
+  /(?:^|[\/\s])(?:dist|build|lib)\/(?:index|server|mcp-server)\.(?:js|mjs|cjs)(?:$|[\s"'`])/i;
 
 export function selectReapablePids(
   procList: readonly ProcessInfo[],
@@ -102,7 +105,10 @@ function isMcpServerCommand(
   command: string,
   knownServerNames: readonly string[],
 ): boolean {
-  if (/-mcp(?:$|[\s/._-])/i.test(command)) {
+  if (
+    MCP_PACKAGE_NAME_PATTERN.test(command) &&
+    MCP_SERVER_ENTRYPOINT_PATTERN.test(command)
+  ) {
     return true;
   }
 

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -75,6 +75,12 @@ describe("selectReapablePids", () => {
         command:
           "node /Users/etan/Gits/official/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
       },
+      {
+        pid: 205,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etan/Gits/acme-mcp/scripts/dev.js",
+      },
     ];
 
     expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -3,6 +3,7 @@ import {
   parseElapsedSeconds,
   parseProcessLine,
   selectReapablePids,
+  signalProcessBatch,
 } from "../src/mcp-reaper.js";
 import type { ProcessInfo } from "../src/mcp-reaper.js";
 
@@ -125,5 +126,39 @@ describe("process table parsing", () => {
       etimes: 183845,
       command: "node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
     });
+  });
+});
+
+describe("signalProcessBatch", () => {
+  it("continues signaling remaining processes when one pid is already gone", () => {
+    const signaled: Array<[number, NodeJS.Signals]> = [];
+    const processes: ProcessInfo[] = [
+      { pid: 401, ppid: 1, etimes: 1200, command: "node a-mcp/index.js" },
+      { pid: 402, ppid: 1, etimes: 1200, command: "node b-mcp/index.js" },
+      { pid: 403, ppid: 1, etimes: 1200, command: "node c-mcp/index.js" },
+    ];
+
+    const attempts = signalProcessBatch(processes, "SIGTERM", (pid, signal) => {
+      if (pid === 402) {
+        throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+      }
+      signaled.push([pid, signal]);
+    });
+
+    expect(signaled).toEqual([
+      [401, "SIGTERM"],
+      [403, "SIGTERM"],
+    ]);
+    expect(attempts).toEqual([
+      { ok: true, pid: 401, signal: "SIGTERM" },
+      {
+        errorCode: "ESRCH",
+        errorMessage: "no such process",
+        ok: false,
+        pid: 402,
+        signal: "SIGTERM",
+      },
+      { ok: true, pid: 403, signal: "SIGTERM" },
+    ]);
   });
 });

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseElapsedSeconds,
+  parseLaunchdServicePids,
   parseProcessLine,
   selectReapablePids,
   signalProcessBatch,
@@ -39,6 +40,13 @@ describe("selectReapablePids", () => {
         ppid: 1,
         etimes: 1200,
         command: "node /Users/etan/Gits/some-mcp-adapter/dist/index.js",
+      },
+      {
+        pid: 106,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etan/Gits/supervised-mcp/dist/index.js",
+        launchdManaged: true,
       },
     ];
 
@@ -132,6 +140,25 @@ describe("process table parsing", () => {
       etimes: 183845,
       command: "node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
     });
+  });
+
+  it("parses nonzero launchd service pids from launchctl print output", () => {
+    expect(
+      Array.from(
+        parseLaunchdServicePids(
+          [
+            "services = {",
+            "        852      -  com.mcplayer.bus",
+            "      71776      0  com.whatsapp-mcp.bridge-business",
+            "          0      0  com.golems.mcp-reaper",
+            "}",
+          ].join("\n"),
+        ).entries(),
+      ),
+    ).toEqual([
+      [852, "com.mcplayer.bus"],
+      [71776, "com.whatsapp-mcp.bridge-business"],
+    ]);
   });
 });
 

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  PROCESS_TABLE_PS_ARGS,
   parseElapsedSeconds,
   parseCliOptions,
   parseLaunchdServicePids,
@@ -205,5 +206,15 @@ describe("parseCliOptions", () => {
     expect(() => parseCliOptions(["--grace-seconds"])).toThrow(
       "--grace-seconds requires a value",
     );
+  });
+});
+
+describe("PROCESS_TABLE_PS_ARGS", () => {
+  it("requests unlimited ps output width before parsing argv", () => {
+    expect(PROCESS_TABLE_PS_ARGS).toEqual([
+      "-ww",
+      "-axo",
+      "pid=,ppid=,etime=,command=",
+    ]);
   });
 });

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseElapsedSeconds,
+  parseCliOptions,
   parseLaunchdServicePids,
   parseProcessLine,
   selectReapablePids,
@@ -193,5 +194,16 @@ describe("signalProcessBatch", () => {
       },
       { ok: true, pid: 403, signal: "SIGTERM" },
     ]);
+  });
+});
+
+describe("parseCliOptions", () => {
+  it("rejects numeric flags without values", () => {
+    expect(() => parseCliOptions(["--min-age-seconds"])).toThrow(
+      "--min-age-seconds requires a value",
+    );
+    expect(() => parseCliOptions(["--grace-seconds"])).toThrow(
+      "--grace-seconds requires a value",
+    );
   });
 });

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseElapsedSeconds,
+  parseProcessLine,
+  selectReapablePids,
+} from "../src/mcp-reaper.js";
+import type { ProcessInfo } from "../src/mcp-reaper.js";
+
+describe("selectReapablePids", () => {
+  it("selects only ppid=1 idle node MCP server processes", () => {
+    const processes: ProcessInfo[] = [
+      {
+        pid: 101,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
+      },
+      {
+        pid: 102,
+        ppid: 4242,
+        etimes: 1200,
+        command: "node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
+      },
+      {
+        pid: 103,
+        ppid: 1,
+        etimes: 120,
+        command: "node /Users/etan/Gits/voicelayer-mcp/dist/index.js",
+      },
+      {
+        pid: 104,
+        ppid: 1,
+        etimes: 1200,
+        command: "python /Users/etan/Gits/brainlayer-mcp/server.py",
+      },
+      {
+        pid: 105,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etan/Gits/some-mcp-adapter/dist/index.js",
+      },
+    ];
+
+    expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
+      101,
+      105,
+    ]);
+  });
+
+  it("does not match bare mcp substrings outside the tight pattern and allowlist", () => {
+    const processes: ProcessInfo[] = [
+      {
+        pid: 201,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /tmp/acme-mcp/dist/index.js",
+      },
+      {
+        pid: 202,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /tmp/mcp/dist/index.js",
+      },
+      {
+        pid: 203,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /tmp/mcproxy/dist/index.js",
+      },
+      {
+        pid: 204,
+        ppid: 1,
+        etimes: 1200,
+        command:
+          "node /Users/etan/Gits/official/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
+      },
+    ];
+
+    expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
+      201,
+      204,
+    ]);
+  });
+
+  it("honors custom known MCP server names without broadening to every mcp string", () => {
+    const processes: ProcessInfo[] = [
+      {
+        pid: 301,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /srv/context7/dist/index.js",
+      },
+      {
+        pid: 302,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /srv/mcp/dist/index.js",
+      },
+    ];
+
+    expect(
+      selectReapablePids(processes, {
+        knownServerNames: ["context7"],
+        minAgeSeconds: 600,
+      }),
+    ).toEqual([301]);
+  });
+});
+
+describe("process table parsing", () => {
+  it("parses macOS ps etime values into elapsed seconds", () => {
+    expect(parseElapsedSeconds("00:01")).toBe(1);
+    expect(parseElapsedSeconds("01:02:03")).toBe(3723);
+    expect(parseElapsedSeconds("2-03:04:05")).toBe(183845);
+  });
+
+  it("parses pid, ppid, etime, and full argv from a ps row", () => {
+    expect(
+      parseProcessLine(
+        "  4242     1 2-03:04:05 node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
+      ),
+    ).toEqual({
+      pid: 4242,
+      ppid: 1,
+      etimes: 183845,
+      command: "node /Users/etan/Gits/brainlayer-mcp/dist/index.js",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone MCP orphan reaper CLI with dry-run default, explicit `--execute` opt-in, ppid/age/node/MCP selection gates, and SIGTERM/SIGKILL grace handling
- add `scripts/mcp-orphan-reaper.sh` wrapper plus dry-run launchd plist template for periodic runs without auto-installing anything
- add TDD coverage for `selectReapablePids()` and macOS `ps etime` parsing

## Safety notes
- does not change cmuxlayer agent lifecycle, `stop_agent`, process groups, or orphan-survival registry behavior
- selector requires `ppid === 1`, `node`, age >= threshold, and either `-mcp`/known MCP server argv matching
- dry-run is default via CLI and plist; actual signaling requires `--execute` or `REAPER_DRY_RUN=0`

## Test plan
- `bun run test` -> 48 test files passed, 825 tests passed
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit`
- `bun run build` -> `tsc -p tsconfig.json`
- `REAPER_MIN_AGE_SECONDS=999999999 scripts/mcp-orphan-reaper.sh` -> `No reapable ppid=1 idle node MCP orphans found.`
- pre-push `scripts/run_tests.sh` -> exit status 0; full hook reran Vitest with 48 test files passed, 825 tests passed

## Review notes
- local `coderabbit review --agent` was started before commit and interrupted after the bounded pre-commit window while still heartbeating in `reviewing`; no findings were emitted locally. PR-level CodeRabbit, Cursor Bugbot, Macroscope, CI test, and build-site checks are green at head `f9721182`. Inline review findings were answered and fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When execute mode is enabled, the tool sends SIGTERM/SIGKILL to user processes; mis-tuned allowlists or age thresholds could terminate long-lived but intentional MCP servers, though defaults are dry-run and filters exclude launchd-managed PIDs.
> 
> **Overview**
> Adds a **standalone macOS cleanup path** for stale MCP server processes that were left parented to pid 1, without wiring into cmuxlayer agent lifecycle or orphan-survival logic.
> 
> **`src/mcp-reaper.ts`** is a new CLI that reads `ps` (and `launchctl print` to skip launchd-managed PIDs), selects candidates only when **ppid === 1**, **node** argv, **minimum age**, and either a tight `-mcp` + dist/build entrypoint pattern or a **known-server allowlist**. Default mode is **dry-run** (log only); **`--execute`** or **`REAPER_DRY_RUN=0`** sends **SIGTERM**, waits a grace period, then **SIGKILL** only for PIDs that still pass the same gates.
> 
> **`scripts/mcp-orphan-reaper.sh`** execs built **`dist/mcp-reaper.js`** or falls back to **tsx** on the source. **`scripts/com.cmuxlayer.mcp-reaper.plist`** is an optional LaunchAgent template (300s interval, **`REAPER_DRY_RUN=1`**, 600s min age) for manual install only.
> 
> **`tests/mcp-reaper.test.ts`** covers selection rules, macOS **`etime`** parsing, launchd PID parsing, batch signaling, and CLI flag validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9721182f0fdeeec8e3162be5a79c37d8fb6c5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dry-run MCP orphan process reaper with launchd agent
> - Adds [`src/mcp-reaper.ts`](https://github.com/EtanHey/cmuxlayer/pull/167/files#diff-32c6a0b7ce6e61ede4270634b60059d84d8b3d8ab0720c01b42204c91552c263), a Node.js CLI that identifies and terminates orphaned MCP server processes (ppid==1, not launchd-managed, age above threshold) using a two-stage SIGTERM then SIGKILL flow with a configurable grace period.
> - Selects only `node` processes whose argv matches strict MCP name patterns (`-mcp` substring in expected positions, entrypoints under `dist/build/lib`) or a known-server allowlist, avoiding false positives on bare `mcp` substrings.
> - Adds [`scripts/mcp-orphan-reaper.sh`](https://github.com/EtanHey/cmuxlayer/pull/167/files#diff-5ca5ebb552df15862a8f28f4ded96711cb3833b9d9ccd0a27a1495fcfa631cf1) as a shell wrapper that locates the repo root and runs the CLI via built JS or `tsx` fallback.
> - Adds [`scripts/com.cmuxlayer.mcp-reaper.plist`](https://github.com/EtanHey/cmuxlayer/pull/167/files#diff-0c9f1ebf6b37bb3644dea2d8e59561ac38715501c98a1c404015b1786c2c121f), a launchd agent that runs the wrapper every 300 seconds with `REAPER_DRY_RUN=1` and `REAPER_MIN_AGE_SECONDS=600` by default.
> - Behavioral Change: when installed and bootstrapped via `launchctl`, the agent runs in dry-run mode by default; passing `--execute` or unsetting `REAPER_DRY_RUN` enables live signal delivery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f972118.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
