### PR TITLE
docs: brew install, on-the-go versioning, dogfooding, invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,15 @@ actually using.
   refuses to destroy a surface backing a still-live agent unless `force: true`, and returns a
   fresh pane read on refusal so callers verify the real screen rather than a stale state record.
 
+### Distribution & releases
+The fleet runs the **brew-pinned** binary, not a working tree:
+`~/.golems/config.yaml` (`mcpServers.cmux`) → `~/.golems/bin/cmuxlayer-mcp` (launcher)
+→ `brew --prefix`/opt/cmuxlayer/bin/cmuxlayer. Set `CMUXLAYER_DEV=1` to run your
+live source instead. Cut a release with `scripts/release.sh <X.Y.Z>` (bumps
+package.json → tags → bumps the `EtanHey/homebrew-layers` formula → pushes).
+Dogfood latest main with `brew install --HEAD etanhey/layers/cmuxlayer`.
+Full guide: [docs/releases-and-brew.md](docs/releases-and-brew.md).
+
 ### Mode Policy
 Two axes per surface:
 - **control**: `autonomous` (full access) or `manual` (read-only for mutating tools)

--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@
 ## Quick Start
 
 ```bash
-npm install -g cmuxlayer
+brew install etanhey/layers/cmuxlayer       # stable, pinned release
+brew install --HEAD etanhey/layers/cmuxlayer # or: dogfood the latest main
 ```
 
