### PR TITLE
fix(mcp): report real package version in serverInfo (was 0.1.0)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
 import { constants as fsConstants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -1122,10 +1123,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  let PKG_VERSION = "0.0.0";
+  try {
+    PKG_VERSION = (
+      createRequire(import.meta.url)("../package.json") as { version: string }
+    ).version;
+  } catch {
+    // package.json not resolvable from here - keep the fallback.
+  }
+
   const server = new McpServer(
     {
       name: "cmuxlayer",
-      version: "0.1.0",
+      version: PKG_VERSION,
     },
     enableClaudeChannels
       ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }


### PR DESCRIPTION
serverInfo.version was hardcoded `0.1.0` while the package shipped 0.2.x — so `/mcp` showed a stale version next to siblings (voicelayer reports its real version). Now read from package.json via `createRequire` (the brew formula installs package.json into libexec alongside dist), with a safe `0.0.0` fallback.

Verified: `serverInfo: {name:'cmuxlayer', version:'0.2.9'}`. 12-line diff, 1074 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change at server construction; no tool or lifecycle behavior affected beyond the reported version string.
> 
> **Overview**
> **MCP `serverInfo.version`** no longer uses the hardcoded `0.1.0` string. At startup, `createServer` loads `../package.json` with `createRequire(import.meta.url)` and passes that `version` into `McpServer` initialization so clients (e.g. `/mcp`) see the shipped semver (0.2.x). If `package.json` cannot be resolved, the server advertises **`0.0.0`** instead of failing startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0227a926575a87fda72554c513400979694ce8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report real package version in `createServer` serverInfo instead of hardcoded `0.1.0`
> Reads the version from `package.json` at runtime using `createRequire(import.meta.url)` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/203/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), replacing the hardcoded `"0.1.0"` passed to the `McpServer` constructor. Falls back to `"0.0.0"` if `package.json` cannot be resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0227a92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The server version is now determined automatically at runtime, so it stays aligned with the app’s packaged version.
  * If version information can’t be loaded, the server now safely falls back to a default value instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->