### PR TITLE
fix(ram-watchdog): close clx-03 live residuals (notify probe-gate, free_ram_pct false-safe, pinned URL) + vitest worktree-exclude

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -318,7 +318,13 @@ notify_breach() {
     '{title:$title,body:$body,source:$source,priority:$priority}' \
     | curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
       -H 'Content-Type: application/json' \
-      --data-binary @- >/dev/null 2>&1 || log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL"
+      --data-binary @- >/dev/null 2>&1 || {
+        if ! notify_listener_available "$CMUX_MEM_WATCHDOG_NOTIFY_URL"; then
+          log "notify listener unavailable at $host:$port; skipping notification"
+        else
+          log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL"
+        fi
+      }
 }
 
 terminate_cmux() {

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -320,6 +320,54 @@ EOF
 }
 run_notify_skip_case
 
+run_notify_reprobe_after_post_failure_case() {
+  local root_dir log_dir stderr_log
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/nc" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="$log_dir/nc-count"
+count=0
+if [[ -f "\$count_file" ]]; then
+  count="\$(cat "\$count_file")"
+fi
+count=\$((count + 1))
+printf '%s\n' "\$count" >"\$count_file"
+if [[ "\$count" == "1" ]]; then
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+exit 7
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  notify_breach 4242 footprint 1073741824 4294967296 "$log_dir/snapshot.log" 2>"$stderr_log"
+  assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+  assert_file_contains "$stderr_log" "notify listener unavailable at localhost:3847; skipping notification"
+  assert_file_not_contains "$stderr_log" "notify post failed at http://localhost:3847/notify"
+
+  printf 'PASS: watchdog re-probes and skip-logs when listener drops after notify probe\n'
+  rm -rf "$root_dir"
+}
+run_notify_reprobe_after_post_failure_case
+
 # Matcher coverage regression guard (2026-06-09): the PID matcher must catch
 # BOTH cmux bundles — stable "cmux.app" AND nightly "cmux NIGHTLY.app". The old
 # `cmux\.app` pattern silently skipped nightly, so a nightly-only fleet (the

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -237,22 +237,27 @@ free_ram_pct() {
   page_size="$(vmstat_page_size_bytes "$output")"
   free_pages="$(vmstat_pages_for_label "$output" "Pages free:")"
   inactive_pages="$(vmstat_pages_for_label "$output" "Pages inactive:")"
-  if [[ -z "$free_pages" && -z "$inactive_pages" ]]; then
-    echo 100
+  if [[ -z "$free_pages" || -z "$inactive_pages" ]]; then
+    log "free_ram_pct unknown: missing vm_stat free/inactive pages"
+    echo unknown
     return
   fi
   total_bytes="$(memsize_bytes)"
   free_pages="${free_pages:-0}"
   inactive_pages="${inactive_pages:-0}"
   total_bytes="${total_bytes:-0}"
+  if [[ ! "$total_bytes" =~ ^[0-9]+$ || "$total_bytes" -le 0 ]]; then
+    log "free_ram_pct unknown: invalid hw.memsize"
+    echo unknown
+    return
+  fi
 
   awk \
     -v pages="$((free_pages + inactive_pages))" \
     -v page_size="$page_size" \
     -v total_bytes="$total_bytes" \
     'BEGIN {
-      if (total_bytes <= 0) print 100
-      else printf "%.0f\n", int((pages * page_size / total_bytes) * 100)
+      printf "%.0f\n", int((pages * page_size / total_bytes) * 100)
     }'
 }
 
