### PR TITLE
feat(doctor): detect .mcp.json launcher-bypass/stale-cmux drift (read-only)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -13,7 +13,9 @@
  *   (b) §3 tap — whether `brew tap` lists etanhey/layers and the formula
  *       resolves (`brew info etanhey/layers/cmuxlayer`). Tap CASKS need
  *       `brew trust etanhey/layers`; cmuxlayer is a formula, not gated.
- *   (c) CMUX_SOCKET_PATH if set, else "unset (auto-discover)".
+ *   (c) CMUX_SOCKET_PATH if set, else "unset (auto-discover)";
+ *   (d) read-only `.mcp.json` drift detection for stale `cmux` keys or entries
+ *       that bypass `~/.golems/bin/cmuxlayer-mcp`.
  *
  * Non-interactivity invariants (§ headline / conformance checks):
  *   - exit 0 when healthy; runs cleanly under `</dev/null` with NONINTERACTIVE=1;
@@ -22,6 +24,9 @@
  */
 
 import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -56,6 +61,29 @@ export type PmsetRunner = () => Promise<CommandResult>;
 /** Runs `launchctl print gui/<uid>/com.golems.cmux-caffeinate`; never throws. */
 export type LaunchctlRunner = () => Promise<CommandResult>;
 
+export interface McpConfigDriftEntry {
+  path: string;
+  serverKey: string;
+  reason: string;
+}
+
+export interface McpConfigDriftReport {
+  scanned: number;
+  drifted: McpConfigDriftEntry[];
+  note: string;
+}
+
+/** Lists candidate `.mcp.json` paths; best-effort callers may include missing files. */
+export type McpConfigPathLister = () => Promise<string[]> | string[];
+
+/** Reads a `.mcp.json` file; failures are skipped by the drift check. */
+export type McpConfigFileReader = (path: string) => Promise<string> | string;
+
+export interface CheckMcpConfigDriftOptions {
+  listMcpConfigPaths?: McpConfigPathLister;
+  readMcpConfigFile?: McpConfigFileReader;
+}
+
 export interface DoctorReport {
   /** Overall health. brew/tap gaps do NOT make the doctor unhealthy. */
   healthy: boolean;
@@ -80,6 +108,8 @@ export interface DoctorReport {
     durable: boolean;
     note: string;
   };
+  /** Read-only `.mcp.json` drift report; does NOT affect health. */
+  mcpConfigDrift: McpConfigDriftReport;
 }
 
 export interface RunDoctorOptions {
@@ -93,6 +123,10 @@ export interface RunDoctorOptions {
   pmset?: PmsetRunner;
   /** Injectable launchctl runner; defaults to the real launchd service probe. */
   launchctl?: LaunchctlRunner;
+  /** Injectable `.mcp.json` path lister for read-only drift checks. */
+  listMcpConfigPaths?: McpConfigPathLister;
+  /** Injectable `.mcp.json` file reader for read-only drift checks. */
+  readMcpConfigFile?: McpConfigFileReader;
 }
 
 /**
@@ -185,6 +219,22 @@ export const realLaunchctlRunner: LaunchctlRunner = async () => {
   }
 };
 
+export const realMcpConfigPathLister: McpConfigPathLister = async () => {
+  try {
+    const entries = await readdir(join(homedir(), "Gits"), {
+      withFileTypes: true,
+    });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(homedir(), "Gits", entry.name, ".mcp.json"));
+  } catch {
+    return [];
+  }
+};
+
+export const realMcpConfigFileReader: McpConfigFileReader = (path) =>
+  readFile(path, "utf-8");
+
 async function checkTap(brew: BrewRunner): Promise<DoctorReport["tap"]> {
   const tapNote = `tap CASKS need \`brew trust ${TAP_NAME}\`; cmuxlayer is a formula, not gated`;
 
@@ -214,6 +264,88 @@ async function checkTap(brew: BrewRunner): Promise<DoctorReport["tap"]> {
     tapPresent,
     formulaResolves,
     note: tapNote,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function serverReferencesLauncher(server: unknown): boolean {
+  if (!isRecord(server)) {
+    return false;
+  }
+
+  const command = typeof server.command === "string" ? server.command : "";
+  const args = Array.isArray(server.args)
+    ? server.args.filter((arg): arg is string => typeof arg === "string")
+    : [];
+
+  return [command, ...args].some((part) => part.includes("cmuxlayer-mcp"));
+}
+
+function driftReason(serverKey: string, server: unknown): string | null {
+  const reasons: string[] = [];
+
+  if (serverKey === "cmux") {
+    reasons.push("stale server key cmux (use cmuxlayer)");
+  }
+
+  if (!serverReferencesLauncher(server)) {
+    reasons.push("does not reference launcher cmuxlayer-mcp");
+  }
+
+  return reasons.length > 0 ? reasons.join("; ") : null;
+}
+
+export async function checkMcpConfigDrift(
+  opts: CheckMcpConfigDriftOptions = {},
+): Promise<McpConfigDriftReport> {
+  const listMcpConfigPaths =
+    opts.listMcpConfigPaths ?? realMcpConfigPathLister;
+  const readMcpConfigFile =
+    opts.readMcpConfigFile ?? realMcpConfigFileReader;
+
+  let paths: string[];
+  try {
+    paths = await listMcpConfigPaths();
+  } catch {
+    paths = [];
+  }
+
+  const drifted: McpConfigDriftEntry[] = [];
+  let scanned = 0;
+
+  for (const path of paths) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readMcpConfigFile(path));
+    } catch {
+      continue;
+    }
+
+    scanned += 1;
+
+    if (!isRecord(parsed) || !isRecord(parsed.mcpServers)) {
+      continue;
+    }
+
+    for (const [serverKey, server] of Object.entries(parsed.mcpServers)) {
+      if (serverKey !== "cmux" && serverKey !== "cmuxlayer") {
+        continue;
+      }
+
+      const reason = driftReason(serverKey, server);
+      if (reason) {
+        drifted.push({ path, serverKey, reason });
+      }
+    }
+  }
+
+  return {
+    scanned,
+    drifted,
+    note: "scanned ~/Gits/*/.mcp.json for cmux/cmuxlayer entries expected to reference launcher cmuxlayer-mcp; read-only, skipped missing/unreadable/invalid JSON",
   };
 }
 
