### PR TITLE
fix(spawn): capture cli_session_id even when launch verification throws

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1239,6 +1239,14 @@ export class AgentEngine {
     }
   }
 
+  async captureBootSessionId(agentId: string): Promise<AgentRecord | null> {
+    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    if (!agent) {
+      return null;
+    }
+    return this.maybeCaptureBootSessionId(agent, {});
+  }
+
   private async maybeMarkBootReady(
     agent: AgentRecord,
     ctx: SweepAgentContext,
@@ -2023,11 +2031,18 @@ export class AgentEngine {
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      let failedAgentId = agentId;
       try {
-        const failed = this.stateMgr.transition(agentId, "error", {
+        failedAgentId =
+          (await this.captureBootSessionId(agentId))?.agent_id ?? agentId;
+      } catch {
+        // Preserve the original launch error for the caller.
+      }
+      try {
+        const failed = this.stateMgr.transition(failedAgentId, "error", {
           error: `Launch failed: ${message}`,
         });
-        this.registry.set(agentId, failed);
+        this.registry.set(failedAgentId, failed);
       } catch {
         // Preserve the original launch error for the caller.
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4398,6 +4398,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return record;
     };
 
+    const captureSpawnSessionBestEffort = async <
+      T extends {
+        agent_id: string;
+        surface_id: string;
+      },
+    >(
+      result: T,
+    ): Promise<AgentRecord | null> => {
+      try {
+        await engine.captureBootSessionId(result.agent_id);
+      } catch {
+        // Keep spawn/boot error handling focused on the original outcome.
+      }
+      return canonicalizeSpawnResult(result);
+    };
+
     const prepareSpawnWorktree = async (
       repo: string,
       worktree: boolean | object | undefined,
@@ -4768,7 +4784,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   }),
               });
 
-              canonicalizeSpawnResult(result);
+              await captureSpawnSessionBestEffort(result);
               if (bootPromptDelivery.prompt_text !== null) {
                 const updated = stateMgr.updateRecord(result.agent_id, {
                   task_summary: bootPromptDelivery.prompt_text,
@@ -4804,7 +4820,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return updated;
             };
             try {
-              canonicalizeSpawnResult(result);
+              await captureSpawnSessionBestEffort(result);
               let updated = clearBootPromptPending();
               if (
                 !(e instanceof BootPromptTimeoutError) &&

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -245,6 +245,44 @@ describe("AgentEngine", () => {
       expect(result.state).toBe("booting");
     });
 
+    it("captures session identity before surfacing launch command failures", async () => {
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:new"),
+      ]);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: (agent) =>
+          agent.surface_id === "surface:new"
+            ? { session_id: sessionId, path: null }
+            : null,
+        launchCommandSender: async () => {
+          throw new Error(
+            "Timed out after 15000ms waiting for agent launch readiness on surface:new",
+          );
+        },
+      });
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "Fix gap F",
+        }),
+      ).rejects.toThrow(/waiting for agent launch readiness/);
+
+      const finalAgentId = "brainlayerCodex-019d9aa5";
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        state: "error",
+        error: expect.stringContaining("Launch failed:"),
+        cli_session_id: sessionId,
+        cli_session_path: null,
+      });
+    });
+
     it("sends the launch command to the surface", async () => {
       await engine.spawnAgent({
         repo: "brainlayer",

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1592,7 +1592,16 @@ describe("agent lifecycle tool handlers", () => {
         stderr: "",
       };
     });
-    const server = createLifecycleServer(mockExec);
+    const sessionId = "019ec0e6-1111-2222-3333-444455556666";
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: (agent) =>
+        agent.surface_id === "surface:new"
+          ? { session_id: sessionId, path: null }
+          : null,
+    });
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
 
@@ -1621,6 +1630,10 @@ describe("agent lifecycle tool handlers", () => {
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(["booting", "ready"]).toContain(state.state);
     expect(state.error).toBeNull();
+    expect(state.cli_session_id).toBe(sessionId);
+    expect(state.resumable).toBe(true);
+    expect(state.health.issue_codes).not.toContain("missing_cli_session_id");
+    expect(state.health.issue_codes).not.toContain("non_resumable");
     expect(mockExec).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- Capture managed spawn CLI session identity before launch command failures transition the agent to error.
- Capture/canonicalize the session in `spawn_agent` boot-prompt success and error paths before readiness/delivery returns can skip later metadata refresh.
- Add regressions for launch-readiness throws and boot-prompt readiness timeouts preserving resumability.

## Test Plan
- [x] CodeRabbit local agent review: findings 0
- [x] `bun run typecheck && bun run test`
- [x] Push pre-hook: `run_tests.sh finished with exit status 0`

## Notes
- Auto-discovered panes remain out of scope: they never pass through managed spawn, so no managed session identity is available to capture here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn and boot error paths and agent id canonicalization timing; regressions could mis-route state updates, though behavior is best-effort with tests for the failure cases.
> 
> **Overview**
> Managed spawn now **persists CLI session identity before error transitions** when launch or boot-prompt paths fail early, so agents stay **resumable** instead of losing `cli_session_id` and canonical `agent_id`.
> 
> **AgentEngine** exposes public `captureBootSessionId` and calls it in the `spawnAgent` launch catch block before moving to `error`, using the renamed agent id when session capture canonicalizes the record. **`spawn_agent`** in the server wraps boot-prompt success and error handling with `captureSpawnSessionBestEffort`, which captures session metadata and then canonicalizes the spawn result’s `agent_id`.
> 
> Tests cover launch-readiness failures and boot-prompt readiness timeouts still exposing `cli_session_id`, `resumable`, and clean health issue codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56289142218d843639ffa8009b54506bbe8b624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `spawnAgent` to capture `cli_session_id` even when launch verification throws
> - When a launch command fails, `AgentEngine.spawnAgent` now calls the new `captureBootSessionId` method before transitioning to error state, so `cli_session_id` is recorded against the canonicalized agent ID even on failure.
> - In [server.ts](https://github.com/EtanHey/cmuxlayer/pull/207/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), a new `captureSpawnSessionBestEffort` helper wraps session capture in a try/catch and is called on both success and failure paths of the boot prompt flow.
> - Tests in [agent-engine.test.ts](https://github.com/EtanHey/cmuxlayer/pull/207/files#diff-23c096d87b5f141db61c3014b45beb25da33800c0513e4ca132c5c9b5a6aac46) and [server-agent-tools.test.ts](https://github.com/EtanHey/cmuxlayer/pull/207/files#diff-b02b20318090fbe2fe9736638b282662f0d778996959f4a29828dc0dab2debff) verify that `cli_session_id` is populated and `missing_cli_session_id` is absent from health issue codes after spawn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c562891.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->