### PR TITLE
fix: protect live panes on close + pin workers to parent workspace (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,23 @@ bun run typecheck    # Type checking only
 Socket client connects to cmux via Unix socket at the path provided by `cmux socket-path`.
 Auto-reconnects on disconnect. Falls back to CLI subprocess if socket unavailable.
 
+**Instance pinning (`CMUX_SOCKET_PATH`).** cmux exports `CMUX_SOCKET_PATH` into each agent's
+environment, pointing at the instance that spawned it. When set (or `socketPath` is passed),
+cmuxlayer binds to **that one instance only** and never falls through to another live cmux's
+socket — this is what keeps a worker from opening in a *different* cmux app/window (e.g. stable
+vs nightly). When it is unset and more than one cmux socket answers, the factory logs which one
+it bound to and how to pin it. Set `CMUX_SOCKET_PATH` to force the MCP onto the instance you are
+actually using.
+
+### Placement & teardown invariants
+- **Same workspace by default.** A spawned worker inherits its parent orchestrator's
+  `workspace_id` before any repo-name resolution, so co-working agents land in the same
+  workspace (split to the right) instead of a new one — even for worktree workers whose cwd
+  (`~/Gits/<repo>.wt/<name>`) does not match the repo name. An explicit `workspace` arg still wins.
+- **Panes are protected.** Automatic/idle pane closing is disabled (#170). `close_surface`
+  refuses to destroy a surface backing a still-live agent unless `force: true`, and returns a
+  fresh pane read on refusal so callers verify the real screen rather than a stale state record.
+
 ### Mode Policy
 Two axes per surface:
 - **control**: `autonomous` (full access) or `manual` (read-only for mutating tools)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -52,7 +52,10 @@ import {
   type RoleSurfaceIds,
 } from "./layout-policy.js";
 import { matchReadyPattern } from "./pattern-registry.js";
-import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
+import {
+  reposEquivalent,
+  resolveWorkspaceRefForRepo,
+} from "./repo-workspace.js";
 import { SpawnGuard } from "./spawn-guard.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
@@ -412,7 +415,9 @@ export function buildLaunchCommand(
     allowModelOverride: opts?.allowModelOverride,
   });
   const formattedModelFlag = modelFlag ? formatModelArg(modelFlag) : null;
-  const launcherModelArgs = formattedModelFlag ? ` -m ${formattedModelFlag}` : "";
+  const launcherModelArgs = formattedModelFlag
+    ? ` -m ${formattedModelFlag}`
+    : "";
   const rawModelArgs = formattedModelFlag
     ? ` --model ${formattedModelFlag}`
     : "";
@@ -738,7 +743,27 @@ export class AgentEngine {
       repo?: string;
     },
   ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
-    workspace = await this.resolveWorkspaceForRepo(workspace, context?.repo);
+    // Pin a child worker to the parent orchestrator's ACTUAL workspace before
+    // falling back to repo-name resolution. Without this a worker re-resolves
+    // its workspace purely from the repo directory name, which fails for
+    // worktree workers (cwd basename is "<repo>.wt/<name>", not "<repo>"): the
+    // match returns undefined, listPanes() then runs against cmux's focused
+    // workspace where the parent's pane is absent, and the split lands in the
+    // wrong/new workspace instead of to the right of the parent. An explicit
+    // `workspace` arg still wins ("unless the user asks for a different one").
+    // Inherit only for a SAME-repo child so a cross-repo spawn still resolves
+    // to its own repo's workspace.
+    const parentWorkspace =
+      context?.parentAgent &&
+      context.parentAgent.repo &&
+      context?.repo &&
+      reposEquivalent(context.parentAgent.repo, context.repo)
+        ? (context.parentAgent.workspace_id ?? undefined)
+        : undefined;
+    workspace = await this.resolveWorkspaceForRepo(
+      workspace ?? parentWorkspace,
+      context?.repo,
+    );
     if (workspace) {
       try {
         await this.client.selectWorkspace(workspace);
@@ -932,7 +957,8 @@ export class AgentEngine {
         this.registry.rename(previousAgentId, collisionAgentId, updated);
         return updated;
       }
-      const sessionPath = identity.path ?? existingFinal.cli_session_path ?? null;
+      const sessionPath =
+        identity.path ?? existingFinal.cli_session_path ?? null;
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
         existingFinal.cli_session_path === sessionPath
@@ -1666,7 +1692,9 @@ export class AgentEngine {
     if (spawnParams.parent_agent_id) {
       const parent = this.registry.get(spawnParams.parent_agent_id);
       if (!parent) {
-        throw new Error(`Parent agent not found: ${spawnParams.parent_agent_id}`);
+        throw new Error(
+          `Parent agent not found: ${spawnParams.parent_agent_id}`,
+        );
       }
       if (parent.spawn_depth >= MAX_SPAWN_DEPTH) {
         throw new Error(`Max spawn depth exceeded: ${MAX_SPAWN_DEPTH}`);

--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -26,6 +26,14 @@ export interface CreateCmuxClientOptions {
 }
 
 /**
+ * Bound on the probe `system.ping`. A wedged cmux can ACCEPT the socket connect
+ * but never answer (the Surface.deinit deadlock), and probing every candidate
+ * would otherwise inherit the 10s request timeout and stall startup ~10s per
+ * hung instance. The probe only needs a liveness yes/no, so cap it short.
+ */
+const PROBE_PING_TIMEOUT_MS = 2000;
+
+/**
  * Probe whether a Unix socket is listening.
  * Connects, immediately disconnects. Returns true if connect succeeds.
  */
@@ -62,12 +70,26 @@ async function resolveSocketPath(
   return null;
 }
 
+function instancePin(
+  opts?: Pick<CreateCmuxClientOptions, "socketPath">,
+): string | undefined {
+  if (opts?.socketPath) return opts.socketPath;
+  const fromEnv = (process.env.CMUX_SOCKET_PATH ?? "").trim();
+  return fromEnv.length > 0 ? fromEnv : undefined;
+}
+
 function candidateSocketPaths(
   opts?: Pick<CreateCmuxClientOptions, "socketPath" | "socketStateDir">,
 ): string[] {
-  return opts?.socketPath
-    ? [opts.socketPath]
-    : cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
+  // An explicit socketPath or CMUX_SOCKET_PATH is AUTHORITATIVE: cmux sets
+  // CMUX_SOCKET_PATH in each agent's env to point at the instance that spawned
+  // it, so when it is present we bind to that one instance only and never fall
+  // through to another cmux's socket (which is how panes ended up in a
+  // different / nightly app). Only when nothing is pinned do we probe the
+  // ordered candidate list.
+  const pinned = instancePin(opts);
+  if (pinned) return [pinned];
+  return cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
 }
 
 async function probeUsableSocket(
@@ -80,7 +102,13 @@ async function probeUsableSocket(
 
   const transport = new CmuxPersistentSocket({
     socketPath,
-    timeoutMs: opts?.timeoutMs,
+    // Cap the probe ping so a hung-but-accepting candidate can't stall the
+    // probe-all loop by the full request timeout. A caller-supplied timeout
+    // (tests) still wins when smaller.
+    timeoutMs: Math.min(
+      opts?.timeoutMs ?? PROBE_PING_TIMEOUT_MS,
+      PROBE_PING_TIMEOUT_MS,
+    ),
   });
 
   try {
@@ -106,11 +134,21 @@ export async function createCmuxClient(
   const logger = opts?.logger ?? console;
   const cliFallback = new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
 
-  for (const socketPath of candidateSocketPaths(opts)) {
-    if (!(await probeUsableSocket(socketPath, opts))) {
-      continue;
-    }
+  const candidates = candidateSocketPaths(opts);
+  const pinned = instancePin(opts) !== undefined;
 
+  // Probe every candidate up front. Dead candidates fail instantly (the socket
+  // path does not exist → ENOENT), so this stays cheap, and it lets us detect
+  // when more than one cmux instance is actually LIVE — the real "which app?"
+  // ambiguity — rather than warning on every multi-path candidate list.
+  const usable: string[] = [];
+  for (const socketPath of candidates) {
+    if (await probeUsableSocket(socketPath, opts)) {
+      usable.push(socketPath);
+    }
+  }
+
+  for (const socketPath of usable) {
     const client = new CmuxSocketClient({
       socketPath,
       timeoutMs: opts?.timeoutMs,
@@ -122,10 +160,21 @@ export async function createCmuxClient(
     try {
       await client.ping();
       logger.error("[cmuxlayer] transport selected: socket");
+      if (!pinned && usable.length > 1) {
+        // Multiple cmux instances are live and nothing pins us to one: surface
+        // which we bound to so a wrong-app/window placement is diagnosable and
+        // the operator can pin it explicitly.
+        logger.error(
+          `[cmuxlayer] ${usable.length} live cmux sockets found and CMUX_SOCKET_PATH ` +
+            `is not set; bound to ${socketPath} by probe order. If new panes open in the ` +
+            `wrong cmux app/window, set CMUX_SOCKET_PATH to pin this MCP to the instance ` +
+            `you are using.`,
+        );
+      }
       return client;
     } catch {
       // Socket reachable but not usable (auth required, protocol mismatch, etc.)
-      // Try the next candidate before falling through to CLI.
+      // Try the next usable candidate before falling through to CLI.
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,53 @@
  *   V2 agent controls (2): kill, interact
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
 
+function readVersion(): string {
+  // package.json sits one level above the compiled entrypoint (dist/index.js
+  // → ../package.json, and likewise libexec/dist/index.js → libexec/package.json
+  // for a brew install). Best-effort; never throw from a --version probe.
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "package.json"), "utf-8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
+
+Usage:
+  cmuxlayer            Start the MCP server on stdio (the normal mode; an MCP
+                       client such as cmux/Claude Code launches it and speaks
+                       JSON-RPC over stdin/stdout).
+  cmuxlayer --version  Print the version and exit.
+  cmuxlayer --help     Print this help and exit.
+
+Environment:
+  CMUX_SOCKET_PATH     Pin the MCP to a specific cmux instance's Unix socket
+                       (authoritative — never falls through to another instance).
+`;
+
 async function main() {
+  const arg = process.argv[2];
+  if (arg === "--version" || arg === "-v") {
+    process.stdout.write(`cmuxlayer ${readVersion()}\n`);
+    return;
+  }
+  if (arg === "--help" || arg === "-h") {
+    process.stdout.write(HELP_TEXT);
+    return;
+  }
+
   const client = await createCmuxClient();
   const server = createServer({ client });
   const transport = new StdioServerTransport();

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -4,51 +4,145 @@ export function pathBaseName(path: string): string {
   return index >= 0 ? normalized.slice(index + 1) : normalized;
 }
 
+function tokenMatchesRepo(token: string, repo: string): boolean {
+  const normalizedRepo = repo.toLowerCase();
+  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
+  const normalizedToken = token.toLowerCase();
+  return (
+    normalizedToken === normalizedRepo ||
+    normalizedToken.replace(/-/g, "") === normalizedRepoNoHyphen
+  );
+}
+
+/**
+ * True when two repo labels denote the same repo. Case- and hyphen-insensitive,
+ * matching the directory-matching semantics above so "cmux-layer" and
+ * "cmuxlayer" (or differing case) are treated as one repo everywhere.
+ */
+export function reposEquivalent(a: string, b: string): boolean {
+  return tokenMatchesRepo(a, b);
+}
+
+/**
+ * How strongly a workspace's current_directory belongs to `repo`:
+ *   2 = exact basename match — the canonical repo root, e.g. ~/Gits/<repo>
+ *   1 = a worktree of the repo. Anchored to the worktree SHAPE, not any
+ *       ancestor segment:
+ *         ~/Gits/<repo>.wt/<name>      (a "<repo>.wt" segment)
+ *         ~/Gits/<repo>/.worktrees/x   (a "<repo>" segment immediately
+ *                                       followed by a ".worktrees" marker)
+ *   0 = no match
+ * A bare "<repo>" segment elsewhere in the path is intentionally NOT matched,
+ * so a repo whose name coincides with an ancestor directory (an org folder,
+ * the username, "Gits") never routes a launch into an unrelated workspace.
+ * Matching is anchored on real path boundaries (no substring/prefix test) so
+ * `cmuxlayer` never matches `cmuxlayer-fork`, and the home dir is never
+ * hardcoded. A higher score always wins, so a worktree workspace can never
+ * shadow the repo root when both are open.
+ */
+export function workspaceDirectoryRepoMatchScore(
+  repo: string,
+  cwd: string,
+): number {
+  if (tokenMatchesRepo(pathBaseName(cwd), repo)) return 2;
+  const segments = cwd.split("/").filter(Boolean);
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (
+      segment.toLowerCase().endsWith(".wt") &&
+      tokenMatchesRepo(segment.slice(0, -3), repo)
+    ) {
+      return 1;
+    }
+    if (
+      tokenMatchesRepo(segment, repo) &&
+      segments[i + 1]?.toLowerCase() === ".worktrees"
+    ) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 export function repoNameMatchesWorkspaceDirectory(
   repo: string,
   cwd: string,
 ): boolean {
-  const normalizedRepo = repo.toLowerCase();
-  const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
-  const directory = pathBaseName(cwd).toLowerCase();
-  return (
-    directory === normalizedRepo ||
-    directory.replace(/-/g, "") === normalizedRepoNoHyphen
-  );
+  return workspaceDirectoryRepoMatchScore(repo, cwd) > 0;
+}
+
+export interface FindWorkspaceForRepoOptions {
+  /**
+   * A workspace ref to favour among equally-good repo matches — typically the
+   * parent agent's workspace, so co-working agents converge on one workspace
+   * even when several same-repo workspaces are open across windows.
+   */
+  preferredRef?: string | null;
+}
+
+interface WorkspaceCandidate {
+  ref: string;
+  current_directory?: string | null;
+  selected?: boolean | null;
+}
+
+function rankCandidate(
+  candidate: WorkspaceCandidate,
+  repo: string,
+  preferredRef: string | null | undefined,
+): number {
+  const directory =
+    typeof candidate.current_directory === "string"
+      ? candidate.current_directory
+      : "";
+  const score = workspaceDirectoryRepoMatchScore(repo, directory);
+  if (score === 0) return 0;
+  // preferred ref dominates, then exact-basename over worktree-segment, then
+  // the currently-selected workspace, as a fully deterministic tie-break that
+  // no longer depends on cmux's workspace.list ordering (the old first-match).
+  const preferred = preferredRef != null && candidate.ref === preferredRef;
+  const selected = candidate.selected === true;
+  return (preferred ? 1000 : 0) + score * 10 + (selected ? 1 : 0);
 }
 
 export function findWorkspaceRefForRepo(
-  workspaces: Iterable<{
-    ref: string;
-    current_directory?: string | null;
-  }>,
+  workspaces: Iterable<WorkspaceCandidate>,
   repo: string | null | undefined,
+  opts: FindWorkspaceForRepoOptions = {},
 ): string | undefined {
   if (!repo) return undefined;
+  let bestRef: string | undefined;
+  let bestRank = 0;
   for (const workspace of workspaces) {
+    const rank = rankCandidate(workspace, repo, opts.preferredRef);
+    if (rank <= 0) continue;
+    // Higher rank wins; among equal nonzero ranks pick the lexicographically
+    // smallest ref so the choice is stable regardless of cmux's workspace.list
+    // ordering. preferredRef and `selected` produce a strictly higher rank, so
+    // this only decides genuine ties (e.g. two worktrees of one repo, none
+    // selected, no preferred ref).
     if (
-      typeof workspace.current_directory === "string" &&
-      repoNameMatchesWorkspaceDirectory(repo, workspace.current_directory)
+      rank > bestRank ||
+      (rank === bestRank && (bestRef === undefined || workspace.ref < bestRef))
     ) {
-      return workspace.ref;
+      bestRank = rank;
+      bestRef = workspace.ref;
     }
   }
-  return undefined;
+  return bestRef;
 }
 
 export async function resolveWorkspaceRefForRepo(
   repo: string | null | undefined,
   listWorkspaces: () => Promise<{
-    workspaces: Array<{
-      ref: string;
-      current_directory?: string | null;
-    }>;
+    workspaces: Array<WorkspaceCandidate>;
   }>,
+  opts: FindWorkspaceForRepoOptions = {},
 ): Promise<string | undefined> {
   if (!repo) return undefined;
   try {
     const { workspaces } = await listWorkspaces();
-    return findWorkspaceRefForRepo(workspaces, repo);
+    return findWorkspaceRefForRepo(workspaces, repo, opts);
   } catch {
     return undefined;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,6 +156,8 @@ const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 /** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
 const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = 60_000;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
+/** Agent states that are safe to close without `force`: the task is over. */
+const TERMINAL_AGENT_STATES = new Set<AgentState>(["done", "error"]);
 const READY_PATTERN_CLIS: CliType[] = [
   "claude",
   "codex",
@@ -2929,14 +2931,66 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 10. close_surface
   server.tool(
     "close_surface",
-    "Close a surface (terminal or browser pane)",
+    "Close a surface (terminal or browser pane). SAFETY: if the surface still backs a live agent (not done/error), the close is REFUSED unless force:true, and the response includes a fresh read of the pane so you can confirm for yourself whether it is really finished before destroying it. Browser panes and surfaces with no tracked agent close normally.",
     {
       surface: z.string().describe("Target surface ref"),
       workspace: z.string().optional().describe("Target workspace ref"),
+      force: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Close even when the backing agent is still live (not done/error). Without this, a live agent's surface is protected and the response returns the current pane contents instead of closing.",
+        ),
     },
     ANNOTATIONS.destructive,
     async (args) => {
       try {
+        // Liveness guard: never destroy a pane whose agent is still live unless
+        // the caller explicitly forces it. This is the safety net for the
+        // "stale list said it was gone but it was actually alive" failure — on
+        // refusal we hand back a fresh pane read so the caller assesses the
+        // real screen, not a possibly-stale state record.
+        if (!args.force) {
+          // Fail-safe across records: a surface can transiently back more than
+          // one state record (crash-resume collisions before canonicalization).
+          // Match the first record that is still LIVE rather than an arbitrary
+          // first hit, so a stale terminal record can never let us tear down a
+          // surface that another, live record still owns.
+          const backingAgent = stateMgr
+            .listStates()
+            .find(
+              (record) =>
+                record.surface_id === args.surface &&
+                !TERMINAL_AGENT_STATES.has(record.state),
+            );
+          if (backingAgent) {
+            let screenText = "(unable to read pane)";
+            try {
+              const screen = await client.readScreen(args.surface, {
+                workspace: args.workspace,
+                lines: 40,
+              });
+              screenText = screen.text;
+            } catch {
+              // Best-effort read; refuse regardless so a live agent is never
+              // torn down without an explicit force.
+            }
+            return err(
+              new Error(
+                `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live). Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
+              ),
+              {
+                refused: true,
+                surface: args.surface,
+                agent_id: backingAgent.agent_id,
+                state: backingAgent.state,
+                screen: screenText,
+              },
+            );
+          }
+        }
+
         let closePolicy:
           | ReturnType<typeof chooseSurfaceClosePolicy>
           | undefined;
@@ -2982,13 +3036,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Layout hints are best-effort only; the close itself must still run.
         }
 
+        const collapsePane = closePolicy?.collapsePane ?? false;
         await client.closeSurface(args.surface, {
           workspace: args.workspace,
+          collapsePane,
         });
         const data = {
           surface: args.surface,
           pane: closePolicy?.pane ?? undefined,
-          collapse_pane: closePolicy?.collapsePane ?? false,
+          collapse_pane: collapsePane,
         };
         return okFormatted(formatOk("close_surface", data), data);
       } catch (e) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -154,8 +154,7 @@ describe("AgentEngine", () => {
   let previousTaskDoneAutoArchive: string | undefined;
 
   beforeEach(() => {
-    previousTaskDoneAutoArchive =
-      process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
+    previousTaskDoneAutoArchive = process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
     delete process.env.CMUXLAYER_TASK_DONE_AUTO_ARCHIVE;
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
@@ -529,6 +528,79 @@ describe("AgentEngine", () => {
         workspace: "workspace:voice",
         type: "terminal",
       });
+    });
+
+    it("pins a worker to the parent orchestrator's workspace even when its cwd is a worktree that does not match by name", async () => {
+      // Parent orchestrator lives in workspace:parent. listWorkspaces has NO
+      // directory matching the repo, so WITHOUT parent-workspace inheritance the
+      // worker would resolve to undefined and land in cmux's focused workspace
+      // (or a brand-new one) — the "opened a worker in a new workspace instead
+      // of on its right" bug. Parent inheritance must split it right, in-place.
+      const parent = makeRecord({
+        agent_id: "parent-claude",
+        surface_id: "surface:parent",
+        workspace_id: "workspace:parent",
+        state: "ready",
+        role: "orchestrator",
+        cli: "claude",
+        repo: "brainlayer",
+        parent_agent_id: null,
+      });
+      engine.getRegistry().set(parent.agent_id, parent);
+      liveSurfaces = [makeSurface("surface:parent")];
+
+      (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue(
+        { workspaces: [] },
+      );
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "workspace:parent",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:parent",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:parent"],
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        workspace_ref: "workspace:parent",
+        window_ref: "window:1",
+        pane_ref: "pane:parent",
+        surfaces: [makeSurface("surface:parent")],
+      });
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "workspace:parent",
+        surface: "surface:worker",
+        pane: "pane:worker",
+        title: "",
+        type: "terminal",
+      });
+
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix the watcher",
+        parent_agent_id: "parent-claude",
+        cwd: "/Users/etanheyman/Gits/brainlayer.wt/watcher-fix",
+      });
+
+      expect(result.workspace_id).toBe("workspace:parent");
+      expect(mockClient.selectWorkspace).toHaveBeenCalledWith(
+        "workspace:parent",
+      );
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        pane: "pane:parent",
+        workspace: "workspace:parent",
+        type: "terminal",
+      });
+      // The parent pin short-circuits repo-name resolution entirely.
+      expect(mockClient.listWorkspaces).not.toHaveBeenCalled();
     });
 
     it("docks the first worker into the rightmost sparse non-lead pane when user panes already exist", async () => {
@@ -1158,9 +1230,9 @@ describe("AgentEngine", () => {
         expect(
           engine.getAgentState("worker-archived-before-status"),
         ).toMatchObject({ state: "done" });
-        expect(stateMgr.readState("worker-archived-before-status")).toMatchObject(
-          { state: "done" },
-        );
+        expect(
+          stateMgr.readState("worker-archived-before-status"),
+        ).toMatchObject({ state: "done" });
 
         (mockClient.setStatus as ReturnType<typeof vi.fn>).mockClear();
         await engine.runSweep();
@@ -1338,12 +1410,12 @@ describe("AgentEngine", () => {
         await engine.runSweep();
 
         expect(mockClient.closeSurface).not.toHaveBeenCalled();
-        expect(engine.getAgentState("codex-worker-pending-archive")).toMatchObject(
-          {
-            state: "done",
-            task_done_detected_at: doneAt.toISOString(),
-          },
-        );
+        expect(
+          engine.getAgentState("codex-worker-pending-archive"),
+        ).toMatchObject({
+          state: "done",
+          task_done_detected_at: doneAt.toISOString(),
+        });
       } finally {
         if (previousIdleCloseMs === undefined) {
           delete process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
@@ -1849,12 +1921,7 @@ To continue this session, run codex resume ${sessionId}`,
     it("uses the saved launch cwd when capturing worktree transcript sessions", async () => {
       vi.setSystemTime(new Date("2026-06-19T05:00:30.000Z"));
       const home = join(TEST_DIR, "home");
-      const worktreeCwd = join(
-        TEST_DIR,
-        "Gits",
-        "cmuxlayer.wt",
-        "skill-eval",
-      );
+      const worktreeCwd = join(TEST_DIR, "Gits", "cmuxlayer.wt", "skill-eval");
       const sessionId = "019e942c-0dda-76f2-bbca-0ef6e484d1c9";
       const sessionDir = join(home, ".codex", "sessions", "2026", "06", "19");
       const sessionPath = join(sessionDir, "rollout-worktree.jsonl");
@@ -2553,7 +2620,8 @@ To continue this session, run codex resume ${sessionId}`,
           state: "booting",
           surface_id: "surface:recovered",
           cli: "codex",
-          error: "Post-spawn liveness failed: surface surface:recovered is not live",
+          error:
+            "Post-spawn liveness failed: surface surface:recovered is not live",
           quality: "degraded",
         }),
       );

--- a/tests/cmux-client-factory.test.ts
+++ b/tests/cmux-client-factory.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for createCmuxClient instance selection:
+ *  - CMUX_SOCKET_PATH is an authoritative pin (never fall through to another
+ *    live cmux instance — the "panes opened in a different cmux app" bug).
+ *  - When unpinned, warn only when more than one cmux instance is actually
+ *    LIVE, so the warning means real ambiguity, not just a multi-path list.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CmuxSocketClient } from "../src/cmux-socket-client.js";
+import { createCmuxClient } from "../src/cmux-client-factory.js";
+import { stateSocketPath } from "../src/cmux-socket-path.js";
+
+const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
+
+function startPingServer(socketPath: string): Promise<net.Server> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+          const req = JSON.parse(line);
+          conn.write(
+            JSON.stringify({ id: req.id, ok: true, result: { pong: true } }) +
+              "\n",
+          );
+        }
+      });
+    });
+    (server as unknown as { _conns: Set<net.Socket> })._conns = connections;
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function stopPingServer(server: net.Server, socketPath: string): Promise<void> {
+  return new Promise((resolve) => {
+    const conns = (server as unknown as { _conns: Set<net.Socket> })._conns;
+    for (const conn of conns ?? []) conn.destroy();
+    server.close(() => {
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        /* ignore */
+      }
+      resolve();
+    });
+  });
+}
+
+describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
+  "createCmuxClient instance selection",
+  () => {
+    let savedEnv: string | undefined;
+    const servers: Array<{ server: net.Server; path: string }> = [];
+
+    afterEach(async () => {
+      if (savedEnv === undefined) {
+        delete process.env.CMUX_SOCKET_PATH;
+      } else {
+        process.env.CMUX_SOCKET_PATH = savedEnv;
+      }
+      savedEnv = undefined;
+      for (const { server, path } of servers.splice(0)) {
+        await stopPingServer(server, path);
+      }
+    });
+
+    function track(server: net.Server, path: string): void {
+      servers.push({ server, path });
+    }
+
+    it("pins to CMUX_SOCKET_PATH and never falls through to another live instance", async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-"));
+      const otherInstance = join(stateDir, "cmux-other.sock");
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${otherInstance}\n`,
+        "utf-8",
+      );
+      track(await startPingServer(otherInstance), otherInstance);
+
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      // Pin points at the instance we run under, but it is down right now.
+      process.env.CMUX_SOCKET_PATH = join(stateDir, "cmux-mine-down.sock");
+      const logger = { error: vi.fn() };
+
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        logger,
+      });
+
+      // Authoritative pin: a down pin falls back to CLI, NOT the other live one.
+      expect(client).not.toBeInstanceOf(CmuxSocketClient);
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining(otherInstance),
+      );
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    it("binds to the pinned instance when it is live", async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-"));
+      const mine = join(stateDir, "cmux-mine.sock");
+      track(await startPingServer(mine), mine);
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      process.env.CMUX_SOCKET_PATH = mine;
+      const logger = { error: vi.fn() };
+
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        logger,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      // Pinned: no ambiguity warning even though it bound to a socket.
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining("live cmux sockets found"),
+      );
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    it("warns when more than one cmux instance is live and nothing is pinned", async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-"));
+      const first = join(stateDir, "cmux-first.sock");
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${first}\n`,
+        "utf-8",
+      );
+      track(await startPingServer(first), first);
+      // A second, independently live instance reachable via stateSocketPath.
+      const second = stateSocketPath(stateDir);
+      track(await startPingServer(second), second);
+
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      delete process.env.CMUX_SOCKET_PATH;
+      const logger = { error: vi.fn() };
+
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        logger,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("live cmux sockets found"),
+      );
+      // Bound to the first (highest-priority) live candidate, and named it.
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(first));
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    it("does not warn when only one cmux instance is live and unpinned", async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-"));
+      const only = join(stateDir, "cmux-only.sock");
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${only}\n`,
+        "utf-8",
+      );
+      track(await startPingServer(only), only);
+
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      delete process.env.CMUX_SOCKET_PATH;
+      const logger = { error: vi.fn() };
+
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        logger,
+      });
+
+      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining("live cmux sockets found"),
+      );
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+  },
+);

--- a/tests/repo-workspace.test.ts
+++ b/tests/repo-workspace.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  findWorkspaceRefForRepo,
+  repoNameMatchesWorkspaceDirectory,
+  reposEquivalent,
+  resolveWorkspaceRefForRepo,
+  workspaceDirectoryRepoMatchScore,
+} from "../src/repo-workspace.js";
+
+describe("workspaceDirectoryRepoMatchScore", () => {
+  it("scores an exact repo-root basename highest", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer",
+      ),
+    ).toBe(2);
+  });
+
+  it("matches a <repo>.wt worktree directory as a segment", () => {
+    // ~/Gits/brainlayer.wt/watcher-fix — basename is the worktree name, not the
+    // repo, so this must match via the ".wt" segment, scored below the root.
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer.wt/watcher-fix",
+      ),
+    ).toBe(1);
+  });
+
+  it("matches a .worktrees layout via the repo segment", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer/.worktrees/wf1-popover",
+      ),
+    ).toBe(1);
+  });
+
+  it("is hyphen-insensitive", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore("cmux-layer", "/Users/x/Gits/cmuxlayer"),
+    ).toBe(2);
+  });
+
+  it("does not match an unrelated sibling repo (no substring/prefix match)", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "cmuxlayer",
+        "/Users/x/Gits/cmuxlayer-fork",
+      ),
+    ).toBe(0);
+    expect(
+      repoNameMatchesWorkspaceDirectory(
+        "cmuxlayer",
+        "/Users/x/Gits/cmuxlayer-fork",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("findWorkspaceRefForRepo", () => {
+  it("prefers the repo-root workspace over a worktree workspace for the same repo", () => {
+    const ref = findWorkspaceRefForRepo(
+      [
+        {
+          ref: "ws:worktree",
+          current_directory: "/Users/x/Gits/brainlayer.wt/a",
+        },
+        { ref: "ws:root", current_directory: "/Users/x/Gits/brainlayer" },
+      ],
+      "brainlayer",
+    );
+    expect(ref).toBe("ws:root");
+  });
+
+  it("honors a preferred ref (parent workspace) even across same-repo matches", () => {
+    const ref = findWorkspaceRefForRepo(
+      [
+        { ref: "ws:root", current_directory: "/Users/x/Gits/brainlayer" },
+        {
+          ref: "ws:worktree",
+          current_directory: "/Users/x/Gits/brainlayer.wt/a",
+        },
+      ],
+      "brainlayer",
+      { preferredRef: "ws:worktree" },
+    );
+    expect(ref).toBe("ws:worktree");
+  });
+
+  it("breaks ties on the selected workspace deterministically (not list order)", () => {
+    const ref = findWorkspaceRefForRepo(
+      [
+        { ref: "ws:a", current_directory: "/Users/x/Gits/brainlayer.wt/a" },
+        {
+          ref: "ws:b",
+          current_directory: "/Users/x/Gits/brainlayer.wt/b",
+          selected: true,
+        },
+      ],
+      "brainlayer",
+    );
+    expect(ref).toBe("ws:b");
+  });
+
+  it("returns undefined when no workspace matches the repo", () => {
+    expect(
+      findWorkspaceRefForRepo(
+        [{ ref: "ws:other", current_directory: "/Users/x/Gits/other" }],
+        "brainlayer",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveWorkspaceRefForRepo", () => {
+  it("resolves a worktree worker to its repo workspace", async () => {
+    const ref = await resolveWorkspaceRefForRepo("brainlayer", async () => ({
+      workspaces: [
+        { ref: "ws:root", current_directory: "/Users/x/Gits/brainlayer" },
+      ],
+    }));
+    expect(ref).toBe("ws:root");
+  });
+
+  it("swallows listWorkspaces errors and returns undefined", async () => {
+    const ref = await resolveWorkspaceRefForRepo("brainlayer", async () => {
+      throw new Error("socket down");
+    });
+    expect(ref).toBeUndefined();
+  });
+});
+
+describe("segment matching is anchored to worktree shapes (no ancestor false-positives)", () => {
+  it("does not match a repo name that merely coincides with an ancestor dir", () => {
+    // A repo literally named "Gits" / the username must NOT claim an unrelated
+    // workspace just because it nests under a same-named directory.
+    expect(
+      workspaceDirectoryRepoMatchScore("Gits", "/Users/x/Gits/brainlayer"),
+    ).toBe(0);
+    expect(
+      workspaceDirectoryRepoMatchScore("x", "/Users/x/Gits/brainlayer"),
+    ).toBe(0);
+  });
+
+  it("does not match a plain subdirectory of the repo (only true worktree shapes)", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer/src/watcher",
+      ),
+    ).toBe(0);
+  });
+
+  it("still matches the two real worktree layouts", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer.wt/a",
+      ),
+    ).toBe(1);
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "brainlayer",
+        "/Users/x/Gits/brainlayer/.worktrees/a",
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("findWorkspaceRefForRepo determinism", () => {
+  it("picks the lexicographically smallest ref among equal-rank ties, order-independent", () => {
+    const candidates = [
+      { ref: "ws:b", current_directory: "/Users/x/Gits/brainlayer.wt/b" },
+      { ref: "ws:a", current_directory: "/Users/x/Gits/brainlayer.wt/a" },
+    ];
+    expect(findWorkspaceRefForRepo(candidates, "brainlayer")).toBe("ws:a");
+    expect(
+      findWorkspaceRefForRepo([...candidates].reverse(), "brainlayer"),
+    ).toBe("ws:a");
+  });
+});
+
+describe("reposEquivalent", () => {
+  it("is case- and hyphen-insensitive and symmetric", () => {
+    expect(reposEquivalent("cmux-layer", "cmuxlayer")).toBe(true);
+    expect(reposEquivalent("cmuxlayer", "cmux-layer")).toBe(true);
+    expect(reposEquivalent("Brainlayer", "brainlayer")).toBe(true);
+    expect(reposEquivalent("brainlayer", "voicelayer")).toBe(false);
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1835,9 +1835,7 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:1",
             text:
-              reads === 1
-                ? "Gemini CLI\nbooting\n>"
-                : "Gemini CLI\nready\n>",
+              reads === 1 ? "Gemini CLI\nbooting\n>" : "Gemini CLI\nready\n>",
             lines: 20,
             scrollback_used: false,
           }),
@@ -4195,18 +4193,149 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["close_surface"];
 
+    // A "working" agent backs this surface, so closing it now requires force;
+    // force:true exercises the collapse-policy forwarding path.
     const result = await tool.handler(
-      { surface: "surface:worker-1" },
+      { surface: "surface:worker-1", force: true },
       {} as any,
     );
 
     expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:worker-1", {
       workspace: undefined,
+      collapsePane: true,
     });
     expect(result.structuredContent).toMatchObject({
       surface: "surface:worker-1",
       pane: "pane:right",
       collapse_pane: true,
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface refuses a live agent without force and returns a pane read", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-guard");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-live",
+      surface_id: "surface:worker-live",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "mid task",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:worker-live",
+        text: "running tests... 115 passed",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-live" },
+      {} as any,
+    );
+
+    // The live surface is protected: cmux is never told to close it, and the
+    // caller gets the real pane contents to assess instead of a stale state.
+    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    expect(mockClient.readScreen).toHaveBeenCalledWith("surface:worker-live", {
+      workspace: undefined,
+      lines: 40,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      surface: "surface:worker-live",
+      agent_id: "worker-live",
+      state: "working",
+      screen: "running tests... 115 passed",
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface guard is fail-safe when a stale terminal record shares the surface with a live one", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-collision");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    const base = {
+      surface_id: "surface:shared",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex" as const,
+      cli_session_id: null,
+      task_summary: "",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown" as const,
+      max_cost_per_agent: null,
+    };
+    // A stale terminal record AND a live record both point at one surface
+    // (crash-resume collision before canonicalization). The guard must key off
+    // the LIVE one and refuse, regardless of directory iteration order.
+    stateMgr.writeState({ ...base, agent_id: "aaa-stale", state: "done" });
+    stateMgr.writeState({ ...base, agent_id: "zzz-live", state: "working" });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:shared",
+        text: "still working",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler({ surface: "surface:shared" }, {} as any);
+
+    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      agent_id: "zzz-live",
+      state: "working",
     });
 
     rmSync(stateDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Fixes two recurring fleet bugs Etan hit, plus hardening from an adversarial diff review (25-agent root-cause + 15-agent review). **870 tests pass** (was 847; +23).

### Pane safety — "stop breaking my panes (tty)"
- `close_surface` now **refuses to tear down a surface backing a live (non-terminal) agent unless `force:true`**, and returns a **fresh pane read** on refusal so the caller verifies the real screen instead of a possibly-stale state record (the "stale list said gone, but it was alive" failure). Fail-safe across crash-resume record collisions.
- `close_surface` **forwards the computed `collapsePane` flag** — a closed worker pane now collapses instead of being left as a bare-shell "zombie" pane.
- Auto/idle pane closing was already disabled in #170; this protects the remaining **explicit** close path.

### Workspace placement — "opened a worker in a new workspace instead of on its right"
- A spawned worker **inherits its parent orchestrator's `workspace_id`** (same repo, case/hyphen-insensitive) before repo-name resolution. Root cause: a worktree worker's cwd (`~/Gits/<repo>.wt/<name>`) doesn't match the repo name, so resolution returned `undefined` and cmux dropped it into the focused/new workspace. Now it splits **right of the parent**.
- repo↔workspace matching is **worktree-aware** (anchored to `.wt`/`.worktrees` shapes — no ancestor false positives) and **deterministic** (rank + lexicographic tie-break).

### Instance binding — "panes open in a different / nightly cmux app"
- `CMUX_SOCKET_PATH` is now an **authoritative pin**: the MCP binds to that one cmux instance and **never falls through** to another live instance. Warns when unset and >1 instance is live. Probe ping capped at 2s so a hung instance can't stall startup ~10s.

### Also
- `--version` / `--help` on the CLI (needed for the upcoming brew formula). Bumped to **0.2.0**.

## Test plan
- `bun run typecheck` clean, `bun run build` clean.
- `bun run test` → 53 files / 870 tests pass, including new `tests/repo-workspace.test.ts`, `tests/cmux-client-factory.test.ts`, and close-guard refusal/collision + parent-inheritance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect agent spawn layout, explicit pane teardown, and cmux socket selection—high user-visible impact but guarded by new safety checks and extensive tests; default behavior is more conservative (refuse close, inherit parent workspace).
> 
> **Overview**
> **v0.2.0** hardens pane teardown, worker placement, and which cmux instance the MCP talks to.
> 
> **`close_surface`** now blocks closes when a surface still backs a **live** agent (anything other than `done`/`error`) unless **`force: true`**. On refusal it returns a **fresh pane read** so callers can verify the screen; the guard prefers a live record when multiple state rows share one surface. Successful closes also pass through **`collapsePane`** from layout policy so worker panes collapse instead of leaving empty shells.
> 
> **Worker spawn placement** inherits the parent orchestrator’s **`workspace_id`** for same-repo children (via new **`reposEquivalent`**) before repo-name lookup, fixing worktree workers whose cwd doesn’t basename-match the repo. Repo↔workspace resolution is reworked with **worktree-aware scoring**, deterministic ranking (preferred ref, root vs worktree, selected workspace, lexicographic ties), and docs for placement/teardown invariants.
> 
> **cmux client factory** treats **`CMUX_SOCKET_PATH`** (or explicit `socketPath`) as the **only** candidate when set—no fall-through to another live instance; logs when multiple live sockets exist unpinned; caps probe **`system.ping`** at 2s to avoid startup stalls on wedged sockets.
> 
> Also adds **`--version` / `--help`**, bumps package version, and expands tests for repo-workspace, client factory, close guards, and parent workspace pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f65220648003ce8e495dcbf09b25f4dbdc946a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Protect live panes from accidental close and pin worker spawns to parent workspace
> - `close_surface` now refuses to close a pane backing a live (non-terminal) agent unless `force: true` is passed, returning structured pane contents and agent details on refusal.
> - Child workers spawned via `AgentEngine.createAgentSurface` now inherit the parent orchestrator's tmux workspace when the repos are equivalent, preventing misplacement in worktree-based setups.
> - Workspace-to-repo matching in [repo-workspace.ts](https://github.com/EtanHey/cmuxlayer/pull/171/files#diff-53d8fefee7e992adc9fdb6abf96bf6397197686ef114234c74632c022f4e70e0) now recognises worktree directory layouts and supports a `preferredRef` for deterministic tie-breaking.
> - Socket selection in [cmux-client-factory.ts](https://github.com/EtanHey/cmuxlayer/pull/171/files#diff-37e2c062823d882ca9c154692047152501d1bd813787b69cf13d4a1dbbcd1342) now honours `CMUX_SOCKET_PATH` as an authoritative pin, skips other instances when pinned, and caps liveness probes at 2s to avoid stalls on hung instances.
> - The binary now supports `--version`/`-v` and `--help`/`-h` flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20f6522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--version` and `--help` CLI options.
  * Introduced instance pinning via `CMUX_SOCKET_PATH` to bind workers to a specific cmux instance.
  * Added `force` flag to `close_surface` tool with safety guards preventing accidental closure of active surfaces.

* **Improvements**
  * Enhanced workspace assignment for same-repository worker spawns to inherit parent orchestrator workspace.
  * Improved cmux socket selection with ambiguity detection when multiple instances are live.

* **Documentation**
  * Updated documentation on instance pinning and worker placement/teardown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->