### PR TITLE
fix(reaper): catch orphaned `node .../cmuxlayer/dist/index.js` MCP servers

### DIFF
--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -86,6 +86,11 @@ const DEFAULT_KNOWN_SERVER_NAMES = [
   "whatsapp-mcp",
 ] as const;
 const MCP_PACKAGE_NAME_PATTERN = /-mcp(?:$|[\s/._-])/i;
+// cmuxlayer is its own MCP server but its package/path is "cmuxlayer", not
+// "cmuxlayer-mcp", so the -mcp gate above never matched its node entrypoint.
+// Matches the dir component in both the worktree (`/Gits/cmuxlayer/dist/...`)
+// and brew (`/Cellar/cmuxlayer/<ver>/libexec/dist/...`) forms.
+const CMUXLAYER_PACKAGE_NAME_PATTERN = /(?:^|[\/\s])cmuxlayer(?:$|[\/\s._-])/i;
 const MCP_SERVER_ENTRYPOINT_PATTERN =
   /(?:^|[\/\s])(?:dist|build|lib)\/(?:index|server|mcp-server)\.(?:js|mjs|cjs)(?:$|[\s"'`])/i;
 
@@ -94,8 +99,7 @@ export function selectReapablePids(
   opts: SelectReapableOptions = {},
 ): number[] {
   const minAgeSeconds = opts.minAgeSeconds ?? DEFAULT_MIN_AGE_SECONDS;
-  const knownServerNames =
-    opts.knownServerNames ?? DEFAULT_KNOWN_SERVER_NAMES;
+  const knownServerNames = opts.knownServerNames ?? DEFAULT_KNOWN_SERVER_NAMES;
 
   return procList
     .filter((proc) => proc.ppid === 1)
@@ -116,7 +120,8 @@ function isMcpServerCommand(
   knownServerNames: readonly string[],
 ): boolean {
   if (
-    MCP_PACKAGE_NAME_PATTERN.test(command) &&
+    (MCP_PACKAGE_NAME_PATTERN.test(command) ||
+      CMUXLAYER_PACKAGE_NAME_PATTERN.test(command)) &&
     MCP_SERVER_ENTRYPOINT_PATTERN.test(command)
   ) {
     return true;
@@ -149,9 +154,7 @@ export function parseElapsedSeconds(etime: string): number {
   }
 
   const [hours, minutes, seconds] =
-    timeParts.length === 3
-      ? timeParts
-      : [0, timeParts[0], timeParts[1]];
+    timeParts.length === 3 ? timeParts : [0, timeParts[0], timeParts[1]];
   return days * 86400 + hours * 3600 + minutes * 60 + seconds;
 }
 
@@ -214,8 +217,7 @@ export function signalProcessBatch(
         pid: proc.pid,
         signal,
         errorCode: signalErrorCode(error),
-        errorMessage:
-          error instanceof Error ? error.message : String(error),
+        errorMessage: error instanceof Error ? error.message : String(error),
       };
     }
   });

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -53,8 +53,7 @@ describe("selectReapablePids", () => {
     ];
 
     expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
-      101,
-      105,
+      101, 105,
     ]);
   });
 
@@ -94,8 +93,7 @@ describe("selectReapablePids", () => {
     ];
 
     expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
-      201,
-      204,
+      201, 204,
     ]);
   });
 
@@ -121,6 +119,52 @@ describe("selectReapablePids", () => {
         minAgeSeconds: 600,
       }),
     ).toEqual([301]);
+  });
+
+  it("reaps orphaned cmuxlayer node MCP servers even though the path has no -mcp suffix", () => {
+    const processes: ProcessInfo[] = [
+      {
+        // worktree dist form
+        pid: 601,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+      },
+      {
+        // brew Cellar form
+        pid: 602,
+        ppid: 1,
+        etimes: 1200,
+        command:
+          "/opt/homebrew/opt/node/bin/node /opt/homebrew/Cellar/cmuxlayer/0.2.9/libexec/dist/index.js",
+      },
+      {
+        // live: parent still alive -> not an orphan
+        pid: 603,
+        ppid: 4242,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+      },
+      {
+        // too young
+        pid: 604,
+        ppid: 1,
+        etimes: 120,
+        command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+      },
+      {
+        // launchd-managed -> left alone
+        pid: 605,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+        launchdManaged: true,
+      },
+    ];
+
+    expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
+      601, 602,
+    ]);
   });
 });
 


