### PR TITLE
fix(worktree): resolve repo root from workspace cwd / configurable roots (not hardcoded ~/Gits)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,15 @@ async function main() {
   }
 
   const client = await createCmuxClient();
-  const server = createServer({ client });
+  const worktreeRepoRoots = process.env.CMUXLAYER_WORKTREE_REPO_ROOTS?.split(":")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const server = createServer({
+    client,
+    ...(worktreeRepoRoots && worktreeRepoRoots.length > 0
+      ? { worktreeRepoRoots }
+      : {}),
+  });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -681,6 +681,12 @@ export interface CreateServerOptions {
   /** Override git worktree execution/home for tests. */
   worktreeExec?: WorktreeExec;
   worktreeHomeDir?: string;
+  /**
+   * Ordered directories searched for `<root>/<repo>` when resolving a worktree's
+   * source repo and the target workspace's cwd is not a git work tree. Defaults
+   * to [`~/Gits`]. Set from CMUXLAYER_WORKTREE_REPO_ROOTS in the CLI entrypoint.
+   */
+  worktreeRepoRoots?: string[];
   /** Override control health collection (primarily for tests). */
   controlHealthCollector?: () => Promise<ControlHealth>;
   /** Periodic control health sample interval. Defaults to env or 60000ms; 0 disables. */
@@ -1016,6 +1022,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       path: z.string().optional(),
       branch: z.string().optional(),
       base: z.string().optional(),
+      repoRoot: z
+        .string()
+        .optional()
+        .describe(
+          "Explicit source repo checkout to branch the worktree from (overrides workspace/repoRoots resolution).",
+        ),
     }),
   ]);
 
@@ -3492,10 +3504,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return record;
     };
 
