### PR TITLE
docs(r-num): disambiguate cmuxlayer-code R-038/R-039 from weave-registry namespace

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -229,7 +229,8 @@ type RefreshedTargetStateEvidenceSource = Exclude<
 
 // AIDEV-NOTE: Cursor has no distinct "done" lifecycle state — it settles to
 // "idle" when a task completes. A wait_for(target="done") on a Cursor agent
-// would otherwise hang the full timeout (R-038: "300s hang on a done Cursor").
+// would otherwise hang the full timeout (R-038(cmuxlayer-code: cursor-idle short-circuit): "300s hang on a done Cursor").
+// AIDEV-NOTE: This is distinct from weave-registry R-038 (wait_for(done) transcript ground-truth) and weave-registry R-039 (delta-wave coverage).
 // Treat a Cursor that has reached idle as satisfying a done wait. Narrowly
 // scoped to cli==="cursor" so Claude/Codex idle (awaiting input ≠ done) is
 // unaffected.
@@ -505,6 +506,8 @@ const REPO_LAUNCHER_ALIASES: Record<string, string[]> = {
  *   - the P10 "hyphen-aware verbatim alias" is emitted ONLY for some repos
  *     (`agent-html-hostCursor` exists for `maakaf-home`/`skill-creator` but
  *     NOT for `agent-html-host`).
+ *
+ * AIDEV-NOTE: R-039(cmuxlayer-code: launcher-name resolution) is distinct from weave-registry R-038 (wait_for(done) transcript ground-truth) and weave-registry R-039 (delta-wave coverage).
  *
  * cmuxlayer cannot know which form a given repo registered, so we generate
  * both and probe in order. Candidate #1 preserves today's behavior (verbatim


### PR DESCRIPTION
## Summary
- Annotate cmuxlayer-code R-038 as the Cursor idle short-circuit rule.
- Add an explicit cmuxlayer-code R-039 note on launcher-name resolution.
- Distinguish both from weave-registry R-038/R-039 so future consolidation cannot conflate namespaces.

## Test plan
- [x] graphify query before source read (`graphify query ... --budget 4000`)
- [x] `bun run test` — 57 files, 926 tests passed
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Push hook reran tests — 57 files, 926 tests passed

## Review notes
- Local `coderabbit review --agent` was attempted before commit and returned a recoverable OSS rate-limit error: wait time 7m03s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no behavioral impact on agent lifecycle or launcher resolution.
> 
> **Overview**
> **Documentation-only** updates to `AIDEV-NOTE` comments in `agent-engine.ts` so **cmuxlayer-code** rule IDs are not confused with **weave-registry** rules that reuse R-038/R-039.
> 
> The Cursor **`wait_for(done)`** idle short-circuit note now labels **R-038(cmuxlayer-code: cursor-idle short-circuit)** and explicitly contrasts it with weave-registry R-038 (transcript ground-truth) and R-039 (delta-wave coverage). A new note above **`launcherNameCandidates`** tags **R-039(cmuxlayer-code: launcher-name resolution)** with the same weave-registry disambiguation.
> 
> No runtime or test logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addd9da114a05fc6d89016ef5b2914c3112a184e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disambiguate cmuxlayer R-038/R-039 comments from weave-registry namespace in agent-engine
> Adds clarifying parentheticals to two comment blocks in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/188/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to distinguish cmuxlayer-specific R-038 and R-039 references from identically numbered references in the weave-registry namespace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized addd9da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->