@@ -262,6 +394,10 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
 
   const tap = await checkTap(brew);
   const sleepGuard = await checkSleepGuard(pmset, launchctl);
+  const mcpConfigDrift = await checkMcpConfigDrift({
+    listMcpConfigPaths: opts.listMcpConfigPaths,
+    readMcpConfigFile: opts.readMcpConfigFile,
+  });
 
   // Health: only the version must resolve. Brew/tap gaps are reported but, per
   // the standard's "brew best-effort" rule, must NOT make the doctor unhealthy
@@ -284,6 +420,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
       : { set: false, value: null, note: "unset (auto-discover)" },
     sleepGuard,
+    mcpConfigDrift,
   };
 }
 
@@ -335,6 +472,21 @@ export function renderDoctorText(report: DoctorReport): string {
   lines.push(
     `│ ${mark(report.sleepGuard.durable)} sleep guard: ${report.sleepGuard.note}`,
   );
+
+  if (report.mcpConfigDrift.drifted.length === 0) {
+    lines.push(
+      `│ ✔ .mcp.json drift: no mcp config drift (${report.mcpConfigDrift.scanned} scanned)`,
+    );
+  } else {
+    lines.push(
+      `│ ✗ .mcp.json drift: ${report.mcpConfigDrift.drifted.length} drifted (${report.mcpConfigDrift.scanned} scanned)`,
+    );
+    for (const entry of report.mcpConfigDrift.drifted) {
+      lines.push(
+        `│      ${entry.path} [${entry.serverKey}]: ${entry.reason}`,
+      );
+    }
+  }
 
   lines.push("└─");
   return lines.join("\n");

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -271,6 +271,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isCmuxlayerMcpLauncher(part: string): boolean {
+  const normalized = part.replaceAll("\\", "/");
+  return (
+    normalized === "cmuxlayer-mcp" ||
+    normalized === "~/.golems/bin/cmuxlayer-mcp" ||
+    normalized.endsWith("/.golems/bin/cmuxlayer-mcp")
+  );
+}
+
 function serverReferencesLauncher(server: unknown): boolean {
   if (!isRecord(server)) {
     return false;
@@ -281,7 +290,7 @@ function serverReferencesLauncher(server: unknown): boolean {
     ? server.args.filter((arg): arg is string => typeof arg === "string")
     : [];
 
-  return [command, ...args].some((part) => part.includes("cmuxlayer-mcp"));
+  return [command, ...args].some(isCmuxlayerMcpLauncher);
 }
 
 function driftReason(serverKey: string, server: unknown): string | null {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -340,6 +340,30 @@ describe("checkMcpConfigDrift", () => {
     ]);
   });
 
+  it("does not treat unrelated paths containing cmuxlayer-mcp as the launcher", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/substring/.mcp.json": mcpConfig({
+          mcpServers: {
+            cmuxlayer: {
+              command: "node",
+              args: ["/Users/etanheyman/Gits/cmuxlayer-mcp/dist/index.js"],
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([
+      {
+        path: "/Users/etanheyman/Gits/substring/.mcp.json",
+        serverKey: "cmuxlayer",
+        reason: expect.stringMatching(/cmuxlayer-mcp/i),
+      },
+    ]);
+  });
+
   it("flags the stale cmux server key even when it points at the launcher", async () => {
     const report = await checkMcpConfigDrift(
       fakeMcpConfigReaders({

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  checkMcpConfigDrift,
   parseSystemSleepPrevented,
   runDoctor,
   renderDoctorText,
@@ -59,9 +60,46 @@ Assertion status system-wide:
    pid 17232(caffeinate): [0x0000000100008001] 00:04:14 PreventUserIdleSystemSleep named: "caffeinate command-line tool"
 `;
 
+const emptyPmset = async () => ({ ok: true, stdout: "", stderr: "" });
+const missingLaunchctl = async () => ({
+  ok: false,
+  stdout: "",
+  stderr: "service not found",
+  notFound: true,
+});
+
+function mcpConfig(content: unknown): string {
+  return JSON.stringify(content);
+}
+
+function fakeMcpConfigReaders(files: Record<string, string>) {
+  return {
+    listMcpConfigPaths: async () => [
+      ...Object.keys(files),
+      "/Users/etanheyman/Gits/missing/.mcp.json",
+    ],
+    readMcpConfigFile: async (path: string) => {
+      if (!(path in files)) {
+        throw new Error("missing");
+      }
+      return files[path];
+    },
+  };
+}
+
+function runDoctorForTest(opts: Parameters<typeof runDoctor>[0]) {
+  return runDoctor({
+    pmset: emptyPmset,
+    launchctl: missingLaunchctl,
+    listMcpConfigPaths: async () => [],
+    readMcpConfigFile: async () => "",
+    ...opts,
+  });
+}
+
 describe("runDoctor — report shape", () => {
   it("reports the version when it resolves", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({}),
@@ -71,7 +109,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("flags an unknown version as not-ok", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "unknown",
       env: {},
       brew: makeBrew({}),
@@ -80,7 +118,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("marks §1 account-rename self-heal as not-applicable (stdio MCP, no cask)", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({}),
@@ -92,7 +130,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("marks §5 daemon integrity as not-applicable (stdio MCP, no daemon)", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({}),
@@ -104,7 +142,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports the tap as present + formula resolvable when brew lists it", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({
@@ -119,7 +157,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports the tap as absent when brew does not list it", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({ tapList: "homebrew/core\n", infoOk: false }),
@@ -128,7 +166,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("degrades gracefully (does not throw / does not fail hard) when brew is not found", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({ found: false }),
@@ -140,7 +178,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports CMUX_SOCKET_PATH when set", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: { CMUX_SOCKET_PATH: "/tmp/cmux-501.sock" },
       brew: makeBrew({}),
@@ -150,7 +188,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports CMUX_SOCKET_PATH as unset (auto-discover) when absent", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({}),
@@ -160,7 +198,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("is healthy on a normal machine (version resolves)", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({ tapList: "etanhey/layers\n" }),
@@ -169,7 +207,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports sleep guard as non-durable without pmset assertion and launchd guard", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({ tapList: "etanhey/layers\n" }),
@@ -190,7 +228,7 @@ describe("runDoctor — report shape", () => {
   });
 
   it("reports sleep guard as durable when pmset assertion is active and launchd guard is loaded", async () => {
-    const report = await runDoctor({
+    const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({ tapList: "etanhey/layers\n" }),
@@ -207,6 +245,36 @@ describe("runDoctor — report shape", () => {
     expect(report.sleepGuard.durable).toBe(true);
     expect(report.sleepGuard.note).toMatch(/durable/i);
     expect(report.healthy).toBe(true);
+  });
+
+  it("includes .mcp.json drift without flipping health", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({ tapList: "etanhey/layers\n" }),
+      pmset: emptyPmset,
+      launchctl: missingLaunchctl,
+      ...fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/one/.mcp.json": mcpConfig({
+          mcpServers: {
+            cmuxlayer: {
+              command: "node",
+              args: ["/Users/etanheyman/Gits/cmuxlayer/dist/index.js"],
+            },
+          },
+        }),
+      }),
+    });
+
+    expect(report.healthy).toBe(true);
+    expect(report.mcpConfigDrift.scanned).toBe(1);
+    expect(report.mcpConfigDrift.drifted).toEqual([
+      {
+        path: "/Users/etanheyman/Gits/one/.mcp.json",
+        serverKey: "cmuxlayer",
+        reason: expect.stringMatching(/cmuxlayer-mcp/i),
+      },
+    ]);
   });
 });
 
@@ -225,6 +293,104 @@ describe("parseSystemSleepPrevented", () => {
         'pid 17232(caffeinate): [0x...] 00:04:14 PreventUserIdleSystemSleep named: "caffeinate command-line tool"',
       ),
     ).toBe(false);
+  });
+});
+
+describe("checkMcpConfigDrift", () => {
+  it("treats a launcher-pointing cmuxlayer entry as clean", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/clean/.mcp.json": mcpConfig({
+          mcpServers: {
+            cmuxlayer: {
+              command: "/Users/etanheyman/.golems/bin/cmuxlayer-mcp",
+              args: [],
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([]);
+    expect(report.note).toMatch(/launcher/i);
+  });
+
+  it("flags a cmuxlayer entry that bypasses the launcher via node dist/index.js", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/drift/.mcp.json": mcpConfig({
+          mcpServers: {
+            cmuxlayer: {
+              command: "node",
+              args: ["/Users/etanheyman/Gits/cmuxlayer/dist/index.js"],
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([
+      {
+        path: "/Users/etanheyman/Gits/drift/.mcp.json",
+        serverKey: "cmuxlayer",
+        reason: expect.stringMatching(/cmuxlayer-mcp/i),
+      },
+    ]);
+  });
+
+  it("flags the stale cmux server key even when it points at the launcher", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/stale/.mcp.json": mcpConfig({
+          mcpServers: {
+            cmux: {
+              command: "/Users/etanheyman/.golems/bin/cmuxlayer-mcp",
+              args: [],
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([
+      {
+        path: "/Users/etanheyman/Gits/stale/.mcp.json",
+        serverKey: "cmux",
+        reason: expect.stringMatching(/stale.*cmux/i),
+      },
+    ]);
+  });
+
+  it("ignores repos with no cmux or cmuxlayer server entry", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/other/.mcp.json": mcpConfig({
+          mcpServers: {
+            other: { command: "node", args: ["server.js"] },
+          },
+        }),
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([]);
+  });
+
+  it("skips missing and invalid JSON files without throwing", async () => {
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/valid/.mcp.json": mcpConfig({
+          mcpServers: {},
+        }),
+        "/Users/etanheyman/Gits/invalid/.mcp.json": "{ not json",
+      }),
+    );
+
+    expect(report.scanned).toBe(1);
+    expect(report.drifted).toEqual([]);
   });
 });
 
@@ -253,6 +419,11 @@ describe("renderDoctorText", () => {
         keepAliveLoaded: false,
         durable: false,
         note: "not durable; install launchd/cmux-caffeinate/README.md",
+      },
+      mcpConfigDrift: {
+        scanned: 0,
+        drifted: [],
+        note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
       },
     };
   }
@@ -289,6 +460,41 @@ describe("renderDoctorText", () => {
     expect(text).toMatch(/sleep guard/i);
     expect(text).toMatch(/launchd\/cmux-caffeinate\/README\.md/);
   });
+
+  it("prints a no-drift line when no .mcp.json drift is detected", () => {
+    const text = renderDoctorText({
+      ...baseReport(),
+      mcpConfigDrift: {
+        scanned: 1,
+        drifted: [],
+        note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
+      },
+    });
+    expect(text).toMatch(/no .*mcp.*drift/i);
+  });
+
+  it("prints drifted .mcp.json paths without changing the healthy header", () => {
+    const text = renderDoctorText({
+      ...baseReport(),
+      healthy: true,
+      mcpConfigDrift: {
+        scanned: 2,
+        drifted: [
+          {
+            path: "/Users/etanheyman/Gits/drift/.mcp.json",
+            serverKey: "cmuxlayer",
+            reason: "does not reference launcher cmuxlayer-mcp",
+          },
+        ],
+        note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
+      },
+    });
+
+    expect(text).toMatch(/doctor .* healthy/i);
+    expect(text).toMatch(/1 drifted/i);
+    expect(text).toMatch(/\/Users\/etanheyman\/Gits\/drift\/\.mcp\.json/);
+    expect(text).toMatch(/cmuxlayer/);
+  });
 });
 
 describe("renderDoctorJson", () => {
@@ -317,6 +523,17 @@ describe("renderDoctorJson", () => {
         durable: true,
         note: "durable",
       },
+      mcpConfigDrift: {
+        scanned: 1,
+        drifted: [
+          {
+            path: "/Users/etanheyman/Gits/drift/.mcp.json",
+            serverKey: "cmuxlayer",
+            reason: "does not reference launcher cmuxlayer-mcp",
+          },
+        ],
+        note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
+      },
     };
     const json = renderDoctorJson(report);
     const parsed = JSON.parse(json) as DoctorReport;
@@ -328,5 +545,7 @@ describe("renderDoctorJson", () => {
     expect(parsed.socketPath.set).toBe(true);
     expect(parsed.socketPath.value).toBe("/tmp/x.sock");
     expect(parsed.sleepGuard.durable).toBe(true);
+    expect(parsed.mcpConfigDrift.scanned).toBe(1);
+    expect(parsed.mcpConfigDrift.drifted[0]?.serverKey).toBe("cmuxlayer");
   });
 });


### PR DESCRIPTION
## Summary
- add a read-only `mcpConfigDrift` section to the doctor report and text/JSON output
- scan `~/Gits/*/.mcp.json` best-effort for `cmux`/`cmuxlayer` entries that bypass `cmuxlayer-mcp` or use the stale `cmux` key
- keep drift report-only so doctor health remains version-gated
- add injected unit coverage for clean launcher configs, node `dist/index.js` bypass, stale `cmux`, ignored unrelated servers, skipped missing/invalid JSON, scanned count, JSON/text output, and health behavior

## Test plan
- [x] `bun run test tests/doctor.test.ts` (red first: 8 expected failures before implementation; green after)
- [x] `bun run typecheck && bun run test`
- [x] `bun src/index.ts doctor --json | jq '.healthy, (.mcpConfigDrift.drifted | length)'`
- [x] `bun src/index.ts doctor | rg -n "mcp\\.json drift|cmuxlayer doctor"`
- [x] pre-push hook completed with `run_tests.sh finished with exit status 0`

## Notes
- Local `coderabbit review --agent` was invoked before commit and hit the 180s timeout with only heartbeat output, so there were no findings to address before commit.
- This PR intentionally does not auto-fix `.mcp.json` files. A future opt-in `--fix` with per-file backups could be added separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only filesystem scans and report-only output; no auto-fix or health gating changes beyond new fields in doctor output.
> 
> **Overview**
> Adds a **read-only** doctor check that scans `~/Gits/*/.mcp.json` and reports `cmux` / `cmuxlayer` entries that use the stale **`cmux`** server key or do not route through **`~/.golems/bin/cmuxlayer-mcp`** (e.g. direct `node …/dist/index.js`).
> 
> `runDoctor` now includes **`mcpConfigDrift`** on the report; text and JSON output show scan counts and per-file reasons. **Overall health stays version-only**—drift is advisory and does not change exit behavior. Path listing and file reads are injectable for tests; missing or invalid JSON is skipped best-effort.
> 
> Tests cover drift logic, rendering, JSON shape, and that drift does not flip **`healthy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d475b17e063c86def0a35c70a735caa14902c43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add read-only `.mcp.json` launcher-bypass and stale-cmux drift detection to `runDoctor`
> - Adds `checkMcpConfigDrift` in [src/doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/208/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068) that scans `~/Gits/*/.mcp.json` files and flags servers with stale `cmux` keys or missing `cmuxlayer-mcp` launcher references.
> - Extends `DoctorReport` with a `mcpConfigDrift` field (scanned count, drifted entries, note); health score is unaffected.
> - Updates `renderDoctorText` to print a drift summary section with per-entry path, server key, and reason.
> - Supports injecting `listMcpConfigPaths` and `readMcpConfigFile` for testability; tolerates listing, read, and parse failures gracefully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d475b17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new check for `.mcp.json` configuration drift in the doctor report.
  * The report now highlights affected config files, server keys, and why they may be outdated.

* **Bug Fixes**
  * Improved doctor output so configuration issues can be spotted without changing the overall health status.

* **Documentation**
  * Updated both text and JSON report output to include the new drift information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->