### PR TITLE
test(ram-watchdog): gate warn-only memory breaches

### DIFF
--- a/tests/ram-watchdog-warn-only.test.ts
+++ b/tests/ram-watchdog-warn-only.test.ts
@@ -1,0 +1,272 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(__dirname, "..");
+const memoryWatchdogScript =
+  process.env.CMUX_MEMORY_WATCHDOG_SCRIPT_PATH ??
+  join(repoRoot, "launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh");
+const ramSamplerScript =
+  process.env.CMUX_RAM_SAMPLER_SCRIPT_PATH ??
+  join(repoRoot, "launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh");
+
+const tmpRoots: string[] = [];
+
+afterEach(() => {
+  while (tmpRoots.length > 0) {
+    const root = tmpRoots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeRoot(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tmpRoots.push(root);
+  mkdirSync(join(root, "bin"), { recursive: true });
+  mkdirSync(join(root, "logs"), { recursive: true });
+  mkdirSync(join(root, "fixtures"), { recursive: true });
+  return root;
+}
+
+function writeExecutable(path: string, body: string) {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+function readIfExists(path: string) {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function fileMissingOrEmpty(path: string) {
+  return !existsSync(path) || statSync(path).size === 0;
+}
+
+function runBash(script: string, env: NodeJS.ProcessEnv) {
+  return spawnSync("/bin/bash", ["--noprofile", "--norc", "-c", script], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+function seedMemoryWatchdogCommands(root: string) {
+  const logDir = join(root, "logs");
+  writeExecutable(
+    join(root, "bin/ps"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '4242 /Applications/cmux.app/Contents/MacOS/cmux\\n'
+printf '9001 /Applications/Browser.app/Contents/MacOS/browser\\n'
+`,
+  );
+  writeExecutable(
+    join(root, "bin/pgrep"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "-x" && "\${2:-}" == "cmux" ]]; then
+  printf '4242\\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "-lf" && "\${2:-}" == "cmux" ]]; then
+  printf '4242 cmux\\n'
+  exit 0
+fi
+exit 1
+`,
+  );
+  writeExecutable(
+    join(root, "bin/nc"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`,
+  );
+  writeExecutable(
+    join(root, "bin/curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'args:%s\\n' "$*" >>"${logDir}/curl.log"
+while IFS= read -r line; do
+  printf 'stdin:%s\\n' "$line" >>"${logDir}/curl.log"
+done
+`,
+  );
+  writeExecutable(
+    join(root, "bin/kill"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${logDir}/kill.log"
+`,
+  );
+  writeFileSync(join(root, "fixtures/footprint.fixture"), "4242 phys_footprint: 6 GB (peak 8 GB)\n");
+  writeFileSync(
+    join(root, "fixtures/vmstat.fixture"),
+    "Mach Virtual Memory Statistics: (page size of 4096 bytes)\nPages occupied by compressor: 0.\n",
+  );
+}
+
+function seedSamplerCommands(root: string) {
+  const logDir = join(root, "logs");
+  writeExecutable(
+    join(root, "bin/pgrep"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "-f" && "\${2:-}" == "/Applications/cmux.app/Contents/MacOS/cmux" ]]; then
+  printf '4242\\n'
+  exit 0
+fi
+exit 1
+`,
+  );
+  writeExecutable(
+    join(root, "bin/ps"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '9999 900000 /Applications/Browser.app/Contents/MacOS/browser --tabs\\n'
+printf '4242 200000 /Applications/cmux.app/Contents/MacOS/cmux\\n'
+`,
+  );
+  writeExecutable(
+    join(root, "bin/nc"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`,
+  );
+  writeExecutable(
+    join(root, "bin/curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'args:%s\\n' "$*" >>"${logDir}/curl.log"
+while IFS= read -r line; do
+  printf 'stdin:%s\\n' "$line" >>"${logDir}/curl.log"
+done
+`,
+  );
+  writeExecutable(
+    join(root, "bin/kill"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${logDir}/kill.log"
+`,
+  );
+  writeFileSync(join(root, "fixtures/footprint.fixture"), "4242 phys_footprint: 1024 MB (peak 2048 MB)\n");
+  writeFileSync(join(root, "fixtures/memsize.fixture"), "1048576\n");
+}
+
+describe("cmux RAM watchdog warn-only regression", () => {
+  it("turns a watchdog memory breach into notification/snapshot work without SIGKILLing cmux", () => {
+    const root = makeRoot("cmux-watchdog-vitest-");
+    const logDir = join(root, "logs");
+    seedMemoryWatchdogCommands(root);
+
+    const result = runBash(
+      `source "${memoryWatchdogScript}"
+run_once`,
+      {
+        PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
+        CMUX_MEM_WATCHDOG_SOURCE_ONLY: "1",
+        CMUX_MEM_WATCHDOG_FOOTPRINT_THRESHOLD_GB: "5",
+        CMUX_MEM_WATCHDOG_COMPRESSOR_THRESHOLD_GB: "12",
+        CMUX_MEM_WATCHDOG_LOG_DIR: logDir,
+        CMUX_MEM_WATCHDOG_NOTIFY_URL: "http://localhost:3847/notify",
+        CMUX_MEM_WATCHDOG_BRAINBAR_SOCK: join(root, "missing-brainbar.sock"),
+        CMUX_MEM_WATCHDOG_KILL_BIN: join(root, "bin/kill"),
+        CMUX_MEM_WATCHDOG_TERM_GRACE_SECONDS: "0",
+        CMUX_MEM_WATCHDOG_FOOTPRINT_FIXTURE: join(root, "fixtures/footprint.fixture"),
+        CMUX_MEM_WATCHDOG_VMSTAT_FIXTURE: join(root, "fixtures/vmstat.fixture"),
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fileMissingOrEmpty(join(logDir, "kill.log"))).toBe(true);
+    expect(readIfExists(join(logDir, "kill.log"))).not.toMatch(/-(TERM|KILL)\s+4242/);
+    expect(readIfExists(join(logDir, "curl.log"))).toContain("http://localhost:3847/notify");
+    expect(readIfExists(join(logDir, "curl.log"))).toContain("Warning only; cmux was not terminated.");
+    expect(result.stderr).toContain("left running after memory breach (warn-only default)");
+  });
+
+  it("pins free_ram_pct calibration at the 12 percent routine-high boundary without alerting or killing", () => {
+    const root = makeRoot("cmux-sampler-vitest-");
+    const logDir = join(root, "logs");
+    seedSamplerCommands(root);
+    writeFileSync(
+      join(root, "fixtures/vmstat.fixture"),
+      [
+        "Mach Virtual Memory Statistics:",
+        "Pages free: 4.",
+        "Pages inactive: 4.",
+        "Pages occupied by compressor: 0.",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runBash(
+      `source "${ramSamplerScript}"
+run_once`,
+      {
+        PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
+        CMUX_RAM_SAMPLER_SOURCE_ONLY: "1",
+        CMUX_RAM_SAMPLER_LOG_DIR: logDir,
+        CMUX_RAM_SAMPLER_SAMPLE_FILE: join(logDir, "samples.jsonl"),
+        CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE: join(logDir, "routed-alerts.jsonl"),
+        CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR: join(logDir, "nearcrash-state"),
+        CMUX_RAM_SAMPLER_NOTIFY_URL: "http://localhost:3847/notify",
+        CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE: join(root, "fixtures/memsize.fixture"),
+        CMUX_RAM_SAMPLER_VMSTAT_FIXTURE: join(root, "fixtures/vmstat.fixture"),
+        CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE: join(root, "fixtures/footprint.fixture"),
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readIfExists(join(logDir, "samples.jsonl"))).toContain('"free_ram_pct":12');
+    expect(readIfExists(join(logDir, "curl.log"))).toBe("");
+    expect(readIfExists(join(logDir, "routed-alerts.jsonl"))).toBe("");
+    expect(fileMissingOrEmpty(join(logDir, "kill.log"))).toBe(true);
+  });
+
+  it("routes a near-crash free_ram_pct breach with offenders and still never invokes kill", () => {
+    const root = makeRoot("cmux-nearcrash-vitest-");
+    const logDir = join(root, "logs");
+    seedSamplerCommands(root);
+    writeFileSync(
+      join(root, "fixtures/vmstat.fixture"),
+      [
+        "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+        "Pages free: 2.",
+        "Pages inactive: 0.",
+        "Pages occupied by compressor: 0.",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runBash(
+      `source "${ramSamplerScript}"
+run_once`,
+      {
+        PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
+        CMUX_RAM_SAMPLER_SOURCE_ONLY: "1",
+        CMUX_RAM_SAMPLER_LOG_DIR: logDir,
+        CMUX_RAM_SAMPLER_SAMPLE_FILE: join(logDir, "samples.jsonl"),
+        CMUX_RAM_SAMPLER_ROUTED_ALERT_FILE: join(logDir, "routed-alerts.jsonl"),
+        CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR: join(logDir, "nearcrash-state"),
+        CMUX_RAM_SAMPLER_NOTIFY_URL: "http://localhost:3847/notify",
+        CMUX_RAM_SAMPLER_MEMSIZE_FIXTURE: join(root, "fixtures/memsize.fixture"),
+        CMUX_RAM_SAMPLER_VMSTAT_FIXTURE: join(root, "fixtures/vmstat.fixture"),
+        CMUX_RAM_SAMPLER_FOOTPRINT_FIXTURE: join(root, "fixtures/footprint.fixture"),
+      },
+    );
+
+    const alert = readIfExists(join(logDir, "routed-alerts.jsonl"));
+    expect(result.status, result.stderr).toBe(0);
+    expect(readIfExists(join(logDir, "samples.jsonl"))).toContain('"free_ram_pct":3');
+    expect(alert).toContain('"type":"near_crash"');
+    expect(alert).toContain('"reason":"near-crash free_ram_pct=3%"');
+    expect(alert).toContain("Browser.app");
+    expect(alert).toContain("cmux.app");
+    expect(fileMissingOrEmpty(join(logDir, "kill.log"))).toBe(true);
+    expect(readIfExists(join(logDir, "kill.log"))).not.toMatch(/-(TERM|KILL)\s+4242/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Vitest replay fixture for the cmux memory watchdog warn-only contract from PR #181.
- Drive the real launchd shell scripts through fake `ps`/`pgrep`/`curl`/`kill` shims, so no live cmux process is touched.
- Cover PR #182 sampler follow-up behavior: 16 KiB `vm_stat` fallback keeps `free_ram_pct` at 12% routine-high without alert spam, and near-crash free RAM routes an alert with offenders without invoking `kill`.

## RED/GREEN evidence
- RED: `CMUX_MEMORY_WATCHDOG_SCRIPT_PATH=$PWD/.red-fixtures/cmux-memory-watchdog.pre181.sh CMUX_RAM_SAMPLER_SCRIPT_PATH=$PWD/.red-fixtures/cmux-ram-sampler.pre182.sh npx vitest run tests/ram-watchdog-warn-only.test.ts` failed 3/3. Old watchdog wrote `kill.log`; old sampler notified at `free_ram_pct=12`; old sampler had no near-crash routed alert.
- GREEN: `npx vitest run tests/ram-watchdog-warn-only.test.ts` passed 3/3.
- Full suite: `npm test` passed 57 files / 907 tests.
- Shell suites: `launchd/cmux-memory-watchdog/tests/run-tests.sh` passed; `launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh` passed.

## Review notes
- Local `coderabbit review --agent` was attempted before commit with a 180s timeout. It returned only review heartbeats and exited 124; PR-level bot review is still required before merge.

Co-Authored-By: Codex <codex@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition; no runtime or launchd script changes in this diff.
> 
> **Overview**
> Adds **`tests/ram-watchdog-warn-only.test.ts`**, a Vitest regression suite that drives the real **`cmux-memory-watchdog.sh`** and **`cmux-ram-sampler.sh`** scripts in **`SOURCE_ONLY`** mode with temp dirs, fixture files, and fake **`PATH`** shims for **`ps`**, **`pgrep`**, **`curl`**, and **`kill`**—so behavior is checked without a live cmux process.
> 
> Three cases lock in the warn-only contract: memory watchdog breaches emit notify/snapshot work and **never** **`TERM`/`KILL`** cmux; RAM sampler reports **`free_ram_pct`: 12** at the routine-high boundary with no curl alerts or routed alerts; and a near-crash **`free_ram_pct`** breach writes a **`near_crash`** routed alert listing offenders while **`kill`** stays unused. Script paths can be overridden via **`CMUX_MEMORY_WATCHDOG_SCRIPT_PATH`** and **`CMUX_RAM_SAMPLER_SCRIPT_PATH`** for RED/GREEN against pre-change fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4da9a190d6aef74b8fff5ee96991acfb07e7ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add warn-only regression tests for RAM watchdog and sampler near-crash routing
> Adds [tests/ram-watchdog-warn-only.test.ts](https://github.com/EtanHey/cmuxlayer/pull/183/files#diff-42c28de9b641161f79e3d2c4deff2ae005c98a1da981497f4a046610ed0cc23d) with three vitest tests that validate warn-only behavior in the RAM watchdog and RAM sampler scripts using sandboxed stub binaries and fixtures.
>
> - Stubs out `ps`, `pgrep`, `nc`, `curl`, `kill`, `footprint`, and `vmstat` in a temp `bin` directory so tests run without real system side-effects; `curl` and `kill` append to log files for assertion.
> - Tests assert: watchdog notifies without sending SIGKILL on a memory breach; sampler records `free_ram_pct=12` without alerting under routine-high memory; sampler routes a `near_crash` alert with offenders but still never calls `kill`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f4da9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->