### PR TITLE
fix(send): send_command/send_input verify+retry submit (not length-conditional)

### DIFF
--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -137,6 +137,7 @@ export interface StateTransition {
 
 export type DeliveryEventType =
   | "spawn_agent"
+  | "send_input"
   | "send_command"
   | "send_to"
   | "send_to_agent"

--- a/src/server.ts
+++ b/src/server.ts
@@ -206,6 +206,16 @@ class DeliveryError extends Error {
   }
 }
 
+class SubmitVerificationError extends Error {
+  constructor(
+    message: string,
+    readonly retry_count: number,
+  ) {
+    super(message);
+    this.name = "SubmitVerificationError";
+  }
+}
+
 class BootPromptTimeoutError extends Error {
   constructor(
     message: string,
@@ -751,7 +761,18 @@ function resolveTargetIdentity(
   surfaceRef: string,
 ): TargetIdentity {
   const identity: TargetIdentity = { surface: surfaceRef };
-  const matches = stateMgr
+  const record = resolveLatestSurfaceAgentRecord(stateMgr, surfaceRef);
+  if (record?.task_summary) identity.title = record.task_summary;
+  if (record?.model) identity.model = record.model;
+  if (record?.cli) identity.agent_type = record.cli;
+  return identity;
+}
+
+function resolveLatestSurfaceAgentRecord(
+  stateMgr: StateManager,
+  surfaceRef: string,
+): AgentRecord | undefined {
+  return stateMgr
     .listStates()
     .filter((record) => record.surface_id === surfaceRef)
     .sort((a, b) => {
@@ -759,12 +780,7 @@ function resolveTargetIdentity(
       return (
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       );
-    });
-  const record = matches[0];
-  if (record?.task_summary) identity.title = record.task_summary;
-  if (record?.model) identity.model = record.model;
-  if (record?.cli) identity.agent_type = record.cli;
-  return identity;
+    })[0];
 }
 
 function enrichParsedScreen(
@@ -1370,6 +1386,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_event: DeliveryEventType;
     source_agent?: string | null;
     verify_submit: boolean;
+    allow_non_agent_clear?: boolean;
   }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
@@ -1395,13 +1412,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return { submit_verified: true, retry_count: retryCount };
       }
 
+      const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
       if (
-        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
-        !screenShowsPendingInput(snapshot.text, opts.text)
+        (screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) ||
+          opts.allow_non_agent_clear === true) &&
+        !hasPendingInput
       ) {
         // The submitted text is no longer echoed in the input box: the terminal
-        // accepted it and cleared the prompt on a parsed agent surface, even if
-        // the agent has already settled back to idle.
+        // accepted it and cleared the prompt. For agent surfaces this catches
+        // the common idle-after-submit case; raw shell clears are only accepted
+        // when the caller explicitly allows non-agent verification.
         return { submit_verified: true, retry_count: retryCount };
       }
 
@@ -1442,6 +1462,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_event?: DeliveryEventType;
     source_agent?: string | null;
     verify_submit?: boolean;
+    allow_non_agent_clear?: boolean;
   }): Promise<{
     bytes: number;
     retry_count: number;
@@ -1491,6 +1512,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         source_event: opts.source_event ?? "send_command",
         source_agent: opts.source_agent,
         verify_submit: opts.verify_submit ?? false,
+        allow_non_agent_clear: opts.allow_non_agent_clear,
       });
       submit_verified = verification.submit_verified;
       retry_count = verification.retry_count;
