### PR TITLE
fix: detect claude ready composer (stop classifying bypass-permissions footer as working)

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -390,8 +390,7 @@ function hasCursorComposerAfterDoneSignal(
 
 function isComposerLine(line: string): boolean {
   return (
-    /^\s*(?:→|>|[│┃║])\s+/.test(line) ||
-    /^\s*(?:╭|╰|┌|└|├|┬|┴|┼)/.test(line)
+    /^\s*(?:→|>|[│┃║])\s+/.test(line) || /^\s*(?:╭|╰|┌|└|├|┬|┴|┼)/.test(line)
   );
 }
 
@@ -693,11 +692,12 @@ function inferStatus(
     return "working";
   }
 
-  const workingMarkers = [
-    " /loop",
-    "bypass permissions on",
-    "esc to interrupt",
-  ];
+  // AIDEV-NOTE: do NOT add "bypass permissions on" here — it is a PERSISTENT
+  // status-bar footer shown in both ready AND working states, so it made a
+  // ready claude composer parse as "working", wedging spawn_agent at "booting"
+  // until wait_for(ready) timed out (~15s). "esc to interrupt" + the
+  // CLAUDE_WORKING_LINE_RE above are the real working signals.
+  const workingMarkers = [" /loop", "esc to interrupt"];
   if (
     workingMarkers.some((marker) =>
       joined.toLowerCase().includes(marker.toLowerCase()),

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -56,6 +56,32 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.status).toBe("working");
   });
 
+  it("treats a Claude ready composer with bypass-permissions footer as idle", () => {
+    const parsed = parseScreen(`
+                                                                                    0 tokens
+─────────────────────────────────────────────────────────────────────
+❯ 
+─────────────────────────────────────────────────────────────────────
+  ⎇ main | 🔧 17
+  🤖 Opus 4.8 (1M context) | 💰 $0.00 | ⏱️  0m | 📚 88%
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("idle");
+  });
+
+  it("treats a Claude working line with esc-to-interrupt as working", () => {
+    const parsed = parseScreen(`
+✻ Working (1m 2s • esc to interrupt)
+  Reading src/server.ts
+  🤖 Opus 4.8 (1M context) | 💰 $0.00 | ⏱️  1m | 📚 88%
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("working");
+  });
+
   it("recognizes Claude permission approval dialogs as Claude", () => {
     const parsed = parseScreen(`
 Do you want to allow this command?


### PR DESCRIPTION
## Fleet-wide blocker: claude/opus "fail to launch" via spawn_agent

**Symptom:** claude/opus agents spawned via cmux `spawn_agent` sat at `state=booting`; `wait_for(ready)` timed out (~15s). codex/cursor spawned fine.

**Root cause (reproduced live — NOT a launch failure):** claude launches healthy and reaches its ready composer, but the screen parser misclassified that ready screen as `working`, so the registry never transitioned `booting → ready`. `inferStatus` listed `"bypass permissions on"` as a working marker — but that string is a **persistent status-bar footer** (`⏵⏵ bypass permissions on (shift+tab to cycle)`) shown in **both** ready and working states. A ready claude (empty `❯` composer + footer) therefore parsed as `working`. codex/cursor have no such footer → unaffected, matching the reported pattern exactly.

**Fix:** remove the marker. The real working signals remain: `CLAUDE_WORKING_LINE_RE` (the `Working (… • esc to interrupt)` line) and `"esc to interrupt"`. An AIDEV-NOTE documents why it must not be re-added.

## Gate (RED→GREEN)
- A ready claude composer **with** the bypass-permissions footer now parses as `idle` (was `working`) — this is the regression that wedged spawns.
- Guard: a working line with `esc to interrupt` still parses as `working` (the fix didn't blind working-detection).

## Verification
`bun run test` (898 tests) + `bun run typecheck` green.

## Method
Codex implemented (root-caused by cmuxLayerClaude/Opus via live `spawn_agent` repro + `read_screen`); Opus reviewed the surgical diff + fixtures. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 344d317255b78ade96daebe821fa8fa045e82913. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `inferStatus` to not classify the bypass-permissions footer as working
> The `bypass permissions on` string was incorrectly included as a working marker in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/177/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50), causing idle Claude composer screens to be classified as `working`. It is removed from `workingMarkers`, leaving only `esc to interrupt` and `/loop` as valid signals. Two tests are added to cover the idle and working cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 344d317.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->