### PR TITLE
fix(stop): positive stop==GONE post-condition + exported-function kill-trap

### DIFF
--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -55,6 +55,32 @@ assert_no_kill_invoked() {
   fi
 }
 
+install_kill_traps() {
+  local log_file="$1"
+  export CMUX_TEST_KILL_TRAP_LOG="$log_file"
+  kill() {
+    printf 'kill %s\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+    return 0
+  }
+  pkill() {
+    printf 'pkill %s\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+    return 0
+  }
+  killall() {
+    printf 'killall %s\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+    return 0
+  }
+  osascript() {
+    printf 'osascript %s\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+    return 0
+  }
+  launchctl() {
+    printf 'launchctl %s\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+    return 0
+  }
+  export -f kill pkill killall osascript launchctl
+}
+
 source_sampler() {
   if [[ -n "${CMUX_RAM_SAMPLER_LOG_DIR:-}" ]]; then
     case "${CMUX_RAM_SAMPLER_NEARCRASH_STATE_DIR:-}" in
@@ -351,12 +377,7 @@ printf '4242 200000 /Applications/cmux.app/Contents/MacOS/cmux\n'
 EOF
   chmod +x "$root_dir/bin/ps"
 
-  cat >"$root_dir/bin/kill" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "\$*" >>"$log_dir/kill.log"
-EOF
-  chmod +x "$root_dir/bin/kill"
+  install_kill_traps "$log_dir/kill.log"
 
   cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
 4242 phys_footprint: 1024 MB (peak 2048 MB)
@@ -405,12 +426,7 @@ printf '4242 200000 /Applications/cmux.app/Contents/MacOS/cmux\n'
 EOF
   chmod +x "$root_dir/bin/ps"
 
-  cat >"$root_dir/bin/kill" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "\$*" >>"$log_dir/kill.log"
-EOF
-  chmod +x "$root_dir/bin/kill"
+  install_kill_traps "$log_dir/kill.log"
 
   cat >"$root_dir/fixtures/footprint.fixture" <<'EOF'
 4242 phys_footprint: 1024 MB (peak 2048 MB)
@@ -434,6 +450,21 @@ EOF
   assert_no_kill_invoked "$log_dir/kill.log"
 
   printf 'PASS: sampler re-routes after near-crash recovery and later cross\n'
+  rm -rf "$root_dir"
+}
+
+run_kill_trap_builtin_case() {
+  local root_dir log_dir
+  root_dir="$(mktemp -d)"
+  log_dir="$root_dir/logs"
+  mkdir -p "$log_dir"
+
+  install_kill_traps "$log_dir/kill.log"
+  kill -9 4242
+
+  assert_file_contains "$log_dir/kill.log" "kill -9 4242"
+
+  printf 'PASS: sampler kill trap catches shell builtin kill\n'
   rm -rf "$root_dir"
 }
 
@@ -753,6 +784,7 @@ run_vmstat_page_size_case
 run_routine_high_records_without_alert_case
 run_nearcrash_routed_alert_edge_case
 run_nearcrash_recovery_reroute_case
+run_kill_trap_builtin_case
 run_never_nearcrash_alert_case
 run_notify_skip_case
 run_notify_skip_all_sampler_paths_case

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -151,6 +151,7 @@ export interface AgentEngineOptions {
   ) => Promise<SpawnPreflightResult | void>;
   spawnGuard?: SpawnGuard;
   postSpawnLivenessMs?: number;
+  stopPostConditionTimeoutMs?: number;
   sessionIdentityResolver?: SessionIdentityResolver;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
@@ -173,6 +174,8 @@ const DEFAULT_SWEEP_IDLE_INTERVAL_MS = 15_000;
 const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
 const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
+const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
+const STOP_POST_CONDITION_POLL_MS = 50;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
 const TASK_DONE_CONFIRMATION_MS = 5_000;
