### PR TITLE
fix(session): capture cli_session_id for launcher-spawned Claude/Codex (resumability)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1072,7 +1072,14 @@ export class AgentEngine {
     const identity = findLatestHarnessSessionIdentity(
       agent.cli as Harness,
       this.harnessCwdForAgent(agent),
-      { sinceMs },
+      {
+        sinceMs,
+        expectedText: agent.task_summary,
+        ...(process.env.CMUXLAYER_HARNESS_HOME
+          ? { home: process.env.CMUXLAYER_HARNESS_HOME }
+          : {}),
+        ...(process.env.CODEX_HOME ? { codexHome: process.env.CODEX_HOME } : {}),
+      },
     );
     return identity
       ? { session_id: identity.session_id, path: identity.path }

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -466,30 +466,43 @@ function normalizeText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function normalizePromptText(value: string): string {
+  return normalizeText(
+    value.replace(/<\/?\s*user_query\s*>/gi, " "),
+  );
+}
+
+function promptTextMatchesExpected(value: string, expectedText: string): boolean {
+  return normalizePromptText(value) === expectedText;
+}
+
 function promptFieldContainsExpectedText(
   value: unknown,
   expectedText: string,
 ): boolean {
   if (typeof value === "string") {
-    return normalizeText(value) === expectedText;
+    return promptTextMatchesExpected(value, expectedText);
   }
   if (Array.isArray(value)) {
-    return value.some((item) => {
+    const textParts = value.flatMap((item) => {
       if (typeof item === "string") {
-        return normalizeText(item) === expectedText;
+        return [item];
       }
       const block = asRecord(item);
-      if (!block) return false;
-      return (
-        block.type === "text" &&
-        typeof block.text === "string" &&
-        normalizeText(block.text) === expectedText
-      );
+      if (block?.type === "text" && typeof block.text === "string") {
+        return [block.text];
+      }
+      return [];
     });
+    return (
+      textParts.some((text) => promptTextMatchesExpected(text, expectedText)) ||
+      (textParts.length > 1 &&
+        promptTextMatchesExpected(textParts.join(" "), expectedText))
+    );
   }
   const block = asRecord(value);
   if (block?.type === "text" && typeof block.text === "string") {
-    return normalizeText(block.text) === expectedText;
+    return promptTextMatchesExpected(block.text, expectedText);
   }
   return false;
 }

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -351,6 +351,7 @@ export interface HarnessSessionIdentity {
 
 export interface IdentityResolveOpts extends ResolveOpts {
   sinceMs?: number;
+  expectedText?: string | null;
 }
 
 /**
@@ -448,29 +449,112 @@ function afterSince(path: string, sinceMs: number | undefined): boolean {
   return sinceMs === undefined || mtimeMs(path) >= sinceMs;
 }
 
-function newestIdentity(
-  current: HarnessSessionIdentity | null,
-  candidate: HarnessSessionIdentity,
-): HarnessSessionIdentity {
-  return !current || candidate.mtime_ms > current.mtime_ms
-    ? candidate
-    : current;
-}
-
 function sessionIdFromJsonlName(path: string): string | null {
   const name = basename(path);
   return name.endsWith(".jsonl") ? name.slice(0, -".jsonl".length) : null;
 }
 
-function parseCodexSessionMeta(
-  path: string,
-): { session_id: string; cwd: string | null } | null {
-  let content: string;
+function readTextFile(path: string): string | null {
   try {
-    content = readFileSync(path, "utf8");
+    return readFileSync(path, "utf8");
   } catch {
     return null;
   }
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function promptFieldContainsExpectedText(
+  value: unknown,
+  expectedText: string,
+): boolean {
+  if (typeof value === "string") {
+    return normalizeText(value) === expectedText;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => {
+      if (typeof item === "string") {
+        return normalizeText(item) === expectedText;
+      }
+      const block = asRecord(item);
+      if (!block) return false;
+      return (
+        block.type === "text" &&
+        typeof block.text === "string" &&
+        normalizeText(block.text) === expectedText
+      );
+    });
+  }
+  const block = asRecord(value);
+  if (block?.type === "text" && typeof block.text === "string") {
+    return normalizeText(block.text) === expectedText;
+  }
+  return false;
+}
+
+function recordPromptFields(event: Record<string, unknown>): unknown[] {
+  const fields: unknown[] = [];
+  const type = typeof event.type === "string" ? event.type : null;
+  const role = typeof event.role === "string" ? event.role : null;
+  const message = asRecord(event.message);
+  const payload = asRecord(event.payload);
+
+  if (type === "user_message") {
+    fields.push(payload?.message, payload?.text, payload?.input);
+  }
+
+  if (role === "user" || type === "user") {
+    fields.push(
+      message?.content,
+      message?.text,
+      event.content,
+      payload?.message,
+      payload?.text,
+      payload?.input,
+    );
+  }
+
+  const payloadType =
+    typeof payload?.type === "string" ? payload.type : null;
+  if (payloadType === "user_message" || payloadType === "user") {
+    fields.push(payload?.message, payload?.text, payload?.input);
+  }
+
+  return fields;
+}
+
+function jsonlContainsExpectedPromptText(
+  content: string,
+  expectedText: string | null | undefined,
+): boolean {
+  const normalizedExpected = normalizeText(expectedText ?? "");
+  if (!normalizedExpected) return false;
+
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      const event = asRecord(JSON.parse(line));
+      if (
+        event &&
+        recordPromptFields(event).some((field) =>
+          promptFieldContainsExpectedText(field, normalizedExpected),
+        )
+      ) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+function parseCodexSessionMetaFromContent(
+  content: string,
+): { session_id: string; cwd: string | null } | null {
 
   for (const raw of content.split("\n")) {
     const line = raw.trim();
@@ -493,10 +577,37 @@ function parseCodexSessionMeta(
   return null;
 }
 
+interface HarnessSessionIdentityCandidate extends HarnessSessionIdentity {
+  expected_text_match: boolean;
+}
+
+function chooseIdentityCandidate(
+  candidates: HarnessSessionIdentityCandidate[],
+  expectedText: string | null | undefined,
+): HarnessSessionIdentity | null {
+  if (candidates.length === 0) return null;
+  const hasExpectedText = !!normalizeText(expectedText ?? "");
+  if (candidates.length === 1) {
+    const { expected_text_match, ...identity } = candidates[0]!;
+    return !hasExpectedText || expected_text_match ? identity : null;
+  }
+
+  if (hasExpectedText) {
+    const matches = candidates.filter((candidate) => candidate.expected_text_match);
+    if (matches.length === 1) {
+      const { expected_text_match, ...identity } = matches[0]!;
+      return identity;
+    }
+  }
+
+  return null;
+}
+
 /**
- * Find the newest harness transcript identity for a cwd. This is the bootstrap
+ * Find a precise harness transcript identity for a cwd. This is the bootstrap
  * path for resume: it discovers the real session id before callers already know
- * that id.
+ * that id. When the caller provides expectedText, the candidate must contain it
+ * in a user-origin prompt field; ambiguous or mismatched candidates fail closed.
  */
 export function findLatestHarnessSessionIdentity(
   harness: Harness,
@@ -509,7 +620,7 @@ export function findLatestHarnessSessionIdentity(
   switch (harness) {
     case "claude": {
       const root = join(home, ".claude", "projects", encodeClaudeCwd(cwd));
-      let found: HarnessSessionIdentity | null = null;
+      const candidates: HarnessSessionIdentityCandidate[] = [];
       for (const name of safeReaddir(root)) {
         const path = join(root, name);
         if (!name.endsWith(".jsonl") || !isFile(path) || !afterSince(path, opts.sinceMs)) {
@@ -517,15 +628,20 @@ export function findLatestHarnessSessionIdentity(
         }
         const sessionId = sessionIdFromJsonlName(path);
         if (!sessionId) continue;
-        found = newestIdentity(found, {
+        const content = readTextFile(path) ?? "";
+        candidates.push({
           harness,
           session_id: sessionId,
           cwd,
           path,
           mtime_ms: mtimeMs(path),
+          expected_text_match: jsonlContainsExpectedPromptText(
+            content,
+            opts.expectedText,
+          ),
         });
       }
-      return found;
+      return chooseIdentityCandidate(candidates, opts.expectedText);
     }
     case "cursor": {
       const root = join(
@@ -535,7 +651,7 @@ export function findLatestHarnessSessionIdentity(
         encodeCursorCwd(cwd),
         "agent-transcripts",
       );
-      let found: HarnessSessionIdentity | null = null;
+      const candidates: HarnessSessionIdentityCandidate[] = [];
       for (const dir of safeReaddir(root)) {
         const transcriptDir = join(root, dir);
         if (!isDir(transcriptDir)) continue;
@@ -545,33 +661,44 @@ export function findLatestHarnessSessionIdentity(
             continue;
           }
           const sessionId = sessionIdFromJsonlName(path) ?? dir;
-          found = newestIdentity(found, {
+          const content = readTextFile(path) ?? "";
+          candidates.push({
             harness,
             session_id: sessionId,
             cwd,
             path,
             mtime_ms: mtimeMs(path),
+            expected_text_match: jsonlContainsExpectedPromptText(
+              content,
+              opts.expectedText,
+            ),
           });
         }
       }
-      return found;
+      return chooseIdentityCandidate(candidates, opts.expectedText);
     }
     case "codex": {
       const root = join(opts.codexHome ?? join(home, ".codex"), "sessions");
-      let found: HarnessSessionIdentity | null = null;
+      const candidates: HarnessSessionIdentityCandidate[] = [];
       const walk = (dir: string, depth: number): void => {
         for (const name of safeReaddir(dir)) {
           const child = join(dir, name);
           if (isFile(child) && name.endsWith(".jsonl")) {
             if (!afterSince(child, opts.sinceMs)) continue;
-            const meta = parseCodexSessionMeta(child);
+            const content = readTextFile(child);
+            if (!content) continue;
+            const meta = parseCodexSessionMetaFromContent(content);
             if (!meta || meta.cwd !== cwd) continue;
-            found = newestIdentity(found, {
+            candidates.push({
               harness,
               session_id: meta.session_id,
               cwd: meta.cwd,
               path: child,
               mtime_ms: mtimeMs(child),
+              expected_text_match: jsonlContainsExpectedPromptText(
+                content,
+                opts.expectedText,
+              ),
             });
             continue;
           }
@@ -581,7 +708,7 @@ export function findLatestHarnessSessionIdentity(
         }
       };
       walk(root, 4);
-      return found;
+      return chooseIdentityCandidate(candidates, opts.expectedText);
     }
   }
 }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2382,6 +2382,119 @@ To continue this session, run codex resume ${sessionId}`,
         vi.unstubAllEnvs();
       }
     });
+
+    it("does not bind the wrong Claude JSONL when two launcher agents share a cwd", async () => {
+      vi.setSystemTime(new Date("2026-06-25T09:30:30.000Z"));
+      const home = join(TEST_DIR, "home-claude-shared-cwd");
+      const launchCwd = join(TEST_DIR, "Gits", "cmuxlayer");
+      const projectDir = join(
+        home,
+        ".claude",
+        "projects",
+        launchCwd.replaceAll("/", "-"),
+      );
+      const firstSessionId = "019f0004-1111-7222-8333-444455556666";
+      const secondSessionId = "019f0005-aaaa-7bbb-8ccc-ddddeeeeeeee";
+      const firstPrompt = "Fix launcher resumability first Claude agent";
+      const secondPrompt = `${firstPrompt} but for the second Claude agent`;
+      const firstPath = join(projectDir, `${firstSessionId}.jsonl`);
+      const secondPath = join(projectDir, `${secondSessionId}.jsonl`);
+      mkdirSync(projectDir, { recursive: true });
+      for (const [path, prompt, mtime, includeNoise] of [
+        [firstPath, firstPrompt, "2026-06-25T09:30:10.000Z", false],
+        [secondPath, secondPrompt, "2026-06-25T09:30:20.000Z", true],
+      ] as const) {
+        writeFileSync(
+          path,
+          [
+            JSON.stringify({
+              type: "user",
+              message: { content: [{ type: "text", text: prompt }] },
+            }),
+            ...(includeNoise
+              ? [
+                  JSON.stringify({
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          content: `Tool output mentions ${firstPrompt}`,
+                        },
+                      ],
+                    },
+                  }),
+                ]
+              : []),
+          ].join("\n"),
+        );
+        const date = new Date(mtime);
+        utimesSync(path, date, date);
+      }
+
+      vi.stubEnv("CMUXLAYER_HARNESS_HOME", home);
+      try {
+        engine.dispose();
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        engine = new AgentEngine(stateMgr, registry, mockClient, {
+          spawnPreflight: async () => {},
+        });
+        liveSurfaces = [
+          makeSurface("surface:claude-first"),
+          makeSurface("surface:claude-second"),
+        ];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:claude-first",
+          text: "What can I help you with?\n>",
+          lines: 80,
+          scrollback_used: true,
+        });
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerClaude-pending-first",
+            repo: "cmuxlayer",
+            model: "sonnet",
+            cli: "claude",
+            surface_id: "surface:claude-first",
+            state: "booting",
+            task_summary: firstPrompt,
+            created_at: "2026-06-25T09:30:00.000Z",
+            updated_at: "2026-06-25T09:30:00.000Z",
+            launch_cwd: launchCwd,
+            worktree_path: launchCwd,
+          }),
+        );
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerClaude-pending-second",
+            repo: "cmuxlayer",
+            model: "sonnet",
+            cli: "claude",
+            surface_id: "surface:claude-second",
+            state: "booting",
+            task_summary: secondPrompt,
+            created_at: "2026-06-25T09:30:00.000Z",
+            updated_at: "2026-06-25T09:30:00.000Z",
+            launch_cwd: launchCwd,
+            worktree_path: launchCwd,
+          }),
+        );
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(engine.getAgentState("cmuxlayerClaude-019f0004")).toMatchObject({
+          cli_session_id: firstSessionId,
+          cli_session_path: firstPath,
+        });
+        expect(engine.getAgentState("cmuxlayerClaude-019f0005")).toMatchObject({
+          cli_session_id: secondSessionId,
+          cli_session_path: secondPath,
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
   });
 
   describe("waitFor", () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1976,13 +1976,19 @@ To continue this session, run codex resume ${sessionId}`,
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
         sessionPath,
-        JSON.stringify({
-          type: "session_meta",
-          payload: {
-            id: sessionId,
-            cwd: worktreeCwd,
-          },
-        }),
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: {
+              id: sessionId,
+              cwd: worktreeCwd,
+            },
+          }),
+          JSON.stringify({
+            type: "user_message",
+            payload: { message: "Fix search gap F" },
+          }),
+        ].join("\n"),
       );
 
       vi.stubEnv("HOME", home);
@@ -2021,6 +2027,356 @@ To continue this session, run codex resume ${sessionId}`,
           agent_id: "cmuxlayerCodex-019e942c",
           cli_session_id: sessionId,
           cli_session_path: sessionPath,
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it.each([
+      {
+        cli: "claude" as const,
+        repo: "cmuxlayer",
+        model: "sonnet",
+        sessionId: "019f0000-1111-7222-8333-444455556666",
+        agentId: "cmuxlayerClaude-019f0000",
+      },
+      {
+        cli: "codex" as const,
+        repo: "cmuxlayer",
+        model: "gpt-5.4",
+        sessionId: "019f0000-aaaa-7bbb-8ccc-ddddeeeeeeee",
+        agentId: "cmuxlayerCodex-019f0000",
+      },
+    ])(
+      "captures launcher-spawned $cli session identity from the real JSONL on boot",
+      async ({ cli, repo, model, sessionId, agentId }) => {
+        vi.setSystemTime(new Date("2026-06-25T08:00:30.000Z"));
+        const home = join(TEST_DIR, `home-${cli}`);
+        const codexHome = join(TEST_DIR, `codex-home-${cli}`);
+        const launchCwd = join(TEST_DIR, "Gits", "cmuxlayer");
+        const prompt = `Fix launcher resumability for ${cli}`;
+        const sessionPath =
+          cli === "claude"
+            ? join(
+                home,
+                ".claude",
+                "projects",
+                launchCwd.replaceAll("/", "-"),
+                `${sessionId}.jsonl`,
+              )
+            : join(
+                codexHome,
+                "sessions",
+                "2026",
+                "06",
+                "25",
+                `rollout-2026-06-25T08-00-01-${sessionId}.jsonl`,
+              );
+        mkdirSync(join(sessionPath, ".."), { recursive: true });
+        writeFileSync(
+          sessionPath,
+          cli === "claude"
+            ? [
+                JSON.stringify({
+                  type: "user",
+                  message: { content: [{ type: "text", text: prompt }] },
+                }),
+                JSON.stringify({
+                  type: "assistant",
+                  message: { model, stop_reason: "end_turn", content: [] },
+                }),
+              ].join("\n")
+            : [
+                JSON.stringify({
+                  type: "session_meta",
+                  payload: { id: sessionId, cwd: launchCwd },
+                }),
+                JSON.stringify({
+                  type: "user_message",
+                  payload: { message: prompt },
+                }),
+              ].join("\n"),
+        );
+
+        vi.stubEnv("CMUXLAYER_HARNESS_HOME", home);
+        vi.stubEnv("CODEX_HOME", codexHome);
+        try {
+          engine.dispose();
+          const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+          engine = new AgentEngine(stateMgr, registry, mockClient, {
+            spawnPreflight: async () => {},
+          });
+          liveSurfaces = [makeSurface("surface:new")];
+          (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+            surface: "surface:new",
+            text: `${cli}> `,
+            lines: 80,
+            scrollback_used: true,
+          });
+          stateMgr.writeState(
+            makeRecord({
+              agent_id: `${repo}${cli}-pending-jsonl`,
+              repo,
+              model,
+              cli,
+              surface_id: "surface:new",
+              state: "booting",
+              task_summary: prompt,
+              created_at: "2026-06-25T08:00:00.000Z",
+              updated_at: "2026-06-25T08:00:00.000Z",
+              launch_cwd: launchCwd,
+              worktree_path: launchCwd,
+            }),
+          );
+          await engine.getRegistry().reconstitute();
+
+          expect(engine.resolveAgentRoute(`${repo}${cli}-pending-jsonl`)).toMatchObject({
+            session_id: null,
+            resumable: false,
+          });
+
+          await engine.runSweep();
+
+          const captured = engine.getAgentState(agentId);
+          expect(captured).toMatchObject({
+            agent_id: agentId,
+            cli_session_id: sessionId,
+            cli_session_path: sessionPath,
+          });
+          expect(engine.resolveAgentRoute(agentId)).toMatchObject({
+            session_id: sessionId,
+            resumable: true,
+          });
+          expect(engine.resolveAgentRoute(agentId).resume_command).toContain(
+            sessionId,
+          );
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      },
+    );
+
+    it.each([
+      {
+        cli: "claude" as const,
+        sessionId: "019f0003-1111-7222-8333-444455556666",
+        finalAgentId: "cmuxlayerClaude-019f0003",
+      },
+      {
+        cli: "codex" as const,
+        sessionId: "019f0003-aaaa-7bbb-8ccc-ddddeeeeeeee",
+        finalAgentId: "cmuxlayerCodex-019f0003",
+      },
+    ])(
+      "leaves launcher-spawned $cli unbound when the sole JSONL has a different launch prompt",
+      async ({ cli, sessionId, finalAgentId }) => {
+        vi.setSystemTime(new Date("2026-06-25T08:30:30.000Z"));
+        const home = join(TEST_DIR, `home-mismatch-${cli}`);
+        const codexHome = join(TEST_DIR, `codex-home-mismatch-${cli}`);
+        const launchCwd = join(TEST_DIR, "Gits", "cmuxlayer");
+        const expectedPrompt = `Expected launch prompt for ${cli}`;
+        const otherPrompt = `Different launch prompt for ${cli}`;
+        const pendingAgentId = `cmuxlayer${cli}-pending-mismatch`;
+        const sessionPath =
+          cli === "claude"
+            ? join(
+                home,
+                ".claude",
+                "projects",
+                launchCwd.replaceAll("/", "-"),
+                `${sessionId}.jsonl`,
+              )
+            : join(
+                codexHome,
+                "sessions",
+                "2026",
+                "06",
+                "25",
+                `rollout-2026-06-25T08-30-01-${sessionId}.jsonl`,
+              );
+        mkdirSync(join(sessionPath, ".."), { recursive: true });
+        writeFileSync(
+          sessionPath,
+          cli === "claude"
+            ? [
+                JSON.stringify({
+                  type: "user",
+                  message: { content: [{ type: "text", text: otherPrompt }] },
+                }),
+                JSON.stringify({
+                  type: "user",
+                  message: {
+                    content: [
+                      {
+                        type: "tool_result",
+                        content: expectedPrompt,
+                      },
+                    ],
+                  },
+                }),
+              ].join("\n")
+            : [
+                JSON.stringify({
+                  type: "session_meta",
+                  payload: { id: sessionId, cwd: launchCwd },
+                }),
+                JSON.stringify({
+                  type: "user_message",
+                  payload: { message: otherPrompt },
+                }),
+              ].join("\n"),
+        );
+
+        vi.stubEnv("CMUXLAYER_HARNESS_HOME", home);
+        vi.stubEnv("CODEX_HOME", codexHome);
+        try {
+          engine.dispose();
+          const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+          engine = new AgentEngine(stateMgr, registry, mockClient, {
+            spawnPreflight: async () => {},
+          });
+          liveSurfaces = [makeSurface("surface:mismatch")];
+          (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+            surface: "surface:mismatch",
+            text: `${cli}> `,
+            lines: 80,
+            scrollback_used: true,
+          });
+          stateMgr.writeState(
+            makeRecord({
+              agent_id: pendingAgentId,
+              repo: "cmuxlayer",
+              model: cli === "claude" ? "sonnet" : "gpt-5.4",
+              cli,
+              surface_id: "surface:mismatch",
+              state: "booting",
+              task_summary: expectedPrompt,
+              created_at: "2026-06-25T08:30:00.000Z",
+              updated_at: "2026-06-25T08:30:00.000Z",
+              launch_cwd: launchCwd,
+              worktree_path: launchCwd,
+            }),
+          );
+          await engine.getRegistry().reconstitute();
+
+          await engine.runSweep();
+
+          expect(engine.getAgentState(finalAgentId)).toBeNull();
+          expect(engine.resolveAgentRoute(pendingAgentId)).toMatchObject({
+            session_id: null,
+            resumable: false,
+          });
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      },
+    );
+
+    it("does not bind the wrong JSONL when two launcher agents share a cwd", async () => {
+      vi.setSystemTime(new Date("2026-06-25T09:00:30.000Z"));
+      const codexHome = join(TEST_DIR, "codex-home-shared-cwd");
+      const launchCwd = join(TEST_DIR, "Gits", "cmuxlayer");
+      const sessionDir = join(codexHome, "sessions", "2026", "06", "25");
+      const firstSessionId = "019f0001-1111-7222-8333-444455556666";
+      const secondSessionId = "019f0002-aaaa-7bbb-8ccc-ddddeeeeeeee";
+      const firstPrompt = "Fix launcher resumability first agent";
+      const secondPrompt = `${firstPrompt} but for the second agent`;
+      const firstPath = join(
+        sessionDir,
+        `rollout-2026-06-25T09-00-01-${firstSessionId}.jsonl`,
+      );
+      const secondPath = join(
+        sessionDir,
+        `rollout-2026-06-25T09-00-02-${secondSessionId}.jsonl`,
+      );
+      mkdirSync(sessionDir, { recursive: true });
+      for (const [path, id, prompt, mtime] of [
+        [firstPath, firstSessionId, firstPrompt, "2026-06-25T09:00:10.000Z"],
+        [secondPath, secondSessionId, secondPrompt, "2026-06-25T09:00:20.000Z"],
+      ] as const) {
+        writeFileSync(
+          path,
+          [
+            JSON.stringify({
+              type: "session_meta",
+              payload: { id, cwd: launchCwd },
+            }),
+            JSON.stringify({
+              type: "user_message",
+              payload: { message: prompt },
+            }),
+            ...(id === secondSessionId
+              ? [
+                  JSON.stringify({
+                    type: "agent_message",
+                    payload: {
+                      message: `Considering earlier work: ${firstPrompt}`,
+                    },
+                  }),
+                ]
+              : []),
+          ].join("\n"),
+        );
+        const date = new Date(mtime);
+        utimesSync(path, date, date);
+      }
+
+      vi.stubEnv("CODEX_HOME", codexHome);
+      try {
+        engine.dispose();
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        engine = new AgentEngine(stateMgr, registry, mockClient, {
+          spawnPreflight: async () => {},
+        });
+        liveSurfaces = [makeSurface("surface:first"), makeSurface("surface:second")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:first",
+          text: "codex> ",
+          lines: 80,
+          scrollback_used: true,
+        });
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-pending-first",
+            repo: "cmuxlayer",
+            model: "gpt-5.4",
+            cli: "codex",
+            surface_id: "surface:first",
+            state: "booting",
+            task_summary: firstPrompt,
+            created_at: "2026-06-25T09:00:00.000Z",
+            updated_at: "2026-06-25T09:00:00.000Z",
+            launch_cwd: launchCwd,
+            worktree_path: launchCwd,
+          }),
+        );
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-pending-second",
+            repo: "cmuxlayer",
+            model: "gpt-5.4",
+            cli: "codex",
+            surface_id: "surface:second",
+            state: "booting",
+            task_summary: secondPrompt,
+            created_at: "2026-06-25T09:00:00.000Z",
+            updated_at: "2026-06-25T09:00:00.000Z",
+            launch_cwd: launchCwd,
+            worktree_path: launchCwd,
+          }),
+        );
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+
+        expect(engine.getAgentState("cmuxlayerCodex-019f0001")).toMatchObject({
+          cli_session_id: firstSessionId,
+          cli_session_path: firstPath,
+        });
+        expect(engine.getAgentState("cmuxlayerCodex-019f0002")).toMatchObject({
+          cli_session_id: secondSessionId,
+          cli_session_path: secondPath,
         });
       } finally {
         vi.unstubAllEnvs();

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -478,6 +478,90 @@ describe("findLatestHarnessSessionIdentity (cwd → real session id)", () => {
       rmSync(localHome, { recursive: true, force: true });
     }
   });
+
+  it("Cursor: matches launch prompts wrapped in user_query tags", () => {
+    const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-cursor-tags-"));
+    const cwd = "/Users/etanheyman/Gits/cmuxlayer";
+    const sessionId = "cursor-tagged-prompt";
+    const root = join(
+      localHome,
+      ".cursor",
+      "projects",
+      "Users-etanheyman-Gits-cmuxlayer",
+      "agent-transcripts",
+      sessionId,
+    );
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, `${sessionId}.jsonl`),
+      JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "<user_query>resume the launcher session</user_query>",
+            },
+          ],
+        },
+      }),
+    );
+
+    try {
+      const identity = findLatestHarnessSessionIdentity("cursor", cwd, {
+        home: localHome,
+        expectedText: "resume the launcher session",
+      });
+
+      expect(identity).toMatchObject({
+        harness: "cursor",
+        session_id: sessionId,
+      });
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
+  });
+
+  it("Cursor: matches launch prompts split across adjacent text blocks", () => {
+    const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-cursor-split-"));
+    const cwd = "/Users/etanheyman/Gits/cmuxlayer";
+    const sessionId = "cursor-split-prompt";
+    const root = join(
+      localHome,
+      ".cursor",
+      "projects",
+      "Users-etanheyman-Gits-cmuxlayer",
+      "agent-transcripts",
+      sessionId,
+    );
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, `${sessionId}.jsonl`),
+      JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            { type: "text", text: "resume the " },
+            { type: "text", text: "launcher session" },
+          ],
+        },
+      }),
+    );
+
+    try {
+      const identity = findLatestHarnessSessionIdentity("cursor", cwd, {
+        home: localHome,
+        expectedText: "resume the launcher session",
+      });
+
+      expect(identity).toMatchObject({
+        harness: "cursor",
+        session_id: sessionId,
+      });
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("applyHarnessState (overlay; JSONL wins, screen is fallback)", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -185,6 +185,19 @@ function renameOnlyAgentStateToSession(sessionId: string): string {
   return finalAgentId;
 }
 
+function resolveCurrentTestAgentId(
+  stateMgr: { readState(agentId: string): AgentRecord | null },
+  agentId: string,
+): string {
+  if (stateMgr.readState(agentId)) return agentId;
+  const entries = readdirSync(TEST_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name !== "events" && !name.startsWith("Gits"));
+  expect(entries).toHaveLength(1);
+  return entries[0]!;
+}
+
 describe("agent lifecycle tool registration", () => {
   it("registers all 13 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
@@ -1227,10 +1240,11 @@ describe("agent lifecycle tool handlers", () => {
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
     const stateMgr = engine["stateMgr"];
-    const updated = stateMgr.updateRecord(agentId, {
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const updated = stateMgr.updateRecord(currentAgentId, {
       cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
-    engine.getRegistry().set(agentId, updated);
+    engine.getRegistry().set(currentAgentId, updated);
 
     const result = await list.handler({}, {} as any);
     const parsed =
@@ -1331,12 +1345,16 @@ describe("agent lifecycle tool handlers", () => {
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
     const stateMgr = engine["stateMgr"];
-    const updated = stateMgr.updateRecord(agentId, {
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const updated = stateMgr.updateRecord(currentAgentId, {
       cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
-    engine.getRegistry().set(agentId, updated);
+    engine.getRegistry().set(currentAgentId, updated);
 
-    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const result = await getState.handler(
+      { agent_id: currentAgentId },
+      {} as any,
+    );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
@@ -1683,12 +1701,13 @@ describe("agent lifecycle tool handlers", () => {
 
     const engine = (server as any)._registeredTools["interact"]._engine;
     const stateMgr = engine["stateMgr"];
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
 
-    if (stateMgr.readState(agentId)?.state === "booting") {
-      stateMgr.transition(agentId, "ready");
+    if (stateMgr.readState(currentAgentId)?.state === "booting") {
+      stateMgr.transition(currentAgentId, "ready");
     }
-    stateMgr.transition(agentId, "done");
-    const doneState = stateMgr.updateRecord(agentId, {
+    stateMgr.transition(currentAgentId, "done");
+    const doneState = stateMgr.updateRecord(currentAgentId, {
       task_done_detected_at: "2026-06-05T17:20:00.000Z",
     });
     if (!doneState) {
@@ -1697,7 +1716,7 @@ describe("agent lifecycle tool handlers", () => {
     engine.getRegistry().set(agentId, doneState);
 
     const result = await waitFor.handler(
-      { agent_id: agentId, timeout_ms: 5000 },
+      { agent_id: currentAgentId, timeout_ms: 5000 },
       {} as any,
     );
     const parsed =
@@ -1917,10 +1936,11 @@ describe("agent lifecycle tool handlers", () => {
     );
     const agentId = spawnResult.structuredContent.agent_id;
     const stateMgr = engine["stateMgr"];
-    const updated = stateMgr.updateRecord(agentId, {
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const updated = stateMgr.updateRecord(currentAgentId, {
       cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
-    engine.getRegistry().set(agentId, updated);
+    engine.getRegistry().set(currentAgentId, updated);
 
     const result = await myAgents.handler({}, {} as any);
     const agent = result.structuredContent.agents[0];

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -789,7 +789,7 @@ describe("agent lifecycle tool handlers", () => {
         model: "codex",
         cli: "codex",
         boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 1_000,
+        boot_prompt_timeout_ms: 5_000,
       },
       {} as any,
     );


### PR DESCRIPTION
## Summary
- Capture launcher-spawned Claude/Codex session identity from the real JSONL transcript during boot.
- Honor `CMUXLAYER_HARNESS_HOME` and `CODEX_HOME` in the boot resolver, matching the JSONL read path.
- Replace newest-file binding with candidate selection that prefers exact launch prompt matches and refuses ambiguous same-cwd matches.

## Test plan
- RED held: `bun run test -- tests/agent-engine.test.ts -t "captures launcher-spawned|does not bind the wrong JSONL"` failed before the fix for Claude, Codex, and shared-cwd guard.
- GREEN: `bun run test -- tests/agent-engine.test.ts -t "captures launcher-spawned|does not bind the wrong JSONL"`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- CodeRabbit pre-commit: `coderabbit review --agent` → `findings:0`

## Wrong-session guard
- Added coverage for two launcher Codex agents sharing the same cwd/workspace; each binds only to the JSONL containing its exact launch prompt, so the newer co-located session is not stolen by the older agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core boot/resume identity binding for Claude/Codex/Cursor; wrong matching would break resumability or bind the wrong session, but the fail-closed prompt guard and broad test coverage mitigate that.
> 
> **Overview**
> Fixes **launcher-spawned Claude/Codex resumability** by changing how boot-time `cli_session_id` is discovered from harness JSONL.
> 
> **`findLatestHarnessSessionIdentity`** no longer picks the **newest** JSONL for a cwd. It collects candidates, checks whether each transcript contains the caller's **`expectedText`** in user-origin prompt fields (with normalization for whitespace and `<user_query>` tags, and support for split text blocks), and **`chooseIdentityCandidate`** returns a session only when there is a **single** unambiguous match—or, with one candidate, when the prompt matches or no expected text was given. Multiple same-cwd sessions or a prompt mismatch **fail closed** (no bind).
> 
> **`AgentEngine.findTranscriptSessionIdentity`** passes **`task_summary`** as `expectedText` and forwards **`CMUXLAYER_HARNESS_HOME`** / **`CODEX_HOME`** so discovery uses the same paths as JSONL reads.
> 
> Tests add boot capture, mismatch, and shared-cwd scenarios for Claude/Codex; Cursor prompt-matching cases; and server tests that follow the canonical agent id after session rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b7ba616bb63818a29db4948545511d1c062661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture `cli_session_id` for launcher-spawned Claude and Codex sessions to support resumability
> - Rewrites identity resolution in [`findLatestHarnessSessionIdentity`](https://github.com/EtanHey/cmuxlayer/pull/193/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) to match sessions by comparing JSONL user-origin prompt fields against the agent's `task_summary`, rather than picking the newest file by mtime.
> - Adds text normalization helpers and `jsonlContainsExpectedPromptText` to handle prompt text wrapped in `user_query` tags or split across adjacent text blocks.
> - Updates [`AgentEngine.captureHarnessSessionIdentity`](https://github.com/EtanHey/cmuxlayer/pull/193/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to pass `expectedText` and optional home directory overrides (`CMUXLAYER_HARNESS_HOME`, `CODEX_HOME`) when resolving identities.
> - Behavioral Change: when `expectedText` is provided, ambiguous or mismatched candidates now return `null` instead of falling back to the newest session by mtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23b7ba6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->