### PR TITLE
fix(boot): accept cleared composer submit evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ Two axes per surface:
 ### Claude Channels (Preview)
 Set `CMUXLAYER_ENABLE_CLAUDE_CHANNELS=1` to enable one-way lifecycle notifications via `notifications/claude/channel`.
 
+### Boot-prompt submit tuning
+`CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS` (positive integer, default `2000`) overrides how long a boot
+prompt's Enter is verified before delivery falls back to readiness/composer-cleared evidence. Raise
+it for agents that stream their first tokens slowly (e.g. Opus-4.8/1M, Gemini on multi-KB prompts) if
+you still see false `Enter submit could not be verified` errors; invalid values fall back to the default.
+
 ## Testing Conventions
 - Test files mirror source: `src/foo.ts` -> `tests/foo.test.ts`
 - Agent engine tests use 1-second timeouts for state change detection

--- a/src/server.ts
+++ b/src/server.ts
@@ -154,7 +154,18 @@ const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
 const SEND_INPUT_ENTER_DELAY_MS = 50;
 const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
-const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
+const DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
+function parsePositiveIntegerMs(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = parsePositiveIntegerMs(
+  process.env.CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS,
+  DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
+);
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
@@ -1494,7 +1505,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
+      const hasClearedAgentComposer =
+        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+        !hasPendingInput;
       if (opts.require_working_status) {
+        if (retried && hasClearedAgentComposer) {
+          // Slow-to-stream boot prompts can clear the composer before the CLI
+          // renders a parsed working marker; identity + cleared input is enough
+          // evidence after the recovery Return has been attempted.
+          return { submit_verified: true, retry_count: retryCount };
+        }
+
         if (!retried) {
           await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
           await sendKeyWithRetry(opts.surface, "return", opts.workspace);
@@ -1517,9 +1538,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       if (
-        (screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) ||
-          opts.allow_non_agent_clear === true) &&
-        !hasPendingInput
+        hasClearedAgentComposer ||
+        (opts.allow_non_agent_clear === true && !hasPendingInput)
       ) {
         // The submitted text is no longer echoed in the input box: the terminal
         // accepted it and cleared the prompt. For agent surfaces this catches
@@ -1761,6 +1781,45 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
   };
 
+  const waitForBootPromptSubmitEvidence = async (opts: {
+    surface: string;
+    workspace?: string;
+    text: string;
+    timeout_ms: number;
+  }): Promise<void> => {
+    const start = Date.now();
+    let lastText = "";
+
+    while (Date.now() - start < opts.timeout_ms) {
+      const snapshot = await readParsedSurface(opts.surface, opts.workspace);
+      if (snapshot) {
+        lastText = snapshot.text;
+        const hasPendingInput = screenShowsPendingInput(
+          snapshot.text,
+          opts.text,
+        );
+        if (
+          isSubmitVerifiedStatus(snapshot.parsed.status) ||
+          (screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+            !hasPendingInput)
+        ) {
+          return;
+        }
+      }
+
+      const remaining = opts.timeout_ms - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(BOOT_PROMPT_READY_POLL_MS, remaining));
+    }
+
+    throw new BootPromptTimeoutError(
+      `Timed out after ${opts.timeout_ms}ms waiting for boot prompt submit evidence on ${opts.surface}`,
+      tailLines(lastText, 10),
+    );
+  };
+
   const waitForLaunchShellReady = async (opts: {
     surface: string;
     workspace?: string;
@@ -1947,6 +2006,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       return { ...delivery, prompt_text: rawPrompt };
     } catch (error) {
+      if (error instanceof SubmitVerificationError) {
+        const snapshot = await readParsedSurface(opts.surface, opts.workspace);
+        if (
+          !snapshot ||
+          !screenShowsPendingInput(snapshot.text, sanitizedText)
+        ) {
+          await waitForBootPromptSubmitEvidence({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            text: sanitizedText,
+            timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
+          });
+          return {
+            bytes: Buffer.byteLength(sanitizedText, "utf8"),
+            retry_count: error.retry_count,
+            submit_verified: true,
+            prompt_text: rawPrompt,
+          };
+        }
+      }
+
       const deliveredChars = chunks
         .slice(0, sentChunks)
         .reduce((sum, chunk) => sum + chunk.length, 0);
@@ -3269,7 +3349,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: true,
             source_event: "send_command",
-            verify_submit: shouldVerifySubmit,
+            verify_submit: bootPromptPath ? false : shouldVerifySubmit,
           }),
         );
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1868,6 +1868,57 @@ describe("tool handler integration", () => {
     );
   });
 
+  it("send_command accepts a cleared Claude boot prompt before a working marker streams", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "slow-claude.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let promptSent = false;
+    let returnPresses = 0;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: "Claude Code\nWhat can I help you with?\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
+    expect(returnPresses).toBe(3);
+  }, 10_000);
+
   it("send_command reports timeout with last screen lines and leaves launcher surface alive", async () => {
     const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -4480,7 +4531,7 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBe(2);
   }, 10_000);
 
