### PR TITLE
feat: add `cmuxlayer doctor` — STDIO reference impl for Robust Brew Layer standard (#7)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,224 @@
+/**
+ * cmuxlayer doctor — the STDIO reference impl for the Robust Brew Layer standard
+ * (~/Gits/orchestrator/standards/robust-brew-layer.md §0, §1, §3, §6).
+ *
+ * cmuxlayer is a stdio MCP server with NO cask and NO daemon, so two of the
+ * standard's conformance classes are structurally not-applicable:
+ *   - §1 (account-rename self-heal): N/A — there is no Caskroom artifact to
+ *     go stale. `doctor` MUST say so explicitly, not silently no-op.
+ *   - §5 (daemon integrity): N/A — there is no socket/launchd daemon.
+ *
+ * The checks `doctor` actually runs:
+ *   (a) version resolves/prints;
+ *   (b) §3 tap — whether `brew tap` lists etanhey/layers and the formula
+ *       resolves (`brew info etanhey/layers/cmuxlayer`). Tap CASKS need
+ *       `brew trust etanhey/layers`; cmuxlayer is a formula, not gated.
+ *   (c) CMUX_SOCKET_PATH if set, else "unset (auto-discover)".
+ *
+ * Non-interactivity invariants (§ headline / conformance checks):
+ *   - exit 0 when healthy; runs cleanly under `</dev/null` with NONINTERACTIVE=1;
+ *   - NO bare `sudo` anywhere (this module shells only to `brew`, best-effort);
+ *   - brew is best-effort: "brew not found" is reported, never a hard failure.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const TAP_NAME = "etanhey/layers";
+export const FORMULA_NAME = "etanhey/layers/cmuxlayer";
+
+/** Result of a single best-effort `brew <args>` invocation. */
+export interface BrewResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  /** true when `brew` itself is not on PATH (ENOENT) — best-effort, not a failure. */
+  notFound?: boolean;
+}
+
+/** Runs `brew <args>`; never throws — failures are reported in the result. */
+export type BrewRunner = (args: string[]) => Promise<BrewResult>;
+
+export interface DoctorReport {
+  /** Overall health. brew/tap gaps do NOT make the doctor unhealthy. */
+  healthy: boolean;
+  version: { ok: boolean; value: string };
+  /** §1 account-rename self-heal — not-applicable for a stdio/no-cask layer. */
+  caskSelfHeal: { applicable: false; note: string };
+  /** §5 daemon integrity — not-applicable for a stdio/no-daemon layer. */
+  daemon: { applicable: false; note: string };
+  /** §3 tap — best-effort report; brew may be absent. */
+  tap: {
+    brewAvailable: boolean;
+    tapPresent: boolean;
+    formulaResolves: boolean;
+    note: string;
+  };
+  /** CMUX_SOCKET_PATH pin (auto-discover when unset). */
+  socketPath: { set: boolean; value: string | null; note: string };
+}
+
+export interface RunDoctorOptions {
+  /** The resolved version string (e.g. from package.json); "unknown" => not-ok. */
+  version: string;
+  /** Environment to inspect; defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Injectable brew runner; defaults to the real `brew` via execFile. */
+  brew?: BrewRunner;
+}
+
+/**
+ * The real `brew` runner. Best-effort and non-interactive:
+ *   - sets NONINTERACTIVE=1 and HOMEBREW_NO_AUTO_UPDATE=1 so brew never prompts;
+ *   - never invokes sudo;
+ *   - on ENOENT (brew not installed) returns `notFound: true` rather than throwing.
+ */
+export const realBrewRunner: BrewRunner = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync("brew", args, {
+      env: {
+        ...process.env,
+        NONINTERACTIVE: "1",
+        HOMEBREW_NO_AUTO_UPDATE: "1",
+        HOMEBREW_NO_ANALYTICS: "1",
+      },
+      timeout: 20_000,
+    });
+    return { ok: true, stdout: stdout ?? "", stderr: stderr ?? "" };
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+    };
+    if (e.code === "ENOENT") {
+      return { ok: false, stdout: "", stderr: "", notFound: true };
+    }
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr:
+        e.stderr ?? (error instanceof Error ? error.message : String(error)),
+    };
+  }
+};
+
+async function checkTap(brew: BrewRunner): Promise<DoctorReport["tap"]> {
+  const tapNote = `tap CASKS need \`brew trust ${TAP_NAME}\`; cmuxlayer is a formula, not gated`;
+
+  const tapList = await brew(["tap"]);
+  if (tapList.notFound) {
+    return {
+      brewAvailable: false,
+      tapPresent: false,
+      formulaResolves: false,
+      note: "brew not found (skipped tap check)",
+    };
+  }
+
+  const tapPresent = tapList.ok
+    ? tapList.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .includes(TAP_NAME)
+    : false;
+
+  // `brew info etanhey/layers/cmuxlayer` — does the formula resolve?
+  const info = await brew(["info", FORMULA_NAME]);
+  const formulaResolves = info.notFound ? false : info.ok;
+
+  return {
+    brewAvailable: true,
+    tapPresent,
+    formulaResolves,
+    note: tapNote,
+  };
+}
+
+export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
+  const env = opts.env ?? process.env;
+  const brew = opts.brew ?? realBrewRunner;
+
+  const versionOk = opts.version !== "unknown" && opts.version.length > 0;
+
+  const socketRaw = env.CMUX_SOCKET_PATH;
+  const socketSet = typeof socketRaw === "string" && socketRaw.length > 0;
+
+  const tap = await checkTap(brew);
+
+  // Health: only the version must resolve. Brew/tap gaps are reported but, per
+  // the standard's "brew best-effort" rule, must NOT make the doctor unhealthy
+  // (so it exits 0 on machines without brew or without the tap added yet).
+  const healthy = versionOk;
+
+  return {
+    healthy,
+    version: { ok: versionOk, value: opts.version },
+    caskSelfHeal: {
+      applicable: false,
+      note: "not-applicable: stdio MCP, no cask (§1 account-rename self-heal)",
+    },
+    daemon: {
+      applicable: false,
+      note: "not-applicable: stdio MCP, no daemon (§5 daemon integrity)",
+    },
+    tap,
+    socketPath: socketSet
+      ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
+      : { set: false, value: null, note: "unset (auto-discover)" },
+  };
+}
+
+function mark(ok: boolean): string {
+  return ok ? "✔" : "✗"; // ✔ / ✗
+}
+
+export function renderDoctorText(report: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `┌─ cmuxlayer doctor ─ ${report.healthy ? "healthy" : "PROBLEMS"}`,
+  );
+
+  // (a) version
+  lines.push(`│ ${mark(report.version.ok)} version: ${report.version.value}`);
+
+  // §1 — not-applicable, stated explicitly (no silent no-op)
+  lines.push(`│ — §1 ${report.caskSelfHeal.note}`);
+
+  // §5 — not-applicable, stated explicitly
+  lines.push(`│ — §5 ${report.daemon.note}`);
+
+  // (b) §3 tap
+  if (!report.tap.brewAvailable) {
+    lines.push(`│ — §3 tap: ${report.tap.note}`);
+  } else {
+    lines.push(
+      `│ ${mark(report.tap.tapPresent)} §3 tap ${TAP_NAME}: ${
+        report.tap.tapPresent
+          ? "present"
+          : "absent (run `brew tap " + TAP_NAME + "`)"
+      }`,
+    );
+    lines.push(
+      `│ ${mark(report.tap.formulaResolves)}    formula ${FORMULA_NAME}: ${
+        report.tap.formulaResolves ? "resolves" : "does not resolve"
+      }`,
+    );
+    lines.push(`│      ${report.tap.note}`);
+  }
+
+  // (c) CMUX_SOCKET_PATH
+  lines.push(
+    `│ — CMUX_SOCKET_PATH: ${
+      report.socketPath.set ? report.socketPath.value : report.socketPath.note
+    }`,
+  );
+
+  lines.push("└─");
+  return lines.join("\n");
+}
+
+export function renderDoctorJson(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
+import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";
 
 function readVersion(): string {
   // package.json sits one level above the compiled entrypoint (dist/index.js
@@ -49,6 +50,10 @@ Usage:
                        JSON-RPC over stdin/stdout).
   cmuxlayer --version  Print the version and exit.
   cmuxlayer --help     Print this help and exit.
+  cmuxlayer doctor     Run non-interactive health checks (Robust Brew Layer
+                       standard §0/§1/§3/§6) and exit. Read-only; no mutation.
+                       Add --json for machine-readable output. Exits 0 when
+                       healthy.
 
 Environment:
   CMUX_SOCKET_PATH     Pin the MCP to a specific cmux instance's Unix socket
@@ -63,6 +68,18 @@ async function main() {
   }
   if (arg === "--help" || arg === "-h") {
     process.stdout.write(HELP_TEXT);
+    return;
+  }
+  if (arg === "doctor") {
+    // Non-interactive, read-only health check (Robust Brew Layer standard).
+    // Best-effort brew probes; exits 0 when healthy, 1 otherwise — so a runbook
+    // can branch on the code. No bare sudo; never prompts.
+    const json = process.argv.includes("--json");
+    const report = await runDoctor({ version: readVersion() });
+    process.stdout.write(
+      (json ? renderDoctorJson(report) : renderDoctorText(report)) + "\n",
+    );
+    process.exitCode = report.healthy ? 0 : 1;
     return;
   }
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  runDoctor,
+  renderDoctorText,
+  renderDoctorJson,
+  type BrewRunner,
+  type DoctorReport,
+} from "../src/doctor.js";
+
+/**
+ * A brew stub: returns canned results keyed on the first meaningful arg.
+ * `found: false` simulates "brew not found" (ENOENT).
+ */
+function makeBrew(opts: {
+  found?: boolean;
+  tapList?: string;
+  infoOk?: boolean;
+}): BrewRunner {
+  const { found = true, tapList = "", infoOk = true } = opts;
+  return async (args: string[]) => {
+    if (!found) {
+      return { ok: false, stdout: "", stderr: "", notFound: true };
+    }
+    if (args[0] === "tap") {
+      return { ok: true, stdout: tapList, stderr: "" };
+    }
+    if (args[0] === "info") {
+      return infoOk
+        ? {
+            ok: true,
+            stdout: "etanhey/layers/cmuxlayer: stable 0.3.0",
+            stderr: "",
+          }
+        : { ok: false, stdout: "", stderr: "Error: No available formula" };
+    }
+    return { ok: true, stdout: "", stderr: "" };
+  };
+}
+
+describe("runDoctor — report shape", () => {
+  it("reports the version when it resolves", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+    });
+    expect(report.version.ok).toBe(true);
+    expect(report.version.value).toBe("0.3.0");
+  });
+
+  it("flags an unknown version as not-ok", async () => {
+    const report = await runDoctor({
+      version: "unknown",
+      env: {},
+      brew: makeBrew({}),
+    });
+    expect(report.version.ok).toBe(false);
+  });
+
+  it("marks §1 account-rename self-heal as not-applicable (stdio MCP, no cask)", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+    });
+    expect(report.caskSelfHeal.applicable).toBe(false);
+    expect(report.caskSelfHeal.note).toMatch(/not-applicable/i);
+    expect(report.caskSelfHeal.note).toMatch(/stdio MCP/i);
+    expect(report.caskSelfHeal.note).toMatch(/no cask/i);
+  });
+
+  it("marks §5 daemon integrity as not-applicable (stdio MCP, no daemon)", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+    });
+    expect(report.daemon.applicable).toBe(false);
+    expect(report.daemon.note).toMatch(/not-applicable/i);
+    expect(report.daemon.note).toMatch(/stdio MCP/i);
+    expect(report.daemon.note).toMatch(/no daemon/i);
+  });
+
+  it("reports the tap as present + formula resolvable when brew lists it", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({
+        tapList: "homebrew/core\netanhey/layers\nfoo/bar\n",
+        infoOk: true,
+      }),
+    });
+    expect(report.tap.tapPresent).toBe(true);
+    expect(report.tap.formulaResolves).toBe(true);
+    expect(report.tap.note).toMatch(/CASKS need .*brew trust etanhey\/layers/i);
+    expect(report.tap.note).toMatch(/formula, not gated/i);
+  });
+
+  it("reports the tap as absent when brew does not list it", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ tapList: "homebrew/core\n", infoOk: false }),
+    });
+    expect(report.tap.tapPresent).toBe(false);
+  });
+
+  it("degrades gracefully (does not throw / does not fail hard) when brew is not found", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ found: false }),
+    });
+    expect(report.tap.brewAvailable).toBe(false);
+    expect(report.tap.note).toMatch(/brew not found/i);
+    // brew unavailability must NOT make the doctor unhealthy.
+    expect(report.healthy).toBe(true);
+  });
+
+  it("reports CMUX_SOCKET_PATH when set", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: { CMUX_SOCKET_PATH: "/tmp/cmux-501.sock" },
+      brew: makeBrew({}),
+    });
+    expect(report.socketPath.set).toBe(true);
+    expect(report.socketPath.value).toBe("/tmp/cmux-501.sock");
+  });
+
+  it("reports CMUX_SOCKET_PATH as unset (auto-discover) when absent", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+    });
+    expect(report.socketPath.set).toBe(false);
+    expect(report.socketPath.note).toMatch(/unset \(auto-discover\)/i);
+  });
+
+  it("is healthy on a normal machine (version resolves)", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ tapList: "etanhey/layers\n" }),
+    });
+    expect(report.healthy).toBe(true);
+  });
+});
+
+describe("renderDoctorText", () => {
+  function baseReport(): DoctorReport {
+    return {
+      healthy: true,
+      version: { ok: true, value: "0.3.0" },
+      caskSelfHeal: {
+        applicable: false,
+        note: "not-applicable: stdio MCP, no cask (§1 account-rename self-heal)",
+      },
+      daemon: {
+        applicable: false,
+        note: "not-applicable: stdio MCP, no daemon (§5 daemon integrity)",
+      },
+      tap: {
+        brewAvailable: true,
+        tapPresent: true,
+        formulaResolves: true,
+        note: "tap CASKS need `brew trust etanhey/layers`; cmuxlayer is a formula, not gated",
+      },
+      socketPath: { set: false, value: null, note: "unset (auto-discover)" },
+    };
+  }
+
+  it("prints the version", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toContain("0.3.0");
+  });
+
+  it("prints the §1 not-applicable line explicitly (no silent no-op)", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/not-applicable: stdio MCP, no cask/i);
+  });
+
+  it("prints the §5 not-applicable line explicitly", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/not-applicable: stdio MCP, no daemon/i);
+  });
+
+  it("prints the tap status and the trust note for casks", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/brew trust etanhey\/layers/i);
+    expect(text).toMatch(/formula, not gated/i);
+  });
+
+  it("prints the CMUX_SOCKET_PATH status", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/CMUX_SOCKET_PATH/);
+    expect(text).toMatch(/unset \(auto-discover\)/i);
+  });
+});
+
+describe("renderDoctorJson", () => {
+  it("emits parseable JSON with the report fields", () => {
+    const report: DoctorReport = {
+      healthy: true,
+      version: { ok: true, value: "0.3.0" },
+      caskSelfHeal: {
+        applicable: false,
+        note: "not-applicable: stdio MCP, no cask",
+      },
+      daemon: {
+        applicable: false,
+        note: "not-applicable: stdio MCP, no daemon",
+      },
+      tap: {
+        brewAvailable: true,
+        tapPresent: true,
+        formulaResolves: true,
+        note: "ok",
+      },
+      socketPath: { set: true, value: "/tmp/x.sock", note: "set" },
+    };
+    const json = renderDoctorJson(report);
+    const parsed = JSON.parse(json) as DoctorReport;
+    expect(parsed.healthy).toBe(true);
+    expect(parsed.version.value).toBe("0.3.0");
+    expect(parsed.caskSelfHeal.applicable).toBe(false);
+    expect(parsed.daemon.applicable).toBe(false);
+    expect(parsed.tap.tapPresent).toBe(true);
+    expect(parsed.socketPath.set).toBe(true);
+    expect(parsed.socketPath.value).toBe("/tmp/x.sock");
+  });
+});