@@ -1515,8 +1537,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     if (submit_verified === false) {
-      throw new Error(
+      throw new SubmitVerificationError(
         `Enter submit could not be verified for ${opts.surface} within ${SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS}ms`,
+        retry_count,
       );
     }
 
@@ -2646,8 +2669,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
 
-        await withSurfaceWrite(args.surface, async () => {
-          await deliverInputChunks({
+        const targetRecord = resolveLatestSurfaceAgentRecord(
+          stateMgr,
+          args.surface,
+        );
+        const shouldVerifySubmit =
+          args.press_enter &&
+          (!targetRecord || INTERACTIVE_AGENT_STATES.has(targetRecord.state));
+        const delivery = await withSurfaceWrite(args.surface, async () => {
+          return deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
             chunks,
@@ -2655,16 +2685,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: args.press_enter,
             rename_to_task: args.rename_to_task,
+            source_event: "send_input",
+            verify_submit: shouldVerifySubmit,
+            allow_non_agent_clear: !targetRecord,
           });
         });
 
         const identity = resolveTargetIdentity(stateMgr, args.surface);
-        const data = { ...identity, delivered: true };
+        const data = {
+          ...identity,
+          delivered: true,
+          retry_count: delivery.retry_count,
+          submit_verified: delivery.submit_verified,
+        };
         return okFormatted(
-          formatDelivery("send_input", { ...identity, delivered: true }),
+          formatDelivery("send_input", {
+            ...identity,
+            delivered: true,
+            submit_verified: delivery.submit_verified,
+          }),
           data,
         );
       } catch (e) {
+        if (e instanceof SubmitVerificationError) {
+          return err(e, {
+            submit_verified: false,
+            retry_count: e.retry_count,
+          });
+        }
         if (e instanceof DeliveryError) {
           return err(e, { failed_chunk: e.failed_chunk ?? null });
         }
@@ -2719,6 +2767,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD
             ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
             : [sanitizedCommand];
+        const targetRecord = resolveLatestSurfaceAgentRecord(
+          stateMgr,
+          args.surface,
+        );
+        const shouldVerifySubmit =
+          !!targetRecord && INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
         const delivery = await withSurfaceWrite(args.surface, async () =>
           deliverInputChunks({
@@ -2729,7 +2783,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: true,
             source_event: "send_command",
-            verify_submit: sanitizedCommand.length > SEND_INPUT_CHUNK_THRESHOLD,
+            verify_submit: shouldVerifySubmit,
           }),
         );
 
@@ -2765,6 +2819,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof SubmitVerificationError) {
+          return err(e, {
+            submit_verified: false,
+            retry_count: e.retry_count,
+          });
+        }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, { last_10_lines: e.last_10_lines });
         }

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -171,6 +171,107 @@ class FakeClaudeSurfaceClient {
   }
 }
 
