### PR TITLE
fix: pin every CLI-fallback exec to the current socket path (collab O2 #8)

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -23,7 +23,11 @@ import { normalizeKeyName } from "./key-names.js";
 const execFileAsync = promisify(execFile);
 
 export interface ExecFn {
-  (cmd: string, args: string[]): Promise<{ stdout: string; stderr: string }>;
+  (
+    cmd: string,
+    args: string[],
+    env?: NodeJS.ProcessEnv,
+  ): Promise<{ stdout: string; stderr: string }>;
 }
 
 interface CmuxIdentifyResult {
@@ -56,10 +60,20 @@ export class CmuxClient {
 
   private async run(args: string[]): Promise<string> {
     try {
+      // Pin every CLI-fallback exec to the instance env (CMUX_SOCKET_PATH) so
+      // the `cmux` subprocess cannot inherit an ambient socket path pointing at
+      // a DIFFERENT instance (e.g. prod) and silently target the wrong one.
+      // The env is forwarded on BOTH the injected-exec path and the real
+      // execFile path; dropping it on either is collab O2 #8.
+      const env = this.env;
       const { stdout } = this.exec
-        ? await this.exec(this.bin, ["--json", ...args])
+        ? await this.exec(
+            this.bin,
+            ["--json", ...args],
+            ...(env ? ([env] as const) : ([] as const)),
+          )
         : await execFileAsync(this.bin, ["--json", ...args], {
-            ...(this.env ? { env: this.env } : {}),
+            ...(env ? { env } : {}),
           });
       return stdout;
     } catch (error) {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -207,6 +207,21 @@ export class CmuxSocketClient {
     }
   }
 
+  /**
+   * Return the CLI fallback re-pinned to THIS client's current socket path.
+   *
+   * The fallback CmuxClient is shared across every CmuxSocketClient the factory
+   * creates, so its env is whatever the last constructor/reconnect synced — not
+   * necessarily this client's instance. Re-syncing immediately before each
+   * delegation guarantees the `cmux` subprocess carries CMUX_SOCKET_PATH =
+   * this.socketPath and cannot leak onto another live instance (collab O2 #8).
+   */
+  private cliFallbackPinned(): CmuxClient | undefined {
+    if (!this.cliFallback) return undefined;
+    this.syncCliFallbackSocketEnv();
+    return this.cliFallback;
+  }
+
   private async reconnectTransport(originalError: unknown): Promise<void> {
     if (!this.reconnecting) {
       this.reconnecting = (async () => {
@@ -243,7 +258,7 @@ export class CmuxSocketClient {
       await this.call("workspace.select", { workspace_id: workspace });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallback.selectWorkspace(workspace);
+        return this.cliFallbackPinned()!.selectWorkspace(workspace);
       }
       throw e;
     }
@@ -259,12 +274,14 @@ export class CmuxSocketClient {
       );
       return {
         workspace:
-          (result.workspace_ref as string) ?? (result.workspace as string) ?? "",
+          (result.workspace_ref as string) ??
+          (result.workspace as string) ??
+          "",
         title: (result.title as string) ?? title,
       };
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallback.createWorkspace(title);
+        return this.cliFallbackPinned()!.createWorkspace(title);
       }
       throw e;
     }
@@ -308,7 +325,9 @@ export class CmuxSocketClient {
       pane: opts.pane,
     });
     const surfaces = paneSurfaces.surfaces ?? [];
-    return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
+    return (
+      surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref
+    );
   }
 
   private async resolveSelectedSurface(opts?: {
@@ -318,7 +337,9 @@ export class CmuxSocketClient {
       workspace: opts?.workspace,
     });
     const surfaces = paneSurfaces.surfaces ?? [];
-    return surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref;
+    return (
+      surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref
+    );
   }
 
   async newSplit(
@@ -361,7 +382,7 @@ export class CmuxSocketClient {
         return this.mapSplitResult(result, "browser");
       } catch (e) {
         if (this.isMethodNotFound(e) && this.cliFallback) {
-          return this.cliFallback.newSplit(direction, opts);
+          return this.cliFallbackPinned()!.newSplit(direction, opts);
         }
         throw e;
       }
@@ -394,7 +415,7 @@ export class CmuxSocketClient {
       return this.mapSplitResult(result, "terminal");
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallback.newSplit(direction, opts);
+        return this.cliFallbackPinned()!.newSplit(direction, opts);
       }
       throw e;
     }
@@ -412,7 +433,7 @@ export class CmuxSocketClient {
         "new-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallback.newSurface(opts);
+    return this.cliFallbackPinned()!.newSurface(opts);
   }
 
   async moveSurface(opts: {
@@ -429,7 +450,7 @@ export class CmuxSocketClient {
         "move-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallback.moveSurface(opts);
+    return this.cliFallbackPinned()!.moveSurface(opts);
   }
 
   async reorderSurface(opts: {
@@ -443,7 +464,7 @@ export class CmuxSocketClient {
         "reorder-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallback.reorderSurface(opts);
+    return this.cliFallbackPinned()!.reorderSurface(opts);
   }
 
   async send(
@@ -472,7 +493,7 @@ export class CmuxSocketClient {
         "method_not_found",
       );
     }
-    await this.cliFallback.pasteText(surface, text, opts);
+    await this.cliFallbackPinned()!.pasteText(surface, text, opts);
   }
 
   async sendKey(
@@ -647,7 +668,7 @@ export class CmuxSocketClient {
       await this.call("surface.close", params);
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallback.closeSurface(surface, opts);
+        return this.cliFallbackPinned()!.closeSurface(surface, opts);
       }
       throw e;
     }

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -486,6 +486,40 @@ describe("CmuxClient.pasteText", () => {
   });
 });
 
+describe("CmuxClient CLI-fallback socket env (instance pin)", () => {
+  it("forwards CMUX_SOCKET_PATH to an injected exec when env is set", async () => {
+    const exec = mockExec({});
+    const client = new CmuxClient({ exec });
+    client.setEnv({ ...process.env, CMUX_SOCKET_PATH: "/tmp/nightly.sock" });
+
+    await client.pasteText("surface:1", "hello", { workspace: "workspace:1" });
+
+    // Every exec call (set-buffer AND paste-buffer) must carry the pinned
+    // socket path, otherwise the CLI inherits the ambient env and can hit a
+    // different cmux instance (e.g. prod) — collab O2 #8.
+    expect(exec).toHaveBeenCalledTimes(2);
+    for (const call of (exec as ReturnType<typeof vi.fn>).mock.calls) {
+      const env = call[2] as NodeJS.ProcessEnv | undefined;
+      expect(env?.CMUX_SOCKET_PATH).toBe("/tmp/nightly.sock");
+    }
+  });
+
+  it("does not pass an env argument to an injected exec when env is unset", async () => {
+    const exec = mockExec({});
+    const client = new CmuxClient({ exec });
+
+    await client.selectWorkspace("workspace:1");
+
+    // Backwards-compatible: no env set => 2-arg invocation as before.
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "select-workspace",
+      "--workspace",
+      "workspace:1",
+    ]);
+  });
+});
+
 describe("CmuxClient.sendKey", () => {
   it("calls cmux send-key with surface and key", async () => {
     const { client, exec } = mockClient({});

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -22,7 +22,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
-import { CmuxClient } from "../src/cmux-client.js";
+import { CmuxClient, type ExecFn } from "../src/cmux-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
 
 // ── Mock V2 Socket Server ──────────────────────────────────────────────
@@ -947,6 +947,48 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
     const result = await client.newSplit("right", { workspace: "workspace:1" });
     expect(cliCalls).toHaveLength(0);
     expect(result.surface).toBe("surface:2"); // from MOCK_RESPONSES
+  });
+
+  it("re-pins the shared CLI fallback to its own socket before pasting (collab O2 #8)", async () => {
+    // Reproduce the live failure: one CmuxClient is shared as cliFallback by
+    // BOTH socket clients (exactly what createCmuxClient does). A long paste to
+    // the nightly-pinned client must carry CMUX_SOCKET_PATH=nightly even though
+    // the prod-pinned client synced the shared fallback last.
+    const execEnvs: (NodeJS.ProcessEnv | undefined)[] = [];
+    const exec: ExecFn = vi.fn(async (_cmd, _args, env) => {
+      execEnvs.push(env);
+      return { stdout: "{}", stderr: "" };
+    });
+    const sharedCli = new CmuxClient({ exec });
+
+    const nightly = "/tmp/cmux-nightly.sock";
+    const prod = "/tmp/cmux-prod.sock";
+
+    // Nightly client constructed first (syncs fallback env -> nightly)...
+    const nightlyClient = new CmuxSocketClient({
+      socketPath: nightly,
+      cliFallback: sharedCli,
+    });
+    // ...then a prod client constructed and used, which last-synced the SHARED
+    // fallback env -> prod. Without a per-delegation re-sync, the nightly paste
+    // below would inherit prod.
+    const prodClient = new CmuxSocketClient({
+      socketPath: prod,
+      cliFallback: sharedCli,
+    });
+    await prodClient.pasteText("surface:p", "prod text", {
+      workspace: "workspace:1",
+    });
+
+    execEnvs.length = 0;
+    await nightlyClient.pasteText("surface:n", "nightly text", {
+      workspace: "workspace:1",
+    });
+
+    expect(execEnvs.length).toBeGreaterThan(0);
+    for (const env of execEnvs) {
+      expect(env?.CMUX_SOCKET_PATH).toBe(nightly);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

The CLI fallback could target the **WRONG cmux instance**. A long `send_input` to a nightly surface failed `Workspace not found` because `cmux paste-buffer` (CLI) hit the **PROD** instance, even though the socket client was pinned to nightly via `CMUX_SOCKET_PATH`.

## Root cause (two defects on the CLI-fallback path)

**1. Injected-exec path dropped env entirely.** `CmuxClient.run()` only forwarded `this.env` (which carries `CMUX_SOCKET_PATH`) on the real `execFileAsync` branch. When an `ExecFn` is injected, env was never passed, so the `cmux` subprocess inherited the *ambient* `CMUX_SOCKET_PATH` — which could point at prod.

**2. Stale shared-fallback snapshot.** `createCmuxClient` constructs **one** `CmuxClient` and shares it as the `cliFallback` across **every** `CmuxSocketClient`. Its env was only synced in the constructor / on reconnect (`syncCliFallbackSocketEnv`), so whichever socket client synced last won. `pasteText` did **not** re-sync before delegating its two `run()` calls (`set-buffer` + `paste-buffer`), so a paste from a nightly-pinned client could carry another instance's path.

## Fix

- `ExecFn` now accepts an optional `env` arg; `run()` forwards `CMUX_SOCKET_PATH`-bearing env on **both** the injected-exec and `execFile` paths.
- New `cliFallbackPinned()` helper re-syncs the shared fallback to **this** client's current `socketPath` immediately before every CLI-fallback delegation (`pasteText`, `newSplit`, `newSurface`, `moveSurface`, `reorderSurface`, `selectWorkspace`, `createWorkspace`, `closeSurface`).

## Tests

RED → GREEN regressions added:
- `cmux-client.test.ts` — an injected exec receives `CMUX_SOCKET_PATH` when env is set; stays 2-arg when env is unset (backwards-compatible).
- `cmux-socket-client.test.ts` — a paste from a nightly-pinned client carries `nightly` even after a prod-pinned client last-synced the shared fallback.

Verified: `bun run typecheck` clean, `bun run test` fully green (889 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-instance routing for mutating CLI operations (paste, splits, workspace changes); behavior is narrowly scoped with regressions, but mis-routing before this fix was already high-impact for operators running several cmux instances.
> 
> **Overview**
> Fixes **CLI fallback targeting the wrong cmux instance** when multiple sockets (e.g. nightly vs prod) are in play—symptoms like `Workspace not found` on long paste/`send_input` even though the socket client was pinned correctly.
> 
> **`CmuxClient`:** `ExecFn` now accepts an optional `env`; `run()` always forwards the instance env (including `CMUX_SOCKET_PATH`) on both the injected-exec and real `execFile` paths, so subprocesses no longer inherit an ambient socket path when env was previously dropped on the mock/injected path.
> 
> **`CmuxSocketClient`:** Adds `cliFallbackPinned()`, which re-syncs the shared fallback’s env to **this** client’s `socketPath` immediately before every CLI delegation (`pasteText`, splits, surface moves, workspace ops, `closeSurface`, etc.), so the last client to touch the factory-shared `CmuxClient` cannot win.
> 
> Regression tests cover injected-exec env forwarding and nightly vs prod shared-fallback paste pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66a54e7b258cee70927c7c31f5a562baf064a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin CLI-fallback exec to the current socket path in `CmuxSocketClient`
> - Adds a `cliFallbackPinned()` helper to `CmuxSocketClient` that re-syncs the shared `CmuxClient` fallback's `CMUX_SOCKET_PATH` env var to the calling instance's socket path before each CLI delegation.
> - Replaces all direct `this.cliFallback` usages across methods (`selectWorkspace`, `createWorkspace`, `newSplit`, `newSurface`, `moveSurface`, `reorderSurface`, `pasteText`, `closeSurface`) with `this.cliFallbackPinned()`.
> - Extends the `ExecFn` type to accept an optional third `env` argument and updates `CmuxClient.run` to forward the env to both injected exec and `execFileAsync`; when no env is set, calls remain two-argument for backward compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e66a54e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed socket path pinning in CLI fallback operations to ensure the correct cmux instance is targeted instead of an unintended one.

* **Tests**
  * Added test coverage for environment variable pinning behavior in fallback execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->