### PR TITLE
feat(doctor): durable sleep-survival guard (cmux-caffeinate launchd + doctor check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ actually using.
 - **Panes are protected.** Automatic/idle pane closing is disabled (#170). `close_surface`
   refuses to destroy a surface backing a still-live agent unless `force: true`, and returns a
   fresh pane read on refusal so callers verify the real screen rather than a stale state record.
+- **Sleep survival is launchd-backed.** The durable guard lives in `launchd/cmux-caffeinate/`;
+  see [docs/sleep-survival.md](docs/sleep-survival.md) before changing sleep assertions.
 
 ### Distribution & releases
 The fleet runs the **brew-pinned** binary, not a working tree. Source of truth is

--- a/docs/sleep-survival.md
+++ b/docs/sleep-survival.md
@@ -1,0 +1,29 @@
+# Sleep Survival
+
+The cmux fleet previously died when the Mac display/system slept and cmux quit.
+The fragile mitigation was a transient `caffeinate -i -t 300` assertion, which
+lapses after five minutes and does not survive process failure.
+
+The durable guard is `launchd/cmux-caffeinate/`: launchd starts
+`bin/cmux-caffeinate.sh` at load and keeps it alive if the `caffeinate` process
+exits. The default flags are `-dis`, covering display sleep, idle system sleep,
+and system sleep on AC.
+
+Install is intentionally out-of-band and human-gated:
+
+```bash
+launchctl bootstrap gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
+```
+
+Do not bootstrap it from tests, releases, or automation while the fleet is live.
+
+`cmuxlayer doctor` reports a sleep guard line. Durable coverage requires both:
+
+- `pmset -g assertions` aggregate `PreventUserIdleSystemSleep` is `1`
+- launchd has `gui/$UID/com.golems.cmux-caffeinate` loaded
+
+If either side is missing, doctor stays healthy when the version resolves, but
+prints the install hint at `launchd/cmux-caffeinate/README.md`.
+
+AC caveat: `-s` only asserts system sleep prevention on AC power. `-i` covers
+battery idle sleep. Drop `-d` if display sleep is acceptable.

--- a/launchd/cmux-caffeinate/README.md
+++ b/launchd/cmux-caffeinate/README.md
@@ -1,0 +1,51 @@
+# cmux Caffeinate Guard
+
+Durable sleep-survival guard for the live cmux fleet. It runs `caffeinate` under
+launchd with `KeepAlive=true`, replacing ad-hoc `caffeinate -t` assertions that
+expire after a few minutes.
+
+## What it does
+
+`bin/cmux-caffeinate.sh` logs its start time and PID to:
+
+```bash
+~/.local/state/cmux/cmux-caffeinate.log
+```
+
+Then it execs `caffeinate` with:
+
+```bash
+-dis
+```
+
+Those defaults prevent display sleep, idle system sleep, and system sleep while
+on AC power. Override them with `CMUX_CAFFEINATE_FLAGS` only when you understand
+the tradeoff.
+
+## Install
+
+Do not arm this from automation. Etan-gated install command:
+
+```bash
+launchctl bootstrap gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
+```
+
+To reload after changes:
+
+```bash
+launchctl bootout gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist 2>/dev/null || true
+launchctl bootstrap gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
+```
+
+## AC caveat
+
+`-s` only asserts system sleep prevention on AC power. `-i` covers battery idle
+sleep. Drop `-d` if you accept display sleep but still want idle system sleep
+coverage.
+
+## Doctor
+
+`cmuxlayer doctor` reports whether `pmset -g assertions` shows
+`PreventUserIdleSystemSleep 1` and whether launchd has
+`com.golems.cmux-caffeinate` loaded. A transient assertion without the launchd
+guard is not durable.

--- a/launchd/cmux-caffeinate/bin/cmux-caffeinate.sh
+++ b/launchd/cmux-caffeinate/bin/cmux-caffeinate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_path="${CMUX_CAFFEINATE_LOG:-$HOME/.local/state/cmux/cmux-caffeinate.log}"
+flags="${CMUX_CAFFEINATE_FLAGS:--dis}"
+
+mkdir -p "$(dirname "$log_path")"
+printf '%s starting pid=%s flags=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$$" "$flags" >>"$log_path"
+
+exec caffeinate $flags

--- a/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
+++ b/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.golems.cmux-caffeinate</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/bin/cmux-caffeinate.sh</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/etanheyman/.local/state/cmux/cmux-caffeinate.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/etanheyman/.local/state/cmux/cmux-caffeinate.stderr.log</string>
+</dict>
+</plist>

--- a/launchd/cmux-caffeinate/tests/cmux-caffeinate.sh
+++ b/launchd/cmux-caffeinate/tests/cmux-caffeinate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/bin/cmux-caffeinate.sh"
+PLIST_PATH="$ROOT_DIR/launchd/com.golems.cmux-caffeinate.plist"
+DEPLOY_SCRIPT_PATH="/Users/etanheyman/Gits/cmuxlayer/launchd/cmux-caffeinate/bin/cmux-caffeinate.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  [[ -f "$file" ]] || fail "missing file: $file"
+  grep -F -- "$needle" "$file" >/dev/null || fail "expected '$needle' in $file"
+}
+
+run_default_flags_case() {
+  local root_dir log_dir
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/caffeinate" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >"$log_dir/argv.log"
+EOF
+  chmod +x "$root_dir/bin/caffeinate"
+
+  PATH="$root_dir/bin:$PATH" CMUX_CAFFEINATE_LOG="$log_dir/cmux-caffeinate.log" "$SCRIPT_PATH"
+
+  assert_eq "-dis" "$(cat "$log_dir/argv.log")"
+  assert_file_contains "$log_dir/cmux-caffeinate.log" "starting pid="
+
+  printf 'PASS: caffeinate guard uses -dis by default\n'
+  rm -rf "$root_dir"
+}
+
+run_override_flags_case() {
+  local root_dir log_dir
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cat >"$root_dir/bin/caffeinate" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >"$log_dir/argv.log"
+EOF
+  chmod +x "$root_dir/bin/caffeinate"
+
+  PATH="$root_dir/bin:$PATH" \
+    CMUX_CAFFEINATE_LOG="$log_dir/cmux-caffeinate.log" \
+    CMUX_CAFFEINATE_FLAGS="-i" \
+    "$SCRIPT_PATH"
+
+  assert_eq "-i" "$(cat "$log_dir/argv.log")"
+
+  printf 'PASS: caffeinate guard honors CMUX_CAFFEINATE_FLAGS\n'
+  rm -rf "$root_dir"
+}
+
+run_plist_case() {
+  [[ -x "$SCRIPT_PATH" ]] || fail "script is missing or not executable: $SCRIPT_PATH"
+
+  assert_file_contains "$PLIST_PATH" "<string>com.golems.cmux-caffeinate</string>"
+  assert_file_contains "$PLIST_PATH" "<key>RunAtLoad</key>"
+  assert_file_contains "$PLIST_PATH" "<true/>"
+  assert_file_contains "$PLIST_PATH" "<key>KeepAlive</key>"
+  assert_file_contains "$PLIST_PATH" "$DEPLOY_SCRIPT_PATH"
+  assert_file_contains "$PLIST_PATH" "<key>StandardOutPath</key>"
+  assert_file_contains "$PLIST_PATH" "<key>StandardErrorPath</key>"
+
+  printf 'PASS: launchd plist has durable guard settings\n'
+}
+
+run_syntax_case() {
+  [[ -x "$SCRIPT_PATH" ]] || fail "script is missing or not executable: $SCRIPT_PATH"
+  bash -n "$SCRIPT_PATH"
+  printf 'PASS: caffeinate guard script is executable and syntax-valid\n'
+}
+
+run_default_flags_case
+run_override_flags_case
+run_plist_case
+run_syntax_case

--- a/launchd/cmux-caffeinate/tests/run-tests.sh
+++ b/launchd/cmux-caffeinate/tests/run-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/tests/cmux-caffeinate.sh"

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -28,6 +28,8 @@ const execFileAsync = promisify(execFile);
 
 export const TAP_NAME = "etanhey/layers";
 export const FORMULA_NAME = "etanhey/layers/cmuxlayer";
+export const SLEEP_GUARD_LABEL = "com.golems.cmux-caffeinate";
+export const SLEEP_GUARD_README = "launchd/cmux-caffeinate/README.md";
 
 /** Result of a single best-effort `brew <args>` invocation. */
 export interface BrewResult {
@@ -40,6 +42,19 @@ export interface BrewResult {
 
 /** Runs `brew <args>`; never throws — failures are reported in the result. */
 export type BrewRunner = (args: string[]) => Promise<BrewResult>;
+
+export interface CommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  notFound?: boolean;
+}
+
+/** Runs `pmset -g assertions`; never throws — failures are reported in the result. */
+export type PmsetRunner = () => Promise<CommandResult>;
+
+/** Runs `launchctl print gui/<uid>/com.golems.cmux-caffeinate`; never throws. */
+export type LaunchctlRunner = () => Promise<CommandResult>;
 
 export interface DoctorReport {
   /** Overall health. brew/tap gaps do NOT make the doctor unhealthy. */
@@ -58,6 +73,13 @@ export interface DoctorReport {
   };
   /** CMUX_SOCKET_PATH pin (auto-discover when unset). */
   socketPath: { set: boolean; value: string | null; note: string };
+  /** Durable sleep-survival guard: pmset assertion plus launchd KeepAlive job. */
+  sleepGuard: {
+    systemSleepPrevented: boolean;
+    keepAliveLoaded: boolean;
+    durable: boolean;
+    note: string;
+  };
 }
 
 export interface RunDoctorOptions {
@@ -67,6 +89,10 @@ export interface RunDoctorOptions {
   env?: NodeJS.ProcessEnv;
   /** Injectable brew runner; defaults to the real `brew` via execFile. */
   brew?: BrewRunner;
+  /** Injectable pmset runner; defaults to the real `pmset -g assertions`. */
+  pmset?: PmsetRunner;
+  /** Injectable launchctl runner; defaults to the real launchd service probe. */
+  launchctl?: LaunchctlRunner;
 }
 
 /**
@@ -86,6 +112,61 @@ export const realBrewRunner: BrewRunner = async (args) => {
       },
       timeout: 20_000,
     });
+    return { ok: true, stdout: stdout ?? "", stderr: stderr ?? "" };
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+    };
+    if (e.code === "ENOENT") {
+      return { ok: false, stdout: "", stderr: "", notFound: true };
+    }
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr:
+        e.stderr ?? (error instanceof Error ? error.message : String(error)),
+    };
+  }
+};
+
+export const realPmsetRunner: PmsetRunner = async () => {
+  try {
+    const { stdout, stderr } = await execFileAsync("pmset", ["-g", "assertions"], {
+      timeout: 10_000,
+    });
+    return { ok: true, stdout: stdout ?? "", stderr: stderr ?? "" };
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+    };
+    if (e.code === "ENOENT") {
+      return { ok: false, stdout: "", stderr: "", notFound: true };
+    }
+    return {
+      ok: false,
+      stdout: e.stdout ?? "",
+      stderr:
+        e.stderr ?? (error instanceof Error ? error.message : String(error)),
+    };
+  }
+};
+
+function currentUid(): string {
+  if (typeof process.getuid === "function") {
+    return String(process.getuid());
+  }
+  return process.env.UID ?? "501";
+}
+
+export const realLaunchctlRunner: LaunchctlRunner = async () => {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "launchctl",
+      ["print", `gui/${currentUid()}/${SLEEP_GUARD_LABEL}`],
+      { timeout: 10_000 },
+    );
     return { ok: true, stdout: stdout ?? "", stderr: stderr ?? "" };
   } catch (error) {
     const e = error as NodeJS.ErrnoException & {
@@ -136,9 +217,43 @@ async function checkTap(brew: BrewRunner): Promise<DoctorReport["tap"]> {
   };
 }
 
+export function parseSystemSleepPrevented(
+  pmsetAssertionsStdout: string,
+): boolean {
+  return pmsetAssertionsStdout.split("\n").some((line) => {
+    const match = line.match(/^\s*PreventUserIdleSystemSleep\s+([01])\s*$/);
+    return match?.[1] === "1";
+  });
+}
+
+async function checkSleepGuard(
+  pmset: PmsetRunner,
+  launchctl: LaunchctlRunner,
+): Promise<DoctorReport["sleepGuard"]> {
+  const pmsetResult = await pmset();
+  const launchctlResult = await launchctl();
+
+  const systemSleepPrevented = pmsetResult.ok
+    ? parseSystemSleepPrevented(pmsetResult.stdout)
+    : false;
+  const keepAliveLoaded = launchctlResult.ok;
+  const durable = systemSleepPrevented && keepAliveLoaded;
+
+  return {
+    systemSleepPrevented,
+    keepAliveLoaded,
+    durable,
+    note: durable
+      ? "durable: pmset assertion active and launchd KeepAlive guard loaded"
+      : `not durable; install ${SLEEP_GUARD_README}`,
+  };
+}
+
 export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
   const env = opts.env ?? process.env;
   const brew = opts.brew ?? realBrewRunner;
+  const pmset = opts.pmset ?? realPmsetRunner;
+  const launchctl = opts.launchctl ?? realLaunchctlRunner;
 
   const versionOk = opts.version !== "unknown" && opts.version.length > 0;
 
@@ -146,6 +261,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
   const socketSet = typeof socketRaw === "string" && socketRaw.length > 0;
 
   const tap = await checkTap(brew);
+  const sleepGuard = await checkSleepGuard(pmset, launchctl);
 
   // Health: only the version must resolve. Brew/tap gaps are reported but, per
   // the standard's "brew best-effort" rule, must NOT make the doctor unhealthy
@@ -167,6 +283,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     socketPath: socketSet
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
       : { set: false, value: null, note: "unset (auto-discover)" },
+    sleepGuard,
   };
 }
 
@@ -213,6 +330,10 @@ export function renderDoctorText(report: DoctorReport): string {
     `│ — CMUX_SOCKET_PATH: ${
       report.socketPath.set ? report.socketPath.value : report.socketPath.note
     }`,
+  );
+
+  lines.push(
+    `│ ${mark(report.sleepGuard.durable)} sleep guard: ${report.sleepGuard.note}`,
   );
 
   lines.push("└─");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  parseSystemSleepPrevented,
   runDoctor,
   renderDoctorText,
   renderDoctorJson,
@@ -36,6 +37,27 @@ function makeBrew(opts: {
     return { ok: true, stdout: "", stderr: "" };
   };
 }
+
+const PMSET_RED_FIXTURE = `
+Assertion status system-wide:
+   BackgroundTask                 0
+   ApplePushServiceTask           0
+   UserIsActive                   1
+   PreventUserIdleDisplaySleep    1
+   PreventSystemSleep             1
+   PreventUserIdleSystemSleep     0
+`;
+
+const PMSET_GREEN_FIXTURE = `
+Assertion status system-wide:
+   BackgroundTask                 0
+   ApplePushServiceTask           0
+   UserIsActive                   1
+   PreventUserIdleDisplaySleep    1
+   PreventSystemSleep             1
+   PreventUserIdleSystemSleep     1
+   pid 17232(caffeinate): [0x0000000100008001] 00:04:14 PreventUserIdleSystemSleep named: "caffeinate command-line tool"
+`;
 
 describe("runDoctor — report shape", () => {
   it("reports the version when it resolves", async () => {
@@ -145,6 +167,65 @@ describe("runDoctor — report shape", () => {
     });
     expect(report.healthy).toBe(true);
   });
+
+  it("reports sleep guard as non-durable without pmset assertion and launchd guard", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ tapList: "etanhey/layers\n" }),
+      pmset: async () => ({ ok: true, stdout: PMSET_RED_FIXTURE, stderr: "" }),
+      launchctl: async () => ({
+        ok: false,
+        stdout: "",
+        stderr: "service not found",
+        notFound: true,
+      }),
+    });
+
+    expect(report.sleepGuard.systemSleepPrevented).toBe(false);
+    expect(report.sleepGuard.keepAliveLoaded).toBe(false);
+    expect(report.sleepGuard.durable).toBe(false);
+    expect(report.sleepGuard.note).toMatch(/launchd\/cmux-caffeinate\/README\.md/);
+    expect(report.healthy).toBe(true);
+  });
+
+  it("reports sleep guard as durable when pmset assertion is active and launchd guard is loaded", async () => {
+    const report = await runDoctor({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ tapList: "etanhey/layers\n" }),
+      pmset: async () => ({ ok: true, stdout: PMSET_GREEN_FIXTURE, stderr: "" }),
+      launchctl: async () => ({
+        ok: true,
+        stdout: "gui/501/com.golems.cmux-caffeinate = {\n  active count = 1\n}",
+        stderr: "",
+      }),
+    });
+
+    expect(report.sleepGuard.systemSleepPrevented).toBe(true);
+    expect(report.sleepGuard.keepAliveLoaded).toBe(true);
+    expect(report.sleepGuard.durable).toBe(true);
+    expect(report.sleepGuard.note).toMatch(/durable/i);
+    expect(report.healthy).toBe(true);
+  });
+});
+
+describe("parseSystemSleepPrevented", () => {
+  it("returns false when the aggregate PreventUserIdleSystemSleep line is 0", () => {
+    expect(parseSystemSleepPrevented(PMSET_RED_FIXTURE)).toBe(false);
+  });
+
+  it("returns true when the aggregate PreventUserIdleSystemSleep line is 1", () => {
+    expect(parseSystemSleepPrevented(PMSET_GREEN_FIXTURE)).toBe(true);
+  });
+
+  it("ignores caffeinate pid lines without the aggregate assertion line", () => {
+    expect(
+      parseSystemSleepPrevented(
+        'pid 17232(caffeinate): [0x...] 00:04:14 PreventUserIdleSystemSleep named: "caffeinate command-line tool"',
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("renderDoctorText", () => {
@@ -167,6 +248,12 @@ describe("renderDoctorText", () => {
         note: "tap CASKS need `brew trust etanhey/layers`; cmuxlayer is a formula, not gated",
       },
       socketPath: { set: false, value: null, note: "unset (auto-discover)" },
+      sleepGuard: {
+        systemSleepPrevented: false,
+        keepAliveLoaded: false,
+        durable: false,
+        note: "not durable; install launchd/cmux-caffeinate/README.md",
+      },
     };
   }
 
@@ -196,6 +283,12 @@ describe("renderDoctorText", () => {
     expect(text).toMatch(/CMUX_SOCKET_PATH/);
     expect(text).toMatch(/unset \(auto-discover\)/i);
   });
+
+  it("prints sleep guard status and install hint when not durable", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/sleep guard/i);
+    expect(text).toMatch(/launchd\/cmux-caffeinate\/README\.md/);
+  });
 });
 
 describe("renderDoctorJson", () => {
@@ -218,6 +311,12 @@ describe("renderDoctorJson", () => {
         note: "ok",
       },
       socketPath: { set: true, value: "/tmp/x.sock", note: "set" },
+      sleepGuard: {
+        systemSleepPrevented: true,
+        keepAliveLoaded: true,
+        durable: true,
+        note: "durable",
+      },
     };
     const json = renderDoctorJson(report);
     const parsed = JSON.parse(json) as DoctorReport;
@@ -228,5 +327,6 @@ describe("renderDoctorJson", () => {
     expect(parsed.tap.tapPresent).toBe(true);
     expect(parsed.socketPath.set).toBe(true);
     expect(parsed.socketPath.value).toBe("/tmp/x.sock");
+    expect(parsed.sleepGuard.durable).toBe(true);
   });
 });


### PR DESCRIPTION
## Durable sleep-survival guard — prevents the screen-sleep cmux crash

The cmux fleet died when the Mac slept and cmux quit (the crash this session was resumed from). The prior mitigation was a transient `caffeinate -i -t 300` that lapsed after 5 minutes and didn't survive process failure.

**Durable guard:** `launchd/cmux-caffeinate/` runs `caffeinate -dis` (display + idle + system sleep) under a KeepAlive launchd job that restarts it if it exits. Install is intentionally **out-of-band + human-gated** — never bootstrapped from tests, releases, or automation while the fleet is live.

**`cmuxlayer doctor` integration:** reports a sleep-guard line. Durable requires BOTH:
- `pmset -g assertions` shows `PreventUserIdleSystemSleep=1`, AND
- launchd has `gui/$UID/com.golems.cmux-caffeinate` loaded.

Injectable `PmsetRunner`/`LaunchctlRunner` (never-throw, matching the existing `BrewRunner` pattern). The sleep guard does NOT gate doctor health (best-effort, consistent with brew/tap). When either side is missing, doctor stays healthy and prints the install hint.

## Provenance
Rescued from `.worktrees/gen18-cmux-sleep-guard` — complete, green, well-architected work left **uncommitted** when the screen-sleep crash interrupted its author (the very failure this guard prevents). Rebased onto current main; the author's `server.test.ts` flaky-isolation change was dropped as redundant (the identical fix already landed in #179).

## Verification
- vitest **56 files / 904 tests** green (898 + 6 new sleep-guard tests); `tsc --noEmit` clean.
- caffeinate shell tests **4/4** green.

## Install (operator, after merge)
```
launchctl bootstrap gui/$UID ~/Gits/cmuxlayer/launchd/cmux-caffeinate/launchd/com.golems.cmux-caffeinate.plist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-only launchd install and best-effort doctor reporting; no changes to MCP runtime, auth, or agent orchestration.
> 
> **Overview**
> Adds a **launchd-backed sleep guard** so the cmux fleet is less likely to die when the Mac sleeps, replacing short-lived `caffeinate -t` assertions. New **`launchd/cmux-caffeinate/`** runs `bin/cmux-caffeinate.sh` under **`KeepAlive`** with default **`caffeinate -dis`**, optional **`CMUX_CAFFEINATE_FLAGS`**, logging, and docs that install is **manual `launchctl bootstrap`** only (not tests/releases).
> 
> **`cmuxlayer doctor`** gains a **sleep guard** line: durable only when aggregate **`PreventUserIdleSystemSleep`** from **`pmset -g assertions`** is `1` **and** **`com.golems.cmux-caffeinate`** is loaded in launchd. Injectable **`pmset`/`launchctl`** runners mirror brew; missing guard does **not** fail doctor health but points at **`launchd/cmux-caffeinate/README.md`**.
> 
> **CLAUDE.md** and **`docs/sleep-survival.md`** document the invariant. Vitest and shell tests cover parsing, report/render output, and the wrapper script/plist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb4142e62dfd21d7e3a239416588b4c3590c3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add durable sleep-survival guard via launchd `cmux-caffeinate` job and doctor check
> - Adds a launchd job ([com.golems.cmux-caffeinate.plist](https://github.com/EtanHey/cmuxlayer/pull/180/files#diff-f2d333a774146f39b7e7b061e4884dd86c545731cef237f6f838b73dfd0c61db)) that runs [cmux-caffeinate.sh](https://github.com/EtanHey/cmuxlayer/pull/180/files#diff-d815502cdb187c826e90813127da0435b728d54f9f735056f3bbcbe60acd85e8) with `caffeinate -dis` to prevent system/display/idle sleep, kept alive automatically by launchd.
> - Extends `runDoctor` in [src/doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/180/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068) with a `checkSleepGuard` function that queries `pmset -g assertions` and `launchctl print` to report whether the guard is loaded and whether `PreventUserIdleSystemSleep` is active.
> - The `renderDoctorText` renderer now outputs a `sleep guard` status line showing durability and an install hint if the launchd job is absent.
> - Adds shell tests for the caffeinate script and plist in [launchd/cmux-caffeinate/tests/](https://github.com/EtanHey/cmuxlayer/pull/180/files#diff-4500896d005279a45628d82e618b6794136e9b1904516fab79d9a629b891508a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fb4142.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->