### PR TITLE
chore: harden pre-pr harness tiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ claude.scratchpad.md
 
 # graphify knowledge graph output (local build artifact)
 graphify-out/
+results/live-agent-harness/
 node_modules
 
 # git worktrees (e.g. isolated PR branches)

--- a/docs/live-agent-harness.md
+++ b/docs/live-agent-harness.md
@@ -1,0 +1,172 @@
+# Live Agent Harness
+
+Deterministic, CI-adjacent live validation for cmuxlayer managed-agent lifecycle.
+
+This harness is **not** part of normal unit CI. It drives a real cmux instance, real
+agent launchers, and local auth/session state through cmuxlayer's stdio MCP server.
+
+## What it proves
+
+For each sequential worker the runner:
+
+1. writes a tiny read-only goal file
+2. calls `spawn_agent` with `boot_prompt_path`
+3. spawns the worker with a sandboxed MCP profile by default
+4. verifies managed id / launcher-model policy
+5. captures verbose `list_surfaces` topology (`selected`, `column`, `column_count`)
+6. waits for file-backed DONE via `wait_for(report_path, done_marker)`
+7. harvests the report marker
+8. closes the worker surface
+9. polls cleanup until no stale managed record or worker surface remains
+
+It writes machine JSON plus human Markdown with an exact final green/red marker.
+The default artifact directory is ignored by git.
+
+## Prerequisites
+
+- cmux app running and reachable (socket or CLI fallback)
+- repo launchers installed (`skillcreatorCursor`, etc.)
+- worker repo checked out locally
+- cmuxlayer built: `bun run build`
+
+Optional:
+
+- `CMUX_SOCKET_PATH` to pin a specific cmux instance
+- `CMUXLAYER_DEV=1` if your MCP config already points at source
+
+## Pre-PR Tier Ladder
+
+Use the deterministic tier for normal local PR hooks and pre-push checks:
+
+```bash
+bun run pre-pr
+```
+
+This runs typecheck plus the fixture-backed harness contract tests. It is
+usage-free: no cmux connection, no agent CLIs, no BrainLayer writes, and no live
+worker artifacts.
+
+The harness-only deterministic tier is:
+
+
+```bash
+bun run pre-pr:harness
+```
+
+This checks the Cursor, Codex, Claude, and Gemini harness contracts with
+fixtures only. It does not connect to cmux, launch agent CLIs, touch BrainLayer,
+or write run artifacts.
+
+Use the explicit live smoke tier only when you are willing to launch one real
+worker:
+
+```bash
+CMUX_LIVE_HARNESS=1 bun run pre-pr:live
+```
+
+`pre-pr:live` delegates to `live:harness`, which defaults to Cursor, `--count 1`,
+and `--mcp-profile sterile`. The script refuses to run unless
+`CMUX_LIVE_HARNESS=1` is present.
+
+Use manual stress only when that is the intended task:
+
+```bash
+CMUX_LIVE_HARNESS=1 bun run live:harness -- --count 8
+```
+
+Do not put the live or stress tiers in normal pre-push hooks; they consume real
+agent usage.
+
+## Local Hook Installer
+
+Install the local pre-push hook explicitly:
+
+```bash
+bun scripts/install-hooks.mjs
+```
+
+The installer writes `.git/hooks/pre-push` with a simple `bun run pre-pr` hook.
+It is never installed or changed automatically.
+
+## Live Runs
+
+Default run directory:
+
+```bash
+CMUX_LIVE_HARNESS=1 \
+bun run live:harness -- \
+  --cli cursor \
+  --repo skill-creator \
+  --workspace workspace:1 \
+  --count 1 \
+  --mcp-profile sterile \
+  --marker-prefix DONE_CURSOR_DUMMY \
+  --final-green GREEN_CURSOR_DUMMY_1_AGENT \
+  --final-red NOT_GREEN_CURSOR_DUMMY_1_AGENT
+```
+
+Explicit run directory:
+
+```bash
+RUN_ROOT="/Users/etanheyman/Gits/orchestrator/collab/2026-06-26-cmux-codex-collab-infra/live-8-agent-test/cursor-dummy-$(date +%Y%m%dT%H%M%S)"
+CMUX_LIVE_HARNESS=1 \
+bun run live:harness -- \
+  --cli cursor \
+  --repo skill-creator \
+  --workspace workspace:1 \
+  --count 8 \
+  --root "$RUN_ROOT" \
+  --mcp-profile sterile \
+  --marker-prefix DONE_CURSOR_DUMMY \
+  --final-green GREEN_CURSOR_DUMMY_8_AGENT \
+  --final-red NOT_GREEN_CURSOR_DUMMY_8_AGENT
+```
+
+Direct script invocation:
+
+```bash
+bun run build
+CMUX_LIVE_HARNESS=1 node scripts/run-live-agent-harness.mjs --root /tmp/cmux-harness-run ...
+```
+
+## Artifacts
+
+Under `--root`:
+
+- `goals/<worker>.md`
+- `reports/<worker>.md` (written by live workers)
+- `mcp-run-results.json`
+- `run-report.md`
+
+The default `results/live-agent-harness/` tree is local scratch and is ignored
+by git. Treat raw harness artifacts as local ignored scratch. Do not
+`brain_store` raw `mcp-run-results.json` payloads or wholesale report trees;
+store only the final summary, final marker, and path to the run when the result
+matters.
+
+The runner defaults to `--mcp-profile sterile` so dummy workers do not inherit
+the normal MCP surface. Use `--mcp-profile skill_eval` or `--mcp-profile inherit`
+only when the test explicitly needs those capabilities.
+
+Exit code `0` only when every worker is green and the final marker matches
+`--final-green`.
+
+## Red conditions
+
+The runner fails red on:
+
+- `spawn_agent` `ok:false`
+- boot prompt typed but not submitted
+- missing report file or wrong DONE marker
+- `wait_for` not reaching `done`
+- duplicate managed id under one run
+- `auto-*` managed id
+- stale managed record after close
+- unexpected extra live worker surfaces in the target workspace
+- worker not in right column / workspace not selected / third column topology
+
+## Scope limits
+
+- Cursor dummy green does **not** prove Codex `cli_session_id` resumability.
+- This is pre-commit-adjacent/local fleet validation, not GitHub Actions unit CI.
+- Helpers in `src/live-agent-harness.ts` are unit-tested; the live loop itself is not.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,11 @@
     "proxy": "node dist/proxy.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "pre-pr": "bun run typecheck && bun run pre-pr:harness",
+    "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/pre-pr-scripts.test.ts",
+    "pre-pr:live": "bun run live:harness",
+    "test:watch": "vitest",
+    "live:harness": "node scripts/run-live-agent-harness.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const hookPath = resolve(repoRoot, ".git", "hooks", "pre-push");
+
+const hook = `#!/bin/sh
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+exec bun run pre-pr
+`;
+
+await mkdir(dirname(hookPath), { recursive: true });
+await writeFile(hookPath, hook, { encoding: "utf8", mode: 0o755 });
+await chmod(hookPath, 0o755);
+
+process.stdout.write(`Installed pre-push hook: ${hookPath}\n`);

