### PR TITLE
fix(tests): isolate server tests from live cmux-agents state

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -977,7 +977,7 @@ export function createServerContext(
   const client =
     opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
   const autoVitestStateDir =
-    !opts?.stateDir && process.env.VITEST
+    !opts?.stateDir && process.env.VITEST === "true"
       ? mkdtempSync(join(tmpdir(), "cmuxlayer-vitest-state-"))
       : null;
   const stateDir =

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, mkdtempSync, rmSync } from "node:fs";
 import { access, readFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
@@ -976,8 +976,14 @@ export function createServerContext(
 ): CmuxServerContext {
   const client =
     opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  const autoVitestStateDir =
+    !opts?.stateDir && process.env.VITEST
+      ? mkdtempSync(join(tmpdir(), "cmuxlayer-vitest-state-"))
+      : null;
   const stateDir =
-    opts?.stateDir ?? join(homedir(), ".local", "state", "cmux-agents");
+    opts?.stateDir ??
+    autoVitestStateDir ??
+    join(homedir(), ".local", "state", "cmux-agents");
   const stateMgr = new StateManager(stateDir);
   const context: CmuxServerContext = {
     client,
@@ -1014,6 +1020,9 @@ export function createServerContext(
       context.lifecycleSweepEngine = null;
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
+      if (autoVitestStateDir) {
+        rmSync(autoVitestStateDir, { recursive: true, force: true });
+      }
     },
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -955,6 +955,8 @@ export interface CmuxServerContext {
 
 const DEFAULT_CONTROL_HEALTH_INTERVAL_MS = 60_000;
 const MIN_CONTROL_HEALTH_INTERVAL_MS = 5_000;
+const autoVitestStateDirs = new Set<string>();
+let autoVitestStateCleanupRegistered = false;
 
 function resolveControlHealthIntervalMs(input?: number): number {
   const raw =
@@ -971,6 +973,25 @@ function resolveControlHealthIntervalMs(input?: number): number {
   return Math.max(MIN_CONTROL_HEALTH_INTERVAL_MS, Math.floor(raw));
 }
 
+function registerAutoVitestStateDir(stateDir: string): void {
+  autoVitestStateDirs.add(stateDir);
+  if (autoVitestStateCleanupRegistered) {
+    return;
+  }
+  autoVitestStateCleanupRegistered = true;
+  process.once("exit", () => {
+    for (const dir of autoVitestStateDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    autoVitestStateDirs.clear();
+  });
+}
+
+function removeAutoVitestStateDir(stateDir: string): void {
+  autoVitestStateDirs.delete(stateDir);
+  rmSync(stateDir, { recursive: true, force: true });
+}
+
 export function createServerContext(
   opts?: Omit<CreateServerOptions, "context">,
 ): CmuxServerContext {
@@ -984,6 +1005,9 @@ export function createServerContext(
     opts?.stateDir ??
     autoVitestStateDir ??
     join(homedir(), ".local", "state", "cmux-agents");
+  if (autoVitestStateDir) {
+    registerAutoVitestStateDir(autoVitestStateDir);
+  }
   const stateMgr = new StateManager(stateDir);
   const context: CmuxServerContext = {
     client,
@@ -1021,7 +1045,7 @@ export function createServerContext(
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
       if (autoVitestStateDir) {
-        rmSync(autoVitestStateDir, { recursive: true, force: true });
+        removeAutoVitestStateDir(autoVitestStateDir);
       }
     },
   };
@@ -1075,6 +1099,7 @@ function buildLifecycleChannelMeta(
 }
 
 export function createServer(opts?: CreateServerOptions): McpServer {
+  const ownsContext = !opts?.context;
   const context = opts?.context ?? createServerContext(opts);
   const client = context.client;
   const stateMgr = context.stateMgr;
@@ -1151,6 +1176,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }
       : undefined,
   );
+  if (ownsContext) {
+    const close = server.close.bind(server);
+    server.close = async (): Promise<void> => {
+      try {
+        await close();
+      } finally {
+        context.dispose();
+      }
+    };
+  }
 
   if (enableClaudeChannels) {
     server.server.registerCapabilities({

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -1,24 +1,30 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
+import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
-const TEST_DIR = join(tmpdir(), "cmuxlayer-false-green-empty-surface");
+let testDir = "";
 
 function parseToolResult(result: any): Record<string, any> {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
 describe("false-green empty surface protection", () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "cmuxlayer-false-green-empty-surface-"));
+  });
+
   afterEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
+    vi.useRealTimers();
+    rmSync(testDir, { recursive: true, force: true });
   });
 
   it("does not deliver a Gemini boot prompt to a bare shell prompt", async () => {
-    mkdirSync(TEST_DIR, { recursive: true });
-    const promptPath = join(TEST_DIR, "boot.md");
+    const promptPath = join(testDir, "boot.md");
     writeFileSync(promptPath, "boot prompt", "utf8");
 
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
@@ -36,7 +42,11 @@ describe("false-green empty surface protection", () => {
       return { stdout: "{}", stderr: "" };
     });
 
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir: testDir,
+    });
     const tool = (server as any)._registeredTools["send_command"];
 
     const result = await tool.handler(
@@ -59,8 +69,7 @@ describe("false-green empty surface protection", () => {
   });
 
   it("does not deliver a Gemini boot prompt to a different agent prompt", async () => {
-    mkdirSync(TEST_DIR, { recursive: true });
-    const promptPath = join(TEST_DIR, "boot.md");
+    const promptPath = join(testDir, "boot.md");
     writeFileSync(promptPath, "boot prompt", "utf8");
 
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
@@ -78,7 +87,11 @@ describe("false-green empty surface protection", () => {
       return { stdout: "{}", stderr: "" };
     });
 
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir: testDir,
+    });
     const tool = (server as any)._registeredTools["send_command"];
 
     const result = await tool.handler(
@@ -100,7 +113,7 @@ describe("false-green empty surface protection", () => {
     );
   });
 
-  it("does not false-fail a cleared long command on a non-agent shell prompt", async () => {
+  it("skips submit verification for a cleared long command when isolated state has no agent record", async () => {
     const longCommand = `echo ${"x".repeat(520)}`;
     const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
@@ -117,7 +130,11 @@ describe("false-green empty surface protection", () => {
       return { stdout: "{}", stderr: "" };
     });
 
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir: testDir,
+    });
     const tool = (server as any)._registeredTools["send_command"];
 
     const result = await tool.handler(
@@ -128,5 +145,75 @@ describe("false-green empty surface protection", () => {
     const parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBeNull();
+  });
+
+  it("runs submit verification when isolated state has an interactive record for the surface", async () => {
+    vi.useFakeTimers();
+    const now = "2026-07-01T20:56:00.000Z";
+    const record: AgentRecord = {
+      agent_id: "auto-claude-surface-2",
+      surface_id: "surface:2",
+      workspace_id: "workspace:1",
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "claude-sonnet-4",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "Live-looking isolated record",
+      pid: null,
+      version: 1,
+      created_at: now,
+      updated_at: now,
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    };
+    new StateManager(testDir).writeState(record);
+
+    const longCommand = `echo ${"x".repeat(520)}`;
+    const mockExec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "\n$\n",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir: testDir,
+    });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const resultPromise = tool.handler(
+      { surface: "surface:2", command: longCommand },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(2500);
+    const result = await resultPromise;
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(
+      (mockExec as any).mock.calls.some(([, args]: [string, string[]]) =>
+        args.includes("read-screen"),
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/test-state-isolation.test.ts
+++ b/tests/test-state-isolation.test.ts
@@ -26,5 +26,10 @@ describe("test state isolation", () => {
     expect(context.stateDir).not.toBe(LIVE_STATE_DIR);
     expect(context.stateDir).toContain("cmuxlayer-vitest-state-");
     expect(existsSync(context.stateDir)).toBe(true);
+
+    const stateDir = context.stateDir;
+    context.dispose();
+    contexts.pop();
+    expect(existsSync(stateDir)).toBe(false);
   });
 });

--- a/tests/test-state-isolation.test.ts
+++ b/tests/test-state-isolation.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  createServerContext,
+  type CmuxServerContext,
+} from "../src/server.js";
+
+const LIVE_STATE_DIR = join(homedir(), ".local", "state", "cmux-agents");
+
+const contexts: CmuxServerContext[] = [];
+
+afterEach(() => {
+  while (contexts.length > 0) {
+    contexts.pop()?.dispose();
+  }
+});
+
+describe("test state isolation", () => {
+  it("does not use the live fleet state dir when Vitest omits stateDir", () => {
+    const context = createServerContext({ skipAgentLifecycle: true });
+    contexts.push(context);
+
+    expect(process.env.VITEST).toBeTruthy();
+    expect(context.stateDir).not.toBe(LIVE_STATE_DIR);
+    expect(context.stateDir).toContain("cmuxlayer-vitest-state-");
+    expect(existsSync(context.stateDir)).toBe(true);
+  });
+});

--- a/tests/test-state-isolation.test.ts
+++ b/tests/test-state-isolation.test.ts
@@ -22,7 +22,7 @@ describe("test state isolation", () => {
     const context = createServerContext({ skipAgentLifecycle: true });
     contexts.push(context);
 
-    expect(process.env.VITEST).toBeTruthy();
+    expect(process.env.VITEST).toBe("true");
     expect(context.stateDir).not.toBe(LIVE_STATE_DIR);
     expect(context.stateDir).toContain("cmuxlayer-vitest-state-");
     expect(existsSync(context.stateDir)).toBe(true);


### PR DESCRIPTION
## Summary
- auto-isolate omitted `stateDir` server contexts under Vitest with temporary state directories, while preserving the production homedir default
- move the false-green empty-surface tests onto per-test temp state directories
- add regressions for both empty isolated state skipping submit verification and seeded interactive state enabling verification

## Test plan
- [x] RED: `bun run test tests/test-state-isolation.test.ts` failed before the fix because `createServerContext()` used `~/.local/state/cmux-agents`
- [x] `bun run test tests/test-state-isolation.test.ts tests/false-green-empty-surface.test.ts`
- [x] `bun run typecheck && bun run test`
- [x] `git push -u origin HEAD` with pre-push hooks enabled

## Notes
- `graphify query` failed in this worktree because `graphify-out/graph.json` is absent here; I queried the main checkout's graph artifact for orientation and kept edits in this worktree.
- `coderabbit review --agent` was attempted before commit with a 180s timeout; it only emitted review heartbeats and timed out with exit 124, so this PR proceeds on fresh local verification and PR-level review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to test runs and temp-dir lifecycle; production `stateDir` resolution is unchanged when not under Vitest.
> 
> **Overview**
> **Vitest and tests no longer read or write the live `~/.local/state/cmux-agents` fleet directory** when `stateDir` is omitted.
> 
> `createServerContext` now picks a temp directory prefixed `cmuxlayer-vitest-state-` when `VITEST === "true"` and no `stateDir` is passed; production still defaults to the homedir path. Those dirs are removed on `dispose()` and registered for cleanup on `process` exit. When `createServer` creates its own context, `server.close()` also calls `context.dispose()`.
> 
> The false-green empty-surface suite uses a unique temp `stateDir` per test and passes it into every `createServer` call. New cases cover long `send_command` submit verification: skipped when isolated state has no agent record, and enforced when an interactive record exists for the surface. A dedicated isolation test asserts the auto-selected path and that `dispose()` removes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499328e5ba3770c041d84a1a4a5d58ce1181d4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate server tests from live cmux-agents state using temporary directories
> - `createServerContext` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/209/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now auto-creates a unique temp directory via `mkdtempSync` when running under Vitest and no `stateDir` is provided, instead of using `~/.local/state/cmux-agents`.
> - Two new helpers, `registerAutoVitestStateDir` and `removeAutoVitestStateDir`, track and clean up these temp directories on `dispose()` and process exit.
> - `createServer` now detects when it owns the context and ensures `server.close()` also calls `dispose()` on that context.
> - [tests/false-green-empty-surface.test.ts](https://github.com/EtanHey/cmuxlayer/pull/209/files#diff-b7859db89dc39454aedb4833638b4299190b539ba63c873267f48f26812f9310) is refactored to create isolated per-test temp directories and pass them as `stateDir`, with a new test verifying submit verification against isolated state.
> - [tests/test-state-isolation.test.ts](https://github.com/EtanHey/cmuxlayer/pull/209/files#diff-5cd4d9c829f3f5c300757f1b99b0ac364d1937e653528401757cb4883eb67ab0) is added to verify that `createServerContext` under Vitest uses a temp directory and removes it on dispose.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 499328e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for temporary server state created during test runs.
  * Improved server shutdown behavior so owned temporary state is cleaned up even on early close.

* **Bug Fixes**
  * Isolated test state is now created per run and removed afterward, reducing state leakage between tests.
  * Updated test coverage to verify temporary state directories are unique and cleaned up properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->