-Requires [cmux](https://github.com/manaflow-ai/cmux) to be running.
+This installs the `cmuxlayer` command (plus `cmuxlayer-app-server` /
+`cmuxlayer-proxy`). Requires [cmux](https://github.com/manaflow-ai/cmux) to be
+running. For how the golem fleet wires, versions, and dogfoods it — and the
+`CMUX_SOCKET_PATH` instance pin — see
+[docs/releases-and-brew.md](docs/releases-and-brew.md).
 
 Add to your MCP config:
 

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -1,0 +1,126 @@
+# Releases, Homebrew, and dogfooding cmuxlayer
+
+> How the cmuxlayer MCP server is versioned, installed, run by the fleet, and
+> developed. Read this before changing how cmuxlayer is launched or cutting a
+> release.
+
+## TL;DR
+
+- The fleet runs the **brew-installed, pinned** cmuxlayer so every agent is on
+  the *same* version (deterministic placement/teardown). No more "runs from a
+  random working tree."
+- Install / update:
+  ```bash
+  brew install etanhey/layers/cmuxlayer            # stable, latest tagged release
+  brew upgrade etanhey/layers/cmuxlayer            # move to a newer tag
+  brew install --HEAD etanhey/layers/cmuxlayer     # dogfood the latest main
+  brew upgrade --fetch-HEAD etanhey/layers/cmuxlayer
+  ```
+- Develop cmuxlayer itself with your **live, uncommitted** working tree:
+  ```bash
+  export CMUXLAYER_DEV=1     # the launcher then runs ~/Gits/cmuxlayer/src via bun
+  ```
+
+## How the fleet launches cmuxlayer
+
+cmuxlayer is an **MCP stdio server** — an MCP client (cmux / Claude Code) spawns
+it and speaks JSON-RPC over stdin/stdout. It is *not* a daemon; there is no
+`brew services`.
+
+The launch chain:
+
+```
+~/.golems/config.yaml          mcpServers.cmux.command →
+~/.golems/bin/cmuxlayer-mcp     (launcher) →
+/opt/homebrew/opt/cmuxlayer/bin/cmuxlayer   (brew, default)
+   └─ or ~/Gits/cmuxlayer/src/index.ts via bun, when CMUXLAYER_DEV=1
+```
+
+The launcher (`~/.golems/bin/cmuxlayer-mcp`):
+- runs the brew bin by default;
+- runs your live source (`bun run src/index.ts`) when `CMUXLAYER_DEV=1`
+  (override the path with `CMUXLAYER_SRC`);
+- falls back to live source with a stderr warning if the brew bin is missing, so
+  the fleet never loses `cmux`.
+
+**Only newly-spawned agents pick up a change** — an already-running agent keeps
+its existing MCP child until it reconnects (`/mcp`) or is respawned.
+
+## Pinning the cmux instance — `CMUX_SOCKET_PATH`
+
+cmux exports `CMUX_SOCKET_PATH` into each agent's environment, pointing at the
+instance that spawned it. When set (or `socketPath` is passed in code) cmuxlayer
+binds to **that one instance only** and never falls through to another live
+cmux's socket. This is what stops a worker from opening in a *different* cmux app
+(e.g. stable vs nightly). If it is unset and more than one cmux instance is live,
+the factory logs which socket it bound to and how to pin it.
+
+## Cutting a release (versioning, on the go)
+
+One command does the whole pipeline:
+
+```bash
+~/Gits/cmuxlayer/scripts/release.sh 0.3.0
+```
+
+It will: verify a clean tree + green build/tests, bump `package.json`, commit,
+push `main`, tag `vX.Y.Z`, then update the Homebrew formula's `url` + `sha256`
+in `~/Gits/homebrew-layers` and push the tap. Afterwards:
+
+```bash
+brew update && brew upgrade etanhey/layers/cmuxlayer
+```
+
+Manual equivalent, if you prefer:
+
+1. `package.json` → bump `version`.
+2. Commit + open PR + merge to `main`.
+3. `git tag -a vX.Y.Z -m "..." <merge-sha> && git push origin vX.Y.Z`.
+4. `curl -fsSL https://github.com/EtanHey/cmuxlayer/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256`.
+5. In `~/Gits/homebrew-layers/Formula/cmuxlayer.rb` set `url` to the new tag and
+   `sha256` to the value from step 4; `brew audit etanhey/layers/cmuxlayer`;
+   commit + push.
+6. `brew upgrade etanhey/layers/cmuxlayer`.
+
+The formula also carries a `head` block, so `--HEAD` installs always track
+`main` with **no** sha/tag bump — that is the on-the-go dogfood path.
+
+## Behavioural invariants (what changed in v0.2.0)
+
+These are enforced in code + tests; rely on them and don't regress them.
+
+### Panes are protected on close (`close_surface`)
+- Automatic/idle pane closing is **disabled** (#170): `TASK_DONE`/idle never
+  auto-close a pane.
+- `close_surface` **refuses** to tear down a surface backing a still-live
+  (non-terminal) agent **unless `force: true`**, and on refusal returns a fresh
+  read of the pane so you can confirm it is actually finished before destroying
+  it. Browser panes and surfaces with no tracked agent close normally.
+- On a real close it forwards the collapse decision, so a worker pane collapses
+  cleanly instead of being left as a bare-shell "zombie" pane.
+
+**Agent guidance:** never force-close to "clean up" a busy agent — read the pane
+the refusal hands you first. Closing a done/error agent needs no force.
+
+### Workers land in the parent's workspace
+- A spawned worker **inherits its parent orchestrator's workspace** (same repo,
+  case/hyphen-insensitive) before any repo-name resolution, so it splits to the
+  **right of the parent** — even for worktree workers whose cwd is
+  `~/Gits/<repo>.wt/<name>` (which does not match the repo name). Pass an
+  explicit `workspace` to override.
+- repo↔workspace matching is worktree-aware (anchored to `.wt` / `.worktrees`
+  shapes — a repo named like an ancestor dir won't hijack an unrelated
+  workspace) and deterministic.
+
+**Agent guidance:** to put a worker in the same workspace as its parent, just
+pass `parent_agent_id`; you don't need to compute `workspace` yourself. Pass an
+explicit `workspace` only when you deliberately want a different one.
+
+## Files
+
+| Path | Role |
+|------|------|
+| `~/.golems/config.yaml` → `mcpServers.cmux` | wires the launcher into the fleet |
+| `~/.golems/bin/cmuxlayer-mcp` | launcher: brew (default) vs live source (`CMUXLAYER_DEV=1`) |
+| `EtanHey/homebrew-layers` → `Formula/cmuxlayer.rb` | the brew formula (stable tag + `head`) |
+| `scripts/release.sh` | one-command release: bump → tag → formula bump → push |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Cut a cmuxlayer release and bump the Homebrew formula, in one go.
+#
+#   scripts/release.sh 0.3.0            # full release (asks once before pushing)
+#   scripts/release.sh 0.3.0 --yes      # no confirmation prompt
+#   scripts/release.sh 0.3.0 --dry-run  # print every step, change nothing
+#
+# Steps: clean-tree + green build/tests gate → bump package.json → commit +
+# push main → tag vX.Y.Z + push tag → update formula url+sha256 in the
+# homebrew-layers tap → push tap → tell you to `brew upgrade`.
+#
+# See docs/releases-and-brew.md.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAP_DIR="${CMUXLAYER_TAP_DIR:-$HOME/Gits/homebrew-layers}"
+FORMULA="$TAP_DIR/Formula/cmuxlayer.rb"
+TARBALL_URL_BASE="https://github.com/EtanHey/cmuxlayer/archive/refs/tags"
+
+VERSION="${1:-}"
+YES=0
+DRY=0
+for arg in "${@:2}"; do
+  case "$arg" in
+    --yes) YES=1 ;;
+    --dry-run) DRY=1 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+die() { echo "release: $*" >&2; exit 1; }
+run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
+
+[ -n "$VERSION" ] || die "usage: release.sh <X.Y.Z> [--yes] [--dry-run]"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver X.Y.Z, got '$VERSION'"
+[ -f "$FORMULA" ] || die "formula not found at $FORMULA (set CMUXLAYER_TAP_DIR)"
+
+cd "$REPO_DIR"
+TAG="v$VERSION"
+
+# --- preflight gates -------------------------------------------------------
+if [ "$DRY" -ne 1 ]; then
+  [ "$(git branch --show-current)" = "main" ] || die "not on main"
+  git diff --quiet && git diff --cached --quiet || die "working tree is dirty; commit or stash first"
+  git fetch -q origin main
+  [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || die "local main is not in sync with origin/main"
+  git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists"
+fi
+
+echo "release: gating on typecheck + tests…"
+run "bun run typecheck"
+run "bun run test"
+
+CURRENT="$(grep -E '^  "version":' package.json | head -1 | sed -E 's/.*"version": "([^"]+)".*/\1/')"
+echo "release: $CURRENT → $VERSION"
+
+if [ "$YES" -ne 1 ] && [ "$DRY" -ne 1 ]; then
+  read -r -p "Release $TAG and push to cmuxlayer + homebrew-layers? [y/N] " ans
+  [ "$ans" = "y" ] || [ "$ans" = "Y" ] || die "aborted"
+fi
+
+# --- bump + commit + tag (cmuxlayer) --------------------------------------
+run "sed -i '' -E 's/^(  \"version\": \")[^\"]+(\",)\$/\\1$VERSION\\2/' package.json"
+run "git commit -aqm 'chore: release $TAG'"
+run "git push origin main"
+run "git tag -a '$TAG' -m 'cmuxlayer $TAG'"
+run "git push origin '$TAG'"
+
+# --- compute tarball sha256 -----------------------------------------------
+URL="$TARBALL_URL_BASE/$TAG.tar.gz"
+if [ "$DRY" -eq 1 ]; then
+  echo "DRY  curl + shasum $URL"
+  SHA="<sha256-of-$TAG>"
+else
+  TMP="$(mktemp)"
+  trap 'rm -f "$TMP"' EXIT
+  # GitHub may take a moment to generate the tag tarball.
+  for i in 1 2 3 4 5; do
+    if curl -fsSL "$URL" -o "$TMP"; then break; fi
+    echo "release: tarball not ready yet (attempt $i), retrying…" >&2; sleep 3
+  done
+  SHA="$(shasum -a 256 "$TMP" | awk '{print $1}')"
+  [ -n "$SHA" ] || die "could not compute sha256 for $URL"
+fi
+echo "release: $TAG sha256 = $SHA"
+
+# --- bump formula (homebrew-layers) ---------------------------------------
+run "sed -i '' -E 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
+run "sed -i '' -E 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
+run "brew audit etanhey/layers/cmuxlayer || true"
+run "git -C '$TAP_DIR' commit -aqm 'cmuxlayer $TAG'"
+run "git -C '$TAP_DIR' push origin main"
+
+cat <<EOF
+
+release: done — cmuxlayer $TAG is tagged and the formula is bumped.
+Next:
+  brew update && brew upgrade etanhey/layers/cmuxlayer
+EOF


### PR DESCRIPTION
Fleet-facing docs + a release helper, following the v0.2.0 fixes (#171) and the brew formula now live in `EtanHey/homebrew-layers`.

- **docs/releases-and-brew.md** — launch chain (golem config → `~/.golems/bin/cmuxlayer-mcp` → brew bin), `CMUX_SOCKET_PATH` pin, stable vs `--HEAD` dogfooding, the release pipeline, and the new pane-safety/placement invariants with agent guidance.
- **scripts/release.sh** — `release.sh <X.Y.Z>`: gates on typecheck+tests, bumps package.json, tags, bumps the formula `url`+`sha256`, pushes both repos. Has `--dry-run` and a confirm gate. (Validated via dry-run + sed checks.)
- **README** — brew install (the npm line was never published); links the guide.
- **CLAUDE.md** — distribution/release pointer.

Docs/scripts only — no runtime code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and a maintainer-only release script only; no application or MCP runtime code changes.
> 
> **Overview**
> Adds fleet-facing documentation and a **one-command release script** so cmuxlayer is installed and versioned via Homebrew instead of ad hoc working trees.
> 
> **New `docs/releases-and-brew.md`** documents the golem launch chain (`config.yaml` → `cmuxlayer-mcp` → brew bin vs `CMUXLAYER_DEV=1`), stable vs `--HEAD` dogfooding, `CMUX_SOCKET_PATH` pinning, the manual release steps, and **agent guidance** for v0.2.0 pane-safety and parent-workspace placement invariants.
> 
> **New `scripts/release.sh`** automates cutting a semver release: gates on typecheck/tests, bumps `package.json`, commits and pushes `main`, tags `vX.Y.Z`, fetches the GitHub tarball sha256, updates `homebrew-layers` formula, and pushes the tap (`--dry-run` / `--yes` supported).
> 
> **README** Quick Start now recommends **`brew install etanhey/layers/cmuxlayer`** (replacing the unpublished npm global install) and links the guide. **CLAUDE.md** adds a short **Distribution & releases** pointer to the same doc and `release.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668577773abb5fbc6649b6380b78c0be9d9db04f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Homebrew install instructions and release automation script for cmuxlayer
> - Updates [README.md](https://github.com/EtanHey/cmuxlayer/pull/172/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) Quick Start to use Homebrew instead of npm, listing installed commands and linking to a new [docs/releases-and-brew.md](https://github.com/EtanHey/cmuxlayer/pull/172/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) guide.
> - Adds [scripts/release.sh](https://github.com/EtanHey/cmuxlayer/pull/172/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389), a Bash script that automates the full release process: validates semver/branch/clean-tree, runs typecheck and tests, bumps `package.json`, commits and tags, computes tarball sha256, and updates the Homebrew formula in a local tap.
> - Adds [docs/releases-and-brew.md](https://github.com/EtanHey/cmuxlayer/pull/172/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) covering fleet launch behavior, `CMUX_SOCKET_PATH` pinning, dogfooding via `--HEAD`, and behavioral invariants (pane protection, workspace inheritance).
> - Updates [CLAUDE.md](https://github.com/EtanHey/cmuxlayer/pull/172/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) with a Distribution & releases section and a link to the new guide.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6685777.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->