### PR TITLE
fix: disable unattended agent pane closes

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1613,15 +1613,20 @@ export class AgentEngine {
       const current =
         this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
       if (current && !TERMINAL_STATES.has(current.state)) {
-        const failed = this.stateMgr.transition(agentId, "error", { error });
-        this.registry.set(agentId, failed);
+        const degraded = this.stateMgr.updateRecord(agentId, {
+          error,
+          quality: "degraded",
+        });
+        this.registry.set(agentId, degraded);
       }
     } catch {
-      // Best-effort liveness assertion; still attempt surface cleanup below.
+      // Best-effort liveness assertion.
     }
 
     // Do not auto-close the surface here. Liveness failures are evidence for
     // spawn/layout bugs, and closing the pane can destroy the user's context.
+    // Keep the agent non-terminal so later sweeps can recover from discovery
+    // races when the surface is actually alive.
   }
 
   /**

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -43,7 +43,6 @@ import {
 import { parseScreen } from "./screen-parser.js";
 import {
   chooseAgentSpawnPlacement,
-  chooseSurfaceClosePolicy,
   collectRoleSurfaceIds,
   inferAgentRole,
   inferRecordRole,
@@ -169,7 +168,6 @@ const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
-const TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS = 30 * 60_000;
 const TASK_DONE_CONFIRMATION_MS = 5_000;
 const DONE_QUIESCENCE_MS = 1_500;
 const SESSION_ID_PATTERN =
@@ -207,12 +205,6 @@ interface SweepAgentContext {
 }
 
 type TargetStateEvidenceSource = "state" | "transcript" | "screen";
-
-function autoArchiveEnabledByEnv(): boolean {
-  return !["0", "false", "off", "no"].includes(
-    (process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE ?? "").toLowerCase(),
-  );
-}
 
 function tailScreenLines(text: string, lines: number): string {
   return text.split(/\r?\n/).slice(-lines).join("\n");
@@ -294,32 +286,6 @@ export function resolveSweepTiming(
     idleIntervalMs,
     idleAfterSweeps,
   };
-}
-
-function taskDoneAutoArchiveMs(): number {
-  const rawMs = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
-  if (rawMs !== undefined) {
-    const parsed = Number(rawMs);
-    return Number.isFinite(parsed) && parsed >= 0
-      ? parsed
-      : TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
-  }
-
-  const rawMinutes = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES;
-  if (rawMinutes === undefined) {
-    return TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
-  }
-  const parsed = Number(rawMinutes);
-  return Number.isFinite(parsed) && parsed >= 0
-    ? parsed * 60_000
-    : TASK_DONE_AUTO_ARCHIVE_DEFAULT_MS;
-}
-
-function idleWorkerCloseMs(): number | null {
-  const rawMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
-  if (rawMs === undefined) return null;
-  const parsed = Number(rawMs);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 interface AgentEngineClient {
@@ -1157,119 +1123,17 @@ export class AgentEngine {
   }
 
   private async maybeArchiveDoneAgent(agent: AgentRecord): Promise<boolean> {
-    if (agent.state !== "done") return false;
-    if (agent.cli !== "codex" || inferRecordRole(agent) !== "worker") {
-      return false;
-    }
-    if (agent.auto_archive_on_done !== true || !autoArchiveEnabledByEnv()) {
-      return false;
-    }
-    if (!agent.task_done_detected_at) return false;
-
-    const detectedAt = Date.parse(agent.task_done_detected_at);
-    if (Number.isNaN(detectedAt)) return false;
-    if (Date.now() - detectedAt < taskDoneAutoArchiveMs()) return false;
-
-    try {
-      await this.client.closeSurface(agent.surface_id, {
-        workspace: agent.workspace_id ?? undefined,
-      });
-      return true;
-    } catch {
-      // Best-effort archive; the next sweep will retry if the surface remains.
-      return false;
-    }
-  }
-
-  private async workerCloseOptions(
-    agent: AgentRecord,
-  ): Promise<{ workspace?: string; collapsePane?: boolean }> {
-    const workspace = agent.workspace_id ?? undefined;
-    const options: { workspace?: string; collapsePane?: boolean } = {
-      workspace,
-    };
-    if (!workspace) return options;
-
-    try {
-      const panes = await this.client.listPanes({ workspace });
-      const rawPaneSurfaces = await Promise.all(
-        panes.panes.map(async (pane) => {
-          const ps = await this.client.listPaneSurfaces({
-            workspace,
-            pane: pane.ref,
-          });
-          return ps.pane_ref ? ps : { ...ps, pane_ref: pane.ref };
-        }),
-      );
-      const paneSurfaces = partitionPaneSurfacesByMembership(
-        panes.panes,
-        rawPaneSurfaces,
-        {
-          workspace_ref: panes.workspace_ref ?? workspace,
-          window_ref: panes.window_ref,
-        },
-      );
-      const workerSurfaceIds = new Set<string>();
-      for (const record of this.registry.list()) {
-        try {
-          if (inferRecordRole(record) === "worker") {
-            workerSurfaceIds.add(record.surface_id);
-          }
-        } catch {
-          // Unknown-role records should not influence worker pane collapse.
-        }
-      }
-      workerSurfaceIds.add(agent.surface_id);
-      const closePolicy = chooseSurfaceClosePolicy(
-        panes.panes,
-        paneSurfaces,
-        workerSurfaceIds,
-        agent.surface_id,
-      );
-      if (closePolicy.collapsePane) {
-        options.collapsePane = true;
-      }
-    } catch {
-      // Pane geometry is advisory; close the worker surface even if it cannot
-      // prove the pane is safe to collapse.
-    }
-
-    return options;
+    void agent;
+    // Sweeps must never close user panes. TASK_DONE marks state only; explicit
+    // close_surface/stop_agent remain available when an orchestrator chooses it.
+    return false;
   }
 
   private async maybeReapIdleWorker(agent: AgentRecord): Promise<boolean> {
-    const closeMs = idleWorkerCloseMs();
-    if (closeMs === null) return false;
-    if (agent.state !== "done" && agent.state !== "idle") return false;
-
-    try {
-      if (inferRecordRole(agent) !== "worker") return false;
-    } catch {
-      return false;
-    }
-    if (
-      agent.cli === "codex" &&
-      agent.auto_archive_on_done === true &&
-      agent.task_done_detected_at &&
-      autoArchiveEnabledByEnv()
-    ) {
-      return false;
-    }
-
-    const updatedAt = Date.parse(agent.updated_at);
-    if (Number.isNaN(updatedAt)) return false;
-    if (Date.now() - updatedAt < closeMs) return false;
-
-    try {
-      await this.client.closeSurface(
-        agent.surface_id,
-        await this.workerCloseOptions(agent),
-      );
-      return true;
-    } catch {
-      // Best-effort reap; the next sweep will retry if the surface remains.
-      return false;
-    }
+    void agent;
+    // The old idle-worker reaper was too destructive for unattended workspaces.
+    // Keep panes visible until an explicit close command is issued.
+    return false;
   }
 
   private isRecoverableCrash(agent: AgentRecord): boolean {
@@ -1546,13 +1410,8 @@ export class AgentEngine {
               await this.client.send(surface_id, "/compact", {});
               await this.client.sendKey(surface_id, "return", {});
             } else {
-              // Non-root: kill and log. No auto-respawn because:
-              // 1. Respawn loses all work-in-progress context (new agent starts from scratch)
-              // 2. The parent orchestrator should decide retry strategy, not the sweep
-              // 3. Each respawn adds a dead child — repeated cycles hit MAX_CHILDREN with corpses
-              await this.stopAgent(agentId, false, { userInitiated: false });
               await this.client.log(
-                `context-limit: killing depth ${agent.spawn_depth} agent ${repo}`,
+                `context-limit: depth ${agent.spawn_depth} agent ${repo} degraded; leaving pane running for orchestrator decision`,
                 { level: "warning", source: "cmux-mcp" },
               );
             }
@@ -1761,14 +1620,8 @@ export class AgentEngine {
       // Best-effort liveness assertion; still attempt surface cleanup below.
     }
 
-    try {
-      await this.client.closeSurface(agent.surface_id, {
-        workspace: agent.workspace_id ?? undefined,
-        collapsePane: true,
-      });
-    } catch {
-      // Best-effort zombie cleanup.
-    }
+    // Do not auto-close the surface here. Liveness failures are evidence for
+    // spawn/layout bugs, and closing the pane can destroy the user's context.
   }
 
   /**

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1052,7 +1052,19 @@ export class AgentEngine {
         return agent;
       }
 
-      const updated = this.stateMgr.transition(agent.agent_id, "ready");
+      let updated = this.stateMgr.transition(agent.agent_id, "ready", {
+        error: agent.error?.startsWith("Post-spawn liveness failed:")
+          ? null
+          : agent.error,
+      });
+      if (
+        updated.quality === "degraded" &&
+        agent.error?.startsWith("Post-spawn liveness failed:")
+      ) {
+        updated = this.stateMgr.updateRecord(agent.agent_id, {
+          quality: "unknown",
+        });
+      }
       this.registry.set(agent.agent_id, updated);
       this.readyPatternMatches.delete(agent.agent_id);
       return updated;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3682,9 +3682,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         auto_archive_on_done: z
           .boolean()
           .optional()
-          .default(true)
+          .default(false)
           .describe(
-            "When true, Codex worker panes that emit TASK_DONE are auto-closed after the inactivity window.",
+            "Deprecated compatibility flag. TASK_DONE updates agent state only; cmuxlayer does not auto-close panes.",
           ),
         max_cost_per_agent: z
           .number()
@@ -3726,7 +3726,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             worktree_branch: worktree.prepared?.branch,
             parent_agent_id: args.parent_agent_id,
             role: args.role,
-            auto_archive_on_done: args.auto_archive_on_done ?? true,
+            auto_archive_on_done: args.auto_archive_on_done ?? false,
             max_cost_per_agent: args.max_cost_per_agent,
             crash_recover: args.crash_recover,
           });
@@ -3872,7 +3872,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .describe("MCP profile hint. Defaults to inherit."),
         parent_agent_id: z.string().optional(),
-        auto_archive_on_done: z.boolean().optional().default(true),
+        auto_archive_on_done: z.boolean().optional().default(false),
         crash_recover: z.boolean().optional(),
       },
       ANNOTATIONS.mutating,
@@ -3899,7 +3899,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             worktree_branch: worktree.prepared?.branch,
             parent_agent_id: args.parent_agent_id,
             role: "worker",
-            auto_archive_on_done: args.auto_archive_on_done ?? true,
+            auto_archive_on_done: args.auto_archive_on_done ?? false,
             crash_recover: args.crash_recover,
           });
 
@@ -4012,7 +4012,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               boot_prompt_pending: hasPrompt,
               workspace,
               role: agent.role,
-              auto_archive_on_done: true,
+              auto_archive_on_done: false,
             });
 
             if (hasPrompt) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -278,8 +278,9 @@ describe("AgentEngine", () => {
         await vi.runOnlyPendingTimersAsync();
 
         expect(stateMgr.readState(result.agent_id)).toMatchObject({
-          state: "error",
+          state: "booting",
           error: "Post-spawn liveness failed: surface surface:new is not live",
+          quality: "degraded",
         });
         expect(mockClient.closeSurface).not.toHaveBeenCalled();
       } finally {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -151,8 +151,12 @@ describe("AgentEngine", () => {
   let mockClient: CmuxClient;
   let engine: AgentEngine;
   let liveSurfaces: CmuxSurface[];
+  let previousTaskDoneAutoArchive: string | undefined;
 
   beforeEach(() => {
+    previousTaskDoneAutoArchive =
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
+    delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
     spawnMock.mockReset();
@@ -171,6 +175,12 @@ describe("AgentEngine", () => {
   afterEach(() => {
     engine.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
+    if (previousTaskDoneAutoArchive === undefined) {
+      delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
+    } else {
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE =
+        previousTaskDoneAutoArchive;
+    }
   });
 
   describe("spawnAgent", () => {
@@ -271,10 +281,7 @@ describe("AgentEngine", () => {
           state: "error",
           error: "Post-spawn liveness failed: surface surface:new is not live",
         });
-        expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:new", {
-          workspace: "ws:1",
-          collapsePane: true,
-        });
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }
@@ -908,7 +915,35 @@ describe("AgentEngine", () => {
       });
     });
 
-    it("auto-closes archived Codex worker panes after TASK_DONE inactivity", async () => {
+    it("does not auto-close opted-in done workers unless env enables auto-archive", async () => {
+      vi.useFakeTimers();
+      try {
+        const doneAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(doneAt.getTime() + 31 * 60_000));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-done-without-env",
+            state: "done",
+            surface_id: "surface:done-worker-without-env",
+            cli: "codex",
+            role: "worker",
+            auto_archive_on_done: true,
+            task_done_detected_at: doneAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:done-worker-without-env")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not auto-close Codex worker panes after TASK_DONE inactivity even when env opts in", async () => {
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE = "1";
       vi.useFakeTimers();
       try {
         const doneAt = new Date("2026-05-25T12:00:00.000Z");
@@ -950,10 +985,11 @@ describe("AgentEngine", () => {
         vi.setSystemTime(new Date(doneAt.getTime() + 5_001 + 30 * 60_000 + 1));
         await engine.runSweep();
 
-        expect(mockClient.closeSurface).toHaveBeenCalledWith(
-          "surface:done-worker",
-          { workspace: undefined },
-        );
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("worker-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: expect.any(String),
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -1004,10 +1040,11 @@ describe("AgentEngine", () => {
       }
     });
 
-    it("prefers TASK_DONE auto-archive milliseconds over minutes when both env vars are set", async () => {
+    it("does not close done workers even when TASK_DONE auto-archive delay has elapsed", async () => {
       const previousMs = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
       const previousMinutes =
         process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES;
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE = "1";
       process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS = "1";
       process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MINUTES = "1";
       vi.useFakeTimers();
@@ -1032,10 +1069,11 @@ describe("AgentEngine", () => {
         vi.setSystemTime(new Date(doneAt.getTime() + 2));
         await engine.runSweep();
 
-        expect(mockClient.closeSurface).toHaveBeenCalledWith(
-          "surface:done-worker-ms",
-          { workspace: undefined },
-        );
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("worker-done-ms")).toMatchObject({
+          state: "done",
+          task_done_detected_at: doneAt.toISOString(),
+        });
       } finally {
         if (previousMs === undefined) {
           delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE_MS;
@@ -1052,7 +1090,8 @@ describe("AgentEngine", () => {
       }
     });
 
-    it("measures TASK_DONE auto-archive delay from detection time, not updated_at", async () => {
+    it("keeps done workers open regardless of TASK_DONE detection time", async () => {
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE = "1";
       vi.useFakeTimers();
       try {
         const detectedAt = new Date("2026-05-25T12:00:00.000Z");
@@ -1075,16 +1114,18 @@ describe("AgentEngine", () => {
 
         await engine.runSweep();
 
-        expect(mockClient.closeSurface).toHaveBeenCalledWith(
-          "surface:detected-done-worker",
-          { workspace: undefined },
-        );
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("worker-detected-done")).toMatchObject({
+          state: "done",
+          task_done_detected_at: detectedAt.toISOString(),
+        });
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it("skips sidebar status writes after auto-archiving a done worker surface", async () => {
+    it("keeps sidebar state for done workers instead of auto-archiving the surface", async () => {
+      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE = "1";
       vi.useFakeTimers();
       try {
         const doneAt = new Date("2026-05-25T12:00:00.000Z");
@@ -1102,25 +1143,23 @@ describe("AgentEngine", () => {
         );
         liveSurfaces = [makeSurface("surface:archived-before-status")];
         await engine.getRegistry().reconstitute();
-        (mockClient.setStatus as ReturnType<typeof vi.fn>).mockRejectedValue(
-          new Error("surface missing"),
-        );
-
         await expect(engine.runSweep()).resolves.toBeUndefined();
 
-        expect(mockClient.closeSurface).toHaveBeenCalledWith(
-          "surface:archived-before-status",
-          { workspace: undefined },
-        );
-        expect(mockClient.clearStatus).toHaveBeenCalledWith(
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(mockClient.clearStatus).not.toHaveBeenCalled();
+        expect(mockClient.setStatus).toHaveBeenCalledWith(
           "worker-archived-before-status",
-          { workspace: undefined },
+          "brainlayer: done",
+          expect.objectContaining({
+            surface: "surface:archived-before-status",
+          }),
         );
-        expect(mockClient.setStatus).not.toHaveBeenCalled();
         expect(
           engine.getAgentState("worker-archived-before-status"),
-        ).toBeNull();
-        expect(stateMgr.readState("worker-archived-before-status")).toBeNull();
+        ).toMatchObject({ state: "done" });
+        expect(stateMgr.readState("worker-archived-before-status")).toMatchObject(
+          { state: "done" },
+        );
 
         (mockClient.setStatus as ReturnType<typeof vi.fn>).mockClear();
         await engine.runSweep();
@@ -1193,7 +1232,7 @@ describe("AgentEngine", () => {
       }
     });
 
-    it("reaps done non-Codex worker panes after the idle close timeout", async () => {
+    it("does not reap done non-Codex worker panes after the idle close timeout", async () => {
       const previousIdleCloseMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
       process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = "1000";
       vi.useFakeTimers();
@@ -1256,12 +1295,13 @@ describe("AgentEngine", () => {
         vi.setSystemTime(new Date(doneAt.getTime() + 1_000));
         await engine.runSweep();
 
-        expect(mockClient.closeSurface).toHaveBeenCalledWith(
-          "surface:cursor-worker",
-          { workspace: "ws:1", collapsePane: true },
-        );
-        expect(engine.getAgentState("cursor-worker-done")).toBeNull();
-        expect(stateMgr.readState("cursor-worker-done")).toBeNull();
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("cursor-worker-done")).toMatchObject({
+          state: "done",
+        });
+        expect(stateMgr.readState("cursor-worker-done")).toMatchObject({
+          state: "done",
+        });
       } finally {
         if (previousIdleCloseMs === undefined) {
           delete process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2546,6 +2546,35 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
+    it("clears stale post-spawn liveness errors when a booting agent reaches ready", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-recovered",
+          state: "booting",
+          surface_id: "surface:recovered",
+          cli: "codex",
+          error: "Post-spawn liveness failed: surface surface:recovered is not live",
+          quality: "degraded",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:recovered")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:recovered",
+        text: "codex> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-recovered")).toMatchObject({
+        state: "ready",
+        error: null,
+        quality: "unknown",
+      });
+    });
+
     it("reuses one tail read for boot capture, readiness, task done, and context checks in a sweep", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -1,6 +1,6 @@
 /**
  * TDD tests for Task 19 — Quality Tracking.
- * Tests parseContextPercent, quality field, /compact at 80%, kill for depth>0.
+ * Tests parseContextPercent, quality field, /compact at 80%, warn for depth>0.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
@@ -170,7 +170,7 @@ describe("Quality Tracking (sweep)", () => {
     expect(mockClient.sendKey).toHaveBeenCalledWith("s:1", "return", {});
   });
 
-  it("at 80% context, depth-1 agent is killed", async () => {
+  it("at 80% context, depth-1 agent is warned but not killed", async () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: "child1",
@@ -193,9 +193,12 @@ describe("Quality Tracking (sweep)", () => {
 
     await engine.runSweep();
 
-    // Should have been killed (sendKey c-c for graceful stop)
-    expect(mockClient.sendKey).toHaveBeenCalledWith("s:2", "c-c", {});
-    // Should log the context-limit kill
+    expect(mockClient.sendKey).not.toHaveBeenCalledWith("s:2", "c-c", {});
+    expect(engine.getAgentState("child1")).toMatchObject({
+      state: "working",
+      quality: "degraded",
+    });
+    // Should log the context-limit warning
     expect(mockClient.log).toHaveBeenCalledWith(
       expect.stringContaining("context-limit"),
       expect.objectContaining({ level: "warning" }),
@@ -262,11 +265,7 @@ describe("Quality Tracking (sweep)", () => {
     );
   });
 
-  it("depth>0 agent at 80% is killed but NOT respawned (kill-only, no auto-respawn)", async () => {
-    // Kill-only is intentional. Auto-respawn is wrong because:
-    // 1. Respawn loses all work-in-progress context (new agent starts from scratch)
-    // 2. Parent orchestrator should decide retry strategy, not the sweep
-    // 3. Each respawn adds a dead child — repeated cycles hit MAX_CHILDREN with corpses
+  it("depth>0 agent at 80% is degraded but not killed or respawned", async () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: "child1",
@@ -289,12 +288,11 @@ describe("Quality Tracking (sweep)", () => {
 
     await engine.runSweep();
 
-    // Agent should be in terminal state (killed)
     const agent = engine.getAgentState("child1");
-    expect(agent!.state).toBe("done");
+    expect(agent!.state).toBe("working");
+    expect(agent!.quality).toBe("degraded");
+    expect(mockClient.sendKey).not.toHaveBeenCalledWith("s:2", "c-c", {});
 
-    // No new agent should have been spawned (newSplit not called for respawn)
-    // newSplit is only called during spawnAgent — 0 calls means no respawn
     expect(mockClient.newSplit).not.toHaveBeenCalled();
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -251,7 +251,7 @@ describe("agent lifecycle tool handlers", () => {
     );
     const persisted =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
-    expect(persisted.auto_archive_on_done).toBe(true);
+    expect(persisted.auto_archive_on_done).toBe(false);
   });
 
   it("spawn_agent accepts an omitted model and resolves the CLI default", async () => {


### PR DESCRIPTION
## Summary
- Stop cmuxlayer sweeps from closing agent panes on TASK_DONE or idle-worker timeout.
- Stop post-spawn liveness cleanup from closing panes when a surface lookup fails.
- Stop context-limit handling from killing non-root agents; it now marks degraded and logs for orchestrator decision.
- Keep explicit close paths intact: `close_surface`, `stop_agent`, and `kill` still work when intentionally invoked.

## Test plan
- `bun run typecheck`
- `bun run test` (51 files, 846 tests)
- Push hook reran `run_tests.sh` successfully, including full Vitest suite.

## Notes
- Local `coderabbit review --agent` was run with a 180s timeout and did not return findings before timing out; PR-level bots are invoked below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change is broad—done/idle/liveness panes stay open until explicit close, which may leave clutter but avoids destroying user context; explicit close paths are unchanged.
> 
> **Overview**
> **Stops sweep-driven pane teardown** so unattended workspaces keep terminal context. `maybeArchiveDoneAgent` and `maybeReapIdleWorker` always return `false`, removing TASK_DONE auto-archive (including env helpers like `CMUXLAYER_TASK_DONE_AUTO_ARCHIVE*`) and idle-worker reaping via `CMUXLAYER_IDLE_WORKER_CLOSE_MS`. **TASK_DONE still transitions agents to `done`**; only explicit `close_surface` / `stop_agent` / kill paths close panes.
> 
> **Post-spawn liveness** no longer moves agents to `error` or closes surfaces on failed checks—it sets **`quality: degraded`** and leaves them **`booting`**, with recovery when readiness clears stale liveness errors.
> 
> **Context limits at ≥80%**: root agents still get `/compact`; **depth &gt; 0 agents are logged and marked degraded** instead of being stopped.
> 
> **API defaults**: `auto_archive_on_done` is **deprecated**, defaults to **`false`** on all spawn MCP paths, and docs state cmuxlayer does not auto-close on TASK_DONE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725254ac8d42f30102da74a5cd1aabfaf291a7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable automatic pane closes for unattended agents
> - Removes auto-archive logic from `AgentEngine.maybeArchiveDoneAgent` and idle-worker reaping from `AgentEngine.maybeReapIdleWorker`, so agent panes are never closed automatically by the sweep.
> - Non-root agents hitting context limits are now left running with degraded quality instead of being killed.
> - Post-spawn liveness failures no longer transition agents to a terminal error state or close their panes; agents remain in `booting` with `degraded` quality.
> - Changes `auto_archive_on_done` default from `true` to `false` in all spawn tool handlers in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/170/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595).
> - Behavioral Change: agents that previously auto-closed after TASK_DONE inactivity or idle timeouts will now remain open indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 725254a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent workers remain open after completion instead of auto-closing, enabling manual cleanup and orchestrator control.
  * Agents hitting context limits are no longer terminated; they continue running for orchestrator decision-making.
  * Liveness check failures no longer automatically close agent surfaces.

* **Deprecations**
  * The `auto_archive_on_done` option is deprecated and now defaults to false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->