### PR TITLE
feat: index surface sessions for crash resume

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -100,6 +100,13 @@ export type SessionIdentityResolver = (
   agent: AgentRecord,
 ) => CapturedSessionIdentity | string | null;
 
+function defaultCrashRecoverForRole(role: AgentRole): boolean {
+  const override = process.env.CMUXLAYER_CRASH_RECOVER_DEFAULT;
+  if (override === "1" || override?.toLowerCase() === "true") return true;
+  if (override === "0" || override?.toLowerCase() === "false") return false;
+  return role === "orchestrator";
+}
+
 /**
  * Result of the spawn preflight. `launcherName` carries the launcher function
  * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
@@ -1724,7 +1731,7 @@ export class AgentEngine {
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: params.max_cost_per_agent ?? null,
-      crash_recover: params.crash_recover ?? false,
+      crash_recover: params.crash_recover ?? defaultCrashRecoverForRole(role),
       respawn_attempts: 0,
       user_killed: false,
       boot_prompt_pending: params.boot_prompt_pending ?? false,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -960,8 +960,22 @@ export class AgentEngine {
     if (updated.agent_id === finalAgentId) {
       return updated;
     }
-    if (this.stateMgr.readState(finalAgentId)) {
-      return updated;
+    const existingFinal = this.stateMgr.readState(finalAgentId);
+    if (existingFinal) {
+      const canonicalFinal =
+        existingFinal.cli_session_id === identity.session_id &&
+        existingFinal.cli_session_path === identity.path
+          ? existingFinal
+          : this.stateMgr.updateRecord(finalAgentId, {
+              cli_session_id: identity.session_id,
+              cli_session_path: identity.path,
+            });
+      const index = this.stateMgr.getSurfaceSessionIndex();
+      index.removeAgent(updated.agent_id);
+      index.persistRecord(canonicalFinal);
+      this.registry.remove(updated.agent_id);
+      this.stateMgr.removeState(updated.agent_id);
+      return canonicalFinal;
     }
 
     const previousAgentId = updated.agent_id;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -973,7 +973,7 @@ export class AgentEngine {
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);
       index.persistRecord(canonicalFinal);
-      this.registry.remove(updated.agent_id);
+      this.registry.rename(updated.agent_id, finalAgentId, canonicalFinal);
       this.stateMgr.removeState(updated.agent_id);
       return canonicalFinal;
     }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -107,6 +107,19 @@ function defaultCrashRecoverForRole(role: AgentRole): boolean {
   return role === "orchestrator";
 }
 
+function sessionCollisionSuffix(sessionId: string): string {
+  const normalized = sessionId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/-+/g, "-");
+  return (
+    normalized.slice(9, 17).replace(/^-+|-+$/g, "") ||
+    normalized.slice(0, 8).replace(/^-+|-+$/g, "") ||
+    "collision"
+  );
+}
+
 /**
  * Result of the spawn preflight. `launcherName` carries the launcher function
  * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
@@ -962,13 +975,32 @@ export class AgentEngine {
     }
     const existingFinal = this.stateMgr.readState(finalAgentId);
     if (existingFinal) {
+      if (
+        existingFinal.cli_session_id &&
+        existingFinal.cli_session_id !== identity.session_id
+      ) {
+        const previousAgentId = updated.agent_id;
+        const collisionBaseAgentId = `${finalAgentId}-${sessionCollisionSuffix(
+          identity.session_id,
+        )}`;
+        let collisionAgentId = collisionBaseAgentId;
+        let collisionAttempt = 2;
+        while (this.stateMgr.readState(collisionAgentId)) {
+          collisionAgentId = `${collisionBaseAgentId}-${collisionAttempt}`;
+          collisionAttempt += 1;
+        }
+        updated = this.stateMgr.renameState(previousAgentId, collisionAgentId);
+        this.registry.rename(previousAgentId, collisionAgentId, updated);
+        return updated;
+      }
+      const sessionPath = identity.path ?? existingFinal.cli_session_path ?? null;
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
-        existingFinal.cli_session_path === identity.path
+        existingFinal.cli_session_path === sessionPath
           ? existingFinal
           : this.stateMgr.updateRecord(finalAgentId, {
               cli_session_id: identity.session_id,
-              cli_session_path: identity.path,
+              cli_session_path: sessionPath,
             });
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3692,7 +3692,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         crash_recover: z
           .boolean()
           .optional()
-          .default(false)
           .describe(
             "When true, automatically respawn the agent after unexpected PTY death using its captured CLI session ID.",
           ),
@@ -3868,7 +3867,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("MCP profile hint. Defaults to inherit."),
         parent_agent_id: z.string().optional(),
         auto_archive_on_done: z.boolean().optional().default(true),
-        crash_recover: z.boolean().optional().default(false),
+        crash_recover: z.boolean().optional(),
       },
       ANNOTATIONS.mutating,
       async (args) => {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -31,18 +31,123 @@ type AgentRecordPatch = Partial<
   Omit<AgentRecord, "agent_id" | "created_at" | "updated_at" | "version" | "state">
 >;
 
+export interface SurfaceSessionIndexEntry {
+  agent_id: string;
+  workspace_id: string | null;
+  surface_id: string;
+  cli_session_id: string;
+  updated_at: string;
+}
+
+export interface SurfaceSessionLookupKey {
+  workspace_id?: string | null;
+  surface_id: string;
+}
+
+interface SurfaceSessionIndexFile {
+  version: 1;
+  by_agent_id: Record<string, SurfaceSessionIndexEntry>;
+}
+
+export class SurfaceSessionIndex {
+  private indexPath: string;
+
+  constructor(private baseDir: string) {
+    this.indexPath = join(baseDir, "surface-session-index.json");
+  }
+
+  private readIndex(): SurfaceSessionIndexFile {
+    if (!existsSync(this.indexPath)) {
+      return { version: 1, by_agent_id: {} };
+    }
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this.indexPath, "utf-8"),
+      ) as SurfaceSessionIndexFile;
+      return {
+        version: 1,
+        by_agent_id: parsed.by_agent_id ?? {},
+      };
+    } catch {
+      return { version: 1, by_agent_id: {} };
+    }
+  }
+
+  private writeIndex(index: SurfaceSessionIndexFile): void {
+    mkdirSync(this.baseDir, { recursive: true });
+    const tmpFile = join(this.baseDir, "surface-session-index.json.tmp");
+    writeFileSync(tmpFile, JSON.stringify(index, null, 2), "utf-8");
+    renameSync(tmpFile, this.indexPath);
+  }
+
+  persist(input: {
+    workspace_id?: string | null;
+    surface_id: string;
+    cli_session_id: string;
+    agent_id: string;
+  }): SurfaceSessionIndexEntry {
+    const index = this.readIndex();
+    const entry: SurfaceSessionIndexEntry = {
+      agent_id: input.agent_id,
+      workspace_id: input.workspace_id ?? null,
+      surface_id: input.surface_id,
+      cli_session_id: input.cli_session_id,
+      updated_at: new Date().toISOString(),
+    };
+    index.by_agent_id[input.agent_id] = entry;
+    this.writeIndex(index);
+    return entry;
+  }
+
+  persistRecord(record: AgentRecord): SurfaceSessionIndexEntry | null {
+    if (!record.cli_session_id) return null;
+    return this.persist({
+      workspace_id: record.workspace_id ?? null,
+      surface_id: record.surface_id,
+      cli_session_id: record.cli_session_id,
+      agent_id: record.agent_id,
+    });
+  }
+
+  removeAgent(agentId: string): void {
+    const index = this.readIndex();
+    if (!index.by_agent_id[agentId]) return;
+    delete index.by_agent_id[agentId];
+    this.writeIndex(index);
+  }
+
+  lookup(key: SurfaceSessionLookupKey): SurfaceSessionIndexEntry | null {
+    const workspaceId = key.workspace_id ?? null;
+    const matches = Object.values(this.readIndex().by_agent_id).filter(
+      (entry) =>
+        entry.workspace_id === workspaceId && entry.surface_id === key.surface_id,
+    );
+    matches.sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+    return matches[0] ?? null;
+  }
+}
+
 export class StateManager {
   private baseDir: string;
   private eventLog: EventLog;
+  private surfaceSessionIndex: SurfaceSessionIndex;
 
   constructor(baseDir: string) {
     this.baseDir = baseDir;
     this.eventLog = new EventLog(baseDir);
+    this.surfaceSessionIndex = new SurfaceSessionIndex(baseDir);
     mkdirSync(baseDir, { recursive: true });
   }
 
   getEventLog(): EventLog {
     return this.eventLog;
+  }
+
+  getSurfaceSessionIndex(): SurfaceSessionIndex {
+    return this.surfaceSessionIndex;
   }
 
   private stateFilePath(dirName: string): string {
@@ -89,6 +194,7 @@ export class StateManager {
 
     writeFileSync(tmpFile, JSON.stringify(record, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(record);
 
     this.eventLog.append({
       ts: new Date().toISOString(),
@@ -142,6 +248,7 @@ export class StateManager {
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
 
     const transition: StateTransition = {
       ts: updated.updated_at,
@@ -180,6 +287,7 @@ export class StateManager {
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
 
     this.eventLog.append({
       ts: updated.updated_at,
@@ -226,6 +334,8 @@ export class StateManager {
     const tmpFile = join(newAgentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
+    this.surfaceSessionIndex.removeAgent(agentId);
 
     rmSync(join(this.baseDir, dirName!), { recursive: true, force: true });
 

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -168,6 +168,7 @@ describe("surface session crash-resume index", () => {
 
   it("removes the pending index entry when the final agent already exists", async () => {
     const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const sessionPath = "/tmp/codex-session.jsonl";
     const finalAgentId = "brainlayerCodex-019e942c";
     const pendingAgentId = "brainlayerCodex-pending-existing";
     const stateMgr = new StateManager(TEST_DIR);
@@ -205,7 +206,9 @@ describe("surface session crash-resume index", () => {
     const engine = new AgentEngine(stateMgr, registry, makeClient(), {
       spawnPreflight: async () => {},
       sessionIdentityResolver: (agent) =>
-        agent.agent_id === pendingAgentId ? sessionId : null,
+        agent.agent_id === pendingAgentId
+          ? { session_id: sessionId, path: sessionPath }
+          : null,
     });
 
     try {
@@ -219,6 +222,16 @@ describe("surface session crash-resume index", () => {
       expect(rawIndex.by_agent_id[finalAgentId]).toMatchObject({
         agent_id: finalAgentId,
         cli_session_id: sessionId,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+      });
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
       });
       expect(stateMgr.readState(pendingAgentId)).toBeNull();
     } finally {

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -165,4 +165,64 @@ describe("surface session crash-resume index", () => {
       engine.dispose();
     }
   });
+
+  it("removes the pending index entry when the final agent already exists", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const pendingAgentId = "brainlayerCodex-pending-existing";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: sessionId,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? sessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      const rawIndex = JSON.parse(
+        readFileSync(join(TEST_DIR, "surface-session-index.json"), "utf-8"),
+      );
+      expect(rawIndex.by_agent_id[pendingAgentId]).toBeUndefined();
+      expect(rawIndex.by_agent_id[finalAgentId]).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+      });
+      expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    } finally {
+      engine.dispose();
+    }
+  });
 });

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -238,4 +238,132 @@ describe("surface session crash-resume index", () => {
       engine.dispose();
     }
   });
+
+  it("preserves an existing final session path when duplicate capture has none", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const existingSessionPath = "/tmp/existing-session.jsonl";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const pendingAgentId = "brainlayerCodex-pending-no-path";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: sessionId,
+        cli_session_path: existingSessionPath,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? sessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: existingSessionPath,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_path: existingSessionPath,
+      });
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("allocates a disambiguated final id when session-id prefixes collide", async () => {
+    const existingSessionId = "019e942c-1111-76f2-bbca-0ef6e484d1c9";
+    const capturedSessionId = "019e942c-2222-76f2-bbca-0ef6e484d1c9";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const disambiguatedAgentId = "brainlayerCodex-019e942c-2222-76f";
+    const pendingAgentId = "brainlayerCodex-pending-collision";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: existingSessionId,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? capturedSessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: existingSessionId,
+      });
+      expect(engine.getAgentState(disambiguatedAgentId)).toMatchObject({
+        agent_id: disambiguatedAgentId,
+        cli_session_id: capturedSessionId,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: disambiguatedAgentId,
+        cli_session_id: capturedSessionId,
+      });
+      expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    } finally {
+      engine.dispose();
+    }
+  });
 });

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AgentEngine } from "../src/agent-engine.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import { StateManager } from "../src/state-manager.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-crash-resume-index-test");
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "brainlayerCodex-pending",
+    surface_id: "surface:42",
+    workspace_id: "workspace:old",
+    state: "booting",
+    repo: "brainlayer",
+    model: "gpt-5.4",
+    cli: "codex",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "Fix crash recovery",
+    pid: null,
+    version: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "orchestrator",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+}
+
+function makeClient(): CmuxClient {
+  return {
+    newSplit: vi.fn().mockResolvedValue({
+      workspace: "workspace:new",
+      surface: "surface:new",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    }),
+    newSurface: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:42",
+      text: "codex> ",
+      lines: 20,
+      scrollback_used: false,
+    }),
+    renameTab: vi.fn(),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn(),
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    listPanes: vi.fn().mockResolvedValue({ panes: [] }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
+    selectWorkspace: vi.fn(),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn(),
+    identify: vi.fn(),
+    browser: vi.fn(),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CmuxClient;
+}
+
+describe("surface session crash-resume index", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("persists surface session lookup independently of agent state", () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const index = stateMgr.getSurfaceSessionIndex();
+    stateMgr.writeState(makeRecord({ agent_id: "agent-a" }));
+
+    index.persist({
+      workspace_id: "workspace:old",
+      surface_id: "surface:42",
+      cli_session_id: "session-a",
+      agent_id: "agent-a",
+    });
+    stateMgr.removeState("agent-a");
+
+    const reloaded = new StateManager(TEST_DIR).getSurfaceSessionIndex();
+    expect(
+      reloaded.lookup({
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      }),
+    ).toMatchObject({
+      agent_id: "agent-a",
+      cli_session_id: "session-a",
+      surface_id: "surface:42",
+      workspace_id: "workspace:old",
+    });
+    expect(
+      reloaded.lookup({
+        workspace_id: "workspace:recycled",
+        surface_id: "surface:42",
+      }),
+    ).toBeNull();
+  });
+
+  it("indexes the final agent id when a boot session is captured", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "brainlayerCodex-pending-1",
+        surface_id: "surface:42",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      { ref: "surface:42", title: "", type: "terminal", index: 0, selected: true },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => sessionId,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      const entry = stateMgr.getSurfaceSessionIndex().lookup({
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      });
+      expect(entry).toMatchObject({
+        agent_id: "brainlayerCodex-019e942c",
+        cli_session_id: sessionId,
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      });
+      const rawIndex = JSON.parse(
+        readFileSync(join(TEST_DIR, "surface-session-index.json"), "utf-8"),
+      );
+      expect(rawIndex.by_agent_id["brainlayerCodex-pending-1"]).toBeUndefined();
+      stateMgr.removeState("brainlayerCodex-019e942c");
+      expect(
+        stateMgr.getSurfaceSessionIndex().lookup({
+          workspace_id: "workspace:old",
+          surface_id: "surface:42",
+        }),
+      ).toMatchObject({ cli_session_id: sessionId });
+    } finally {
+      engine.dispose();
+    }
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1059,15 +1059,13 @@ describe("agent lifecycle tool handlers", () => {
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
-    const spawnResult = await spawn.handler(
-      {
+    const spawnArgs = spawn.inputSchema.parse({
         repo: "brainlayer",
         model: "sonnet",
         cli: "claude",
         prompt: "fix gap F",
-      },
-      {} as any,
-    );
+    });
+    const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
@@ -1087,16 +1085,14 @@ describe("agent lifecycle tool handlers", () => {
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
-    const spawnResult = await spawn.handler(
-      {
+    const spawnArgs = spawn.inputSchema.parse({
         repo: "cmuxlayer",
         model: "gpt-5.4",
         cli: "codex",
         prompt: "fix gap F",
         role: "worker",
-      },
-      {} as any,
-    );
+    });
+    const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1054,7 +1054,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(state.crash_recover).toBe(true);
   });
 
-  it("spawn_agent defaults crash_recover to false", async () => {
+  it("spawn_agent defaults crash_recover to true for orchestrators", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
@@ -1065,6 +1065,35 @@ describe("agent lifecycle tool handlers", () => {
         model: "sonnet",
         cli: "claude",
         prompt: "fix gap F",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+
+    expect(state.crash_recover).toBe(true);
+  });
+
+  it("spawn_agent keeps worker crash_recover default off", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "fix gap F",
+        role: "worker",
       },
       {} as any,
     );


### PR DESCRIPTION
## Summary
- add a persisted SurfaceSessionIndex keyed by workspace_id + surface_id with agent_id-primary storage
- keep the index in sync when session-bearing agent state is written, updated, transitioned, or renamed
- default crash_recover on for orchestrator spawns while keeping workers opt-in/off by default

## TDD / Verification
- RED: `bun run test tests/crash-resume-index.test.ts tests/server-agent-tools.test.ts` failed with missing `getSurfaceSessionIndex` and orchestrator `crash_recover` still false
- RED follow-up: `bun run test tests/crash-resume-index.test.ts` failed because the pending agent_id remained in the index after final session-id rename
- GREEN: `bun run test tests/crash-resume-index.test.ts tests/state-manager.test.ts tests/agent-engine.test.ts tests/server-agent-tools.test.ts` passed (4 files, 192 tests)
- GREEN: `bun run typecheck` passed (`$ tsc -p tsconfig.json --noEmit`)
- pre-push: full suite passed (49 files, 820 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent identity, persistence, and crash-recovery defaults; incorrect index or merge logic could mis-route resumes or duplicate agents.
> 
> **Overview**
> Adds a persisted **`SurfaceSessionIndex`** (`surface-session-index.json`) that maps workspace + surface to the latest CLI session, kept in sync on state writes, updates, transitions, and renames. Entries survive agent state removal so crash resume can still resolve sessions after cleanup.
> 
> **Session capture** now merges into an existing final agent id when one already exists (instead of bailing), drops duplicate pending records, and allocates a disambiguated id when session-id prefixes collide. **Crash recover** defaults to on for orchestrators (workers stay off), with optional `CMUXLAYER_CRASH_RECOVER_DEFAULT`; spawn APIs no longer force `false` at the schema layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafafd81195682e9e490d429d5bcd12bc6139c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Index surface sessions for crash resume and handle agent ID collisions on session capture
> - Introduces `SurfaceSessionIndex` in [state-manager.ts](https://github.com/EtanHey/cmuxlayer/pull/168/files#diff-48f5aae831d763ad62d5e44527c3e96d45cfccfa451f8f81674c26e9bb0448a8), a JSON-backed persistent index (`surface-session-index.json`) mapping agent IDs to workspace, surface, and CLI session metadata, updated on every state write, transition, update, and rename.
> - Adds collision handling in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/168/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5): when a pending agent's final ID already exists with a different `cli_session_id`, the agent is renamed to a disambiguated ID using a suffix derived from the session ID; if it matches, the pending agent is merged into the existing final agent.
> - Changes the default value of `crash_recover` from `false` to `true` for orchestrator-role agents (overridable via `CMUXLAYER_CRASH_RECOVER_DEFAULT`); worker agents still default to `false`.
> - Removes the schema-level `default(false)` for `crash_recover` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/168/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) so role-based defaults from `AgentEngine` take effect.
> - Behavioral Change: orchestrator agents spawned without an explicit `crash_recover` value will now default to `true` instead of `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aafafd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crash recovery now defaults to enabled for orchestrator role agents
  * Added enhanced session indexing and canonical session tracking for improved crash-resume reliability
  * Improved handling of duplicate session captures during recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->