### PR TITLE
chore(naming): call the MCP layer "cmuxlayer", not "cmux"

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1454,14 +1454,14 @@ export class AgentEngine {
         this.registry.remove(agentId);
         await this.client.log(
           `crash-recovery: dropped missing agent ${agentId} after failure`,
-          { level: "warning", source: "cmux-mcp" },
+          { level: "warning", source: "cmuxlayer" },
         );
         return;
       }
 
       await this.client.log(
         `crash-recovery: failed to persist error for ${agentId}: ${persistMessage}`,
-        { level: "error", source: "cmux-mcp" },
+        { level: "error", source: "cmuxlayer" },
       );
     }
   }
@@ -1473,7 +1473,7 @@ export class AgentEngine {
     this.registry.set(agent.agent_id, updated);
     await this.client.log(
       `crash-recovery: max crash recoveries exceeded for ${agent.agent_id}`,
-      { level: "error", source: "cmux-mcp" },
+      { level: "error", source: "cmuxlayer" },
     );
   }
 
@@ -1545,7 +1545,7 @@ export class AgentEngine {
         );
         await this.client.log(
           `crash-recovery: respawned ${agent.agent_id} on ${surface.surface}`,
-          { level: "warning", source: "cmux-mcp" },
+          { level: "warning", source: "cmuxlayer" },
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1566,7 +1566,7 @@ export class AgentEngine {
     const spec = LIFECYCLE_LOGS[event];
     await this.client.log(`${spec.message}: ${agent.repo}`, {
       level: spec.level,
-      source: "cmux-mcp",
+      source: "cmuxlayer",
     });
 
     try {
@@ -1695,7 +1695,7 @@ export class AgentEngine {
             } else {
               await this.client.log(
                 `context-limit: depth ${agent.spawn_depth} agent ${repo} degraded; leaving pane running for orchestrator decision`,
-                { level: "warning", source: "cmux-mcp" },
+                { level: "warning", source: "cmuxlayer" },
               );
             }
           }
@@ -1831,7 +1831,7 @@ export class AgentEngine {
       try {
         await this.runSweep();
       } catch (e) {
-        console.error("[cmux-mcp] sweep failed (will retry):", e);
+        console.error("[cmuxlayer] sweep failed (will retry):", e);
       } finally {
         this.recordSweepStability();
         if (this.sweepTiming) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,5 @@
 /**
- * Beautiful terminal output formatting for cmux MCP tool responses.
+ * Beautiful terminal output formatting for cmuxlayer MCP tool responses.
  *
  * Uses Unicode box-drawing characters for clean, professional display.
  * No ANSI color codes (MCP tool output doesn't support them in Claude Code).

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -399,7 +399,7 @@ export function collectRoleSurfaceIds(
       if (isAgentRoleInferenceError(error)) {
         ids.unknown?.add(agent.surface_id);
         console.warn(
-          `[cmux-mcp] Unable to classify agent role for ${agent.surface_id}; not counting it as a worker`,
+          `[cmuxlayer] Unable to classify agent role for ${agent.surface_id}; not counting it as a worker`,
           error.message,
         );
         continue;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /**
- * cmux MCP server — registers core tools + agent lifecycle tools.
+ * cmuxlayer MCP server — registers core tools + agent lifecycle tools.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -1124,7 +1124,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   const server = new McpServer(
     {
-      name: "@golems/cmux-mcp",
+      name: "@golems/cmuxlayer",
       version: "0.1.0",
     },
     enableClaudeChannels
@@ -1406,7 +1406,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     context.controlHealthTimer = setInterval(() => {
       appendControlHealthSnapshot().catch((error) => {
         console.error(
-          "[cmux-mcp] control_health periodic sample failed:",
+          "[cmuxlayer] control_health periodic sample failed:",
           error,
         );
       });
@@ -4483,7 +4483,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .reconstitute()
         .then(() => engine.enableStartupPurge())
         .catch((e) =>
-          console.error("[cmux-mcp] registry reconstitution failed:", e),
+          console.error("[cmuxlayer] registry reconstitution failed:", e),
         );
       engine.startSweep(resolveSweepTiming());
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-// Shared types for cmux MCP server
+// Shared types for cmuxlayer MCP server
 
 export type ControlMode = "autonomous" | "manual";
 export type IntentMode = "chat" | "audit";

--- a/tests/naming-convention.test.ts
+++ b/tests/naming-convention.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Deterministic guard for the cmux vs cmuxlayer naming distinction.
+ *
+ *   - `cmux`      = the terminal app / terminal CLI / terminal surfaces
+ *                   (a separate product: github.com/manaflow-ai/cmux).
+ *   - `cmuxlayer` = THIS repo — the MCP server / managed-agent / orchestration
+ *                   layer that sits on top of cmux.
+ *
+ * The repo's own voice (source, docs, README, CLAUDE.md) must call the layer
+ * `cmuxlayer`, never `cmux MCP` / `cmux-mcp` / `cmux.layer` / `cmux layer`.
+ * Legitimate references to the cmux terminal app, the `cmux` CLI binary, the
+ * cmux socket, or the `CMUX_SOCKET_PATH` env var are NOT matched by these
+ * patterns and stay as-is.
+ *
+ * Test fixtures under tests/ that simulate *agent* prose (an agent loosely
+ * saying "the cmux MCP transport closed") are intentionally out of scope —
+ * that is third-party voice, not the repo describing itself.
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Each pattern collapses the cmux/cmuxlayer distinction when it appears in the
+// repo's own voice. Note: "cmuxlayer" never matches — there is no separator
+// between "cmux" and the following token, which every pattern requires.
+const FORBIDDEN: Array<{ re: RegExp; why: string }> = [
+  {
+    re: /cmux[ ._-]mcp/i,
+    why: 'use "cmuxlayer" (the layer), not "cmux MCP"/"cmux-mcp"',
+  },
+  {
+    re: /cmux[ .]layer/i,
+    why: 'the layer is one word: "cmuxlayer", not "cmux layer"/"cmux.layer"',
+  },
+  { re: /cmuxMcp/, why: 'use a cmuxlayer-based identifier, not "cmuxMcp"' },
+];
+
+const SCAN_EXT = new Set([".ts", ".md"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".git",
+  "tests",
+  "fixtures",
+]);
+
+function collectFiles(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      collectFiles(full, out);
+    } else if (SCAN_EXT.has(entry.slice(entry.lastIndexOf(".")))) {
+      out.push(full);
+    }
+  }
+}
+
+function ownVoiceFiles(): string[] {
+  const out: string[] = [];
+  collectFiles(join(repoRoot, "src"), out);
+  if (existsSync(join(repoRoot, "docs")))
+    collectFiles(join(repoRoot, "docs"), out);
+  for (const top of ["README.md", "CLAUDE.md"]) {
+    const full = join(repoRoot, top);
+    if (existsSync(full)) out.push(full);
+  }
+  return out;
+}
+
+describe("cmux vs cmuxlayer naming convention", () => {
+  it("the repo's own voice never collapses the distinction", () => {
+    const offenders: string[] = [];
+    for (const file of ownVoiceFiles()) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        for (const { re, why } of FORBIDDEN) {
+          if (re.test(line)) {
+            offenders.push(
+              `${relative(repoRoot, file)}:${i + 1}  ${line.trim()}\n      -> ${why}`,
+            );
+          }
+        }
+      });
+    }
+    expect(
+      offenders,
+      `Found references that confuse the cmux terminal app with the cmuxlayer MCP layer:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("scans a non-trivial number of own-voice files (guard is actually wired up)", () => {
+    expect(ownVoiceFiles().length).toBeGreaterThan(5);
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5806,7 +5806,7 @@ describe("registry reconstitution error logging", () => {
     }
 
     expect(console.error).toHaveBeenCalledWith(
-      "[cmux-mcp] registry reconstitution failed:",
+      "[cmuxlayer] registry reconstitution failed:",
       expect.any(Error),
     );
   });

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -243,7 +243,7 @@ describe("Sidebar Sync", () => {
 
     expect(mockClient.log).toHaveBeenCalledWith(
       "spawned: brainlayer",
-      expect.objectContaining({ level: "info", source: "cmux-mcp" }),
+      expect.objectContaining({ level: "info", source: "cmuxlayer" }),
     );
     expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
       "spawned",
@@ -277,7 +277,7 @@ describe("Sidebar Sync", () => {
 
     expect(mockClient.log).toHaveBeenCalledWith(
       "done: brainlayer",
-      expect.objectContaining({ level: "success", source: "cmux-mcp" }),
+      expect.objectContaining({ level: "success", source: "cmuxlayer" }),
     );
     expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
       "done",
@@ -305,7 +305,7 @@ describe("Sidebar Sync", () => {
 
     expect(mockClient.log).toHaveBeenCalledWith(
       "errored: brainlayer",
-      expect.objectContaining({ level: "error", source: "cmux-mcp" }),
+      expect.objectContaining({ level: "error", source: "cmuxlayer" }),
     );
     expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
       "errored",


### PR DESCRIPTION
## What

Disambiguate the two products this repo straddles so agents and users stop confusing them:

- **`cmux`** = the terminal app / CLI / terminal surfaces ([manaflow-ai/cmux](https://github.com/manaflow-ai/cmux))
- **`cmuxlayer`** = THIS MCP / managed-agent / orchestration layer

## Canonical decision

The layer's canonical name is **`cmuxlayer`** (already the `package.json` name). The repo's own-voice references to the layer are renamed; true `cmux` terminal-app/CLI references are left as-is.

### Changed (own-voice → cmuxlayer)
- MCP server identity `@golems/cmux-mcp` → `@golems/cmuxlayer` (server.ts)
- File-header comments "cmux MCP server/responses" → "cmuxlayer MCP …" (server.ts, types.ts, format.ts)
- Sidebar/event-log telemetry `source: "cmux-mcp"` → `source: "cmuxlayer"` (agent-engine.ts) — this is what attributes lifecycle events in the cmux sidebar to the layer
- Console log prefixes `[cmux-mcp]` → `[cmuxlayer]` (agent-engine.ts, layout-policy.ts, server.ts)
- Mirrored the label changes in the asserting tests (sidebar-sync, server)

### Left untouched (true `cmux` terminal app / CLI)
`CMUX_SOCKET_PATH`, `cmux socket-path`, the `cmux` binary, socket paths, the github URL, and the `notify` "cmux notification banner" (the banner is genuinely a cmux UI surface). A simulated-agent test fixture in screen-parser.test.ts saying "cmux MCP transport" is preserved — that's third-party agent prose, not the repo's own voice.

## Compatibility
- The MCP server `name` string is advertised in the initialize handshake but no client keys off it — clients reference the server by the `mcpServers` config key (`cmux`, in the out-of-repo golems config), which is **not** changed here. Safe rename.
- `source` / log-prefix labels are internal, free-form display strings with no external consumer keying off the literal.

## Regression guard
`tests/naming-convention.test.ts` fails if the repo's own voice (src/, docs/, README, CLAUDE.md) ever reintroduces `cmux MCP` / `cmux-mcp` / `cmux.layer` / `cmux layer` / `cmuxMcp`. Test fixtures are excluded by design (they may simulate agent prose).

## Verification
- `bun run typecheck` — clean
- `bun run build` — clean
- `bun run test` — 1074 passed (63 files), including the new guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label-only and documentation renames plus a new lint-style test; no runtime behavior or wire protocol changes beyond the MCP initialize `name` string, which clients are not expected to depend on.
> 
> **Overview**
> Renames the repo’s **own-voice** branding from `cmux-mcp` / “cmux MCP” to **`cmuxlayer`**, so the MCP/orchestration layer is not confused with the separate **cmux** terminal app.
> 
> The MCP server advertises **`@golems/cmuxlayer`** instead of `@golems/cmux-mcp`. Lifecycle sidebar logs, crash-recovery messages, and internal `console.error` prefixes now use **`source: "cmuxlayer"`** and **`[cmuxlayer]`**. Header comments in `server.ts`, `types.ts`, and `format.ts` are updated to match.
> 
> Adds **`tests/naming-convention.test.ts`** to scan `src/`, docs, and top-level markdown and fail if forbidden patterns (`cmux-mcp`, `cmux MCP`, `cmux layer`, etc.) reappear. Existing tests that assert log `source` and registry error prefixes are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb910d5891d14d64c84497ff42af297b3ec0595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename MCP layer identifier from `cmux-mcp` to `cmuxlayer` across source and tests
> Renames all occurrences of the old `cmux-mcp` identifier to `cmuxlayer` to distinguish this repo from the `cmux` terminal app. Updates log `source` metadata, console error/warn prefixes, and the MCP server name (`@golems/cmuxlayer`) in [`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/200/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5), [`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/200/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), and [`src/layout-policy.ts`](https://github.com/EtanHey/cmuxlayer/pull/200/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed). Adds a Vitest naming-convention suite in [`tests/naming-convention.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/200/files#diff-10dc28afa4915247b7a4997532b45c71e6928c7a6b80257d2008e5e7aaf3411d) that enforces the distinction going forward by scanning `src`, `docs`, and top-level docs files for forbidden patterns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fb910d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->