### PR TITLE
fix(ram-watchdog): clx-03 — Apple-Silicon page size, free-RAM trigger, resilient notify, process-agnostic offenders

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -10,6 +10,7 @@ CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS="${CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS:-10
 CMUX_MEM_WATCHDOG_SOURCE="${CMUX_MEM_WATCHDOG_SOURCE:-alerts}"
 CMUX_MEM_WATCHDOG_PRIORITY="${CMUX_MEM_WATCHDOG_PRIORITY:-high}"
 CMUX_MEM_WATCHDOG_KILL_BIN="${CMUX_MEM_WATCHDOG_KILL_BIN:-kill}"
+CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT="${CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT:-5}"
 
 log() {
   printf '[cmux-watchdog] %s\n' "$*" >&2
@@ -142,7 +143,7 @@ aggregate_cmux_footprint_bytes() {
 }
 
 vmstat_compressor_bytes() {
-  local pages
+  local pages page_size
   local vmstat_output
 
   if [[ -n "${CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE:-}" ]]; then
@@ -151,9 +152,44 @@ vmstat_compressor_bytes() {
     vmstat_output="$(vm_stat)"
   fi
 
+  page_size="$(printf '%s\n' "$vmstat_output" | awk '
+    BEGIN { page_size = 16384 }
+    /page size of [0-9][0-9]* bytes/ {
+      line = $0
+      sub(/^.*page size of /, "", line)
+      sub(/ bytes.*$/, "", line)
+      page_size = line
+      exit
+    }
+    END { print page_size }')"
   pages="$(printf '%s\n' "$vmstat_output" | awk '/Pages occupied by compressor/ {gsub(/\./,"",$NF); print $NF}')"
   pages="${pages:-0}"
-  echo $((pages * 4096))
+  echo $((pages * page_size))
+}
+
+top_rss_offenders() {
+  local limit="$CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT"
+  local ps_output
+
+  if [[ -n "${CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE:-}" ]]; then
+    ps_output="$(cat "$CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE")"
+  else
+    ps_output="$(ps -axo pid,rss,comm 2>/dev/null || true)"
+  fi
+
+  printf '%s\n' "$ps_output" | awk '
+    NR == 1 && $1 == "PID" { next }
+    NF >= 3 {
+      pid = $1
+      rss = $2
+      $1 = ""
+      $2 = ""
+      sub(/^[[:space:]]+/, "")
+      print rss "\t" pid "\t" $0
+    }' \
+    | sort -rn \
+    | head -n "$limit" \
+    | awk -F '\t' '{ printf "pid=%s rss_mb=%.0f command=%s\n", $2, $1 / 1024, $3 }'
 }
 
 snapshot_path() {
@@ -189,6 +225,8 @@ capture_process_snapshot() {
     ps -o pid,ppid,rss,vsz,%cpu,etime,command -p "$pid" || true
     printf '\n[pgrep]\n'
     pgrep -lf cmux || true
+    printf '\n[top_rss_offenders]\n'
+    top_rss_offenders || true
   } >"$path"
 }
 
@@ -218,6 +256,37 @@ brain_store_breach() {
     | socat - UNIX-CONNECT:"$CMUX_MEM_WATCHDOG_BRAINBAR_SOCK" >/dev/null
 }
 
+notify_url_host_port() {
+  local url="$1"
+  local scheme host port
+  if [[ "$url" =~ ^(https?)://([^/:]+)(:([0-9]+))?(/.*)?$ ]]; then
+    scheme="${BASH_REMATCH[1]}"
+    host="${BASH_REMATCH[2]}"
+    port="${BASH_REMATCH[4]}"
+    if [[ -z "$port" ]]; then
+      if [[ "$scheme" == "https" ]]; then
+        port="443"
+      else
+        port="80"
+      fi
+    fi
+    printf '%s %s\n' "$host" "$port"
+    return 0
+  fi
+  return 1
+}
+
+notify_listener_available() {
+  local url="$1"
+  local host port
+  read -r host port < <(notify_url_host_port "$url") || return 1
+  if command -v nc >/dev/null 2>&1; then
+    nc -z -G 1 "$host" "$port" >/dev/null 2>&1 || nc -z -w 1 "$host" "$port" >/dev/null 2>&1
+    return
+  fi
+  (: >"/dev/tcp/$host/$port") >/dev/null 2>&1
+}
+
 notify_breach() {
   local pid="$1"
   local tripped="$2"
@@ -230,15 +299,26 @@ notify_breach() {
   cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
 
+  local host port
+  if ! read -r host port < <(notify_url_host_port "$CMUX_MEM_WATCHDOG_NOTIFY_URL"); then
+    log "notify URL malformed ($CMUX_MEM_WATCHDOG_NOTIFY_URL); skipping notification"
+    return 0
+  fi
+
+  if ! notify_listener_available "$CMUX_MEM_WATCHDOG_NOTIFY_URL"; then
+    log "notify listener unavailable at $host:$port; skipping notification"
+    return 0
+  fi
+
   jq -cn \
     --arg title "cmux watchdog" \
     --arg body "cmux hit $cmux_footprint_gb GB phys_footprint / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Terminating." \
     --arg source "$CMUX_MEM_WATCHDOG_SOURCE" \
     --arg priority "$CMUX_MEM_WATCHDOG_PRIORITY" \
     '{title:$title,body:$body,source:$source,priority:$priority}' \
-    | curl -sS -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
+    | curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
       -H 'Content-Type: application/json' \
-      --data-binary @- >/dev/null
+      --data-binary @- >/dev/null 2>&1 || log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL"
 }
 
 terminate_cmux() {
@@ -262,7 +342,7 @@ handle_breach() {
 
   snapshot="$(snapshot_path)"
   capture_process_snapshot "$pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$tripped" "$snapshot"
-  processes="$(pgrep -lf cmux | tr '\n' ';' | sed 's/;$/\n/' || true)"
+  processes="$(top_rss_offenders | tr '\n' ';' | sed 's/;$/\n/' || true)"
   brain_store_breach "$pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot" "$processes" "$tripped"
   notify_breach "$pid" "$tripped" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot"
   terminate_cmux "$pid"

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -24,6 +24,12 @@ assert_file_not_contains() {
   fi
 }
 
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
 seed_fake_commands() {
   local root_dir="$1"
   local log_dir="$2"
@@ -34,6 +40,13 @@ set -euo pipefail
 printf '%s\n' "\$*" >>"$log_dir/curl.log"
 EOF
   chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
 
   cat >"$root_dir/bin/socat" <<EOF
 #!/usr/bin/env bash
@@ -107,6 +120,13 @@ set -euo pipefail
 printf '%s\n' "\$*" >>"$log_dir/curl.log"
 EOF
   chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
 
   cat >"$root_dir/bin/socat" <<EOF
 #!/usr/bin/env bash
@@ -209,37 +229,96 @@ run_case() {
 run_case "no breach when both below threshold" \
   0 "" \
   $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
-  $'Pages occupied by compressor: 1048576.\n' \
+  $'Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 1048576.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "breach when footprint above threshold" \
   1 "footprint" \
   $'4242 phys_footprint: 9.5 GB (peak 25 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
-  $'Pages occupied by compressor: 1048576.\n' \
+  $'Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 1048576.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "breach when compressor above threshold" \
   1 "compressor" \
   $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 512 MB (peak 1 GB)\n' \
-  $'Pages occupied by compressor: 3145729.\n' \
+  $'Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 3145729.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "breach when both above threshold" \
   1 "footprint,compressor" \
   $'4242 phys_footprint: 3 GB (peak 4 GB)\n5001 phys_footprint: 3 GB (peak 4 GB)\n' \
-  $'Pages occupied by compressor: 4194305.\n' \
+  $'Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 4194305.\n' \
   $'4242\n5001\n' \
   $'4242\n5001\n'
 
 run_case "no cmux pid exits cleanly" \
   0 "" \
   $'4242 phys_footprint: 1024 MB (peak 2 GB)\n5001 phys_footprint: 1024 MB (peak 2 GB)\n' \
-  $'Pages occupied by compressor: 4194305.\n' \
+  $'Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 4194305.\n' \
   "" \
   ""
+
+run_vmstat_page_size_case() {
+  local root_dir compressor_bytes
+  root_dir="$(mktemp -d)"
+  mkdir -p "$root_dir/fixtures"
+
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages occupied by compressor: 262144.
+EOF
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  compressor_bytes="$(vmstat_compressor_bytes)"
+  assert_eq "4294967296" "$compressor_bytes"
+
+  printf 'PASS: watchdog derives compressor bytes from vm_stat page size\n'
+  rm -rf "$root_dir"
+}
+run_vmstat_page_size_case
+
+run_notify_skip_case() {
+  local root_dir log_dir stderr_log
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  notify_breach 4242 footprint 1073741824 4294967296 "$log_dir/snapshot.log" 2>"$stderr_log"
+  assert_file_contains "$stderr_log" "notify listener unavailable"
+  assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+
+  printf 'PASS: watchdog skips notification loudly when listener is down\n'
+  rm -rf "$root_dir"
+}
+run_notify_skip_case
 
 # Matcher coverage regression guard (2026-06-09): the PID matcher must catch
 # BOTH cmux bundles — stable "cmux.app" AND nightly "cmux NIGHTLY.app". The old
@@ -284,6 +363,7 @@ run_ps_fallback_case() {
 4242 phys_footprint: 6 GB (peak 8 GB)
 EOF
   cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
 Pages occupied by compressor: 1048576.
 EOF
 
@@ -309,3 +389,50 @@ EOF
 }
 
 run_ps_fallback_case
+
+run_top_rss_offenders_case() {
+  local root_dir log_dir snapshot
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 6 GB (peak 8 GB)
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages occupied by compressor: 1048576.
+EOF
+  cat >"$root_dir/fixtures/top-ps.fixture" <<'EOF'
+  PID   RSS COMM
+ 9001 2097152 python3.11
+ 9002 1048576 ugrep
+ 4242  262144 /Applications/cmux.app/Contents/MacOS/cmux
+EOF
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB=5
+  export CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB=12
+  export CMUX_MEM_WATCHDOG_LOG_DIR="$log_dir"
+  export CMUX_MEM_WATCHDOG_KILL_BIN="$root_dir/bin/kill"
+  export CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  export CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE="$root_dir/fixtures/top-ps.fixture"
+  export CMUX_MEM_WATCHDOG_PGREP_CMUX=$'4242\n'
+  export CMUX_MEM_WATCHDOG_PGREP_CMUXPIDS=$'4242\n'
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  run_once
+
+  snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
+  assert_file_contains "$snapshot" "[top_rss_offenders]"
+  assert_file_contains "$snapshot" "command=python3.11"
+  assert_file_contains "$snapshot" "command=ugrep"
+
+  printf 'PASS: watchdog breach snapshot includes process-agnostic top RSS offenders\n'
+  rm -rf "$root_dir"
+}
+run_top_rss_offenders_case

--- a/launchd/cmux-ram-sampler/README.md
+++ b/launchd/cmux-ram-sampler/README.md
@@ -35,6 +35,8 @@ Defaults:
 
 - danger footprint: `20` GB
 - danger swap free: `2` GB
+- danger free RAM: `12` percent
+- stale sample warning: `600` seconds
 - warning lead time: `30` minutes
 - regression window: `12` samples
 
@@ -52,6 +54,8 @@ Notification failures are non-fatal.
 - `CMUX_RAM_SAMPLER_SAMPLE_FILE`
 - `CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB`
 - `CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB`
+- `CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT`
+- `CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS`
 - `CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES`
 - `CMUX_RAM_SAMPLER_WINDOW_SAMPLES`
 - `CMUX_RAM_SAMPLER_NOTIFY_URL`
@@ -63,7 +67,8 @@ Notification failures are non-fatal.
 Do not arm this from automation. Etan-gated arm command:
 
 ```bash
-launchctl load /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+launchctl bootout gui/$(id -u) /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
 ```
 
 ## Test

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -5,6 +5,8 @@ CMUX_RAM_SAMPLER_LOG_DIR="${CMUX_RAM_SAMPLER_LOG_DIR:-$HOME/Library/Logs/cmux-ra
 CMUX_RAM_SAMPLER_SAMPLE_FILE="${CMUX_RAM_SAMPLER_SAMPLE_FILE:-$CMUX_RAM_SAMPLER_LOG_DIR/samples.jsonl}"
 CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB="${CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB:-20}"
 CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB="${CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB:-2}"
+CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT="${CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT:-12}"
+CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS="${CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS:-600}"
 CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES="${CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES:-30}"
 CMUX_RAM_SAMPLER_WINDOW_SAMPLES="${CMUX_RAM_SAMPLER_WINDOW_SAMPLES:-12}"
 CMUX_RAM_SAMPLER_NOTIFY_URL="${CMUX_RAM_SAMPLER_NOTIFY_URL:-http://localhost:3847/notify}"
@@ -171,16 +173,87 @@ swap_free_mb() {
     }' | while read -r value; do bytes_to_mb "$(bytes_from_human "$value")"; done
 }
 
-vmstat_compressor_mb() {
-  local output pages
+vmstat_output() {
   if [[ -n "${CMUX_RAM_SAMPLER_VMSTAT_FIXTURE:-}" ]]; then
-    output="$(cat "$CMUX_RAM_SAMPLER_VMSTAT_FIXTURE")"
+    cat "$CMUX_RAM_SAMPLER_VMSTAT_FIXTURE"
   else
-    output="$(vm_stat 2>/dev/null || true)"
+    vm_stat 2>/dev/null || true
   fi
-  pages="$(printf '%s\n' "$output" | awk '/Pages occupied by compressor/ {gsub(/\./,"",$NF); print $NF}')"
+}
+
+vmstat_page_size_bytes() {
+  local output="$1"
+  printf '%s\n' "$output" | awk '
+    BEGIN { page_size = 16384 }
+    /page size of [0-9][0-9]* bytes/ {
+      line = $0
+      sub(/^.*page size of /, "", line)
+      sub(/ bytes.*$/, "", line)
+      page_size = line
+      exit
+    }
+    END { print page_size }'
+}
+
+vmstat_pages_for_label() {
+  local output="$1"
+  local label="$2"
+  printf '%s\n' "$output" | awk -v label="$label" '
+    index($0, label) == 1 {
+      value = $NF
+      gsub(/[.]/, "", value)
+      gsub(/[^0-9]/, "", value)
+      print value
+      exit
+    }'
+}
+
+memsize_bytes() {
+  if [[ -n "${CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE:-}" && -f "$CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE" ]]; then
+    cat "$CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE"
+  else
+    sysctl hw.memsize 2>/dev/null || true
+  fi | awk '
+    {
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^[0-9]+$/) value = $i
+    }
+    }
+    END { if (value != "") print value; else print 0 }'
+}
+
+vmstat_compressor_mb() {
+  local output page_size pages
+  output="$(vmstat_output)"
+  page_size="$(vmstat_page_size_bytes "$output")"
+  pages="$(vmstat_pages_for_label "$output" "Pages occupied by compressor:")"
   pages="${pages:-0}"
-  bytes_to_mb "$((pages * 4096))"
+  bytes_to_mb "$((pages * page_size))"
+}
+
+free_ram_pct() {
+  local output page_size free_pages inactive_pages total_bytes
+  output="$(vmstat_output)"
+  page_size="$(vmstat_page_size_bytes "$output")"
+  free_pages="$(vmstat_pages_for_label "$output" "Pages free:")"
+  inactive_pages="$(vmstat_pages_for_label "$output" "Pages inactive:")"
+  if [[ -z "$free_pages" && -z "$inactive_pages" ]]; then
+    echo 100
+    return
+  fi
+  total_bytes="$(memsize_bytes)"
+  free_pages="${free_pages:-0}"
+  inactive_pages="${inactive_pages:-0}"
+  total_bytes="${total_bytes:-0}"
+
+  awk \
+    -v pages="$((free_pages + inactive_pages))" \
+    -v page_size="$page_size" \
+    -v total_bytes="$total_bytes" \
+    'BEGIN {
+      if (total_bytes <= 0) print 100
+      else printf "%.0f\n", int((pages * page_size / total_bytes) * 100)
+    }'
 }
 
 json_number_field() {
@@ -259,6 +332,7 @@ append_sample() {
   local swap_used="$6"
   local swap_free="$7"
   local compressor="$8"
+  local free_ram_pct_value="$9"
 
   mkdir -p "$CMUX_RAM_SAMPLER_LOG_DIR"
   jq -cn \
@@ -270,8 +344,66 @@ append_sample() {
     --argjson swap_used "$swap_used" \
     --argjson swap_free "$swap_free" \
     --argjson compressor "$compressor" \
-    '{ts:$ts,instance:$instance,pid:$pid,phys_footprint_mb:$footprint,phys_footprint_peak_mb:$peak,swap_used_mb:$swap_used,swap_free_mb:$swap_free,compressor_mb:$compressor}' \
+    --argjson free_ram_pct "$free_ram_pct_value" \
+    '{ts:$ts,instance:$instance,pid:$pid,phys_footprint_mb:$footprint,phys_footprint_peak_mb:$peak,swap_used_mb:$swap_used,swap_free_mb:$swap_free,compressor_mb:$compressor,free_ram_pct:$free_ram_pct}' \
     >>"$CMUX_RAM_SAMPLER_SAMPLE_FILE"
+}
+
+notify_url_host_port() {
+  local url="$1"
+  local scheme host port
+  if [[ "$url" =~ ^(https?)://([^/:]+)(:([0-9]+))?(/.*)?$ ]]; then
+    scheme="${BASH_REMATCH[1]}"
+    host="${BASH_REMATCH[2]}"
+    port="${BASH_REMATCH[4]}"
+    if [[ -z "$port" ]]; then
+      if [[ "$scheme" == "https" ]]; then
+        port="443"
+      else
+        port="80"
+      fi
+    fi
+    printf '%s %s\n' "$host" "$port"
+    return 0
+  fi
+  return 1
+}
+
+notify_listener_available() {
+  local url="$1"
+  local host port
+  read -r host port < <(notify_url_host_port "$url") || return 1
+  if command -v nc >/dev/null 2>&1; then
+    nc -z -G 1 "$host" "$port" >/dev/null 2>&1 || nc -z -w 1 "$host" "$port" >/dev/null 2>&1
+    return
+  fi
+  (: >"/dev/tcp/$host/$port") >/dev/null 2>&1
+}
+
+post_notification() {
+  local title="$1"
+  local body="$2"
+  local host port
+
+  if ! read -r host port < <(notify_url_host_port "$CMUX_RAM_SAMPLER_NOTIFY_URL"); then
+    log "notify URL malformed ($CMUX_RAM_SAMPLER_NOTIFY_URL); skipping notification"
+    return 0
+  fi
+
+  if ! notify_listener_available "$CMUX_RAM_SAMPLER_NOTIFY_URL"; then
+    log "notify listener unavailable at $host:$port; skipping notification"
+    return 0
+  fi
+
+  jq -cn \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg source "$CMUX_RAM_SAMPLER_SOURCE" \
+    --arg priority "$CMUX_RAM_SAMPLER_PRIORITY" \
+    '{title:$title,body:$body,source:$source,priority:$priority}' \
+    | curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_RAM_SAMPLER_NOTIFY_URL" \
+      -H 'Content-Type: application/json' \
+      --data-binary @- >/dev/null 2>&1 || log "notify post failed at $CMUX_RAM_SAMPLER_NOTIFY_URL"
 }
 
 notify_warning() {
@@ -280,16 +412,46 @@ notify_warning() {
   local footprint_mb="$3"
   local eta_minutes="$4"
   local swap_free="$5"
+  local free_ram_pct_value="${6:-unknown}"
 
-  jq -cn \
-    --arg title "cmux RAM sampler" \
-    --arg body "$instance pid $pid phys_footprint=${footprint_mb} MB; projected danger ETA=${eta_minutes} min; swap_free=${swap_free} MB" \
-    --arg source "$CMUX_RAM_SAMPLER_SOURCE" \
-    --arg priority "$CMUX_RAM_SAMPLER_PRIORITY" \
-    '{title:$title,body:$body,source:$source,priority:$priority}' \
-    | curl -sS -X POST "$CMUX_RAM_SAMPLER_NOTIFY_URL" \
-      -H 'Content-Type: application/json' \
-      --data-binary @- >/dev/null 2>&1 || true
+  post_notification \
+    "cmux RAM sampler" \
+    "$instance pid $pid phys_footprint=${footprint_mb} MB; projected danger ETA=${eta_minutes} min; swap_free=${swap_free} MB; free_ram_pct=${free_ram_pct_value}"
+}
+
+sample_file_mtime_epoch() {
+  if [[ -n "${CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH:-}" ]]; then
+    printf '%s\n' "$CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH"
+    return
+  fi
+  stat -f '%m' "$CMUX_RAM_SAMPLER_SAMPLE_FILE" 2>/dev/null || stat -c '%Y' "$CMUX_RAM_SAMPLER_SAMPLE_FILE" 2>/dev/null || echo 0
+}
+
+now_epoch() {
+  if [[ -n "${CMUX_RAM_SAMPLER_NOW_EPOCH:-}" ]]; then
+    printf '%s\n' "$CMUX_RAM_SAMPLER_NOW_EPOCH"
+  else
+    date '+%s'
+  fi
+}
+
+check_sample_freshness() {
+  local mtime now age
+  [[ -s "$CMUX_RAM_SAMPLER_SAMPLE_FILE" ]] || return 0
+
+  mtime="$(sample_file_mtime_epoch)"
+  now="$(now_epoch)"
+  if [[ -z "$mtime" || "$mtime" == "0" || "$now" -le "$mtime" ]]; then
+    return 0
+  fi
+
+  age=$((now - mtime))
+  if (( age > CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS )); then
+    log "samples.jsonl stale: age=${age}s threshold=${CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS}s path=$CMUX_RAM_SAMPLER_SAMPLE_FILE"
+    post_notification \
+      "cmux RAM sampler stale" \
+      "samples.jsonl stale for ${age}s (threshold ${CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS}s): $CMUX_RAM_SAMPLER_SAMPLE_FILE"
+  fi
 }
 
 sample_instance() {
@@ -299,7 +461,8 @@ sample_instance() {
   local swap_used="$4"
   local swap_free="$5"
   local compressor="$6"
-  local danger_footprint_mb="$7"
+  local free_ram_pct_value="$7"
+  local danger_footprint_mb="$8"
   local pid output footprint_mb peak_mb eta_minutes=""
 
   pid="$(pid_for_path "$app_path")"
@@ -311,28 +474,33 @@ sample_instance() {
   output="$(footprint_output_for_pid "$pid")"
   footprint_mb="$(parse_footprint_mb "$output")"
   peak_mb="$(parse_footprint_peak_mb "$output")"
-  append_sample "$ts" "$instance" "$pid" "$footprint_mb" "$peak_mb" "$swap_used" "$swap_free" "$compressor"
+  append_sample "$ts" "$instance" "$pid" "$footprint_mb" "$peak_mb" "$swap_used" "$swap_free" "$compressor" "$free_ram_pct_value"
 
   eta_minutes="$(predict_eta_minutes "$CMUX_RAM_SAMPLER_SAMPLE_FILE" "$instance" "$danger_footprint_mb" "$CMUX_RAM_SAMPLER_WINDOW_SAMPLES" || true)"
   if [[ -n "$eta_minutes" && "$eta_minutes" -lt "$CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES" ]]; then
     log "$instance pid $pid projected to reach $CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB GB phys_footprint in ${eta_minutes}m"
-    notify_warning "$instance" "$pid" "$footprint_mb" "$eta_minutes" "$swap_free"
+    notify_warning "$instance" "$pid" "$footprint_mb" "$eta_minutes" "$swap_free" "$free_ram_pct_value"
+  elif [[ "$free_ram_pct_value" =~ ^[0-9]+$ && "$free_ram_pct_value" -le "$CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT" ]]; then
+    log "$instance pid $pid sampled with low free_ram_pct=${free_ram_pct_value}%"
+    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free" "$free_ram_pct_value"
   elif [[ "$swap_free" -lt "$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB")" ]]; then
     log "$instance pid $pid sampled with low swap_free=${swap_free}MB"
-    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free"
+    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free" "$free_ram_pct_value"
   fi
 }
 
 run_once() {
-  local ts swap_used swap_free compressor danger_footprint_mb
+  local ts swap_used swap_free compressor free_ram_pct_value danger_footprint_mb
   ts="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  check_sample_freshness
   swap_used="$(swap_used_mb)"
   swap_free="$(swap_free_mb)"
   compressor="$(vmstat_compressor_mb)"
+  free_ram_pct_value="$(free_ram_pct)"
   danger_footprint_mb="$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB")"
 
-  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$danger_footprint_mb"
-  sample_instance nightly "$CMUX_RAM_SAMPLER_NIGHTLY_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$danger_footprint_mb"
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$free_ram_pct_value" "$danger_footprint_mb"
+  sample_instance nightly "$CMUX_RAM_SAMPLER_NIGHTLY_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$free_ram_pct_value" "$danger_footprint_mb"
 }
 
 if [[ "${CMUX_RAM_SAMPLER_SOURCE_ONLY:-0}" != "1" ]]; then

--- a/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+++ b/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
@@ -16,6 +16,10 @@
     <string>20</string>
     <key>CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB</key>
     <string>2</string>
+    <key>CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT</key>
+    <string>12</string>
+    <key>CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS</key>
+    <string>600</string>
     <key>CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES</key>
     <string>30</string>
   </dict>

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -22,6 +22,14 @@ assert_eq() {
   [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
 }
 
+assert_file_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if [[ -f "$file" ]] && grep -F -- "$needle" "$file" >/dev/null; then
+    fail "did not expect '$needle' in $file"
+  fi
+}
+
 seed_fake_commands() {
   local root_dir="$1"
   local log_dir="$2"
@@ -32,6 +40,13 @@ set -euo pipefail
 printf '%s\n' "\$*" >>"$log_dir/curl.log"
 EOF
   chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
 
   cat >"$root_dir/bin/pgrep" <<EOF
 #!/usr/bin/env bash
@@ -59,6 +74,13 @@ set -euo pipefail
 printf '%s\n' "\$*" >>"$log_dir/curl.log"
 EOF
   chmod +x "$root_dir/bin/curl"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
 
   cat >"$root_dir/bin/pgrep" <<'EOF'
 #!/usr/bin/env bash
@@ -115,6 +137,7 @@ EOF
 vm.swapusage: total = 8192.00M  used = 6144.00M  free = 2048.00M  (encrypted)
 EOF
   cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
 Pages occupied by compressor: 262144.
 EOF
 
@@ -159,6 +182,7 @@ EOF
 vm.swapusage: total = 8192.00M  used = 6144.00M  free = 1024.00M  (encrypted)
 EOF
   cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
 Pages occupied by compressor: 262144.
 EOF
 
@@ -185,6 +209,175 @@ EOF
   rm -rf "$root_dir"
 }
 
+run_vmstat_page_size_case() {
+  local root_dir compressor_mb
+  root_dir="$(mktemp -d)"
+  mkdir -p "$root_dir/fixtures"
+
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages occupied by compressor: 262144.
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  compressor_mb="$(vmstat_compressor_mb)"
+  assert_eq "4096" "$compressor_mb"
+
+  printf 'PASS: sampler derives compressor MB from vm_stat page size\n'
+  rm -rf "$root_dir"
+}
+
+run_free_ram_threshold_case() {
+  local root_dir log_dir
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+5151 phys_footprint: 2048 MB (peak 4096 MB)
+EOF
+  cat >"$root_dir/fixtures/swap.fixture" <<'EOF'
+vm.swapusage: total = 8192.00M  used = 1024.00M  free = 4096.00M  (encrypted)
+EOF
+  cat >"$root_dir/fixtures/memsize.fixture" <<'EOF'
+hw.memsize: 1638400
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_SWAP_FIXTURE="$root_dir/fixtures/swap.fixture"
+  export CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE="$root_dir/fixtures/memsize.fixture"
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free: 6.
+Pages inactive: 6.
+Pages occupied by compressor: 0.
+EOF
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  run_once
+  assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+  assert_file_contains "$log_dir/samples.jsonl" '"free_ram_pct":12'
+
+  : >"$log_dir/curl.log"
+  : >"$log_dir/samples.jsonl"
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free: 7.
+Pages inactive: 6.
+Pages occupied by compressor: 0.
+EOF
+  run_once
+  assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+  assert_file_contains "$log_dir/samples.jsonl" '"free_ram_pct":13'
+
+  printf 'PASS: sampler warns at free_ram_pct <= 12 and not at 13\n'
+  rm -rf "$root_dir"
+}
+
+run_notify_skip_case() {
+  local root_dir log_dir stderr_log
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  notify_warning stable 4242 1024 unknown 4096 12 2>"$stderr_log"
+  assert_file_contains "$stderr_log" "notify listener unavailable"
+  assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+
+  printf 'PASS: sampler skips notification loudly when listener is down\n'
+  rm -rf "$root_dir"
+}
+
+run_sample_freshness_case() {
+  local root_dir log_dir stderr_log
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  printf '{"ts":"2026-06-09T10:00:00+0000","instance":"stable"}\n' >"$log_dir/samples.jsonl"
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH=1000
+  export CMUX_RAM_SAMPLER_NOW_EPOCH=2200
+  export CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS=600
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  check_sample_freshness 2>"$stderr_log"
+  assert_file_contains "$stderr_log" "samples.jsonl stale"
+  assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+
+  printf 'PASS: sampler emits loud warning for stale samples.jsonl\n'
+  rm -rf "$root_dir"
+}
+
+run_plist_case() {
+  local plist program interval run_at_load
+  plist="$ROOT_DIR/launchd/com.golems.cmux-ram-sampler.plist"
+  program="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$plist")"
+  interval="$(/usr/libexec/PlistBuddy -c 'Print :StartInterval' "$plist")"
+  run_at_load="$(/usr/libexec/PlistBuddy -c 'Print :RunAtLoad' "$plist")"
+
+  [[ -x "$program" ]] || fail "plist ProgramArguments path is not executable: $program"
+  assert_eq "300" "$interval"
+  assert_eq "true" "$run_at_load"
+  /usr/libexec/PlistBuddy -c 'Print :StandardOutPath' "$plist" | grep -F 'cmux-ram-sampler' >/dev/null \
+    || fail "plist missing sampler stdout log path"
+  /usr/libexec/PlistBuddy -c 'Print :StandardErrorPath' "$plist" | grep -F 'cmux-ram-sampler' >/dev/null \
+    || fail "plist missing sampler stderr log path"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT' "$plist" | grep -Fx '12' >/dev/null \
+    || fail "plist missing free RAM threshold env"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS' "$plist" | grep -Fx '600' >/dev/null \
+    || fail "plist missing sample freshness env"
+
+  printf 'PASS: sampler launchd plist is armable with expected structure\n'
+}
+
+run_vmstat_page_size_case
+run_free_ram_threshold_case
+run_notify_skip_case
+run_sample_freshness_case
+run_plist_case
 run_prediction_case
 run_sampling_case
 run_ps_fallback_sampling_case


### PR DESCRIPTION
## D6 — RAM watchdog clx-03 fix (owned in cmuxlayer)

The cmux RAM sampler + memory watchdog (`launchd/cmux-ram-sampler/`, `launchd/cmux-memory-watchdog/`) under-counted memory and fired on the wrong signal — contributing to the gen-16 RAM-livelock + 2 kernel panics. Each fix ships a RED→GREEN shell test.

| # | Fix |
|---|-----|
| 1 | **Page size** derived from `vm_stat` "page size of N bytes" header (16384 fallback), not hardcoded 4096 → Apple Silicon's 16 KB pages were undercounting compressor memory 4× |
| 2 | **Trigger on free physical RAM**: `free_ram_pct <= 12` (`(free+inactive)·page_size / hw.memsize`), replacing the noisy swap_free signal; sample rows now carry `free_ram_pct` |
| 3 | **Resilient notify**: probe the listener (host:port) before POST, GRACEFUL-SKIP + loud log when down (port 3847 was frequently dead, silently swallowing breach alerts) — never hang/abort the guard |
| 4 | **Process-agnostic offenders**: breach snapshot includes top-N RSS processes (`ps -axo pid,rss,comm | sort`), naming the real hog (python ML pile, runaway ugrep), not just cmux |
| 5 | **Sampler-freshness self-check**: loud warning when `samples.jsonl` is stale (sampler silently died Jun 11) |
| 6 | **Plist** carries the new thresholds so `launchctl bootstrap` re-arms cleanly |

## Verification
Sampler suite **8/8**, watchdog suite **10/10** green (`tests/run-tests.sh`). These are shell scripts deployed via launchd (separate from the cmux-mcp brew binary).

**Re-arm after merge:**
```
launchctl bootout gui/$UID/com.golems.cmux-ram-sampler 2>/dev/null
launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.golems.cmux-ram-sampler.plist
```

## Method
Codex implemented in an isolated worktree (RED-first); cmuxLayerClaude (Opus) reviewed the numeric logic (page-size derivation, free_ram_pct formula) + ran both suites independently. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live launchd memory guards that terminate cmux and drive alerts; logic fixes reduce false negatives but new free-RAM and notify paths alter when warnings fire and when POSTs are skipped.
> 
> **Overview**
> Hardens the **cmux RAM sampler** and **memory watchdog** launchd scripts so memory signals and alerts match Apple Silicon and real fleet conditions.
> 
> **Memory math:** Compressor sizing now reads **`vm_stat`’s reported page size** (16 KB fallback) instead of assuming 4 KB, fixing under-counted compressor pressure on Apple Silicon in both tools.
> 
> **Sampler behavior:** Each JSONL row adds **`free_ram_pct`** from free+inactive pages vs `hw.memsize`, and warnings fire when free RAM is **≤ 12%** (alongside existing footprint/swap paths). A **stale `samples.jsonl` check** logs and notifies if the log hasn’t been updated within the configured window. The launchd plist and README document the new thresholds and a **bootout/bootstrap** re-arm flow.
> 
> **Watchdog behavior:** Breach snapshots and brain-store context include **system-wide top-N RSS processes** (not only `pgrep cmux`), configurable via `CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT`.
> 
> **Notifications:** Both scripts **probe the notify URL’s host:port** before POSTing, skip with explicit stderr when the listener is down or the URL is bad, and use **short curl timeouts** so guards don’t hang or abort the kill path silently.
> 
> Shell tests cover page-size derivation, free-RAM thresholds, notify skip, stale samples, top-RSS snapshots, and plist env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605f45d879f1525512cc6177900401b002e80276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Apple Silicon page size, add free-RAM warnings, and harden notify in ram-sampler and memory-watchdog
> - Fixes `vm_stat` compressor byte calculation in both [cmux-ram-sampler](https://github.com/EtanHey/cmuxlayer/pull/178/files#diff-8a20a2da4bb278f0b8f4b4be5abb9ab8140a99dafb5f8748d92e55ef3d93dfb9) and [cmux-memory-watchdog](https://github.com/EtanHey/cmuxlayer/pull/178/files#diff-e67359a7bbbc7ad3ee4d8d37b25d23790c5567c97896c5fc3f9159f9ce0ac2ef) to derive page size from `vm_stat` output (default 16384) instead of hardcoding 4096 bytes.
> - Adds `free_ram_pct` computation to `cmux-ram-sampler`, recording it in `samples.jsonl` and triggering a warning when free RAM is at or below `CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT` (default 12%).
> - Adds `check_sample_freshness` to `cmux-ram-sampler`, posting a notification when `samples.jsonl` is older than `CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS` (default 600s).
> - Replaces `pgrep -lf cmux` in `cmux-memory-watchdog` breach payloads with a process-agnostic `top_rss_offenders` function using `ps -axo pid,rss,comm`, capped by `CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT` (default 5).
> - Hardens notification in both scripts: validates URL format, checks TCP reachability via `nc` or `/dev/tcp` before posting, and applies short `curl` timeouts (`--connect-timeout 1 --max-time 3`) with logged failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 605f45d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory watchdog now reports top RSS-consuming processes during memory pressure events
  * Free RAM percentage monitoring with configurable danger threshold

* **Bug Fixes**
  * Improved system memory calculation accuracy
  * Enhanced notification reliability with URL validation and listener availability checks

* **Documentation**
  * Added configuration parameters for new memory safety thresholds
  * Updated installation procedures with improved boot commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->