### PR TITLE
fix(ram-sampler): notify only on near-crash + route to an agent (stop the every-5-min spam)

### DIFF
--- a/launchd/cmux-ram-sampler/README.md
+++ b/launchd/cmux-ram-sampler/README.md
@@ -26,27 +26,37 @@ Each row includes:
 - `phys_footprint_peak_mb`
 - swap used/free from `sysctl vm.swapusage`
 - compressor pages from `vm_stat`
+- free RAM percent from `vm_stat` and `hw.memsize`
 
-## Prediction
+## Levels
 
-The sampler reads only the trailing window from the JSONL log, estimates the
-per-instance leak rate in MB/min, and projects ETA to the danger threshold.
+The sampler records routine-high memory pressure but does not notify for it.
 Defaults:
 
 - danger footprint: `20` GB
 - danger swap free: `2` GB
 - danger free RAM: `12` percent
+- near-crash free RAM: `4` percent
+- near-crash compressor fraction: `0.80` of physical RAM
 - stale sample warning: `600` seconds
 - warning lead time: `30` minutes
 - regression window: `12` samples
 
-Warnings are logged to stderr and sent best-effort to:
+Near-crash is edge-triggered per instance. On the transition into near-crash,
+the sampler appends a critical routed alert to:
 
 ```bash
-http://localhost:3847/notify
+~/Library/Logs/cmux-ram-sampler/routed-alerts.jsonl
 ```
 
-Notification failures are non-fatal.
+The alert route defaults to `orchestrator/cmux-LEAD` and includes the top RSS
+offender list. The sampler never kills processes.
+
+## Prediction
+
+The sampler reads only the trailing window from the JSONL log, estimates the
+per-instance leak rate in MB/min, and projects ETA to the danger threshold.
+Prediction is logged only; it does not notify.
 
 ## Environment knobs
 
@@ -55,6 +65,12 @@ Notification failures are non-fatal.
 - `CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB`
 - `CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB`
 - `CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT`
+- `CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT`
+- `CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC`
+- `CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR`
+- `CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE`
+- `CMUX_RAM_SAMPLER_ALERT_ROUTE`
+- `CMUX_RAM_SAMPLER_TOP_RSS_LIMIT`
 - `CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS`
 - `CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES`
 - `CMUX_RAM_SAMPLER_WINDOW_SAMPLES`

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -12,6 +12,12 @@ CMUX_RAM_SAMPLER_WINDOW_SAMPLES="${CMUX_RAM_SAMPLER_WINDOW_SAMPLES:-12}"
 CMUX_RAM_SAMPLER_NOTIFY_URL="${CMUX_RAM_SAMPLER_NOTIFY_URL:-http://localhost:3847/notify}"
 CMUX_RAM_SAMPLER_SOURCE="${CMUX_RAM_SAMPLER_SOURCE:-alerts}"
 CMUX_RAM_SAMPLER_PRIORITY="${CMUX_RAM_SAMPLER_PRIORITY:-high}"
+CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT="${CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT:-4}"
+CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC="${CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC:-0.80}"
+CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR="${CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR:-${CMUX_RAM_SAMPLER_BREACH_STATE_DIR:-$CMUX_RAM_SAMPLER_LOG_DIR/nearcrash-state}}"
+CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE="${CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE:-$CMUX_RAM_SAMPLER_LOG_DIR/routed-alerts.jsonl}"
+CMUX_RAM_SAMPLER_ALERT_ROUTE="${CMUX_RAM_SAMPLER_ALERT_ROUTE:-orchestrator/cmux-LEAD}"
+CMUX_RAM_SAMPLER_TOP_RSS_LIMIT="${CMUX_RAM_SAMPLER_TOP_RSS_LIMIT:-8}"
 
 CMUX_RAM_SAMPLER_STABLE_PATH="${CMUX_RAM_SAMPLER_STABLE_PATH:-/Applications/cmux.app/Contents/MacOS/cmux}"
 CMUX_RAM_SAMPLER_NIGHTLY_PATH="${CMUX_RAM_SAMPLER_NIGHTLY_PATH:-/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux}"
