### PR TITLE
fix(resync): evict surfaceless/dead-PTY registry ghosts + force-kill removes entry

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -29,6 +29,7 @@ import type {
 import {
   generateAgentId,
   isCrashRecoveryEligible,
+  isCrashRecoveryExhausted,
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
   MAX_RESPAWN_ATTEMPTS,
@@ -2291,6 +2292,39 @@ export class AgentEngine {
     }
   }
 
+  private isTerminalDeadRegistryGhost(agent: AgentRecord): boolean {
+    if (!TERMINAL_STATES.has(agent.state)) {
+      return false;
+    }
+
+    return (
+      agent.user_killed === true ||
+      agent.pid === null ||
+      (agent.respawn_attempts ?? 0) >= MAX_RESPAWN_ATTEMPTS ||
+      isCrashRecoveryExhausted(agent.error)
+    );
+  }
+
+  evictDeadProcessAgents(): string[] {
+    const evicted: string[] = [];
+
+    for (const agent of this.registry.list()) {
+      if (
+        !this.isTerminalDeadRegistryGhost(agent) &&
+        (!agent.pid || !this.isProcessGone(agent.pid))
+      ) {
+        continue;
+      }
+
+      const removedAgentId = this.registry.evict(agent.agent_id);
+      if (removedAgentId) {
+        evicted.push(removedAgentId);
+      }
+    }
+
+    return evicted;
+  }
+
   private async isSurfaceGone(surfaceId: string): Promise<boolean> {
     try {
       return !(await this.registry.hasLiveSurface(surfaceId));
@@ -2386,6 +2420,10 @@ export class AgentEngine {
     const userInitiated = opts?.userInitiated ?? true;
 
     if (TERMINAL_STATES.has(agent.state)) {
+      if (force) {
+        this.registry.evict(canonicalAgentId);
+        return;
+      }
       if (
         agent.state === "error" &&
         userInitiated &&
@@ -2453,6 +2491,11 @@ export class AgentEngine {
         // Preserve the post-condition error for the caller.
       }
       throw new Error(error);
+    }
+
+    if (force) {
+      this.registry.evict(canonicalAgentId);
+      return;
     }
 
     const current = this.registry.get(canonicalAgentId) ?? agent;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2299,7 +2299,6 @@ export class AgentEngine {
 
     return (
       agent.user_killed === true ||
-      agent.pid === null ||
       (agent.respawn_attempts ?? 0) >= MAX_RESPAWN_ATTEMPTS ||
       isCrashRecoveryExhausted(agent.error)
     );

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -421,11 +421,17 @@ export class AgentRegistry {
     } catch {
       return [];
     }
+    if (surfaces.length === 0) {
+      return [];
+    }
 
     const liveSurfaceRefs = new Set(surfaces.map((surface) => surface.ref));
     const evicted: string[] = [];
 
     for (const [id, agent] of [...this.agents.entries()]) {
+      if (isCrashRecoveryEligible(agent)) {
+        continue;
+      }
       if (liveSurfaceRefs.has(agent.surface_id)) {
         continue;
       }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -403,6 +403,42 @@ export class AgentRegistry {
     this.deleteAgentAndAliases(agentId);
   }
 
+  evict(agentId: string): string | null {
+    const resolved = this.resolveAlias(agentId);
+    if (!this.agents.has(resolved) && this.stateMgr.readState(resolved) === null) {
+      return null;
+    }
+
+    const removedAgentId = this.deleteAgentAndAliases(agentId);
+    this.stateMgr.removeState(removedAgentId);
+    return removedAgentId;
+  }
+
+  async evictSurfaceless(): Promise<string[]> {
+    let surfaces: CmuxSurface[];
+    try {
+      surfaces = await this.surfaceProvider();
+    } catch {
+      return [];
+    }
+
+    const liveSurfaceRefs = new Set(surfaces.map((surface) => surface.ref));
+    const evicted: string[] = [];
+
+    for (const [id, agent] of [...this.agents.entries()]) {
+      if (liveSurfaceRefs.has(agent.surface_id)) {
+        continue;
+      }
+
+      const removedAgentId = this.evict(id);
+      if (removedAgentId) {
+        evicted.push(removedAgentId);
+      }
+    }
+
+    return evicted;
+  }
+
   private evictMissingStateAgent(agentId: string): boolean {
     if (this.getMissingStateSentinel(agentId) === null) {
       return false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4288,6 +4288,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             registry.list().map((agent) => agent.agent_id),
           );
           discovery.invalidate();
+          await registry.listMerged(discovery, { force: true });
+          await registry.evictSurfaceless();
+          engine.evictDeadProcessAgents();
+          discovery.invalidate();
           const after = await registry.listMerged(discovery, { force: true });
           const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3610,7 +3610,7 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
-    it("force stop kills the process when pid is available", async () => {
+    it("force stop kills the process and removes the tracked entry", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-force",
@@ -3625,8 +3625,8 @@ To continue this session, run codex resume ${sessionId}`,
       // Force stop — won't actually kill since PID doesn't exist, but should not throw
       await engine.stopAgent("agent-force", true);
 
-      const state = stateMgr.readState("agent-force");
-      expect(["done", "error"]).toContain(state!.state);
+      expect(stateMgr.readState("agent-force")).toBeNull();
+      expect(engine.getAgentState("agent-force")).toBeNull();
     });
 
     it("rejects force stop when the pid remains alive after SIGKILL", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -414,6 +414,55 @@ function makeMultiWorkspaceExec(): ExecFn {
   });
 }
 
+function makeEmptySurfaceExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [],
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
 describe("resync_agents tool", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
@@ -631,7 +680,7 @@ describe("resync_agents tool", () => {
         cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
         role: "orchestrator",
         error: "Surface surface:ghost disappeared",
-        crash_recover: true,
+        crash_recover: false,
       }),
     );
 
@@ -736,6 +785,63 @@ describe("resync_agents tool", () => {
     }
   });
 
+  it("resync_agents does not evict terminal records when surface enumeration is empty", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "lead-agent-during-empty-layout",
+        surface_id: "surface:lead",
+        state: "error",
+        role: "orchestrator",
+        pid: null,
+        error: "temporary layout read",
+      }),
+    );
+
+    const server = createServer({
+      exec: makeEmptySurfaceExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools[
+      "resync_agents"
+    ].handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).not.toContain("lead-agent-during-empty-layout");
+    expect(stateMgr.readState("lead-agent-during-empty-layout")).not.toBeNull();
+  });
+
+  it("resync_agents keeps recoverable crash-recovery errors for respawn", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "recoverable-crash-agent",
+        surface_id: "surface:missing-recoverable",
+        state: "error",
+        cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
+        error: "Surface surface:missing-recoverable disappeared",
+        crash_recover: true,
+        user_killed: false,
+      }),
+    );
+
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools[
+      "resync_agents"
+    ].handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).not.toContain("recoverable-crash-agent");
+    expect(stateMgr.readState("recoverable-crash-agent")).not.toBeNull();
+  });
+
   it("resync_agents evicts the exact exhausted Cursor ghost even when its stale surface is in a non-active workspace", async () => {
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState(
@@ -771,6 +877,35 @@ describe("resync_agents tool", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.diff.evicted).toContain("orchestratorCursor-2ec13c6e");
     expect(stateMgr.readState("orchestratorCursor-2ec13c6e")).toBeNull();
+  });
+
+  it("resync_agents keeps pidless terminal records with live surfaces and no dead evidence", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "inspectable-terminal-agent",
+        surface_id: "surface:287",
+        workspace_id: "workspace:12",
+        state: "done",
+        pid: null,
+        user_killed: false,
+        respawn_attempts: 0,
+      }),
+    );
+
+    const server = createServer({
+      exec: makeMultiWorkspaceExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools[
+      "resync_agents"
+    ].handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).not.toContain("inspectable-terminal-agent");
+    expect(stateMgr.readState("inspectable-terminal-agent")).not.toBeNull();
   });
 
   it("resync_agents never evicts a healthy agent whose surface is in a non-active workspace", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -5,11 +5,40 @@ import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-resync-tool");
 
 function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+function makeAgentRecord(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "agent",
+    surface_id: "surface:agent",
+    workspace_id: "workspace:1",
+    state: "working",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "test agent",
+    pid: null,
+    version: 1,
+    created_at: "2026-04-19T20:00:00.000Z",
+    updated_at: "2026-04-19T20:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
 }
 
 function makeDiscoveryExec(): ExecFn {
@@ -233,6 +262,158 @@ function makeShellPromptExec(): ExecFn {
   });
 }
 
+function makeMultiWorkspaceExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Active",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+            {
+              ref: "workspace:12",
+              title: "Other",
+              index: 1,
+              selected: false,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      const workspace = args.includes("--workspace")
+        ? args[args.indexOf("--workspace") + 1]
+        : "workspace:1";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: workspace,
+          window_ref:
+            workspace === "workspace:12" ? "window:12" : "window:1",
+          panes:
+            workspace === "workspace:12"
+              ? [
+                  {
+                    ref: "pane:12",
+                    index: 0,
+                    focused: false,
+                    surface_count: 2,
+                    surface_refs: ["surface:286", "surface:287"],
+                    selected_surface_ref: "surface:287",
+                  },
+                ]
+              : [
+                  {
+                    ref: "pane:1",
+                    index: 0,
+                    focused: true,
+                    surface_count: 1,
+                    surface_refs: ["surface:1"],
+                    selected_surface_ref: "surface:1",
+                  },
+                ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      const workspace = args.includes("--workspace")
+        ? args[args.indexOf("--workspace") + 1]
+        : "workspace:1";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: workspace,
+          window_ref:
+            workspace === "workspace:12" ? "window:12" : "window:1",
+          pane_ref: workspace === "workspace:12" ? "pane:12" : "pane:1",
+          surfaces:
+            workspace === "workspace:12"
+              ? [
+                  {
+                    ref: "surface:286",
+                    title: "orchestratorCursor",
+                    type: "terminal",
+                    index: 0,
+                    selected: false,
+                  },
+                  {
+                    ref: "surface:287",
+                    title: "brainlayerClaude",
+                    type: "terminal",
+                    index: 1,
+                    selected: true,
+                  },
+                ]
+              : [
+                  {
+                    ref: "surface:1",
+                    title: "notes",
+                    type: "terminal",
+                    index: 0,
+                    selected: true,
+                  },
+                ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      const surface = args[args.indexOf("--surface") + 1];
+      if (surface === "surface:287") {
+        return {
+          stdout: JSON.stringify({
+            surface,
+            text: `
+✻ Working…
+  Reading files
+🤖 Sonnet 4.6 | 💰 $0.50 | ⏱️  41s
+`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+
+      if (surface === "surface:286") {
+        return {
+          stdout: JSON.stringify({
+            surface,
+            text: "cursor> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
 describe("resync_agents tool", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
@@ -438,6 +619,197 @@ describe("resync_agents tool", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.diff.evicted).toContain("ghost-agent");
     expect(parsed.count).toBe(1);
+  });
+
+  it("resync_agents evicts surfaceless error agents with resumable sessions", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "surfaceless-error-agent",
+        surface_id: "surface:ghost",
+        state: "error",
+        cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
+        role: "orchestrator",
+        error: "Surface surface:ghost disappeared",
+        crash_recover: true,
+      }),
+    );
+
+    const server = createServer({
+      exec: makeDiscoveryExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).toContain("surfaceless-error-agent");
+    expect(stateMgr.readState("surfaceless-error-agent")).toBeNull();
+
+    const listed = parseResult(
+      await (server as any)._registeredTools["list_agents"].handler({}, {} as any),
+    );
+    expect(
+      listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
+    ).not.toContain("surfaceless-error-agent");
+  });
+
+  it("resync_agents evicts dead-PTY agents even when their surface still lingers", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "dead-pty-agent",
+        surface_id: "surface:1",
+        state: "working",
+        pid: 424242,
+      }),
+    );
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+        if (pid === 424242 && (signal ?? 0) === 0) {
+          const error = new Error("No such process") as NodeJS.ErrnoException;
+          error.code = "ESRCH";
+          throw error;
+        }
+        return true;
+      }) as typeof process.kill);
+
+    try {
+      const server = createServer({
+        exec: makeDiscoveryExec(),
+        stateDir: TEST_DIR,
+      });
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.diff.evicted).toContain("dead-pty-agent");
+      expect(stateMgr.readState("dead-pty-agent")).toBeNull();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it("resync_agents never evicts a live registered agent with a healthy surface", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "healthy-live-agent",
+        surface_id: "surface:1",
+        state: "working",
+        pid: 31337,
+      }),
+    );
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+        if (pid === 31337 && (signal ?? 0) === 0) {
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+    try {
+      const server = createServer({
+        exec: makeDiscoveryExec(),
+        stateDir: TEST_DIR,
+      });
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.diff.evicted).not.toContain("healthy-live-agent");
+      expect(stateMgr.readState("healthy-live-agent")).not.toBeNull();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it("resync_agents evicts the exact exhausted Cursor ghost even when its stale surface is in a non-active workspace", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "orchestratorCursor-2ec13c6e",
+        surface_id: "surface:286",
+        workspace_id: "workspace:12",
+        state: "error",
+        repo: "orchestrator",
+        model: "cursor",
+        cli: "cursor",
+        cli_session_id: null,
+        task_summary: "exact registry ghost repro",
+        pid: null,
+        error: "Max crash recoveries exceeded: 10",
+        role: "orchestrator",
+        crash_recover: true,
+        respawn_attempts: 10,
+        user_killed: true,
+      }),
+    );
+
+    const server = createServer({
+      exec: makeMultiWorkspaceExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools[
+      "resync_agents"
+    ].handler({}, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.evicted).toContain("orchestratorCursor-2ec13c6e");
+    expect(stateMgr.readState("orchestratorCursor-2ec13c6e")).toBeNull();
+  });
+
+  it("resync_agents never evicts a healthy agent whose surface is in a non-active workspace", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "healthy-other-workspace-agent",
+        surface_id: "surface:287",
+        workspace_id: "workspace:12",
+        state: "working",
+        pid: 31338,
+      }),
+    );
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+        if (pid === 31338 && (signal ?? 0) === 0) {
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+    try {
+      const server = createServer({
+        exec: makeMultiWorkspaceExec(),
+        stateDir: TEST_DIR,
+      });
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.diff.evicted).not.toContain("healthy-other-workspace-agent");
+      expect(stateMgr.readState("healthy-other-workspace-agent")).not.toBeNull();
+    } finally {
+      killSpy.mockRestore();
+    }
   });
 
   it("resync_agents evicts booting ghosts when the surface is alive but no agent is detected", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -599,4 +599,35 @@ describe("kill — scoped targets", () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
   });
+
+  it("kill force removes surfaceless terminal registry ghosts", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "surfaceless-error-agent",
+        surface_id: "surface:ghost",
+        state: "error",
+        cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
+        role: "orchestrator",
+        error: "Surface surface:ghost disappeared",
+        crash_recover: true,
+      }),
+    );
+    await callTool(server, "list_agents", {});
+
+    const result = await callTool(server, "kill", {
+      target: "surfaceless-error-agent",
+      force: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.killed).toContain("surfaceless-error-agent");
+    expect(stateMgr.readState("surfaceless-error-agent")).toBeNull();
+
+    const listed = parseResult(await callTool(server, "list_agents", {}));
+    expect(
+      listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
+    ).not.toContain("surfaceless-error-agent");
+  });
 });


### PR DESCRIPTION
## Summary
- Evict registry entries whose backing surface is absent from the full multi-workspace surface set during `resync_agents`.
- Evict confirmed-dead terminal records during resync, including the exact exhausted Cursor ghost shape: `user_killed:true`, `respawn_attempts:10`, `pid:null`, `Max crash recoveries exceeded`.
- Make force stop remove the registry/state entry after confirmed stop, including terminal error ghosts.
- Preserve pane safety: no idle/live pane auto-close behavior was added; healthy agents in non-active workspaces are guarded.

## Test plan
- `bun run test`
- `bun run typecheck`
- `bun run build`

## Notes
- Local CodeRabbit pre-commit review was attempted twice with a bounded `coderabbit review --agent`; it stayed in `reviewing`/heartbeat and was stopped after the bound without findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent lifecycle and registry persistence (force-stop semantics and resync eviction); mistakes could drop live agents, though tests guard empty layout, recoverable crashes, and healthy cross-workspace surfaces.
> 
> **Overview**
> **Registry cleanup** adds explicit eviction that drops in-memory registry entries and persisted state together, instead of leaving terminal ghosts in `list_agents`.
> 
> **`resync_agents`** now runs a forced merge, then **`evictSurfaceless`** (agents whose `surface_id` is absent from the live multi-workspace surface list, skipping crash-recovery-eligible records) and **`evictDeadProcessAgents`** (terminal “dead ghost” records or agents whose PID is gone), before computing the diff.
> 
> **Force stop / force kill** on an agent now **evicts** the entry after a successful forced stop (including when the agent was already in `done`/`error`), so callers see **no** tracked state instead of a lingering terminal record.
> 
> **Behavioral note:** force-stop no longer guarantees a `done`/`error` row remains; state reads return null after eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466138f0b81f21583fb16461a5bb940510ab01bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Evict surfaceless/dead-PTY registry ghosts during resync and on force-kill
> - Adds `AgentRegistry.evict` to remove an agent's registry entry and persisted state, and `AgentRegistry.evictSurfaceless` to bulk-evict agents whose surfaces no longer exist (skipping crash-recoverable agents).
> - Adds `AgentEngine.evictDeadProcessAgents` to bulk-evict terminal ghosts and agents with missing/terminated PIDs, and `AgentEngine.isTerminalDeadRegistryGhost` as a helper to classify them.
> - `resync_agents` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/191/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now runs surfaceless and dead-process evictions before computing the diff, so stale registry entries are reflected in the returned result.
> - `stopAgent(force=true)` now calls `registry.evict` immediately instead of leaving a terminal record in the registry.
> - Behavioral Change: force-killing an agent deletes its persisted state and removes it from `list_agents`; previously it remained as a terminal record.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 466138f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved agent cleanup during resync and force-stop actions.
  * Agents that are no longer active, missing their process, or tied to stale surfaces are now removed more reliably.
* **Bug Fixes**
  * Force-stopping an agent now fully removes it from visible agent lists and stored state.
  * Resync now catches more stale agents, including dead or surfaceless ones, to keep results accurate.
* **Tests**
  * Expanded coverage for force-stop behavior and multiple stale-agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->