### PR TITLE
fix(send): chunker skips empty chunks so blank-line boot prompts deliver

### DIFF
--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -26,22 +26,51 @@ const LAUNCH_SHELL_READY_POLL_MS = 100;
 type CmuxLikeClient = CmuxClient | CmuxSocketClient;
 
 function chunkTerminalInput(text: string, chunkSize: number): string[] {
-  if (!text || text.length <= chunkSize) {
-    return [text];
-  }
-
-  const chunks: string[] = [];
+  const rawChunks: string[] = [];
   let remaining = text;
 
   while (remaining.length > chunkSize) {
     const newlineIndex = remaining.lastIndexOf("\n", chunkSize);
     const splitAt = newlineIndex >= 0 ? newlineIndex + 1 : chunkSize;
-    chunks.push(remaining.slice(0, splitAt));
+    rawChunks.push(remaining.slice(0, splitAt));
     remaining = remaining.slice(splitAt);
   }
 
   if (remaining.length > 0) {
-    chunks.push(remaining);
+    rawChunks.push(remaining);
+  }
+
+  const chunks: string[] = [];
+  let whitespaceCarry = "";
+  for (const chunk of rawChunks) {
+    if (chunk.trim().length === 0) {
+      whitespaceCarry += chunk;
+      continue;
+    }
+
+    if (!whitespaceCarry) {
+      chunks.push(chunk);
+      continue;
+    }
+
+    let candidate = whitespaceCarry + chunk;
+    whitespaceCarry = "";
+    while (candidate.length > chunkSize) {
+      const firstTextIndex = candidate.search(/\S/);
+      const splitAt =
+        firstTextIndex >= chunkSize ? firstTextIndex + 1 : chunkSize;
+      chunks.push(candidate.slice(0, splitAt));
+      candidate = candidate.slice(splitAt);
+    }
+    if (candidate.trim().length === 0) {
+      whitespaceCarry = candidate;
+    } else {
+      chunks.push(candidate);
+    }
+  }
+
+  if (whitespaceCarry && chunks.length > 0) {
+    chunks[chunks.length - 1] += whitespaceCarry;
   }
 
   return chunks;

--- a/src/server.ts
+++ b/src/server.ts
@@ -514,22 +514,51 @@ function applySurfaceWorkingDirectory(
 }
 
 function chunkTerminalInput(text: string, chunkSize: number): string[] {
-  if (!text || text.length <= chunkSize) {
-    return [text];
-  }
-
-  const chunks: string[] = [];
+  const rawChunks: string[] = [];
   let remaining = text;
 
   while (remaining.length > chunkSize) {
     const newlineIndex = remaining.lastIndexOf("\n", chunkSize);
     const splitAt = newlineIndex >= 0 ? newlineIndex + 1 : chunkSize;
-    chunks.push(remaining.slice(0, splitAt));
+    rawChunks.push(remaining.slice(0, splitAt));
     remaining = remaining.slice(splitAt);
   }
 
   if (remaining.length > 0) {
-    chunks.push(remaining);
+    rawChunks.push(remaining);
+  }
+
+  const chunks: string[] = [];
+  let whitespaceCarry = "";
+  for (const chunk of rawChunks) {
+    if (chunk.trim().length === 0) {
+      whitespaceCarry += chunk;
+      continue;
+    }
+
+    if (!whitespaceCarry) {
+      chunks.push(chunk);
+      continue;
+    }
+
+    let candidate = whitespaceCarry + chunk;
+    whitespaceCarry = "";
+    while (candidate.length > chunkSize) {
+      const firstTextIndex = candidate.search(/\S/);
+      const splitAt =
+        firstTextIndex >= chunkSize ? firstTextIndex + 1 : chunkSize;
+      chunks.push(candidate.slice(0, splitAt));
+      candidate = candidate.slice(splitAt);
+    }
+    if (candidate.trim().length === 0) {
+      whitespaceCarry = candidate;
+    } else {
+      chunks.push(candidate);
+    }
+  }
+
+  if (whitespaceCarry && chunks.length > 0) {
+    chunks[chunks.length - 1] += whitespaceCarry;
   }
 
   return chunks;

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -438,6 +438,76 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
+  it("spawn_agent delivers inline prompts with blank lines without empty chunks", async () => {
+    const baseExec = makeLifecycleExec();
+    const prompt = `${"a".repeat(500)}\n\n${"b".repeat(600)}`;
+    const buffers = new Map<string, string>();
+    let promptPasted = false;
+    let promptSubmitted = false;
+    mockExec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (args.includes("set-buffer")) {
+        const chunk = String(args.at(-1) ?? "");
+        if (chunk.trim().length === 0) {
+          throw new Error("set-buffer requires text");
+        }
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        buffers.set(name, chunk);
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("paste-buffer")) {
+        promptPasted = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (
+        args.includes("send-key") &&
+        args.includes("return") &&
+        promptPasted
+      ) {
+        promptSubmitted = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen") && promptSubmitted) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const chunks = mockExec.mock.calls
+      .filter(([, args]) => Array.isArray(args) && args.includes("set-buffer"))
+      .map(([, args]) => String(args.at(-1) ?? ""));
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.trim().length > 0)).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 501)).toBe(true);
+    expect(chunks.join("")).toBe(prompt);
+    expect(chunks.join("")).toContain("\n\n");
+  });
+
   it("spawn_agent canonicalizes the agent id after session capture renames pending state", async () => {
     const sessionId = "019ec0e6-1111-2222-3333-444455556666";
     let finalAgentId: string | null = null;


### PR DESCRIPTION
## Summary
- Coalesce whitespace-only chunks into adjacent chunks so `cmux set-buffer` is never called with empty/blank text during chunked prompt delivery.
- Apply the fix to both `src/server.ts` and the mirrored app-server runtime chunker.
- Add a regression test for a multi-paragraph inline `spawn_agent` boot prompt with a blank line at the chunk boundary, asserting no whitespace-only chunks and exact prompt preservation.

## Test plan
- `graphify query "chunkTerminalInput deliverInputChunks SEND_INPUT_CHUNK_THRESHOLD empty chunk blank line set-buffer" --budget 3000`
- `bun test tests/server-agent-tools.test.ts -t "spawn_agent delivers inline prompts with blank lines without empty chunks"`
- `bun test tests/server-agent-tools.test.ts -t "spawn_agent sends inline prompt after the agent is ready"`
- `bun test tests/server.test.ts -t "send_input chunks long text transparently before sending"`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `coderabbit review --agent` (second pass: 0 findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to chunk assembly plus a test; behavior for prompts without blank-line-only chunks should match the prior newline-first splitting.
> 
> **Overview**
> Fixes **chunked terminal/prompt delivery** when a newline-aligned split leaves a **whitespace-only segment** (e.g. a blank line between paragraphs). Those segments used to become their own chunks and could fail **`set-buffer`** / paste delivery during **`spawn_agent`** boot prompts.
> 
> **`chunkTerminalInput`** now builds raw line-bounded chunks first, then **carries whitespace-only pieces forward**—merging them with the next non-empty chunk (re-splitting if needed) or **appending to the last chunk**—so every emitted chunk has non-empty trimmed content while **joining chunks still reproduces the original text**.
> 
> The same logic is applied in **`src/server.ts`** and the mirrored **`src/app-server-runtime.ts`**. A regression test covers a long inline **`spawn_agent`** prompt with `\n\n` at a chunk boundary, asserting multiple chunks, no empty chunks, size limits, and exact prompt preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7452e9cb518c5c3f51b8cf6c694fa371e1ebcecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `chunkTerminalInput` to skip whitespace-only chunks so blank-line boot prompts deliver
> - Rewrites the chunking algorithm in [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/196/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/196/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): first slices input at newline boundaries, then merges whitespace-only segments into adjacent text chunks via a `whitespaceCarry` accumulator.
> - Any trailing `whitespaceCarry` is appended to the last non-empty chunk rather than emitted as a standalone empty chunk.
> - Adds a test in [server-agent-tools.test.ts](https://github.com/EtanHey/cmuxlayer/pull/196/files#diff-b02b20318090fbe2fe9736638b282662f0d778996959f4a29828dc0dab2debff) that verifies `spawn_agent` with a blank-line-containing prompt returns `boot_prompt_delivered=true`, emits no empty chunks, and round-trips the full prompt.
> - Behavioral Change: `chunkTerminalInput` now returns `[]` for empty input instead of `['']`, and chunk split boundaries may shift to one character past the first non-whitespace index.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7452e9c. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->