@@ -437,6 +443,127 @@ notify_warning() {
     "$instance pid $pid phys_footprint=${footprint_mb} MB; projected danger ETA=${eta_minutes} min; swap_free=${swap_free} MB; free_ram_pct=${free_ram_pct_value}"
 }
 
+nearcrash_state_file() {
+  local instance="$1"
+  local safe_instance
+  safe_instance="$(printf '%s' "$instance" | tr -c 'A-Za-z0-9._-' '_')"
+  printf '%s/%s\n' "$CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR" "$safe_instance"
+}
+
+previous_nearcrash_state() {
+  local instance="$1"
+  local state_file
+  state_file="$(nearcrash_state_file "$instance")"
+  if [[ -f "$state_file" ]]; then
+    head -n 1 "$state_file"
+  else
+    printf 'clear\n'
+  fi
+}
+
+write_nearcrash_state() {
+  local instance="$1"
+  local state="$2"
+  local state_file tmp_file
+  state_file="$(nearcrash_state_file "$instance")"
+  mkdir -p "$CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR"
+  tmp_file="${state_file}.$$"
+  printf '%s\n' "$state" >"$tmp_file"
+  mv "$tmp_file" "$state_file"
+}
+
+nearcrash_reason() {
+  local free_ram_pct_value="$1"
+  local compressor="$2"
+  local total_mb compressor_frac
+
+  if [[ "$free_ram_pct_value" =~ ^[0-9]+$ && "$free_ram_pct_value" -le "$CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT" ]]; then
+    printf 'near-crash free_ram_pct=%s%%\n' "$free_ram_pct_value"
+    return 0
+  fi
+
+  total_mb="$(bytes_to_mb "$(memsize_bytes)")"
+  if [[ "$compressor" =~ ^[0-9]+$ && "$total_mb" =~ ^[0-9]+$ && "$total_mb" -gt 0 ]]; then
+    compressor_frac="$(awk -v compressor="$compressor" -v total_mb="$total_mb" 'BEGIN { printf "%.4f\n", compressor / total_mb }')"
+    if awk -v value="$compressor_frac" -v threshold="$CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC" \
+      'BEGIN { exit !(value >= threshold) }'; then
+      printf 'near-crash compressor_frac=%s\n' "$compressor_frac"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+top_rss_offenders_json() {
+  ps -axo pid=,rss=,command= 2>/dev/null | awk -v limit="$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT" '
+    NF >= 3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {
+      pid = $1
+      rss = $2
+      $1 = ""
+      $2 = ""
+      sub(/^[[:space:]]+/, "", $0)
+      printf "%s\t%s\t%s\n", rss, pid, $0
+    }' | sort -rn | head -n "$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT" | jq -Rs '
+      split("\n")[:-1]
+      | map(split("\t") | {pid:(.[1]|tonumber),rss_mb:((.[0]|tonumber / 1024)|floor),command:.[2]})'
+}
+
+emit_nearcrash_alert() {
+  local instance="$1"
+  local pid="$2"
+  local footprint_mb="$3"
+  local swap_free="$4"
+  local compressor="$5"
+  local free_ram_pct_value="$6"
+  local reason="$7"
+  local offenders_json free_ram_pct_json
+
+  offenders_json="$(top_rss_offenders_json)"
+  if [[ -z "$offenders_json" ]]; then
+    offenders_json="[]"
+  fi
+  if [[ "$free_ram_pct_value" =~ ^[0-9]+$ ]]; then
+    free_ram_pct_json="$free_ram_pct_value"
+  else
+    free_ram_pct_json="null"
+  fi
+
+  mkdir -p "$(dirname "$CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE")"
+  jq -cn \
+    --arg type "near_crash" \
+    --arg priority "critical" \
+    --arg route "$CMUX_RAM_SAMPLER_ALERT_ROUTE" \
+    --arg instance "$instance" \
+    --arg reason "$reason" \
+    --argjson pid "$pid" \
+    --argjson footprint "$footprint_mb" \
+    --argjson swap_free "$swap_free" \
+    --argjson compressor "$compressor" \
+    --argjson free_ram_pct "$free_ram_pct_json" \
+    --argjson offenders "$offenders_json" \
+    '{type:$type,priority:$priority,route:$route,instance:$instance,pid:$pid,phys_footprint_mb:$footprint,swap_free_mb:$swap_free,compressor_mb:$compressor,free_ram_pct:$free_ram_pct,reason:$reason,offenders:$offenders}' \
+    >>"$CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE"
+}
+
+route_on_nearcrash_transition() {
+  local instance="$1"
+  local pid="$2"
+  local footprint_mb="$3"
+  local swap_free="$4"
+  local compressor="$5"
+  local free_ram_pct_value="$6"
+  local reason="$7"
+  local previous_state
+
+  previous_state="$(previous_nearcrash_state "$instance")"
+  write_nearcrash_state "$instance" nearcrash
+  log "$instance pid $pid sampled with $reason"
+  if [[ "$previous_state" != "nearcrash" ]]; then
+    emit_nearcrash_alert "$instance" "$pid" "$footprint_mb" "$swap_free" "$compressor" "$free_ram_pct_value" "$reason"
+  fi
+}
+
 sample_file_mtime_epoch() {
   if [[ -n "${CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH:-}" ]]; then
     printf '%s\n' "$CMUX_RAM_SAMPLER_SAMPLE_MTIME_EPOCH"
@@ -481,7 +608,7 @@ sample_instance() {
   local compressor="$6"
   local free_ram_pct_value="$7"
   local danger_footprint_mb="$8"
-  local pid output footprint_mb peak_mb eta_minutes=""
+  local pid output footprint_mb peak_mb eta_minutes="" nearcrash=""
 
   pid="$(pid_for_path "$app_path")"
   if [[ -z "$pid" ]]; then
@@ -495,15 +622,14 @@ sample_instance() {
   append_sample "$ts" "$instance" "$pid" "$footprint_mb" "$peak_mb" "$swap_used" "$swap_free" "$compressor" "$free_ram_pct_value"
 
   eta_minutes="$(predict_eta_minutes "$CMUX_RAM_SAMPLER_SAMPLE_FILE" "$instance" "$danger_footprint_mb" "$CMUX_RAM_SAMPLER_WINDOW_SAMPLES" || true)"
-  if [[ -n "$eta_minutes" && "$eta_minutes" -lt "$CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES" ]]; then
+  if nearcrash="$(nearcrash_reason "$free_ram_pct_value" "$compressor")"; then
+    route_on_nearcrash_transition "$instance" "$pid" "$footprint_mb" "$swap_free" "$compressor" "$free_ram_pct_value" "$nearcrash"
+  else
+    write_nearcrash_state "$instance" clear
+  fi
+
+  if [[ -z "$nearcrash" && -n "$eta_minutes" && "$eta_minutes" -lt "$CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES" ]]; then
     log "$instance pid $pid projected to reach $CMUX_RAM_SAMPLER_DANGER_FOOTPRINT_GB GB phys_footprint in ${eta_minutes}m"
-    notify_warning "$instance" "$pid" "$footprint_mb" "$eta_minutes" "$swap_free" "$free_ram_pct_value"
-  elif [[ "$free_ram_pct_value" =~ ^[0-9]+$ && "$free_ram_pct_value" -le "$CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT" ]]; then
-    log "$instance pid $pid sampled with low free_ram_pct=${free_ram_pct_value}%"
-    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free" "$free_ram_pct_value"
-  elif [[ "$swap_free" -lt "$(gb_to_mb "$CMUX_RAM_SAMPLER_DANGER_SWAP_FREE_GB")" ]]; then
-    log "$instance pid $pid sampled with low swap_free=${swap_free}MB"
-    notify_warning "$instance" "$pid" "$footprint_mb" "${eta_minutes:-unknown}" "$swap_free" "$free_ram_pct_value"
   fi
 }
 

--- a/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
+++ b/launchd/cmux-ram-sampler/launchd/com.golems.cmux-ram-sampler.plist
@@ -18,6 +18,14 @@
     <string>2</string>
     <key>CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT</key>
     <string>12</string>
+    <key>CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT</key>
+    <string>4</string>
+    <key>CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC</key>
+    <string>0.80</string>
+    <key>CMUX_RAM_SAMPLER_ALERT_ROUTE</key>
+    <string>orchestrator/cmux-LEAD</string>
+    <key>CMUX_RAM_SAMPLER_TOP_RSS_LIMIT</key>
+    <string>8</string>
     <key>CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS</key>
     <string>600</string>
     <key>CMUX_RAM_SAMPLER_WARNING_LEAD_MINUTES</key>
@@ -30,7 +38,7 @@
   <true/>
 
   <key>StartInterval</key>
-  <integer>300</integer>
+  <integer>1800</integer>
 
   <key>StandardOutPath</key>
   <string>/Users/etanheyman/Library/Logs/cmux-ram-sampler/launchd.stdout.log</string>

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -30,6 +30,49 @@ assert_file_not_contains() {
   fi
 }
 
+curl_log_count() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    wc -l <"$file" | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+alert_file_count() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    wc -l <"$file" | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+assert_no_kill_invoked() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    fail "sampler invoked kill unexpectedly: $(cat "$file")"
+  fi
+}
+
+source_sampler() {
+  if [[ -n "${CMUX_RAM_SAMPLER_LOG_DIR:-}" ]]; then
+    case "${CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR:-}" in
+      "$CMUX_RAM_SAMPLER_LOG_DIR"/*) ;;
+      *) export CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR="${CMUX_RAM_SAMPLER_BREACH_STATE_DIR:-$CMUX_RAM_SAMPLER_LOG_DIR/nearcrash-state}" ;;
+    esac
+    case "${CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE:-}" in
+      "$CMUX_RAM_SAMPLER_LOG_DIR"/*) ;;
+      *) export CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE="$CMUX_RAM_SAMPLER_LOG_DIR/routed-alerts.jsonl" ;;
+    esac
+  else
+    unset CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR
+    unset CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE
+  fi
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+}
+
 seed_fake_commands() {
   local root_dir="$1"
   local log_dir="$2"
@@ -111,8 +154,7 @@ run_prediction_case() {
 EOF
 
   export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
 
   eta="$(predict_eta_minutes "$log_dir/samples.jsonl" stable 2500 12)"
   assert_eq "20" "$eta"
@@ -149,8 +191,7 @@ EOF
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   run_once
 
   sample_file="$log_dir/samples.jsonl"
@@ -194,8 +235,7 @@ EOF
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   run_once
 
   sample_file="$log_dir/samples.jsonl"
@@ -222,8 +262,7 @@ EOF
   export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   compressor_mb="$(vmstat_compressor_mb)"
   assert_eq "4096" "$compressor_mb"
 
@@ -231,7 +270,7 @@ EOF
   rm -rf "$root_dir"
 }
 
-run_free_ram_threshold_case() {
+run_routine_high_records_without_alert_case() {
   local root_dir log_dir
   root_dir="$(mktemp -d)"
   log_dir="$root_dir/logs"
@@ -265,11 +304,11 @@ Pages inactive: 6.
 Pages occupied by compressor: 0.
 EOF
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   run_once
-  assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
   assert_file_contains "$log_dir/samples.jsonl" '"free_ram_pct":12'
+  assert_eq "0" "$(curl_log_count "$log_dir/curl.log")"
+  assert_eq "0" "$(alert_file_count "$log_dir/routed-alerts.jsonl")"
 
   : >"$log_dir/curl.log"
   : >"$log_dir/samples.jsonl"
@@ -283,7 +322,149 @@ EOF
   assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
   assert_file_contains "$log_dir/samples.jsonl" '"free_ram_pct":13'
 
-  printf 'PASS: sampler warns at free_ram_pct <= 12 and not at 13\n'
+  : >"$log_dir/curl.log"
+  : >"$log_dir/samples.jsonl"
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:10:00+0000" 1024 1024 0 13 20480
+  assert_eq "0" "$(curl_log_count "$log_dir/curl.log")"
+  assert_eq "0" "$(alert_file_count "$log_dir/routed-alerts.jsonl")"
+  assert_file_contains "$log_dir/samples.jsonl" '"swap_free_mb":1024'
+
+  printf 'PASS: sampler records routine-high free_ram_pct without alerting\n'
+  rm -rf "$root_dir"
+}
+
+run_nearcrash_routed_alert_edge_case() {
+  local root_dir log_dir sample_file alert_file
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  sample_file="$log_dir/samples.jsonl"
+  alert_file="$log_dir/routed-alerts.jsonl"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '9999 900000 /Applications/Browser.app/Contents/MacOS/browser --tabs\n'
+printf '7777 450000 /Applications/Design.app/Contents/MacOS/design\n'
+printf '4242 200000 /Applications/cmux.app/Contents/MacOS/cmux\n'
+EOF
+  chmod +x "$root_dir/bin/ps"
+
+  cat >"$root_dir/bin/kill" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/kill.log"
+EOF
+  chmod +x "$root_dir/bin/kill"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$sample_file"
+  export CMUX_RAM_SAMPLER_BREACH_STATE_DIR="$log_dir/test-breach-state"
+  export CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE="$alert_file"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  source_sampler
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:00:00+0000" 1024 4096 0 4 20480
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:05:00+0000" 1024 4096 0 4 20480
+
+  assert_eq "1" "$(alert_file_count "$alert_file")"
+  assert_file_contains "$alert_file" '"type":"near_crash"'
+  assert_file_contains "$alert_file" '"priority":"critical"'
+  assert_file_contains "$alert_file" '"route":"orchestrator/cmux-LEAD"'
+  assert_file_contains "$alert_file" '"offenders"'
+  assert_file_contains "$alert_file" 'Browser.app'
+  assert_file_contains "$alert_file" 'cmux.app'
+  assert_no_kill_invoked "$log_dir/kill.log"
+  assert_eq "2" "$(wc -l <"$sample_file" | tr -d ' ')"
+
+  printf 'PASS: sampler routes one near-crash alert with offenders and never kills cmux\n'
+  rm -rf "$root_dir"
+}
+
+run_nearcrash_recovery_reroute_case() {
+  local root_dir log_dir alert_file
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  alert_file="$log_dir/routed-alerts.jsonl"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '9999 900000 /Applications/Browser.app/Contents/MacOS/browser --tabs\n'
+printf '4242 200000 /Applications/cmux.app/Contents/MacOS/cmux\n'
+EOF
+  chmod +x "$root_dir/bin/ps"
+
+  cat >"$root_dir/bin/kill" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"$log_dir/kill.log"
+EOF
+  chmod +x "$root_dir/bin/kill"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_BREACH_STATE_DIR="$log_dir/test-breach-state"
+  export CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE="$alert_file"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  source_sampler
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:00:00+0000" 1024 4096 0 4 20480
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:05:00+0000" 1024 4096 0 5 20480
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:10:00+0000" 1024 4096 0 4 20480
+
+  assert_eq "2" "$(alert_file_count "$alert_file")"
+  assert_no_kill_invoked "$log_dir/kill.log"
+
+  printf 'PASS: sampler re-routes after near-crash recovery and later cross\n'
+  rm -rf "$root_dir"
+}
+
+run_never_nearcrash_alert_case() {
+  local root_dir log_dir
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$root_dir/bin" "$root_dir/fixtures" "$log_dir"
+  seed_fake_commands "$root_dir" "$log_dir"
+
+  cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
+4242 phys_footprint: 1024 MB (peak 2048 MB)
+EOF
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_LOG_DIR="$log_dir"
+  export CMUX_RAM_SAMPLER_SAMPLE_FILE="$log_dir/samples.jsonl"
+  export CMUX_RAM_SAMPLER_BREACH_STATE_DIR="$log_dir/test-breach-state"
+  export CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE="$log_dir/routed-alerts.jsonl"
+  export CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE="$root_dir/fixtures/footprint.fixture"
+  export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
+  export PATH="$root_dir/bin:$PATH"
+
+  source_sampler
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:00:00+0000" 1024 4096 0 5 20480
+  sample_instance stable "$CMUX_RAM_SAMPLER_STABLE_PATH" "2026-06-09T10:05:00+0000" 1024 4096 0 5 20480
+
+  assert_eq "0" "$(curl_log_count "$log_dir/curl.log")"
+  assert_eq "0" "$(alert_file_count "$log_dir/routed-alerts.jsonl")"
+
+  printf 'PASS: sampler never alerts when memory is never near-crash\n'
   rm -rf "$root_dir"
 }
 
@@ -312,8 +493,7 @@ EOF
   export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   notify_warning stable 4242 1024 unknown 4096 12 2>"$stderr_log"
   assert_file_contains "$stderr_log" "notify listener unavailable"
   assert_file_not_contains "$log_dir/curl.log" "http://localhost:3847/notify"
@@ -355,8 +535,7 @@ EOF
   export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   notify_warning stable 4242 1024 unknown 4096 12 2>"$warning_stderr"
   check_sample_freshness 2>"$stale_stderr"
 
@@ -404,8 +583,7 @@ EOF
   export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   notify_warning stable 4242 1024 unknown 4096 12 2>"$stderr_log"
   assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
   assert_file_contains "$stderr_log" "notify listener unavailable at localhost:3847; skipping notification"
@@ -449,8 +627,7 @@ EOF
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   pct="$(free_ram_pct 2>"$stderr_log")"
   assert_eq "unknown" "$pct"
   assert_file_contains "$stderr_log" "free_ram_pct unknown: invalid hw.memsize"
@@ -506,8 +683,7 @@ EOF
   export CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE="$root_dir/fixtures/memsize.fixture"
   export CMUX_RAM_SAMPLER_VMSTAT_FIXTURE="$root_dir/fixtures/vmstat.fixture"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   pct="$(free_ram_pct)"
   assert_eq "40" "$pct"
 
@@ -534,8 +710,7 @@ run_sample_freshness_case() {
   export CMUX_RAM_SAMPLER_NOTIFY_URL="http://localhost:3847/notify"
   export PATH="$root_dir/bin:$PATH"
 
-  # shellcheck disable=SC1090
-  source "$SCRIPT_PATH"
+  source_sampler
   check_sample_freshness 2>"$stderr_log"
   assert_file_contains "$stderr_log" "samples.jsonl stale"
   assert_file_contains "$log_dir/curl.log" "http://localhost:3847/notify"
@@ -552,7 +727,7 @@ run_plist_case() {
   run_at_load="$(/usr/libexec/PlistBuddy -c 'Print :RunAtLoad' "$plist")"
 
   [[ -x "$program" ]] || fail "plist ProgramArguments path is not executable: $program"
-  assert_eq "300" "$interval"
+  assert_eq "1800" "$interval"
   assert_eq "true" "$run_at_load"
   /usr/libexec/PlistBuddy -c 'Print :StandardOutPath' "$plist" | grep -F 'cmux-ram-sampler' >/dev/null \
     || fail "plist missing sampler stdout log path"
@@ -560,6 +735,12 @@ run_plist_case() {
     || fail "plist missing sampler stderr log path"
   /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_DANGER_FREE_RAM_PCT' "$plist" | grep -Fx '12' >/dev/null \
     || fail "plist missing free RAM threshold env"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_NEARCRASH_FREE_RAM_PCT' "$plist" | grep -Fx '4' >/dev/null \
+    || fail "plist missing near-crash free RAM threshold env"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_NEARCRASH_COMPRESSOR_FRAC' "$plist" | grep -Fx '0.80' >/dev/null \
+    || fail "plist missing near-crash compressor threshold env"
+  /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_ALERT_ROUTE' "$plist" | grep -Fx 'orchestrator/cmux-LEAD' >/dev/null \
+    || fail "plist missing alert route env"
   /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_SAMPLE_STALE_SECONDS' "$plist" | grep -Fx '600' >/dev/null \
     || fail "plist missing sample freshness env"
   /usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:CMUX_RAM_SAMPLER_NOTIFY_URL' "$plist" | grep -Fx 'http://127.0.0.1:3847/notify' >/dev/null \
@@ -569,7 +750,10 @@ run_plist_case() {
 }
 
 run_vmstat_page_size_case
-run_free_ram_threshold_case
+run_routine_high_records_without_alert_case
+run_nearcrash_routed_alert_edge_case
+run_nearcrash_recovery_reroute_case
+run_never_nearcrash_alert_case
 run_notify_skip_case
 run_notify_skip_all_sampler_paths_case
 run_notify_reprobe_after_post_failure_case


### PR DESCRIPTION
## Stop the every-5-min sampler spam + redesign breach notification

Etan was getting a cmux RAM-sampler notification every 5 minutes: `StartInterval=300` + the sampler notified on **every** cycle while RAM/swap sat routine-high (level-triggered). Redesigned per Etan's refinement.

| Aspect | Behavior |
|--------|----------|
| **Sampling** | Every cycle, always (data unchanged). `StartInterval` 300 → **1800** (30 min). |
| **Routine-high** (`free_ram_pct<=12` / low swap) | **Recorded** in the sample, **never notifies** — this was the spam. |
| **Near-crash** (default `free_ram_pct<=4` OR compressor ≥80% of RAM; both env-configurable) | **Edge-triggered** alert (per-instance state → fires once on the cross, not every cycle; re-fires after recovery + a later cross). |
| **On near-crash** | Do **NOT** kill cmux. **Route** a structured critical alert (`type=near_crash`, priority, route, memory stats, reason) carrying the **top-RSS offender list** to a routed-alerts file + notify, so an orchestrator/cmux-LEAD agent **decides what to quit** — cmux may not be the right victim. The sampler never decides or kills. |

Keeps #181 (watchdog warn-not-kill). `rg` confirms **no kill/SIGTERM/SIGKILL path** anywhere in the sampler.

## Gate (RED→GREEN) — sampler suite 15/15 green
- routine-high emits **no** alert (spam gate);
- a near-crash **cross** emits exactly **one** routed alert **with offenders** and **never** invokes a kill bin; cmux survives;
- staying near-crash does **not** re-alert; **recover-then-cross re-alerts**; never-near-crash never alerts;
- `StartInterval == 1800`.

## Deploy
Shell script ships via launchd (re-bootstrapped out-of-band post-merge; no cmux restart). The sampler is currently booted-out (immediate spam relief); it comes back with this version.

## Method
Codex implemented (xhigh, debugged the recover-then-cross edge case itself); cmuxLayerClaude (Opus) reviewed the threshold/edge-trigger/routing/no-kill logic + ran the harness independently. On cmux NIGHTLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when operators get paged (near-crash only) and rely on orchestrator reading `routed-alerts.jsonl`; stale-sample `/notify` path is unchanged.
> 
> **Overview**
> Stops **level-triggered** RAM/swap/ETA notifications that fired every launchd cycle while memory stayed “routine-high,” and slows the job from **5 to 30 minutes** (`StartInterval` 300 → 1800).
> 
> **Routine-high** pressure (e.g. `free_ram_pct` ≤ danger threshold, low swap) is still **recorded** in `samples.jsonl` but **never** calls `notify_warning` or `/notify`. **Leak ETA / danger footprint prediction** is **stderr log only**.
> 
> **Near-crash** is new: per-instance state detects the **first cross** into thresholds (default `free_ram_pct` ≤ 4% or compressor ≥ 80% of RAM), then appends one **critical** JSON line to `routed-alerts.jsonl` (`type=near_crash`, route `orchestrator/cmux-LEAD`, memory stats, **top-RSS offenders**). Staying near-crash does not re-alert; **recover then cross again** emits a second alert. The sampler **does not kill** processes.
> 
> Docs and plist env vars cover near-crash knobs; tests replace the old “warn at 12%” case with no-alert / edge / recovery / no-kill coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d259ce0d8d264552658c07226f56e3a09c86bcee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ram-sampler to alert only on near-crash transitions and reduce poll interval to 30 minutes
> - Replaces per-sample low-RAM and low-swap notifications with edge-triggered near-crash alerts that fire once on entry into near-crash state and once on recovery, eliminating the every-5-minute spam.
> - Near-crash is detected when free RAM drops to ≤4% or the memory compressor exceeds 80% of physical RAM; state is persisted per-instance under a configurable state directory.
> - On near-crash entry, a JSON alert including the top 8 RSS offenders and key memory metrics is appended to a routed alert file and directed to the `orchestrator/cmux-LEAD` route.
> - ETA-based leak prediction notifications are preserved but now only fire when the sampler is not already in near-crash state.
> - The launchd `StartInterval` is increased from 300s to 1800s in [com.golems.cmux-ram-sampler.plist](https://github.com/EtanHey/cmuxlayer/pull/182/files#diff-470a6cd78faf41ec047ca4ad974063c91dfaaffa10f9aed2ed3a5c9fdb687cbf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d259ce0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->