### PR TITLE
Reap idle worker panes

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -933,8 +933,22 @@ export class AgentEngine {
     if (updated.agent_id === finalAgentId) {
       return updated;
     }
-    if (this.stateMgr.readState(finalAgentId)) {
-      return updated;
+    const existingFinal = this.stateMgr.readState(finalAgentId);
+    if (existingFinal) {
+      const canonicalFinal =
+        existingFinal.cli_session_id === identity.session_id &&
+        existingFinal.cli_session_path === identity.path
+          ? existingFinal
+          : this.stateMgr.updateRecord(finalAgentId, {
+              cli_session_id: identity.session_id,
+              cli_session_path: identity.path,
+            });
+      const index = this.stateMgr.getSurfaceSessionIndex();
+      index.removeAgent(updated.agent_id);
+      index.persistRecord(canonicalFinal);
+      this.registry.remove(updated.agent_id);
+      this.stateMgr.removeState(updated.agent_id);
+      return canonicalFinal;
     }
 
     const previousAgentId = updated.agent_id;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -110,6 +110,13 @@ export type SessionIdentityResolver = (
   agent: AgentRecord,
 ) => CapturedSessionIdentity | string | null;
 
+function defaultCrashRecoverForRole(role: AgentRole): boolean {
+  const override = process.env.CMUXLAYER_CRASH_RECOVER_DEFAULT;
+  if (override === "1" || override?.toLowerCase() === "true") return true;
+  if (override === "0" || override?.toLowerCase() === "false") return false;
+  return role === "orchestrator";
+}
+
 /**
  * Result of the spawn preflight. `launcherName` carries the launcher function
  * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
@@ -1794,7 +1801,8 @@ export class AgentEngine {
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: spawnParams.max_cost_per_agent ?? null,
-      crash_recover: spawnParams.crash_recover ?? false,
+      crash_recover:
+        spawnParams.crash_recover ?? defaultCrashRecoverForRole(role),
       respawn_attempts: 0,
       user_killed: false,
       boot_prompt_pending: spawnParams.boot_prompt_pending ?? false,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -43,6 +43,7 @@ import {
 import { parseScreen } from "./screen-parser.js";
 import {
   chooseAgentSpawnPlacement,
+  chooseSurfaceClosePolicy,
   collectRoleSurfaceIds,
   inferAgentRole,
   inferRecordRole,
@@ -292,6 +293,13 @@ function taskDoneAutoArchiveMs(): number {
   return Number.isFinite(parsed) && parsed >= 0
     ? parsed * 60_000
     : TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
+}
+
+function idleWorkerCloseMs(): number | null {
+  const rawMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+  if (rawMs === undefined) return null;
+  const parsed = Number(rawMs);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 interface AgentEngineClient {
@@ -1120,6 +1128,89 @@ export class AgentEngine {
     }
   }
 
+  private async workerCloseOptions(
+    agent: AgentRecord,
+  ): Promise<{ workspace?: string; collapsePane?: boolean }> {
+    const workspace = agent.workspace_id ?? undefined;
+    const options: { workspace?: string; collapsePane?: boolean } = {
+      workspace,
+    };
+    if (!workspace) return options;
+
+    try {
+      const panes = await this.client.listPanes({ workspace });
+      const rawPaneSurfaces = await Promise.all(
+        panes.panes.map(async (pane) => {
+          const ps = await this.client.listPaneSurfaces({
+            workspace,
+            pane: pane.ref,
+          });
+          return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
+        }),
+      );
+      const paneSurfaces = partitionPaneSurfacesByMembership(
+        panes.panes,
+        rawPaneSurfaces,
+        {
+          workspace_ref: panes.workspace_ref ?? workspace,
+          window_ref: panes.window_ref,
+        },
+      );
+      const workerSurfaceIds = new Set<string>();
+      for (const record of this.registry.list()) {
+        try {
+          if (inferRecordRole(record) === "worker") {
+            workerSurfaceIds.add(record.surface_id);
+          }
+        } catch {
+          // Unknown-role records should not influence worker pane collapse.
+        }
+      }
+      workerSurfaceIds.add(agent.surface_id);
+      const closePolicy = chooseSurfaceClosePolicy(
+        panes.panes,
+        paneSurfaces,
+        workerSurfaceIds,
+        agent.surface_id,
+      );
+      if (closePolicy.collapsePane) {
+        options.collapsePane = true;
+      }
+    } catch {
+      // Pane geometry is advisory; close the worker surface even if it cannot
+      // prove the pane is safe to collapse.
+    }
+
+    return options;
+  }
+
+  private async maybeReapIdleWorker(agent: AgentRecord): Promise<boolean> {
+    const closeMs = idleWorkerCloseMs();
+    if (closeMs === null) return false;
+    if (agent.state !== "done" && agent.state !== "idle") return false;
+
+    try {
+      if (inferRecordRole(agent) !== "worker") return false;
+    } catch {
+      return false;
+    }
+
+    const updatedAt = Date.parse(agent.updated_at);
+    if (Number.isNaN(updatedAt)) return false;
+    if (Date.now() - updatedAt < closeMs) return false;
+
+    try {
+      await this.client.closeSurface(
+        agent.surface_id,
+        await this.workerCloseOptions(agent),
+      );
+      return true;
+    } catch {
+      // Best-effort reap; the next sweep will retry if the surface remains.
+      return false;
+    }
+  }
+
   private isRecoverableCrash(agent: AgentRecord): boolean {
     return isCrashRecoveryEligible(agent);
   }
@@ -1323,7 +1414,8 @@ export class AgentEngine {
       }
 
       const archived = await this.maybeArchiveDoneAgent(agent);
-      if (archived) {
+      const reaped = archived ? false : await this.maybeReapIdleWorker(agent);
+      if (archived || reaped) {
         try {
           await this.client.clearStatus(agentId, {
             workspace: agent.workspace_id ?? undefined,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -946,7 +946,7 @@ export class AgentEngine {
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);
       index.persistRecord(canonicalFinal);
-      this.registry.remove(updated.agent_id);
+      this.registry.rename(updated.agent_id, finalAgentId, canonicalFinal);
       this.stateMgr.removeState(updated.agent_id);
       return canonicalFinal;
     }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -117,6 +117,19 @@ function defaultCrashRecoverForRole(role: AgentRole): boolean {
   return role === "orchestrator";
 }
 
+function sessionCollisionSuffix(sessionId: string): string {
+  const normalized = sessionId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/-+/g, "-");
+  return (
+    normalized.slice(9, 17).replace(/^-+|-+$/g, "") ||
+    normalized.slice(0, 8).replace(/^-+|-+$/g, "") ||
+    "collision"
+  );
+}
+
 /**
  * Result of the spawn preflight. `launcherName` carries the launcher function
  * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
@@ -935,13 +948,32 @@ export class AgentEngine {
     }
     const existingFinal = this.stateMgr.readState(finalAgentId);
     if (existingFinal) {
+      if (
+        existingFinal.cli_session_id &&
+        existingFinal.cli_session_id !== identity.session_id
+      ) {
+        const previousAgentId = updated.agent_id;
+        const collisionBaseAgentId = `${finalAgentId}-${sessionCollisionSuffix(
+          identity.session_id,
+        )}`;
+        let collisionAgentId = collisionBaseAgentId;
+        let collisionAttempt = 2;
+        while (this.stateMgr.readState(collisionAgentId)) {
+          collisionAgentId = `${collisionBaseAgentId}-${collisionAttempt}`;
+          collisionAttempt += 1;
+        }
+        updated = this.stateMgr.renameState(previousAgentId, collisionAgentId);
+        this.registry.rename(previousAgentId, collisionAgentId, updated);
+        return updated;
+      }
+      const sessionPath = identity.path ?? existingFinal.cli_session_path ?? null;
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
-        existingFinal.cli_session_path === identity.path
+        existingFinal.cli_session_path === sessionPath
           ? existingFinal
           : this.stateMgr.updateRecord(finalAgentId, {
               cli_session_id: identity.session_id,
-              cli_session_path: identity.path,
+              cli_session_path: sessionPath,
             });
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1194,6 +1194,14 @@ export class AgentEngine {
     } catch {
       return false;
     }
+    if (
+      agent.cli === "codex" &&
+      agent.auto_archive_on_done === true &&
+      agent.task_done_detected_at &&
+      autoArchiveEnabledByEnv()
+    ) {
+      return false;
+    }
 
     const updatedAt = Date.parse(agent.updated_at);
     if (Number.isNaN(updatedAt)) return false;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2208,5 +2208,7 @@ export class AgentEngine {
     if (pressEnter) {
       await this.client.sendKey(route.surface_id, "return", { workspace });
     }
+    const refreshed = this.stateMgr.updateRecord(agent.agent_id, {});
+    this.registry.set(agent.agent_id, refreshed);
   }
 }

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -559,10 +559,11 @@ export class CmuxClient {
 
   async closeSurface(
     surface: string,
-    opts?: { workspace?: string },
+    opts?: { workspace?: string; collapsePane?: boolean },
   ): Promise<void> {
     const args = ["close-surface", "--surface", surface];
     if (opts?.workspace) args.push("--workspace", opts.workspace);
+    if (opts?.collapsePane) args.push("--collapse-pane");
     await this.run(args);
   }
 

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -633,13 +633,16 @@ export class CmuxSocketClient {
 
   async closeSurface(
     surface: string,
-    opts?: { workspace?: string },
+    opts?: { workspace?: string; collapsePane?: boolean },
   ): Promise<void> {
     const workspace = await this.resolveWorkspace(surface, opts?.workspace);
     const params: Record<string, unknown> = {
       surface_id: surface,
       workspace_id: workspace,
     };
+    if (opts?.collapsePane) {
+      params.collapse_pane = true;
+    }
     try {
       await this.call("surface.close", params);
     } catch (e) {

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -111,17 +111,19 @@ function roleForSurface(
 }
 
 export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
-  // A pixel_frame is only usable for column detection when it has real area.
-  // cmux reports {x:0, width:0, ...} for panes in a workspace it isn't
-  // currently rendering (background/unfocused workspaces), and that frame is
-  // truthy — so a naive `pane.pixel_frame` check would treat every pane as
-  // sharing x:0, collapse them into a single column, and silently disable the
-  // left-vs-right (lead-vs-worker) docking logic. Require non-zero width on
-  // every pane before trusting geometry; otherwise fall back to pane.index,
-  // which is monotonic left-to-right and always present.
-  const useGeometry = panes.every(
-    (pane) => pane.pixel_frame && pane.pixel_frame.width > 0,
-  );
+  // cmux can report zero-area frames for background or partially rendered
+  // panes. Those frames still carry an x position, but must not be grouped with
+  // real same-x panes or every {x:0,width:0} pane collapses into one column.
+  // When every pane has a frame, use x ordering and keep zero-width frames as
+  // unique columns; if any frame is missing entirely, fall back to pane.index.
+  const useGeometry = panes.every((pane) => pane.pixel_frame);
+  const columnKey = (pane: CmuxPane): string => {
+    if (!useGeometry) return `index:${pane.index}`;
+    const frame = pane.pixel_frame!;
+    return frame.width > 0
+      ? `x:${frame.x}`
+      : `zero:${frame.x}:index:${pane.index}`;
+  };
   const sortedGroups = [
     ...new Map(
       [...panes]
@@ -130,10 +132,7 @@ export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
           const bPosition = useGeometry ? b.pixel_frame!.x : b.index;
           return aPosition - bPosition || a.index - b.index;
         })
-        .map((pane) => [
-          useGeometry ? `x:${pane.pixel_frame!.x}` : `index:${pane.index}`,
-          pane,
-        ]),
+        .map((pane) => [columnKey(pane), pane]),
     ).keys(),
   ];
   const columnByGroup = new Map(
@@ -142,9 +141,7 @@ export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
 
   return new Map(
     panes.map((pane) => {
-      const group = useGeometry
-        ? `x:${pane.pixel_frame!.x}`
-        : `index:${pane.index}`;
+      const group = columnKey(pane);
       return [pane.ref, columnByGroup.get(group) ?? 0];
     }),
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -3693,7 +3693,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         crash_recover: z
           .boolean()
           .optional()
-          .default(false)
           .describe(
             "When true, automatically respawn the agent after unexpected PTY death using its captured CLI session ID.",
           ),
@@ -3874,7 +3873,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("MCP profile hint. Defaults to inherit."),
         parent_agent_id: z.string().optional(),
         auto_archive_on_done: z.boolean().optional().default(true),
-        crash_recover: z.boolean().optional().default(false),
+        crash_recover: z.boolean().optional(),
       },
       ANNOTATIONS.mutating,
       async (args) => {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -31,18 +31,123 @@ type AgentRecordPatch = Partial<
   Omit<AgentRecord, "agent_id" | "created_at" | "updated_at" | "version" | "state">
 >;
 
+export interface SurfaceSessionIndexEntry {
+  agent_id: string;
+  workspace_id: string | null;
+  surface_id: string;
+  cli_session_id: string;
+  updated_at: string;
+}
+
+export interface SurfaceSessionLookupKey {
+  workspace_id?: string | null;
+  surface_id: string;
+}
+
+interface SurfaceSessionIndexFile {
+  version: 1;
+  by_agent_id: Record<string, SurfaceSessionIndexEntry>;
+}
+
+export class SurfaceSessionIndex {
+  private indexPath: string;
+
+  constructor(private baseDir: string) {
+    this.indexPath = join(baseDir, "surface-session-index.json");
+  }
+
+  private readIndex(): SurfaceSessionIndexFile {
+    if (!existsSync(this.indexPath)) {
+      return { version: 1, by_agent_id: {} };
+    }
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this.indexPath, "utf-8"),
+      ) as SurfaceSessionIndexFile;
+      return {
+        version: 1,
+        by_agent_id: parsed.by_agent_id ?? {},
+      };
+    } catch {
+      return { version: 1, by_agent_id: {} };
+    }
+  }
+
+  private writeIndex(index: SurfaceSessionIndexFile): void {
+    mkdirSync(this.baseDir, { recursive: true });
+    const tmpFile = join(this.baseDir, "surface-session-index.json.tmp");
+    writeFileSync(tmpFile, JSON.stringify(index, null, 2), "utf-8");
+    renameSync(tmpFile, this.indexPath);
+  }
+
+  persist(input: {
+    workspace_id?: string | null;
+    surface_id: string;
+    cli_session_id: string;
+    agent_id: string;
+  }): SurfaceSessionIndexEntry {
+    const index = this.readIndex();
+    const entry: SurfaceSessionIndexEntry = {
+      agent_id: input.agent_id,
+      workspace_id: input.workspace_id ?? null,
+      surface_id: input.surface_id,
+      cli_session_id: input.cli_session_id,
+      updated_at: new Date().toISOString(),
+    };
+    index.by_agent_id[input.agent_id] = entry;
+    this.writeIndex(index);
+    return entry;
+  }
+
+  persistRecord(record: AgentRecord): SurfaceSessionIndexEntry | null {
+    if (!record.cli_session_id) return null;
+    return this.persist({
+      workspace_id: record.workspace_id ?? null,
+      surface_id: record.surface_id,
+      cli_session_id: record.cli_session_id,
+      agent_id: record.agent_id,
+    });
+  }
+
+  removeAgent(agentId: string): void {
+    const index = this.readIndex();
+    if (!index.by_agent_id[agentId]) return;
+    delete index.by_agent_id[agentId];
+    this.writeIndex(index);
+  }
+
+  lookup(key: SurfaceSessionLookupKey): SurfaceSessionIndexEntry | null {
+    const workspaceId = key.workspace_id ?? null;
+    const matches = Object.values(this.readIndex().by_agent_id).filter(
+      (entry) =>
+        entry.workspace_id === workspaceId && entry.surface_id === key.surface_id,
+    );
+    matches.sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+    return matches[0] ?? null;
+  }
+}
+
 export class StateManager {
   private baseDir: string;
   private eventLog: EventLog;
+  private surfaceSessionIndex: SurfaceSessionIndex;
 
   constructor(baseDir: string) {
     this.baseDir = baseDir;
     this.eventLog = new EventLog(baseDir);
+    this.surfaceSessionIndex = new SurfaceSessionIndex(baseDir);
     mkdirSync(baseDir, { recursive: true });
   }
 
   getEventLog(): EventLog {
     return this.eventLog;
+  }
+
+  getSurfaceSessionIndex(): SurfaceSessionIndex {
+    return this.surfaceSessionIndex;
   }
 
   private stateFilePath(dirName: string): string {
@@ -89,6 +194,7 @@ export class StateManager {
 
     writeFileSync(tmpFile, JSON.stringify(record, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(record);
 
     this.eventLog.append({
       ts: new Date().toISOString(),
@@ -142,6 +248,7 @@ export class StateManager {
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
 
     const transition: StateTransition = {
       ts: updated.updated_at,
@@ -180,6 +287,7 @@ export class StateManager {
     const tmpFile = join(agentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
 
     this.eventLog.append({
       ts: updated.updated_at,
@@ -226,6 +334,8 @@ export class StateManager {
     const tmpFile = join(newAgentDir, "state.json.tmp");
     writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
     renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
+    this.surfaceSessionIndex.removeAgent(agentId);
 
     rmSync(join(this.baseDir, dirName!), { recursive: true, force: true });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1193,6 +1193,85 @@ describe("AgentEngine", () => {
       }
     });
 
+    it("reaps done non-Codex worker panes after the idle close timeout", async () => {
+      const previousIdleCloseMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+      process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = "1000";
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cursor-worker-done",
+            state: "done",
+            surface_id: "surface:cursor-worker",
+            workspace_id: "ws:1",
+            cli: "cursor",
+            role: "worker",
+            updated_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [
+          makeSurface("surface:orchestrator"),
+          makeSurface("surface:cursor-worker"),
+        ];
+        (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:left",
+              index: 0,
+              focused: false,
+              surface_count: 1,
+              surface_refs: ["surface:orchestrator"],
+              selected_surface_ref: "surface:orchestrator",
+            },
+            {
+              ref: "pane:right",
+              index: 1,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:cursor-worker"],
+              selected_surface_ref: "surface:cursor-worker",
+            },
+          ],
+        });
+        (
+          mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+        ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces:
+            pane === "pane:right"
+              ? [makeSurface("surface:cursor-worker")]
+              : [makeSurface("surface:orchestrator")],
+        }));
+        await engine.getRegistry().reconstitute();
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 999));
+        await engine.runSweep();
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+
+        vi.setSystemTime(new Date(doneAt.getTime() + 1_000));
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).toHaveBeenCalledWith(
+          "surface:cursor-worker",
+          { workspace: "ws:1", collapsePane: true },
+        );
+        expect(engine.getAgentState("cursor-worker-done")).toBeNull();
+        expect(stateMgr.readState("cursor-worker-done")).toBeNull();
+      } finally {
+        if (previousIdleCloseMs === undefined) {
+          delete process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+        } else {
+          process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = previousIdleCloseMs;
+        }
+        vi.useRealTimers();
+      }
+    });
+
     it("does not auto-close legacy Codex workers without explicit archive opt-in", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3057,18 +3057,30 @@ To continue this session, run codex resume ${sessionId}`,
     });
 
     it("works for agents in idle state", async () => {
+      vi.useFakeTimers();
+      const sentAt = new Date("2026-05-25T13:00:00.000Z");
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-idle",
           state: "idle",
           surface_id: "surface:42",
+          updated_at: "2026-05-25T12:00:00.000Z",
         }),
       );
       liveSurfaces = [makeSurface("surface:42")];
       await engine.getRegistry().reconstitute();
 
-      await engine.sendToAgent("agent-idle", "continue");
-      expect(mockClient.send).toHaveBeenCalled();
+      try {
+        vi.setSystemTime(sentAt);
+        await engine.sendToAgent("agent-idle", "continue");
+
+        expect(mockClient.send).toHaveBeenCalled();
+        expect(engine.getAgentState("agent-idle")?.updated_at).toBe(
+          sentAt.toISOString(),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("rejects sending to agents in non-interactive states", async () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1272,6 +1272,47 @@ describe("AgentEngine", () => {
       }
     });
 
+    it("does not let idle worker reap bypass the Codex TASK_DONE archive delay", async () => {
+      const previousIdleCloseMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+      process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = "1000";
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(doneAt.getTime() + 1_001));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "codex-worker-pending-archive",
+            state: "done",
+            surface_id: "surface:codex-pending-archive",
+            cli: "codex",
+            role: "worker",
+            updated_at: doneAt.toISOString(),
+            auto_archive_on_done: true,
+            task_done_detected_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:codex-pending-archive")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("codex-worker-pending-archive")).toMatchObject(
+          {
+            state: "done",
+            task_done_detected_at: doneAt.toISOString(),
+          },
+        );
+      } finally {
+        if (previousIdleCloseMs === undefined) {
+          delete process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+        } else {
+          process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = previousIdleCloseMs;
+        }
+        vi.useRealTimers();
+      }
+    });
+
     it("does not auto-close legacy Codex workers without explicit archive opt-in", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -715,6 +715,25 @@ describe("CmuxClient.closeSurface", () => {
       "surface:1",
     ]);
   });
+
+  it("forwards collapse-pane close option", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.closeSurface("surface:1", {
+      workspace: "workspace:1",
+      collapsePane: true,
+    });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "close-surface",
+      "--surface",
+      "surface:1",
+      "--workspace",
+      "workspace:1",
+      "--collapse-pane",
+    ]);
+  });
 });
 
 describe("CmuxClient CLI error handling", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -817,6 +817,24 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
     }
   });
 
+  it("closeSurface forwards collapse-pane over the socket", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.closeSurface("surface:1", {
+      workspace: "workspace:1",
+      collapsePane: true,
+    });
+
+    expect(lastV2Request).toMatchObject({
+      method: "surface.close",
+      params: {
+        surface_id: "surface:1",
+        workspace_id: "workspace:1",
+        collapse_pane: true,
+      },
+    });
+  });
+
   it("newSurface uses CLI fallback", async () => {
     const client = new CmuxSocketClient({
       socketPath: MOCK_SOCKET_PATH,

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -168,6 +168,7 @@ describe("surface session crash-resume index", () => {
 
   it("removes the pending index entry when the final agent already exists", async () => {
     const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const sessionPath = "/tmp/codex-session.jsonl";
     const finalAgentId = "brainlayerCodex-019e942c";
     const pendingAgentId = "brainlayerCodex-pending-existing";
     const stateMgr = new StateManager(TEST_DIR);
@@ -205,7 +206,9 @@ describe("surface session crash-resume index", () => {
     const engine = new AgentEngine(stateMgr, registry, makeClient(), {
       spawnPreflight: async () => {},
       sessionIdentityResolver: (agent) =>
-        agent.agent_id === pendingAgentId ? sessionId : null,
+        agent.agent_id === pendingAgentId
+          ? { session_id: sessionId, path: sessionPath }
+          : null,
     });
 
     try {
@@ -219,6 +222,16 @@ describe("surface session crash-resume index", () => {
       expect(rawIndex.by_agent_id[finalAgentId]).toMatchObject({
         agent_id: finalAgentId,
         cli_session_id: sessionId,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+      });
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
       });
       expect(stateMgr.readState(pendingAgentId)).toBeNull();
     } finally {

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -165,4 +165,64 @@ describe("surface session crash-resume index", () => {
       engine.dispose();
     }
   });
+
+  it("removes the pending index entry when the final agent already exists", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const pendingAgentId = "brainlayerCodex-pending-existing";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: sessionId,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? sessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      const rawIndex = JSON.parse(
+        readFileSync(join(TEST_DIR, "surface-session-index.json"), "utf-8"),
+      );
+      expect(rawIndex.by_agent_id[pendingAgentId]).toBeUndefined();
+      expect(rawIndex.by_agent_id[finalAgentId]).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+      });
+      expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    } finally {
+      engine.dispose();
+    }
+  });
 });

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -238,4 +238,132 @@ describe("surface session crash-resume index", () => {
       engine.dispose();
     }
   });
+
+  it("preserves an existing final session path when duplicate capture has none", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const existingSessionPath = "/tmp/existing-session.jsonl";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const pendingAgentId = "brainlayerCodex-pending-no-path";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: sessionId,
+        cli_session_path: existingSessionPath,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? sessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: sessionId,
+        cli_session_path: existingSessionPath,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_path: existingSessionPath,
+      });
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("allocates a disambiguated final id when session-id prefixes collide", async () => {
+    const existingSessionId = "019e942c-1111-76f2-bbca-0ef6e484d1c9";
+    const capturedSessionId = "019e942c-2222-76f2-bbca-0ef6e484d1c9";
+    const finalAgentId = "brainlayerCodex-019e942c";
+    const disambiguatedAgentId = "brainlayerCodex-019e942c-2222-76f";
+    const pendingAgentId = "brainlayerCodex-pending-collision";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: finalAgentId,
+        surface_id: "surface:final",
+        workspace_id: "workspace:old",
+        cli_session_id: existingSessionId,
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        surface_id: "surface:pending",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      {
+        ref: "surface:final",
+        title: "",
+        type: "terminal",
+        index: 0,
+        selected: false,
+      },
+      {
+        ref: "surface:pending",
+        title: "",
+        type: "terminal",
+        index: 1,
+        selected: true,
+      },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: (agent) =>
+        agent.agent_id === pendingAgentId ? capturedSessionId : null,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        cli_session_id: existingSessionId,
+      });
+      expect(engine.getAgentState(disambiguatedAgentId)).toMatchObject({
+        agent_id: disambiguatedAgentId,
+        cli_session_id: capturedSessionId,
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: disambiguatedAgentId,
+        cli_session_id: capturedSessionId,
+      });
+      expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    } finally {
+      engine.dispose();
+    }
+  });
 });

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AgentEngine } from "../src/agent-engine.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import { StateManager } from "../src/state-manager.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-crash-resume-index-test");
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "brainlayerCodex-pending",
+    surface_id: "surface:42",
+    workspace_id: "workspace:old",
+    state: "booting",
+    repo: "brainlayer",
+    model: "gpt-5.4",
+    cli: "codex",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "Fix crash recovery",
+    pid: null,
+    version: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "orchestrator",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+}
+
+function makeClient(): CmuxClient {
+  return {
+    newSplit: vi.fn().mockResolvedValue({
+      workspace: "workspace:new",
+      surface: "surface:new",
+      pane: "pane:1",
+      title: "",
+      type: "terminal",
+    }),
+    newSurface: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:42",
+      text: "codex> ",
+      lines: 20,
+      scrollback_used: false,
+    }),
+    renameTab: vi.fn(),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn(),
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    listPanes: vi.fn().mockResolvedValue({ panes: [] }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
+    selectWorkspace: vi.fn(),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn(),
+    identify: vi.fn(),
+    browser: vi.fn(),
+    log: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CmuxClient;
+}
+
+describe("surface session crash-resume index", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("persists surface session lookup independently of agent state", () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const index = stateMgr.getSurfaceSessionIndex();
+    stateMgr.writeState(makeRecord({ agent_id: "agent-a" }));
+
+    index.persist({
+      workspace_id: "workspace:old",
+      surface_id: "surface:42",
+      cli_session_id: "session-a",
+      agent_id: "agent-a",
+    });
+    stateMgr.removeState("agent-a");
+
+    const reloaded = new StateManager(TEST_DIR).getSurfaceSessionIndex();
+    expect(
+      reloaded.lookup({
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      }),
+    ).toMatchObject({
+      agent_id: "agent-a",
+      cli_session_id: "session-a",
+      surface_id: "surface:42",
+      workspace_id: "workspace:old",
+    });
+    expect(
+      reloaded.lookup({
+        workspace_id: "workspace:recycled",
+        surface_id: "surface:42",
+      }),
+    ).toBeNull();
+  });
+
+  it("indexes the final agent id when a boot session is captured", async () => {
+    const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "brainlayerCodex-pending-1",
+        surface_id: "surface:42",
+        workspace_id: "workspace:old",
+      }),
+    );
+    const registry = new AgentRegistry(stateMgr, async () => [
+      { ref: "surface:42", title: "", type: "terminal", index: 0, selected: true },
+    ]);
+    const engine = new AgentEngine(stateMgr, registry, makeClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => sessionId,
+    });
+
+    try {
+      await registry.reconstitute();
+      await engine.runSweep();
+
+      const entry = stateMgr.getSurfaceSessionIndex().lookup({
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      });
+      expect(entry).toMatchObject({
+        agent_id: "brainlayerCodex-019e942c",
+        cli_session_id: sessionId,
+        workspace_id: "workspace:old",
+        surface_id: "surface:42",
+      });
+      const rawIndex = JSON.parse(
+        readFileSync(join(TEST_DIR, "surface-session-index.json"), "utf-8"),
+      );
+      expect(rawIndex.by_agent_id["brainlayerCodex-pending-1"]).toBeUndefined();
+      stateMgr.removeState("brainlayerCodex-019e942c");
+      expect(
+        stateMgr.getSurfaceSessionIndex().lookup({
+          workspace_id: "workspace:old",
+          surface_id: "surface:42",
+        }),
+      ).toMatchObject({ cli_session_id: sessionId });
+    } finally {
+      engine.dispose();
+    }
+  });
+});

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -144,6 +144,26 @@ describe("layout policy", () => {
     expect(columns.get("pane:geometric-left")).toBe(2);
   });
 
+  it("orders partial zero-width geometry by reported x without collapsing panes", () => {
+    const columns = deriveColumnIndex([
+      makePane("pane:visible-right", 0, [], {
+        x: 640,
+        y: 0,
+        width: 320,
+        height: 800,
+      }),
+      makePane("pane:zero-left", 1, [], {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      }),
+    ]);
+
+    expect(columns.get("pane:zero-left")).toBe(0);
+    expect(columns.get("pane:visible-right")).toBe(1);
+  });
+
   it("stays two-way (worker docks right, never a third column) when an unfocused workspace reports zero-area frames", () => {
     // THE invariant: cmux geometry is two-way — a LEFT lead column and a RIGHT
     // worker column, never three. cmux reports {x:0, width:0} for every pane in

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1087,7 +1087,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(state.crash_recover).toBe(true);
   });
 
-  it("spawn_agent defaults crash_recover to false", async () => {
+  it("spawn_agent defaults crash_recover to true for orchestrators", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
@@ -1098,6 +1098,35 @@ describe("agent lifecycle tool handlers", () => {
         model: "sonnet",
         cli: "claude",
         prompt: "fix gap F",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+
+    expect(state.crash_recover).toBe(true);
+  });
+
+  it("spawn_agent keeps worker crash_recover default off", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "fix gap F",
+        role: "worker",
       },
       {} as any,
     );

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1092,15 +1092,13 @@ describe("agent lifecycle tool handlers", () => {
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
-    const spawnResult = await spawn.handler(
-      {
+    const spawnArgs = spawn.inputSchema.parse({
         repo: "brainlayer",
         model: "sonnet",
         cli: "claude",
         prompt: "fix gap F",
-      },
-      {} as any,
-    );
+    });
+    const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
@@ -1120,16 +1118,14 @@ describe("agent lifecycle tool handlers", () => {
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
-    const spawnResult = await spawn.handler(
-      {
+    const spawnArgs = spawn.inputSchema.parse({
         repo: "cmuxlayer",
         model: "gpt-5.4",
         cli: "codex",
         prompt: "fix gap F",
         role: "worker",
-      },
-      {} as any,
-    );
+    });
+    const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;


### PR DESCRIPTION
## Summary
- add opt-in `CMUXLAYER_IDLE_WORKER_CLOSE_MS` sweep reaping for done/idle worker agents across CLIs
- collapse only proven dedicated worker panes by using live pane/surface membership and `chooseSurfaceClosePolicy`
- make partial zero-width pane geometry deterministic without collapsing same-x zero-area panes

## TDD / Verification
- RED: `bun run test tests/agent-engine.test.ts -t "reaps done non-Codex worker panes"` failed with `Number of calls: 0` for `closeSurface`.
- RED: `bun run test tests/layout-policy.test.ts -t "partial zero-width geometry"` failed with `expected 1 to be +0`.
- GREEN: `bun run test tests/agent-engine.test.ts -t "reaps done non-Codex worker panes"` => 1 passed, 126 skipped.
- GREEN: `bun run test tests/layout-policy.test.ts -t "partial zero-width geometry"` => 1 passed, 45 skipped.
- `bun run test tests/agent-engine.test.ts tests/layout-policy.test.ts` => 2 files passed, 173 tests passed.
- `bun run typecheck` => `tsc -p tsconfig.json --noEmit` passed.
- pre-push full suite => 49 files passed, 823 tests passed.

Do not merge; stacked PR 4/4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatic surface/pane closure and optional MCP process termination can remove live UI or processes if env thresholds or allowlists are misconfigured; spawn model and session-id rename paths also change default agent behavior.
> 
> **Overview**
> **Idle worker cleanup** is the headline change: when `CMUXLAYER_IDLE_WORKER_CLOSE_MS` is set, sweeps close worker agents in `done` or `idle` after their `updated_at` ages out, using `closeSurface` with **`collapsePane`** only when `chooseSurfaceClosePolicy` says the pane is a dedicated worker column. Codex workers still waiting on TASK_DONE auto-archive are skipped so idle reap does not race that path.
> 
> **Pane layout** fixes `deriveColumnIndex` so zero-width `pixel_frame` panes keep distinct columns by x/index instead of collapsing every `{x:0,width:0}` pane into one column (which broke left/right worker docking).
> 
> **Surface close** now threads `collapsePane` through CLI and socket clients (`--collapse-pane` / `collapse_pane`).
> 
> The same diff also lands **standalone MCP orphan reaping** (`mcp-reaper.ts`, shell wrapper, launchd plist; dry-run by default), a **`model-policy`** module (optional `spawn_agent` model, Cursor coercion unless `REPOGOLEM_ALLOW_MODEL=1`, role-based default `crash_recover`), **surface-session index** persistence for boot session rename/collision handling, and **screen-parser** 1M context rules for current Opus/Sonnet versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10aab67a3f12e7617848b53dd04c877b31da2578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reap idle worker panes after a configurable timeout and enforce CLI-specific model policies on spawn
> - Adds `AgentEngine.maybeReapIdleWorker` which closes done/idle non-Codex worker surfaces after `CMUXLAYER_IDLE_WORKER_CLOSE_MS` milliseconds, optionally collapsing the pane via `closeSurface({collapsePane: true})`.
> - Introduces a model policy layer in [src/model-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/169/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d) with per-CLI defaults and override rules; Cursor suppresses model flags by default, Claude defaults to `opus-4-8[1m]`, and Gemini passes aliases through.
> - `spawn_agent` now applies `resolveSpawnModelPolicy` to coerce disallowed models, returns `requested_model` and `warning` fields, and derives `crash_recover` defaults from role (true for orchestrators, false for workers).
> - Adds a `SurfaceSessionIndex` in [src/state-manager.ts](https://github.com/EtanHey/cmuxlayer/pull/169/files#diff-48f5aae831d763ad62d5e44527c3e96d45cfccfa451f8f81674c26e9bb0448a8) that maintains an on-disk `surface-session-index.json` keyed by `agent_id` for surface/workspace lookup across restarts.
> - Adds [src/mcp-reaper.ts](https://github.com/EtanHey/cmuxlayer/pull/169/files#diff-32c6a0b7ce6e61ede4270634b60059d84d8b3d8ab0720c01b42204c91552c263) and supporting [scripts/mcp-orphan-reaper.sh](https://github.com/EtanHey/cmuxlayer/pull/169/files#diff-5ca5ebb552df15862a8f28f4ded96711cb3833b9d9ccd0a27a1495fcfa631cf1) with a launchd plist to periodically kill orphaned Node MCP server processes.
> - Risk: idle worker reaping is gated on `CMUXLAYER_IDLE_WORKER_CLOSE_MS` being set; without it no reaping occurs. Codex workers with `auto_archive_on_done` are explicitly excluded from reaping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10aab67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->