-  it("new_split fails when the boot prompt clears after retry but the agent stays idle", async () => {
+  it("new_split fails when the boot prompt clears after retry without agent identity", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-idle-after-clear.md");
     const prompt = "short boot prompt";
@@ -4515,9 +4566,11 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:2",
             text:
-              !promptSent || returnPresses >= 1
+              !promptSent
                 ? "codex> "
-                : `codex> ${prompt}`,
+                : returnPresses >= 1
+                  ? "> "
+                  : `> ${prompt}`,
             lines: 80,
             scrollback_used: false,
           }),
@@ -4534,6 +4587,7 @@ describe("tool handler integration", () => {
       {
         direction: "right",
         boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 50,
       },
       {} as any,
     );
@@ -4542,7 +4596,7 @@ describe("tool handler integration", () => {
 
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(parsed.error).toContain("Timed out");
     expect(parsed.boot_prompt_delivered).not.toBe(true);
     expect(returnPresses).toBe(2);
   }, 10_000);

--- a/tests/submit-verify-timeout-env.test.ts
+++ b/tests/submit-verify-timeout-env.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-submit-verify-timeout-env-test");
+const ENV_KEY = "CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS";
+
+class StuckAgentClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:agent";
+  readonly title = "brainlayerClaude";
+  private pendingText = "";
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+    this.pendingText += text;
+  }
+
+  async pasteText(surface: string, text: string) {
+    await this.send(surface, text);
+  }
+
+  async sendKey(surface: string, _key: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+    return {
+      surface,
+      text: `Claude Code\n> ${this.pendingText.slice(-160)}\nCLAUDE_COUNTER:1\n`,
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+}
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+function registerReadyAgent(server: any, client: StuckAgentClient): void {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"];
+  const registry = engine.getRegistry();
+  const now = "2026-07-01T00:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: client.surface,
+    workspace_id: client.workspace,
+    state: "ready",
+    repo: "brainlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "submit timeout env test",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+  };
+
+  stateMgr.writeState(record);
+  registry.set(record.agent_id, record);
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") {
+    engine.dispose();
+  }
+}
+
+async function runSubmitFailureWithEnv(value: string): Promise<any> {
+  const previous = process.env[ENV_KEY];
+  process.env[ENV_KEY] = value;
+  vi.resetModules();
+  const { createServer } = await import("../src/server.js");
+  const client = new StuckAgentClient();
+  const server = createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+  });
+  registerReadyAgent(server, client);
+  const tool = (server as any)._registeredTools["send_command"];
+
+  const resultPromise = tool.handler(
+    { surface: client.surface, command: "ping" },
+    {} as any,
+  );
+  await vi.advanceTimersByTimeAsync(2500);
+  const result = await resultPromise;
+  disposeServer(server);
+
+  if (previous === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = previous;
+  }
+
+  return parseResult(result);
+}
+
+describe("submit verification timeout env", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("reads a positive CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS override once at module load", async () => {
+    vi.useFakeTimers();
+    mkdirSync(TEST_DIR, { recursive: true });
+
+    const parsed = await runSubmitFailureWithEnv("25");
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("within 25ms");
+  });
+
+  it("falls back to 2000ms for an invalid CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS", async () => {
+    vi.useFakeTimers();
+    mkdirSync(TEST_DIR, { recursive: true });
+
+    const parsed = await runSubmitFailureWithEnv("not-a-number");
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("within 2000ms");
+  });
+});


### PR DESCRIPTION
## Summary
- Accept boot-prompt submit verification when agent identity is visible and the composer has cleared after the recovery Return, even if a parsed working/thinking marker has not streamed yet.
- Keep false-green protection by requiring identity plus cleared composer for boot-prompt fallback evidence, and route no-identity cleared prompts to the boot timeout path.
- Add `CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS` positive-integer env override with invalid fallback to 2000ms.

## Test plan
- [x] `bunx vitest run tests/server.test.ts tests/enter-reliability.test.ts tests/false-green-empty-surface.test.ts tests/submit-verify-timeout-env.test.ts`
- [x] `bun run typecheck && bun run test`
- [x] Pre-push hook reran regression fixtures and full `vitest run`
- [x] `coderabbit review --agent` (0 findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input delivery and submit verification for boot prompts and send_command; wrong heuristics could mark failed submits as success, though identity is still required for the new fallback paths.
> 
> **Overview**
> Fixes false **Enter submit could not be verified** failures when slow agents clear the composer before a working/thinking marker appears on screen.
> 
> **Submit verification** now treats **agent identity + empty composer** as success after the recovery Return when `require_working_status` is set, and uses the same cleared-composer rule in the general verify path (non-agent clears still need `allow_non_agent_clear`). **Boot prompt delivery** adds `waitForBootPromptSubmitEvidence` and, on `SubmitVerificationError`, succeeds if the prompt is no longer pending and identity/cleared-input evidence shows up within the boot timeout. **`send_command`** skips submit verify on the launcher command when a boot prompt will be delivered in the same call.
> 
> **`CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS`** (positive integer, default 2000ms) is read at module load via `parsePositiveIntegerMs`; invalid values fall back to 2000ms. Docs and tests cover the env override, slow Claude boot prompt, and stricter failure when the composer clears without agent identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac536f45dcc34c48ff7b2842bcd76da4ea31af71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix boot prompt submit verification to accept cleared composer as submit evidence
> - Boot prompt delivery now succeeds when the agent identity is visible and the composer input is cleared, even if a parsed `working` status marker has not yet rendered after the recovery Enter.
> - Adds `waitForBootPromptSubmitEvidence` helper in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/205/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that polls for either a verified working status or identity + cleared input, throwing `BootPromptTimeoutError` on timeout.
> - Skips immediate submit verification for the main command when a boot prompt will be delivered, deferring all verification to the boot prompt flow.
> - The submit verification timeout is now configurable via `CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS` (default 2000ms), with invalid values falling back to the default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac536f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->