### PR TITLE
fix(wait_for): screen-truth for ready/idle targets (port boot poller)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -53,6 +53,7 @@ import {
 } from "./layout-policy.js";
 import {
   matchReadyPattern,
+  readyPatternRequiresAgentIdentity,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
 import {
@@ -622,9 +623,6 @@ export class AgentEngine {
   private loggedEvents = new Set<string>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
-  /** agentId → waitFor-local consecutive ready-prompt matches */
-  private waitForReadyPatternMatches = new Map<string, number>();
-
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
@@ -754,12 +752,17 @@ export class AgentEngine {
   private async refreshTargetStateEvidence(
     agent: AgentRecord,
     targetState: AgentState,
+    waitForReadyPatternMatches: Map<string, number>,
   ): Promise<{
     agent: AgentRecord;
     source?: RefreshedTargetStateEvidenceSource;
   }> {
     if (targetState === "ready" || targetState === "idle") {
-      return this.refreshInteractiveTargetStateEvidence(agent, targetState);
+      return this.refreshInteractiveTargetStateEvidence(
+        agent,
+        targetState,
+        waitForReadyPatternMatches,
+      );
     }
     if (!this.requiresOutputDoneEvidence(targetState)) return { agent };
     if (TERMINAL_STATES.has(agent.state)) return { agent };
@@ -769,6 +772,7 @@ export class AgentEngine {
   private async refreshInteractiveTargetStateEvidence(
     agent: AgentRecord,
     targetState: "ready" | "idle",
+    waitForReadyPatternMatches: Map<string, number>,
   ): Promise<{
     agent: AgentRecord;
     source?: RefreshedTargetStateEvidenceSource;
@@ -778,11 +782,11 @@ export class AgentEngine {
         ? agent.state === "booting"
         : agent.state === "working";
     if (!canTransition || TERMINAL_STATES.has(agent.state)) {
-      this.waitForReadyPatternMatches.delete(agent.agent_id);
+      waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent };
     }
     if (agent.boot_prompt_pending) {
-      this.waitForReadyPatternMatches.delete(agent.agent_id);
+      waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent };
     }
 
@@ -791,43 +795,55 @@ export class AgentEngine {
         lines: BOOT_SESSION_CAPTURE_LINES,
       });
       const match = matchReadyPattern(agent.cli, screen.text);
-      const ready =
-        match.matched &&
+      const hasReadyIdentity =
+        !readyPatternRequiresAgentIdentity(agent.cli) ||
         screenHasReadyAgentIdentity(
           agent.cli,
           screen.text,
           parseScreen(screen.text),
         );
+      const ready = match.matched && hasReadyIdentity;
       if (!ready) {
-        this.waitForReadyPatternMatches.delete(agent.agent_id);
+        waitForReadyPatternMatches.delete(agent.agent_id);
         return { agent };
       }
 
       const count =
-        (this.waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
-      this.waitForReadyPatternMatches.set(agent.agent_id, count);
+        (waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+      waitForReadyPatternMatches.set(agent.agent_id, count);
       if (count < Math.max(1, match.consecutive)) {
         return { agent };
       }
 
-      let updated = this.stateMgr.transition(agent.agent_id, targetState, {
-        error:
-          targetState === "ready" &&
-          agent.error?.startsWith("Post-spawn liveness failed:")
-            ? null
-            : agent.error,
-      });
+      const transitionAgent =
+        targetState === "ready"
+          ? await this.maybeCaptureBootSessionId(agent, {
+              screen: Promise.resolve(screen),
+            })
+          : agent;
+      let updated = this.stateMgr.transition(
+        transitionAgent.agent_id,
+        targetState,
+        {
+          error:
+            targetState === "ready" &&
+            transitionAgent.error?.startsWith("Post-spawn liveness failed:")
+              ? null
+              : transitionAgent.error,
+        },
+      );
       if (
         targetState === "ready" &&
         updated.quality === "degraded" &&
-        agent.error?.startsWith("Post-spawn liveness failed:")
+        transitionAgent.error?.startsWith("Post-spawn liveness failed:")
       ) {
-        updated = this.stateMgr.updateRecord(agent.agent_id, {
+        updated = this.stateMgr.updateRecord(transitionAgent.agent_id, {
           quality: "unknown",
         });
       }
-      this.registry.set(agent.agent_id, updated);
-      this.waitForReadyPatternMatches.delete(agent.agent_id);
+      this.registry.set(transitionAgent.agent_id, updated);
+      waitForReadyPatternMatches.delete(agent.agent_id);
+      waitForReadyPatternMatches.delete(transitionAgent.agent_id);
       return { agent: updated, source: "screen" };
     } catch {
       return { agent };
@@ -1974,14 +1990,21 @@ export class AgentEngine {
       };
     }
 
+    const waitForReadyPatternMatches = new Map<string, number>();
+
     // Polling sweep loop
     return new Promise<WaitResult>((resolve) => {
+      const finish = (result: WaitResult) => {
+        waitForReadyPatternMatches.clear();
+        resolve(result);
+      };
+
       const checkInterval = setInterval(async () => {
         const elapsed = Date.now() - start;
         if (elapsed >= timeoutMs) {
           clearInterval(checkInterval);
           const current = this.registry.get(agentId);
-          resolve({
+          finish({
             matched: false,
             state: current?.state ?? "error",
             elapsed,
@@ -1997,7 +2020,7 @@ export class AgentEngine {
         let current = this.registry.get(agentId);
         if (!current) {
           clearInterval(checkInterval);
-          resolve({
+          finish({
             matched: false,
             state: "error",
             elapsed,
@@ -2011,6 +2034,7 @@ export class AgentEngine {
         const refreshed = await this.refreshTargetStateEvidence(
           current,
           targetState,
+          waitForReadyPatternMatches,
         );
         current = refreshed.agent;
 
@@ -2020,7 +2044,7 @@ export class AgentEngine {
         );
         if (evidenceSource) {
           clearInterval(checkInterval);
-          resolve({
+          finish({
             matched: true,
             state: current.state,
             elapsed,
@@ -2038,7 +2062,7 @@ export class AgentEngine {
           current.state !== targetState
         ) {
           clearInterval(checkInterval);
-          resolve({
+          finish({
             matched: false,
             state: current.state,
             elapsed,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -622,6 +622,8 @@ export class AgentEngine {
   private loggedEvents = new Set<string>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
+  /** agentId → waitFor-local consecutive ready-prompt matches */
+  private waitForReadyPatternMatches = new Map<string, number>();
 
   constructor(
     stateMgr: StateManager,
@@ -776,11 +778,11 @@ export class AgentEngine {
         ? agent.state === "booting"
         : agent.state === "working";
     if (!canTransition || TERMINAL_STATES.has(agent.state)) {
-      this.readyPatternMatches.delete(agent.agent_id);
+      this.waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent };
     }
     if (agent.boot_prompt_pending) {
-      this.readyPatternMatches.delete(agent.agent_id);
+      this.waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent };
     }
 
@@ -797,12 +799,13 @@ export class AgentEngine {
           parseScreen(screen.text),
         );
       if (!ready) {
-        this.readyPatternMatches.delete(agent.agent_id);
+        this.waitForReadyPatternMatches.delete(agent.agent_id);
         return { agent };
       }
 
-      const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
-      this.readyPatternMatches.set(agent.agent_id, count);
+      const count =
+        (this.waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+      this.waitForReadyPatternMatches.set(agent.agent_id, count);
       if (count < Math.max(1, match.consecutive)) {
         return { agent };
       }
@@ -824,7 +827,7 @@ export class AgentEngine {
         });
       }
       this.registry.set(agent.agent_id, updated);
-      this.readyPatternMatches.delete(agent.agent_id);
+      this.waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent: updated, source: "screen" };
     } catch {
       return { agent };

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -51,7 +51,10 @@ import {
   launcherNameForCli,
   type RoleSurfaceIds,
 } from "./layout-policy.js";
-import { matchReadyPattern } from "./pattern-registry.js";
+import {
+  matchReadyPattern,
+  screenHasReadyAgentIdentity,
+} from "./pattern-registry.js";
 import {
   reposEquivalent,
   resolveWorkspaceRefForRepo,
@@ -208,6 +211,10 @@ interface SweepAgentContext {
 }
 
 type TargetStateEvidenceSource = "state" | "transcript" | "screen";
+type RefreshedTargetStateEvidenceSource = Exclude<
+  TargetStateEvidenceSource,
+  "state"
+>;
 
 // AIDEV-NOTE: Cursor has no distinct "done" lifecycle state — it settles to
 // "idle" when a task completes. A wait_for(target="done") on a Cursor agent
@@ -745,10 +752,83 @@ export class AgentEngine {
   private async refreshTargetStateEvidence(
     agent: AgentRecord,
     targetState: AgentState,
-  ): Promise<AgentRecord> {
-    if (!this.requiresOutputDoneEvidence(targetState)) return agent;
-    if (TERMINAL_STATES.has(agent.state)) return agent;
-    return (await this.maybeMarkTaskDone(agent, {})).agent;
+  ): Promise<{
+    agent: AgentRecord;
+    source?: RefreshedTargetStateEvidenceSource;
+  }> {
+    if (targetState === "ready" || targetState === "idle") {
+      return this.refreshInteractiveTargetStateEvidence(agent, targetState);
+    }
+    if (!this.requiresOutputDoneEvidence(targetState)) return { agent };
+    if (TERMINAL_STATES.has(agent.state)) return { agent };
+    return { agent: (await this.maybeMarkTaskDone(agent, {})).agent };
+  }
+
+  private async refreshInteractiveTargetStateEvidence(
+    agent: AgentRecord,
+    targetState: "ready" | "idle",
+  ): Promise<{
+    agent: AgentRecord;
+    source?: RefreshedTargetStateEvidenceSource;
+  }> {
+    const canTransition =
+      targetState === "ready"
+        ? agent.state === "booting"
+        : agent.state === "working";
+    if (!canTransition || TERMINAL_STATES.has(agent.state)) {
+      this.readyPatternMatches.delete(agent.agent_id);
+      return { agent };
+    }
+    if (agent.boot_prompt_pending) {
+      this.readyPatternMatches.delete(agent.agent_id);
+      return { agent };
+    }
+
+    try {
+      const screen = await this.client.readScreen(agent.surface_id, {
+        lines: BOOT_SESSION_CAPTURE_LINES,
+      });
+      const match = matchReadyPattern(agent.cli, screen.text);
+      const ready =
+        match.matched &&
+        screenHasReadyAgentIdentity(
+          agent.cli,
+          screen.text,
+          parseScreen(screen.text),
+        );
+      if (!ready) {
+        this.readyPatternMatches.delete(agent.agent_id);
+        return { agent };
+      }
+
+      const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+      this.readyPatternMatches.set(agent.agent_id, count);
+      if (count < Math.max(1, match.consecutive)) {
+        return { agent };
+      }
+
+      let updated = this.stateMgr.transition(agent.agent_id, targetState, {
+        error:
+          targetState === "ready" &&
+          agent.error?.startsWith("Post-spawn liveness failed:")
+            ? null
+            : agent.error,
+      });
+      if (
+        targetState === "ready" &&
+        updated.quality === "degraded" &&
+        agent.error?.startsWith("Post-spawn liveness failed:")
+      ) {
+        updated = this.stateMgr.updateRecord(agent.agent_id, {
+          quality: "unknown",
+        });
+      }
+      this.registry.set(agent.agent_id, updated);
+      this.readyPatternMatches.delete(agent.agent_id);
+      return { agent: updated, source: "screen" };
+    } catch {
+      return { agent };
+    }
   }
 
   private async createAgentSurface(
@@ -1925,7 +2005,11 @@ export class AgentEngine {
           return;
         }
 
-        current = await this.refreshTargetStateEvidence(current, targetState);
+        const refreshed = await this.refreshTargetStateEvidence(
+          current,
+          targetState,
+        );
+        current = refreshed.agent;
 
         const evidenceSource = await this.getTargetStateEvidenceSource(
           current,
@@ -1937,7 +2021,9 @@ export class AgentEngine {
             matched: true,
             state: current.state,
             elapsed,
-            source: evidenceSource === "state" ? "sweep" : evidenceSource,
+            source:
+              refreshed.source ??
+              (evidenceSource === "state" ? "sweep" : evidenceSource),
             agent: toPublicAgent(current),
           });
           return;

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -5,6 +5,8 @@
  */
 
 import type { CliType } from "./agent-types.js";
+import { parseScreen } from "./screen-parser.js";
+import type { ParsedScreenResult } from "./types.js";
 
 export interface ReadyPattern {
   pattern: RegExp;
@@ -83,4 +85,29 @@ export function matchReadyPattern(
     confidence: entry.confidence,
     consecutive: entry.consecutive,
   };
+}
+
+export function screenHasReadyAgentIdentity(
+  cli: CliType,
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  if (parsed.agent_type === cli) {
+    return true;
+  }
+
+  switch (cli) {
+    case "claude":
+      return /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
+        screenText,
+      );
+    case "codex":
+      return /(?:^|\n)\s*codex>\s*$/im.test(screenText);
+    case "cursor":
+      return /(?:^|\n)\s*(?:cursor>|Cursor Agent)\s*$/im.test(screenText);
+    case "kiro":
+      return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
+    case "gemini":
+      return false;
+  }
 }

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -111,3 +111,7 @@ export function screenHasReadyAgentIdentity(
       return false;
   }
 }
+
+export function readyPatternRequiresAgentIdentity(cli: CliType): boolean {
+  return cli !== "gemini" && cli !== "kiro";
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,7 +83,10 @@ import type {
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
-import { matchReadyPattern } from "./pattern-registry.js";
+import {
+  matchReadyPattern,
+  screenHasReadyAgentIdentity,
+} from "./pattern-registry.js";
 import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
@@ -506,31 +509,6 @@ function screenHasAnyAgentIdentity(
       screenText,
     )
   );
-}
-
-function screenHasReadyAgentIdentity(
-  cli: CliType,
-  screenText: string,
-  parsed: ParsedScreenResult = parseScreen(screenText),
-): boolean {
-  if (parsed.agent_type === cli) {
-    return true;
-  }
-
-  switch (cli) {
-    case "claude":
-      return /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
-        screenText,
-      );
-    case "codex":
-      return /(?:^|\n)\s*codex>\s*$/im.test(screenText);
-    case "cursor":
-      return /(?:^|\n)\s*(?:cursor>|Cursor Agent)\s*$/im.test(screenText);
-    case "kiro":
-      return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
-    case "gemini":
-      return false;
-  }
 }
 
 function screenShowsPendingInput(

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2161,6 +2161,63 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not clear sweep ready-prompt progress when waitFor polls a non-ready screen", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "gemini-sweep-progress",
+            state: "booting",
+            surface_id: "surface:gemini-sweep-progress",
+            cli: "gemini",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:gemini-sweep-progress")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-sweep-progress",
+          text: "ready\n> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+        expect(engine.getAgentState("gemini-sweep-progress")?.state).toBe(
+          "booting",
+        );
+
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-sweep-progress",
+          text: "still booting\n",
+          lines: 80,
+          scrollback_used: false,
+        });
+        const pending = engine.waitFor(
+          "gemini-sweep-progress",
+          "ready",
+          1_500,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const waitResult = await pending;
+        expect(waitResult.matched).toBe(false);
+
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-sweep-progress",
+          text: "ready\n> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.runSweep();
+
+        expect(engine.getAgentState("gemini-sweep-progress")?.state).toBe(
+          "ready",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not resolve done for a Codex worker from registry state without TASK_DONE output", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -78,6 +78,12 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
     renameTab: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),
+    moveSurface: vi.fn().mockResolvedValue({
+      ok: true,
+      workspace: "ws:1",
+      surface: "surface:new",
+      pane: "pane:1",
+    }),
     listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     listPanes: vi.fn().mockResolvedValue({ panes: [] }),
     listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
@@ -2037,6 +2043,122 @@ To continue this session, run codex resume ${sessionId}`,
       expect(result.agent?.agent_id).toBe("agent-ready");
       expect(result.agent?.state).toBe("ready");
       expect(result.agent?.session_id).toBeNull();
+    });
+
+    it("resolves ready from screen truth when registry still says booting", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "claude-screen-ready",
+            state: "booting",
+            surface_id: "surface:claude-screen-ready",
+            workspace_id: "ws:screen-ready",
+            cli: "claude",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-screen-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-screen-ready",
+          text: ["Claude Code", "What can I help you with?", "❯ "].join("\n"),
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("claude-screen-ready", "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.state).toBe("ready");
+        expect(engine.getAgentState("claude-screen-ready")?.state).toBe("ready");
+        expect(mockClient.moveSurface).not.toHaveBeenCalled();
+        expect(mockClient.readScreen).toHaveBeenCalledWith(
+          "surface:claude-screen-ready",
+          { lines: 80 },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve ready from a prompt-looking active Claude screen", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "claude-screen-active",
+            state: "booting",
+            surface_id: "surface:claude-screen-active",
+            workspace_id: "ws:screen-active",
+            cli: "claude",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-screen-active")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-screen-active",
+          text: ["Claude Code", "✻ Thinking", "❯ "].join("\n"),
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("claude-screen-active", "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("booting");
+        expect(engine.getAgentState("claude-screen-active")?.state).toBe(
+          "booting",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves idle from Cursor screen truth when registry still says working", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cursor-screen-idle",
+            state: "working",
+            surface_id: "surface:cursor-screen-idle",
+            workspace_id: "ws:cursor-idle",
+            cli: "cursor",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:cursor-screen-idle")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:cursor-screen-idle",
+          text: [
+            "Cursor Agent",
+            "⬡ Idle  1.2k tokens",
+            "/ commands · @ files · ! shell · ctrl+r to review edits",
+          ].join("\n"),
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("cursor-screen-idle", "idle", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.state).toBe("idle");
+        expect(engine.getAgentState("cursor-screen-idle")?.state).toBe("idle");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("does not resolve done for a Codex worker from registry state without TASK_DONE output", async () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2085,6 +2085,141 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("captures the boot session before waitFor marks a ready screen", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-03-14T03:40:10.000Z"));
+        const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+        const provisionalAgentId = "brainlayerClaude-pending-wait";
+        const finalAgentId = "brainlayerClaude-019d9aa5";
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: provisionalAgentId,
+            repo: "brainlayer",
+            model: "claude-sonnet-4.5",
+            cli: "claude",
+            state: "booting",
+            surface_id: "surface:claude-screen-session",
+            workspace_id: "ws:screen-session",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:claude-screen-session")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-screen-session",
+          text: [
+            `Session ID: ${sessionId}`,
+            "Claude Code",
+            "What can I help you with?",
+            "❯ ",
+          ].join("\n"),
+          lines: 80,
+          scrollback_used: true,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(provisionalAgentId, "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.agent?.agent_id).toBe(finalAgentId);
+        expect(result.agent?.session_id).toBe(sessionId);
+        expect(engine.getAgentState(finalAgentId)).toMatchObject({
+          agent_id: finalAgentId,
+          state: "ready",
+          cli_session_id: sessionId,
+        });
+        expect(engine.getAgentState(provisionalAgentId)).toMatchObject({
+          agent_id: finalAgentId,
+          state: "ready",
+          cli_session_id: sessionId,
+        });
+        expect(stateMgr.readState(provisionalAgentId)).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves Gemini ready from consecutive screen-truth prompts", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "gemini-screen-ready",
+            state: "booting",
+            surface_id: "surface:gemini-screen-ready",
+            cli: "gemini",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:gemini-screen-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-screen-ready",
+          text: "ready\n> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("gemini-screen-ready", "ready", 2_500);
+        await vi.advanceTimersByTimeAsync(3_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.state).toBe("ready");
+        expect(engine.getAgentState("gemini-screen-ready")?.state).toBe(
+          "ready",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears waitFor prompt progress when a ready wait times out", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "kiro-wait-timeout",
+            state: "booting",
+            surface_id: "surface:kiro-wait-timeout",
+            cli: "kiro",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:kiro-wait-timeout")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:kiro-wait-timeout",
+          text: "kiro> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const firstWait = engine.waitFor("kiro-wait-timeout", "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(await firstWait).toMatchObject({
+          matched: false,
+          source: "timeout",
+        });
+
+        const secondWait = engine.waitFor("kiro-wait-timeout", "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const secondResult = await secondWait;
+
+        expect(secondResult.matched).toBe(false);
+        expect(secondResult.source).toBe("timeout");
+        expect(engine.getAgentState("kiro-wait-timeout")?.state).toBe(
+          "booting",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not resolve ready from a prompt-looking active Claude screen", async () => {
       vi.useFakeTimers();
       try {


### PR DESCRIPTION
## Summary
- Port direct ready/idle screen-truth polling into `AgentEngine.waitFor` so `wait_for(ready|idle)` can resolve from live pane output even when registry state is stale.
- Share `screenHasReadyAgentIdentity` from `pattern-registry.ts` with both `server.ts` and `agent-engine.ts` to avoid duplicated boot-poller identity logic.
- Keep `done` target evidence behavior unchanged and avoid focusing/moving surfaces during waits.

## Test plan
- `bun run test` — 57 files / 910 tests passed
- `bun run typecheck` — passed
- `bun run build` — passed
- local `coderabbit review --agent` — completed with 0 findings before commit

## Notes
- Worker endpoint: PR opened and review feedback addressed. Do not merge here; cmuxlayerClaude-LEAD owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent lifecycle transitions and wait_for semantics; incorrect screen heuristics could mark agents ready/idle early or leave waits stuck, though done-target behavior is unchanged and tests cover major CLIs.
> 
> **Overview**
> **`waitFor(ready|idle)`** no longer depends only on registry state during its poll loop. Each tick can **read the agent pane**, apply ready-pattern + identity checks (shared with the boot poller), honor **per-CLI consecutive match counts**, and **transition** `booting→ready` or `working→idle` when the screen proves it—returning **`source: "screen"`** when that path wins.
> 
> Ready waits also run **boot session capture** from that same screen read before marking ready. A **wait-scoped** consecutive-match map is used so **`waitFor` polling does not reset** the engine sweep’s separate ready-progress tracking.
> 
> **`screenHasReadyAgentIdentity`** and **`readyPatternRequiresAgentIdentity`** move from **`server.ts`** into **`pattern-registry.ts`** for reuse by **`agent-engine`** and the server. **`done`** evidence handling in **`refreshTargetStateEvidence`** is unchanged.
> 
> Tests cover screen-truth ready/idle, Gemini consecutive prompts, Claude “active” false positives, session capture during wait, timeout counter cleanup, and sweep vs wait counter isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e86ce001936fc50c89de352ba27fc54eb87e56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add screen-truth transitions for ready/idle targets in `AgentEngine.waitFor`
> - `AgentEngine.waitFor` can now transition agents to `ready` or `idle` based on terminal screen content during polling, without waiting for an external registry update. The wait result reports `'screen'` as the source when this path is taken.
> - A new `refreshInteractiveTargetStateEvidence` method in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/186/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) reads the screen, checks `matchReadyPattern` plus an optional identity check, and requires consecutive matches before confirming the transition.
> - Two new utilities in [pattern-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/186/files#diff-1f1872f4b73cb466921af9511f51f36eab87d558851ccc6f9e68a0a552286b4a) — `screenHasReadyAgentIdentity` and `readyPatternRequiresAgentIdentity` — provide per-CLI policy for whether identity confirmation is required alongside a ready-pattern match.
> - The local `screenHasReadyAgentIdentity` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/186/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) is removed in favor of the shared implementation.
> - For `ready` transitions, the boot session ID is captured from the screen before the state change, and any post-spawn liveness error is cleared on success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e86ce0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->