### PR TITLE
fix(mcp): serverInfo name @golems/cmuxlayer -> cmuxlayer (match layers family)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1124,7 +1124,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   const server = new McpServer(
     {
-      name: "@golems/cmuxlayer",
+      name: "cmuxlayer",
       version: "0.1.0",
     },
     enableClaudeChannels


### PR DESCRIPTION
The MCP advertised `@golems/cmuxlayer`, so in `/mcp` it read as belonging to **golems** while its siblings on the same `etanhey/layers` brew tap advertise as plain `brainlayer` / `voicelayer`. Drop the `@golems/` scope → plain **`cmuxlayer`**.

Verified the convention: probing the live voicelayer MCP returns `serverInfo.name: "voicelayer"` (no scope).

1-line change, 1074 tests pass. No test asserted the old name.

Follow-up (separate): serverInfo `version` is still hardcoded `0.1.0` vs the real package version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic MCP metadata only; no runtime logic, auth, or tool behavior changes.
> 
> **Overview**
> Changes the MCP **`serverInfo.name`** sent at initialize from **`@golems/cmuxlayer`** to **`cmuxlayer`**, so clients and `/mcp` listings show the same unscoped id as sibling **layers** servers (e.g. `voicelayer`, `brainlayer`).
> 
> Behavior and tools are unchanged; only the advertised server identity string in `McpServer` construction in `server.ts` is updated. **`serverInfo.version`** remains hardcoded `0.1.0` (not part of this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c5aba04e686649531ace9967b6dbb19dc3ee14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `McpServer` name from `@golems/cmuxlayer` to `cmuxlayer`
> Updates the `name` metadata passed to the `McpServer` constructor in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/202/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to match the naming convention used by the layers family.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22c5aba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->