@@ -209,6 +212,13 @@ type SweepTimingInput = number | Partial<SweepTimingOptions>;
 
 interface SweepAgentContext {
   screen?: Promise<CmuxReadScreenResult>;
+}
+
+interface StopPostConditionResult {
+  processGone: boolean;
+  surfaceGone: boolean;
+  paneGone: boolean;
+  paneRef: string | null;
 }
 
 type TargetStateEvidenceSource = "state" | "transcript" | "screen";
@@ -534,22 +544,50 @@ function runDetachedShellProbe(shell: string, probe: string): Promise<void> {
       stdio: "ignore",
       windowsHide: true,
     });
+    let timedOut = false;
+    let settled = false;
+    let postTermTimer: ReturnType<typeof setTimeout> | null = null;
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill("SIGTERM");
-      reject(new Error("launcher probe timed out"));
+      postTermTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+        finishReject(
+          new Error("launcher probe failed to terminate after SIGTERM"),
+        );
+      }, 1_000);
     }, 5_000);
 
-    child.once("error", (error) => {
+    const cleanup = () => {
       clearTimeout(timer);
+      if (postTermTimer) clearTimeout(postTermTimer);
+    };
+    const finishResolve = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const finishReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       reject(error);
+    };
+
+    child.once("error", (error) => {
+      finishReject(error);
     });
     child.once("exit", (code, signal) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve();
+      if (timedOut) {
+        finishReject(new Error("launcher probe timed out"));
         return;
       }
-      reject(
+      if (code === 0) {
+        finishResolve();
+        return;
+      }
+      finishReject(
         new Error(
           `launcher probe exited with ${code ?? `signal ${signal ?? "unknown"}`}`,
         ),
@@ -604,6 +642,7 @@ export class AgentEngine {
   ) => Promise<SpawnPreflightResult | void>;
   private spawnGuard: SpawnGuard;
   private postSpawnLivenessMs: number;
+  private stopPostConditionTimeoutMs: number;
   private roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -643,6 +682,12 @@ export class AgentEngine {
       parseNonNegativeInteger(
         process.env.CMUXLAYER_POST_SPAWN_LIVENESS_MS,
         DEFAULT_POST_SPAWN_LIVENESS_MS,
+      );
+    this.stopPostConditionTimeoutMs =
+      opts?.stopPostConditionTimeoutMs ??
+      parseNonNegativeInteger(
+        process.env.CMUXLAYER_STOP_POST_CONDITION_TIMEOUT_MS,
+        DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS,
       );
     this.spawnPreflight =
       opts?.spawnPreflight ??
@@ -2137,6 +2182,128 @@ export class AgentEngine {
     };
   }
 
+  private async resolvePaneForSurface(
+    surfaceId: string,
+    workspaceId?: string | null,
+  ): Promise<string | null> {
+    try {
+      const opts = workspaceId ? { workspace: workspaceId } : undefined;
+      const panes = await this.client.listPanes(opts);
+      for (const pane of panes.panes) {
+        if (
+          pane.surface_refs.includes(surfaceId) ||
+          pane.selected_surface_ref === surfaceId
+        ) {
+          return pane.ref;
+        }
+      }
+
+      for (const pane of panes.panes) {
+        try {
+          const paneSurfaces = await this.client.listPaneSurfaces({
+            ...(workspaceId ? { workspace: workspaceId } : {}),
+            pane: pane.ref,
+          });
+          if (paneSurfaces.surfaces.some((surface) => surface.ref === surfaceId)) {
+            return paneSurfaces.pane_ref || pane.ref;
+          }
+        } catch {
+          // Keep scanning panes; a stale pane ref should not hide a later match.
+        }
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  private isProcessGone(pid: number | null | undefined): boolean {
+    if (!pid) return true;
+    try {
+      process.kill(pid, 0);
+      return false;
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as { code?: unknown }).code === "ESRCH"
+      ) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private async isSurfaceGone(surfaceId: string): Promise<boolean> {
+    try {
+      return !(await this.registry.hasLiveSurface(surfaceId));
+    } catch {
+      return false;
+    }
+  }
+
+  private async isPaneGone(
+    paneRef: string | null,
+    workspaceId?: string | null,
+  ): Promise<boolean> {
+    if (!paneRef) return true;
+    try {
+      const panes = await this.client.listPanes(
+        workspaceId ? { workspace: workspaceId } : undefined,
+      );
+      return !panes.panes.some((pane) => pane.ref === paneRef);
+    } catch {
+      return false;
+    }
+  }
+
+  private async readStopPostCondition(
+    agent: AgentRecord,
+    paneRef: string | null,
+  ): Promise<StopPostConditionResult> {
+    const processGone = this.isProcessGone(agent.pid);
+    const [surfaceGone, paneGone] = await Promise.all([
+      this.isSurfaceGone(agent.surface_id),
+      this.isPaneGone(paneRef, agent.workspace_id),
+    ]);
+    return { processGone, surfaceGone, paneGone, paneRef };
+  }
+
+  private async waitForStopPostCondition(
+    agent: AgentRecord,
+    paneRef: string | null,
+  ): Promise<StopPostConditionResult> {
+    const deadline = Date.now() + this.stopPostConditionTimeoutMs;
+    let result = await this.readStopPostCondition(agent, paneRef);
+    while (
+      !(result.processGone && result.surfaceGone && result.paneGone) &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, STOP_POST_CONDITION_POLL_MS),
+      );
+      result = await this.readStopPostCondition(agent, paneRef);
+    }
+    return result;
+  }
+
+  private formatStopPostConditionError(
+    agent: AgentRecord,
+    result: StopPostConditionResult,
+  ): string {
+    const failed = [
+      result.processGone ? null : "process still alive",
+      result.surfaceGone ? null : "surface still live",
+      result.paneGone ? null : "pane still open",
+    ].filter((part): part is string => part !== null);
+    return [
+      `Stop post-condition failed for ${agent.agent_id}: ${failed.join(", ")}`,
+      `(pid=${agent.pid ?? "unknown"} surface=${agent.surface_id}`,
+      `pane=${result.paneRef ?? "unknown"})`,
+    ].join(" ");
+  }
+
   /**
    * Stop an agent gracefully (Ctrl+C) or forcefully (kill PID).
    */
@@ -2168,6 +2335,11 @@ export class AgentEngine {
       return; // Already stopped
     }
 
+    const stopPaneRef = await this.resolvePaneForSurface(
+      route.surface_id,
+      route.workspace_id,
+    );
+
     if (force && agent.pid) {
       try {
         process.kill(agent.pid, "SIGKILL");
@@ -2179,6 +2351,30 @@ export class AgentEngine {
       await this.client.sendKey(route.surface_id, "c-c", {
         workspace: route.workspace_id ?? undefined,
       });
+    }
+
+    await this.client.closeSurface(route.surface_id, {
+      workspace: route.workspace_id ?? undefined,
+      collapsePane: true,
+    });
+
+    const stopResult = await this.waitForStopPostCondition(agent, stopPaneRef);
+    if (
+      !stopResult.processGone ||
+      !stopResult.surfaceGone ||
+      !stopResult.paneGone
+    ) {
+      const error = this.formatStopPostConditionError(agent, stopResult);
+      try {
+        const updated = this.stateMgr.updateRecord(canonicalAgentId, {
+          error,
+          quality: "degraded",
+        });
+        this.registry.set(canonicalAgentId, updated);
+      } catch {
+        // Preserve the post-condition error for the caller.
+      }
+      throw new Error(error);
     }
 
     const current = this.registry.get(canonicalAgentId) ?? agent;

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -66,6 +66,7 @@ export interface SignalAttempt {
 }
 
 export type KillProcess = (pid: number, signal: NodeJS.Signals) => void;
+export type IsProcessAlive = (pid: number) => boolean;
 
 export const PROCESS_TABLE_PS_ARGS = [
   "-ww",
@@ -192,10 +193,20 @@ export function signalProcessBatch(
   processes: readonly ProcessInfo[],
   signal: NodeJS.Signals,
   killProcess: KillProcess = process.kill,
+  isProcessAlive: IsProcessAlive = () => false,
 ): SignalAttempt[] {
   return processes.map((proc) => {
     try {
       killProcess(proc.pid, signal);
+      if (isProcessAlive(proc.pid)) {
+        return {
+          ok: false,
+          pid: proc.pid,
+          signal,
+          errorCode: "STILL_ALIVE",
+          errorMessage: `pid ${proc.pid} still alive after ${signal}`,
+        };
+      }
       return { ok: true, pid: proc.pid, signal };
     } catch (error) {
       return {
@@ -208,6 +219,23 @@ export function signalProcessBatch(
       };
     }
   });
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ESRCH"
+    ) {
+      return false;
+    }
+    return true;
+  }
 }
 
 function signalErrorCode(error: unknown): string {
@@ -439,7 +467,7 @@ async function runReaper(opts: CliOptions): Promise<void> {
   }
   await logSignalFailures(
     opts.logFile,
-    signalProcessBatch(killable, "SIGKILL"),
+    signalProcessBatch(killable, "SIGKILL", process.kill, processAlive),
   );
 }
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3348,6 +3348,14 @@ To continue this session, run codex resume ${sessionId}`,
   });
 
   describe("stopAgent", () => {
+    beforeEach(() => {
+      (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async (surface: string) => {
+          liveSurfaces = liveSurfaces.filter((item) => item.ref !== surface);
+        },
+      );
+    });
+
     it("sends Ctrl+C for graceful stop", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -3383,6 +3391,99 @@ To continue this session, run codex resume ${sessionId}`,
 
       const state = stateMgr.readState("agent-stop");
       expect(state!.state).toBe("done");
+    });
+
+    it("rejects graceful stop when the agent surface remains live", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-still-live",
+          state: "working",
+          surface_id: "surface:still-live",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:still-live")];
+      (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockResolvedValue(
+        undefined,
+      );
+      await engine.getRegistry().reconstitute();
+
+      await expect(engine.stopAgent("agent-still-live")).rejects.toThrow(
+        /post-condition/i,
+      );
+      expect(stateMgr.readState("agent-still-live")?.state).not.toBe("done");
+    });
+
+    it("rejects graceful stop when the pane respawns a fresh idle surface", async () => {
+      const pane = {
+        ref: "pane:agent",
+        index: 0,
+        focused: true,
+        surface_count: 1,
+        surface_refs: ["surface:old-agent"],
+        selected_surface_ref: "surface:old-agent",
+      };
+      mockClient = makeMockClient({
+        listPanes: vi
+          .fn()
+          .mockResolvedValueOnce({
+            workspace_ref: "ws:1",
+            window_ref: "window:1",
+            panes: [pane],
+          })
+          .mockResolvedValue({
+            workspace_ref: "ws:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ...pane,
+                surface_refs: ["surface:fresh-idle"],
+                selected_surface_ref: "surface:fresh-idle",
+              },
+            ],
+          }),
+        listPaneSurfaces: vi
+          .fn()
+          .mockResolvedValueOnce({
+            workspace_ref: "ws:1",
+            window_ref: "window:1",
+            pane_ref: "pane:agent",
+            surfaces: [makeSurface("surface:old-agent")],
+          })
+          .mockResolvedValue({
+            workspace_ref: "ws:1",
+            window_ref: "window:1",
+            pane_ref: "pane:agent",
+            surfaces: [
+              {
+                ...makeSurface("surface:fresh-idle"),
+                title: "What can I help you with?",
+              },
+            ],
+          }),
+        closeSurface: vi.fn().mockImplementation(async () => {
+          liveSurfaces = [makeSurface("surface:fresh-idle")];
+        }),
+      });
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-respawned-pane",
+          state: "working",
+          surface_id: "surface:old-agent",
+          workspace_id: "ws:1",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:old-agent")];
+      await engine.getRegistry().reconstitute();
+
+      await expect(engine.stopAgent("agent-respawned-pane")).rejects.toThrow(
+        /post-condition/i,
+      );
+      expect(stateMgr.readState("agent-respawned-pane")?.state).not.toBe("done");
     });
 
     it("resolves provisional agent aliases before stopping", async () => {
@@ -3473,6 +3574,38 @@ To continue this session, run codex resume ${sessionId}`,
 
       const state = stateMgr.readState("agent-force");
       expect(["done", "error"]).toContain(state!.state);
+    });
+
+    it("rejects force stop when the pid remains alive after SIGKILL", async () => {
+      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          killCalls.push([pid, signal ?? 0]);
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-force-live",
+            state: "working",
+            surface_id: "surface:force-live",
+            pid: 12345,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:force-live")];
+        await engine.getRegistry().reconstitute();
+
+        await expect(engine.stopAgent("agent-force-live", true)).rejects.toThrow(
+          /post-condition/i,
+        );
+        expect(killCalls).toContainEqual([12345, "SIGKILL"]);
+        expect(killCalls).toContainEqual([12345, 0]);
+        expect(stateMgr.readState("agent-force-live")?.state).not.toBe("done");
+      } finally {
+        killSpy.mockRestore();
+      }
     });
 
     it("does not mark naturally completed agents as user-killed", async () => {
@@ -3881,6 +4014,46 @@ describe("assertLauncherAvailable", () => {
     await expect(
       assertLauncherAvailable("skill-creator", "Cursor"),
     ).rejects.toThrow(/skill-creatorCursor.*skillcreatorCursor.*cli="kiro"/s);
+  });
+
+  it("waits for the launcher probe process to exit after SIGTERM timeout", async () => {
+    vi.useFakeTimers();
+    let exitCallback: ((code: number | null, signal: NodeJS.Signals | null) => void)
+      | null = null;
+    const child = {
+      kill: vi.fn(),
+      once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "exit") {
+          exitCallback = callback as typeof exitCallback;
+        }
+        return child;
+      }),
+    };
+    spawnMock.mockImplementation(() => child);
+
+    try {
+      const probe = assertLauncherAvailable("brainlayer", "Cursor");
+      let settled = false;
+      probe.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await Promise.resolve();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(settled).toBe(false);
+
+      exitCallback?.(null, "SIGTERM");
+      await expect(probe).rejects.toThrow(/Launcher not found/);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -196,6 +196,36 @@ describe("signalProcessBatch", () => {
       { ok: true, pid: 403, signal: "SIGTERM" },
     ]);
   });
+
+  it.each(["SIGTERM", "SIGKILL"] as const)(
+    "marks %s failed when the pid remains alive after signaling",
+    (signal) => {
+      const processes: ProcessInfo[] = [
+        { pid: 501, ppid: 1, etimes: 1200, command: "node live-mcp/index.js" },
+      ];
+      const signaled: Array<[number, NodeJS.Signals]> = [];
+
+      const attempts = signalProcessBatch(
+        processes,
+        signal,
+        (pid, attemptedSignal) => {
+          signaled.push([pid, attemptedSignal]);
+        },
+        () => true,
+      );
+
+      expect(signaled).toEqual([[501, signal]]);
+      expect(attempts).toEqual([
+        {
+          errorCode: "STILL_ALIVE",
+          errorMessage: `pid 501 still alive after ${signal}`,
+          ok: false,
+          pid: 501,
+          signal,
+        },
+      ]);
+    },
+  );
 });
 
 describe("parseCliOptions", () => {

--- a/tests/ram-watchdog-warn-only.test.ts
+++ b/tests/ram-watchdog-warn-only.test.ts
@@ -43,6 +43,33 @@ function fileMissingOrEmpty(path: string) {
   return !existsSync(path) || statSync(path).size === 0;
 }
 
+function samplerKillTrap(logDir: string) {
+  return `
+export CMUX_TEST_KILL_TRAP_LOG=${JSON.stringify(join(logDir, "kill.log"))}
+kill() {
+  printf 'kill %s\\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+  return 0
+}
+pkill() {
+  printf 'pkill %s\\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+  return 0
+}
+killall() {
+  printf 'killall %s\\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+  return 0
+}
+osascript() {
+  printf 'osascript %s\\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+  return 0
+}
+launchctl() {
+  printf 'launchctl %s\\n' "$*" >>"$CMUX_TEST_KILL_TRAP_LOG"
+  return 0
+}
+export -f kill pkill killall osascript launchctl
+`;
+}
+
 function runBash(script: string, env: NodeJS.ProcessEnv) {
   return spawnSync("/bin/bash", ["--noprofile", "--norc", "-c", script], {
     cwd: repoRoot,
@@ -145,13 +172,6 @@ while IFS= read -r line; do
 done
 `,
   );
-  writeExecutable(
-    join(root, "bin/kill"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >>"${logDir}/kill.log"
-`,
-  );
   writeFileSync(join(root, "fixtures/footprint.fixture"), "4242 phys_footprint: 1024 MB (peak 2048 MB)\n");
   writeFileSync(join(root, "fixtures/memsize.fixture"), "1048576\n");
 }
@@ -204,7 +224,8 @@ run_once`,
     );
 
     const result = runBash(
-      `source "${ramSamplerScript}"
+      `${samplerKillTrap(logDir)}
+source "${ramSamplerScript}"
 run_once`,
       {
         PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
@@ -243,7 +264,8 @@ run_once`,
     );
 
     const result = runBash(
-      `source "${ramSamplerScript}"
+      `${samplerKillTrap(logDir)}
+source "${ramSamplerScript}"
 run_once`,
       {
         PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
@@ -268,5 +290,25 @@ run_once`,
     expect(alert).toContain("cmux.app");
     expect(fileMissingOrEmpty(join(logDir, "kill.log"))).toBe(true);
     expect(readIfExists(join(logDir, "kill.log"))).not.toMatch(/-(TERM|KILL)\s+4242/);
+  });
+
+  it("records injected shell kill builtin attempts in the sampler no-kill guard", () => {
+    const root = makeRoot("cmux-sampler-killtrap-vitest-");
+    const logDir = join(root, "logs");
+    seedSamplerCommands(root);
+
+    const result = runBash(
+      `${samplerKillTrap(logDir)}
+source "${ramSamplerScript}"
+kill -9 4242 || true`,
+      {
+        PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
+        CMUX_RAM_SAMPLER_SOURCE_ONLY: "1",
+        CMUX_RAM_SAMPLER_LOG_DIR: logDir,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readIfExists(join(logDir, "kill.log"))).toContain("-9 4242");
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -35,9 +35,17 @@ const AGENT_TOOLS = [
   "my_agents",
 ] as const;
 
-function makeLifecycleExec(): ExecFn {
+function makeLifecycleExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
   let readyText = "What can I help you with?\n>";
+  let surfaceLive = true;
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("new-split") || args.includes("new-surface")) {
+      surfaceLive = true;
+    }
+    if (args.includes("close-surface") && !opts?.closeKeepsSurface) {
+      surfaceLive = false;
+      return { stdout: "{}", stderr: "" };
+    }
     if (args.includes("send")) {
       const text = String(args[args.length - 1] ?? "");
       if (text.includes("Codex")) readyText = "codex> ";
@@ -67,16 +75,18 @@ function makeLifecycleExec(): ExecFn {
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
           window_ref: "window:1",
-          panes: [
-            {
-              ref: "pane:1",
-              index: 0,
-              focused: true,
-              surface_count: 1,
-              surface_refs: ["surface:new"],
-              selected_surface_ref: "surface:new",
-            },
-          ],
+          panes: surfaceLive
+            ? [
+                {
+                  ref: "pane:1",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:new"],
+                  selected_surface_ref: "surface:new",
+                },
+              ]
+            : [],
         }),
         stderr: "",
       };
@@ -88,15 +98,17 @@ function makeLifecycleExec(): ExecFn {
           workspace_ref: "workspace:1",
           window_ref: "window:1",
           pane_ref: "pane:1",
-          surfaces: [
-            {
-              ref: "surface:new",
-              title: "agent-pane",
-              type: "terminal",
-              index: 0,
-              selected: true,
-            },
-          ],
+          surfaces: surfaceLive
+            ? [
+                {
+                  ref: "surface:new",
+                  title: "agent-pane",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [],
         }),
         stderr: "",
       };
@@ -564,6 +576,36 @@ describe("agent lifecycle tool handlers", () => {
       stopResult.structuredContent ?? JSON.parse(stopResult.content[0].text);
     expect(stopped.ok).toBe(true);
     expect(stopped.state).toBe("done");
+  });
+
+  it("stop_agent returns an error when the stopped pane remains live", async () => {
+    mockExec = makeLifecycleExec({ closeKeepsSurface: true });
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const stop = (server as any)._registeredTools["stop_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "idle after stop",
+      },
+      {} as any,
+    );
+    const spawned =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    const stopResult = await stop.handler(
+      { agent_id: spawned.agent_id },
+      {} as any,
+    );
+    const stopped =
+      stopResult.structuredContent ?? JSON.parse(stopResult.content[0].text);
+
+    expect(stopResult.isError).toBe(true);
+    expect(stopped.ok).toBe(false);
+    expect(stopped.error).toMatch(/post-condition/i);
   });
 
   it("spawn_agent sends boot_prompt_path contents after readiness", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -28,9 +28,17 @@ function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
-function makeSpawnReadyExec(): ExecFn {
+function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
   let launchSent = false;
+  let surfaceLive = true;
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("new-split") || args.includes("new-surface")) {
+      surfaceLive = true;
+    }
+    if (args.includes("close-surface") && !opts?.closeKeepsSurface) {
+      surfaceLive = false;
+      return { stdout: "{}", stderr: "" };
+    }
     if (args.includes("send")) {
       launchSent = true;
     }
@@ -38,7 +46,46 @@ function makeSpawnReadyExec(): ExecFn {
       return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
     }
     if (args.includes("list-panes")) {
-      return { stdout: JSON.stringify({ panes: [] }), stderr: "" };
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          panes: surfaceLive
+            ? [
+                {
+                  ref: "pane:1",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:new"],
+                  selected_surface_ref: "surface:new",
+                },
+              ]
+            : [],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "ws:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: surfaceLive
+            ? [
+                {
+                  ref: "surface:new",
+                  title: "agent-pane",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [],
+        }),
+        stderr: "",
+      };
     }
     if (args.includes("read-screen")) {
       return {
@@ -294,6 +341,26 @@ describe("kill — scoped targets", () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.killed).toContain(agentId);
+  });
+
+  it("kill returns an error when the target remains interactable", async () => {
+    mockExec = makeSpawnReadyExec({ closeKeepsSurface: true });
+    server = createV2Server(mockExec);
+    const spawn = await callTool(server, "spawn_agent", {
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+    });
+    const agentId = parseResult(spawn).agent_id;
+
+    const result = await callTool(server, "kill", {
+      target: agentId,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/post-condition/i);
   });
 
   it("kill resolves a finalized agent through its pending alias", async () => {


### PR DESCRIPTION
gen-19 T4 stop-lifecycle + kill-safety gate. Two-sided RED/GREEN, HELD-verified (926 tests green, typecheck + build clean).

## Stop-lifecycle — positive `stop == GONE` post-condition
`stop_agent` now asserts the agent **process is GONE + pane/surface closed**, instead of trusting a `state:done`/`ok:true` return. Kills two live false-greens:
- **M-32:** `stop_agent` returned `state:done` while the pane respawned a fresh idle agent.
- **M-21:** cmux kill returned `ok:true` while the agent stayed interactable.

Covers all kill paths: `stopAgent` graceful + force (SIGKILL), launcher-probe SIGTERM→SIGKILL escalation, mcp-reaper. Configurable via `CMUXLAYER_STOP_POST_CONDITION_TIMEOUT_MS`.

RED specimens (now passing): rejects graceful stop when surface remains live / when pane respawns a fresh idle surface; rejects force stop when the pid remains alive after SIGKILL.

## W2b kill-trap PATCH
The RAM-sampler "never kills cmux" test was a false-green: it seeded a fake `bin/kill` on PATH, but the shell `kill` **builtin shadows it**, so an injected `kill -9` bypassed the fixture. Replaced with **exported shell functions** trapping `kill/pkill/killall/osascript/launchctl`. RED = `kill -9` via builtin is now caught (was silently green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent stop/kill semantics and error surfaces for MCP tools; failures now throw instead of reporting success when panes or PIDs remain.
> 
> **Overview**
> **Agent stop/kill** no longer treats `state: done` / `ok: true` as success by itself. After Ctrl+C or SIGKILL, `stopAgent` always **closes the surface** (with pane collapse), then **polls** until the PID is gone, the surface is no longer live, and the resolved pane is closed—or **throws** with a post-condition error (timeout via `CMUXLAYER_STOP_POST_CONDITION_TIMEOUT_MS`, default 1s). That surfaces false-greens where the pane respawns a fresh idle agent or the process survives SIGKILL. **`stop_agent`** and **`kill`** inherit this behavior through the engine.
> 
> Related hardening: launcher **shell probes** escalate SIGTERM → SIGKILL and wait for exit before failing; **mcp-reaper** SIGKILL marks failure when the PID is still alive after signal; RAM-sampler tests replace PATH **`bin/kill`** stubs with **exported shell traps** for `kill`/`pkill`/etc. so the shell **builtin** cannot bypass the no-kill guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746791fb9a6bcd315159562f6f8fe3f286969deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce stop post-conditions and export kill-trap functions for agent shutdown
> - `AgentEngine.stopAgent` in [src/agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/187/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now waits (up to `stopPostConditionTimeoutMs`, default 1s) for the process, surface, and pane to be fully gone after sending the kill signal and closing the surface; it throws a formatted error and marks the record `degraded` if any condition remains.
> - Adds helper methods `isProcessGone`, `isSurfaceGone`, `isPaneGone`, `readStopPostCondition`, and `waitForStopPostCondition` to poll shutdown state concurrently.
> - `signalProcessBatch` in [src/mcp-reaper.ts](https://github.com/EtanHey/cmuxlayer/pull/187/files#diff-32c6a0b7ce6e61ede4270634b60059d84d8b3d8ab0720c01b42204c91552c263) accepts an optional aliveness check and records `STILL_ALIVE` failures when a process survives immediately after SIGKILL.
> - Shell kill-trap helpers in test files are refactored into a shared `install_kill_traps` function that overrides `kill`, `pkill`, `killall`, `osascript`, and `launchctl` and exports them to subshells, replacing per-test custom bin/kill scripts.
> - Behavioral Change: `stopAgent` now rejects instead of silently succeeding when the agent process or pane remains alive after the stop sequence.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 746791f. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->