### PR TITLE
fix: harden cmux agent lifecycle health

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -56,6 +56,7 @@ import {
 import {
   matchReadyPattern,
   readyPatternRequiresAgentIdentity,
+  screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
 import {
@@ -768,9 +769,12 @@ export class AgentEngine {
     return Date.now() - session.mtime_ms >= DONE_QUIESCENCE_MS;
   }
 
-  private screenContradictsTranscriptDone(text: string): boolean {
+  private screenContradictsTranscriptDone(
+    cli: CliType,
+    text: string,
+  ): boolean {
     const parsed = parseScreen(text);
-    return parsed.status === "working" || parsed.status === "thinking";
+    return screenHasActiveAgentMarker(cli, text, parsed);
   }
 
   private async hasGroundTruthDone(
@@ -784,9 +788,9 @@ export class AgentEngine {
         : await this.client.readScreen(agent.surface_id, {
             lines: BOOT_SESSION_CAPTURE_LINES,
           });
-      return !this.screenContradictsTranscriptDone(screen.text);
+      return !this.screenContradictsTranscriptDone(agent.cli, screen.text);
     } catch {
-      return true;
+      return false;
     }
   }
 
@@ -1255,7 +1259,8 @@ export class AgentEngine {
         const match = matchReadyPattern(agent.cli, screen.text);
         if (
           match.matched &&
-          screenHasReadyAgentIdentity(agent.cli, screen.text, parsed)
+          (!readyPatternRequiresAgentIdentity(agent.cli) ||
+            screenHasReadyAgentIdentity(agent.cli, screen.text, parsed))
         ) {
           this.stateMgr.updateRecord(agent.agent_id, {
             boot_prompt_pending: false,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -762,10 +762,32 @@ export class AgentEngine {
       : null;
   }
 
-  private hasGroundTruthDone(agent: AgentRecord): boolean {
+  private transcriptHasSettledDone(agent: AgentRecord): boolean {
     const session = this.loadGroundTruthSession(agent);
     if (!session?.state.done) return false;
     return Date.now() - session.mtime_ms >= DONE_QUIESCENCE_MS;
+  }
+
+  private screenContradictsTranscriptDone(text: string): boolean {
+    const parsed = parseScreen(text);
+    return parsed.status === "working" || parsed.status === "thinking";
+  }
+
+  private async hasGroundTruthDone(
+    agent: AgentRecord,
+    ctx?: SweepAgentContext,
+  ): Promise<boolean> {
+    if (!this.transcriptHasSettledDone(agent)) return false;
+    try {
+      const screen = ctx
+        ? await this.readSweepScreen(agent, ctx)
+        : await this.client.readScreen(agent.surface_id, {
+            lines: BOOT_SESSION_CAPTURE_LINES,
+          });
+      return !this.screenContradictsTranscriptDone(screen.text);
+    } catch {
+      return true;
+    }
   }
 
   private async hasCurrentOutputDoneEvidence(
@@ -797,7 +819,7 @@ export class AgentEngine {
     if (isCursorTerminalIdleTarget(agent, targetState)) return "state";
     if (agent.state !== targetState) return null;
     if (!this.requiresOutputDoneEvidence(targetState)) return "state";
-    if (this.hasGroundTruthDone(agent)) return "transcript";
+    if (await this.hasGroundTruthDone(agent)) return "transcript";
     return this.hasRecordedOutputDoneEvidence(agent) ||
       (await this.hasCurrentOutputDoneEvidence(agent))
       ? "screen"
@@ -1228,6 +1250,28 @@ export class AgentEngine {
       }
 
       try {
+        const screen = await this.readSweepScreen(agent, ctx);
+        const parsed = parseScreen(screen.text);
+        const match = matchReadyPattern(agent.cli, screen.text);
+        if (
+          match.matched &&
+          screenHasReadyAgentIdentity(agent.cli, screen.text, parsed)
+        ) {
+          this.stateMgr.updateRecord(agent.agent_id, {
+            boot_prompt_pending: false,
+          });
+          const ready = this.stateMgr.transition(agent.agent_id, "ready", {
+            error: null,
+          });
+          this.registry.set(agent.agent_id, ready);
+          this.readyPatternMatches.delete(agent.agent_id);
+          return ready;
+        }
+      } catch {
+        // Fall through to the explicit interrupted-delivery error below.
+      }
+
+      try {
         this.stateMgr.updateRecord(agent.agent_id, {
           boot_prompt_pending: false,
         });
@@ -1282,7 +1326,7 @@ export class AgentEngine {
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
     if (TERMINAL_STATES.has(agent.state)) return { agent };
 
-    if (this.hasGroundTruthDone(agent)) {
+    if (await this.hasGroundTruthDone(agent, ctx)) {
       try {
         const marked = this.stateMgr.updateRecord(agent.agent_id, {
           task_done_candidate_at: null,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1248,12 +1248,12 @@ export class AgentEngine {
       return agent;
     }
     if (agent.boot_prompt_pending) {
-      this.readyPatternMatches.delete(agent.agent_id);
       const since = Date.parse(agent.updated_at);
       if (
         Number.isNaN(since) ||
         Date.now() - since < BOOT_PROMPT_PENDING_STALE_MS
       ) {
+        this.readyPatternMatches.delete(agent.agent_id);
         return agent;
       }
 
@@ -1266,6 +1266,12 @@ export class AgentEngine {
           (!readyPatternRequiresAgentIdentity(agent.cli) ||
             screenHasReadyAgentIdentity(agent.cli, screen.text, parsed))
         ) {
+          const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+          this.readyPatternMatches.set(agent.agent_id, count);
+          if (count < Math.max(1, match.consecutive)) {
+            return agent;
+          }
+
           this.stateMgr.updateRecord(agent.agent_id, {
             boot_prompt_pending: false,
           });
@@ -1284,6 +1290,7 @@ export class AgentEngine {
           this.readyPatternMatches.delete(agent.agent_id);
           return ready;
         }
+        this.readyPatternMatches.delete(agent.agent_id);
       } catch {
         // Fall through to the explicit interrupted-delivery error below.
       }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -730,9 +730,13 @@ export class AgentEngine {
     return this.registry;
   }
 
-  private hasOutputDoneEvidence(text: string): boolean {
+  private hasOutputDoneEvidence(cli: CliType, text: string): boolean {
     const parsed = parseScreen(text);
-    return parsed.status === "done" && parsed.done_signal !== null;
+    return (
+      parsed.status === "done" &&
+      parsed.done_signal !== null &&
+      !screenHasActiveAgentMarker(cli, text, parsed)
+    );
   }
 
   private requiresOutputDoneEvidence(targetState: AgentState): boolean {
@@ -801,7 +805,7 @@ export class AgentEngine {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
       });
-      return this.hasOutputDoneEvidence(screen.text);
+      return this.hasOutputDoneEvidence(agent.cli, screen.text);
     } catch {
       return false;
     }
@@ -1349,7 +1353,7 @@ export class AgentEngine {
 
     try {
       const screen = await this.readSweepScreen(agent, ctx);
-      if (!this.hasOutputDoneEvidence(screen.text)) {
+      if (!this.hasOutputDoneEvidence(agent.cli, screen.text)) {
         if (agent.task_done_candidate_at) {
           const updated = this.stateMgr.updateRecord(agent.agent_id, {
             task_done_candidate_at: null,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1269,9 +1269,17 @@ export class AgentEngine {
           this.stateMgr.updateRecord(agent.agent_id, {
             boot_prompt_pending: false,
           });
-          const ready = this.stateMgr.transition(agent.agent_id, "ready", {
+          let ready = this.stateMgr.transition(agent.agent_id, "ready", {
             error: null,
           });
+          if (
+            ready.quality === "degraded" &&
+            agent.error?.startsWith("Post-spawn liveness failed:")
+          ) {
+            ready = this.stateMgr.updateRecord(agent.agent_id, {
+              quality: "unknown",
+            });
+          }
           this.registry.set(agent.agent_id, ready);
           this.readyPatternMatches.delete(agent.agent_id);
           return ready;

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -173,12 +173,17 @@ export function evaluateAgentHealth(
 
   const screenActive =
     input.screen_status === "working" || input.screen_status === "thinking";
+  const screenDone = input.screen_status === "done";
+  const registryActive =
+    agent.state === "creating" ||
+    agent.state === "booting" ||
+    agent.state === "working";
   const registryInactive =
     agent.state === "ready" ||
     agent.state === "idle" ||
     agent.state === "done" ||
     agent.state === "error";
-  if (screenActive && registryInactive) {
+  if ((screenActive && registryInactive) || (screenDone && registryActive)) {
     addIssue(
       issueCodes,
       issues,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -1,0 +1,279 @@
+import type { AgentRecord } from "./agent-types.js";
+import { inferRecordRoleOrNull } from "./layout-policy.js";
+
+export type AgentHealthStatus = "healthy" | "unhealthy";
+
+export type AgentHealthIssueCode =
+  | "auto_discovered_agent"
+  | "missing_cli_session_id"
+  | "non_resumable"
+  | "inbox_monitor_not_alive"
+  | "stale_inbox_dispatches"
+  | "registry_screen_disagreement"
+  | "registry_surface_workspace_mismatch"
+  | "closure_without_artifact"
+  | "recoverable_blocker_requires_action"
+  | "missing_managed_lead_agent_id"
+  | "ambiguous_repo_cwd_label"
+  | "non_claude_orchestrator"
+  | "topology_three_or_more_columns"
+  | "orchestrator_not_leftmost"
+  | "worker_in_leftmost_column";
+
+export interface AgentTopologyHealthInput {
+  column: number | null;
+  column_count: number | null;
+}
+
+export interface AgentHealthInput {
+  monitor_alive?: boolean | null;
+  stale_count?: number;
+  screen_status?: string | null;
+  surface_workspace_id?: string | null;
+  surface_title?: string | null;
+  closure_artifact_verified?: boolean | null;
+  screen_actions?: string[] | null;
+  topology?: AgentTopologyHealthInput | null;
+}
+
+export interface AgentHealth {
+  status: AgentHealthStatus;
+  issue_codes: AgentHealthIssueCode[];
+  issues: string[];
+  recommended_actions?: string[];
+}
+
+function addIssue(
+  codes: AgentHealthIssueCode[],
+  issues: string[],
+  code: AgentHealthIssueCode,
+  message: string,
+): void {
+  codes.push(code);
+  issues.push(message);
+}
+
+const RECOVERABLE_ACTION_RECOMMENDATIONS: Record<string, string> = {
+  "recoverable_blocker:pr_loop": "route_pr_loop",
+  "recoverable_blocker:restart": "restart_in_scope_mcp_or_daemon",
+  "recoverable_blocker:successor": "resume_or_spawn_managed_successor",
+};
+
+function addRecommendedAction(actions: string[], action: string): void {
+  if (!actions.includes(action)) actions.push(action);
+}
+
+function isLongRunning(agent: AgentRecord): boolean {
+  return (
+    agent.state !== "creating" &&
+    agent.state !== "booting" &&
+    agent.state !== "done" &&
+    agent.state !== "error"
+  );
+}
+
+function isAutoDiscovered(agent: AgentRecord): boolean {
+  return (
+    agent.agent_id.startsWith("auto-") ||
+    agent.task_summary === "(auto-discovered)"
+  );
+}
+
+function looksLeadLike(text: string | null | undefined): boolean {
+  return /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(text ?? "");
+}
+
+function hasAmbiguousRepoOrCwdLabel(agent: AgentRecord): boolean {
+  const repo = agent.repo.trim().toLowerCase();
+  const cwd = (agent.launch_cwd ?? "").trim().toLowerCase();
+  const ambiguousNames = new Set([
+    "",
+    "git",
+    "gits",
+    "repo",
+    "repos",
+    "workspace",
+    "workspaces",
+    "projects",
+  ]);
+  return (
+    ambiguousNames.has(repo) ||
+    /\/(?:gits|repos|projects|workspaces)\/?$/.test(cwd)
+  );
+}
+
+export function evaluateAgentHealth(
+  agent: AgentRecord,
+  input: AgentHealthInput = {},
+): AgentHealth {
+  const issueCodes: AgentHealthIssueCode[] = [];
+  const issues: string[] = [];
+  const recommendedActions: string[] = [];
+  const role = inferRecordRoleOrNull(agent);
+
+  if (isAutoDiscovered(agent)) {
+    addIssue(
+      issueCodes,
+      issues,
+      "auto_discovered_agent",
+      "agent was auto-discovered, not created through managed spawn_agent",
+    );
+
+    if (looksLeadLike(input.surface_title) || looksLeadLike(agent.repo)) {
+      addIssue(
+        issueCodes,
+        issues,
+        "missing_managed_lead_agent_id",
+        "lead/coordinator surface has no managed agent_id; recover/register or replace with a managed lead",
+      );
+    }
+
+    if (hasAmbiguousRepoOrCwdLabel(agent)) {
+      addIssue(
+        issueCodes,
+        issues,
+        "ambiguous_repo_cwd_label",
+        "auto-discovered agent has an ambiguous repo/cwd label; tab title is not lane ownership",
+      );
+    }
+  }
+
+  if (isLongRunning(agent) && !agent.cli_session_id) {
+    addIssue(
+      issueCodes,
+      issues,
+      "missing_cli_session_id",
+      "managed long-running agent has no cli_session_id",
+    );
+    addIssue(
+      issueCodes,
+      issues,
+      "non_resumable",
+      "agent cannot be resumed because no CLI session id was captured",
+    );
+  }
+
+  if (input.monitor_alive === false) {
+    addIssue(
+      issueCodes,
+      issues,
+      "inbox_monitor_not_alive",
+      "agent inbox monitor heartbeat is absent or stale",
+    );
+  }
+
+  if ((input.stale_count ?? 0) > 0) {
+    addIssue(
+      issueCodes,
+      issues,
+      "stale_inbox_dispatches",
+      "agent has unacked inbox dispatches past the ACK timeout",
+    );
+  }
+
+  const screenActive =
+    input.screen_status === "working" || input.screen_status === "thinking";
+  const registryInactive =
+    agent.state === "ready" ||
+    agent.state === "idle" ||
+    agent.state === "done" ||
+    agent.state === "error";
+  if (screenActive && registryInactive) {
+    addIssue(
+      issueCodes,
+      issues,
+      "registry_screen_disagreement",
+      `registry state is ${agent.state} while screen parses as ${input.screen_status}`,
+    );
+  }
+
+  if (
+    input.surface_workspace_id !== undefined &&
+    input.surface_workspace_id !== null &&
+    (agent.workspace_id ?? null) !== input.surface_workspace_id
+  ) {
+    addIssue(
+      issueCodes,
+      issues,
+      "registry_surface_workspace_mismatch",
+      `registry workspace is ${agent.workspace_id ?? "null"} while surface is in ${input.surface_workspace_id}`,
+    );
+  }
+
+  if (input.closure_artifact_verified === false) {
+    addIssue(
+      issueCodes,
+      issues,
+      "closure_without_artifact",
+      "worker closure is not backed by a verified DONE marker, BLOCKED/NOT_GREEN handoff, or successor transfer",
+    );
+  }
+
+  const recoverableBlockerActions = Array.from(
+    new Set(
+      (input.screen_actions ?? []).filter((action) =>
+        action.startsWith("recoverable_blocker:"),
+      ),
+    ),
+  );
+  if (recoverableBlockerActions.length > 0) {
+    addIssue(
+      issueCodes,
+      issues,
+      "recoverable_blocker_requires_action",
+      `screen reports recoverable blocker(s): ${recoverableBlockerActions.join(", ")}; route recovery instead of waiting for user`,
+    );
+    for (const action of recoverableBlockerActions) {
+      const recommendation = RECOVERABLE_ACTION_RECOMMENDATIONS[action];
+      if (recommendation) {
+        addRecommendedAction(recommendedActions, recommendation);
+      }
+    }
+  }
+
+  if (agent.cli !== "claude" && role === "orchestrator") {
+    addIssue(
+      issueCodes,
+      issues,
+      "non_claude_orchestrator",
+      "non-Claude agent was assigned orchestrator topology role; use worker unless this is the single explicit left-side coordinator",
+    );
+  }
+
+  const topology = input.topology;
+  if (topology && topology.column_count !== null) {
+    if (topology.column_count >= 3) {
+      addIssue(
+        issueCodes,
+        issues,
+        "topology_three_or_more_columns",
+        `workspace has ${topology.column_count} columns; expected at most two lead/worker columns`,
+      );
+    }
+    if (role === "orchestrator" && topology.column !== null && topology.column > 0) {
+      addIssue(
+        issueCodes,
+        issues,
+        "orchestrator_not_leftmost",
+        `orchestrator is in column ${topology.column}; expected leftmost column 0`,
+      );
+    }
+    if (role === "worker" && topology.column === 0 && topology.column_count >= 2) {
+      addIssue(
+        issueCodes,
+        issues,
+        "worker_in_leftmost_column",
+        "worker is in the leftmost lead column; expected worker column on the right",
+      );
+    }
+  }
+
+  return {
+    status: issueCodes.length === 0 ? "healthy" : "unhealthy",
+    issue_codes: issueCodes,
+    issues,
+    ...(recommendedActions.length > 0
+      ? { recommended_actions: recommendedActions }
+      : {}),
+  };
+}

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -312,6 +312,50 @@ export class AgentRegistry {
     return filtered;
   }
 
+  async refreshManagedSurfaceMetadata(
+    discovery: AgentDiscovery,
+    opts?: { agentId?: string; force?: boolean },
+  ): Promise<AgentRecord | null> {
+    const records = opts?.agentId
+      ? [this.get(opts.agentId)].filter(
+          (record): record is AgentRecord => record !== null,
+        )
+      : this.list();
+    if (records.length === 0) {
+      return null;
+    }
+
+    const discovered = await discovery.scan(opts?.force ?? false);
+    const bySurface = new Map(
+      discovered
+        .filter((entry) => !entry.read_error)
+        .map((entry) => [entry.surface_id, entry]),
+    );
+
+    let requested: AgentRecord | null = null;
+    for (const record of records) {
+      if (record.agent_id.startsWith("auto-")) {
+        continue;
+      }
+      const discoveredEntry = bySurface.get(record.surface_id);
+      if (!discoveredEntry) {
+        continue;
+      }
+      const updated = this.syncManagedRecordSurfaceMetadata(
+        record,
+        discoveredEntry,
+      );
+      if (!updated) {
+        continue;
+      }
+      if (!opts?.agentId || updated.agent_id === this.resolveAlias(opts.agentId)) {
+        requested = updated;
+      }
+    }
+
+    return opts?.agentId ? requested ?? this.get(opts.agentId) : null;
+  }
+
   /**
    * Sync an auto-discovered record with the latest parsed surface state.
    *
@@ -380,6 +424,9 @@ export class AgentRegistry {
     record: AgentRecord,
     discoveredEntry: DiscoveredAgent,
   ): AgentRecord | null {
+    if (discoveredEntry.workspace_id === undefined) {
+      return record;
+    }
     const workspaceId = discoveredEntry.workspace_id ?? null;
     if ((record.workspace_id ?? null) === workspaceId) {
       return record;

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -424,10 +424,10 @@ export class AgentRegistry {
     record: AgentRecord,
     discoveredEntry: DiscoveredAgent,
   ): AgentRecord | null {
-    if (discoveredEntry.workspace_id === undefined) {
+    if (discoveredEntry.workspace_id == null) {
       return record;
     }
-    const workspaceId = discoveredEntry.workspace_id ?? null;
+    const workspaceId = discoveredEntry.workspace_id;
     if ((record.workspace_id ?? null) === workspaceId) {
       return record;
     }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -242,6 +242,15 @@ export class AgentRegistry {
           continue;
         }
       }
+      if (!isAutoRecord && discoveredEntry && !discoveredEntry.read_error) {
+        liveRecord = this.syncManagedRecordSurfaceMetadata(
+          record,
+          discoveredEntry,
+        );
+        if (!liveRecord) {
+          continue;
+        }
+      }
 
       seenSurfaces.add(record.surface_id);
       merged.push({
@@ -365,6 +374,29 @@ export class AgentRegistry {
     }
 
     return record;
+  }
+
+  private syncManagedRecordSurfaceMetadata(
+    record: AgentRecord,
+    discoveredEntry: DiscoveredAgent,
+  ): AgentRecord | null {
+    const workspaceId = discoveredEntry.workspace_id ?? null;
+    if ((record.workspace_id ?? null) === workspaceId) {
+      return record;
+    }
+
+    try {
+      const updated = this.stateMgr.updateRecord(record.agent_id, {
+        workspace_id: workspaceId,
+      });
+      this.agents.set(record.agent_id, updated);
+      return updated;
+    } catch (error) {
+      if (this.evictMissingStateAgent(record.agent_id)) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -55,6 +55,8 @@ export interface AgentRecord {
   user_killed?: boolean;
   // Boot prompt delivery guard
   boot_prompt_pending?: boolean;
+  // File-backed goal contract for superseded/long-running collab tasks
+  goal_file?: string | null;
   // Launch context for worktree/profile-aware spawns
   launch_cwd?: string | null;
   mcp_profile?: string | null;
@@ -142,6 +144,7 @@ export type DeliveryEventType =
   | "send_command"
   | "send_to"
   | "send_to_agent"
+  | "supersede_agent_goal"
   | "interact"
   | "press_enter"
   | "dispatch_nudge";

--- a/src/format.ts
+++ b/src/format.ts
@@ -124,6 +124,18 @@ export function formatReadScreen(
     );
   }
 
+  const recoveryActions =
+    parsed.actions?.filter((action) =>
+      action.startsWith("recoverable_blocker:"),
+    ) ?? [];
+  if (recoveryActions.length > 0) {
+    result.push(
+      `\u2502 actions: ${recoveryActions
+        .map((action) => truncate(action, 40))
+        .join(", ")}`,
+    );
+  }
+
   if (parsed.response) {
     result.push(`\u251c\u2500 Response`);
     result.push(`\u2502 ${truncate(parsed.response, 70)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,12 @@
  *              read_screen, rename_tab, notify, set_status, set_progress,
  *              close_surface, browser_surface
  *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
- *   Agent lifecycle (14): spawn_agent, new_worktree_split, spawn_in_workspace,
+ *   Agent lifecycle (16): spawn_agent, new_worktree_split, spawn_in_workspace,
  *                         resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
  *                         supersede_agent_goal, read_agent_output,
  *                         get_agent_state, list_agents, my_agents, wait_for,
- *                         wait_for_all, stop_agent
- *   V2 agent controls (2): kill, interact
+ *                         wait_for_all, stop_agent, kill, interact
  */
 
 import { readFileSync } from "node:fs";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 35 MCP tools across three categories (keep in sync with server.ts and the
+ * 36 MCP tools across three categories (keep in sync with server.ts and the
  * "total tool count" assertion in tests/server-agent-tools.test.ts):
  *   Core (18): list_surfaces, control_health, select_workspace,
  *              create_workspace, new_split, new_surface, move_surface,
@@ -11,11 +11,12 @@
  *              read_screen, rename_tab, notify, set_status, set_progress,
  *              close_surface, browser_surface
  *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
- *   Agent lifecycle (13): spawn_agent, new_worktree_split, spawn_in_workspace,
+ *   Agent lifecycle (14): spawn_agent, new_worktree_split, spawn_in_workspace,
  *                         resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),
- *                         read_agent_output, get_agent_state, list_agents,
- *                         my_agents, wait_for, wait_for_all, stop_agent
+ *                         supersede_agent_goal, read_agent_output,
+ *                         get_agent_state, list_agents, my_agents, wait_for,
+ *                         wait_for_all, stop_agent
  *   V2 agent controls (2): kill, interact
  */
 

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -57,7 +57,7 @@ export const MODEL_POLICY_CONTRACT: {
     },
     codex: {
       defaultModel: "codex",
-      allowModelOverrideByDefault: true,
+      allowModelOverrideByDefault: false,
       forbiddenModelPatterns: [],
       modelAliases: {
         "gpt-5": "gpt-5",
@@ -142,6 +142,11 @@ export function resolveLaunchModelFlag(
 ): string | null {
   const requested = model?.trim();
   if (!requested) return null;
+
+  if (cli === "codex") {
+    if (modelMatchesDefault(cli, requested)) return null;
+    if (!opts?.allowModelOverride) return null;
+  }
 
   if (cli === "cursor") {
     if (modelMatchesDefault(cli, requested)) return null;

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -101,7 +101,13 @@ export function screenHasActiveAgentMarker(
   screenText: string,
   parsed: ParsedScreenResult = parseScreen(screenText),
 ): boolean {
-  if (parsed.status === "working" || parsed.status === "thinking") {
+  if (
+    parsed.status === "working" ||
+    parsed.status === "thinking" ||
+    parsed.actions?.some((action) =>
+      action.startsWith("recoverable_blocker:"),
+    ) === true
+  ) {
     return true;
   }
 

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -96,6 +96,31 @@ export function matchReadyPattern(
   };
 }
 
+export function screenHasActiveAgentMarker(
+  cli: CliType,
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): boolean {
+  if (parsed.status === "working" || parsed.status === "thinking") {
+    return true;
+  }
+
+  switch (cli) {
+    case "claude":
+      return CLAUDE_ACTIVE_RE.test(screenText);
+    case "codex":
+      return CODEX_ACTIVE_RE.test(screenText);
+    case "cursor":
+      return CURSOR_ACTIVE_RE.test(screenText);
+    case "gemini":
+      return /(?:^|\n)\s*(?:✦\s*)?Working(?:\.\.\.|…)?\s*$/im.test(
+        screenText,
+      );
+    case "kiro":
+      return false;
+  }
+}
+
 export function screenHasReadyAgentIdentity(
   cli: CliType,
   screenText: string,

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -39,6 +39,15 @@ const CURSOR_READY_RE = new RegExp(
   ].join("|"),
   "i",
 );
+const CODEX_READY_RE = new RegExp(
+  [
+    String.raw`codex>`,
+    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[^\n]+`,
+    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)[^\n]*\b(?:Model|model)\s*:?\s*gpt-\d[\w.-]*(?:\s+\w+)?\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)`,
+  ].join("|"),
+  "im",
+);
+const CODEX_ACTIVE_RE = /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b|Working\s*\(/i;
 
 export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
   claude: {
@@ -47,8 +56,7 @@ export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
     consecutive: 1,
   },
   codex: {
-    pattern:
-      /codex>|^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[^\n]+/,
+    pattern: CODEX_READY_RE,
     confidence: "high",
     consecutive: 1,
   },
@@ -81,6 +89,7 @@ export function matchReadyPattern(
     matched:
       entry.pattern.test(screenContent) &&
       (cli !== "claude" || !CLAUDE_ACTIVE_RE.test(screenContent)) &&
+      (cli !== "codex" || !CODEX_ACTIVE_RE.test(screenContent)) &&
       (cli !== "cursor" || !CURSOR_ACTIVE_RE.test(screenContent)),
     confidence: entry.confidence,
     consecutive: entry.consecutive,
@@ -102,7 +111,11 @@ export function screenHasReadyAgentIdentity(
         screenText,
       );
     case "codex":
-      return /(?:^|\n)\s*codex>\s*$/im.test(screenText);
+      return (
+        /(?:^|\n)\s*codex>\s*$/im.test(screenText) ||
+        parsed.agent_type === "codex" ||
+        /(?:^|\n)\s*OpenAI\s+Codex\s*(?:\n|$)/i.test(screenText)
+      );
     case "cursor":
       return /(?:^|\n)\s*(?:cursor>|Cursor Agent)\s*$/im.test(screenText);
     case "kiro":

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -263,7 +263,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
 
   if (
     CODEX_HEADER_RE.test(text) ||
-    CODEX_BOOT_PANEL_RE.test(text) ||
+    (CODEX_BOOT_PANEL_RE.test(text) && CODEX_PANEL_MODEL_RE.test(text)) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -108,6 +108,8 @@ export function inferContextWindow(
 }
 
 const ANSI_ESCAPE_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const ORPHAN_TTY_CONTROL_TRAILER_RE =
+  /(?:^|\s)(?:(?:;[0-9]+[:;][0-9]+[A-Za-z])|(?:\[[0-9;:]*[A-Za-z]))+\s*$/;
 const DONE_SIGNAL_LINE_RE =
   /^\s*([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_DONE)(?:\s+\S{1,16})?\s*$/;
 const CLAUDE_COUNTER_RE = /^\s*CLAUDE_COUNTER:\s*(\d+)\s*$/m;
@@ -132,6 +134,9 @@ const CLAUDE_PERMISSION_APPROVAL_RE =
   /allow for this session|do you want to allow|\[y\/n\]/i;
 const CODEX_HEADER_RE =
   /^\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)(?:\s*[·•]\s*[^\n]*)?\s*$/m;
+const CODEX_BOOT_PANEL_RE = /(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)/i;
+const CODEX_PANEL_MODEL_RE =
+  /(?:^|\n)[^\n]*\b(?:Model|model)\s*:?\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)\b/im;
 const CODEX_CONTEXT_LEFT_RE =
   /^\s*gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?\s*[·•]\s*(\d+)%\s+left(?:\s*[·•]\s*[^\n]*)?\s*$/m;
 const CODEX_WORKING_RE =
@@ -180,6 +185,14 @@ const CURSOR_USING_LINE_RE = /^\s*Using\s*:?\s*(.+)$/im;
 const CURSOR_MODEL_INLINE_RE =
   /\b(claude-[0-9][0-9a-z.-]*|gpt-[0-9][0-9a-z.-]*(?:\s+(?:high|low|mini))?|gemini-[0-9][0-9a-z.-]*)\b/i;
 const RULE_LINE_RE = /^[\s─-╿▀-▟\-=_~·•—–]+$/;
+const RECOVERABLE_BLOCKER_PREFIX =
+  /(?:\b(?:I|we|agent|codex)\s+(?:can(?:not|'t)|cannot|won't|am unable to|are unable to|unable to|do not have permission to|need permission to)\b|\bwaiting\s+for\s+(?:Etan|user|human|approval|permission)\b|\bblocked\b.{0,80}\b(?:approval|permission|user|human|Etan)\b)/is;
+const RECOVERABLE_PR_LOOP_BLOCKER_RE =
+  /(?:(?:\b(?:I|we|agent|codex)\s+(?:can(?:not|'t)|cannot|won't|am unable to|are unable to|unable to|do not have permission to|need permission to)\b|\bwaiting\s+for\s+(?:Etan|user|human|approval|permission)\b|\bblocked\b.{0,80}\b(?:approval|permission|user|human|Etan)\b).{0,160}\b(?:commit|push|(?:open|create)\s+(?:a\s+)?PR|PR|merge)\b|\b(?:commit|push|PR|merge)\b.{0,80}\b(?:waiting\s+for|approval|permission)\b)/is;
+const RECOVERABLE_RESTART_BLOCKER_RE =
+  /(?:(?:\b(?:I|we|agent|codex)\s+(?:can(?:not|'t)|cannot|won't|am unable to|are unable to|unable to|do not have permission to|need permission to)\b|\bwaiting\s+for\s+(?:Etan|user|human|approval|permission)\b|\bblocked\b.{0,80}\b(?:approval|permission|user|human|Etan)\b).{0,160}\b(?:restart|reload)\b.{0,80}\b(?:MCP|daemon|server|cmuxlayer|cmux)\b|\b(?:MCP|daemon|server|cmuxlayer|cmux)\b.{0,80}\b(?:restart|reload)\b.{0,80}\b(?:waiting|approval|permission|cannot|can't|need permission))/is;
+const RECOVERABLE_SUCCESSOR_BLOCKER_RE =
+  /(?:\b(?:MCP|cmux)\s+(?:transport|connection)\s+(?:closed|disconnected|died|lost)\b|\b(?:can(?:not|'t)|cannot|unable to)\s+reconnect\b.{0,80}\b(?:MCPs?|cmux|transport)\b|\b(?:resume|spawn)\b.{0,80}\b(?:managed\s+)?successor\b)/is;
 
 function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_RE, "");
@@ -187,6 +200,10 @@ function stripAnsi(text: string): string {
 
 function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function stripOrphanTtyControlTrailer(line: string): string {
+  return line.replace(ORPHAN_TTY_CONTROL_TRAILER_RE, "").replace(/\s+$/, "");
 }
 
 function isCursorAgentScreen(text: string): boolean {
@@ -246,6 +263,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
 
   if (
     CODEX_HEADER_RE.test(text) ||
+    CODEX_BOOT_PANEL_RE.test(text) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {
@@ -489,8 +507,9 @@ function parseModelAndCost(
 ): { model: string | null; cost: number | null } {
   if (agentType === "codex") {
     const codexMatch = text.match(CODEX_HEADER_RE);
+    const panelModelMatch = text.match(CODEX_PANEL_MODEL_RE);
     return {
-      model: codexMatch?.[1]?.trim() ?? null,
+      model: codexMatch?.[1]?.trim() ?? panelModelMatch?.[1]?.trim() ?? null,
       cost: null,
     };
   }
@@ -538,6 +557,30 @@ function parseCodexContextPct(text: string): number | null {
 
 function parseCodexActions(text: string): string[] {
   return Array.from(text.matchAll(CODEX_ACTION_RE), (match) => match[1].trim());
+}
+
+function uniqueActions(actions: string[]): string[] {
+  return Array.from(new Set(actions));
+}
+
+function parseRecoverableBlockerActions(text: string): string[] {
+  const actions: string[] = [];
+  if (RECOVERABLE_PR_LOOP_BLOCKER_RE.test(text)) {
+    actions.push("recoverable_blocker:pr_loop");
+  }
+  if (RECOVERABLE_RESTART_BLOCKER_RE.test(text)) {
+    actions.push("recoverable_blocker:restart");
+  }
+  if (
+    RECOVERABLE_SUCCESSOR_BLOCKER_RE.test(text) &&
+    (RECOVERABLE_BLOCKER_PREFIX.test(text) ||
+      /\b(?:MCP|cmux)\s+(?:transport|connection)\s+(?:closed|disconnected|died|lost)\b/is.test(
+        text,
+      ))
+  ) {
+    actions.push("recoverable_blocker:successor");
+  }
+  return actions;
 }
 
 function parseCursorScaledTokenCount(raw: string, suffix?: string): number {
@@ -769,6 +812,11 @@ export function parseScreen(text: string): ParsedScreenResult {
     contextPct = Math.min(100, Math.round((tokenCount / contextWindow) * 100));
   }
 
+  const actions = parseRecoverableBlockerActions(normalized);
+  if (agentType === "codex") {
+    actions.push(...parseCodexActions(normalized));
+  }
+
   const result: ParsedScreenResult = {
     agent_type: agentType,
     status: inferStatus(normalized, doneSignal, errors, agentType),
@@ -782,8 +830,8 @@ export function parseScreen(text: string): ParsedScreenResult {
     cost,
   };
 
-  if (agentType === "codex") {
-    result.actions = parseCodexActions(normalized);
+  if (actions.length > 0) {
+    result.actions = uniqueActions(actions);
   }
 
   return result;
@@ -814,7 +862,7 @@ const CHROME_LINE_RES: RegExp[] = [
 export function cleanScreenText(text: string, maxLines = 8): string {
   const out: string[] = [];
   for (const rawLine of normalizeText(text).split("\n")) {
-    const line = rawLine.replace(/\s+$/, "");
+    const line = stripOrphanTtyControlTrailer(rawLine);
     const trimmed = line.trim();
     if (!trimmed) {
       if (out.length > 0 && out[out.length - 1] !== "") out.push("");

--- a/src/server.ts
+++ b/src/server.ts
@@ -2259,7 +2259,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const closureArtifactVerified =
       overrides?.closure_artifact_verified !== undefined
         ? overrides.closure_artifact_verified
-        : TERMINAL_AGENT_STATES.has(agent.state) &&
+        : agent.state === "done" &&
             (agent.role ?? "worker") !== "orchestrator"
           ? Boolean(agent.task_done_detected_at)
           : null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,12 +23,13 @@ import {
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
-import { AgentDiscovery } from "./agent-discovery.js";
+import { AgentDiscovery, type DiscoveredAgent } from "./agent-discovery.js";
 import {
   resumeCommandForAgent,
   toAgentStatePayload,
   toPublicAgent,
 } from "./agent-facade.js";
+import { evaluateAgentHealth } from "./agent-health.js";
 import type {
   AgentRecord,
   AgentRole,
@@ -82,6 +83,7 @@ import type {
   CmuxNewSurfaceResult,
   CmuxSurface,
   CmuxTerminalMetadata,
+  CmuxWorkspace,
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
@@ -89,7 +91,7 @@ import {
   matchReadyPattern,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
-import { resolveWorkspaceRefForRepo } from "./repo-workspace.js";
+import { reposEquivalent, resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
   collectControlHealth,
@@ -1954,6 +1956,43 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // split failed for exactly this reason), then restore the prior focus AFTER
   // the new terminal is fully rendered — but ONLY when a jump was needed.
 
+  const envWorkspaceMatches = (
+    workspace: CmuxWorkspace,
+    candidate: string,
+  ): boolean => {
+    const normalized = candidate.trim();
+    if (!normalized) return false;
+    return (
+      workspace.ref === normalized ||
+      workspace.id === normalized ||
+      workspace.ref === `workspace:${normalized}` ||
+      workspace.id === `workspace:${normalized}`
+    );
+  };
+
+  /** Caller pane workspace ref first, then focused workspace as fallback. */
+  const currentCallerWorkspace = async (): Promise<string | undefined> => {
+    try {
+      const { workspaces } = await client.listWorkspaces();
+      const envCandidates = [
+        process.env.CMUX_WORKSPACE_ID,
+        process.env.CMUX_TAB_ID,
+      ].filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      );
+      for (const candidate of envCandidates) {
+        const match = workspaces.find((workspace) =>
+          envWorkspaceMatches(workspace, candidate),
+        );
+        if (match) return match.ref;
+      }
+      return workspaces.find((w) => w.selected)?.ref;
+    } catch {
+      return undefined;
+    }
+  };
+
   /** Currently-focused workspace ref, or undefined if it can't be read. */
   const currentFocusedWorkspace = async (): Promise<string | undefined> => {
     try {
@@ -2121,6 +2160,175 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     return { column: null, column_count: null };
+  };
+
+  const resolveSurfaceWorkspace = async (
+    surfaceRef: string,
+  ): Promise<string | null> => {
+    try {
+      const workspaceRefs = (await client.listWorkspaces()).workspaces.map(
+        (ws) => ws.ref,
+      );
+      for (const workspaceRef of workspaceRefs) {
+        const panes = await client.listPanes({ workspace: workspaceRef });
+        const rawGroups = await Promise.all(
+          panes.panes.map(async (pane) => {
+            const group = await client.listPaneSurfaces({
+              workspace: workspaceRef,
+              pane: pane.ref,
+            });
+            return {
+              ...group,
+              workspace_ref: group.workspace_ref ?? workspaceRef,
+              pane_ref: group.pane_ref ?? pane.ref,
+            };
+          }),
+        );
+        const groups = partitionPaneSurfacesByMembership(
+          panes.panes,
+          rawGroups,
+          {
+            workspace_ref: panes.workspace_ref ?? workspaceRef,
+            window_ref: panes.window_ref,
+          },
+        );
+        for (const group of groups) {
+          if (group.surfaces.some((surface) => surface.ref === surfaceRef)) {
+            return group.workspace_ref ?? workspaceRef;
+          }
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  };
+
+  const evaluateServerAgentHealth = async (
+    agent: AgentRecord,
+    overrides?: {
+      monitor_alive?: boolean | null;
+      stale_count?: number;
+      screen_status?: string | null;
+      screen_actions?: string[] | null;
+      surface_workspace_id?: string | null;
+      surface_title?: string | null;
+      topology?: { column: number | null; column_count: number | null } | null;
+    },
+  ) => {
+    const topology =
+      overrides?.topology !== undefined
+        ? overrides.topology
+        : await resolveSurfaceColumn(
+            agent.surface_id,
+            agent.workspace_id ?? undefined,
+          );
+    const alive =
+      overrides?.monitor_alive ??
+      monitorAlive(agent.agent_id, INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS, inboxOpts);
+    const staleCount =
+      overrides?.stale_count ??
+      pendingDispatches(agent.agent_id, 120000, inboxOpts).length;
+    const parsedScreen =
+      overrides?.screen_status === undefined ||
+      overrides?.screen_actions === undefined
+        ? await readParsedSurface(agent.surface_id, agent.workspace_id ?? undefined)
+        : null;
+    const screenStatus =
+      overrides?.screen_status !== undefined
+        ? overrides.screen_status
+        : parsedScreen?.parsed.status;
+    const screenActions =
+      overrides?.screen_actions !== undefined
+        ? overrides.screen_actions
+        : parsedScreen?.parsed.actions;
+    const surfaceWorkspaceId =
+      overrides?.surface_workspace_id !== undefined
+        ? overrides.surface_workspace_id
+        : await resolveSurfaceWorkspace(agent.surface_id);
+    return evaluateAgentHealth(agent, {
+      monitor_alive: alive,
+      stale_count: staleCount,
+      screen_status: screenStatus,
+      screen_actions: screenActions,
+      surface_workspace_id: surfaceWorkspaceId,
+      surface_title: overrides?.surface_title,
+      topology,
+    });
+  };
+
+  const isLeadLikeSurfaceTitle = (title: string): boolean =>
+    /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
+
+  const buildOrphanSurfaceHealth = (surface: DiscoveredAgent) => {
+    const issueCodes: string[] = [];
+    const issues: string[] = [];
+    if (isLeadLikeSurfaceTitle(surface.surface_title)) {
+      issueCodes.push("missing_managed_lead_agent_id");
+      issues.push(
+        "lead/coordinator surface has no managed agent_id; recover/register or replace with a managed lead",
+      );
+    }
+
+    const title = surface.surface_title.trim().toLowerCase();
+    if (
+      title === "" ||
+      title === "gits" ||
+      title === "git" ||
+      title === "repos" ||
+      title === "projects" ||
+      title === "workspace"
+    ) {
+      issueCodes.push("ambiguous_repo_cwd_label");
+      issues.push(
+        "orphan terminal surface has an ambiguous repo/cwd label; tab title is not lane ownership",
+      );
+    }
+
+    return {
+      surface_id: surface.surface_id,
+      surface_title: surface.surface_title,
+      workspace_id: surface.workspace_id ?? null,
+      status: issueCodes.length > 0 ? "unhealthy" : "unknown",
+      issue_codes: issueCodes,
+      issues,
+    };
+  };
+
+  const collectDeliveryEvidence = async (agentId: string) => {
+    const agent = context.lifecycleSweepEngine?.getAgentState(agentId) ?? null;
+    if (!agent) {
+      return {
+        registry_state: null,
+        screen: null,
+        state_conflict: false,
+        health: undefined,
+      };
+    }
+    const screen = await readParsedSurface(
+      agent.surface_id,
+      agent.workspace_id ?? undefined,
+    );
+    const health = await evaluateServerAgentHealth(agent, {
+      screen_status: screen?.parsed.status ?? null,
+      screen_actions: screen?.parsed.actions ?? null,
+    });
+    return {
+      registry_state: agent.state,
+      screen: screen
+        ? {
+            status: screen.parsed.status,
+            agent_type: screen.parsed.agent_type,
+            model: screen.parsed.model,
+            done_signal: screen.parsed.done_signal,
+            actions: screen.parsed.actions ?? [],
+          }
+        : null,
+      state_conflict: health.issue_codes.includes(
+        "registry_screen_disagreement",
+      ),
+      health,
+    };
   };
 
   // 1. list_surfaces
@@ -3400,6 +3608,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.destructive,
     async (args) => {
       try {
+        let staleRegistryDoneConsolidated:
+          | { agent_id: string; previous_state: AgentState; done_signal: string }
+          | undefined;
         // Liveness guard: never destroy a pane whose agent is still live unless
         // the caller explicitly forces it. This is the safety net for the
         // "stale list said it was gone but it was actually alive" failure — on
@@ -3420,28 +3631,58 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           if (backingAgent) {
             let screenText = "(unable to read pane)";
+            let screenParsed: ReturnType<typeof parseScreen> | null = null;
             try {
               const screen = await client.readScreen(args.surface, {
                 workspace: args.workspace,
                 lines: 40,
               });
               screenText = screen.text;
+              screenParsed = parseScreen(screen.text);
             } catch {
               // Best-effort read; refuse regardless so a live agent is never
               // torn down without an explicit force.
             }
-            return err(
-              new Error(
-                `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live). Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
-              ),
-              {
-                refused: true,
-                surface: args.surface,
-                agent_id: backingAgent.agent_id,
-                state: backingAgent.state,
-                screen: screenText,
-              },
-            );
+            if (screenParsed?.done_signal) {
+              try {
+                const done = stateMgr.transition(backingAgent.agent_id, "done");
+                context.lifecycleRegistry?.set(backingAgent.agent_id, done);
+                staleRegistryDoneConsolidated = {
+                  agent_id: backingAgent.agent_id,
+                  previous_state: backingAgent.state,
+                  done_signal: screenParsed.done_signal,
+                };
+              } catch {
+                // If consolidation fails, keep the fail-safe refusal path.
+                return err(
+                  new Error(
+                    `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live) and registry consolidation failed. Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
+                  ),
+                  {
+                    refused: true,
+                    surface: args.surface,
+                    agent_id: backingAgent.agent_id,
+                    state: backingAgent.state,
+                    screen: screenText,
+                    parsed: screenParsed,
+                  },
+                );
+              }
+            } else {
+              return err(
+                new Error(
+                  `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live). Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
+                ),
+                {
+                  refused: true,
+                  surface: args.surface,
+                  agent_id: backingAgent.agent_id,
+                  state: backingAgent.state,
+                  screen: screenText,
+                  parsed: screenParsed,
+                },
+              );
+            }
           }
         }
 
@@ -3499,6 +3740,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           surface: args.surface,
           pane: closePolicy?.pane ?? undefined,
           collapse_pane: collapsePane,
+          stale_registry_done_consolidated: staleRegistryDoneConsolidated,
         };
         return okFormatted(formatOk("close_surface", data), data);
       } catch (e) {
@@ -3670,6 +3912,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS,
           inboxOpts,
         );
+        const pending = pendingDispatches(args.agent_id, 120000, inboxOpts);
         const nudge = { attempted: false, sent: false, reason: "" };
         if (args.nudge === "never") {
           nudge.reason = "nudge disabled by caller";
@@ -3714,10 +3957,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
           }
         }
+        const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+        const health = record
+          ? await evaluateServerAgentHealth(record, {
+              monitor_alive,
+              stale_count: pending.length,
+            })
+          : undefined;
         return ok({
           dispatched: msg,
           inbox: inboxPath(args.agent_id, inboxOpts),
           monitor_alive,
+          health,
           nudge,
         });
       } catch (e) {
@@ -3763,9 +4014,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           args.heartbeat_max_age_ms,
           inboxOpts,
         );
+        const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+        const health = record
+          ? await evaluateServerAgentHealth(record, {
+              monitor_alive: alive,
+              stale_count: pending.length,
+            })
+          : undefined;
         return ok({
           agent_id: args.agent_id,
           monitor_alive: alive,
+          health,
           undelivered_count: undelivered.length,
           undelivered,
           stale_count: pending.length,
@@ -4133,7 +4392,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      "Spawn a managed AI agent in a new terminal surface and return an agent_id for future routing. Use send_to and wait_for with that agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot prompt, and returns after submission. boot_prompt_path is checked before spawning and read after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.",
+      "Spawn a managed AI agent in a terminal surface and return an agent_id plus health for future routing. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot prompt, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. boot_prompt_path is checked before spawning and read after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.",
       {
         repo: z
           .string()
@@ -4167,7 +4426,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "Timeout in milliseconds waiting for the agent ready prompt",
           ),
-        workspace: z.string().optional().describe("Target workspace ref"),
+        workspace: z
+          .string()
+          .optional()
+          .describe(
+            "Target workspace ref. Omit to use the caller/current workspace; pass only when intentionally spawning in a different workspace.",
+          ),
         worktree: worktreeArgSchema
           .optional()
           .describe(
@@ -4207,6 +4471,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "When true, automatically respawn the agent after unexpected PTY death using its captured CLI session ID.",
           ),
+        force_new: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "When true, suppress same repo/workspace/role duplicate-lane warnings. Default false so collab leads see reusable existing agents before spawning another lane.",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
@@ -4223,6 +4494,48 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.mcp_profile as McpProfile | undefined,
           );
 
+          const spawnWorkspace = args.workspace ?? (await currentCallerWorkspace());
+          const requestedRole = inferAgentRole({
+            role: args.role,
+            cli: args.cli,
+            launcherName: launcherNameForCli(args.repo, args.cli),
+          });
+          const existingSameLaneAgents = args.force_new
+            ? []
+            : registry
+                .list()
+                .filter(
+                  (agent) =>
+                    (agent.state === "ready" || agent.state === "idle") &&
+                    reposEquivalent(agent.repo, args.repo) &&
+                    (agent.workspace_id ?? null) === (spawnWorkspace ?? null) &&
+                    (agent.role ??
+                      inferAgentRole({
+                        cli: agent.cli,
+                        launcherName:
+                          agent.launcher_name ??
+                          launcherNameForCli(agent.repo, agent.cli),
+                      })) === requestedRole,
+                )
+                .map((agent) => ({
+                  agent_id: agent.agent_id,
+                  surface_id: agent.surface_id,
+                  workspace_id: agent.workspace_id ?? null,
+                  state: agent.state,
+                  role:
+                    agent.role ??
+                    inferAgentRole({
+                      cli: agent.cli,
+                      launcherName:
+                        agent.launcher_name ??
+                        launcherNameForCli(agent.repo, agent.cli),
+                    }),
+                  task_summary: agent.task_summary,
+                }));
+          const duplicateSpawnWarning =
+            existingSameLaneAgents.length > 0
+              ? `Existing same-lane agent(s) are idle/ready in ${spawnWorkspace ?? "unknown workspace"}; reuse or supersede unless a new lane is intentional. Pass force_new:true to suppress this warning.`
+              : undefined;
           const result = await engine.spawnAgent({
             repo: args.repo,
             model: args.model,
@@ -4230,7 +4543,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             prompt: args.prompt ?? "",
             boot_prompt_pending:
               hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
-            workspace: args.workspace,
+            workspace: spawnWorkspace,
             cwd: worktree.prepared?.path,
             mcp_env: worktree.mcpEnv,
             mcp_profile_label: worktree.mcpProfileLabel,
@@ -4247,7 +4560,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             | undefined;
           try {
             if (hasInlinePrompt(args.prompt) || bootPromptPath) {
-              const deliveryWorkspace = result.workspace_id ?? args.workspace;
+              const deliveryWorkspace = result.workspace_id ?? spawnWorkspace;
               bootPromptDelivery = await deliverBootPrompt({
                 surface: result.surface_id,
                 workspace: deliveryWorkspace,
@@ -4345,6 +4658,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             role === "orchestrator"
               ? ensureMonitorBoot(result.agent_id)
               : undefined;
+          const currentAgent = engine.getAgentState(result.agent_id);
+          const health = currentAgent
+            ? await evaluateServerAgentHealth(currentAgent)
+            : undefined;
 
           return okFormatted(
             formatOk("spawn_agent", {
@@ -4358,6 +4675,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   : undefined,
               surface: result.surface_id,
               role,
+              health,
+              duplicate_spawn_warning: duplicateSpawnWarning,
               monitor_boot: monitorBoot,
               boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
             }),
@@ -4366,6 +4685,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               worktree: worktree.prepared,
               mcp_profile: worktree.mcpProfileLabel,
               role,
+              health,
+              duplicate_spawn_warning: duplicateSpawnWarning,
+              existing_same_lane_agents: existingSameLaneAgents,
               monitor_boot: monitorBoot,
               boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
               boot_prompt_bytes: bootPromptDelivery?.bytes,
@@ -4468,6 +4790,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.surface_id,
             result.workspace_id ?? args.workspace,
           );
+          const currentAgent = engine.getAgentState(result.agent_id);
+          const health = currentAgent
+            ? await evaluateServerAgentHealth(currentAgent)
+            : undefined;
 
           return okFormatted(
             formatOk("new_worktree_split", {
@@ -4475,10 +4801,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               surface: result.surface_id,
               worktree: worktree.prepared?.path ?? "",
               mcp_profile: worktree.mcpProfileLabel ?? "inherit",
+              health,
             }),
             {
               ...result,
               role: "worker",
+              health,
               worktree: worktree.prepared,
               mcp_profile: worktree.mcpProfileLabel ?? "inherit",
               boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
@@ -4542,6 +4870,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             repo: string;
             cli: CliType;
             role: AgentRole;
+            health?: ReturnType<typeof evaluateAgentHealth>;
             monitor_boot?: MonitorBootResult;
             boot_prompt_delivered?: boolean;
             boot_prompt_submit_verified?: boolean | null;
@@ -4609,6 +4938,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role === "orchestrator"
                 ? ensureMonitorBoot(result.agent_id)
                 : undefined;
+            const currentAgent = engine.getAgentState(result.agent_id);
+            const health = currentAgent
+              ? await evaluateServerAgentHealth(currentAgent)
+              : undefined;
 
             spawnedAgents.push({
               agent_id: result.agent_id,
@@ -4616,6 +4949,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               repo: agent.repo,
               cli: agent.cli,
               role,
+              health,
               monitor_boot: monitorBoot,
               boot_prompt_delivered: hasPrompt
                 ? isBootPromptDelivered(bootPromptDelivery)
@@ -4650,7 +4984,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 12. wait_for
     server.tool(
       "wait_for",
-      "Block until an agent reaches a target state. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography.",
+      "Block until an agent reaches a target registry state and return health. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography. This does not yet watch report files or DONE markers; if a collab goal defines a report path/DONE marker, verify that file separately and treat registry/file or registry/screen disagreement as health evidence.",
       {
         agent_id: z.string().describe("Agent ID from spawn_agent"),
         target_state: z
@@ -4675,14 +5009,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             targetState,
             args.timeout_ms,
           );
+          const resultAgent = result.agent
+            ? engine.getAgentState(result.agent.agent_id)
+            : null;
+          const health = resultAgent
+            ? await evaluateServerAgentHealth(resultAgent)
+            : undefined;
           return okFormatted(
             formatOk("wait_for", {
               agent_id: args.agent_id,
               state: result.state,
+              health,
             }),
             {
               agent_id: args.agent_id,
               ...result,
+              health,
+              agent:
+                result.agent && health
+                  ? { ...result.agent, health }
+                  : result.agent,
             },
           );
         } catch (e) {
@@ -4694,7 +5040,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 13. wait_for_all
     server.tool(
       "wait_for_all",
-      "Block until ALL agents reach target state OR any agent errors (fail-fast with partial results).",
+      "Block until ALL agents reach a target registry state OR any agent errors, returning per-agent health with partial results. This does not yet watch report files or DONE markers; collab leads must verify required output files separately.",
       {
         agent_ids: z.array(z.string()).describe("Array of agent IDs"),
         target_state: z
@@ -4716,12 +5062,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.target_state,
             args.timeout_ms,
           );
+          const enrichedResults = await Promise.all(
+            results.map(async (result) => {
+              const resultAgent = result.agent
+                ? engine.getAgentState(result.agent.agent_id)
+                : null;
+              const health = resultAgent
+                ? await evaluateServerAgentHealth(resultAgent)
+                : undefined;
+              return {
+                ...result,
+                health,
+                agent:
+                  result.agent && health
+                    ? { ...result.agent, health }
+                    : result.agent,
+              };
+            }),
+          );
           return okFormatted(
             formatOk("wait_for_all", {
               count: results.length,
               target: args.target_state,
             }),
-            { results },
+            { results: enrichedResults },
           );
         } catch (e) {
           return err(e);
@@ -4732,7 +5096,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 14. get_agent_state
     server.tool(
       "get_agent_state",
-      "Get the full state of an agent including cli_session_id for resume.",
+      "Get the full registry state of an agent, including cli_session_id/resume data and health. Health may flag missing sessions, dead inbox monitors, topology drift, or registry/screen disagreement.",
       {
         agent_id: z.string().describe("Agent ID"),
       },
@@ -4742,8 +5106,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const state = engine.getAgentState(args.agent_id);
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
-          const formatted = formatAgentState(state);
-          const payload = toAgentStatePayload(state);
+          const health = await evaluateServerAgentHealth(state);
+          const formatted =
+            formatAgentState(state) +
+            `\nhealth: ${health.status}${
+              health.issues.length > 0
+                ? ` (${health.issues.join("; ")})`
+                : ""
+            }`;
+          const payload = { ...toAgentStatePayload(state), health };
           return okFormatted(
             formatted,
             payload as unknown as Record<string, unknown>,
@@ -4757,7 +5128,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 15. list_agents
     server.tool(
       "list_agents",
-      "List public agent handles with optional filters by state, repo, or model. Use these agent_id values with send_to and wait_for; use get_agent_state only when you need internal route/session details.",
+      "List public agent handles with optional filters by state, repo, or model, including health. In collabs, use this before spawn_agent to find an existing lane agent to reuse or supersede. Use returned agent_id values with send_to and wait_for; use get_agent_state when you need internal route/session details.",
       {
         state: z
           .enum([
@@ -4784,7 +5155,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               model: args.model,
             },
           });
-          const agents = merged.map(toPublicAgent);
+          const agents = await Promise.all(
+            merged.map(async (agent) => ({
+              ...toPublicAgent(agent),
+              health: await evaluateServerAgentHealth(agent),
+            })),
+          );
           const data = {
             agents: agents as unknown as Record<string, unknown>[],
             count: agents.length,
@@ -4815,15 +5191,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const after = await registry.listMerged(discovery, { force: true });
           const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));
+          const orphanedSurfaces = discovered.filter(
+            (surface) => !surface.has_agent && !surface.read_error,
+          );
+          const orphanedHealth = orphanedSurfaces.map(buildOrphanSurfaceHealth);
           const diff = {
             added: [...afterIds].filter((id) => !beforeIds.has(id)),
             evicted: [...beforeIds].filter((id) => !afterIds.has(id)),
             mismatches: after
               .filter((agent) => agent.parsed_cli_mismatch)
               .map((agent) => agent.agent_id),
-            orphaned: discovered
-              .filter((surface) => !surface.has_agent && !surface.read_error)
-              .map((surface) => surface.surface_id),
+            orphaned: orphanedSurfaces.map((surface) => surface.surface_id),
+            orphaned_health: orphanedHealth,
+            health_failures: orphanedHealth.filter(
+              (health) => health.status === "unhealthy",
+            ),
           };
 
           return okFormatted(formatResync(diff), {
@@ -4867,7 +5249,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      "Preferred path for sending text to a tracked agent by agent_id. Resolves the current backing surface internally so clients do not need pane or surface references, and should be used instead of send_input whenever an agent_id is available.",
+      "Preferred path for sending text to a tracked agent by agent_id. Resolves the current backing surface internally so clients do not need pane or surface references, and should be used instead of send_input whenever an agent_id is available. For collab supersession, send a short `/goal Read and follow <absolute goal file>` reference rather than a long lossy paste. Returns submission evidence plus registry state, parsed screen status, state_conflict, and health; submit_verified means the input was submitted/cleared, not that the agent accepted, started, or completed the task.",
       {
         ...SendToArgsSchema.shape,
         press_enter: SendToArgsSchema.shape.press_enter.describe(
@@ -4895,10 +5277,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allow_busy: args.allow_busy,
             source_event: "send_to",
           });
+          const evidence = await collectDeliveryEvidence(args.agent_id);
           const data = {
             agent_id: args.agent_id,
             retry_count: delivery.retry_count,
             submit_verified: delivery.submit_verified,
+            ...evidence,
           };
           return okFormatted(formatOk("send_to", data), data);
         } catch (e) {
@@ -4910,7 +5294,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 18. send_to_agent
     server.tool(
       "send_to_agent",
-      "Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state.",
+      "Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state. Returns the same post-delivery registry/screen health evidence as send_to.",
       {
         ...SendToArgsSchema.shape,
         press_enter: SendToArgsSchema.shape.press_enter.describe(
@@ -4940,12 +5324,77 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allow_busy: args.allow_busy,
             source_event: "send_to_agent",
           });
+          const evidence = await collectDeliveryEvidence(args.agent_id);
           const data = {
             agent_id: args.agent_id,
             retry_count: delivery.retry_count,
             submit_verified: delivery.submit_verified,
+            ...evidence,
           };
           return okFormatted(formatOk("send_to_agent", data), data);
+        } catch (e) {
+          return err(e);
+        }
+      },
+    );
+
+    server.tool(
+      "supersede_agent_goal",
+      "Replace an existing managed agent's active mission with a file-backed /goal contract. Updates registry task_summary/goal_file, sends `/goal Read and execute this goal file until complete: <path>` through the guarded agent relay, and returns delivery evidence plus health. Use this to reuse an existing pane instead of spawning a duplicate lane.",
+      {
+        agent_id: z.string().describe("Managed agent_id to supersede"),
+        goal_file: z
+          .string()
+          .describe("Absolute path to the goal file the agent must execute"),
+        summary: z
+          .string()
+          .optional()
+          .describe(
+            "Optional task_summary to store in the registry. Defaults to the goal_file path.",
+          ),
+        allow_busy: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "If true, supersede even while the agent is working. Defaults true because supersession intentionally replaces the active mission.",
+          ),
+      },
+      ANNOTATIONS.mutating,
+      async (args) => {
+        try {
+          const current = engine.getAgentState(args.agent_id);
+          if (!current) {
+            return err(new Error(`Agent not found: ${args.agent_id}`));
+          }
+          await preflightBootPromptFile(args.goal_file);
+          const taskSummary = args.summary?.trim() || args.goal_file;
+          let updated = stateMgr.updateRecord(args.agent_id, {
+            task_summary: taskSummary,
+            goal_file: args.goal_file,
+          });
+          registry.set(args.agent_id, updated);
+          const delivery = await deliverAgentInput({
+            agent_id: args.agent_id,
+            text: `/goal Read and execute this goal file until complete: ${args.goal_file}`,
+            press_enter: true,
+            allow_busy: args.allow_busy ?? true,
+            source_event: "supersede_agent_goal",
+          });
+          if (updated.state === "ready" || updated.state === "idle") {
+            updated = stateMgr.transition(args.agent_id, "working");
+            registry.set(args.agent_id, updated);
+          }
+          const evidence = await collectDeliveryEvidence(args.agent_id);
+          const data = {
+            agent_id: args.agent_id,
+            goal_file: args.goal_file,
+            task_summary: taskSummary,
+            retry_count: delivery.retry_count,
+            submit_verified: delivery.submit_verified,
+            ...evidence,
+          };
+          return okFormatted(formatOk("supersede_agent_goal", data), data);
         } catch (e) {
           return err(e);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3733,6 +3733,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   },
                 );
               }
+              const remainingLiveAgent = stateMgr
+                .listStates()
+                .find(
+                  (record) =>
+                    record.surface_id === args.surface &&
+                    !TERMINAL_AGENT_STATES.has(record.state),
+                );
+              if (remainingLiveAgent) {
+                return err(
+                  new Error(
+                    `Refused to close ${args.surface}: agent ${remainingLiveAgent.agent_id} is "${remainingLiveAgent.state}" (still live) after stale registry consolidation. Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
+                  ),
+                  {
+                    refused: true,
+                    surface: args.surface,
+                    agent_id: remainingLiveAgent.agent_id,
+                    state: remainingLiveAgent.state,
+                    screen: screenText,
+                    parsed: screenParsed,
+                    stale_registry_done_consolidated:
+                      staleRegistryDoneConsolidated,
+                  },
+                );
+              }
             } else {
               return err(
                 new Error(
@@ -5501,6 +5525,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             goal_file: args.goal_file,
             task_done_candidate_at: null,
             task_done_detected_at: null,
+            boot_prompt_pending: false,
             error: null,
           };
           let updated =

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,7 @@ import type {
 import { normalizeKeyName } from "./key-names.js";
 import {
   matchReadyPattern,
+  screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
 import { reposEquivalent, resolveWorkspaceRefForRepo } from "./repo-workspace.js";
@@ -3643,7 +3644,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               // Best-effort read; refuse regardless so a live agent is never
               // torn down without an explicit force.
             }
-            if (screenParsed?.done_signal) {
+            if (
+              screenParsed?.done_signal &&
+              !screenHasActiveAgentMarker(
+                backingAgent.cli,
+                screenText,
+                screenParsed,
+              )
+            ) {
               try {
                 const done = stateMgr.transition(backingAgent.agent_id, "done");
                 context.lifecycleRegistry?.set(backingAgent.agent_id, done);
@@ -4195,7 +4203,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         {
           cwd: launchCwd,
           envPrefix: opts.mcpEnv,
-          allowModelOverride: true,
+          allowModelOverride: process.env.REPOGOLEM_ALLOW_MODEL === "1",
         },
       );
       await sendLauncherCommandToSurface({
@@ -5369,11 +5377,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           await preflightBootPromptFile(args.goal_file);
           const taskSummary = args.summary?.trim() || args.goal_file;
-          let updated = stateMgr.updateRecord(args.agent_id, {
-            task_summary: taskSummary,
-            goal_file: args.goal_file,
-          });
-          registry.set(args.agent_id, updated);
           const delivery = await deliverAgentInput({
             agent_id: args.agent_id,
             text: `/goal Read and execute this goal file until complete: ${args.goal_file}`,
@@ -5381,6 +5384,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allow_busy: args.allow_busy ?? true,
             source_event: "supersede_agent_goal",
           });
+          let updated = stateMgr.updateRecord(args.agent_id, {
+            task_summary: taskSummary,
+            goal_file: args.goal_file,
+          });
+          registry.set(args.agent_id, updated);
           if (updated.state === "ready" || updated.state === "idle") {
             updated = stateMgr.transition(args.agent_id, "working");
             registry.set(args.agent_id, updated);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5496,15 +5496,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_event: "supersede_agent_goal",
           });
           const canonicalAgentId = current.agent_id;
-          let updated = stateMgr.updateRecord(canonicalAgentId, {
+          const supersedePatch = {
             task_summary: taskSummary,
             goal_file: args.goal_file,
-          });
+            task_done_candidate_at: null,
+            task_done_detected_at: null,
+            error: null,
+          };
+          let updated =
+            current.state === "working"
+              ? stateMgr.updateRecord(canonicalAgentId, supersedePatch)
+              : stateMgr.resetState(
+                  canonicalAgentId,
+                  "working",
+                  supersedePatch,
+                  "supersede_agent_goal",
+                );
           registry.set(canonicalAgentId, updated);
-          if (updated.state === "ready" || updated.state === "idle") {
-            updated = stateMgr.transition(canonicalAgentId, "working");
-            registry.set(canonicalAgentId, updated);
-          }
           const evidence = await collectDeliveryEvidence(canonicalAgentId);
           const data = {
             agent_id: canonicalAgentId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1109,6 +1109,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }) => Promise<unknown>)
     | null = null;
   let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
+  let lifecycleRefreshManagedMetadata:
+    | ((agentId?: string) => Promise<void>)
+    | null = null;
+  const refreshManagedMetadataBestEffort = async (
+    agentId?: string,
+  ): Promise<void> => {
+    try {
+      await lifecycleRefreshManagedMetadata?.(agentId);
+    } catch {
+      // Health/read paths should not fail just because a refresh scan failed.
+    }
+  };
 
   const server = new McpServer(
     {
@@ -1963,12 +1975,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): boolean => {
     const normalized = candidate.trim();
     if (!normalized) return false;
+    const aliasNormalized = normalized.replace(/^ws:/, "workspace:");
     return (
       workspace.ref === normalized ||
       workspace.id === normalized ||
+      workspace.ref === aliasNormalized ||
+      workspace.id === aliasNormalized ||
       workspace.ref === `workspace:${normalized}` ||
       workspace.id === `workspace:${normalized}`
     );
+  };
+
+  const canonicalWorkspaceRef = async (
+    candidate?: string,
+  ): Promise<string | undefined> => {
+    if (!candidate) return undefined;
+    try {
+      const { workspaces } = await client.listWorkspaces();
+      return (
+        workspaces.find((workspace) => envWorkspaceMatches(workspace, candidate))
+          ?.ref ?? candidate
+      );
+    } catch {
+      return candidate;
+    }
   };
 
   /** Caller pane workspace ref first, then focused workspace as fallback. */
@@ -2107,19 +2137,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return null;
   };
 
-  // Resolve a surface's 0-based column + the workspace column_count using the
-  // SAME reliable post-F5 logic as list_surfaces: derive columns from pane
-  // geometry, then attribute the surface to its pane by membership (pane_id),
-  // NOT the unfiltered surface.list. Best-effort: returns nulls on any failure
-  // so callers (e.g. read_screen) never break when geometry is unavailable.
-  const resolveSurfaceColumn = async (
-    surfaceRef: string,
+  type SurfaceTopology = { column: number | null; column_count: number | null };
+  type SurfaceTopologySnapshot = {
+    workspaceBySurface: Map<string, string>;
+    titleBySurface: Map<string, string>;
+    topologyBySurface: Map<string, SurfaceTopology>;
+  };
+  const emptySurfaceTopology: SurfaceTopology = {
+    column: null,
+    column_count: null,
+  };
+
+  const collectSurfaceTopology = async (
     workspace?: string,
-  ): Promise<{ column: number | null; column_count: number | null }> => {
+  ): Promise<SurfaceTopologySnapshot | null> => {
     try {
       const workspaceRefs = workspace
         ? [workspace]
         : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+      const snapshot: SurfaceTopologySnapshot = {
+        workspaceBySurface: new Map(),
+        titleBySurface: new Map(),
+        topologyBySurface: new Map(),
+      };
 
       for (const workspaceRef of workspaceRefs) {
         const panes = await client.listPanes({ workspace: workspaceRef });
@@ -2150,60 +2190,58 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           },
         );
         for (const group of partitioned) {
-          if (group.surfaces.some((surface) => surface.ref === surfaceRef)) {
-            const column = columnIndex.get(group.pane_ref);
-            return { column: column ?? null, column_count: columnCount };
+          for (const surface of group.surfaces) {
+            snapshot.workspaceBySurface.set(
+              surface.ref,
+              group.workspace_ref ?? workspaceRef,
+            );
+            snapshot.titleBySurface.set(surface.ref, surface.title);
+            snapshot.topologyBySurface.set(surface.ref, {
+              column: columnIndex.get(group.pane_ref) ?? null,
+              column_count: columnCount,
+            });
           }
         }
       }
-    } catch {
-      return { column: null, column_count: null };
-    }
 
-    return { column: null, column_count: null };
+      return snapshot;
+    } catch {
+      return null;
+    }
   };
+
+  const healthTopologyOverrides = (
+    agent: AgentRecord,
+    snapshot: SurfaceTopologySnapshot | null,
+  ) =>
+    snapshot
+      ? {
+          topology:
+            snapshot.topologyBySurface.get(agent.surface_id) ??
+            emptySurfaceTopology,
+          surface_workspace_id:
+            snapshot.workspaceBySurface.get(agent.surface_id) ?? null,
+          surface_title: snapshot.titleBySurface.get(agent.surface_id) ?? null,
+        }
+      : {};
+
+  // Resolve a surface's 0-based column + the workspace column_count using the
+  // SAME reliable post-F5 logic as list_surfaces: derive columns from pane
+  // geometry, then attribute the surface to its pane by membership (pane_id),
+  // NOT the unfiltered surface.list. Best-effort: returns nulls on any failure
+  // so callers (e.g. read_screen) never break when geometry is unavailable.
+  const resolveSurfaceColumn = async (
+    surfaceRef: string,
+    workspace?: string,
+  ): Promise<SurfaceTopology> =>
+    (await collectSurfaceTopology(workspace))?.topologyBySurface.get(
+      surfaceRef,
+    ) ?? emptySurfaceTopology;
 
   const resolveSurfaceWorkspace = async (
     surfaceRef: string,
-  ): Promise<string | null> => {
-    try {
-      const workspaceRefs = (await client.listWorkspaces()).workspaces.map(
-        (ws) => ws.ref,
-      );
-      for (const workspaceRef of workspaceRefs) {
-        const panes = await client.listPanes({ workspace: workspaceRef });
-        const rawGroups = await Promise.all(
-          panes.panes.map(async (pane) => {
-            const group = await client.listPaneSurfaces({
-              workspace: workspaceRef,
-              pane: pane.ref,
-            });
-            return {
-              ...group,
-              workspace_ref: group.workspace_ref ?? workspaceRef,
-              pane_ref: group.pane_ref ?? pane.ref,
-            };
-          }),
-        );
-        const groups = partitionPaneSurfacesByMembership(
-          panes.panes,
-          rawGroups,
-          {
-            workspace_ref: panes.workspace_ref ?? workspaceRef,
-            window_ref: panes.window_ref,
-          },
-        );
-        for (const group of groups) {
-          if (group.surfaces.some((surface) => surface.ref === surfaceRef)) {
-            return group.workspace_ref ?? workspaceRef;
-          }
-        }
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  };
+  ): Promise<string | null> =>
+    (await collectSurfaceTopology())?.workspaceBySurface.get(surfaceRef) ?? null;
 
   const evaluateServerAgentHealth = async (
     agent: AgentRecord,
@@ -2310,9 +2348,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       agent.surface_id,
       agent.workspace_id ?? undefined,
     );
+    const topology = await collectSurfaceTopology();
     const health = await evaluateServerAgentHealth(agent, {
       screen_status: screen?.parsed.status ?? null,
       screen_actions: screen?.parsed.actions ?? null,
+      ...healthTopologyOverrides(agent, topology),
     });
     return {
       registry_state: agent.state,
@@ -3932,6 +3972,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // INTERACTIVE_STATES gate, but the guarded relay path keeps the
           // stale-surface resync + recycled-occupant identity checks so the
           // pointer can never land in a foreign agent's pane.
+          await refreshManagedMetadataBestEffort(args.agent_id);
           let record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
           if (!record) {
             try {
@@ -3965,6 +4006,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
           }
         }
+        await refreshManagedMetadataBestEffort(args.agent_id);
         const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
         const health = record
           ? await evaluateServerAgentHealth(record, {
@@ -4022,6 +4064,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           args.heartbeat_max_age_ms,
           inboxOpts,
         );
+        await refreshManagedMetadataBestEffort(args.agent_id);
         const record = context.lifecycleRegistry?.get(args.agent_id) ?? null;
         const health = record
           ? await evaluateServerAgentHealth(record, {
@@ -4086,6 +4129,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
     lifecycleEnsureRegistered = async () => {
       await registry.listMerged(discovery, { force: true });
+    };
+    lifecycleRefreshManagedMetadata = async (agentId?: string) => {
+      await registry.refreshManagedSurfaceMetadata(discovery, {
+        agentId,
+        force: true,
+      });
     };
     const notifyLifecycleEvent = async (
       event: AgentLifecycleEvent,
@@ -4262,6 +4311,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       allow_busy?: boolean;
       source_event: DeliveryEventType;
     }) => {
+      await refreshManagedMetadataBestEffort(args.agent_id);
       let route = engine.resolveAgentRoute(args.agent_id);
       // Guard against stale surface refs before sending. Registry refs drift
       // after a crash/respawn (a pane closes or is recycled), so a cached
@@ -4502,12 +4552,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.mcp_profile as McpProfile | undefined,
           );
 
-          const spawnWorkspace = args.workspace ?? (await currentCallerWorkspace());
+          const spawnWorkspace =
+            (await canonicalWorkspaceRef(args.workspace)) ??
+            (await currentCallerWorkspace());
           const requestedRole = inferAgentRole({
             role: args.role,
             cli: args.cli,
             launcherName: launcherNameForCli(args.repo, args.cli),
           });
+          await refreshManagedMetadataBestEffort();
           const existingSameLaneAgents = args.force_new
             ? []
             : registry
@@ -4655,8 +4708,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return err(e, extra);
           }
 
+          await refreshManagedMetadataBestEffort(result.agent_id);
+          const currentAgent = engine.getAgentState(result.agent_id);
           const role =
-            engine.getAgentState(result.agent_id)?.role ??
+            currentAgent?.role ??
             inferAgentRole({
               role: args.role,
               cli: args.cli,
@@ -4666,9 +4721,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             role === "orchestrator"
               ? ensureMonitorBoot(result.agent_id)
               : undefined;
-          const currentAgent = engine.getAgentState(result.agent_id);
+          const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
-            ? await evaluateServerAgentHealth(currentAgent)
+            ? await evaluateServerAgentHealth(currentAgent, {
+                ...healthTopologyOverrides(currentAgent, topology),
+              })
             : undefined;
 
           return okFormatted(
@@ -4798,9 +4855,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.surface_id,
             result.workspace_id ?? args.workspace,
           );
+          await refreshManagedMetadataBestEffort(result.agent_id);
           const currentAgent = engine.getAgentState(result.agent_id);
+          const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
-            ? await evaluateServerAgentHealth(currentAgent)
+            ? await evaluateServerAgentHealth(currentAgent, {
+                ...healthTopologyOverrides(currentAgent, topology),
+              })
             : undefined;
 
           return okFormatted(
@@ -4935,8 +4996,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
 
+            await refreshManagedMetadataBestEffort(result.agent_id);
+            const currentAgent = engine.getAgentState(result.agent_id);
             const role =
-              engine.getAgentState(result.agent_id)?.role ??
+              currentAgent?.role ??
               inferAgentRole({
                 role: agent.role,
                 cli: agent.cli,
@@ -4946,9 +5009,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role === "orchestrator"
                 ? ensureMonitorBoot(result.agent_id)
                 : undefined;
-            const currentAgent = engine.getAgentState(result.agent_id);
+            const topology = currentAgent ? await collectSurfaceTopology() : null;
             const health = currentAgent
-              ? await evaluateServerAgentHealth(currentAgent)
+              ? await evaluateServerAgentHealth(currentAgent, {
+                  ...healthTopologyOverrides(currentAgent, topology),
+                })
               : undefined;
 
             spawnedAgents.push({
@@ -5017,11 +5082,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             targetState,
             args.timeout_ms,
           );
+          await refreshManagedMetadataBestEffort(result.agent?.agent_id);
           const resultAgent = result.agent
             ? engine.getAgentState(result.agent.agent_id)
             : null;
+          const topology = resultAgent ? await collectSurfaceTopology() : null;
           const health = resultAgent
-            ? await evaluateServerAgentHealth(resultAgent)
+            ? await evaluateServerAgentHealth(resultAgent, {
+                ...healthTopologyOverrides(resultAgent, topology),
+              })
             : undefined;
           return okFormatted(
             formatOk("wait_for", {
@@ -5070,13 +5139,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.target_state,
             args.timeout_ms,
           );
+          await Promise.all(
+            results
+              .map((result) => result.agent?.agent_id)
+              .filter((agentId): agentId is string => Boolean(agentId))
+              .map((agentId) => refreshManagedMetadataBestEffort(agentId)),
+          );
+          const topology = await collectSurfaceTopology();
           const enrichedResults = await Promise.all(
             results.map(async (result) => {
               const resultAgent = result.agent
                 ? engine.getAgentState(result.agent.agent_id)
                 : null;
               const health = resultAgent
-                ? await evaluateServerAgentHealth(resultAgent)
+                ? await evaluateServerAgentHealth(resultAgent, {
+                    ...healthTopologyOverrides(resultAgent, topology),
+                  })
                 : undefined;
               return {
                 ...result,
@@ -5111,10 +5189,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.readOnly,
       async (args) => {
         try {
+          await refreshManagedMetadataBestEffort(args.agent_id);
           const state = engine.getAgentState(args.agent_id);
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
-          const health = await evaluateServerAgentHealth(state);
+          const topology = await collectSurfaceTopology();
+          const health = await evaluateServerAgentHealth(state, {
+            ...healthTopologyOverrides(state, topology),
+          });
           const formatted =
             formatAgentState(state) +
             `\nhealth: ${health.status}${
@@ -5163,10 +5245,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               model: args.model,
             },
           });
+          const topology = await collectSurfaceTopology();
           const agents = await Promise.all(
             merged.map(async (agent) => ({
               ...toPublicAgent(agent),
-              health: await evaluateServerAgentHealth(agent),
+              health: await evaluateServerAgentHealth(agent, {
+                ...healthTopologyOverrides(agent, topology),
+              }),
             })),
           );
           const data = {
@@ -5371,6 +5456,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
+          await refreshManagedMetadataBestEffort(args.agent_id);
           const current = engine.getAgentState(args.agent_id);
           if (!current) {
             return err(new Error(`Agent not found: ${args.agent_id}`));
@@ -5551,6 +5637,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           // Resolve agent
+          await refreshManagedMetadataBestEffort(args.agent);
           const agent = engine.getAgentState(args.agent);
           if (!agent) {
             return err(

--- a/src/server.ts
+++ b/src/server.ts
@@ -2253,8 +2253,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_workspace_id?: string | null;
       surface_title?: string | null;
       topology?: { column: number | null; column_count: number | null } | null;
+      closure_artifact_verified?: boolean | null;
     },
   ) => {
+    const closureArtifactVerified =
+      overrides?.closure_artifact_verified !== undefined
+        ? overrides.closure_artifact_verified
+        : TERMINAL_AGENT_STATES.has(agent.state) &&
+            (agent.role ?? "worker") !== "orchestrator"
+          ? Boolean(agent.task_done_detected_at)
+          : null;
     const topology =
       overrides?.topology !== undefined
         ? overrides.topology
@@ -2293,6 +2301,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_workspace_id: surfaceWorkspaceId,
       surface_title: overrides?.surface_title,
       topology,
+      closure_artifact_verified: closureArtifactVerified,
     });
   };
 
@@ -3693,6 +3702,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               )
             ) {
               try {
+                const marked = stateMgr.updateRecord(backingAgent.agent_id, {
+                  task_done_candidate_at: null,
+                  task_done_detected_at: new Date().toISOString(),
+                  ...(backingAgent.boot_prompt_pending
+                    ? { boot_prompt_pending: false }
+                    : {}),
+                });
+                context.lifecycleRegistry?.set(backingAgent.agent_id, marked);
                 const done = stateMgr.transition(backingAgent.agent_id, "done");
                 context.lifecycleRegistry?.set(backingAgent.agent_id, done);
                 staleRegistryDoneConsolidated = {
@@ -4552,9 +4569,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.mcp_profile as McpProfile | undefined,
           );
 
+          await refreshManagedMetadataBestEffort(args.parent_agent_id);
+          const parentWorkspace = args.parent_agent_id
+            ? (engine.getAgentState(args.parent_agent_id)?.workspace_id ??
+              undefined)
+            : undefined;
+          const explicitWorkspace = await canonicalWorkspaceRef(args.workspace);
           const spawnWorkspace =
-            (await canonicalWorkspaceRef(args.workspace)) ??
-            (await currentCallerWorkspace());
+            explicitWorkspace ??
+            (args.parent_agent_id ? undefined : await currentCallerWorkspace());
+          const comparisonWorkspace = spawnWorkspace ?? parentWorkspace;
           const requestedRole = inferAgentRole({
             role: args.role,
             cli: args.cli,
@@ -4569,7 +4593,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   (agent) =>
                     (agent.state === "ready" || agent.state === "idle") &&
                     reposEquivalent(agent.repo, args.repo) &&
-                    (agent.workspace_id ?? null) === (spawnWorkspace ?? null) &&
+                    (agent.workspace_id ?? null) ===
+                      (comparisonWorkspace ?? null) &&
                     (agent.role ??
                       inferAgentRole({
                         cli: agent.cli,
@@ -4595,7 +4620,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 }));
           const duplicateSpawnWarning =
             existingSameLaneAgents.length > 0
-              ? `Existing same-lane agent(s) are idle/ready in ${spawnWorkspace ?? "unknown workspace"}; reuse or supersede unless a new lane is intentional. Pass force_new:true to suppress this warning.`
+              ? `Existing same-lane agent(s) are idle/ready in ${comparisonWorkspace ?? "unknown workspace"}; reuse or supersede unless a new lane is intentional. Pass force_new:true to suppress this warning.`
               : undefined;
           const result = await engine.spawnAgent({
             repo: args.repo,
@@ -5470,18 +5495,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allow_busy: args.allow_busy ?? true,
             source_event: "supersede_agent_goal",
           });
-          let updated = stateMgr.updateRecord(args.agent_id, {
+          const canonicalAgentId = current.agent_id;
+          let updated = stateMgr.updateRecord(canonicalAgentId, {
             task_summary: taskSummary,
             goal_file: args.goal_file,
           });
-          registry.set(args.agent_id, updated);
+          registry.set(canonicalAgentId, updated);
           if (updated.state === "ready" || updated.state === "idle") {
-            updated = stateMgr.transition(args.agent_id, "working");
-            registry.set(args.agent_id, updated);
+            updated = stateMgr.transition(canonicalAgentId, "working");
+            registry.set(canonicalAgentId, updated);
           }
-          const evidence = await collectDeliveryEvidence(args.agent_id);
+          const evidence = await collectDeliveryEvidence(canonicalAgentId);
           const data = {
-            agent_id: args.agent_id,
+            agent_id: canonicalAgentId,
             goal_file: args.goal_file,
             task_summary: taskSummary,
             retry_count: delivery.retry_count,

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -303,6 +303,52 @@ export class StateManager {
     return updated;
   }
 
+  /**
+   * Explicitly reset an agent's lifecycle state after an operation that has
+   * already established new ground truth outside the normal state machine.
+   * This bypass is intentionally separate from transition().
+   */
+  resetState(
+    agentId: string,
+    toState: AgentState,
+    fields: AgentRecordPatch,
+    source: string,
+  ): AgentRecord {
+    const dirName = this.resolveStateDir(agentId);
+    const current = dirName ? this.readStateFromDir(dirName) : null;
+    if (!current) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+
+    const updated: AgentRecord = {
+      ...current,
+      ...fields,
+      state: toState,
+      version: current.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+
+    const agentDir = join(this.baseDir, dirName!);
+    const stateFile = this.stateFilePath(dirName!);
+    const tmpFile = join(agentDir, "state.json.tmp");
+    writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
+    renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
+
+    this.eventLog.append({
+      ts: updated.updated_at,
+      agent_id: agentId,
+      event: toState === "error" ? "error" : "transition",
+      from_state: current.state,
+      to_state: toState,
+      surface_id: updated.surface_id,
+      source,
+      error: fields.error ?? null,
+    });
+
+    return updated;
+  }
+
   renameState(agentId: string, newAgentId: string): AgentRecord {
     if (agentId === newAgentId) {
       const current = this.readState(agentId);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3378,6 +3378,60 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not resolve stale transcript done while the live pane has a recoverable blocker", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-26T20:36:30.000Z");
+        const stale = new Date(now.getTime() - 2_000);
+        vi.setSystemTime(now);
+        const transcript = join(
+          TEST_DIR,
+          "stale-codex-done-recoverable-blocker.jsonl",
+        );
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, stale, stale);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-recoverable-blocker",
+            state: "working",
+            surface_id: "surface:worker-transcript-recoverable-blocker",
+            cli: "codex",
+            role: "worker",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-recoverable-blocker")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-transcript-recoverable-blocker",
+          text: [
+            "OpenAI Codex",
+            "Model: gpt-5.5",
+            "I cannot commit, push, or open a PR without explicit permission, so I am parked.",
+            "TASK_DONE",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "worker-transcript-recoverable-blocker",
+          "done",
+          1_200,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("worker-transcript-recoverable-blocker");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not resolve stale transcript done when the current screen cannot be read", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3890,7 +3890,12 @@ To continue this session, run codex resume ${sessionId}`,
       await engine.getRegistry().reconstitute();
 
       await engine.runSweep();
+      expect(engine.getAgentState("agent-gemini-boot-ready")).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+      });
 
+      await engine.runSweep();
       expect(engine.getAgentState("agent-gemini-boot-ready")).toMatchObject({
         state: "ready",
         boot_prompt_pending: false,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3276,6 +3276,58 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not resolve stale transcript done while the live Codex pane is actively working", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-26T20:35:00.000Z");
+        const stale = new Date(now.getTime() - 2_000);
+        vi.setSystemTime(now);
+        const transcript = join(TEST_DIR, "stale-codex-done-active-screen.jsonl");
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, stale, stale);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-active-screen",
+            state: "working",
+            surface_id: "surface:worker-transcript-active-screen",
+            cli: "codex",
+            role: "worker",
+            cli_session_id: "019f04ff-40c8-70c0-aca4-f0defa559e81",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-active-screen")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-transcript-active-screen",
+          text: [
+            "gpt-5.5 · 70% left · ~/Gits/voicelayer",
+            "Working (1m 02s • esc to interrupt)",
+            "• Explored",
+            "  └ Read package.json",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "worker-transcript-active-screen",
+          "done",
+          1_200,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("worker-transcript-active-screen");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("resolves done from stale transcript ground truth with no screen banner", async () => {
       vi.useFakeTimers();
       try {
@@ -3540,6 +3592,44 @@ To continue this session, run codex resume ${sessionId}`,
         state: "error",
         boot_prompt_pending: false,
         error: "Boot prompt delivery interrupted before completion",
+      });
+    });
+
+    it("recovers stale pending Codex boot prompt when the pane is already usable", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-ready",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "codex",
+          boot_prompt_pending: true,
+          updated_at: new Date(Date.now() - 6 * 60_000).toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: [
+          "╭──────────────────────────╮",
+          "│ OpenAI Codex             │",
+          "│ Model: gpt-5.5 xhigh     │",
+          "│ Directory: /Users/etanheyman/Gits/voicelayer │",
+          "│ Permissions: YOLO        │",
+          "╰──────────────────────────╯",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 80,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-ready")).toMatchObject({
+        state: "ready",
+        boot_prompt_pending: false,
+        error: null,
       });
     });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3328,6 +3328,99 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not resolve stale transcript done while the live Codex pane is waiting", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-26T20:36:00.000Z");
+        const stale = new Date(now.getTime() - 2_000);
+        vi.setSystemTime(now);
+        const transcript = join(TEST_DIR, "stale-codex-done-waiting-screen.jsonl");
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, stale, stale);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-waiting-screen",
+            state: "working",
+            surface_id: "surface:worker-transcript-waiting-screen",
+            cli: "codex",
+            role: "worker",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-waiting-screen")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:worker-transcript-waiting-screen",
+          text: [
+            "gpt-5.5 · 70% left · ~/Gits/voicelayer",
+            "• Waiting for command approval",
+            "TASK_DONE",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "worker-transcript-waiting-screen",
+          "done",
+          1_200,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("worker-transcript-waiting-screen");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve stale transcript done when the current screen cannot be read", async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-06-26T20:37:00.000Z");
+        const stale = new Date(now.getTime() - 2_000);
+        vi.setSystemTime(now);
+        const transcript = join(TEST_DIR, "stale-codex-done-read-failure.jsonl");
+        writeCodexDoneTranscript(transcript);
+        utimesSync(transcript, stale, stale);
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-transcript-read-failure",
+            state: "working",
+            surface_id: "surface:worker-transcript-read-failure",
+            cli: "codex",
+            role: "worker",
+            cli_session_path: transcript,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:worker-transcript-read-failure")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new Error("cmux read failed"),
+        );
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "worker-transcript-read-failure",
+          "done",
+          1_200,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("worker-transcript-read-failure");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("resolves done from stale transcript ground truth with no screen banner", async () => {
       vi.useFakeTimers();
       try {
@@ -3627,6 +3720,35 @@ To continue this session, run codex resume ${sessionId}`,
       await engine.runSweep();
 
       expect(engine.getAgentState("agent-boot-ready")).toMatchObject({
+        state: "ready",
+        boot_prompt_pending: false,
+        error: null,
+      });
+    });
+
+    it("recovers stale pending Gemini boot prompt without requiring identity parsing", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-gemini-boot-ready",
+          state: "booting",
+          surface_id: "surface:gemini",
+          cli: "gemini",
+          boot_prompt_pending: true,
+          updated_at: new Date(Date.now() - 6 * 60_000).toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:gemini")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:gemini",
+        text: "> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-gemini-boot-ready")).toMatchObject({
         state: "ready",
         boot_prompt_pending: false,
         error: null,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3015,6 +3015,54 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not resolve done when TASK_DONE appears with a recoverable blocker", async () => {
+      vi.useFakeTimers();
+      try {
+        const candidateAt = new Date("2026-06-26T20:38:00.000Z");
+        vi.setSystemTime(new Date(candidateAt.getTime() + 5_001));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "incident-recoverable-blocker-done",
+            state: "working",
+            surface_id: "surface:incident-recoverable-blocker-done",
+            cli: "codex",
+            role: "worker",
+            task_done_candidate_at: candidateAt.toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:incident-recoverable-blocker-done")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:incident-recoverable-blocker-done",
+          text: [
+            "OpenAI Codex",
+            "Model: gpt-5.5",
+            "I cannot commit, push, or open a PR without explicit permission, so I am parked.",
+            "TASK_DONE",
+          ].join("\n"),
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "incident-recoverable-blocker-done",
+          "done",
+          7_000,
+        );
+        await vi.advanceTimersByTimeAsync(8_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        const agent = engine.getAgentState("incident-recoverable-blocker-done");
+        expect(agent?.state).toBe("working");
+        expect(agent?.task_done_candidate_at ?? null).toBeNull();
+        expect(agent?.task_done_detected_at ?? null).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not resolve done from a Claude completion banner without an explicit done signal", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4289,6 +4289,15 @@ describe("buildLaunchCommand", () => {
     );
     expect(
       buildLaunchCommand("codex", "brainlayer", "gpt-5.3-codex-spark"),
+    ).toBe("brainlayerCodex -s");
+    expect(
+      buildLaunchCommand(
+        "codex",
+        "brainlayer",
+        "gpt-5.3-codex-spark",
+        undefined,
+        { allowModelOverride: true },
+      ),
     ).toBe("brainlayerCodex -s -m gpt-5.3-codex-spark");
     expect(buildLaunchCommand("codex", "brainlayer", "codex")).toBe(
       "brainlayerCodex -s",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3828,6 +3828,47 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
+    it("restores degraded quality when stale pending Codex boot recovery proves the pane is ready", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-ready-degraded",
+          state: "booting",
+          surface_id: "surface:42",
+          cli: "codex",
+          boot_prompt_pending: true,
+          quality: "degraded",
+          error: "Post-spawn liveness failed: surface surface:42 is not live",
+          updated_at: new Date(Date.now() - 6 * 60_000).toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:42",
+        text: [
+          "╭──────────────────────────╮",
+          "│ OpenAI Codex             │",
+          "│ Model: gpt-5.5 xhigh     │",
+          "│ Directory: /Users/etanheyman/Gits/voicelayer │",
+          "│ Permissions: YOLO        │",
+          "╰──────────────────────────╯",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 80,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-ready-degraded")).toMatchObject({
+        state: "ready",
+        boot_prompt_pending: false,
+        error: null,
+        quality: "unknown",
+      });
+    });
+
     it("recovers stale pending Gemini boot prompt without requiring identity parsing", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -136,6 +136,22 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("registry_screen_disagreement");
   });
 
+  it("marks registry working while the screen parses done as unhealthy", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        state: "working",
+        cli_session_id: "019f0001-1111-7222-8333-444455556666",
+      }),
+      {
+        monitor_alive: true,
+        screen_status: "done",
+      },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("registry_screen_disagreement");
+  });
+
   it("marks registry workspace mismatch against the live surface as unhealthy", () => {
     const health = evaluateAgentHealth(makeRecord({ workspace_id: "workspace:5" }), {
       monitor_alive: true,

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { evaluateAgentHealth } from "../src/agent-health.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "cmuxlayerCodex-pending-1-abcd",
+    surface_id: "surface:1",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "cmuxlayer",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: "019f0001-1111-7222-8333-444455556666",
+    cli_session_path: null,
+    launcher_name: "cmuxlayerCodex",
+    task_summary: "Fix lifecycle",
+    pid: null,
+    version: 1,
+    created_at: "2026-06-26T20:00:00.000Z",
+    updated_at: "2026-06-26T20:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    boot_prompt_pending: false,
+    launch_cwd: null,
+    mcp_profile: null,
+    worktree_path: null,
+    worktree_branch: null,
+    ...overrides,
+  };
+}
+
+describe("agent lifecycle health", () => {
+  it("marks a ready managed agent without a CLI session or monitor as unhealthy", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({ cli_session_id: null, cli_session_path: null }),
+      { monitor_alive: false },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toEqual([
+      "missing_cli_session_id",
+      "non_resumable",
+      "inbox_monitor_not_alive",
+    ]);
+  });
+
+  it("marks auto-discovered agents as unhealthy even if they look ready", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "auto-codex-surface-306",
+        task_summary: "(auto-discovered)",
+        cli_session_id: null,
+      }),
+      { monitor_alive: false },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("auto_discovered_agent");
+    expect(health.issue_codes).toContain("missing_cli_session_id");
+  });
+
+  it("marks auto-discovered lead surfaces as missing managed lead ids", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "auto-codex-surface-325",
+        task_summary: "(auto-discovered)",
+        repo: "M1 Lead",
+        cli_session_id: null,
+      }),
+      { monitor_alive: false, surface_title: "M1 LEAD VoiceLayerCodex" },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("auto_discovered_agent");
+    expect(health.issue_codes).toContain("missing_managed_lead_agent_id");
+  });
+
+  it("marks ambiguous auto-discovered repo labels as unhealthy", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "auto-codex-surface-999",
+        task_summary: "(auto-discovered)",
+        repo: "Gits",
+        cli_session_id: null,
+      }),
+      { monitor_alive: false },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("ambiguous_repo_cwd_label");
+  });
+
+  it("marks non-Claude orchestrators as role health failures", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({ cli: "codex", role: "orchestrator" }),
+      { monitor_alive: true },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("non_claude_orchestrator");
+  });
+
+  it("marks unexpected three-column topology as unhealthy", () => {
+    const health = evaluateAgentHealth(makeRecord(), {
+      monitor_alive: true,
+      topology: { column: 2, column_count: 3 },
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("topology_three_or_more_columns");
+  });
+
+  it("marks registry done while the screen is working as unhealthy", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        state: "done",
+        cli_session_id: "019f0001-1111-7222-8333-444455556666",
+      }),
+      {
+        monitor_alive: true,
+        screen_status: "working",
+      },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("registry_screen_disagreement");
+  });
+
+  it("marks registry workspace mismatch against the live surface as unhealthy", () => {
+    const health = evaluateAgentHealth(makeRecord({ workspace_id: "workspace:5" }), {
+      monitor_alive: true,
+      surface_workspace_id: "workspace:1",
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("registry_surface_workspace_mismatch");
+  });
+
+  it("marks worker closure without a verified artifact as unhealthy", () => {
+    const health = evaluateAgentHealth(makeRecord({ state: "done" }), {
+      monitor_alive: true,
+      closure_artifact_verified: false,
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("closure_without_artifact");
+  });
+
+  it("marks recoverable permission-parking blockers as action-required health failures", () => {
+    const health = evaluateAgentHealth(makeRecord(), {
+      monitor_alive: true,
+      screen_actions: [
+        "recoverable_blocker:pr_loop",
+        "recoverable_blocker:restart",
+        "recoverable_blocker:successor",
+      ],
+    } as any);
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("recoverable_blocker_requires_action");
+    expect(health.recommended_actions).toEqual([
+      "route_pr_loop",
+      "restart_in_scope_mcp_or_daemon",
+      "resume_or_spawn_managed_successor",
+    ]);
+  });
+
+  it("keeps a sessionful worker with live monitor in a two-column layout healthy", () => {
+    const health = evaluateAgentHealth(makeRecord(), {
+      monitor_alive: true,
+      topology: { column: 1, column_count: 2 },
+    });
+
+    expect(health).toEqual({
+      status: "healthy",
+      issue_codes: [],
+      issues: [],
+    });
+  });
+});

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -310,6 +310,46 @@ describe("AgentRegistry", () => {
       );
       expect(removeStateSpy).not.toHaveBeenCalled();
     });
+
+    it("does not clear managed workspace_id when discovery omits workspace metadata", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "managed-codex",
+          surface_id: "surface:42",
+          workspace_id: "workspace:known",
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:42"),
+      ]);
+      await registry.reconstitute();
+
+      const discovery = {
+        scan: vi.fn().mockResolvedValue([
+          {
+            surface_id: "surface:42",
+            surface_title: "brainlayerCodex",
+            cli: "codex",
+            parsed_status: "working",
+            model: "gpt-5.5",
+            token_count: null,
+            context_pct: null,
+            has_agent: true,
+            read_error: false,
+          },
+        ]),
+      };
+
+      await registry.listMerged(discovery as any);
+
+      expect(stateMgr.readState("managed-codex")?.workspace_id).toBe(
+        "workspace:known",
+      );
+      expect(registry.get("managed-codex")?.workspace_id).toBe(
+        "workspace:known",
+      );
+    });
   });
 
   describe("purgeTerminal", () => {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -350,6 +350,47 @@ describe("AgentRegistry", () => {
         "workspace:known",
       );
     });
+
+    it("does not clear managed workspace_id when discovery reports null workspace metadata", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "managed-codex-null",
+          surface_id: "surface:42",
+          workspace_id: "workspace:known",
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:42"),
+      ]);
+      await registry.reconstitute();
+
+      const discovery = {
+        scan: vi.fn().mockResolvedValue([
+          {
+            surface_id: "surface:42",
+            surface_title: "brainlayerCodex",
+            cli: "codex",
+            parsed_status: "working",
+            model: "gpt-5.5",
+            token_count: null,
+            context_pct: null,
+            has_agent: true,
+            read_error: false,
+            workspace_id: null,
+          },
+        ]),
+      };
+
+      await registry.listMerged(discovery as any);
+
+      expect(stateMgr.readState("managed-codex-null")?.workspace_id).toBe(
+        "workspace:known",
+      );
+      expect(registry.get("managed-codex-null")?.workspace_id).toBe(
+        "workspace:known",
+      );
+    });
   });
 
   describe("purgeTerminal", () => {

--- a/tests/clean-screen.test.ts
+++ b/tests/clean-screen.test.ts
@@ -55,6 +55,14 @@ describe("cleanScreenText (read_screen leanness)", () => {
     expect(cleanScreenText(input)).toBe("Green output");
   });
 
+  it("strips orphaned TTY cursor-control trailers from cmux pane previews", () => {
+    const input =
+      "etanheyman ~/Gits/cmuxlayer [fix/branch] $ ;1:1A;1:3A\nReal output";
+    expect(cleanScreenText(input)).toBe(
+      "etanheyman ~/Gits/cmuxlayer [fix/branch] $\nReal output",
+    );
+  });
+
   it("empty / all-chrome input → empty string", () => {
     expect(cleanScreenText("")).toBe("");
     expect(cleanScreenText("─────\n🤖 model\n  esc to interrupt")).toBe("");

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -207,6 +207,20 @@ describe("layout policy", () => {
     expect(inferAgentRole({ launcherName: "brainlayerCursor" })).toBe("worker");
   });
 
+  it("treats Codex leads as worker topology by default unless role is explicit", () => {
+    expect(inferAgentRole({ cli: "codex" })).toBe("worker");
+    expect(inferAgentRole({ cli: "codex", launcherName: "cmuxlayerCodex" })).toBe(
+      "worker",
+    );
+    expect(
+      inferAgentRole({
+        cli: "codex",
+        launcherName: "cmuxlayerCodex",
+        role: "orchestrator",
+      }),
+    ).toBe("orchestrator");
+  });
+
   it("uses the final launcher marker when repo names contain role words", () => {
     expect(inferAgentRole({ launcherName: "myClaude-toolsCodex" })).toBe(
       "worker",

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -52,6 +52,25 @@ describe("model-policy drift gate", () => {
       "claude-opus-4-8[1m]",
     );
 
+    const codex = MODEL_POLICY_CONTRACT.cli.codex;
+    expect(codex.allowModelOverrideByDefault).toBe(false);
+
+    const codexCoerced = resolveSpawnModelPolicy("codex", "gpt-5.5", {});
+    expect(codexCoerced.coerced).toBe(true);
+    expect(codexCoerced.effective_model).toBe(codex.defaultModel);
+    expect(codexCoerced.launcher_model).toBeNull();
+    expect(codexCoerced.warnings).toHaveLength(1);
+    expect(codexCoerced.warnings[0]).toContain("CODEX MODEL POLICY");
+    expect(codexCoerced.warnings[0]).toContain("gpt-5.5");
+
+    const codexEscaped = resolveSpawnModelPolicy("codex", "gpt-5.5", {
+      [MODEL_OVERRIDE_ENV]: "1",
+    });
+    expect(codexEscaped.coerced).toBe(false);
+    expect(codexEscaped.effective_model).toBe("gpt-5.5");
+    expect(codexEscaped.launcher_model).toBe("gpt-5.5");
+    expect(codexEscaped.override_allowed).toBe(true);
+
     const coerced = resolveSpawnModelPolicy("cursor", "sonnet-4", {});
     expect(coerced.coerced).toBe(true);
     expect(coerced.effective_model).toBe(cursor.defaultModel);

--- a/tests/model-policy.test.ts
+++ b/tests/model-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   MODEL_OVERRIDE_ENV,
   MODEL_POLICY_CONTRACT,
+  resolveLaunchModelFlag,
   resolveModelAlias,
   resolveSpawnModelPolicy,
 } from "../src/model-policy.js";
@@ -17,6 +18,9 @@ describe("model policy contract", () => {
       "claude-opus-4-8[1m]",
     );
     expect(MODEL_POLICY_CONTRACT.cli.codex.defaultModel).toBe("codex");
+    expect(MODEL_POLICY_CONTRACT.cli.codex.allowModelOverrideByDefault).toBe(
+      false,
+    );
   });
 
   it("coerces Cursor model overrides to auto unless the escape env is enabled", () => {
@@ -36,6 +40,37 @@ describe("model policy contract", () => {
     expect(escaped.launcher_model).toBe("sonnet");
     expect(escaped.coerced).toBe(false);
     expect(escaped.override_allowed).toBe(true);
+  });
+
+  it("does not pass Codex model overrides to repoGolem launchers without the escape env", () => {
+    const coerced = resolveSpawnModelPolicy("codex", "gpt-5.5", {});
+
+    expect(coerced.effective_model).toBe("codex");
+    expect(coerced.launcher_model).toBeNull();
+    expect(coerced.coerced).toBe(true);
+    expect(coerced.warnings[0]).toContain("CODEX MODEL POLICY");
+    expect(coerced.warnings[0]).toContain("gpt-5.5");
+
+    const escaped = resolveSpawnModelPolicy("codex", "gpt-5.5", {
+      [MODEL_OVERRIDE_ENV]: "1",
+    });
+
+    expect(escaped.effective_model).toBe("gpt-5.5");
+    expect(escaped.launcher_model).toBe("gpt-5.5");
+    expect(escaped.coerced).toBe(false);
+    expect(escaped.override_allowed).toBe(true);
+
+    expect(
+      resolveLaunchModelFlag("codex", "gpt-5.5", {
+        allowModelOverride: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveLaunchModelFlag("codex", "gpt-5.5", {
+        allowModelOverride: true,
+      }),
+    ).toBe("gpt-5.5");
   });
 
   it("resolves omitted models to per-CLI defaults without pinning launcher args", () => {

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -188,6 +188,24 @@ gpt-5.5 xhigh · /workspaces/cmuxlayer
     expect(result.matched).toBe(true);
   });
 
+  it("matches Codex boot panel readiness even when the panel is above the composer", () => {
+    const result = matchReadyPattern(
+      "codex",
+      `
+╭──────────────────────────╮
+│ OpenAI Codex             │
+│ Model: gpt-5.5 xhigh     │
+│ Directory: /Users/etanheyman/Gits/voicelayer │
+│ Permissions: YOLO        │
+╰──────────────────────────╯
+
+›
+`,
+    );
+
+    expect(result.matched).toBe(true);
+  });
+
   it("does not match modern Codex while it is working on a queued prompt", () => {
     const result = matchReadyPattern(
       "codex",

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   CLI_READY_PATTERNS,
   matchReadyPattern,
+  screenHasActiveAgentMarker,
   type PatternMatch,
 } from "../src/pattern-registry.js";
 
@@ -173,6 +174,20 @@ gpt-5.5 xhigh · ~/Gits/brainlayer
 `,
     );
     expect(result.matched).toBe(true);
+  });
+
+  it("does not treat bare active Codex status lines as ready", () => {
+    for (const marker of ["Working", "Waiting for command approval", "Thinking"]) {
+      const screen = [
+        "gpt-5.5 xhigh · 70% left · ~/Gits/cmuxlayer",
+        marker,
+        "",
+        "›",
+      ].join("\n");
+
+      expect(matchReadyPattern("codex", screen).matched).toBe(false);
+      expect(screenHasActiveAgentMarker("codex", screen)).toBe(true);
+    }
   });
 
   it("matches modern Codex idle prompt outside ~/Gits", () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -143,6 +143,103 @@ function makeDiscoveryExec(): ExecFn {
   });
 }
 
+function makeMovedManagedSurfaceExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Collab",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+            {
+              ref: "workspace:5",
+              title: "SkillCreator",
+              index: 1,
+              selected: false,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      const workspace = args.includes("--workspace")
+        ? args[args.indexOf("--workspace") + 1]
+        : "workspace:1";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: workspace,
+          window_ref: workspace === "workspace:1" ? "window:1" : "window:5",
+          panes:
+            workspace === "workspace:1"
+              ? [
+                  {
+                    ref: "pane:6",
+                    index: 1,
+                    focused: true,
+                    surface_count: 1,
+                    surface_refs: ["surface:315"],
+                    selected_surface_ref: "surface:315",
+                  },
+                ]
+              : [],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      const workspace = args.includes("--workspace")
+        ? args[args.indexOf("--workspace") + 1]
+        : "workspace:1";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: workspace,
+          window_ref: workspace === "workspace:1" ? "window:1" : "window:5",
+          pane_ref: workspace === "workspace:1" ? "pane:6" : null,
+          surfaces:
+            workspace === "workspace:1"
+              ? [
+                  {
+                    ref: "surface:315",
+                    title: "skillcreatorCodex",
+                    type: "terminal",
+                    index: 0,
+                    selected: true,
+                  },
+                ]
+              : [],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:315",
+          text: "gpt-5.5 · 82% left · ~/Gits/skillcreator\nWorking (1m 03s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
 function makeIdleDiscoveryExec(): ExecFn {
   const base = makeDiscoveryExec();
   return vi.fn().mockImplementation(async (cmd, args) => {
@@ -259,6 +356,65 @@ function makeShellPromptExec(): ExecFn {
       stdout: JSON.stringify({}),
       stderr: "",
     };
+  });
+}
+
+function makeOrphanLeadExec(): ExecFn {
+  const base = makeShellPromptExec();
+  return vi.fn().mockImplementation(async (cmd, args) => {
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:325",
+              title: "M1 LEAD VoiceLayerCodex",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:325",
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:325"],
+              selected_surface_ref: "surface:325",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    return base(cmd, args);
   });
 }
 
@@ -576,6 +732,39 @@ describe("resync_agents tool", () => {
     expect(parsed.count).toBe(1);
     expect(parsed.agents[0].state).toBe("idle");
     expect(stateMgr.readState("auto-claude-surface-1")?.state).toBe("idle");
+  });
+
+  it("resync_agents reconciles managed record workspace_id after a surface move", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "skillcreatorCodex-019fmove",
+        surface_id: "surface:315",
+        workspace_id: "workspace:5",
+        state: "working",
+        repo: "skillcreator",
+        model: "gpt-5.5",
+        cli: "codex",
+        cli_session_id: "019f0001-1111-7222-8333-444455556666",
+        role: "worker",
+      }),
+    );
+
+    const server = createServer({
+      exec: makeMovedManagedSurfaceExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(stateMgr.readState("skillcreatorCodex-019fmove")?.workspace_id).toBe(
+      "workspace:1",
+    );
   });
 
   it("resync_agents keeps existing auto agents when discovery hits read-screen errors", async () => {
@@ -1006,6 +1195,30 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.mismatches).toEqual([]);
     expect(parsed.diff.orphaned).toEqual(["surface:999"]);
     expect(parsed.count).toBe(0);
+  });
+
+  it("resync_agents reports orphan lead surfaces as health failures", async () => {
+    const server = createServer({
+      exec: makeOrphanLeadExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.orphaned).toEqual(["surface:325"]);
+    expect(parsed.diff.health_failures).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:325",
+        surface_title: "M1 LEAD VoiceLayerCodex",
+        status: "unhealthy",
+        issue_codes: ["missing_managed_lead_agent_id"],
+      }),
+    ]);
   });
 
   it("resync_agents evicts registry-only phantom agents instead of failing", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -767,6 +767,39 @@ describe("resync_agents tool", () => {
     );
   });
 
+  it("get_agent_state refreshes managed workspace_id after a surface move", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "skillcreatorCodex-019fdirect",
+        surface_id: "surface:315",
+        workspace_id: "workspace:5",
+        state: "working",
+        repo: "skillcreator",
+        model: "gpt-5.5",
+        cli: "codex",
+        cli_session_id: "019f0001-1111-7222-8333-444455556666",
+        role: "worker",
+      }),
+    );
+
+    const server = createServer({
+      exec: makeMovedManagedSurfaceExec(),
+      stateDir: TEST_DIR,
+    });
+
+    const result = await (server as any)._registeredTools[
+      "get_agent_state"
+    ].handler({ agent_id: "skillcreatorCodex-019fdirect" }, {} as any);
+    const parsed = parseResult(result);
+
+    expect(parsed.workspace_id).toBe("workspace:1");
+    expect(stateMgr.readState("skillcreatorCodex-019fdirect")?.workspace_id).toBe(
+      "workspace:1",
+    );
+    expect(parsed.health.issue_codes).not.toContain("workspace_mismatch");
+  });
+
   it("resync_agents keeps existing auto agents when discovery hits read-screen errors", async () => {
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState({

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -101,6 +101,7 @@ Do you want to allow this command?
   it("detects recoverable pr-loop parking as an action instead of plain idle text", () => {
     const parsed = parseScreen(`
 OpenAI Codex
+Model: gpt-5.5
 
 I cannot commit, push, or open a PR without explicit permission, so I am waiting for Etan.
 
@@ -115,6 +116,7 @@ codex>
   it("detects recoverable MCP restart and successor blockers", () => {
     const parsed = parseScreen(`
 OpenAI Codex
+Model: gpt-5.5
 
 The cmux MCP transport closed and I cannot reconnect MCPs from this session.
 I need permission to restart the cmuxlayer MCP before continuing.
@@ -347,6 +349,17 @@ TASK_DONE
     expect(parsed.agent_type).toBe("codex");
     expect(parsed.status).toBe("idle");
     expect(parsed.model).toBe("gpt-5.5 xhigh");
+  });
+
+  it("does not classify ordinary prose mentioning OpenAI Codex as a Codex pane", () => {
+    const parsed = parseScreen(`
+Claude Code
+I read the OpenAI Codex release notes and updated the docs.
+❯
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("idle");
   });
 
   it("does not revive stale done evidence when later output starts with an arrow", () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -98,6 +98,38 @@ Do you want to allow this command?
     expect(parsed.errors).toContain("permission_prompt");
   });
 
+  it("detects recoverable pr-loop parking as an action instead of plain idle text", () => {
+    const parsed = parseScreen(`
+OpenAI Codex
+
+I cannot commit, push, or open a PR without explicit permission, so I am waiting for Etan.
+
+codex>
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.actions).toContain("recoverable_blocker:pr_loop");
+  });
+
+  it("detects recoverable MCP restart and successor blockers", () => {
+    const parsed = parseScreen(`
+OpenAI Codex
+
+The cmux MCP transport closed and I cannot reconnect MCPs from this session.
+I need permission to restart the cmuxlayer MCP before continuing.
+
+codex>
+`);
+
+    expect(parsed.actions).toEqual(
+      expect.arrayContaining([
+        "recoverable_blocker:restart",
+        "recoverable_blocker:successor",
+      ]),
+    );
+  });
+
   it("extracts model from no-cost status line (production format)", () => {
     const parsed = parseScreen(`
 ✻ Working…
@@ -298,6 +330,23 @@ TASK_DONE
     expect(parsed.agent_type).toBe("codex");
     expect(parsed.done_signal).toBe("TASK_DONE");
     expect(parsed.status).toBe("done");
+  });
+
+  it("parses a Codex boot panel that is not bottom-aligned", () => {
+    const parsed = parseScreen(`
+╭──────────────────────────╮
+│ OpenAI Codex             │
+│ Model: gpt-5.5 xhigh     │
+│ Directory: /Users/etanheyman/Gits/voicelayer │
+│ Permissions: YOLO        │
+╰──────────────────────────╯
+
+›
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.model).toBe("gpt-5.5 xhigh");
   });
 
   it("does not revive stale done evidence when later output starts with an arrow", () => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -62,6 +62,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "spawn_in_workspace",
     "resync_agents",
     "send_to",
+    "supersede_agent_goal",
     "send_to_agent",
     "wait_for",
     "wait_for_all",
@@ -84,9 +85,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 35 tools have annotations", () => {
+  it("all 36 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(35);
+    expect(toolNames.length).toBe(36);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -554,6 +554,68 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("spawn_agent preserves parent workspace inheritance when workspace is omitted", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const parentRecord: AgentRecord = {
+      agent_id: "parent-codex",
+      surface_id: "surface:parent",
+      workspace_id: "workspace:parent",
+      state: "working",
+      repo: "brainlayer",
+      model: "gpt-5.5",
+      cli: "codex",
+      cli_session_id: "019f0001-1111-7222-8333-444455556666",
+      cli_session_path: null,
+      task_summary: "parent mission",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      role: "worker",
+      auto_archive_on_done: false,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      boot_prompt_pending: false,
+      launch_cwd: null,
+      mcp_profile: null,
+      worktree_path: null,
+      worktree_branch: null,
+    };
+    engine.stateMgr.writeState(parentRecord);
+    engine.getRegistry().set(parentRecord.agent_id, parentRecord);
+    mockExec.mockClear();
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        parent_agent_id: parentRecord.agent_id,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const splitCall = mockExec.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args.includes("new-split"),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(splitCall?.[1]).toEqual(
+      expect.arrayContaining(["--workspace", "workspace:parent"]),
+    );
+  });
+
   it("spawn_agent warns when an existing same-lane idle agent can be reused", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -1743,6 +1805,37 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
+  it("get_agent_state reports terminal workers without done evidence as closure health failures", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "golems",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const done = engine.stateMgr.transition(agentId, "done");
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining(["closure_without_artifact"]),
+    });
+  });
+
   it("get_agent_state reports recoverable blocker health from parsed screen actions", async () => {
     const blockerScreen = `
 OpenAI Codex
@@ -2350,6 +2443,61 @@ codex>
     const state =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(state.task_summary).toBe("full baseline mission");
+    expect(state.goal_file).toBe(goalPath);
+  });
+
+  it("supersede_agent_goal updates the canonical record when called through an alias", async () => {
+    const goalPath = join(TEST_DIR, "alias-mission.md");
+    writeFileSync(goalPath, "# Mission\n\nUse the canonical state.\n", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const pendingAgentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const currentAgentId = resolveCurrentTestAgentId(
+      engine.stateMgr,
+      pendingAgentId,
+    );
+    const finalAgentId = "brainlayerCodex-019f0001";
+    const renamed = engine.stateMgr.renameState(currentAgentId, finalAgentId);
+    engine.getRegistry().rename(currentAgentId, finalAgentId, renamed);
+    mockExec.mockClear();
+
+    const result = await supersede.handler(
+      {
+        agent_id: pendingAgentId,
+        goal_file: goalPath,
+        summary: "alias mission",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.agent_id).toBe(finalAgentId);
+    expect(parsed.task_summary).toBe("alias mission");
+
+    const stateResult = await getState.handler(
+      { agent_id: finalAgentId },
+      {} as any,
+    );
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(state.task_summary).toBe("alias mission");
     expect(state.goal_file).toBe(goalPath);
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -246,7 +246,7 @@ function resolveCurrentTestAgentId(
 }
 
 describe("agent lifecycle tool registration", () => {
-  it("registers all 14 agent lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 14 phase-5 lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -274,7 +274,7 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 36 (20 low-level + 14 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 36", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -329,7 +329,6 @@ describe("agent lifecycle tool handlers", () => {
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
-        "inbox_monitor_not_alive",
       ]),
     });
 
@@ -594,7 +593,7 @@ describe("agent lifecycle tool handlers", () => {
       expect.objectContaining({
         agent_id: first.agent_id,
         surface_id: first.surface_id,
-        workspace_id: first.workspace_id,
+        workspace_id: "workspace:1",
         state: "idle",
         role: "worker",
       }),
@@ -1669,7 +1668,6 @@ describe("agent lifecycle tool handlers", () => {
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
-        "inbox_monitor_not_alive",
       ]),
     });
   });
@@ -2017,7 +2015,7 @@ codex>
     expect(parsed.agent_id).toBe(agentId);
     expect(deliveredText).toBe("interject while working");
     expect(sendCalls[0]?.[1]).toEqual(
-      expect.arrayContaining(["--workspace", "ws:1"]),
+      expect.arrayContaining(["--workspace", "workspace:1"]),
     );
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2355,6 +2355,60 @@ codex>
     expect(state.goal_file).toBe(goalPath);
   });
 
+  it("supersede_agent_goal does not update registry metadata when delivery fails", async () => {
+    const goalPath = join(TEST_DIR, "undelivered-mission.md");
+    writeFileSync(goalPath, "# Mission\n\nThis should not be recorded.\n", "utf8");
+    const backingExec = makeLifecycleExec();
+    const failingExec: ExecFn = vi.fn().mockImplementation(async (cmd, args) => {
+      const text = String(args[args.length - 1] ?? "");
+      if (args.includes("send") && text.startsWith("/goal ")) {
+        throw new Error("send failed");
+      }
+      return backingExec(cmd, args);
+    });
+    const server = createLifecycleServer(failingExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const stateMgr = engine.stateMgr;
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const registry = engine.getRegistry();
+    const oldState = stateMgr.updateRecord(currentAgentId, {
+      task_summary: "old mission",
+      goal_file: null,
+    });
+    registry.set(currentAgentId, oldState);
+
+    const result = await supersede.handler(
+      {
+        agent_id: currentAgentId,
+        goal_file: goalPath,
+        summary: "new mission",
+      },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.error).toMatch(/send failed/);
+
+    const state = stateMgr.readState(currentAgentId);
+    expect(state?.task_summary).toBe("old mission");
+    expect(state?.goal_file).toBeNull();
+  });
+
   it("supersede_agent_goal rejects a missing goal file", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2550,6 +2550,51 @@ codex>
     expect(state.goal_file).toBe(goalPath);
   });
 
+  it("supersede_agent_goal clears stale boot prompt metadata after delivery", async () => {
+    const goalPath = join(TEST_DIR, "boot-pending-mission.md");
+    writeFileSync(goalPath, "# Mission\n\nReplace boot prompt state.\n", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const current = engine.stateMgr.updateRecord(agentId, {
+      boot_prompt_pending: true,
+    });
+    engine.getRegistry().set(agentId, current);
+    mockExec.mockClear();
+
+    const result = await supersede.handler(
+      {
+        agent_id: agentId,
+        goal_file: goalPath,
+        summary: "boot replacement mission",
+      },
+      {} as any,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(state.state).toBe("working");
+    expect(state.boot_prompt_pending).toBe(false);
+    expect(state.task_summary).toBe("boot replacement mission");
+  });
+
   it.each(["done", "error"] as const)(
     "supersede_agent_goal resets stale %s lifecycle metadata after delivery",
     async (terminalState) => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -555,6 +555,8 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("spawn_agent preserves parent workspace inheritance when workspace is omitted", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    process.env.CMUX_WORKSPACE_ID = "workspace:caller";
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const engine = (server as any)._registeredTools["interact"]._engine;
@@ -594,26 +596,37 @@ describe("agent lifecycle tool handlers", () => {
     engine.getRegistry().set(parentRecord.agent_id, parentRecord);
     mockExec.mockClear();
 
-    const result = await spawn.handler(
-      {
-        repo: "brainlayer",
-        model: "gpt-5.5",
-        cli: "codex",
-        role: "worker",
-        parent_agent_id: parentRecord.agent_id,
-      },
-      {} as any,
-    );
-    const parsed =
-      result.structuredContent ?? JSON.parse(result.content[0].text);
-    const splitCall = mockExec.mock.calls.find(
-      ([, args]) => Array.isArray(args) && args.includes("new-split"),
-    );
+    try {
+      const result = await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          role: "worker",
+          parent_agent_id: parentRecord.agent_id,
+        },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      const splitCall = mockExec.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args.includes("new-split"),
+      );
 
-    expect(parsed.ok).toBe(true);
-    expect(splitCall?.[1]).toEqual(
-      expect.arrayContaining(["--workspace", "workspace:parent"]),
-    );
+      expect(parsed.ok).toBe(true);
+      expect(splitCall?.[1]).toEqual(
+        expect.arrayContaining(["--workspace", "workspace:parent"]),
+      );
+      expect(splitCall?.[1]).not.toEqual(
+        expect.arrayContaining(["--workspace", "workspace:caller"]),
+      );
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+    }
   });
 
   it("spawn_agent warns when an existing same-lane idle agent can be reused", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1849,6 +1849,42 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
+  it("get_agent_state does not require closure artifacts for errored workers", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "golems",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    engine
+      .getRegistry()
+      .set(agentId, engine.stateMgr.transition(agentId, "ready"));
+    engine
+      .getRegistry()
+      .set(agentId, engine.stateMgr.transition(agentId, "working"));
+    const errored = engine.stateMgr.transition(agentId, "error", {
+      error: "tool transport closed",
+    });
+    engine.getRegistry().set(agentId, errored);
+
+    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.health.issue_codes).not.toContain("closure_without_artifact");
+  });
+
   it("get_agent_state reports recoverable blocker health from parsed screen actions", async () => {
     const blockerScreen = `
 OpenAI Codex

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2514,6 +2514,73 @@ codex>
     expect(state.goal_file).toBe(goalPath);
   });
 
+  it.each(["done", "error"] as const)(
+    "supersede_agent_goal resets stale %s lifecycle metadata after delivery",
+    async (terminalState) => {
+      const goalPath = join(TEST_DIR, `reset-${terminalState}-mission.md`);
+      writeFileSync(goalPath, "# Mission\n\nReplace stale lifecycle state.\n", "utf8");
+      const server = createLifecycleServer(mockExec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+      const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+      const getState = (server as any)._registeredTools["get_agent_state"];
+
+      const spawnResult = await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          role: "worker",
+        },
+        {} as any,
+      );
+      const agentId = (
+        spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+      ).agent_id;
+      const engine = (server as any)._registeredTools["interact"]._engine;
+      const registry = engine.getRegistry();
+      let current = engine.stateMgr.transition(agentId, "ready");
+      registry.set(agentId, current);
+      current = engine.stateMgr.transition(agentId, "working");
+      registry.set(agentId, current);
+      current =
+        terminalState === "done"
+          ? engine.stateMgr.transition(agentId, "done")
+          : engine.stateMgr.transition(agentId, "error", {
+              error: "stale terminal error",
+            });
+      current = engine.stateMgr.updateRecord(agentId, {
+        task_done_candidate_at: "2026-06-26T21:00:00.000Z",
+        task_done_detected_at: "2026-06-26T21:01:00.000Z",
+      });
+      registry.set(agentId, current);
+      mockExec.mockClear();
+
+      const result = await supersede.handler(
+        {
+          agent_id: agentId,
+          goal_file: goalPath,
+          summary: "replacement mission",
+        },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(result.isError).toBeFalsy();
+      expect(parsed.registry_state).toBe("working");
+
+      const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+      const state =
+        stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+      expect(state.state).toBe("working");
+      expect(state.task_summary).toBe("replacement mission");
+      expect(state.goal_file).toBe(goalPath);
+      expect(state.task_done_candidate_at ?? null).toBeNull();
+      expect(state.task_done_detected_at ?? null).toBeNull();
+      expect(state.error ?? null).toBeNull();
+    },
+  );
+
   it("supersede_agent_goal does not update registry metadata when delivery fails", async () => {
     const goalPath = join(TEST_DIR, "undelivered-mission.md");
     writeFileSync(goalPath, "# Mission\n\nThis should not be recorded.\n", "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -32,6 +32,7 @@ const AGENT_TOOLS = [
   "spawn_in_workspace",
   "resync_agents",
   "send_to",
+  "supersede_agent_goal",
   "wait_for",
   "wait_for_all",
   "get_agent_state",
@@ -245,7 +246,7 @@ function resolveCurrentTestAgentId(
 }
 
 describe("agent lifecycle tool registration", () => {
-  it("registers all 13 agent lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 14 agent lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -273,11 +274,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 35 (20 low-level + 13 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 36 (20 low-level + 14 agent lifecycle + 2 v2)", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(35);
+    expect(Object.keys(registeredTools)).toHaveLength(36);
   });
 });
 
@@ -323,6 +324,14 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toMatch(/^brainlayerClaude-pending-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
+    expect(parsed.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining([
+        "missing_cli_session_id",
+        "non_resumable",
+        "inbox_monitor_not_alive",
+      ]),
+    });
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -332,6 +341,303 @@ describe("agent lifecycle tool handlers", () => {
     const persisted =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(persisted.auto_archive_on_done).toBe(false);
+  });
+
+  it("spawn_agent inherits the selected workspace when workspace is omitted", async () => {
+    const calls: string[] = [];
+    const mockClient = {
+      createWorkspace: vi.fn(),
+      selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+        calls.push(`select:${workspace}`);
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Collab",
+            selected: true,
+            current_directory: "/Users/etanheyman/Gits/orchestrator",
+          },
+          {
+            ref: "workspace:5",
+            title: "SkillCreator",
+            selected: false,
+            current_directory: "/Users/etanheyman/Gits/skillcreator",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [],
+      }),
+      newSplit: vi.fn().mockImplementation(async (_direction, opts) => {
+        calls.push(`spawn:${opts.workspace}`);
+        return {
+          workspace: opts.workspace,
+          surface: "surface:inherit",
+          pane: "pane:inherit",
+          title: "",
+          type: "terminal",
+        };
+      }),
+      newSurface: vi.fn(),
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:inherit",
+        text: "Codex\n>",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      log: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue(undefined),
+      clearStatus: vi.fn().mockResolvedValue(undefined),
+      setProgress: vi.fn().mockResolvedValue(undefined),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+      listSurfaces: vi.fn().mockResolvedValue([
+        {
+          ref: "surface:inherit",
+          title: "skillcreatorCodex",
+          type: "terminal",
+          index: 0,
+          selected: true,
+          workspace_ref: "workspace:1",
+        },
+      ]),
+      identify: vi.fn().mockResolvedValue({}),
+      browser: vi.fn().mockResolvedValue({}),
+    };
+    const server = createTrackedServer({
+      client: mockClient as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "skillcreator",
+        model: "gpt-5.5",
+        cli: "codex",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace_id).toBe("workspace:1");
+    expect(calls).toContain("spawn:workspace:1");
+    expect(calls).not.toContain("spawn:workspace:5");
+  });
+
+  it("spawn_agent prefers the caller pane workspace over the selected workspace when workspace is omitted", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    delete process.env.CMUX_TAB_ID;
+
+    try {
+      const calls: string[] = [];
+      const mockClient = {
+        createWorkspace: vi.fn(),
+        selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+          calls.push(`select:${workspace}`);
+        }),
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:1",
+              title: "Voice Remediation",
+              selected: false,
+              current_directory: "/Users/etanheyman/Gits/orchestrator",
+            },
+            {
+              id: "selected-workspace-uuid",
+              ref: "workspace:5",
+              title: "Other Active Workspace",
+              selected: true,
+              current_directory: "/Users/etanheyman/Gits/voicelayer",
+            },
+          ],
+        }),
+        listPanes: vi.fn().mockImplementation(async ({ workspace }) => ({
+          workspace_ref: workspace,
+          window_ref: "window:1",
+          panes: [],
+        })),
+        listPaneSurfaces: vi.fn().mockImplementation(async ({ workspace }) => ({
+          workspace_ref: workspace,
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [],
+        })),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => {
+          calls.push(`spawn:${opts.workspace}`);
+          return {
+            workspace: opts.workspace,
+            surface: "surface:caller",
+            pane: "pane:caller",
+            title: "",
+            type: "terminal",
+          };
+        }),
+        newSurface: vi.fn(),
+        send: vi.fn().mockResolvedValue(undefined),
+        sendKey: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:caller",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+        log: vi.fn().mockResolvedValue(undefined),
+        setStatus: vi.fn().mockResolvedValue(undefined),
+        clearStatus: vi.fn().mockResolvedValue(undefined),
+        setProgress: vi.fn().mockResolvedValue(undefined),
+        closeSurface: vi.fn().mockResolvedValue(undefined),
+        listSurfaces: vi.fn().mockResolvedValue([
+          {
+            ref: "surface:caller",
+            title: "voicelayerCodex",
+            type: "terminal",
+            index: 0,
+            selected: true,
+            workspace_ref: "workspace:1",
+          },
+        ]),
+        identify: vi.fn().mockResolvedValue({}),
+        browser: vi.fn().mockResolvedValue({}),
+      };
+      const server = createTrackedServer({
+        client: mockClient as any,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      });
+      const tool = (server as any)._registeredTools["spawn_agent"];
+
+      const result = await tool.handler(
+        {
+          repo: "voicelayer",
+          model: "gpt-5.5",
+          cli: "codex",
+        },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.workspace_id).toBe("workspace:1");
+      expect(calls).toContain("spawn:workspace:1");
+      expect(calls).not.toContain("spawn:workspace:5");
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
+  });
+
+  it("spawn_agent warns when an existing same-lane idle agent can be reused", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const firstResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "ws:1",
+      },
+      {} as any,
+    );
+    const first = firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const firstRecord = registry.get(first.agent_id);
+    registry.set(first.agent_id, { ...firstRecord, state: "idle" });
+
+    const secondResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "ws:1",
+      },
+      {} as any,
+    );
+    const second =
+      secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
+
+    expect(second.ok).toBe(true);
+    expect(second.duplicate_spawn_warning).toMatch(/Existing same-lane agent/);
+    expect(second.existing_same_lane_agents).toEqual([
+      expect.objectContaining({
+        agent_id: first.agent_id,
+        surface_id: first.surface_id,
+        workspace_id: first.workspace_id,
+        state: "idle",
+        role: "worker",
+      }),
+    ]);
+  });
+
+  it("spawn_agent force_new suppresses same-lane duplicate warnings", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const firstResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "ws:1",
+      },
+      {} as any,
+    );
+    const first = firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const firstRecord = registry.get(first.agent_id);
+    registry.set(first.agent_id, { ...firstRecord, state: "ready" });
+
+    const secondResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "ws:1",
+        force_new: true,
+      },
+      {} as any,
+    );
+    const second =
+      secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
+
+    expect(second.ok).toBe(true);
+    expect(second.duplicate_spawn_warning).toBeUndefined();
+    expect(second.existing_same_lane_agents).toEqual([]);
   });
 
   it("spawn_agent accepts an omitted model and resolves the CLI default", async () => {
@@ -386,6 +692,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("ic");
+    expect(parsed.health.status).toBe("unhealthy");
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -1357,6 +1664,14 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agents[0].session_id).toBeNull();
     expect(parsed.agents[0].resume_command).toBeUndefined();
     expect(parsed.agents[0].surface_id).toBeUndefined();
+    expect(parsed.agents[0].health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining([
+        "missing_cli_session_id",
+        "non_resumable",
+        "inbox_monitor_not_alive",
+      ]),
+    });
   });
 
   it("list_agents includes resume_command when a session id is captured", async () => {
@@ -1420,6 +1735,114 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.cli).toBe("codex");
     expect(parsed.resume_command).toBeUndefined();
+    expect(parsed.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining([
+        "missing_cli_session_id",
+        "non_resumable",
+        "inbox_monitor_not_alive",
+      ]),
+    });
+  });
+
+  it("get_agent_state reports recoverable blocker health from parsed screen actions", async () => {
+    const blockerScreen = `
+OpenAI Codex
+
+I cannot commit, push, or open a PR without explicit permission, so I am waiting for Etan.
+
+codex>
+`;
+    const mockClient = {
+      createWorkspace: vi.fn(),
+      selectWorkspace: vi.fn().mockResolvedValue(undefined),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "Main",
+            selected: true,
+            current_directory: "/Users/etanheyman/Gits/cmuxlayer",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [],
+      }),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:1",
+        surface: "surface:blocker",
+        pane: "pane:blocker",
+        title: "",
+        type: "terminal",
+      }),
+      newSurface: vi.fn(),
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:blocker",
+        text: blockerScreen,
+        lines: 20,
+        scrollback_used: false,
+      }),
+      log: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue(undefined),
+      clearStatus: vi.fn().mockResolvedValue(undefined),
+      setProgress: vi.fn().mockResolvedValue(undefined),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+      listSurfaces: vi.fn().mockResolvedValue([
+        {
+          ref: "surface:blocker",
+          title: "cmuxlayerCodex",
+          type: "terminal",
+          index: 0,
+          selected: true,
+          workspace_ref: "workspace:1",
+        },
+      ]),
+      identify: vi.fn().mockResolvedValue({}),
+      browser: vi.fn().mockResolvedValue({}),
+    };
+    const server = createTrackedServer({
+      client: mockClient as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining([
+        "recoverable_blocker_requires_action",
+      ]),
+      recommended_actions: ["route_pr_loop"],
+    });
   });
 
   it("get_agent_state marks auto-discovered null-session agents unresumable", async () => {
@@ -1461,6 +1884,16 @@ describe("agent lifecycle tool handlers", () => {
       cli_session_path: null,
       pid: null,
       resumable: false,
+      health: {
+        status: "unhealthy",
+        issue_codes: expect.arrayContaining([
+          "auto_discovered_agent",
+          "missing_cli_session_id",
+          "non_resumable",
+          "inbox_monitor_not_alive",
+        ]),
+        issues: expect.any(Array),
+      },
     });
     expect(parsed.resume_command).toBeUndefined();
   });
@@ -1559,8 +1992,8 @@ describe("agent lifecycle tool handlers", () => {
 
     const engine = (server as any)._registeredTools["interact"]._engine;
     const registry = engine.getRegistry();
-    const agent = registry.get(agentId);
-    registry.set(agentId, { ...agent, state: "working" });
+    const working = engine.stateMgr.transition(agentId, "working");
+    registry.set(agentId, working);
     mockExec.mockClear();
 
     const result = await sendTo.handler(
@@ -1658,6 +2091,46 @@ describe("agent lifecycle tool handlers", () => {
     expect(result.isError).toBeFalsy();
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
+  });
+
+  it("send_to returns post-delivery screen evidence and health disagreement", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const agent = registry.get(agentId);
+    registry.set(agentId, { ...agent, state: "ready" });
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: "begin work", press_enter: true },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.registry_state).toBe("ready");
+    expect(parsed.screen).toMatchObject({
+      agent_type: "claude",
+      status: "working",
+    });
+    expect(parsed.state_conflict).toBe(true);
+    expect(parsed.health.issue_codes).toContain("registry_screen_disagreement");
   });
 
   it("send_to sanitizes and chunks delivery through the agent surface", async () => {
@@ -1819,6 +2292,97 @@ describe("agent lifecycle tool handlers", () => {
 
     expect(result.isError).toBe(true);
     expect(result.structuredContent?.error).toMatch(/Agent not found/);
+  });
+
+  it("supersede_agent_goal updates registry metadata and delivers a file-backed goal", async () => {
+    const goalPath = join(TEST_DIR, "mission.md");
+    writeFileSync(goalPath, "# Mission\n\nFinish the lifecycle repair.\n", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const ready = engine.stateMgr.transition(agentId, "ready");
+    registry.set(agentId, ready);
+    const working = engine.stateMgr.transition(agentId, "working");
+    registry.set(agentId, working);
+    mockExec.mockClear();
+
+    const result = await supersede.handler(
+      {
+        agent_id: agentId,
+        goal_file: goalPath,
+        summary: "full baseline mission",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.task_summary).toBe("full baseline mission");
+    expect(parsed.goal_file).toBe(goalPath);
+    expect(parsed.registry_state).toBe("working");
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "send",
+        "--surface",
+        "surface:new",
+        `/goal Read and execute this goal file until complete: ${goalPath}`,
+      ]),
+    );
+
+    const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+    const state =
+      stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+    expect(state.task_summary).toBe("full baseline mission");
+    expect(state.goal_file).toBe(goalPath);
+  });
+
+  it("supersede_agent_goal rejects a missing goal file", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+
+    const result = await supersede.handler(
+      {
+        agent_id: agentId,
+        goal_file: join(TEST_DIR, "missing.md"),
+      },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.error).toMatch(/ENOENT/);
   });
 
   it("wait_for defaults to done when target_state is omitted", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4012,6 +4012,10 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
     expect(launcherSends).toBe(2);
+    expect(sentTexts.filter((text) => text.includes("cmuxlayerCodex"))).toEqual([
+      "cmuxlayerCodex -s",
+      "cmuxlayerCodex -s",
+    ]);
     expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
     expect(returnPresses).toBeGreaterThanOrEqual(3);
 
@@ -5334,6 +5338,77 @@ describe("tool handler integration", () => {
         previous_state: "working",
         done_signal: "TASK_DONE",
       },
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface refuses stale DONE consolidation when pane shows an active Codex marker", async () => {
+    const stateDir = join(
+      tmpdir(),
+      "cmuxlayer-close-surface-done-active-refuse",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-done-active",
+      surface_id: "surface:worker-done-active",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "still active",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const screenText = [
+      "gpt-5.5 xhigh · 60% left · ~/Gits/brainlayer",
+      "• Waiting for command approval",
+      "TASK_DONE",
+    ].join("\n");
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:worker-done-active",
+        text: screenText,
+        lines: 3,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-done-active" },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    expect(stateMgr.readState("worker-done-active")?.state).toBe("working");
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      surface: "surface:worker-done-active",
+      agent_id: "worker-done-active",
+      state: "working",
+      screen: screenText,
     });
 
     rmSync(stateDir, { recursive: true, force: true });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5378,18 +5378,26 @@ describe("tool handler integration", () => {
       "• Waiting for command approval",
       "TASK_DONE",
     ].join("\n");
-    const mockClient = {
-      readScreen: vi.fn().mockResolvedValue({
-        surface: "surface:worker-done-active",
-        text: screenText,
-        lines: 3,
-        scrollback_used: false,
-      }),
-      closeSurface: vi.fn().mockResolvedValue(undefined),
-    };
-
+    const closeSurfaceSpy = vi.fn();
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:worker-done-active",
+            text: screenText,
+            lines: 3,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("close-surface")) {
+        closeSurfaceSpy(args);
+      }
+      return { stdout: JSON.stringify({}), stderr: "" };
+    });
     const server = createServer({
-      client: mockClient as any,
+      exec,
       stateDir,
       skipAgentLifecycle: true,
     });
@@ -5401,7 +5409,7 @@ describe("tool handler integration", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    expect(closeSurfaceSpy).not.toHaveBeenCalled();
     expect(stateMgr.readState("worker-done-active")?.state).toBe("working");
     expect(result.structuredContent).toMatchObject({
       refused: true,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5497,6 +5497,93 @@ describe("tool handler integration", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
+  it("close_surface refuses after stale DONE consolidation when another live agent shares the surface", async () => {
+    const stateDir = join(
+      tmpdir(),
+      "cmuxlayer-close-surface-post-consolidation-live",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    const base = {
+      surface_id: "surface:shared-done",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex" as const,
+      cli_session_id: null,
+      task_summary: "",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown" as const,
+      max_cost_per_agent: null,
+    };
+    stateMgr.writeState({
+      ...base,
+      agent_id: "aaa-live-done",
+      state: "working",
+    });
+    stateMgr.writeState({
+      ...base,
+      agent_id: "zzz-live-shared",
+      state: "working",
+    });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:shared-done",
+        text: "All done.\nTASK_DONE",
+        lines: 2,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:shared-done" },
+      {} as any,
+    );
+
+    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    const finalStates = [
+      stateMgr.readState("aaa-live-done"),
+      stateMgr.readState("zzz-live-shared"),
+    ];
+    const doneState = finalStates.find((state) => state?.state === "done");
+    const liveState = finalStates.find((state) => state?.state === "working");
+    expect(doneState).toMatchObject({
+      state: "done",
+      task_done_detected_at: expect.any(String),
+    });
+    expect(liveState).toMatchObject({ state: "working" });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      agent_id: liveState?.agent_id,
+      state: "working",
+      stale_registry_done_consolidated: {
+        agent_id: doneState?.agent_id,
+        previous_state: "working",
+        done_signal: "TASK_DONE",
+      },
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("rename_tab handler calls cmux rename-tab", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5330,7 +5330,11 @@ describe("tool handler integration", () => {
         collapsePane: false,
       },
     );
-    expect(stateMgr.readState("worker-done-stale")?.state).toBe("done");
+    expect(stateMgr.readState("worker-done-stale")).toMatchObject({
+      state: "done",
+      task_done_detected_at: expect.any(String),
+      task_done_candidate_at: null,
+    });
     expect(result.structuredContent).toMatchObject({
       surface: "surface:worker-done-stale",
       stale_registry_done_consolidated: {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3892,6 +3892,8 @@ describe("tool handler integration", () => {
 
   it("spawn_agent waits out a Codex auto-update, relaunches after bare shell, then delivers the boot prompt", async () => {
     vi.useRealTimers();
+    const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
+    process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-relaunch-state");
     const promptPath = join(CHANNEL_TEST_DIR, "spawn-update-relaunch.md");
     const prompt = "boot after update";
@@ -3952,6 +3954,9 @@ describe("tool handler integration", () => {
         const text = String(args.at(-1) ?? "");
         sentTexts.push(text);
         if (text.includes("cmuxlayerCodex")) {
+          if (launcherSends === 0) {
+            delete process.env.REPOGOLEM_ALLOW_MODEL;
+          }
           launcherSends += 1;
         } else if (text === prompt) {
           promptSent = true;
@@ -3997,29 +4002,35 @@ describe("tool handler integration", () => {
     });
     const tool = (server as any)._registeredTools["spawn_agent"];
 
-    const result = await tool.handler(
-      {
-        repo: "cmuxlayer",
-        model: "gpt-5.5",
-        cli: "codex",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 2_000,
-      },
-      {} as any,
-    );
-    const parsed =
-      result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.boot_prompt_delivered).toBe(true);
-    expect(launcherSends).toBe(2);
-    expect(sentTexts.filter((text) => text.includes("cmuxlayerCodex"))).toEqual([
-      "cmuxlayerCodex -s",
-      "cmuxlayerCodex -s",
-    ]);
-    expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
-    expect(returnPresses).toBeGreaterThanOrEqual(3);
-
-    rmSync(stateDir, { recursive: true, force: true });
+    try {
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.boot_prompt_delivered).toBe(true);
+      expect(launcherSends).toBe(2);
+      expect(
+        sentTexts.filter((text) => text.includes("cmuxlayerCodex")),
+      ).toEqual(["cmuxlayerCodex -s -m gpt-5.5", "cmuxlayerCodex -s"]);
+      expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
+      expect(returnPresses).toBeGreaterThanOrEqual(3);
+    } finally {
+      if (previousAllowModel === undefined) {
+        delete process.env.REPOGOLEM_ALLOW_MODEL;
+      } else {
+        process.env.REPOGOLEM_ALLOW_MODEL = previousAllowModel;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   }, 10_000);
 
   it("new_split times out when a CLI auto-update marker never clears", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5269,6 +5269,76 @@ describe("tool handler integration", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
+  it("close_surface consolidates stale live registry when pane shows TASK_DONE", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-done-consolidate");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-done-stale",
+      surface_id: "surface:worker-done-stale",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "finished task",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:worker-done-stale",
+        text: "gpt-5.5 xhigh · 60% left · ~/Gits/brainlayer\nImplemented.\nTASK_DONE",
+        lines: 3,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-done-stale" },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(mockClient.closeSurface).toHaveBeenCalledWith(
+      "surface:worker-done-stale",
+      {
+        workspace: undefined,
+        collapsePane: false,
+      },
+    );
+    expect(stateMgr.readState("worker-done-stale")?.state).toBe("done");
+    expect(result.structuredContent).toMatchObject({
+      surface: "surface:worker-done-stale",
+      stale_registry_done_consolidated: {
+        agent_id: "worker-done-stale",
+        previous_state: "working",
+        done_signal: "TASK_DONE",
+      },
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("close_surface guard is fail-safe when a stale terminal record shares the surface with a live one", async () => {
     const stateDir = join(tmpdir(), "cmuxlayer-close-surface-collision");
     rmSync(stateDir, { recursive: true, force: true });

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -251,14 +251,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 35 (20 low-level + 13 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 36 (20 low-level + 14 agent lifecycle + 2 v2)", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(35);
+    expect(count).toBe(36);
   });
 });
 

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -251,7 +251,7 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 36 (20 low-level + 14 agent lifecycle + 2 v2)", () => {
+  it("total tool count is 36", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",


### PR DESCRIPTION
## Summary
- add lifecycle health evaluation for unmanaged/auto-discovered agents, missing `cli_session_id`, non-resumable workers, stale inbox monitors, registry/screen disagreement, stale workspace placement, topology/role drift, closure without artifacts, and recoverable permission-parking blockers
- make omitted-workspace `spawn_agent` prefer caller pane identity from `CMUX_WORKSPACE_ID` / `CMUX_TAB_ID` before falling back to global selected workspace
- add `supersede_agent_goal`, duplicate same-lane warnings, post-delivery screen evidence, stale-DONE close consolidation, Codex boot-panel readiness, TTY preview cleanup, and recoverable blocker `recommended_actions`
- keep the original Codex launcher model-override guard work on this branch

## Verification
- `bun run test` passed: 58 files, 991 tests
- pre-push hook reran `bun run test` and passed: 58 files, 991 tests
- `bun run typecheck` passed
- `bun run build` passed
- `git diff --check` passed
- `node dist/index.js doctor --json` returned `healthy:true`
- newline-framed MCP stdio smoke against `node dist/index.js` initialized and listed all 36 tools
- local `coderabbit review --agent --type uncommitted` was attempted and timed out after 180s with no findings returned

## Runtime Notes
- Rebuilt `dist/` locally.
- Terminated stale Homebrew cmuxlayer MCP child `/opt/homebrew/Cellar/cmuxlayer/0.2.1/libexec/dist/index.js` after rebuild.
- Did not restart or kill the cmux app.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden cmux agent lifecycle health checks with screen-aware done detection and per-agent health evaluation
> - Adds [src/agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/197/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3), a new module that evaluates per-agent health across multiple dimensions: missing CLI session, monitor liveness, workspace mismatch, closure artifacts, recoverable blockers, and topology issues.
> - Fixes done-state detection in [src/agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/197/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to reject done evidence when the live screen still shows an active agent marker (e.g. Codex waiting for approval), preventing premature task closure.
> - Adds `supersede_agent_goal` tool to deliver a file-backed `/goal` directive to a running agent and update registry metadata, bringing the total tool count to 36.
> - Updates spawn logic to default to the caller's workspace when no explicit workspace is given, and emits a `duplicate_spawn_warning` when an idle/ready same-lane agent already exists unless `force_new` is true.
> - Extends `close_surface` to attempt stale registry consolidation to `done` when the screen shows a done signal with no active agent marker, but still refuses closing if any live agent shares the surface.
> - Adds `screenHasActiveAgentMarker` to [src/pattern-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/197/files#diff-1f1872f4b73cb466921af9511f51f36eab87d558851ccc6f9e68a0a552286b4a) and improves Codex ready/identity detection and recoverable-blocker action parsing in [src/screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/197/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50).
> - Risk: `hasGroundTruthDone` now requires both a quiescent transcript and a non-active screen; agents that previously resolved to done via transcript alone will remain in `working` until the screen clears.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 883ac93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured “agent health” evaluation and included it in lifecycle tool responses (spawn, wait/list/get state, inbox checks, resync, and related delivery flows).
  * Introduced `supersede_agent_goal` for file-backed goal delivery with delivery evidence.
  * Enhanced screen action reporting for recoverable blockers (including formatted “actions:” output).

* **Bug Fixes**
  * Improved ground-truth completion (“done”) confirmation and made boot-prompt recovery more resilient.
  * Tightened Codex model policy and readiness/active-state detection to prevent unintended overrides.

* **Tests**
  * Expanded coverage for health evaluation, Codex parsing/readiness, model-policy drift, and close-surface consolidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core lifecycle transitions (done/boot/close), spawn workspace selection, and adds a mutating supersede tool—misclassification could leave agents stuck or mark them done prematurely.
> 
> **Overview**
> This PR **hardens managed agent lifecycle** so registry state, terminal screens, and collab topology are easier to trust and recover.
> 
> **Done and boot behavior** no longer treats `TASK_DONE` or settled transcripts as completion when the live pane still shows working/waiting/thinking or **recoverable blockers** (parsed as `recoverable_blocker:*` actions). Stale **`boot_prompt_pending`** agents can recover to **ready** via CLI ready patterns instead of failing immediately; **`close_surface`** can consolidate a stale “live” registry to **done** when the pane shows a clean done signal.
> 
> New **`evaluateAgentHealth`** drives **`health`** on spawn, wait, list/get state, inbox, resync, and **`send_to`** (plus registry/screen **`state_conflict`** evidence). Issues cover missing sessions, inbox staleness, registry/screen/workspace drift, topology/role problems, unverified worker closure, and blocker **`recommended_actions`**.
> 
> **Collab-oriented MCP changes**: **`supersede_agent_goal`** (file-backed `/goal`, **`goal_file`** on records, **`resetState`** for supersession); **`spawn_agent`** defaults workspace from caller env / parent, warns on duplicate same-lane idle agents unless **`force_new`**; managed **`workspace_id`** syncs on discovery/resync. **Codex** model `-m` is gated like Cursor unless **`REPOGOLEM_ALLOW_MODEL`**. Screen parsing gains Codex boot-panel readiness, TTY trailer cleanup, and recoverable-blocker detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883ac93842597337181688a3d7902f037fbe3d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->