--- a/scripts/run-live-agent-harness.mjs
+++ b/scripts/run-live-agent-harness.mjs
@@ -1,0 +1,653 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+let harness;
+
+function usage() {
+  process.stderr.write(`Usage: run-live-agent-harness.mjs [options]
+
+Options:
+  --cli <claude|codex|cursor|gemini|kiro>   Agent CLI (default: cursor)
+  --repo <name>                             Repo name (default: skill-creator)
+  --workspace <ref>                         Workspace ref (default: workspace:1)
+  --count <n>                               Sequential worker count (default: 1)
+  --root <dir>                              Run directory root (default: results/live-agent-harness/<cli>-<timestamp>)
+  --marker-prefix <PREFIX>                  Report marker prefix (default: DONE_CURSOR_DUMMY)
+  --worker-name-prefix <prefix>             Worker name prefix (default: cursor)
+  --final-green <MARKER>                    Final green marker line
+  --final-red <MARKER>                      Final red marker line
+  --mcp-profile <inherit|sterile|skill_eval> Worker MCP profile (default: sterile)
+  --wait-timeout-ms <ms>                    wait_for timeout (default: 300000)
+  --cleanup-timeout-ms <ms>                 close cleanup timeout (default: 10000)
+  --cleanup-poll-ms <ms>                    close cleanup poll interval (default: 500)
+  --server-command <cmd>                    MCP server executable
+  --server-arg <arg>                        Repeatable MCP server arg
+  --help                                    Show help
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    cli: "cursor",
+    repo: "skill-creator",
+    workspace: "workspace:1",
+    count: 1,
+    root: "",
+    markerPrefix: "DONE_CURSOR_DUMMY",
+    workerNamePrefix: "cursor",
+    finalGreen: "GREEN_CURSOR_DUMMY_1_AGENT",
+    finalRed: "NOT_GREEN_CURSOR_DUMMY_1_AGENT",
+    mcpProfile: "sterile",
+    waitTimeoutMs: 300_000,
+    cleanupTimeoutMs: 10_000,
+    cleanupPollMs: 500,
+    serverCommand: "",
+    serverArgs: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        usage();
+        process.exit(0);
+        break;
+      case "--cli":
+        options.cli = argv[++index];
+        break;
+      case "--repo":
+        options.repo = argv[++index];
+        break;
+      case "--workspace":
+        options.workspace = argv[++index];
+        break;
+      case "--count":
+        options.count = Number(argv[++index]);
+        break;
+      case "--root":
+        options.root = resolve(argv[++index]);
+        break;
+      case "--marker-prefix":
+        options.markerPrefix = argv[++index];
+        break;
+      case "--worker-name-prefix":
+        options.workerNamePrefix = argv[++index];
+        break;
+      case "--final-green":
+        options.finalGreen = argv[++index];
+        break;
+      case "--final-red":
+        options.finalRed = argv[++index];
+        break;
+      case "--mcp-profile":
+        options.mcpProfile = argv[++index];
+        break;
+      case "--wait-timeout-ms":
+        options.waitTimeoutMs = Number(argv[++index]);
+        break;
+      case "--cleanup-timeout-ms":
+        options.cleanupTimeoutMs = Number(argv[++index]);
+        break;
+      case "--cleanup-poll-ms":
+        options.cleanupPollMs = Number(argv[++index]);
+        break;
+      case "--server-command":
+        options.serverCommand = argv[++index];
+        break;
+      case "--server-arg":
+        options.serverArgs.push(argv[++index]);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.root === "/path/to/run-dir" || options.root.startsWith("/path/to/")) {
+    throw new Error(
+      "--root received the placeholder path /path/to/run-dir. Pass a real run directory or omit --root to use the default under results/live-agent-harness/.",
+    );
+  }
+  if (!options.root) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    options.root = resolve(
+      REPO_ROOT,
+      "results",
+      "live-agent-harness",
+      `${options.cli}-${stamp}`,
+    );
+  }
+  if (!Number.isFinite(options.count) || options.count < 1) {
+    throw new Error("--count must be a positive integer");
+  }
+  if (!["inherit", "sterile", "skill_eval"].includes(options.mcpProfile)) {
+    throw new Error("--mcp-profile must be one of: inherit, sterile, skill_eval");
+  }
+  if (!Number.isFinite(options.waitTimeoutMs) || options.waitTimeoutMs < 1) {
+    throw new Error("--wait-timeout-ms must be a positive integer");
+  }
+  if (
+    !Number.isFinite(options.cleanupTimeoutMs) ||
+    options.cleanupTimeoutMs < 1
+  ) {
+    throw new Error("--cleanup-timeout-ms must be a positive integer");
+  }
+  if (!Number.isFinite(options.cleanupPollMs) || options.cleanupPollMs < 1) {
+    throw new Error("--cleanup-poll-ms must be a positive integer");
+  }
+  return options;
+}
+
+function assertLiveHarnessOptIn(env = process.env) {
+  if (env.CMUX_LIVE_HARNESS === "1") return;
+  throw new Error(
+    "Refusing to run live cmux/agent harness. Set CMUX_LIVE_HARNESS=1 to opt in.",
+  );
+}
+
+function defaultServerCommand() {
+  const distEntry = join(REPO_ROOT, "dist", "index.js");
+  return {
+    command: process.execPath,
+    args: [distEntry],
+  };
+}
+
+class McpStdioClient {
+  constructor(command, args, env = process.env) {
+    this.nextId = 1;
+    this.pending = new Map();
+    this.buffer = "";
+    this.closed = false;
+    this.stderr = "";
+    this.child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env,
+    });
+    this.child.stdout.setEncoding("utf8");
+    this.child.stderr.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk) => this.onStdout(chunk));
+    this.child.stderr.on("data", (chunk) => {
+      this.stderr += chunk;
+    });
+    this.child.on("close", () => {
+      this.closed = true;
+      for (const [, pending] of this.pending) {
+        pending.reject(new Error("MCP server exited"));
+      }
+      this.pending.clear();
+    });
+  }
+
+  onStdout(chunk) {
+    this.buffer += chunk;
+    let newlineIndex = this.buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = this.buffer.slice(0, newlineIndex).trim();
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        this.onMessage(JSON.parse(line));
+      }
+      newlineIndex = this.buffer.indexOf("\n");
+    }
+  }
+
+  onMessage(message) {
+    if (typeof message.id !== "number") return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    if (message.error) {
+      pending.reject(
+        new Error(message.error.message ?? JSON.stringify(message.error)),
+      );
+      return;
+    }
+    pending.resolve(message.result ?? {});
+  }
+
+  send(message) {
+    if (this.closed) {
+      throw new Error("MCP server already closed");
+    }
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  request(method, params, timeoutMs = 120_000) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out waiting for ${method} after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  async initialize() {
+    await this.request("initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: {
+        name: "cmuxlayer-live-agent-harness",
+        version: "0.1.0",
+      },
+    });
+    this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  }
+
+  async callTool(name, args, timeoutMs) {
+    const result = await this.request(
+      "tools/call",
+      { name, arguments: args },
+      timeoutMs,
+    );
+    return harness.parseToolPayload(result);
+  }
+
+  close() {
+    this.child.stdin.end();
+    this.child.kill("SIGTERM");
+  }
+}
+
+function recordEvent(events, event) {
+  events.push({ at: new Date().toISOString(), ...event });
+}
+
+function countBaselineWorkerSurfaces(topology, workerTitlePattern) {
+  return topology?.workerSurfacesInWorkspace.length ?? 0;
+}
+
+async function ensureGoalFiles(config, specs) {
+  await mkdir(join(config.root, "goals"), { recursive: true });
+  await mkdir(join(config.root, "reports"), { recursive: true });
+  for (const spec of specs) {
+    await writeFile(
+      spec.goal,
+      harness.buildWorkerGoalContent(spec.name, spec.report, spec.marker),
+      "utf8",
+    );
+  }
+}
+
+async function readReportIfExists(reportPath) {
+  try {
+    return await readFile(reportPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => {
+    setTimeout(resolveSleep, ms);
+  });
+}
+
+function errorLooksNotFound(call) {
+  const text = `${call?.error ?? ""}\n${call?.text ?? ""}`;
+  return /not found/i.test(text);
+}
+
+function listIncludesAgent(call, agentId) {
+  const agents = call?.structured?.agents;
+  if (!agentId || !Array.isArray(agents)) return false;
+  return agents.some((agent) => {
+    if (typeof agent !== "object" || agent === null) return false;
+    const id =
+      typeof agent.agent_id === "string"
+        ? agent.agent_id
+        : typeof agent.id === "string"
+          ? agent.id
+          : "";
+    return id === agentId;
+  });
+}
+
+function listIncludesSurface(call, surfaceId) {
+  const surfaces = call?.structured?.surfaces;
+  if (!surfaceId || !Array.isArray(surfaces)) return false;
+  return surfaces.some((surface) => {
+    if (typeof surface !== "object" || surface === null) return false;
+    return surface.ref === surfaceId || surface.id === surfaceId;
+  });
+}
+
+async function pollCloseCleanup(client, config, worker) {
+  const startedAt = Date.now();
+  let attempts = 0;
+  let stateAfterClose;
+  let agentsAfterClose;
+  let surfacesAfterClose;
+
+  while (Date.now() - startedAt <= config.cleanupTimeoutMs) {
+    attempts += 1;
+    if (worker.agent_id) {
+      stateAfterClose = await client.callTool("get_agent_state", {
+        agent_id: worker.agent_id,
+      });
+    }
+    agentsAfterClose = await client.callTool("list_agents", {
+      repo: config.repo,
+    });
+    surfacesAfterClose = await client.callTool("list_surfaces", {
+      workspace: config.workspace,
+      verbose: true,
+    });
+
+    const stateGone =
+      !worker.agent_id ||
+      stateAfterClose?.ok === false ||
+      errorLooksNotFound(stateAfterClose);
+    const agentListed = listIncludesAgent(agentsAfterClose, worker.agent_id);
+    const surfacePresent = listIncludesSurface(
+      surfacesAfterClose,
+      worker.surface_id,
+    );
+
+    if (stateGone && !agentListed && !surfacePresent) {
+      break;
+    }
+
+    await sleep(config.cleanupPollMs);
+  }
+
+  return {
+    stateAfterClose,
+    agentsAfterClose,
+    surfacesAfterClose,
+    attempts,
+  };
+}
+
+async function main() {
+  assertLiveHarnessOptIn();
+  const cliOptions = parseArgs(process.argv.slice(2));
+  harness = await import("../dist/live-agent-harness.js");
+  const config = {
+    cli: cliOptions.cli,
+    repo: cliOptions.repo,
+    workspace: cliOptions.workspace,
+    count: cliOptions.count,
+    root: cliOptions.root,
+    markerPrefix: cliOptions.markerPrefix,
+    workerNamePrefix: cliOptions.workerNamePrefix,
+    finalGreen: cliOptions.finalGreen,
+    finalRed: cliOptions.finalRed,
+    mcpProfile: cliOptions.mcpProfile,
+    waitTimeoutMs: cliOptions.waitTimeoutMs,
+    cleanupTimeoutMs: cliOptions.cleanupTimeoutMs,
+    cleanupPollMs: cliOptions.cleanupPollMs,
+    workerTitlePattern:
+      cliOptions.cli === "cursor"
+        ? /cursor agent/i
+        : new RegExp(`${cliOptions.cli}`, "i"),
+  };
+
+  const specs = harness.buildWorkerSpecs(config);
+  await ensureGoalFiles(config, specs);
+
+  const server =
+    cliOptions.serverCommand.length > 0
+      ? {
+          command: cliOptions.serverCommand,
+          args: cliOptions.serverArgs,
+        }
+      : defaultServerCommand();
+
+  const results = {
+    started_at: new Date().toISOString(),
+    config,
+    workers: [],
+    events: [],
+  };
+
+  const client = new McpStdioClient(server.command, server.args, process.env);
+  const seenAgentIds = new Set();
+  let baselineWorkerSurfaceCount = 0;
+
+  try {
+    await client.initialize();
+
+    recordEvent(results.events, { step: "baseline" });
+    results.baseline_agents = await client.callTool("list_agents", {
+      repo: config.repo,
+    });
+    const baselineSurfaces = await client.callTool("list_surfaces", {
+      workspace: config.workspace,
+      verbose: true,
+    });
+    results.baseline_surfaces = baselineSurfaces;
+    const baselineTopology = harness.summarizeTopology(
+      baselineSurfaces.structured,
+      config.workspace,
+      null,
+      config.workerTitlePattern,
+    );
+    baselineWorkerSurfaceCount = countBaselineWorkerSurfaces(
+      baselineTopology,
+      config.workerTitlePattern,
+    );
+
+    for (const spec of specs) {
+      const worker = {
+        name: spec.name,
+        goal: spec.goal,
+        report: spec.report,
+        marker: spec.marker,
+        started_at: new Date().toISOString(),
+      };
+      results.workers.push(worker);
+      recordEvent(results.events, {
+        worker: spec.name,
+        step: "spawn_start",
+      });
+
+      worker.spawn = await client.callTool(
+        "spawn_agent",
+        {
+          repo: config.repo,
+          cli: config.cli,
+          role: "worker",
+          workspace: config.workspace,
+          force_new: true,
+          boot_prompt_path: spec.goal,
+          mcp_profile: config.mcpProfile,
+        },
+        config.waitTimeoutMs,
+      );
+
+      worker.agent_id =
+        typeof worker.spawn.structured?.agent_id === "string"
+          ? worker.spawn.structured.agent_id
+          : undefined;
+      worker.surface_id =
+        typeof worker.spawn.structured?.surface_id === "string"
+          ? worker.spawn.structured.surface_id
+          : typeof worker.spawn.structured?.surface === "string"
+            ? worker.spawn.structured.surface
+            : undefined;
+      worker.duplicate_agent_id =
+        Boolean(worker.agent_id) && seenAgentIds.has(worker.agent_id);
+      if (worker.agent_id) {
+        seenAgentIds.add(worker.agent_id);
+      }
+
+      recordEvent(results.events, {
+        worker: spec.name,
+        step: "spawn_done",
+        agent_id: worker.agent_id,
+        surface_id: worker.surface_id,
+        ok: worker.spawn.ok === true,
+        health:
+          typeof worker.spawn.structured?.health === "object" &&
+          worker.spawn.structured.health !== null
+            ? worker.spawn.structured.health.status
+            : undefined,
+        issues:
+          typeof worker.spawn.structured?.health === "object" &&
+          worker.spawn.structured.health !== null &&
+          Array.isArray(worker.spawn.structured.health.issue_codes)
+            ? worker.spawn.structured.health.issue_codes
+            : [],
+      });
+
+      if (worker.agent_id) {
+        worker.state_after_spawn = await client.callTool("get_agent_state", {
+          agent_id: worker.agent_id,
+        });
+      }
+
+      worker.surfaces_after_spawn = await client.callTool("list_surfaces", {
+        workspace: config.workspace,
+        verbose: true,
+      });
+      worker.topology = harness.summarizeTopology(
+        worker.surfaces_after_spawn.structured,
+        config.workspace,
+        worker.surface_id ?? null,
+        config.workerTitlePattern,
+      );
+      worker.topology.text = worker.surfaces_after_spawn.text;
+
+      recordEvent(results.events, { worker: spec.name, step: "wait_start" });
+      if (worker.agent_id) {
+        worker.wait = await client.callTool(
+          "wait_for",
+          {
+            agent_id: worker.agent_id,
+            target_state: "done",
+            timeout_ms: config.waitTimeoutMs,
+            report_path: spec.report,
+            done_marker: spec.marker,
+          },
+          config.waitTimeoutMs + 30_000,
+        );
+      }
+
+      recordEvent(results.events, {
+        worker: spec.name,
+        step: "wait_done",
+        wait_state:
+          typeof worker.wait?.structured?.state === "string"
+            ? worker.wait.structured.state
+            : undefined,
+        ok: worker.wait?.ok === true,
+      });
+
+      worker.report_text = await readReportIfExists(spec.report);
+      worker.report_missing = worker.report_text == null;
+      if (worker.report_text) {
+        worker.report_final_line = worker.report_text
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .at(-1);
+      }
+
+      if (worker.agent_id) {
+        worker.state_after_done = await client.callTool("get_agent_state", {
+          agent_id: worker.agent_id,
+        });
+      }
+
+      if (worker.surface_id) {
+        worker.close = await client.callTool("close_surface", {
+          surface: worker.surface_id,
+          workspace: config.workspace,
+        });
+      }
+
+      const cleanup = await pollCloseCleanup(client, config, worker);
+      worker.state_after_close = cleanup.stateAfterClose;
+      worker.agents_after_close = cleanup.agentsAfterClose;
+      worker.surfaces_after_close = cleanup.surfacesAfterClose;
+      worker.cleanup_attempts = cleanup.attempts;
+
+      worker.stale_state = harness.isStaleManagedRecord(
+        worker.state_after_close,
+        worker.agents_after_close,
+        worker.agent_id,
+      );
+
+      worker.failures = harness.classifyWorkerFailures({
+        repo: config.repo,
+        cli: config.cli,
+        workspace: config.workspace,
+        marker: spec.marker,
+        spawn: worker.spawn,
+        wait: worker.wait,
+        reportText: worker.report_text ?? undefined,
+        reportMissing: worker.report_missing,
+        duplicateAgentId: worker.duplicate_agent_id,
+        agentId: worker.agent_id,
+        topology: worker.topology,
+        stateAfterSpawnText: worker.state_after_spawn?.text,
+        stateAfterClose: worker.state_after_close,
+        agentsAfterClose: worker.agents_after_close,
+        surfacesAfterClose: worker.surfaces_after_close,
+        baselineWorkerSurfaceCount,
+        workerTitlePattern: config.workerTitlePattern,
+      });
+
+      worker.green = harness.workerIsGreen(worker.failures);
+      worker.finished_at = new Date().toISOString();
+
+      recordEvent(results.events, {
+        worker: spec.name,
+        step: "closed",
+        final_line: worker.report_final_line,
+        stale_state: worker.stale_state,
+        green: worker.green,
+        failures: worker.failures,
+      });
+    }
+  } finally {
+    results.stderr = client.stderr.trim() || undefined;
+    results.finished_at = new Date().toISOString();
+    client.close();
+  }
+
+  const summary = harness.summarizeHarnessRun(results.workers);
+  results.green = summary.green;
+  results.final_marker = summary.green
+    ? config.finalGreen
+    : config.finalRed;
+
+  const jsonPath = join(config.root, "mcp-run-results.json");
+  const reportPath = join(config.root, "run-report.md");
+  const workerFailures = Object.fromEntries(
+    results.workers.map((worker) => [worker.name, worker.failures ?? []]),
+  );
+  const reportMarkdown = harness.buildRunReportMarkdown(results, workerFailures);
+
+  await writeFile(jsonPath, `${JSON.stringify(results, null, 2)}\n`, "utf8");
+  await writeFile(reportPath, reportMarkdown, "utf8");
+
+  process.stdout.write(`${reportMarkdown}\n`);
+  process.exit(summary.green ? 0 : 1);
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/live-agent-harness.ts
+++ b/src/live-agent-harness.ts
@@ -1,0 +1,572 @@
+import type { CliType } from "./agent-types.js";
+import { MODEL_POLICY_CONTRACT } from "./model-policy.js";
+
+export interface HarnessWorkerSpec {
+  name: string;
+  index: number;
+  goal: string;
+  report: string;
+  marker: string;
+}
+
+export interface HarnessRunConfig {
+  cli: CliType;
+  repo: string;
+  workspace: string;
+  count: number;
+  root: string;
+  markerPrefix: string;
+  workerNamePrefix: string;
+  finalGreen: string;
+  finalRed: string;
+  mcpProfile: "inherit" | "sterile" | "skill_eval";
+  waitTimeoutMs: number;
+  cleanupTimeoutMs: number;
+  cleanupPollMs: number;
+  workerTitlePattern: RegExp;
+}
+
+export interface TopologySnapshot {
+  workspaceRef: string;
+  selectedWorkspaceRef: string | null;
+  focusedWorkspaceRef: string | null;
+  columnCount: number | null;
+  workerSurfaceRef: string | null;
+  workerColumn: number | null;
+  workerSurfacesInWorkspace: string[];
+  surfaces: Array<Record<string, unknown>>;
+  workspaces: Array<Record<string, unknown>>;
+  text?: string;
+}
+
+export interface ToolCallRecord {
+  text?: string;
+  ok?: boolean;
+  error?: string;
+  structured?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface WorkerRunRecord {
+  name: string;
+  goal: string;
+  report: string;
+  marker: string;
+  started_at: string;
+  finished_at?: string;
+  spawn?: ToolCallRecord;
+  agent_id?: string;
+  surface_id?: string;
+  duplicate_agent_id?: boolean;
+  state_after_spawn?: ToolCallRecord;
+  surfaces_after_spawn?: ToolCallRecord;
+  topology?: TopologySnapshot;
+  wait?: ToolCallRecord;
+  report_text?: string;
+  report_final_line?: string;
+  report_missing?: boolean;
+  state_after_done?: ToolCallRecord;
+  close?: ToolCallRecord;
+  state_after_close?: ToolCallRecord;
+  agents_after_close?: ToolCallRecord;
+  surfaces_after_close?: ToolCallRecord;
+  cleanup_attempts?: number;
+  stale_state?: boolean;
+  failures?: string[];
+  green?: boolean;
+}
+
+export interface HarnessRunResults {
+  started_at: string;
+  finished_at?: string;
+  config: HarnessRunConfig;
+  stderr?: string;
+  baseline_agents?: ToolCallRecord;
+  baseline_surfaces?: ToolCallRecord;
+  workers: WorkerRunRecord[];
+  events: Array<Record<string, unknown>>;
+  green?: boolean;
+  final_marker?: string;
+}
+
+const CLI_LAUNCHER_SUFFIX: Record<CliType, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+  gemini: "Gemini",
+  kiro: "Kiro",
+};
+
+export function formatWorkerIndex(index: number): string {
+  return String(index).padStart(2, "0");
+}
+
+export function formatWorkerName(prefix: string, index: number): string {
+  return `${prefix}-${formatWorkerIndex(index)}`;
+}
+
+export function formatWorkerMarker(prefix: string, index: number): string {
+  return `${prefix}_${formatWorkerIndex(index)}`;
+}
+
+export function buildWorkerGoalContent(
+  workerName: string,
+  reportPath: string,
+  marker: string,
+): string {
+  return `# ${workerName} Goal
+
+You are \`${workerName}\` in a read-only cmux live harness test.
+
+Run exactly:
+
+\`\`\`bash
+pwd
+command -v cmuxlayer
+\`\`\`
+
+Write a report to:
+
+\`${reportPath}\`
+
+The report must include:
+
+- \`pwd\` output
+- \`command -v cmuxlayer\` output
+- \`Status: COMPLETE\`
+
+The final report line must be exactly:
+
+\`${marker}\`
+`;
+}
+
+export function buildWorkerSpecs(
+  config: HarnessRunConfig,
+): HarnessWorkerSpec[] {
+  const specs: HarnessWorkerSpec[] = [];
+  for (let index = 1; index <= config.count; index += 1) {
+    const name = formatWorkerName(config.workerNamePrefix, index);
+    specs.push({
+      name,
+      index,
+      goal: `${config.root}/goals/${name}.md`,
+      report: `${config.root}/reports/${name}.md`,
+      marker: formatWorkerMarker(config.markerPrefix, index),
+    });
+  }
+  return specs;
+}
+
+export function isAutoAgentId(agentId: string | undefined): boolean {
+  return typeof agentId === "string" && agentId.startsWith("auto-");
+}
+
+export function expectedManagedAgentPrefix(repo: string, cli: CliType): string {
+  return `${repo}${CLI_LAUNCHER_SUFFIX[cli]}-`;
+}
+
+export function isManagedAgentId(
+  agentId: string | undefined,
+  repo: string,
+  cli: CliType,
+): boolean {
+  if (!agentId || isAutoAgentId(agentId)) return false;
+  return agentId.startsWith(expectedManagedAgentPrefix(repo, cli));
+}
+
+export function extractReportFinalLine(reportText: string): string {
+  const lines = reportText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return lines.at(-1) ?? "";
+}
+
+export function reportMarkerMatches(
+  reportText: string | undefined,
+  expectedMarker: string,
+): boolean {
+  if (!reportText) return false;
+  return extractReportFinalLine(reportText) === expectedMarker;
+}
+
+export function parseToolPayload(
+  result: Record<string, unknown> | null | undefined,
+): ToolCallRecord {
+  if (!result) {
+    return { ok: false, error: "missing tool result" };
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  const textBlock = content.find(
+    (block): block is { type: string; text?: string } =>
+      typeof block === "object" &&
+      block !== null &&
+      (block as { type?: string }).type === "text",
+  );
+  const text = typeof textBlock?.text === "string" ? textBlock.text : undefined;
+  const structured =
+    typeof result.structuredContent === "object" &&
+    result.structuredContent !== null
+      ? (result.structuredContent as Record<string, unknown>)
+      : undefined;
+  const ok =
+    structured && typeof structured.ok === "boolean"
+      ? structured.ok
+      : result.isError
+        ? false
+        : undefined;
+  const error =
+    structured && typeof structured.error === "string"
+      ? structured.error
+      : undefined;
+  return {
+    text,
+    ok,
+    error,
+    structured,
+    isError: Boolean(result.isError),
+  };
+}
+
+export function summarizeTopology(
+  structured: Record<string, unknown> | undefined,
+  workspaceRef: string,
+  workerSurfaceRef: string | null,
+  workerTitlePattern: RegExp,
+): TopologySnapshot {
+  const workspaces = Array.isArray(structured?.workspaces)
+    ? (structured.workspaces as Array<Record<string, unknown>>)
+    : [];
+  const surfaces = Array.isArray(structured?.surfaces)
+    ? (structured.surfaces as Array<Record<string, unknown>>)
+    : [];
+  const selectedWorkspaceRef =
+    workspaces.find((workspace) => workspace.selected === true)?.ref ??
+    (typeof structured?.workspace_ref === "string"
+      ? structured.workspace_ref
+      : null);
+  const focusedWorkspaceRef =
+    workspaces.find((workspace) => workspace.focused === true)?.ref ?? null;
+  const columnCount =
+    typeof structured?.column_count === "number"
+      ? structured.column_count
+      : null;
+  const workerSurface = workerSurfaceRef
+    ? surfaces.find((surface) => surface.ref === workerSurfaceRef)
+    : undefined;
+  const workerColumn =
+    workerSurface && typeof workerSurface.column === "number"
+      ? workerSurface.column
+      : null;
+  const workerSurfacesInWorkspace = surfaces
+    .filter((surface) => {
+      if (surface.workspace_ref !== workspaceRef) return false;
+      const title = typeof surface.title === "string" ? surface.title : "";
+      return workerTitlePattern.test(title);
+    })
+    .map((surface) => String(surface.ref ?? ""));
+
+  return {
+    workspaceRef,
+    selectedWorkspaceRef:
+      typeof selectedWorkspaceRef === "string" ? selectedWorkspaceRef : null,
+    focusedWorkspaceRef:
+      typeof focusedWorkspaceRef === "string" ? focusedWorkspaceRef : null,
+    columnCount,
+    workerSurfaceRef,
+    workerColumn,
+    workerSurfacesInWorkspace,
+    surfaces,
+    workspaces,
+  };
+}
+
+export function validateLauncherPolicy(
+  stateText: string | undefined,
+): string[] {
+  const failures: string[] = [];
+  if (!stateText) return failures;
+  const resumeMatch = stateText.match(/resume:\s*(.+)/);
+  if (resumeMatch && /skill-creatorCursor\b/.test(resumeMatch[1])) {
+    failures.push("launcher_uses_hyphenated_skill-creatorCursor");
+  }
+  if (/\s-m\s/.test(stateText) || /\s--model\s/.test(stateText)) {
+    failures.push("launcher_passes_visible_model_flag");
+  }
+  return failures;
+}
+
+export function validateSpawnModelPolicy(
+  structured: Record<string, unknown> | undefined,
+  cli: CliType,
+): string[] {
+  const failures: string[] = [];
+  if (!structured) return ["spawn_missing_structured_payload"];
+  const model = typeof structured.model === "string" ? structured.model : "";
+  const requestedModel =
+    typeof structured.requested_model === "string"
+      ? structured.requested_model
+      : "";
+  const expectedDefault = MODEL_POLICY_CONTRACT.cli[cli].defaultModel;
+  if (requestedModel.trim().length > 0) {
+    failures.push("spawn_requested_model_should_be_omitted");
+  }
+  if (model !== expectedDefault) {
+    failures.push(`spawn_model_not_default:${model || "missing"}`);
+  }
+  return failures;
+}
+
+export function isBootPromptSubmitted(
+  structured: Record<string, unknown> | undefined,
+): boolean {
+  if (!structured) return false;
+  if (structured.boot_prompt_submit_verified === true) return true;
+  return structured.boot_prompt_delivered === true;
+}
+
+export function isStaleManagedRecord(
+  stateAfterClose: ToolCallRecord | undefined,
+  agentsAfterClose: ToolCallRecord | undefined,
+  agentId: string | undefined,
+): boolean {
+  if (!agentId) return false;
+  if (stateAfterClose?.ok === true) return true;
+  const agents = agentsAfterClose?.structured?.agents;
+  if (!Array.isArray(agents)) return false;
+  return agents.some((agent) => {
+    if (typeof agent !== "object" || agent === null) return false;
+    const id =
+      typeof (agent as { agent_id?: unknown }).agent_id === "string"
+        ? (agent as { agent_id: string }).agent_id
+        : typeof (agent as { id?: unknown }).id === "string"
+          ? (agent as { id: string }).id
+          : "";
+    return id === agentId;
+  });
+}
+
+export function countUnexpectedWorkerSurfaces(
+  topology: TopologySnapshot | undefined,
+  baselineWorkerSurfaceCount: number,
+  phase: "after_spawn" | "after_close",
+): number {
+  if (!topology) return phase === "after_close" ? 1 : 0;
+  const observed = topology.workerSurfacesInWorkspace.length;
+  const expected =
+    phase === "after_spawn"
+      ? baselineWorkerSurfaceCount + 1
+      : baselineWorkerSurfaceCount;
+  return Math.max(0, observed - expected);
+}
+
+export function classifyWorkerFailures(input: {
+  repo: string;
+  cli: CliType;
+  workspace: string;
+  marker: string;
+  spawn?: ToolCallRecord;
+  wait?: ToolCallRecord;
+  reportText?: string;
+  reportMissing?: boolean;
+  duplicateAgentId?: boolean;
+  agentId?: string;
+  topology?: TopologySnapshot;
+  stateAfterSpawnText?: string;
+  stateAfterClose?: ToolCallRecord;
+  agentsAfterClose?: ToolCallRecord;
+  surfacesAfterClose?: ToolCallRecord;
+  baselineWorkerSurfaceCount: number;
+  workerTitlePattern: RegExp;
+}): string[] {
+  const failures: string[] = [];
+
+  if (!input.spawn || input.spawn.ok !== true) {
+    failures.push("spawn_ok_false");
+    if (input.spawn?.error) {
+      failures.push(`spawn_error:${input.spawn.error}`);
+    }
+  } else {
+    failures.push(
+      ...validateSpawnModelPolicy(input.spawn.structured, input.cli),
+    );
+    if (!isBootPromptSubmitted(input.spawn.structured)) {
+      failures.push("boot_prompt_not_submitted");
+    }
+  }
+
+  if (!isManagedAgentId(input.agentId, input.repo, input.cli)) {
+    failures.push("managed_agent_id_invalid");
+  }
+  if (isAutoAgentId(input.agentId)) {
+    failures.push("managed_agent_id_is_auto");
+  }
+  if (input.duplicateAgentId) {
+    failures.push("duplicate_managed_agent_id");
+  }
+
+  failures.push(...validateLauncherPolicy(input.stateAfterSpawnText));
+
+  if (input.topology) {
+    if (input.topology.selectedWorkspaceRef !== input.workspace) {
+      failures.push("workspace_not_selected");
+    }
+    if (input.topology.workerColumn !== 1) {
+      failures.push(
+        `worker_not_in_right_column:${input.topology.workerColumn ?? "missing"}`,
+      );
+    }
+    if (
+      typeof input.topology.columnCount === "number" &&
+      input.topology.columnCount > 2
+    ) {
+      failures.push(`unexpected_column_count:${input.topology.columnCount}`);
+    }
+    if (
+      countUnexpectedWorkerSurfaces(
+        input.topology,
+        input.baselineWorkerSurfaceCount,
+        "after_spawn",
+      ) > 0
+    ) {
+      failures.push("unexpected_extra_worker_surfaces_after_spawn");
+    }
+  }
+
+  if (input.surfacesAfterClose?.structured) {
+    const afterCloseTopology = summarizeTopology(
+      input.surfacesAfterClose.structured,
+      input.workspace,
+      null,
+      input.workerTitlePattern,
+    );
+    if (
+      countUnexpectedWorkerSurfaces(
+        afterCloseTopology,
+        input.baselineWorkerSurfaceCount,
+        "after_close",
+      ) > 0
+    ) {
+      failures.push("unexpected_extra_worker_surfaces_after_close");
+    }
+  }
+
+  if (!input.wait || input.wait.ok !== true) {
+    failures.push("wait_for_not_ok");
+  } else {
+    const waitState =
+      typeof input.wait.structured?.state === "string"
+        ? input.wait.structured.state
+        : "";
+    if (waitState !== "done") {
+      failures.push(`wait_for_state_${waitState || "missing"}`);
+    }
+  }
+
+  if (input.reportMissing || !input.reportText) {
+    failures.push("report_missing");
+  } else if (!reportMarkerMatches(input.reportText, input.marker)) {
+    failures.push("report_marker_mismatch");
+  }
+
+  if (
+    isStaleManagedRecord(
+      input.stateAfterClose,
+      input.agentsAfterClose,
+      input.agentId,
+    )
+  ) {
+    failures.push("stale_managed_record_after_close");
+  }
+
+  return failures;
+}
+
+export function workerIsGreen(failures: string[]): boolean {
+  return failures.length === 0;
+}
+
+export function summarizeHarnessRun(workers: WorkerRunRecord[]): {
+  green: boolean;
+  finalMarker: string;
+  workerFailures: Record<string, string[]>;
+} {
+  const workerFailures: Record<string, string[]> = {};
+  let green = true;
+  for (const worker of workers) {
+    const failures = worker.failures ?? [];
+    workerFailures[worker.name] = failures;
+    if (!workerIsGreen(failures)) {
+      green = false;
+    }
+  }
+  return { green, workerFailures, finalMarker: "" };
+}
+
+export function buildRunReportMarkdown(
+  results: HarnessRunResults,
+  workerFailures: Record<string, string[]>,
+): string {
+  const lines: string[] = [
+    `# Live Agent Harness Run Report`,
+    "",
+    `Started: ${results.started_at}`,
+    `Finished: ${results.finished_at ?? "in progress"}`,
+    "",
+    "## Config",
+    "",
+    `- CLI: \`${results.config.cli}\``,
+    `- Repo: \`${results.config.repo}\``,
+    `- Workspace: \`${results.config.workspace}\``,
+    `- Workers: ${results.config.count}`,
+    `- Root: \`${results.config.root}\``,
+    `- MCP profile: \`${results.config.mcpProfile}\``,
+    `- Cleanup timeout: ${results.config.cleanupTimeoutMs}ms`,
+    "",
+    "## Worker Summary",
+    "",
+    "| Worker | Agent ID | Spawn | Wait | Report | Failures |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+
+  for (const worker of results.workers) {
+    const failures = workerFailures[worker.name] ?? worker.failures ?? [];
+    lines.push(
+      `| ${worker.name} | \`${worker.agent_id ?? "—"}\` | ${worker.spawn?.ok === true ? "ok" : "fail"} | ${worker.wait?.structured && worker.wait.structured.state === "done" ? "done" : "fail"} | ${worker.report_missing ? "missing" : (worker.report_final_line ?? "—")} | ${failures.length === 0 ? "—" : failures.join(", ")} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Artifacts",
+    "",
+    `- JSON: \`${results.config.root}/mcp-run-results.json\``,
+    "",
+  );
+
+  const allFailures = results.workers.flatMap(
+    (worker) => worker.failures ?? [],
+  );
+  const finalMarker =
+    allFailures.length === 0
+      ? results.config.finalGreen
+      : results.config.finalRed;
+
+  lines.push("## Verdict", "");
+  if (allFailures.length === 0) {
+    lines.push("All workers passed the live harness checks.", "");
+  } else {
+    lines.push("One or more workers failed live harness checks.", "");
+    lines.push("Primary failures:", "");
+    for (const worker of results.workers) {
+      const failures = worker.failures ?? [];
+      if (failures.length === 0) continue;
+      lines.push(`- ${worker.name}: ${failures.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(finalMarker);
+  return `${lines.join("\n")}\n`;
+}

--- a/tests/live-agent-harness-ci.test.ts
+++ b/tests/live-agent-harness-ci.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import type { CliType } from "../src/agent-types.js";
+import {
+  buildRunReportMarkdown,
+  buildWorkerGoalContent,
+  buildWorkerSpecs,
+  classifyWorkerFailures,
+  expectedManagedAgentPrefix,
+  isStaleManagedRecord,
+  summarizeHarnessRun,
+  workerIsGreen,
+} from "../src/live-agent-harness.js";
+import { MODEL_POLICY_CONTRACT } from "../src/model-policy.js";
+
+const PRE_PR_CLIS: CliType[] = ["cursor", "codex", "claude", "gemini"];
+
+function configFor(cli: CliType) {
+  return {
+    cli,
+    repo: "skill-creator",
+    workspace: "workspace:1",
+    count: 1,
+    root: `/tmp/cmux-pre-pr-${cli}`,
+    markerPrefix: `DONE_${cli.toUpperCase()}_DUMMY`,
+    workerNamePrefix: cli,
+    finalGreen: `GREEN_${cli.toUpperCase()}_DUMMY_1_AGENT`,
+    finalRed: `NOT_GREEN_${cli.toUpperCase()}_DUMMY_1_AGENT`,
+    mcpProfile: "sterile" as const,
+    waitTimeoutMs: 300_000,
+    cleanupTimeoutMs: 10_000,
+    cleanupPollMs: 500,
+    workerTitlePattern: new RegExp(`${cli} agent`, "i"),
+  };
+}
+
+function greenFailuresFor(cli: CliType): string[] {
+  const config = configFor(cli);
+  const spec = buildWorkerSpecs(config)[0];
+  const agentId = `${expectedManagedAgentPrefix("skill-creator", cli)}abc123`;
+  return classifyWorkerFailures({
+    repo: config.repo,
+    cli,
+    workspace: config.workspace,
+    marker: spec.marker,
+    spawn: {
+      ok: true,
+      structured: {
+        ok: true,
+        model: MODEL_POLICY_CONTRACT.cli[cli].defaultModel,
+        requested_model: "",
+        boot_prompt_submit_verified: true,
+      },
+    },
+    wait: { ok: true, structured: { state: "done" } },
+    reportText: `Status: COMPLETE\n${spec.marker}\n`,
+    reportMissing: false,
+    duplicateAgentId: false,
+    agentId,
+    topology: {
+      workspaceRef: config.workspace,
+      selectedWorkspaceRef: config.workspace,
+      focusedWorkspaceRef: config.workspace,
+      columnCount: 2,
+      workerSurfaceRef: "surface:worker",
+      workerColumn: 1,
+      workerSurfacesInWorkspace: ["surface:worker"],
+      surfaces: [],
+      workspaces: [],
+    },
+    stateAfterSpawnText: `agent_id: ${agentId}`,
+    stateAfterClose: {
+      ok: false,
+      error: `Agent not found: ${agentId}`,
+    },
+    agentsAfterClose: { ok: true, structured: { agents: [] } },
+    surfacesAfterClose: {
+      ok: true,
+      structured: {
+        surfaces: [],
+        workspaces: [{ ref: config.workspace, selected: true }],
+      },
+    },
+    baselineWorkerSurfaceCount: 0,
+    workerTitlePattern: config.workerTitlePattern,
+  });
+}
+
+describe("pre-PR live harness contract without live workers", () => {
+  it.each(PRE_PR_CLIS)(
+    "has a deterministic green path for %s without spawning agents",
+    (cli) => {
+      expect(workerIsGreen(greenFailuresFor(cli))).toBe(true);
+    },
+  );
+
+  it.each(PRE_PR_CLIS)(
+    "uses sterile MCP profile in generated %s harness config",
+    (cli) => {
+      expect(configFor(cli).mcpProfile).toBe("sterile");
+    },
+  );
+
+  it.each(PRE_PR_CLIS)(
+    "builds a read-only worker goal for %s without BrainLayer instructions",
+    (cli) => {
+      const config = configFor(cli);
+      const spec = buildWorkerSpecs(config)[0];
+      const content = buildWorkerGoalContent(
+        spec.name,
+        spec.report,
+        spec.marker,
+      );
+      expect(content).toContain("read-only cmux live harness test");
+      expect(content).toContain("command -v cmuxlayer");
+      expect(content).not.toMatch(/brain_store|BrainLayer/i);
+    },
+  );
+
+  it("fails red when cleanup leaves a directly resolvable managed record", () => {
+    const agentId = "skill-creatorCursor-abc123";
+    expect(
+      isStaleManagedRecord(
+        { ok: true, structured: { agent_id: agentId } },
+        { ok: true, structured: { agents: [] } },
+        agentId,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps final report markers deterministic", () => {
+    const config = configFor("cursor");
+    const spec = buildWorkerSpecs(config)[0];
+    const worker = {
+      name: spec.name,
+      goal: spec.goal,
+      report: spec.report,
+      marker: spec.marker,
+      started_at: "2026-06-27T00:00:00.000Z",
+      agent_id: "skill-creatorCursor-abc123",
+      spawn: { ok: true },
+      wait: { ok: true, structured: { state: "done" } },
+      report_missing: false,
+      report_final_line: spec.marker,
+      failures: [],
+      green: true,
+    };
+    const summary = summarizeHarnessRun([worker]);
+    const markdown = buildRunReportMarkdown(
+      {
+        started_at: "2026-06-27T00:00:00.000Z",
+        finished_at: "2026-06-27T00:00:01.000Z",
+        config,
+        workers: [worker],
+        events: [],
+      },
+      summary.workerFailures,
+    );
+    expect(markdown).toContain(config.finalGreen);
+    expect(markdown).not.toContain(config.finalRed);
+  });
+});

--- a/tests/live-agent-harness.test.ts
+++ b/tests/live-agent-harness.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkerGoalContent,
+  buildWorkerSpecs,
+  classifyWorkerFailures,
+  extractReportFinalLine,
+  formatWorkerMarker,
+  formatWorkerName,
+  isAutoAgentId,
+  isBootPromptSubmitted,
+  isManagedAgentId,
+  isStaleManagedRecord,
+  parseToolPayload,
+  reportMarkerMatches,
+  summarizeTopology,
+  validateLauncherPolicy,
+  validateSpawnModelPolicy,
+  workerIsGreen,
+} from "../src/live-agent-harness.js";
+
+describe("live-agent-harness helpers", () => {
+  it("formats worker names and markers deterministically", () => {
+    expect(formatWorkerName("cursor", 1)).toBe("cursor-01");
+    expect(formatWorkerMarker("DONE_CURSOR_DUMMY", 8)).toBe(
+      "DONE_CURSOR_DUMMY_08",
+    );
+  });
+
+  it("builds worker specs from config", () => {
+    const specs = buildWorkerSpecs({
+      cli: "cursor",
+      repo: "skill-creator",
+      workspace: "workspace:1",
+      count: 2,
+      root: "/tmp/run",
+      markerPrefix: "DONE_CURSOR_DUMMY",
+      workerNamePrefix: "cursor",
+      finalGreen: "GREEN",
+      finalRed: "RED",
+      mcpProfile: "sterile",
+      waitTimeoutMs: 1000,
+      cleanupTimeoutMs: 10_000,
+      cleanupPollMs: 500,
+      workerTitlePattern: /cursor agent/i,
+    });
+    expect(specs).toHaveLength(2);
+    expect(specs[0].goal).toBe("/tmp/run/goals/cursor-01.md");
+    expect(specs[1].marker).toBe("DONE_CURSOR_DUMMY_02");
+  });
+
+  it("builds read-only worker goal content", () => {
+    const content = buildWorkerGoalContent(
+      "cursor-03",
+      "/tmp/reports/cursor-03.md",
+      "DONE_CURSOR_DUMMY_03",
+    );
+    expect(content).toContain("cursor-03");
+    expect(content).toContain("command -v cmuxlayer");
+    expect(content).toContain("DONE_CURSOR_DUMMY_03");
+  });
+
+  it("detects managed and auto agent ids", () => {
+    expect(isAutoAgentId("auto-codex-surface-123")).toBe(true);
+    expect(
+      isManagedAgentId("skill-creatorCursor-abc123", "skill-creator", "cursor"),
+    ).toBe(true);
+    expect(
+      isManagedAgentId("auto-codex-surface-123", "skill-creator", "cursor"),
+    ).toBe(false);
+  });
+
+  it("parses MCP tool payloads from structured content", () => {
+    const parsed = parseToolPayload({
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: {
+        ok: true,
+        agent_id: "skill-creatorCursor-1",
+        boot_prompt_delivered: true,
+      },
+    });
+    expect(parsed.ok).toBe(true);
+    expect(parsed.structured?.agent_id).toBe("skill-creatorCursor-1");
+  });
+
+  it("validates report markers from final line", () => {
+    const report = "Status: COMPLETE\n\nDONE_CURSOR_DUMMY_01\n";
+    expect(extractReportFinalLine(report)).toBe("DONE_CURSOR_DUMMY_01");
+    expect(reportMarkerMatches(report, "DONE_CURSOR_DUMMY_01")).toBe(true);
+    expect(reportMarkerMatches(report, "DONE_CURSOR_DUMMY_02")).toBe(false);
+  });
+
+  it("accepts boot prompt submission evidence", () => {
+    expect(isBootPromptSubmitted({ boot_prompt_submit_verified: true })).toBe(
+      true,
+    );
+    expect(isBootPromptSubmitted({ boot_prompt_delivered: true })).toBe(true);
+    expect(isBootPromptSubmitted({ boot_prompt_delivered: false })).toBe(false);
+  });
+
+  it("enforces cursor spawn model policy defaults", () => {
+    expect(
+      validateSpawnModelPolicy(
+        { model: "auto", requested_model: "" },
+        "cursor",
+      ),
+    ).toEqual([]);
+    expect(
+      validateSpawnModelPolicy(
+        { model: "sonnet", requested_model: "" },
+        "cursor",
+      ),
+    ).toContain("spawn_model_not_default:sonnet");
+  });
+
+  it("flags hyphenated cursor launcher resume commands", () => {
+    expect(
+      validateLauncherPolicy(
+        "resume: skill-creatorCursor -s --resume abc\nagent_id: skill-creatorCursor-abc",
+      ),
+    ).toContain("launcher_uses_hyphenated_skill-creatorCursor");
+    expect(
+      validateLauncherPolicy(
+        "resume: skillcreatorCursor -s --resume abc\nagent_id: skill-creatorCursor-abc",
+      ),
+    ).toEqual([]);
+  });
+
+  it("summarizes topology from verbose list_surfaces payload", () => {
+    const topology = summarizeTopology(
+      {
+        workspace_ref: "workspace:1",
+        column_count: 2,
+        workspaces: [
+          { ref: "workspace:1", selected: true },
+          { ref: "workspace:2", selected: false },
+        ],
+        surfaces: [
+          {
+            ref: "surface:1",
+            title: "skill-creator",
+            workspace_ref: "workspace:1",
+            column: 0,
+          },
+          {
+            ref: "surface:2",
+            title: "Cursor Agent",
+            workspace_ref: "workspace:1",
+            column: 1,
+          },
+        ],
+      },
+      "workspace:1",
+      "surface:2",
+      /cursor agent/i,
+    );
+    expect(topology.selectedWorkspaceRef).toBe("workspace:1");
+    expect(topology.workerColumn).toBe(1);
+    expect(topology.workerSurfacesInWorkspace).toEqual(["surface:2"]);
+  });
+
+  it("detects stale managed records after close", () => {
+    expect(
+      isStaleManagedRecord(
+        { ok: true, structured: { agent_id: "skill-creatorCursor-1" } },
+        undefined,
+        "skill-creatorCursor-1",
+      ),
+    ).toBe(true);
+    expect(
+      isStaleManagedRecord(
+        { ok: false, error: "Agent not found: skill-creatorCursor-1" },
+        { structured: { agents: [] } },
+        "skill-creatorCursor-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("classifies worker failures for common red cases", () => {
+    const failures = classifyWorkerFailures({
+      repo: "skill-creator",
+      cli: "cursor",
+      workspace: "workspace:1",
+      marker: "DONE_CURSOR_DUMMY_01",
+      spawn: {
+        ok: false,
+        error: "Boot prompt delivery failed",
+      },
+      wait: { ok: false, structured: { state: "error" } },
+      reportMissing: true,
+      duplicateAgentId: false,
+      agentId: "auto-codex-surface-1",
+      baselineWorkerSurfaceCount: 0,
+      workerTitlePattern: /cursor agent/i,
+    });
+    expect(failures).toContain("spawn_ok_false");
+    expect(failures).toContain("managed_agent_id_invalid");
+    expect(failures).toContain("report_missing");
+    expect(workerIsGreen(failures)).toBe(false);
+  });
+});

--- a/tests/pre-pr-scripts.test.ts
+++ b/tests/pre-pr-scripts.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(__dirname, "..");
+
+function packageScripts(): Record<string, string> {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  return pkg.scripts;
+}
+
+describe("pre-PR script ladder", () => {
+  it("keeps the default pre-pr gate deterministic and usage-free", () => {
+    const scripts = packageScripts();
+
+    expect(scripts["pre-pr"]).toContain("bun run typecheck");
+    expect(scripts["pre-pr"]).toContain("bun run pre-pr:harness");
+    expect(scripts["pre-pr"]).not.toContain("live:harness");
+    expect(scripts["pre-pr"]).not.toContain("pre-pr:live");
+  });
+
+  it("exposes an explicit live pre-pr tier through the live harness", () => {
+    const scripts = packageScripts();
+
+    expect(scripts["pre-pr:live"]).toBe("bun run live:harness");
+  });
+
+  it("refuses the live harness unless CMUX_LIVE_HARNESS=1 is set", () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(repoRoot, "scripts", "run-live-agent-harness.mjs"), "--help"],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, CMUX_LIVE_HARNESS: "" },
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("CMUX_LIVE_HARNESS=1");
+  });
+
+  it("defaults the live harness to one sterile Cursor worker", () => {
+    const script = readFileSync(
+      join(repoRoot, "scripts", "run-live-agent-harness.mjs"),
+      "utf8",
+    );
+
+    expect(script).toContain('cli: "cursor"');
+    expect(script).toContain("count: 1");
+    expect(script).toContain('mcpProfile: "sterile"');
+    expect(script).not.toContain("count: 8");
+  });
+
+  it("keeps the hook installer explicit and transparent", () => {
+    const script = readFileSync(
+      join(repoRoot, "scripts", "install-hooks.mjs"),
+      "utf8",
+    );
+
+    expect(script).toContain(".git");
+    expect(script).toContain("pre-push");
+    expect(script).toContain("exec bun run pre-pr");
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic `pre-pr` and `pre-pr:harness` gates for typecheck plus fixture-backed harness contracts
- add explicit `pre-pr:live` / `live:harness` path gated by `CMUX_LIVE_HARNESS=1`, defaulting to one sterile Cursor worker
- add a transparent local hook installer and docs for deterministic, live-smoke, and manual-stress tiers

## Test plan
- [x] `bun run test` - 61 files, 1071 tests passed
- [x] `bun run build && bun run pre-pr` - build, typecheck, and 31 deterministic harness/script tests passed
- [x] `node scripts/run-live-agent-harness.mjs --help` without `CMUX_LIVE_HARNESS=1` exits 1 and refuses live execution
- [x] push hook ran `scripts/run_tests.sh` successfully, including full Vitest suite: 61 files, 1071 tests passed

## Review notes
- Local `coderabbit review --agent` was invoked before commit with a 180s timeout. It connected and began analysis, but timed out without returning findings.
- Live workers were not run; this PR intentionally makes live workers explicit opt-in.

## Working tree note
- Unrelated unstaged runtime edits and local scratch directories were present before this PR loop and are not included in this branch/PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default pre-pr is usage-free; live harness can spawn real agents and validate spawn/model/topology policy when explicitly enabled, but does not modify core MCP server behavior in this diff.
> 
> **Overview**
> Introduces a **tiered pre-PR workflow**: default `pre-pr` runs typecheck plus fixture-only harness contract tests (no cmux, no agent CLIs); optional `pre-pr:live` / `live:harness` drives real workers only when `CMUX_LIVE_HARNESS=1`.
> 
> Adds **`src/live-agent-harness.ts`** (worker specs, topology summarization, spawn/wait/report/cleanup failure classification, markdown/JSON reporting) and **`scripts/run-live-agent-harness.mjs`**, which talks to the built cmuxlayer MCP server over stdio and sequentially exercises `spawn_agent`, `wait_for`, and `close_surface` with sterile MCP profile by default.
> 
> Adds **`scripts/install-hooks.mjs`** to opt-in install a pre-push hook that runs `bun run pre-pr`, documents the ladder in **`docs/live-agent-harness.md`**, and ignores **`results/live-agent-harness/`** artifacts. Vitest suites lock script wiring, opt-in refusal, and per-CLI green contracts without live workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d970edb128c275bfb9d5d5c37ca3d0d150b3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live agent harness and pre-PR script ladder with git hook installer
> - Adds [`scripts/run-live-agent-harness.mjs`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-30a43e915e6ca4f59e966331e9dfc85691ba296086564137484c9dd12043a4b8), a CLI that drives a real MCP stdio server and agent CLIs to validate agent lifecycle, writing JSON and Markdown reports under `results/live-agent-harness/`.
> - Adds [`src/live-agent-harness.ts`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-863315af5dca599c9644590952ba3185e4c9d1a58323999b1836c75447c3fcb2) with helpers for worker spec generation, failure classification, topology summarization, and Markdown report building.
> - Introduces a `pre-pr` script ladder in [`package.json`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519): `pre-pr` runs typecheck + deterministic harness tests; `pre-pr:live` and `live:harness` opt into the live runner via `CMUX_LIVE_HARNESS=1`.
> - Adds [`scripts/install-hooks.mjs`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-a7ce0f645252b5b37ca92f730a1c35962b74b4d1f9421880f47fc690db622c72) to write a `.git/hooks/pre-push` hook that invokes `bun run pre-pr`.
> - Adds deterministic CI tests in [`tests/live-agent-harness-ci.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-bfc5ca4056c272d47af4cabe47a761be6a359eff219d9e7913126f0b0b825b0a) and unit tests in [`tests/live-agent-harness.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/198/files#diff-b51d17076eacf5f9a0ebc8753a260545a8b1701adc161a707b8b672cc6c5c362) covering all harness helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 77d970e. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live validation harness for agent lifecycle checks, including new run commands and generated reports.
  * Added repository hook installation support to automatically run pre-push checks.
  * Added documentation for running, gating, and interpreting harness results.

* **Tests**
  * Expanded automated coverage for harness behavior, script wiring, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->