### PR DESCRIPTION
## ISSUE-2 (P0) — MCP-orphan reaper misses the node dist entrypoint

The orphan reaper's `-mcp` package-name gate never matched cmuxlayer's own node entrypoint, because its package/path is `cmuxlayer` (not `cmuxlayer-mcp`). After the bun→node/dist migration the real orphans are `node .../cmuxlayer/dist/index.js` (ppid=1) — **291 leaked (~7.5GB) in one day** went uncollected.

### Fix
Add `CMUXLAYER_PACKAGE_NAME_PATTERN` matching the `cmuxlayer` dir component in both worktree (`/Gits/cmuxlayer/dist/...`) and brew (`/Cellar/cmuxlayer/<ver>/libexec/dist/...`) forms, OR'd with the existing `-mcp` gate and still AND'd with the dist/build/lib entrypoint pattern.

Stays **PRECISE and warn-only by default**: only `ppid===1` orphans past min-age are selected, so live-attached servers (real parent) are never touched — verified by the lead's own live MCP (ppid≠1) being excluded.

### Tests (12/12 reaper tests pass)
Cover worktree + brew Cellar forms reaped; live (real parent), too-young, and launchd-managed procs left alone.

### Deploy follow-up (operational, not code)
Repoint the loaded launchd job (currently the old `com.golems.mcp-reaper`) to run this reaper. The shipped `com.cmuxlayer.mcp-reaper.plist` intentionally defaults to `REAPER_DRY_RUN=1`; flip to `--execute` after reviewing dry-run logs. No reapable orphans exist right now (today's 291 already culled), so this is non-urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows reaper matching to cmuxlayer paths that already satisfy the dist entrypoint gate; no change to dry-run default or signal behavior.
> 
> **Overview**
> Extends MCP orphan detection so **`node …/cmuxlayer/dist/index.js`** processes are treated like other MCP servers. The existing **`-mcp`** package gate never matched cmuxlayer’s path; a new **`CMUXLAYER_PACKAGE_NAME_PATTERN`** matches the `cmuxlayer` directory segment (worktree and Homebrew Cellar layouts) and is **OR**’d with the `-mcp` rule while still requiring the usual **dist/build/lib entrypoint** pattern.
> 
> Selection rules are unchanged: only **ppid=1**, past **min age**, non-**launchd** **node** orphans are reapable. Tests add coverage for worktree and brew argv forms and confirm live parents, young PIDs, and launchd-managed processes stay excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5122a85a5ecba016da4d82f2558aa7aec675259e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isMcpServerCommand` to catch orphaned `node .../cmuxlayer/dist/index.js` MCP server processes
> Previously, the MCP reaper only matched processes whose package path contained a `-mcp` suffix. This missed orphaned `node` processes launched from `cmuxlayer` paths (both worktree and Homebrew Cellar forms) that lack that suffix.
>
> - Adds a `CMUXLAYER_PACKAGE_NAME_PATTERN` regex in [mcp-reaper.ts](https://github.com/EtanHey/cmuxlayer/pull/206/files#diff-32c6a0b7ce6e61ede4270634b60059d84d8b3d8ab0720c01b42204c91552c263) that matches `cmuxlayer` paths without requiring `-mcp`.
> - Broadens `isMcpServerCommand` to accept a match from either the existing `-mcp` pattern or the new `cmuxlayer` pattern, while still requiring the entrypoint path to match.
> - Adds test cases in [mcp-reaper.test.ts](https://github.com/EtanHey/cmuxlayer/pull/206/files#diff-fc64cbdbbf8a896482ef9c76488ce0e2a4d6b17cf304751459efa0dcb4f90ff6) covering worktree and Homebrew Cellar `cmuxlayer` paths, confirming non-orphans, too-young processes, and launchd-managed ones are still excluded.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5122a85. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->