### PR TITLE
fix(kill): GONE includes surface close + resync flags orphaned panes

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -43,6 +43,7 @@ import {
 import { parseScreen } from "./screen-parser.js";
 import {
   chooseAgentSpawnPlacement,
+  chooseSurfaceClosePolicy,
   collectRoleSurfaceIds,
   inferAgentRole,
   inferRecordRole,
@@ -219,6 +220,11 @@ interface StopPostConditionResult {
   surfaceGone: boolean;
   paneGone: boolean;
   paneRef: string | null;
+}
+
+interface StopSurfaceClosePolicy {
+  paneRef: string | null;
+  collapsePane: boolean;
 }
 
 type TargetStateEvidenceSource = "state" | "transcript" | "screen";
@@ -2220,6 +2226,53 @@ export class AgentEngine {
     return null;
   }
 
+  private async resolveStopSurfaceClosePolicy(
+    surfaceId: string,
+    workspaceId?: string | null,
+  ): Promise<StopSurfaceClosePolicy> {
+    try {
+      const opts = workspaceId ? { workspace: workspaceId } : undefined;
+      const panes = await this.client.listPanes(opts);
+      const rawPaneSurfaces = await Promise.all(
+        panes.panes.map(async (pane) => {
+          const paneSurfaces = await this.client.listPaneSurfaces({
+            ...(opts ?? {}),
+            pane: pane.ref,
+          });
+          return paneSurfaces.pane_ref
+            ? paneSurfaces
+            : { ...paneSurfaces, pane_ref: pane.ref };
+        }),
+      );
+      const paneSurfaces = partitionPaneSurfacesByMembership(
+        panes.panes,
+        rawPaneSurfaces,
+        {
+          workspace_ref: panes.workspace_ref ?? workspaceId ?? undefined,
+          window_ref: panes.window_ref,
+        },
+      );
+      const workerSurfaceIds = new Set(
+        this.registry.list().map((record) => record.surface_id),
+      );
+      const policy = chooseSurfaceClosePolicy(
+        panes.panes,
+        paneSurfaces,
+        workerSurfaceIds,
+        surfaceId,
+      );
+      return {
+        paneRef: policy.pane,
+        collapsePane: policy.collapsePane,
+      };
+    } catch {
+      return {
+        paneRef: await this.resolvePaneForSurface(surfaceId, workspaceId),
+        collapsePane: false,
+      };
+    }
+  }
+
   private isProcessGone(pid: number | null | undefined): boolean {
     if (!pid) return true;
     try {
@@ -2276,11 +2329,16 @@ export class AgentEngine {
   private async waitForStopPostCondition(
     agent: AgentRecord,
     paneRef: string | null,
+    expectPaneGone: boolean,
   ): Promise<StopPostConditionResult> {
     const deadline = Date.now() + this.stopPostConditionTimeoutMs;
     let result = await this.readStopPostCondition(agent, paneRef);
     while (
-      !(result.processGone && result.surfaceGone && result.paneGone) &&
+      !(
+        result.processGone &&
+        result.surfaceGone &&
+        (!expectPaneGone || result.paneGone)
+      ) &&
       Date.now() < deadline
     ) {
       await new Promise((resolve) =>
@@ -2294,11 +2352,14 @@ export class AgentEngine {
   private formatStopPostConditionError(
     agent: AgentRecord,
     result: StopPostConditionResult,
+    expectPaneGone: boolean,
+    closeError: string | null,
   ): string {
     const failed = [
       result.processGone ? null : "process still alive",
       result.surfaceGone ? null : "surface still live",
-      result.paneGone ? null : "pane still open",
+      expectPaneGone && !result.paneGone ? "pane still open" : null,
+      closeError ? `close failed: ${closeError}` : null,
     ].filter((part): part is string => part !== null);
     return [
       `Stop post-condition failed for ${agent.agent_id}: ${failed.join(", ")}`,
@@ -2338,7 +2399,7 @@ export class AgentEngine {
       return; // Already stopped
     }
 
-    const stopPaneRef = await this.resolvePaneForSurface(
+    const stopClosePolicy = await this.resolveStopSurfaceClosePolicy(
       route.surface_id,
       route.workspace_id,
     );
@@ -2356,18 +2417,32 @@ export class AgentEngine {
       });
     }
 
-    await this.client.closeSurface(route.surface_id, {
-      workspace: route.workspace_id ?? undefined,
-      collapsePane: true,
-    });
+    let closeError: string | null = null;
+    try {
+      await this.client.closeSurface(route.surface_id, {
+        workspace: route.workspace_id ?? undefined,
+        collapsePane: stopClosePolicy.collapsePane,
+      });
+    } catch (error) {
+      closeError = error instanceof Error ? error.message : String(error);
+    }
 
-    const stopResult = await this.waitForStopPostCondition(agent, stopPaneRef);
+    const stopResult = await this.waitForStopPostCondition(
+      agent,
+      stopClosePolicy.paneRef,
+      stopClosePolicy.collapsePane,
+    );
     if (
       !stopResult.processGone ||
       !stopResult.surfaceGone ||
-      !stopResult.paneGone
+      (stopClosePolicy.collapsePane && !stopResult.paneGone)
     ) {
-      const error = this.formatStopPostConditionError(agent, stopResult);
+      const error = this.formatStopPostConditionError(
+        agent,
+        stopResult,
+        stopClosePolicy.collapsePane,
+        closeError,
+      );
       try {
         const updated = this.stateMgr.updateRecord(canonicalAgentId, {
           error,

--- a/src/format.ts
+++ b/src/format.ts
@@ -268,9 +268,11 @@ export function formatResync(diff: {
   added: string[];
   evicted: string[];
   mismatches: string[];
+  orphaned?: string[];
 }): string {
   const added = diff.added.length;
   const evicted = diff.evicted.length;
   const mismatches = diff.mismatches.length;
-  return `✔ resync_agents — added: ${added}  evicted: ${evicted}  mismatches: ${mismatches}`;
+  const orphaned = diff.orphaned?.length ?? 0;
+  return `✔ resync_agents — added: ${added}  evicted: ${evicted}  mismatches: ${mismatches}  orphaned: ${orphaned}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4289,6 +4289,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
           discovery.invalidate();
           const after = await registry.listMerged(discovery, { force: true });
+          const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));
           const diff = {
             added: [...afterIds].filter((id) => !beforeIds.has(id)),
@@ -4296,6 +4297,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             mismatches: after
               .filter((agent) => agent.parsed_cli_mismatch)
               .map((agent) => agent.agent_id),
+            orphaned: discovered
+              .filter((surface) => !surface.has_agent && !surface.read_error)
+              .map((surface) => surface.surface_id),
           };
 
           return okFormatted(formatResync(diff), {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3486,6 +3486,59 @@ To continue this session, run codex resume ${sessionId}`,
       expect(stateMgr.readState("agent-respawned-pane")?.state).not.toBe("done");
     });
 
+    it("closes only the stopped agent surface when another live agent shares the pane", async () => {
+      const pane = {
+        ref: "pane:shared",
+        index: 0,
+        focused: true,
+        surface_count: 2,
+        surface_refs: ["surface:dying", "surface:other"],
+        selected_surface_ref: "surface:dying",
+      };
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        panes: [pane],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: "pane:shared",
+        surfaces: [
+          makeSurface("surface:dying"),
+          makeSurface("surface:other"),
+        ],
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-dying",
+          state: "working",
+          surface_id: "surface:dying",
+          workspace_id: "ws:1",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-other",
+          state: "working",
+          surface_id: "surface:other",
+          workspace_id: "ws:1",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dying"), makeSurface("surface:other")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.stopAgent("agent-dying");
+
+      expect(mockClient.closeSurface).toHaveBeenCalledWith("surface:dying", {
+        workspace: "ws:1",
+        collapsePane: false,
+      });
+      expect(mockClient.closeSurface).toHaveBeenCalledTimes(1);
+      expect(stateMgr.readState("agent-dying")?.state).toBe("done");
+      expect(stateMgr.readState("agent-other")?.state).toBe("working");
+    });
+
     it("resolves provisional agent aliases before stopping", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -481,6 +481,26 @@ describe("resync_agents tool", () => {
     expect(parsed.count).toBe(0);
   });
 
+  it("resync_agents reports agent-less terminal surfaces as orphaned instead of clean", async () => {
+    const server = createServer({
+      exec: makeShellPromptExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.added).toEqual([]);
+    expect(parsed.diff.evicted).toEqual([]);
+    expect(parsed.diff.mismatches).toEqual([]);
+    expect(parsed.diff.orphaned).toEqual(["surface:999"]);
+    expect(parsed.count).toBe(0);
+  });
+
   it("resync_agents evicts registry-only phantom agents instead of failing", async () => {
     const server = createServer({
       exec: makeDiscoveryExec(),

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -15,6 +15,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
+import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-v2");
 
@@ -109,6 +111,117 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
       stderr: "",
     };
   });
+}
+
+function makeSharedPaneExec(): ExecFn {
+  const liveSurfaces = new Set(["surface:dying", "surface:other"]);
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("close-surface")) {
+      const surface = String(args[args.indexOf("--surface") + 1] ?? "");
+      liveSurfaces.delete(surface);
+      return { stdout: "{}", stderr: "" };
+    }
+    if (args.includes("send")) {
+      return { stdout: "{}", stderr: "" };
+    }
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      const surfaces = [...liveSurfaces];
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes:
+            surfaces.length > 0
+              ? [
+                  {
+                    ref: "pane:shared",
+                    index: 0,
+                    focused: true,
+                    surface_count: surfaces.length,
+                    surface_refs: surfaces,
+                    selected_surface_ref: surfaces[0],
+                  },
+                ]
+              : [],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:shared",
+          surfaces: [...liveSurfaces].map((ref, index) => ({
+            ref,
+            title: "agent-pane",
+            type: "terminal",
+            index,
+            selected: index === 0,
+          })),
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("read-screen")) {
+      const surface = String(args[args.indexOf("--surface") + 1] ?? "");
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: JSON.stringify({}), stderr: "" };
+  });
+}
+
+function makeAgentRecord(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "agent",
+    surface_id: "surface:agent",
+    workspace_id: "workspace:1",
+    state: "working",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "test agent",
+    pid: null,
+    version: 1,
+    created_at: "2026-04-19T20:00:00.000Z",
+    updated_at: "2026-04-19T20:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
 }
 
 function createV2Server(exec: ExecFn) {
@@ -341,6 +454,48 @@ describe("kill — scoped targets", () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.killed).toContain(agentId);
+  });
+
+  it("kill closes a shared-pane target without collapsing another live agent", async () => {
+    mockExec = makeSharedPaneExec();
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "agent-dying",
+        surface_id: "surface:dying",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "agent-other",
+        surface_id: "surface:other",
+      }),
+    );
+    server = createV2Server(mockExec);
+    await callTool(server, "list_agents", {});
+
+    const result = await callTool(server, "kill", {
+      target: "agent-dying",
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.killed).toContain("agent-dying");
+    const closeCalls = (mockExec as any).mock.calls.filter(([, args]: any[]) =>
+      args.includes("close-surface"),
+    );
+    expect(closeCalls).toHaveLength(1);
+    const closeCall = closeCalls[0];
+    expect(closeCall?.[1]).toEqual(
+      expect.arrayContaining([
+        "close-surface",
+        "--surface",
+        "surface:dying",
+        "--workspace",
+        "workspace:1",
+      ]),
+    );
+    expect(closeCall?.[1]).not.toContain("--collapse-pane");
   });
 
   it("kill returns an error when the target remains interactable", async () => {


### PR DESCRIPTION
## Summary
- Make stop/kill surface teardown use the existing close policy so the killed agent's surface is closed while shared panes with other live agents are not collapsed.
- Keep the stop post-condition strict for process + surface gone, and require pane gone only when the close policy intentionally collapses that pane.
- Add `resync_agents.diff.orphaned` for agent-less terminal surfaces so leftover panes are visible instead of false-clean.

## Test plan
- RED confirmed:
  - `bun run test tests/agent-engine.test.ts -t "closes only the stopped agent surface"` failed with `pane still open` before implementation.
  - `bun run test tests/v2-interact-kill.test.ts -t "kill closes a shared-pane target"` failed with `parsed.ok` false before implementation.
  - `bun run test tests/resync-tool.test.ts -t "agent-less terminal surfaces"` failed because `diff.orphaned` was undefined before implementation.
- GREEN:
  - `bun run test tests/agent-engine.test.ts`
  - `bun run test tests/v2-interact-kill.test.ts`
  - `bun run test tests/resync-tool.test.ts tests/format.test.ts`
  - `bun run test` — 57 files, 929 tests
  - `bun run typecheck`
  - `bun run build`
- Local CodeRabbit pre-commit review: 2 minor test-strength findings, both fixed by asserting exactly one close call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent stop/kill teardown and resync diff semantics; behavior is covered by new tests but affects live pane layout when multiple agents share a pane.
> 
> **Overview**
> **Stop/kill teardown** no longer always passes `collapsePane: true` on `closeSurface`. `AgentEngine` resolves a **stop close policy** via `chooseSurfaceClosePolicy` (pane layout + live worker surfaces), closes only the target surface, and treats **pane gone** as a post-condition **only when** collapse was chosen. Close failures are surfaced in post-condition errors; shared-pane kills succeed without tearing down a co-located agent.
> 
> **`resync_agents`** extends the returned diff with **`orphaned`**: terminal surfaces with no agent and no read error, so empty leftover panes show up in the formatted summary instead of looking clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be37cb59e6b51feacabacf1e3db74f71dbe313b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent stop to skip pane collapse when another live agent shares the pane and flag orphaned panes in resync
> - `AgentEngine.stopAgent` now calls `resolveStopSurfaceClosePolicy` (via `chooseSurfaceClosePolicy`) to decide per-stop whether to collapse the pane or only close the agent's surface, based on whether other live agents share the pane.
> - `waitForStopPostCondition` and `formatStopPostConditionError` are updated to only require the pane to disappear when a collapse was actually requested, fixing false post-condition failures.
> - `resync_agents` now scans for orphaned terminal surfaces (surfaces with no agent and no read error) and includes the count in the formatted diff response.
> - `formatResync` in [format.ts](https://github.com/EtanHey/cmuxlayer/pull/189/files#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36b) accepts and displays an optional orphaned surface count.
> - Behavioral Change: stopping an agent in a shared pane no longer collapses that pane; only the target surface is closed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized be37cb5. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->