### PR TITLE
test: gen-18 Track 3 RED→GREEN gates (model-pin drift, pane-survival role-exclusion, wait_for Cursor)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -209,6 +209,21 @@ interface SweepAgentContext {
 
 type TargetStateEvidenceSource = "state" | "transcript" | "screen";
 
+// AIDEV-NOTE: Cursor has no distinct "done" lifecycle state — it settles to
+// "idle" when a task completes. A wait_for(target="done") on a Cursor agent
+// would otherwise hang the full timeout (R-038: "300s hang on a done Cursor").
+// Treat a Cursor that has reached idle as satisfying a done wait. Narrowly
+// scoped to cli==="cursor" so Claude/Codex idle (awaiting input ≠ done) is
+// unaffected.
+function isCursorTerminalIdleTarget(
+  agent: AgentRecord,
+  targetState: AgentState,
+): boolean {
+  return (
+    targetState === "done" && agent.cli === "cursor" && agent.state === "idle"
+  );
+}
+
 function tailScreenLines(text: string, lines: number): string {
   return text.split(/\r?\n/).slice(-lines).join("\n");
 }
@@ -717,6 +732,7 @@ export class AgentEngine {
     agent: AgentRecord,
     targetState: AgentState,
   ): Promise<TargetStateEvidenceSource | null> {
+    if (isCursorTerminalIdleTarget(agent, targetState)) return "state";
     if (agent.state !== targetState) return null;
     if (!this.requiresOutputDoneEvidence(targetState)) return "state";
     if (this.hasGroundTruthDone(agent)) return "transcript";

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -506,6 +506,9 @@ export class AgentRegistry {
       if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
+      if (agent.role === "orchestrator" || agent.role === "ic") {
+        continue;
+      }
       if (
         TERMINAL_STATES.has(agent.state) &&
         !liveSurfaceRefs.has(agent.surface_id)

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -72,7 +72,7 @@ export const MODEL_POLICY_CONTRACT: {
       },
     },
     claude: {
-      defaultModel: "opus-4-8[1m]",
+      defaultModel: "claude-opus-4-8[1m]",
       allowModelOverrideByDefault: true,
       forbiddenModelPatterns: [],
       modelAliases: {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1385,6 +1385,48 @@ describe("AgentEngine", () => {
       }
     });
 
+    it("does not reap an idle orchestrator pane after the idle close timeout", async () => {
+      const previousIdleCloseMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+      process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = "1000";
+      vi.useFakeTimers();
+      try {
+        const idleAt = new Date("2026-05-25T12:00:00.000Z");
+        vi.setSystemTime(new Date(idleAt.getTime() + 1_001));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "lead-idle",
+            state: "idle",
+            surface_id: "surface:lead-idle",
+            workspace_id: "ws:1",
+            cli: "claude",
+            role: "orchestrator",
+            updated_at: idleAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:lead-idle")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(mockClient.closeSurface).not.toHaveBeenCalled();
+        expect(engine.getAgentState("lead-idle")).toMatchObject({
+          state: "idle",
+          role: "orchestrator",
+        });
+        expect(stateMgr.readState("lead-idle")).toMatchObject({
+          state: "idle",
+          role: "orchestrator",
+        });
+      } finally {
+        if (previousIdleCloseMs === undefined) {
+          delete process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
+        } else {
+          process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = previousIdleCloseMs;
+        }
+        vi.useRealTimers();
+      }
+    });
+
     it("does not let idle worker reap bypass the Codex TASK_DONE archive delay", async () => {
       const previousIdleCloseMs = process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS;
       process.env.CMUXLAYER_IDLE_WORKER_CLOSE_MS = "1000";

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -313,6 +313,50 @@ describe("AgentRegistry", () => {
   });
 
   describe("purgeTerminal", () => {
+    it("keeps absent terminal lead roles while purging absent terminal workers", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "orchestrator-terminal",
+          state: "done",
+          surface_id: "surface:missing-orchestrator",
+          role: "orchestrator",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "ic-terminal",
+          state: "error",
+          surface_id: "surface:missing-ic",
+          role: "ic",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-terminal",
+          state: "done",
+          surface_id: "surface:missing-worker",
+          role: "worker",
+        }),
+      );
+
+      const surfaceProvider = async () => [] as CmuxSurface[];
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+
+      const purged = await registry.purgeTerminal();
+
+      expect(purged).toBe(1);
+      expect(registry.get("orchestrator-terminal")).toMatchObject({
+        agent_id: "orchestrator-terminal",
+        role: "orchestrator",
+      });
+      expect(registry.get("ic-terminal")).toMatchObject({
+        agent_id: "ic-terminal",
+        role: "ic",
+      });
+      expect(registry.get("worker-terminal")).toBeNull();
+    });
+
     it("purges crash_recover errors that are no longer recoverable", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import {
   MODEL_OVERRIDE_ENV,
   MODEL_POLICY_CONTRACT,
@@ -77,7 +77,13 @@ const dispatchPath = join(
 const golemsAbsent = !existsSync(dispatchPath);
 
 describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
-  const dispatchText = readFileSync(dispatchPath, "utf8");
+  // Read lazily in beforeAll, not at describe-body collection time: a skipped
+  // suite (golems absent, e.g. CI) still evaluates the describe body, so a
+  // top-level readFileSync would throw ENOENT before the skip takes effect.
+  let dispatchText: string;
+  beforeAll(() => {
+    dispatchText = readFileSync(dispatchPath, "utf8");
+  });
 
   it("shares the explicit model override escape hatch", () => {
     expect(dispatchText).toContain(MODEL_OVERRIDE_ENV);

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  MODEL_OVERRIDE_ENV,
+  MODEL_POLICY_CONTRACT,
+  resolveSpawnModelPolicy,
+} from "../src/model-policy.js";
+
+function expectPatternMatches(patterns: string[], model: string): void {
+  expect(
+    patterns.some((pattern) => new RegExp(pattern, "i").test(model)),
+    `expected one forbidden cursor pattern to match ${model}`,
+  ).toBe(true);
+}
+
+function parseClaudeDefault(dispatchText: string): string {
+  const branch = dispatchText.match(
+    /else\s*\n\s*_claude_model="([^"]+)"\s*\n\s*fi/,
+  );
+  expect(
+    branch,
+    "could not parse golem-dispatch default _claude_model branch",
+  ).not.toBeNull();
+  return branch![1];
+}
+
+function parseCursorLauncher(dispatchText: string): string {
+  const launcher = dispatchText.match(
+    /_golem_launch_cursor\(\)\s*\{([\s\S]*?)\n\}/,
+  );
+  expect(
+    launcher,
+    "could not parse _golem_launch_cursor from golem-dispatch",
+  ).not.toBeNull();
+  return launcher![1];
+}
+
+describe("model-policy drift gate", () => {
+  it("pins the server-side model policy contract used by spawn_agent", () => {
+    expect(MODEL_OVERRIDE_ENV).toBe("REPOGOLEM_ALLOW_MODEL");
+    expect(MODEL_POLICY_CONTRACT.escapeEnv).toBe(MODEL_OVERRIDE_ENV);
+
+    const cursor = MODEL_POLICY_CONTRACT.cli.cursor;
+    expect(cursor.allowModelOverrideByDefault).toBe(false);
+    for (const model of ["claude-opus-4-8", "sonnet", "opus", "haiku"]) {
+      expectPatternMatches(cursor.forbiddenModelPatterns, model);
+    }
+
+    expect(MODEL_POLICY_CONTRACT.cli.claude.defaultModel).toBe(
+      "claude-opus-4-8[1m]",
+    );
+
+    const coerced = resolveSpawnModelPolicy("cursor", "sonnet-4", {});
+    expect(coerced.coerced).toBe(true);
+    expect(coerced.effective_model).toBe(cursor.defaultModel);
+    expect(coerced.launcher_model).toBeNull();
+    expect(coerced.warnings).toHaveLength(1);
+    expect(coerced.warnings[0]).toContain("CURSOR MODEL POLICY");
+    expect(coerced.warnings[0]).toContain("sonnet-4");
+
+    const escaped = resolveSpawnModelPolicy("cursor", "sonnet-4", {
+      [MODEL_OVERRIDE_ENV]: "1",
+    });
+    expect(escaped.coerced).toBe(false);
+    expect(escaped.effective_model).toBe("sonnet-4");
+    expect(escaped.launcher_model).toBe("sonnet-4");
+    expect(escaped.override_allowed).toBe(true);
+  });
+});
+
+const dispatchPath = join(
+  homedir(),
+  "Gits/golems/scripts/repogolem/golem-dispatch.zsh",
+);
+const golemsAbsent = !existsSync(dispatchPath);
+
+describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
+  const dispatchText = readFileSync(dispatchPath, "utf8");
+
+  it("shares the explicit model override escape hatch", () => {
+    expect(dispatchText).toContain(MODEL_OVERRIDE_ENV);
+    expect(MODEL_OVERRIDE_ENV).toBe("REPOGOLEM_ALLOW_MODEL");
+  });
+
+  it("keeps the Claude default model aligned across launch paths", () => {
+    const dispatchDefault = parseClaudeDefault(dispatchText);
+    const contractDefault = MODEL_POLICY_CONTRACT.cli.claude.defaultModel;
+
+    expect(
+      contractDefault,
+      `golem-dispatch default ${dispatchDefault} must match MODEL_POLICY_CONTRACT cli.claude.defaultModel ${contractDefault}`,
+    ).toBe(dispatchDefault);
+  });
+
+  it("refuses Cursor agent -m overrides in both policy paths", () => {
+    const cursorLauncher = parseCursorLauncher(dispatchText);
+
+    expect(cursorLauncher).toContain("_golem_refuse_agent_model_override");
+    expect(MODEL_POLICY_CONTRACT.cli.cursor.allowModelOverrideByDefault).toBe(
+      false,
+    );
+  });
+});

--- a/tests/model-policy.test.ts
+++ b/tests/model-policy.test.ts
@@ -14,7 +14,7 @@ describe("model policy contract", () => {
     });
     expect(MODEL_POLICY_CONTRACT.cli.gemini.defaultModel).toBe("pro");
     expect(MODEL_POLICY_CONTRACT.cli.claude.defaultModel).toBe(
-      "opus-4-8[1m]",
+      "claude-opus-4-8[1m]",
     );
     expect(MODEL_POLICY_CONTRACT.cli.codex.defaultModel).toBe("codex");
   });
@@ -43,7 +43,7 @@ describe("model policy contract", () => {
       "auto",
     );
     expect(resolveSpawnModelPolicy("claude", undefined, {}).effective_model).toBe(
-      "opus-4-8[1m]",
+      "claude-opus-4-8[1m]",
     );
     expect(resolveSpawnModelPolicy("gemini", undefined, {}).effective_model).toBe(
       "pro",

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -270,7 +270,7 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(parsed.model).toBe("opus-4-8[1m]");
+    expect(parsed.model).toBe("claude-opus-4-8[1m]");
     expect(parsed.requested_model).toBe("");
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
@@ -284,7 +284,7 @@ describe("agent lifecycle tool handlers", () => {
     );
     const persisted =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
-    expect(persisted.model).toBe("opus-4-8[1m]");
+    expect(persisted.model).toBe("claude-opus-4-8[1m]");
   });
 
   it("spawn_agent accepts explicit role and returns persisted role", async () => {

--- a/tests/wait-for-cursor.test.ts
+++ b/tests/wait-for-cursor.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentEngine } from "../src/agent-engine.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import { parseScreen } from "../src/screen-parser.js";
+import { StateManager } from "../src/state-manager.js";
+import type { CmuxSurface } from "../src/types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-agents-test-wait-for-cursor");
+const CURSOR_IDLE_SCREEN = readFileSync(
+  join(process.cwd(), "tests/fixtures/cursor-2026-06-04-boot-ready.txt"),
+  "utf8",
+);
+
+function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
+  return {
+    newSplit: vi.fn(),
+    newSurface: vi.fn(),
+    send: vi.fn(),
+    sendKey: vi.fn(),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:cursor-idle",
+      text: CURSOR_IDLE_SCREEN,
+      lines: 80,
+      scrollback_used: false,
+    }),
+    renameTab: vi.fn(),
+    setStatus: vi.fn(),
+    closeSurface: vi.fn(),
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    listPanes: vi.fn().mockResolvedValue({ panes: [] }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
+    selectWorkspace: vi.fn(),
+    clearStatus: vi.fn(),
+    setProgress: vi.fn(),
+    clearProgress: vi.fn(),
+    identify: vi.fn().mockResolvedValue({}),
+    browser: vi.fn().mockResolvedValue({}),
+    log: vi.fn(),
+    ...overrides,
+  } as unknown as CmuxClient;
+}
+
+function makeSurface(ref: string): CmuxSurface {
+  return { ref, title: "", type: "terminal", index: 0, selected: false };
+}
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "cmuxlayerCursor-idle",
+    surface_id: "surface:cursor-idle",
+    state: "idle",
+    repo: "cmuxlayer",
+    model: "auto",
+    cli: "cursor",
+    cli_session_id: null,
+    task_summary: "Cursor idle wait_for fixture",
+    pid: null,
+    version: 0,
+    created_at: "2026-06-04T22:00:00.000Z",
+    updated_at: "2026-06-04T22:01:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+}
+
+describe("wait_for Cursor terminal idle", () => {
+  let stateMgr: StateManager;
+  let engine: AgentEngine;
+  let liveSurfaces: CmuxSurface[];
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    stateMgr = new StateManager(TEST_DIR);
+    liveSurfaces = [makeSurface("surface:cursor-idle")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine = new AgentEngine(stateMgr, registry, makeMockClient(), {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+    });
+  });
+
+  afterEach(() => {
+    engine.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("resolves done promptly when a Cursor agent reaches its terminal idle state", async () => {
+    const parsed = parseScreen(CURSOR_IDLE_SCREEN);
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("idle");
+
+    stateMgr.writeState(makeRecord({ state: parsed.status }));
+    await engine.getRegistry().reconstitute();
+
+    const result = await engine.waitFor("cmuxlayerCursor-idle", "done", 50);
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("idle");
+    expect(result.source).toBe("immediate");
+    expect(result.agent).toMatchObject({
+      agent_id: "cmuxlayerCursor-idle",
+      state: "idle",
+    });
+  });
+});


### PR DESCRIPTION
## gen-18 Track 3 — build the gate, not the prose

The prior-window Track-3 code fixes landed **without replayable fixtures** — exactly why R-006 (panes-vanish) reopened ("retirement-without-fixture"). This PR pins the three still-ungated top_eval behaviors as replayable RED→GREEN gates. Two of the five top_eval behaviors were already gated (B2 TASK_DONE pane-survival, B5 Nightly socket false-down) and are untouched.

### B1 — model-policy ↔ golem-dispatch drift gate
`tests/model-policy-drift.test.ts`:
- **Always-on** contract invariants: escape env (`REPOGOLEM_ALLOW_MODEL`), cursor `allowModelOverrideByDefault=false` + forbidden-Claude patterns, and a live `resolveSpawnModelPolicy("cursor","sonnet-4")` → coerced/`launcher_model:null`/warning proof, plus the `REPOGOLEM_ALLOW_MODEL=1` escape path.
- **Cross-path parity** (`skipIf` golems absent): parses `golem-dispatch.zsh`, asserts the shared escape env + that the launcher's `_claude_model` default equals `MODEL_POLICY_CONTRACT.cli.claude.defaultModel`, and that `_golem_launch_cursor` calls `_golem_refuse_agent_model_override`. **Fails loud** (not skip) on a parse miss so the gate can't rot.
- Caught a **real drift**: cmux's claude default was `opus-4-8[1m]` while the launcher boots the canonical `claude-opus-4-8[1m]` → aligned. (R-041)

### B3 — purgeTerminal role-exclusion (R-006 / R-036)
`src/agent-registry.ts`: `purgeTerminal()` dropped **any** terminal-state agent whose surface was absent, with no role guard — so under a Nightly socket false-down a **lead's** registry entry was silently purged → orc loses sight of it → duplicate-spawn (~386K tokens discarded). Now orchestrator/ic records are retained; only workers are purged. Fixtures: leads survive while a worker is purged (`tests/agent-registry.test.ts`); an idle orchestrator is never idle-reaped (`tests/agent-engine.test.ts`).

### B4 — wait_for resolves Cursor done via terminal idle (R-038)
`src/agent-engine.ts`: Cursor has no distinct `done` lifecycle state — it settles to `idle`. `wait_for(target="done")` on a Cursor previously hung the full timeout ("300s hang on a done Cursor"). Now a Cursor at `idle` satisfies a done-wait, **narrowly scoped to `cli==="cursor"`** so Claude/Codex idle (awaiting input ≠ done) is unaffected. `tests/wait-for-cursor.test.ts` uses a 50ms timeout so the pre-fix path *fails* rather than hangs.

## Verification
- `bun run test`: **56 files / 896 tests pass**
- `bun run typecheck`: clean

## Method
Codex (gpt-5.5-high) implemented; cmuxLayerClaude (Opus) reviewed each fixture for genuine RED→GREEN (non-tautological) and each source change for scope/collateral. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle (purge rules and wait_for semantics) and spawn default models; scope is narrow but orchestrators depend on correct registry retention and Cursor waits.
> 
> **Overview**
> Adds **Track 3 RED→GREEN gates** for three production behaviors: model policy drift, lead pane survival, and Cursor `wait_for` completion.
> 
> **Model policy:** Changes the Claude default in `MODEL_POLICY_CONTRACT` from `opus-4-8[1m]` to **`claude-opus-4-8[1m]`** so spawn defaults match the repoGolem launcher. New **`tests/model-policy-drift.test.ts`** pins contract invariants (Cursor coercion, `REPOGOLEM_ALLOW_MODEL`) and optionally asserts parity with `golem-dispatch.zsh` when present.
> 
> **Registry / sweeps:** **`purgeTerminal()`** now **skips** agents with role **`orchestrator`** or **`ic`**, so terminal lead records are not dropped when their surface is missing (e.g. transient socket/list failures). Workers without live surfaces are still purged.
> 
> **Wait semantics:** **`wait_for(..., "done")`** treats a **Cursor** agent in **`idle`** as satisfied (Cursor has no distinct `done` state), scoped to `cli === "cursor"` so Claude/Codex idle is unchanged.
> 
> Tests cover orchestrator idle survival, role-aware purge, and a short-timeout Cursor idle `wait_for` fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08aa974520a26e927db600a65f8e05bc8745e6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model-pin drift, pane-survival role-exclusion, and `wait_for` resolution for Cursor agents
> - Fixes the Claude default model string in `MODEL_POLICY_CONTRACT` from `opus-4-8[1m]` to `claude-opus-4-8[1m]` and adds a drift-pinning test suite in [tests/model-policy-drift.test.ts](https://github.com/EtanHey/cmuxlayer/pull/176/files#diff-34cf6f9dcef9f8112e36436649447aeb516f4073f30d2e153ca9e684972d7826) to catch future divergence.
> - Prevents `AgentRegistry.purgeTerminal` from removing absent terminal agents whose role is `orchestrator` or `ic`, ensuring lead-role agents survive pane loss.
> - Adds `isCursorTerminalIdleTarget` in [src/agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/176/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) so that `wait_for(target="done")` resolves immediately (via `state` evidence) for Cursor agents already in `idle`, without requiring transcript or screen evidence.
> - Behavioral Change: orchestrator/ic agents in terminal states are no longer purged when their surface is absent; previously they would be removed from the registry and state files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08aa974.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->