### PR DESCRIPTION
## What

Adds a non-interactive `cmuxlayer doctor` subcommand (and `cmuxlayer doctor --json`) — the **STDIO reference impl** for the Robust Brew Layer standard (`orchestrator/standards/robust-brew-layer.md` §0/§1/§3/§6, collab task #7).

## Why

cmuxlayer is the stdio reference layer for the standard: brew-pinned formula, **no cask, no socket-served daemon**. The standard's §1 (account-rename self-heal) and §5 (daemon integrity) are therefore structurally not-applicable — but `doctor` MUST say so **explicitly** rather than silently no-op.

## Behaviour

`cmuxlayer doctor` is non-interactive and read-only:
- exits **0 when healthy**; runs cleanly under `</dev/null` with `NONINTERACTIVE=1`; contains **no bare `sudo`** (best-effort `brew` probes only, with `NONINTERACTIVE=1`/`HOMEBREW_NO_AUTO_UPDATE=1`);
- states **§1** and **§5** as not-applicable explicitly: `not-applicable: stdio MCP, no cask` / `no daemon`;
- **(a)** reports the resolved version (`unknown` → not-ok);
- **(b) §3 tap**: whether `brew tap` lists `etanhey/layers` and the formula resolves (`brew info etanhey/layers/cmuxlayer`), noting tap **CASKS** need `brew trust etanhey/layers` while cmuxlayer (a **formula**) is not gated;
- **(c)** reports `CMUX_SOCKET_PATH` when set, else `unset (auto-discover)`.

`brew` is best-effort: **"brew not found" is reported, never a hard failure**, so the doctor stays healthy (exit 0) on machines without brew or without the tap added yet. Read-only — no mutation (§7). `doctor --json` emits the same report as parseable JSON.

### Live, non-interactive run (this machine)

```
$ printf '' | NONINTERACTIVE=1 cmuxlayer doctor </dev/null ; echo $?
┌─ cmuxlayer doctor ─ healthy
│ ✔ version: 0.2.0
│ — §1 not-applicable: stdio MCP, no cask (§1 account-rename self-heal)
│ — §5 not-applicable: stdio MCP, no daemon (§5 daemon integrity)
│ ✔ §3 tap etanhey/layers: present
│ ✔    formula etanhey/layers/cmuxlayer: resolves
│      tap CASKS need `brew trust etanhey/layers`; cmuxlayer is a formula, not gated
│ — CMUX_SOCKET_PATH: unset (auto-discover)
└─
0
```

## Implementation

A pure, injectable `runDoctor` / `renderDoctorText` / `renderDoctorJson` in `src/doctor.ts` (brew runner and env are injected) so the report shape, the not-applicable lines, the exit code, and the `--json` shape are unit-tested without shelling to real brew. Wired into `src/index.ts` arg handling alongside `--version`/`--help` (`process.argv[2] === "doctor"`, with `--json`).

## Tests

- New `tests/doctor.test.ts` (16 tests): version resolution, §1/§5 not-applicable assertions, tap present/absent + formula-resolves, brew-not-found graceful degradation, `CMUX_SOCKET_PATH` set/unset, text render lines, `--json` shape.
- `bun run typecheck` clean; `bun run test` green (**886 tests, 54 files**).
- Conformance checks from the standard verified live: no-bare-sudo source grep returns no matches; `</dev/null` + `NONINTERACTIVE=1` run exits 0 with no prompt/hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and isolated doctor module; no changes to MCP server startup or cmux client behavior beyond new argv handling.
> 
> **Overview**
> Adds a **read-only, non-interactive** `cmuxlayer doctor` CLI (plus `doctor --json`) aligned with the Robust Brew Layer standard, without starting the MCP server.
> 
> **`runDoctor`** builds a structured report: version must resolve for **healthy** (exit 0); missing brew or tap gaps are reported but do not fail health. It explicitly marks **§1** (cask self-heal) and **§5** (daemon integrity) as *not-applicable* for this stdio/no-cask/no-daemon layer. **§3** tap checks use best-effort `brew tap` / `brew info` via an injectable runner (`NONINTERACTIVE`, no `sudo`). **`CMUX_SOCKET_PATH`** is reported when pinned vs auto-discover.
> 
> **`index.ts`** routes `doctor`, prints text or JSON, and sets exit code from `report.healthy`. **`tests/doctor.test.ts`** covers report shape, N/A lines, tap/brew degradation, socket env, and renderers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42601f90d488bba4276d12f23b88cefabc192398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `cmuxlayer doctor` subcommand for Robust Brew Layer health checks
> - Adds a new `doctor` subcommand to the CLI that runs non-interactive health checks and exits 0 when healthy, 1 otherwise; supports `--json` for machine-readable output.
> - Implements `runDoctor` in [src/doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/173/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068) to produce a structured `DoctorReport` covering version validity, Homebrew tap presence, formula resolvability, and `CMUX_SOCKET_PATH` status.
> - Adds `realBrewRunner` to shell out to `brew` non-interactively (with `HOMEBREW_NO_AUTO_UPDATE` and a 20s timeout), returning structured results without throwing; ENOENT is reported as `notFound: true`.
> - Overall health is determined solely by version resolution — brew/tap issues are reported but do not mark the report unhealthy.
> - Adds Vitest coverage in [tests/doctor.test.ts](https://github.com/EtanHey/cmuxlayer/pull/173/files#diff-badd68b87ba5be0f3906c28517dee68e8088a15f7f14ae9d06c0296785274336) using a stubbed `BrewRunner`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42601f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->