### PR TITLE
fix(ram-watchdog): KILL THE KILL — never SIGKILL cmux on a memory breach (warn-only)

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -6,10 +6,8 @@ CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB="${CMUX_MEM_WATCHDOG_COMPRESSOR_THRESH
 CMUX_MEM_WATCHDOG_LOG_DIR="${CMUX_MEM_WATCHDOG_LOG_DIR:-$HOME/Library/Logs/cmux-watchdog}"
 CMUX_MEM_WATCHDOG_NOTIFY_URL="${CMUX_MEM_WATCHDOG_NOTIFY_URL:-http://localhost:3847/notify}"
 CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="${CMUX_MEM_WATCHDOG_BRAINBAR_SOCK:-/tmp/brainbar.sock}"
-CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS="${CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS:-10}"
 CMUX_MEM_WATCHDOG_SOURCE="${CMUX_MEM_WATCHDOG_SOURCE:-alerts}"
 CMUX_MEM_WATCHDOG_PRIORITY="${CMUX_MEM_WATCHDOG_PRIORITY:-high}"
-CMUX_MEM_WATCHDOG_KILL_BIN="${CMUX_MEM_WATCHDOG_KILL_BIN:-kill}"
 CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT="${CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT:-5}"
 
 log() {
@@ -312,7 +310,7 @@ notify_breach() {
 
   jq -cn \
     --arg title "cmux watchdog" \
-    --arg body "cmux hit $cmux_footprint_gb GB phys_footprint / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Terminating." \
+    --arg body "cmux hit $cmux_footprint_gb GB phys_footprint / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Warning only; cmux was not terminated." \
     --arg source "$CMUX_MEM_WATCHDOG_SOURCE" \
     --arg priority "$CMUX_MEM_WATCHDOG_PRIORITY" \
     '{title:$title,body:$body,source:$source,priority:$priority}' \
@@ -325,15 +323,6 @@ notify_breach() {
           log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL"
         fi
       }
-}
-
-terminate_cmux() {
-  local pid="$1"
-  "$CMUX_MEM_WATCHDOG_KILL_BIN" -TERM "$pid" || true
-  sleep "$CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS"
-  if "$CMUX_MEM_WATCHDOG_KILL_BIN" -0 "$pid" 2>/dev/null; then
-    "$CMUX_MEM_WATCHDOG_KILL_BIN" -KILL "$pid" || true
-  fi
 }
 
 handle_breach() {
@@ -351,7 +340,7 @@ handle_breach() {
   processes="$(top_rss_offenders | tr '\n' ';' | sed 's/;$/\n/' || true)"
   brain_store_breach "$pid" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot" "$processes" "$tripped"
   notify_breach "$pid" "$tripped" "$cmux_footprint_bytes" "$vmstat_compressor_bytes_value" "$snapshot"
-  terminate_cmux "$pid"
+  log "cmux process $pid left running after memory breach (warn-only default)"
 }
 
 run_once() {

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -24,10 +24,23 @@ assert_file_not_contains() {
   fi
 }
 
+assert_file_missing_or_empty() {
+  local file="$1"
+  if [[ -f "$file" && -s "$file" ]]; then
+    fail "expected $file to be missing or empty"
+  fi
+}
+
 assert_eq() {
   local expected="$1"
   local actual="$2"
   [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+stop_brainbar_socket() {
+  local pid="$1"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
 }
 
 seed_fake_commands() {
@@ -185,11 +198,18 @@ run_case() {
   local pgrep_cmux="$6"
   local pgrep_pids="$7"
 
-  local root_dir log_dir snapshot
+  local root_dir log_dir snapshot brainbar_sock brainbar_pid
   root_dir="$(mktemp -d)"
   log_dir="$root_dir/logs"
   mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
   seed_fake_commands "$root_dir" "$log_dir"
+  brainbar_sock="$root_dir/brainbar.sock"
+  /usr/bin/nc -Ul "$brainbar_sock" >/dev/null &
+  brainbar_pid="$!"
+  for _ in 1 2 3 4 5; do
+    [[ -S "$brainbar_sock" ]] && break
+    sleep 0.1
+  done
 
   printf '%s' "$footprint_fixture" >"$root_dir/fixtures/footprint.fixture"
   printf '%s' "$vmstat_fixture" >"$root_dir/fixtures/vmstat.fixture"
@@ -198,6 +218,7 @@ run_case() {
   export CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB=5
   export CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB=12
   export CMUX_MEM_WATCHDOG_LOG_DIR="$log_dir"
+  export CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="$brainbar_sock"
   export CMUX_MEM_WATCHDOG_KILL_BIN="$root_dir/bin/kill"
   export CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
   export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
@@ -207,12 +228,13 @@ run_case() {
 
   # shellcheck disable=SC1090
   source "$SCRIPT_PATH"
-  run_once
+  run_once 2>"$log_dir/stderr.log"
 
   if [[ "$expect_breach" == "1" ]]; then
     assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
-    assert_file_contains "$log_dir/kill.log" "-TERM 4242"
-    assert_file_contains "$log_dir/kill.log" "-KILL 4242"
+    assert_file_contains "$log_dir/socat.log" "UNIX-CONNECT:$brainbar_sock"
+    assert_file_contains "$log_dir/stderr.log" "breached memory thresholds"
+    assert_file_missing_or_empty "$log_dir/kill.log"
     snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
     if [[ -n "$expected_signals" ]]; then
       assert_file_contains "$snapshot" "breached_signals=$expected_signals"
@@ -223,6 +245,7 @@ run_case() {
   fi
 
   printf 'PASS: %s\n' "$name"
+  stop_brainbar_socket "$brainbar_pid"
   rm -rf "$root_dir"
 }
 
@@ -401,11 +424,18 @@ run_matcher_coverage() {
 run_matcher_coverage
 
 run_ps_fallback_case() {
-  local root_dir log_dir snapshot
+  local root_dir log_dir snapshot brainbar_sock brainbar_pid
   root_dir="$(mktemp -d)"
   log_dir="$root_dir/logs"
   mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
   seed_ps_fallback_commands "$root_dir" "$log_dir"
+  brainbar_sock="$root_dir/brainbar.sock"
+  /usr/bin/nc -Ul "$brainbar_sock" >/dev/null &
+  brainbar_pid="$!"
+  for _ in 1 2 3 4 5; do
+    [[ -S "$brainbar_sock" ]] && break
+    sleep 0.1
+  done
 
   cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
 4242 phys_footprint: 6 GB (peak 8 GB)
@@ -419,6 +449,7 @@ EOF
   export CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB=5
   export CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB=12
   export CMUX_MEM_WATCHDOG_LOG_DIR="$log_dir"
+  export CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="$brainbar_sock"
   export CMUX_MEM_WATCHDOG_KILL_BIN="$root_dir/bin/kill"
   export CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
   export CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
@@ -428,11 +459,13 @@ EOF
   source "$SCRIPT_PATH"
   run_once
 
-  assert_file_contains "$log_dir/kill.log" "-TERM 4242"
+  assert_file_missing_or_empty "$log_dir/kill.log"
+  assert_file_contains "$log_dir/socat.log" "UNIX-CONNECT:$brainbar_sock"
   snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
   assert_file_contains "$snapshot" "breached_signals=footprint"
 
   printf 'PASS: watchdog falls back to ps command discovery when pgrep misses GUI apps\n'
+  stop_brainbar_socket "$brainbar_pid"
   rm -rf "$root_dir"
 }
 
@@ -475,6 +508,7 @@ EOF
   source "$SCRIPT_PATH"
   run_once
 
+  assert_file_missing_or_empty "$log_dir/kill.log"
   snapshot="$(find "$log_dir" -maxdepth 1 -type f -name '20*.log' | head -n 1)"
   assert_file_contains "$snapshot" "[top_rss_offenders]"
   assert_file_contains "$snapshot" "command=python3.11"


### PR DESCRIPTION
## The fleet-killer: the watchdog SIGKILLed cmux on breach

`launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh` `handle_breach()` called `terminate_cmux()`, which sent `kill -TERM` then `kill -KILL` to the **cmux pid** on ANY breach (footprint ≥5GB OR compressor ≥12GB). That killed cmux — and every agent in the fleet running inside it — for merely being high. This is the regression that took the fleet down.

## Directive — "KILL THE KILL"
The watchdog must **NEVER** kill cmux for being merely high. Agents-keep-working >> RAM-reclaim; a manual Mac restart beats a needless fleet-kill.

## Fix (warn-only)
- Removed the `terminate_cmux` function entirely (no kill path at all), plus its now-dead `CMUX_MEM_WATCHDOG_KILL_BIN` / `CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS` env.
- `handle_breach` now: log → top-RSS offender snapshot → BrainLayer store → notify → log "cmux left running (warn-only default)". cmux survives.
- Notify body: "Terminating." → "Warning only; cmux was not terminated."

## Gate (RED→GREEN)
The harness stubs the kill binary to write to `kill.log`. RED captured the old killer (`-TERM <pid>` written on breach). GREEN: with default config a breach writes **no** `kill.log` (asserted missing/empty + contains no `-TERM`) while notify + BrainLayer store + snapshots still fire.

## Verification
Watchdog suite **11/11**, sampler suite **12/12** green. (Shell scripts; ships via launchd, re-armed post-merge.)

## Method
Codex implemented (xhigh); cmuxLayerClaude (Opus) scoped the kill flow, reviewed the surgical diff (no leftover kill refs / dead env), and ran both harnesses independently. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launchd watchdog behavior on high memory: cmux and in-process agents no longer get auto-killed, so sustained pressure may persist until manual intervention instead of a forced restart.
> 
> **Overview**
> **Stops the memory watchdog from killing cmux** when footprint or compressor thresholds trip. The **`terminate_cmux`** path (TERM → grace → KILL) is removed, along with **`CMUX_MEM_WATCHDOG_KILL_BIN`** and **`CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS`**.
> 
> On breach, **`handle_breach`** still snapshots, records top RSS offenders, posts to BrainLayer, and sends notify—but ends with a log that cmux was **left running (warn-only)**. The notify body now says **warning only; cmux was not terminated** instead of implying termination.
> 
> **Tests** spin up a fake BrainBar socket, assert **`socat`** / notify / breach logging on breach, and require **`kill.log`** to stay **missing or empty** (replacing expectations for `-TERM`/`-KILL`). A helper asserts empty kill logs across breach scenarios including ps-fallback and top-RSS snapshot cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cce3c33fbabb72578ed14094a95c8d40fdf053b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove SIGTERM/SIGKILL behavior from cmux memory watchdog (warn-only)
> - Removes `terminate_cmux` from [cmux-memory-watchdog.sh](https://github.com/EtanHey/cmuxlayer/pull/181/files#diff-e67359a7bbbc7ad3ee4d8d37b25d23790c5567c97896c5fc3f9159f9ce0ac2ef), which previously sent SIGTERM then SIGKILL after a configurable grace period.
> - On breach, the watchdog now logs that cmux remains running and sends a notification stating "Warning only; cmux was not terminated."
> - Tests in [cmux-memory-watchdog.sh](https://github.com/EtanHey/cmuxlayer/pull/181/files#diff-da57b6fd4035e035947b69f57112359f90a86a1a770d0c3c11b0ee78030ab357) are updated to assert `kill.log` is missing or empty and that the brainbar socket receives a connection on breach.
> - Behavioral Change: memory threshold breaches no longer cause cmux to be terminated under any circumstance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cce3c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory watchdog now operates in warning-only mode, leaving the process running when memory breaches occur instead of terminating it
  * Updated notification messages to reflect this new behavior
  * Simplified default configuration

* **Tests**
  * Enhanced test harness for improved socket lifecycle management and breach scenario validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->