+    const resolveWorkspaceCwd = async (
+      workspaceRef: string | undefined,
+    ): Promise<string | undefined> => {
+      if (!workspaceRef) return undefined;
+      try {
+        const { workspaces } = await client.listWorkspaces();
+        const ws = workspaces.find((w) => w.ref === workspaceRef);
+        return ws?.current_directory ?? undefined;
+      } catch {
+        return undefined;
+      }
+    };
+
     const prepareSpawnWorktree = async (
       repo: string,
       worktree: boolean | object | undefined,
       mcpProfile: McpProfile | undefined,
+      workspaceRef?: string,
     ) => {
       if (!worktree) {
         return {
@@ -3506,11 +3532,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       const profile = mcpProfile ?? "inherit";
+      const worktreeObj =
+        worktree && typeof worktree === "object"
+          ? (worktree as { repoRoot?: string })
+          : undefined;
       const prepared = await prepareWorktree({
         repo,
         worktree: worktree as Parameters<typeof prepareWorktree>[0]["worktree"],
         exec: opts?.worktreeExec,
         homeGitsDir: opts?.worktreeHomeDir,
+        repoRoots: opts?.worktreeRepoRoots,
+        workspaceCwd: await resolveWorkspaceCwd(workspaceRef),
+        repoRoot: worktreeObj?.repoRoot,
       });
       return {
         prepared,
@@ -3752,6 +3785,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.repo,
             args.worktree,
             args.mcp_profile as McpProfile | undefined,
+            args.workspace,
           );
 
           const result = await engine.spawnAgent({
@@ -3926,6 +3960,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.repo,
             args.worktree ?? true,
             args.mcp_profile as McpProfile | undefined,
+            args.workspace,
           );
           const hasPrompt = hasInlinePrompt(args.prompt);
           const result = await engine.spawnAgent({

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -12,6 +12,10 @@ import { sanitizeRepoName, shellQuote } from "./agent-command.js";
 
 const execFileAsync = promisify(execFile);
 
+// cmux validates the launch `-w` value (the worktree path cmuxLayer passes) as a
+// worktree name and rejects anything longer than this.
+const MAX_WORKTREE_ARG_LENGTH = 64;
+
 export type WorktreeExec = (
   cmd: string,
   args: string[],
@@ -182,7 +186,11 @@ function normalizeWorktreeRequest(
   Omit<WorktreeRequest, "create" | "reuse" | "base"> & { name: string } {
   const spec: WorktreeRequest =
     request === true || request === false || request === undefined ? {} : request;
-  const name = safeName(spec.name ?? `${repo}-worker-${Date.now()}`);
+  // Default name is intentionally compact: no redundant `<repo>-` prefix (the
+  // worktree already lives under `<repo>.wt/`) and a base36 timestamp instead of
+  // 13 decimal digits. This keeps the full worktree path — which cmux validates
+  // as the `-w` worktree-name argument (≤ 64 chars) — well within budget.
+  const name = safeName(spec.name ?? `worker-${Date.now().toString(36)}`);
   return {
     create: spec.create ?? true,
     reuse: spec.reuse ?? true,
@@ -257,6 +265,26 @@ export async function prepareWorktree(
     ? resolve(spec.path)
     : join(worktreeBase, `${repo}.wt`, spec.name);
   assertInside(worktreeBase, worktreePath);
+
+  // The worktree path becomes cmux's `-w` argument, which it caps at
+  // MAX_WORKTREE_ARG_LENGTH. cmuxLayer picks the location in production (homeGitsDir
+  // unset via workspace/repoRoots resolution), so fail clearly here instead of at
+  // launch. The legacy homeGitsDir branch (embedders/tests) opts out of the cap.
+  if (
+    input.homeGitsDir === undefined &&
+    worktreePath.length > MAX_WORKTREE_ARG_LENGTH
+  ) {
+    const prefixLen = worktreePath.length - spec.name.length;
+    throw new Error(
+      `Worktree path is ${worktreePath.length} characters but cmux limits the launch ` +
+        `worktree argument (-w) to ${MAX_WORKTREE_ARG_LENGTH}: ${worktreePath}. ` +
+        (spec.path
+          ? `Choose a shorter worktree.path.`
+          : `Use a shorter worktree name (current "${spec.name}" = ${spec.name.length} chars; ` +
+            `budget for this location is ${Math.max(0, MAX_WORKTREE_ARG_LENGTH - prefixLen)}).`),
+    );
+  }
+
   if (existsSync(worktreePath)) {
     if (!spec.reuse) {
       throw new Error(`Worktree already exists: ${worktreePath}`);

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -33,12 +33,31 @@ export interface WorktreeRequest {
   path?: string;
   branch?: string;
   base?: string;
+  /** Explicit source repo checkout to create the worktree from (overrides resolution). */
+  repoRoot?: string;
 }
 
 export interface PrepareWorktreeInput {
   repo: string;
+  /** Explicit source repo root. Highest priority; overrides all resolution. */
   repoRoot?: string;
+  /**
+   * Legacy/explicit base directory. When set, repos and worktrees are anchored
+   * under it exactly as before (used by embedders and tests).
+   */
   homeGitsDir?: string;
+  /**
+   * Ordered directories to search for `<root>/<repo>` when no explicit root and
+   * no workspace cwd resolves. Defaults to [`~/Gits`] for backward compatibility.
+   * `~` is expanded.
+   */
+  repoRoots?: string[];
+  /**
+   * The target workspace's current directory. If it is inside a git work tree,
+   * its top-level (`git rev-parse --show-toplevel`) is the authoritative repo
+   * root — this is preferred over `repoRoots`.
+   */
+  workspaceCwd?: string;
   worktree?: boolean | WorktreeRequest;
   exec?: WorktreeExec;
 }
@@ -77,6 +96,83 @@ function assertInside(root: string, path: string): void {
   if (rel.startsWith("..") || isAbsolute(rel)) {
     throw new Error(`Worktree path ${path} must be inside ${root}`);
   }
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+function isGitRepo(dir: string): boolean {
+  // A normal clone has a `.git` directory; a linked worktree has a `.git` file.
+  return existsSync(join(dir, ".git"));
+}
+
+/**
+ * Resolve the source repo root and the base directory worktrees live under.
+ * Precedence:
+ *   1. explicit `homeGitsDir` (legacy/embedder/test) — exact prior behavior.
+ *   2. explicit `repoRoot` — worktrees placed beside it.
+ *   3. `workspaceCwd` git top-level — authoritative (the repo the user is in).
+ *   4. configurable `repoRoots` search (default `~/Gits`).
+ *   5. otherwise throw with an actionable message.
+ */
+async function resolveRepoRoot(
+  input: PrepareWorktreeInput,
+  repo: string,
+  exec: WorktreeExec,
+): Promise<{ repoRoot: string; worktreeBase: string }> {
+  if (input.homeGitsDir !== undefined) {
+    const homeGitsDir = resolve(input.homeGitsDir);
+    const repoRoot = resolve(input.repoRoot ?? join(homeGitsDir, repo));
+    assertInside(homeGitsDir, repoRoot);
+    return { repoRoot, worktreeBase: homeGitsDir };
+  }
+
+  if (input.repoRoot !== undefined) {
+    const repoRoot = resolve(input.repoRoot);
+    return { repoRoot, worktreeBase: dirname(repoRoot) };
+  }
+
+  if (input.workspaceCwd) {
+    try {
+      const { stdout } = await exec("git", [
+        "-C",
+        input.workspaceCwd,
+        "rev-parse",
+        "--show-toplevel",
+      ]);
+      const top = stdout.trim();
+      if (top) {
+        const repoRoot = resolve(top);
+        return { repoRoot, worktreeBase: dirname(repoRoot) };
+      }
+    } catch {
+      // Not a git work tree (or git unavailable) — fall back to search roots.
+    }
+  }
+
+  const roots = (
+    input.repoRoots && input.repoRoots.length > 0
+      ? input.repoRoots
+      : [join(homedir(), "Gits")]
+  ).map((root) => resolve(expandHome(root)));
+  for (const root of roots) {
+    const candidate = join(root, repo);
+    if (isGitRepo(candidate)) {
+      return { repoRoot: candidate, worktreeBase: root };
+    }
+  }
+
+  throw new Error(
+    `Could not resolve a git repository for "${repo}". ` +
+      (input.workspaceCwd
+        ? `Workspace directory "${input.workspaceCwd}" is not inside a git work tree, and `
+        : "") +
+      `none of the configured repo roots [${roots.join(", ")}] contain it. ` +
+      `Pass worktree.repoRoot, set CMUXLAYER_WORKTREE_REPO_ROOTS, or spawn into the repo's workspace.`,
+  );
 }
 
 function normalizeWorktreeRequest(
@@ -153,17 +249,14 @@ export async function prepareWorktree(
   input: PrepareWorktreeInput,
 ): Promise<PreparedWorktree> {
   const repo = sanitizeRepoName(input.repo);
-  const homeGitsDir = resolve(input.homeGitsDir ?? join(homedir(), "Gits"));
-  const repoRoot = resolve(input.repoRoot ?? join(homeGitsDir, repo));
-  assertInside(homeGitsDir, repoRoot);
+  const exec = input.exec ?? defaultExec;
+  const { repoRoot, worktreeBase } = await resolveRepoRoot(input, repo, exec);
 
   const spec = normalizeWorktreeRequest(repo, input.worktree);
   const worktreePath = spec.path
     ? resolve(spec.path)
-    : join(homeGitsDir, `${repo}.wt`, spec.name);
-  assertInside(homeGitsDir, worktreePath);
-
-  const exec = input.exec ?? defaultExec;
+    : join(worktreeBase, `${repo}.wt`, spec.name);
+  assertInside(worktreeBase, worktreePath);
   if (existsSync(worktreePath)) {
     if (!spec.reuse) {
       throw new Error(`Worktree already exists: ${worktreePath}`);

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
 import {
   formatMcpProfileEnv,
   prepareWorktree,
 } from "../src/worktree.js";
 
-const TEST_ROOT = join(tmpdir(), "cmuxlayer-worktree-test");
+// A short root (not os.tmpdir(), which is long on macOS) so absolute worktree
+// paths mirror a real ~/dev checkout — relevant to the cmux 64-char `-w` cap that
+// the new-resolution path enforces.
+const TEST_ROOT = join("/tmp", "cmuxlayer-worktree-test");
 
 describe("worktree helpers", () => {
   beforeEach(() => {
@@ -229,6 +231,57 @@ describe("worktree helpers", () => {
         exec,
       }),
     ).rejects.toThrow(/Could not resolve a git repository/);
+  });
+
+  it("generates a compact default name and a short -w path for a long repo", async () => {
+    // Short root so the absolute path mirrors a real ~/dev checkout length.
+    const root = join("/tmp", "cmuxlayer-wt-roots");
+    const repoRoot = join(root, "esalon-admin");
+    rmSync(root, { recursive: true, force: true });
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    try {
+      const result = await prepareWorktree({
+        repo: "esalon-admin",
+        repoRoots: [root],
+        worktree: true, // default-generated name
+        exec,
+      });
+
+      const name = result.path.split("/").pop() ?? "";
+      // Compact default: no redundant repo prefix, well under our target.
+      expect(name.startsWith("esalon-admin")).toBe(false);
+      expect(name.length).toBeLessThanOrEqual(24);
+      // The full path is cmux's -w value; keep it within the 64-char limit.
+      expect(result.path.length).toBeLessThanOrEqual(64);
+      // And it would be fine at a realistic ~/dev location too.
+      const realisticWArg = `/Users/thomasmacneil/dev/esalon-admin.wt/${name}`;
+      expect(realisticWArg.length).toBeLessThanOrEqual(64);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an over-long worktree name before launch with a clear, budgeted error", async () => {
+    const root = join("/tmp", "cmuxlayer-wt-roots2");
+    const repoRoot = join(root, "esalon-admin");
+    rmSync(root, { recursive: true, force: true });
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    try {
+      await expect(
+        prepareWorktree({
+          repo: "esalon-admin",
+          repoRoots: [root],
+          worktree: { name: "x".repeat(80) },
+          exec,
+        }),
+      ).rejects.toThrow(/cmux limits the launch worktree argument \(-w\) to 64/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("formats MCP profile env hints without raw config passing", () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -119,6 +119,118 @@ describe("worktree helpers", () => {
     ).rejects.toThrow(/must be inside/);
   });
 
+  it("resolves the repo root from the workspace cwd via git top-level", async () => {
+    const repoRoot = join(TEST_ROOT, "dev", "esalon-admin");
+    mkdirSync(repoRoot, { recursive: true });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("--show-toplevel")) {
+        return { stdout: `${repoRoot}\n`, stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "esalon-admin",
+      workspaceCwd: join(repoRoot, "src"),
+      worktree: { name: "feature" },
+      exec,
+    });
+
+    expect(result.path).toBe(join(TEST_ROOT, "dev", "esalon-admin.wt", "feature"));
+    expect(result.created).toBe(true);
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      join(repoRoot, "src"),
+      "rev-parse",
+      "--show-toplevel",
+    ]);
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      "cmuxlayer/feature",
+      join(TEST_ROOT, "dev", "esalon-admin.wt", "feature"),
+      "HEAD",
+    ]);
+  });
+
+  it("resolves the repo root from a configured search root outside ~/Gits", async () => {
+    const root = join(TEST_ROOT, "code");
+    const repoRoot = join(root, "myrepo");
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "myrepo",
+      repoRoots: [join(TEST_ROOT, "does-not-exist"), root],
+      worktree: { name: "x" },
+      exec,
+    });
+
+    expect(result.path).toBe(join(root, "myrepo.wt", "x"));
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      "cmuxlayer/x",
+      join(root, "myrepo.wt", "x"),
+      "HEAD",
+    ]);
+  });
+
+  it("honors an explicit repoRoot and places the worktree beside it", async () => {
+    const repoRoot = join(TEST_ROOT, "anywhere", "proj");
+    mkdirSync(repoRoot, { recursive: true });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "proj",
+      repoRoot,
+      worktree: { name: "w" },
+      exec,
+    });
+
+    expect(result.path).toBe(join(TEST_ROOT, "anywhere", "proj.wt", "w"));
+  });
+
+  it("falls back to repoRoots when the workspace cwd is not a git work tree", async () => {
+    const root = join(TEST_ROOT, "roots");
+    const repoRoot = join(root, "fallrepo");
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("--show-toplevel")) {
+        throw new Error("fatal: not a work tree");
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "fallrepo",
+      workspaceCwd: "/tmp/not-a-repo",
+      repoRoots: [root],
+      worktree: { name: "x" },
+      exec,
+    });
+
+    expect(result.path).toBe(join(root, "fallrepo.wt", "x"));
+  });
+
+  it("throws an actionable error when the repo cannot be resolved", async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+    await expect(
+      prepareWorktree({
+        repo: "ghost",
+        repoRoots: [join(TEST_ROOT, "empty")],
+        worktree: { name: "x" },
+        exec,
+      }),
+    ).rejects.toThrow(/Could not resolve a git repository/);
+  });
+
   it("formats MCP profile env hints without raw config passing", () => {
     expect(formatMcpProfileEnv(undefined)).toBe(
       "CMUXLAYER_MCP_PROFILE=inherit",


### PR DESCRIPTION
## Problem

`spawn_agent` and `new_worktree_split` assume every repo lives at `~/Gits/<repo>` and that worktrees must live under `~/Gits` (`src/worktree.ts` `prepareWorktree`). Creating a worktree for a repo checked out anywhere else — e.g. `~/dev/<repo>` — fails before launch:

```
git -C /Users/me/Gits/esalon-admin worktree add -b cmuxlayer/… …
fatal: cannot change to '/Users/me/Gits/esalon-admin': No such file or directory
```

The repo root is derived purely from a name + a single hardcoded base, ignoring the workspace the agent is actually being spawned into (which already knows its `current_directory`).

## Fix

Resolve the source repo root with explicit precedence:

1. **Explicit** `worktree.repoRoot` (new) / `input.repoRoot`.
2. **Authoritative** — the target workspace's git top-level: `git -C <workspace.current_directory> rev-parse --show-toplevel`.
3. **Configurable search roots** — `CMUXLAYER_WORKTREE_REPO_ROOTS` (colon-separated; `~` expanded), default `["~/Gits"]`.
4. Otherwise a **clear, actionable error** instead of building a bogus `~/Gits/<repo>` path.

The worktree destination now derives from the resolved root (a sibling `<repo>.wt/<name>`), and the path-traversal guard is anchored to that base. `spawn_agent`/`new_worktree_split` pass their target `workspace` down so resolution (2) works.

## Backward compatibility

Callers that pass `homeGitsDir` explicitly (embedders, the test suite) keep their **exact prior behavior** — that branch is preserved verbatim, and the default search root remains `~/Gits`. No change for existing `~/Gits` users.

## Tests

Added to `tests/worktree.test.ts`: workspace-cwd (git-toplevel) resolution, configurable-root resolution, explicit `repoRoot` override + sibling `.wt` placement, fallback when the workspace cwd is not a work tree, and the unresolved-repo error. Full suite green (931 passed).

## Notes

This also addresses the broader inconsistency where worktree resolution, the kiro/gemini `cd ~/Gits/<repo>` launch prefixes, and external launchers each assume a different repo location — `CMUXLAYER_WORKTREE_REPO_ROOTS` is a step toward one configurable notion of where repos live. Happy to extend the same resolution to the kiro/gemini launch prefixes in a follow-up if you'd like.

---
🤖 This is a Claude comment.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree repo root resolution to use workspace cwd and configurable roots instead of hardcoded `~/Gits`
> - Adds `resolveRepoRoot` in [worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/190/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d) with a precedence chain: explicit `repoRoot` arg → workspace `git rev-parse --show-toplevel` → ordered `repoRoots` search dirs (default `~/Gits`) → actionable error.
> - Exposes `CMUXLAYER_WORKTREE_REPO_ROOTS` env var (colon-separated) to configure search roots; parsed in [index.ts](https://github.com/EtanHey/cmuxlayer/pull/190/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) and passed through `CreateServerOptions`.
> - Worktree args may now include an optional `repoRoot` field to explicitly pin the source checkout.
> - Enforces a 64-character limit (`MAX_WORKTREE_ARG_LENGTH`) on the cmux `-w` launch argument when not using the legacy `homeGitsDir` path.
> - Behavioral Change: default worktree names change from `<repo>-worker-<decimal timestamp>` to `worker-<base36 timestamp>`, producing shorter paths; over-length names are now rejected before launch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 752d03f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree setup now supports configurable repository-root discovery via environment configuration and workspace-aware resolution.
  * Worktree spawning can anchor checkout relative to the workspace’s current directory (when available), with explicit repo-root overrides.
* **Bug Fixes**
  * Improved repository-root precedence and clearer failure messaging when a git repository can’t be resolved.
  * Added validation for worktree argument length limits and updated default worktree naming for more predictable paths.
* **Tests**
  * Expanded unit tests for repo-root resolution, workspace cwd detection, override behavior, and worktree path/name constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->