### PR TITLE
fix(surfaces): real per-pane cwd + mark auto-discovered panes unresumable

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2188,6 +2188,7 @@ export class AgentEngine {
       workspace_id: agent.workspace_id ?? null,
       state: agent.state,
       session_id: agent.cli_session_id,
+      resumable: !!agent.cli_session_id,
       ...(resumeCommand ? { resume_command: resumeCommand } : {}),
     };
   }

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -1,7 +1,10 @@
 import type { AgentRecord, AgentRoute, PublicAgent } from "./agent-types.js";
 import { buildResumeCommand } from "./agent-command.js";
 
-export type AgentStatePayload = AgentRecord & { resume_command?: string };
+export type AgentStatePayload = AgentRecord & {
+  resumable: boolean;
+  resume_command?: string;
+};
 
 export function resumeCommandForAgent(
   record: Pick<AgentRecord, "cli" | "repo" | "cli_session_id" | "launcher_name">,
@@ -18,12 +21,14 @@ export function resumeCommandForAgent(
 
 export function toPublicAgent(record: AgentRecord): PublicAgent {
   const resumeCommand = resumeCommandForAgent(record);
+  const resumable = !!record.cli_session_id;
   return {
     agent_id: record.agent_id,
     repo: record.repo,
     model: record.model,
     state: record.state,
     session_id: record.cli_session_id,
+    resumable,
     ...(resumeCommand ? { resume_command: resumeCommand } : {}),
   };
 }
@@ -32,6 +37,7 @@ export function toAgentStatePayload(record: AgentRecord): AgentStatePayload {
   const resumeCommand = resumeCommandForAgent(record);
   return {
     ...record,
+    resumable: !!record.cli_session_id,
     ...(resumeCommand ? { resume_command: resumeCommand } : {}),
   };
 }
@@ -49,6 +55,7 @@ export function buildRouteTable(
       workspace_id: record.workspace_id ?? null,
       state: record.state,
       session_id: record.cli_session_id,
+      resumable: !!record.cli_session_id,
       ...(resumeCommand ? { resume_command: resumeCommand } : {}),
     };
     const existing = routes.get(record.agent_id);

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -73,6 +73,7 @@ export interface PublicAgent {
   model: string;
   state: AgentState;
   session_id: string | null;
+  resumable: boolean;
   resume_command?: string;
 }
 
@@ -82,6 +83,7 @@ export interface AgentRoute {
   workspace_id?: string | null;
   state: AgentState;
   session_id: string | null;
+  resumable: boolean;
   resume_command?: string;
 }
 

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -17,6 +17,7 @@ import type {
   CmuxReadScreenResult,
   CmuxSendOptions,
   CmuxStatusEntry,
+  CmuxTerminalMetadata,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 
@@ -253,6 +254,17 @@ export class CmuxClient {
     if (opts?.workspace) args.push("--workspace", opts.workspace);
     const raw = await this.run(args);
     return this.parse(raw, "list-panes");
+  }
+
+  async listTerminalMetadata(): Promise<{
+    terminals: CmuxTerminalMetadata[];
+  }> {
+    const raw = await this.run(["debug-terminals"]);
+    const parsed = this.parse<{ terminals?: CmuxTerminalMetadata[] }>(
+      raw,
+      "debug-terminals",
+    );
+    return { terminals: parsed.terminals ?? [] };
   }
 
   private async resolvePaneAnchorSurface(opts: {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -19,6 +19,7 @@ import type {
   CmuxReadScreenResult,
   CmuxSendOptions,
   CmuxStatusEntry,
+  CmuxTerminalMetadata,
 } from "./types.js";
 import { CmuxClient } from "./cmux-client.js";
 import { normalizeKeyName } from "./key-names.js";
@@ -314,6 +315,12 @@ export class CmuxSocketClient {
     const params: Record<string, unknown> = {};
     if (opts?.workspace) params.workspace_id = opts.workspace;
     return this.call("pane.list", params);
+  }
+
+  async listTerminalMetadata(): Promise<{
+    terminals: CmuxTerminalMetadata[];
+  }> {
+    return this.cliFallbackPinned()?.listTerminalMetadata() ?? { terminals: [] };
   }
 
   private async resolvePaneAnchorSurface(opts: {

--- a/src/format.ts
+++ b/src/format.ts
@@ -188,6 +188,8 @@ export function formatAgentState(agent: AgentRecord): string {
     lines.push(
       `\u2502 resume: ${buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id, agent.launcher_name)}`,
     );
+  } else {
+    lines.push("\u2502 resumable: false (no cli_session_id)");
   }
   if (agent.cli_session_path) {
     lines.push(`\u2502 transcript: ${agent.cli_session_path}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,6 +80,7 @@ import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
   CmuxSurface,
+  CmuxTerminalMetadata,
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
@@ -348,8 +349,148 @@ function toMinimalSurface(
   if (typeof surface.screen_preview_error === "string") {
     minimal.screen_preview_error = surface.screen_preview_error;
   }
+  if (typeof surface.current_directory === "string") {
+    minimal.current_directory = surface.current_directory;
+  } else if (surface.current_directory === null) {
+    minimal.current_directory = null;
+  }
+  if (typeof surface.requested_working_directory === "string") {
+    minimal.requested_working_directory = surface.requested_working_directory;
+  } else if (surface.requested_working_directory === null) {
+    minimal.requested_working_directory = null;
+  }
+  if (typeof surface.working_directory_source === "string") {
+    minimal.working_directory_source = surface.working_directory_source;
+  }
+  if (typeof surface.working_directory_fallback === "boolean") {
+    minimal.working_directory_fallback = surface.working_directory_fallback;
+  }
 
   return minimal;
+}
+
+type SurfaceWorkingDirectorySource =
+  | "terminal_metadata"
+  | "surface"
+  | "pane"
+  | "workspace_fallback"
+  | "unavailable";
+
+interface SurfaceWorkingDirectory {
+  cwd: string | null;
+  source: SurfaceWorkingDirectorySource;
+}
+
+interface SurfaceWorkingDirectoryMaps {
+  terminalBySurface: Map<string, CmuxTerminalMetadata>;
+  paneByWorkspaceAndRef: Map<string, Record<string, unknown>>;
+  workspaceCwdByRef: Map<string, string>;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function workingDirectoryFromRecord(
+  record: Record<string, unknown> | null | undefined,
+): string | null {
+  return (
+    nonEmptyString(record?.current_directory) ??
+    nonEmptyString(record?.cwd) ??
+    nonEmptyString(record?.working_directory)
+  );
+}
+
+function paneWorkingDirectoryKey(
+  workspaceRef: string,
+  paneRef: string,
+): string {
+  return `${workspaceRef}\0${paneRef}`;
+}
+
+async function loadTerminalMetadataBySurface(
+  client: CmuxLayerClient,
+): Promise<Map<string, CmuxTerminalMetadata>> {
+  const metadataClient = client as CmuxLayerClient & {
+    listTerminalMetadata?: () => Promise<{ terminals: CmuxTerminalMetadata[] }>;
+  };
+  if (typeof metadataClient.listTerminalMetadata !== "function") {
+    return new Map();
+  }
+
+  try {
+    const { terminals } = await metadataClient.listTerminalMetadata();
+    const bySurface = new Map<string, CmuxTerminalMetadata>();
+    for (const terminal of terminals) {
+      const surfaceRef =
+        nonEmptyString(terminal.surface_ref) ??
+        nonEmptyString(terminal.surface_id) ??
+        nonEmptyString(terminal.ref);
+      if (surfaceRef) {
+        bySurface.set(surfaceRef, terminal);
+      }
+    }
+    return bySurface;
+  } catch {
+    return new Map();
+  }
+}
+
+function resolveSurfaceWorkingDirectory(
+  surface: Record<string, unknown>,
+  workspaceRef: string,
+  paneRef: string,
+  maps: SurfaceWorkingDirectoryMaps,
+): SurfaceWorkingDirectory {
+  const surfaceRef = nonEmptyString(surface.ref);
+  const terminal =
+    surfaceRef === null ? undefined : maps.terminalBySurface.get(surfaceRef);
+  const terminalCwd = workingDirectoryFromRecord(
+    terminal ? (terminal as Record<string, unknown>) : null,
+  );
+  if (terminalCwd) {
+    return { cwd: terminalCwd, source: "terminal_metadata" };
+  }
+
+  const surfaceCwd = workingDirectoryFromRecord(surface);
+  if (surfaceCwd) {
+    return { cwd: surfaceCwd, source: "surface" };
+  }
+
+  const pane = maps.paneByWorkspaceAndRef.get(
+    paneWorkingDirectoryKey(workspaceRef, paneRef),
+  );
+  const paneCwd = workingDirectoryFromRecord(pane);
+  if (paneCwd) {
+    return { cwd: paneCwd, source: "pane" };
+  }
+
+  const workspaceCwd = maps.workspaceCwdByRef.get(workspaceRef);
+  if (workspaceCwd) {
+    return { cwd: workspaceCwd, source: "workspace_fallback" };
+  }
+
+  return { cwd: null, source: "unavailable" };
+}
+
+function applySurfaceWorkingDirectory(
+  surface: Record<string, unknown>,
+  workspaceRef: string,
+  paneRef: string,
+  maps: SurfaceWorkingDirectoryMaps,
+): void {
+  const resolved = resolveSurfaceWorkingDirectory(
+    surface,
+    workspaceRef,
+    paneRef,
+    maps,
+  );
+  surface.current_directory = resolved.cwd;
+  surface.requested_working_directory = resolved.cwd;
+  surface.working_directory_source = resolved.source;
+  surface.working_directory_fallback =
+    resolved.source === "workspace_fallback" ||
+    resolved.source === "unavailable";
 }
 
 function chunkTerminalInput(text: string, chunkSize: number): string[] {
@@ -1805,6 +1946,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             panes: await client.listPanes({ workspace: workspaceRef }),
           })),
         );
+        const workspaceCwdByRef = new Map<string, string>();
+        for (const workspace of workspaces.workspaces) {
+          const cwd = nonEmptyString(workspace.current_directory);
+          if (cwd) {
+            workspaceCwdByRef.set(workspace.ref, cwd);
+          }
+        }
+        const paneByWorkspaceAndRef = new Map<string, Record<string, unknown>>();
+        for (const { workspaceRef, panes } of panesByWorkspace) {
+          for (const pane of panes.panes) {
+            paneByWorkspaceAndRef.set(
+              paneWorkingDirectoryKey(workspaceRef, pane.ref),
+              pane as unknown as Record<string, unknown>,
+            );
+          }
+        }
         const columnIndexByWorkspace = new Map<string, Map<string, number>>();
         const columnCountByWorkspace = new Map<string, number>();
         for (const { workspaceRef, panes } of panesByWorkspace) {
@@ -1896,6 +2053,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return enrichedSurface;
           }),
         );
+        const terminalBySurface = await loadTerminalMetadataBySurface(client);
+        const workingDirectoryMaps: SurfaceWorkingDirectoryMaps = {
+          terminalBySurface,
+          paneByWorkspaceAndRef,
+          workspaceCwdByRef,
+        };
+        for (const surface of verboseSurfaces) {
+          const workspaceRef = nonEmptyString(surface.workspace_ref) ?? "";
+          const paneRef = nonEmptyString(surface.pane_ref) ?? "";
+          applySurfaceWorkingDirectory(
+            surface,
+            workspaceRef,
+            paneRef,
+            workingDirectoryMaps,
+          );
+        }
 
         const verboseWorkspaces = workspaces.workspaces as unknown as Array<
           Record<string, unknown>
@@ -4825,6 +4998,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 model: agent.model,
                 cli: agent.cli,
                 session_id: agent.cli_session_id,
+                resumable: !!agent.cli_session_id,
                 ...(resumeCommand ? { resume_command: resumeCommand } : {}),
                 surface_id: agent.surface_id,
                 token_count: screenData?.token_count ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,10 @@ export interface CmuxSurface {
   workspace_ref?: string;
   pane_ref?: string;
   pane_id?: string;
+  current_directory?: string | null;
+  cwd?: string | null;
+  working_directory?: string | null;
+  requested_working_directory?: string | null;
 }
 
 export interface CmuxPane {
@@ -39,6 +43,10 @@ export interface CmuxPane {
   surface_refs: string[];
   surface_ids?: string[];
   selected_surface_ref?: string;
+  current_directory?: string | null;
+  cwd?: string | null;
+  working_directory?: string | null;
+  requested_working_directory?: string | null;
   pixel_frame?: {
     x: number;
     y: number;
@@ -52,6 +60,18 @@ export interface CmuxPaneSurfaces {
   window_ref: string;
   pane_ref: string;
   surfaces: CmuxSurface[];
+}
+
+export interface CmuxTerminalMetadata {
+  surface_ref?: string | null;
+  surface_id?: string | null;
+  ref?: string | null;
+  workspace_ref?: string | null;
+  pane_ref?: string | null;
+  current_directory?: string | null;
+  cwd?: string | null;
+  working_directory?: string | null;
+  requested_working_directory?: string | null;
 }
 
 export interface CmuxNewSplitResult {

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -44,6 +44,7 @@ describe("agent facade projections", () => {
       model: "sonnet",
       state: "ready",
       session_id: "session-1",
+      resumable: true,
       resume_command: "brainlayerClaude -s --resume session-1",
     });
     expect((projected as any).surface_id).toBeUndefined();
@@ -58,6 +59,7 @@ describe("agent facade projections", () => {
       model: "sonnet",
       state: "ready",
       session_id: null,
+      resumable: false,
     });
   });
 });
@@ -75,6 +77,7 @@ describe("agent route table", () => {
       workspace_id: "ws:1",
       state: "ready",
       session_id: "session-1",
+      resumable: true,
       resume_command: "brainlayerClaude -s --resume session-1",
     });
     expect(table.get("agent-2")?.surface_id).toBe("surface:2");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -13,7 +13,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer } from "../src/server.js";
+import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 
@@ -1267,6 +1267,48 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.cli).toBe("codex");
+    expect(parsed.resume_command).toBeUndefined();
+  });
+
+  it("get_agent_state marks auto-discovered null-session agents unresumable", async () => {
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    context.stateMgr.ensureAutoRecord("auto-codex-surface-new", {
+      surface_id: "surface:new",
+      surface_title: "cmuxlayerCodex",
+      workspace_id: "workspace:1",
+      cli: "codex",
+      parsed_status: "idle",
+      model: null,
+      token_count: null,
+      context_pct: null,
+      has_agent: true,
+      read_error: false,
+    });
+    const server = createServer({ context });
+    await context.lifecycleStartPromise;
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const result = await getState.handler(
+      { agent_id: "auto-codex-surface-new" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      agent_id: "auto-codex-surface-new",
+      task_summary: "(auto-discovered)",
+      cli_session_id: null,
+      cli_session_path: null,
+      pid: null,
+      resumable: false,
+    });
     expect(parsed.resume_command).toBeUndefined();
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -558,6 +558,10 @@ describe("tool handler integration", () => {
       column: 0,
       title: "One",
       type: "terminal",
+      current_directory: "/tmp/main",
+      requested_working_directory: "/tmp/main",
+      working_directory_source: "workspace_fallback",
+      working_directory_fallback: true,
     });
     expect(parsed.surfaces[1]).toEqual({
       ref: "surface:2",
@@ -566,6 +570,10 @@ describe("tool handler integration", () => {
       column: 1,
       title: "Two",
       type: "browser",
+      current_directory: "/tmp/main",
+      requested_working_directory: "/tmp/main",
+      working_directory_source: "workspace_fallback",
+      working_directory_fallback: true,
     });
   });
 
@@ -1021,6 +1029,102 @@ describe("tool handler integration", () => {
       workspace_ref: "workspace:1",
       window_ref: "window:1",
       pane_ref: "pane:1",
+    });
+  });
+
+  it("list_surfaces reports terminal metadata cwd instead of workspace fallback cwd", async () => {
+    const workspaceCwd = "/Users/etanheyman/Gits/golems";
+    const realSurfaceCwd =
+      "/Users/etanheyman/Gits/cmuxlayer.wt/adopted-pane-binding";
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "golems",
+                index: 0,
+                selected: true,
+                pinned: false,
+                current_directory: workspaceCwd,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:worker",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:adopted"],
+                selected_surface_ref: "surface:adopted",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:worker",
+            surfaces: [
+              {
+                ref: "surface:adopted",
+                title: "adopted-pane-binding",
+                type: "terminal",
+                index: 0,
+                selected: true,
+                requested_working_directory: workspaceCwd,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("debug-terminals")) {
+        return {
+          stdout: JSON.stringify({
+            terminals: [
+              {
+                surface_ref: "surface:adopted",
+                pane_ref: "pane:worker",
+                workspace_ref: "workspace:1",
+                current_directory: realSurfaceCwd,
+                requested_working_directory: workspaceCwd,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["list_surfaces"];
+
+    const result = await tool.handler({ verbose: true }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.surfaces[0]).toMatchObject({
+      ref: "surface:adopted",
+      pane_ref: "pane:worker",
+      current_directory: realSurfaceCwd,
+      requested_working_directory: realSurfaceCwd,
+      working_directory_source: "terminal_metadata",
+      working_directory_fallback: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Report per-surface cwd in `list_surfaces` from terminal metadata when available, overriding stale workspace-derived `requested_working_directory` values.
- Add `working_directory_source` and `working_directory_fallback` so callers can tell when cwd fell back to the workspace.
- Add `resumable` markers to agent state/public route payloads so auto-discovered null-session panes are explicitly unresumable.

## Test plan
- `bun test tests/server.test.ts -t "terminal metadata cwd"` (RED first, then GREEN)
- `bun test tests/server-agent-tools.test.ts -t "auto-discovered null-session agents unresumable"` (RED first, then GREEN)
- `bun test tests/server.test.ts -t "list_surfaces"`
- `bun test tests/server-agent-tools.test.ts`
- `bun test tests/agent-facade.test.ts`
- `bun test tests/cmux-socket-client.test.ts`
- `bun run test` (57 files / 940 tests)
- `bun run typecheck`
- `bun run build`

## Review notes
- Pre-commit `coderabbit review --agent` was attempted and returned a recoverable OSS rate-limit error with a 12m26s wait. PR-level bot review requested below.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-pane working directory resolution and mark auto-discovered panes as unresumable
> - Resolves the working directory for each surface in `list_surfaces` using a precedence chain: terminal metadata (via a new `debug-terminals` CLI command), surface-level fields, pane-level fields, and workspace fallback. Each surface now includes `current_directory`, `requested_working_directory`, `working_directory_source`, and `working_directory_fallback`.
> - Adds a `resumable: boolean` field to `PublicAgent`, `AgentRoute`, and `AgentStatePayload`, derived from the presence of `cli_session_id`. Auto-discovered panes (no session ID) are explicitly marked `resumable: false`.
> - Adds `listTerminalMetadata()` to `CmuxClient` and `CmuxSocketClient` to fetch pane working directory data via the `debug-terminals` CLI command.
> - Behavioral Change: `list_surfaces` responses now include additional working directory fields; consumers expecting a fixed surface shape will need to handle these new optional fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 22c8ed3. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->