+class FakeShellSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:shell";
+  readonly title = "zsh";
+  readonly sendCalls: string[] = [];
+  readonly sendKeyCalls: string[] = [];
+  readonly renameTabCalls: string[] = [];
+  private pendingText = "";
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    this.sendCalls.push(text);
+    this.pendingText += text;
+  }
+
+  async pasteText(surface: string, text: string) {
+    await this.send(surface, text);
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    this.sendKeyCalls.push(key);
+    if (key === "return") {
+      this.pendingText = "";
+    }
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    const prompt = this.pendingText ? `$ ${this.pendingText}` : "$";
+    return {
+      surface,
+      text: `${prompt}\n`,
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab(_surface: string, title: string) {
+    this.renameTabCalls.push(title);
+  }
+}
+
 function createReliabilityServer(client: FakeClaudeSurfaceClient) {
   return createServer({
     client: client as any,
@@ -312,6 +413,7 @@ describe("enter reliability", () => {
   it("retries Enter for send_command on a Claude surface", async () => {
     const client = new FakeClaudeSurfaceClient();
     server = createReliabilityServer(client);
+    registerAgent(server);
 
     const result = await callTool(server, "send_command", {
       surface: client.surface,
@@ -332,6 +434,117 @@ describe("enter reliability", () => {
           event.retry_count === 1,
       ),
     ).toBe(true);
+  });
+
+  it("reports a failed short send_command submit after retry leaves Claude idle", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_command", {
+      surface: client.surface,
+      command: "ping",
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      2,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_command" &&
+          event.submit_verified === false &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a failed short send_input submit after retry leaves Claude idle", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_input", {
+      surface: client.surface,
+      text: "ping",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      2,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_input" &&
+          event.submit_verified === false &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not false-fail send_input to a busy cached agent surface", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working" });
+
+    const result = await callTool(server, "send_input", {
+      surface: client.surface,
+      text: "interrupt",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_input",
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBeNull();
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBeNull();
+  });
+
+  it("verifies send_input to an uncached shell when the prompt clears", async () => {
+    const client = new FakeShellSurfaceClient();
+    server = createReliabilityServer(client as any);
+
+    const result = await callTool(server, "send_input", {
+      surface: client.surface,
+      text: "printf ok",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_input",
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBe(true);
   });
 
   it("uses the verified send path for interact(action=send)", async () => {

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -100,7 +100,7 @@ describe("false-green empty surface protection", () => {
     );
   });
 
-  it("does not verify a cleared long command on a non-agent shell prompt", async () => {
+  it("does not false-fail a cleared long command on a non-agent shell prompt", async () => {
     const longCommand = `echo ${"x".repeat(520)}`;
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
@@ -126,7 +126,7 @@ describe("false-green empty surface protection", () => {
     );
 
     const parsed = parseToolResult(result);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBeNull();
   });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1562,8 +1562,8 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Should have called send and then send-key
-    expect(mockExec).toHaveBeenCalledTimes(2);
+    // Should have called send, then send-key, then the submit verification read.
+    expect(mockExec).toHaveBeenCalledTimes(3);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -1573,6 +1573,11 @@ describe("tool handler integration", () => {
       2,
       "cmux",
       expect.arrayContaining(["send-key"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      3,
+      "cmux",
+      expect.arrayContaining(["read-screen"]),
     );
   });
 


### PR DESCRIPTION
## Summary
- Make `send_command` verify final Enter for cached interactive agent surfaces regardless of command length.
- Make foreground `send_input` return `submit_verified`/`retry_count`, verify `press_enter` submits for interactive or uncached raw surfaces, and avoid false-failing cached busy/non-interactive agents.
- Keep boot prompt and `send_to` verification paths intact; update tests for short dropped returns and shell/busy guard behavior.

## Test plan
- [x] RED held first: `bun run test tests/enter-reliability.test.ts` failed on missing `submit_verified`/verification behavior before implementation.
- [x] `bun run test tests/enter-reliability.test.ts`
- [x] `bun run test tests/false-green-empty-surface.test.ts`
- [x] `bun run test tests/server.test.ts`
- [x] `bun run test` (57 files, 944 tests)
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Pre-push hook reran tests and finished with exit status 0.

## Notes
- `coderabbit review --agent` was run pre-commit under `timeout 180`; it connected and reached review/heartbeat status, then exited with code 124 before returning findings.
- Busy-target guard: `send_input` to a cached `working` agent with a stuck composer returns `ok:true`, `submit_verified:null`, `retry_count:0`, and sends only one return.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal delivery and success/failure semantics for MCP send tools; mis-tuned verification could block orchestration or mask real submit failures, though guards limit scope to interactive/uncached surfaces.
> 
> **Overview**
> **Enter submit verification** for `send_input` and `send_command` is no longer tied to command length. Both paths poll the terminal after Return, retry Enter once when input still looks pending, and surface **`submit_verified`** and **`retry_count`** on success and structured errors on timeout via **`SubmitVerificationError`**.
> 
> **When verification runs:** `send_command` verifies only when the surface has a cached agent in **`ready`/`idle`**. Foreground **`send_input`** with **`press_enter`** verifies for the same interactive agents, or for **uncached** surfaces (raw shell) using **`allow_non_agent_clear`** when the prompt clears. Cached agents in **`working`** skip verification so interjections are not reported as failed submits.
> 
> **`verifySubmitAfterEnter`** can treat a cleared prompt as success on non-agent surfaces when allowed; failed verification throws **`SubmitVerificationError`** with retry metadata instead of a generic error.
> 
> Telemetry adds **`send_input`** to **`DeliveryEventType`**. Tests cover stuck submits, busy-surface guard, shell prompt clears, and updated expectations for shell long commands (**ok** with **`submit_verified: null`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ca87a0b5ecedab380c1455114136c11d9c3d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `send_command`/`send_input` to verify and retry submit based on agent state rather than command length
> - `send_command` now gates submit verification on the target surface being in an interactive agent state, replacing the previous length-based condition.
> - `send_input` gains submit verification support: non-agent (shell) surfaces verify success when the prompt clears (`allow_non_agent_clear=true`); busy cached agents skip verification entirely.
> - Introduces `SubmitVerificationError` (carrying `retry_count`) so callers can distinguish verification failures from other errors; both handlers return structured errors with `submit_verified=false` and `retry_count` on failure.
> - Success responses for both handlers now include `submit_verified` and `retry_count` fields.
> - Behavioral Change: short commands that previously skipped verification in `send_command` will now attempt verify+retry if the surface is in an interactive agent state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 57ca87a. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->