@@ -333,6 +338,13 @@ append_sample() {
   local swap_free="$7"
   local compressor="$8"
   local free_ram_pct_value="$9"
+  local free_ram_pct_json
+
+  if [[ "$free_ram_pct_value" =~ ^[0-9]+$ ]]; then
+    free_ram_pct_json="$free_ram_pct_value"
+  else
+    free_ram_pct_json="null"
+  fi
 
   mkdir -p "$CMUX_RAM_SAMPLER_LOG_DIR"
   jq -cn \
@@ -344,7 +356,7 @@ append_sample() {
     --argjson swap_used "$swap_used" \
     --argjson swap_free "$swap_free" \
     --argjson compressor "$compressor" \
-    --argjson free_ram_pct "$free_ram_pct_value" \
+    --argjson free_ram_pct "$free_ram_pct_json" \
     '{ts:$ts,instance:$instance,pid:$pid,phys_footprint_mb:$footprint,phys_footprint_peak_mb:$peak,swap_used_mb:$swap_used,swap_free_mb:$swap_free,compressor_mb:$compressor,free_ram_pct:$free_ram_pct}' \
     >>"$CMUX_RAM_SAMPLER_SAMPLE_FILE"
 }
@@ -403,7 +415,13 @@ post_notification() {
     '{title:$title,body:$body,source:$source,priority:$priority}' \
     | curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_RAM_SAMPLER_NOTIFY_URL" \
       -H 'Content-Type: application/json' \
-      --data-binary @- >/dev/null 2>&1 || log "notify post failed at $CMUX_RAM_SAMPLER_NOTIFY_URL"
+      --data-binary @- >/dev/null 2>&1 || {
+        if ! notify_listener_available "$CMUX_RAM_SAMPLER_NOTIFY_URL"; then
+          log "notify listener unavailable at $host:$port; skipping notification"
+        else
+          log "notify post failed at $CMUX_RAM_SAMPLER_NOTIFY_URL"
+        fi
+      }
 }
 
 notify_warning() {
@@ -497,6 +515,9 @@ run_once() {
   swap_free="$(swap_free_mb)"
   compressor="$(vmstat_compressor_mb)"
   free_ram_pct_value="$(free_ram_pct)"
+  if [[ ! "$free_ram_pct_value" =~ ^[0-9]+$ ]]; then
+    log "free_ram_pct unavailable; skipping free-RAM trigger"
+  fi
   danger_footprint_mb="$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB")"
 
   sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "$ts" "${swap_used:-0}" "${swap_free:-0}" "$compressor" "$free_ram_pct_value" "$danger_footprint_mb"

--- a/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+++ b/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
@@ -22,6 +22,8 @@
     <string>600</string>
     <key>CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES</key>
     <string>30</string>
+    <key>CMUX_RAM_SAMPLER_NOTIFY_URL</key>
+    <string>http://127.0.0.1:3847/notify</string>
   </dict>
 
   <key>RunAtLoad</key>

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -322,6 +322,199 @@ EOF
   rm -rf "$root_dir"
 }
 
+run_notify_skip_all_sampler_paths_case() {
+  local root_dir log_dir warning_stderr stale_stderr
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  warning_stderr="$root_dir/warning.stderr.log"
+  stale_stderr="$root_dir/stale.stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  printf '{"ts":"2026-06-09T10:00:00+0000","instance":"stable"}\n' >"$log_dir/samples.jsonl"
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH=1000
+  export CMUX_RAM_SAMPLER_NOW_EPOCH=2200
+  export CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS=600
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  notify_warning stable 4242 1024 unknown 4096 12 2>"$warning_stderr"
+  check_sample_freshness 2>"$stale_stderr"
+
+  assert_file_contains "$warning_stderr" "notify listener unavailable at localhost:3847; skipping notification"
+  assert_file_contains "$stale_stderr" "notify listener unavailable at localhost:3847; skipping notification"
+  assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+
+  printf 'PASS: sampler skips curl posts on every notify path when listener is down\n'
+  rm -rf "$root_dir"
+}
+
+run_notify_reprobe_after_post_failure_case() {
+  local root_dir log_dir stderr_log
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/nc" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="$log_dir/nc-count"
+count=0
+if [[ -f "\$count_file" ]]; then
+  count="\$(cat "\$count_file")"
+fi
+count=\$((count + 1))
+printf '%s\n' "\$count" >"\$count_file"
+if [[ "\$count" == "1" ]]; then
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  cat >"$root_dir/bin/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/curl.log"
+exit 7
+EOF
+  chmod +x "$root_dir/bin/curl"
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  notify_warning stable 4242 1024 unknown 4096 12 2>"$stderr_log"
+  assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
+  assert_file_contains "$stderr_log" "notify listener unavailable at localhost:3847; skipping notification"
+  assert_file_not_contains "$stderr_log" "notify post failed at http://localhost:3847/notify"
+
+  printf 'PASS: sampler re-probes and skip-logs when listener drops after notify probe\n'
+  rm -rf "$root_dir"
+}
+
+run_free_ram_unknown_on_parse_failure_case() {
+  local root_dir log_dir stderr_log pct
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+5151 phys_footprint: 2048 MB (peak 4096 MB)
+EOF
+  cat >"$root_dir/fixtures/swap.fixture" <<'EOF'
+vm.swapusage: total = 8192.00M  used = 1024.00M  free = 4096.00M  (encrypted)
+EOF
+  cat >"$root_dir/fixtures/memsize.fixture" <<'EOF'
+hw.memsize:
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free: 100.
+Pages inactive: 100.
+Pages occupied by compressor: 0.
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_SWAP_FIXTURE="$root_dir/fixtures/swap.fixture"
+  export CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE="$root_dir/fixtures/memsize.fixture"
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+  export PATH="$root_dir/bin:$PATH"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  pct="$(free_ram_pct 2>"$stderr_log")"
+  assert_eq "unknown" "$pct"
+  assert_file_contains "$stderr_log" "free_ram_pct unknown: invalid hw.memsize"
+  run_once 2>>"$stderr_log"
+  assert_file_contains "$log_dir/samples.jsonl" '"free_ram_pct":null'
+  assert_file_contains "$stderr_log" "free_ram_pct unavailable; skipping free-RAM trigger"
+
+  : >"$stderr_log"
+  cat >"$root_dir/fixtures/memsize.fixture" <<'EOF'
+hw.memsize: 1638400
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+garbage
+Pages occupied by compressor: 0.
+EOF
+
+  pct="$(free_ram_pct 2>"$stderr_log")"
+  assert_eq "unknown" "$pct"
+  assert_file_contains "$stderr_log" "free_ram_pct unknown: missing vm_stat free/inactive pages"
+
+  : >"$stderr_log"
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free: 100.
+Pages occupied by compressor: 0.
+EOF
+
+  pct="$(free_ram_pct 2>"$stderr_log")"
+  assert_eq "unknown" "$pct"
+  assert_file_contains "$stderr_log" "free_ram_pct unknown: missing vm_stat free/inactive pages"
+
+  printf 'PASS: sampler reports unknown instead of false-safe free_ram_pct on parse failures\n'
+  rm -rf "$root_dir"
+}
+
+run_free_ram_midrange_case() {
+  local root_dir pct
+  root_dir="$(mktemp -d)"
+  mkdir -p "$root_dir/fixtures"
+
+  cat >"$root_dir/fixtures/memsize.fixture" <<'EOF'
+hw.memsize: 3276800
+EOF
+  cat >"$root_dir/fixtures/vmstat.fixture" <<'EOF'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free: 40.
+Pages inactive: 40.
+Pages occupied by compressor: 0.
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE="$root_dir/fixtures/memsize.fixture"
+  export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  pct="$(free_ram_pct)"
+  assert_eq "40" "$pct"
+
+  printf 'PASS: sampler computes mid-range free_ram_pct from valid vm_stat and memsize\n'
+  rm -rf "$root_dir"
+}
+
 run_sample_freshness_case() {
   local root_dir log_dir stderr_log
   root_dir="$(mktemp -d)"
@@ -369,6 +562,8 @@ run_plist_case() {
     || fail "plist missing free RAM threshold env"
   /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS' "$plist" | grep -Fx '600' >/dev/null \
     || fail "plist missing sample freshness env"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_NOTIFY_URL' "$plist" | grep -Fx 'http://127.0.0.1:3847/notify' >/dev/null \
+    || fail "plist missing pinned notify URL env"
 
   printf 'PASS: sampler launchd plist is armable with expected structure\n'
 }
@@ -376,6 +571,10 @@ run_plist_case() {
 run_vmstat_page_size_case
 run_free_ram_threshold_case
 run_notify_skip_case
+run_notify_skip_all_sampler_paths_case
+run_notify_reprobe_after_post_failure_case
+run_free_ram_unknown_on_parse_failure_case
+run_free_ram_midrange_case
 run_sample_freshness_case
 run_plist_case
 run_prediction_case

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1502,8 +1502,15 @@ describe("tool handler integration", () => {
   });
 
   it("send_input background reads 'delivering' (not FAILED) while in flight (F8)", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input-background");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
     const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
     const tool = (server as any)._registeredTools["send_input"];
     const result = await tool.handler(
       { surface: "surface:7", text: "hi", background: true },
@@ -1514,6 +1521,7 @@ describe("tool handler integration", () => {
     expect(typeof data.delivery_id).toBe("string");
     expect(result.content[0].text).toContain("delivering to surface:7");
     expect(result.content[0].text).not.toContain("FAILED");
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("send_input returns delivered + cheap target identity from the state cache (F8)", async () => {
@@ -4092,9 +4100,16 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface handler calls cmux close-surface", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-basic");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["close_surface"];
 
@@ -4104,6 +4119,7 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["close-surface"]),
     );
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("close_surface reports pane collapse when closing the last dedicated worker tab", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "**/.worktrees/**"],
+  },
+});


### PR DESCRIPTION
## D6 follow-up — close the clx-03 live residuals surfaced by re-arming the sampler

Re-arming `com.golems.cmux-ram-sampler` exposed three residuals in the live launchd logs. Codex implemented; cmuxLayerClaude (Opus) reviewed + verified.

| # | Residual | Fix |
|---|----------|-----|
| 1 | **free_ram_pct false-safe** — a parse failure reported `100` (a live 02:05 sample had `free_ram_pct:100` with `swap_used/free:0` — the all-zeros parse-failure signature — bracketed by normal 43/34 samples) | missing free **or** inactive pages, or an invalid `hw.memsize`, → `unknown` (loud log), serialized as JSON `null`, and the free-RAM trigger is skipped — never a fabricated safe number. Removed the `print 100` fallback. |
| 2 | **Notify didn't probe-gate all paths** — dead listener logged `notify post failed` instead of a graceful skip | sampler + watchdog now classify a failed POST: listener-unavailable → loud "skipping" log; else "post failed". Bounded curl keeps it hang-free. |
| 3 | **`:9` env leak** — a leaked `CMUX_RAM_SAMPLER_NOTIFY_URL` was inherited at `launchctl bootstrap` | plist now pins `CMUX_RAM_SAMPLER_NOTIFY_URL=http://127.0.0.1:3847/notify` so a caller env can't redirect breach alerts. |

**Verdict on the live `free_ram_pct:100`:** confirmed a real false-safe (parse failure), not a legitimate idle reading.

## Test-infra (unblocks the pre-push hook for everyone)
- `vitest.config.ts` excludes `**/.worktrees/**` — the regression hook was globbing test files from *sibling* git worktrees nested in-repo (another agent's mid-edit branch), failing unrelated pushes.
- Excluding them surfaced two genuinely flaky tests (`F8 send_input background`, `close_surface basic`) that shared a default state dir; each now gets its own temp `stateDir` and passes deterministically.

## Verification
- Sampler suite **12/12**, watchdog suite **11/11** green (shell harnesses).
- Real vitest suite **56 files / 898 tests** green; `tsc --noEmit` clean.

## Method
Orchestrator/worker split per standing rule: Codex implemented (xhigh), Opus reviewed numeric/scoping correctness + ran every harness independently + empirically confirmed the flaky-test fix was needed. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live launchd RAM alerting and threshold logic; misclassification of free_ram_pct or notify skips could miss or misreport memory pressure, though behavior is heavily covered by shell harnesses.
> 
> **Overview**
> Closes live **clx-03** residuals in the cmux RAM sampler and memory watchdog after re-arming launchd.
> 
> **free_ram_pct** no longer falls back to `100` on parse failures. Missing `vm_stat` pages or invalid `hw.memsize` now yield **`unknown`** (logged), JSON **`null`** in samples, and the free-RAM alert path is skipped so triggers are not suppressed by a fake “safe” reading.
> 
> **Notify delivery** in both scripts **re-probes** the listener after a failed `curl` POST: if the port is down, logs a clear skip instead of “post failed”; if the listener is still up, keeps the post-failure message. Shell tests cover skip-on-down, re-probe after probe-then-drop, and sampler paths (warning + stale).
> 
> The sampler **launchd plist** pins **`CMUX_RAM_SAMPLER_NOTIFY_URL`** to `http://127.0.0.1:3847/notify` so inherited env cannot redirect alerts.
> 
> **Test infra:** new **`vitest.config.ts`** excludes `**/.worktrees/**` from the test glob; two server tests get isolated temp **`stateDir`** to avoid flaky shared-state failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52c8797c9cee24e6d519e874bb091712c4c47ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix false-safe free_ram_pct, re-probe notify listener on POST failure, and pin notify URL in ram-watchdog/sampler
> - `free_ram_pct` in [cmux-ram-sampler.sh](https://github.com/EtanHey/cmuxlayer/pull/179/files#diff-8a20a2da4bb278f0b8f4b4be5abb9ab8140a99dafb5f8748d92e55ef3d93dfb9) now returns `'unknown'` (instead of `100`) when `vm_stat` pages are missing or `hw.memsize` is invalid; downstream callers skip the free-RAM trigger and serialize `null` in sample records.
> - Both `notify_breach` (watchdog) and `post_notification` (sampler) re-probe listener availability on curl POST failure, logging a targeted 'listener unavailable' skip message instead of a generic POST failure.
> - Pins `CMUX_RAM_SAMPLER_NOTIFY_URL` as an explicit env var in [com.golems.cmux-ram-sampler.plist](https://github.com/EtanHey/cmuxlayer/pull/179/files#diff-470a6cd78faf41ec047ca4ad974063c91dfaaffa10f9aed2ed3a5c9fdb687cbf).
> - Adds tests covering re-probe behavior, parse failure paths, and plist URL presence.
> - Excludes `.worktrees/` from vitest in [vitest.config.ts](https://github.com/EtanHey/cmuxlayer/pull/179/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) to prevent spurious test discovery.
> - Risk: `free_ram_pct` returning `'unknown'` instead of `100` changes the false-safe default — systems that previously coasted on a 100% free assumption will now skip threshold checks when RAM data is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d52c879.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->