### PR TITLE
fix(spawn): boot_prompt_delivered must reflect verified submit (kills the unsent-return false-green)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1591,7 +1591,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           onChunkDelivered: (count) => {
             sentChunks = count;
           },
-          verify_submit: sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD,
+          verify_submit: true,
         }),
       );
       return { ...delivery, prompt_text: rawPrompt };
@@ -1606,6 +1606,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
     }
   };
+
+  const isBootPromptDelivered = (
+    delivery: Awaited<ReturnType<typeof deliverBootPrompt>> | undefined,
+  ): boolean => delivery?.submit_verified === true;
 
   // ── Auto-focus discipline for split/pane creation ──────────────────
   // cmux attaches a new split to the *currently focused* workspace. When a
@@ -2203,7 +2207,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data.role = inferredRole;
         }
         if (bootPromptDelivery) {
-          data.boot_prompt_delivered = true;
+          data.boot_prompt_delivered = isBootPromptDelivered(
+            bootPromptDelivery,
+          );
           data.boot_prompt_bytes = bootPromptDelivery.bytes;
         }
         return okFormatted(
@@ -2214,7 +2220,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             type: args.type,
             title: result.title,
             role: inferredRole ?? undefined,
-            boot_prompt_delivered: Boolean(bootPromptDelivery),
+            boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           }),
           data,
         );
@@ -2304,7 +2310,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         const data: Record<string, unknown> = { ...result };
         if (bootPromptDelivery) {
-          data.boot_prompt_delivered = true;
+          data.boot_prompt_delivered = isBootPromptDelivered(
+            bootPromptDelivery,
+          );
           data.boot_prompt_bytes = bootPromptDelivery.bytes;
         }
         return okFormatted(
@@ -2313,7 +2321,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface: result.surface,
             type: result.type,
             title: result.title,
-            boot_prompt_delivered: Boolean(bootPromptDelivery),
+            boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           }),
           data,
         );
@@ -2594,7 +2602,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivered: true,
           retry_count: delivery.retry_count,
           submit_verified: delivery.submit_verified,
-          boot_prompt_delivered: Boolean(bootPromptDelivery),
+          boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           boot_prompt_bytes: bootPromptDelivery?.bytes,
         };
         return okFormatted(
@@ -3884,7 +3892,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               surface: result.surface_id,
               role,
               monitor_boot: monitorBoot,
-              boot_prompt_delivered: Boolean(bootPromptDelivery),
+              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
             }),
             {
               ...result,
@@ -3892,7 +3900,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               mcp_profile: worktree.mcpProfileLabel,
               role,
               monitor_boot: monitorBoot,
-              boot_prompt_delivered: Boolean(bootPromptDelivery),
+              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
             },
           );
@@ -3996,7 +4004,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role: "worker",
               worktree: worktree.prepared,
               mcp_profile: worktree.mcpProfileLabel ?? "inherit",
-              boot_prompt_delivered: Boolean(bootPromptDelivery),
+              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
             },
           );

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1836,6 +1836,7 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
     let reads = 0;
+    let readsWhenBootPromptSent: number | null = null;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         reads += 1;
@@ -1849,6 +1850,12 @@ describe("tool handler integration", () => {
           }),
           stderr: "",
         };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        readsWhenBootPromptSent = reads;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -1867,7 +1874,8 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(reads).toBe(2);
+    expect(readsWhenBootPromptSent).toBe(2);
+    expect(reads).toBe(3);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
@@ -3756,6 +3764,197 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.surface).toBe("surface:2");
     expect(parsed.last_10_lines).toContain("$ waiting");
+  });
+
+  it("new_split fails loudly when a short boot prompt stays pending after submit retry", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-short-dropped-return.md");
+    const prompt = "short boot prompt";
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+    let returnPresses = 0;
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        promptSent = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text:
+              promptSent && returnPresses > 0
+                ? `codex> ${prompt}`
+                : "codex> ",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(parsed.boot_prompt_delivered).not.toBe(true);
+    expect(returnPresses).toBe(2);
+  }, 10_000);
+
+  it("new_split reports a short boot prompt delivered after submit verification succeeds", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-short-submitted.md");
+    const prompt = "short boot prompt";
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+    let returnPresses = 0;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "codex> ",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(returnPresses).toBe(1);
+  });
+
+  it("new_split keeps verifying long boot prompts and retries a missed submit", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-long-retry.md");
+    const prompt = "long boot prompt ".repeat(40);
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+    let returnPresses = 0;
+    let typedText = "";
+    const sendCalls: string[] = [];
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send") || args.includes("set-buffer")) {
+        const chunk = String(args.at(-1) ?? "");
+        sendCalls.push(chunk);
+        typedText += chunk;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text:
+              returnPresses === 1
+                ? `codex> ${typedText.slice(-100)}`
+                : "codex> ",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(sendCalls.length).toBeGreaterThan(1);
+    expect(returnPresses).toBe(2);
   });
 
   it("new_split renames the new surface when a title is provided", async () => {


### PR DESCRIPTION
## Summary
- Fixes the boot prompt false-green where short boot prompts could remain typed in the agent composer while callers reported `boot_prompt_delivered:true`.
- `deliverBootPrompt` now always verifies the final submit and reuses the existing retry path.
- `boot_prompt_delivered` now reflects `submit_verified === true` at all delivery report sites.

## RED / GREEN
- RED: short boot prompt with dropped return previously reported delivered:true while text stayed pending in the composer.
- GREEN: always verify + retry the final submit; fail loudly if submit remains unverifiable.
- Regression coverage keeps short success and long-prompt retry behavior covered.

## Verification
- `coderabbit review --agent` -> 0 findings
- `bun run test` -> 57 files / 910 tests passed
- `bun run typecheck` -> passed
- `bun run build` -> passed

## Merge
- Do not merge from this worker. cmuxlayerClaude-LEAD owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn/split boot prompt semantics and API flags callers rely on; behavior is more correct but short prompts may now fail where they previously reported success.
> 
> **Overview**
> Fixes a **false-green** where short boot prompts could stay typed in the agent composer while callers still saw **`boot_prompt_delivered: true`**.
> 
> **`deliverBootPrompt`** now always runs submit verification (`verify_submit: true`), including for prompts under the chunk threshold, so the existing Enter retry path applies to short prompts too. Failures surface as **`BootPromptDeliveryError`** (e.g. unverifiable submit) instead of reporting success.
> 
> A shared **`isBootPromptDelivered`** helper sets **`boot_prompt_delivered`** only when **`submit_verified === true`**, replacing checks that treated “delivery ran” as delivered across **`new_split`**, **`new_surface`**, **`send_command`**, and spawn-related tools.
> 
> Tests cover short-prompt failure after a dropped return, short success after verification, long-prompt retry, and stricter **`send_command`** readiness timing before boot prompt send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80055c4ad92d01f5ca08be0676ace9d1d52ccab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `boot_prompt_delivered` to reflect verified submit rather than delivery attempt
> - Changes `verify_submit` in `deliverInputChunks` from a length-based predicate to unconditional `true`, so all boot prompt deliveries request submit verification regardless of prompt size.
> - Replaces `Boolean(bootPromptDelivery)` with `delivery?.submit_verified === true` when setting `boot_prompt_delivered` in all tool response paths (new splits, new surfaces, send commands, spawn/worker).
> - Adds tests covering submit verification failure, success for short prompts, and retry behavior for long prompts.
> - Behavioral Change: `boot_prompt_delivered: true` is no longer reported when a delivery was merely attempted — it now requires confirmed submit verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80055c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->