### PR TITLE
feat(input): guard oversized send_input/inline-prompt with file-pointer guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ prompt's Enter is verified before delivery falls back to readiness/composer-clea
 it for agents that stream their first tokens slowly (e.g. Opus-4.8/1M, Gemini on multi-KB prompts) if
 you still see false `Enter submit could not be verified` errors; invalid values fall back to the default.
 
+`CMUXLAYER_MAX_INLINE_CHARS` (positive integer >= 500, default `1800`) caps raw pane-keystroke payloads
+for `send_input.text`, `send_command.command`, and `spawn_agent.prompt`. Larger task payloads should live
+in a file and be delivered as one line (`Read and follow <path>`); launcher boot prompts should use
+`boot_prompt_path`. Invalid values fall back to the default.
+
 ## Testing Conventions
 - Test files mirror source: `src/foo.ts` -> `tests/foo.test.ts`
 - Agent engine tests use 1-second timeouts for state change detection

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,6 +149,7 @@ const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 const SEND_INPUT_CHUNK_THRESHOLD = 500;
+const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
@@ -165,6 +166,19 @@ function parsePositiveIntegerMs(
 const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = parsePositiveIntegerMs(
   process.env.CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS,
   DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
+);
+function parseMaxInlineChars(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= SEND_INPUT_CHUNK_THRESHOLD
+    ? parsed
+    : fallback;
+}
+const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
+  process.env.CMUXLAYER_MAX_INLINE_CHARS,
+  DEFAULT_SEND_INPUT_MAX_INLINE_CHARS,
 );
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
@@ -603,6 +617,30 @@ function getBootPromptPath(value: string | null | undefined): string | null {
 
 function hasInlinePrompt(value: string | undefined): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function assertInlineInputAllowed(opts: {
+  tool: "send_input" | "send_command" | "spawn_agent";
+  arg: "text" | "command" | "prompt";
+  value: string | undefined;
+  allowLongInline?: boolean;
+}): void {
+  if (
+    opts.allowLongInline ||
+    opts.value === undefined ||
+    opts.value.length <= SEND_INPUT_MAX_INLINE_CHARS
+  ) {
+    return;
+  }
+
+  const argName = `${opts.tool}.${opts.arg}`;
+  const promptPathGuidance =
+    opts.tool === "spawn_agent" || opts.tool === "send_command"
+      ? " For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path."
+      : " For launchers, put the full boot prompt in a file and pass boot_prompt_path.";
+  throw new Error(
+    `${argName} is ${opts.value.length} characters, above CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}. Pane keystrokes are capped to one-line pointers: write the payload to a file and send "Read and follow <path>" instead.${promptPathGuidance} To deliberately send raw inline text, pass allow_long_inline:true. CMUXLAYER_MAX_INLINE_CHARS may be set to a positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}.`,
+  );
 }
 
 function assertBootPromptMode(
@@ -3238,10 +3276,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 6. send_input
   server.tool(
     "send_input",
-    "Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxlayer resolves the current backing surface. WARNING — DO NOT include a bare `@word` (e.g. `@narration-lead`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats `@` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (`narration-lead:`) for pane-to-pane addressing; reserve `@<name>` for collab-file posts where monitors match it. If a literal `@` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Long text over 500 characters is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.",
+    `Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxlayer resolves the current backing surface. WARNING — DO NOT include a bare \`@word\` (e.g. \`@narration-lead\`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats \`@\` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (\`narration-lead:\`) for pane-to-pane addressing; reserve \`@<name>\` for collab-file posts where monitors match it. If a literal \`@\` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); write large payloads to a file and send one line: "Read and follow <path>". Pass allow_long_inline:true only for deliberate raw sends. Text over ${SEND_INPUT_CHUNK_THRESHOLD} characters that is allowed is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.`,
     {
       surface: z.string().describe("Target surface ref"),
-      text: z.string().describe("Text to send"),
+      text: z
+        .string()
+        .describe(
+          `Text to send. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters by default; for large payloads write a file and send "Read and follow <path>" instead.`,
+        ),
       workspace: z.string().optional().describe("Target workspace ref"),
       chunk_size: z
         .number()
@@ -3266,10 +3308,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .string()
         .optional()
         .describe("Rename tab suffix to this task name"),
+      allow_long_inline: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Bypass the inline length cap for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
+        ),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        assertInlineInputAllowed({
+          tool: "send_input",
+          arg: "text",
+          value: args.text,
+          allowLongInline: args.allow_long_inline,
+        });
         const sanitizedText = sanitizeTerminalInput(args.text);
         const chunks =
           sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
@@ -3365,12 +3420,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 7. send_command
   server.tool(
     "send_command",
-    "Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command. WARNING — never include a bare `@word` in text destined for an interactive agent composer: it fires the receiver's file-reference picker and corrupts delivery (use the bare name; `@<name>` belongs in collab files, not pane keystrokes). For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path reads a prompt file after the launcher reaches readiness and submits it; passing boot_prompt_path for plain shell commands is rejected.",
+    `Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command only when it fits the ${SEND_INPUT_MAX_INLINE_CHARS}-character inline cap. WARNING — never include a bare \`@word\` in text destined for an interactive agent composer: it fires the receiver's file-reference picker and corrupts delivery (use the bare name; \`@<name>\` belongs in collab files, not pane keystrokes). For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path reads a prompt file after the launcher reaches readiness and submits it; use boot_prompt_path instead of embedding a long boot prompt in pane keystrokes. Passing boot_prompt_path for plain shell commands is rejected. Pass allow_long_inline:true only for deliberate raw long commands.`,
     {
       surface: z.string().describe("Target surface ref"),
       command: z
         .string()
-        .describe("Command text to send before pressing return"),
+        .describe(
+          `Command text to send before pressing return. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters by default; for agent boot prompts, keep the command short and pass boot_prompt_path.`,
+        ),
       workspace: z.string().optional().describe("Target workspace ref"),
       boot_prompt_path: z
         .string()
@@ -3386,10 +3443,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .optional()
         .default(BOOT_PROMPT_TIMEOUT_MS)
         .describe("Timeout in milliseconds waiting for the agent ready prompt"),
+      allow_long_inline: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Bypass the inline command length cap for a deliberate raw send.",
+        ),
     },
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        assertInlineInputAllowed({
+          tool: "send_command",
+          arg: "command",
+          value: args.command,
+          allowLongInline: args.allow_long_inline,
+        });
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         const launcherCli = bootPromptPath
           ? inferLauncherCli(args.command)
@@ -4662,7 +4732,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      "Spawn a managed AI agent in a terminal surface and return an agent_id plus health for future routing. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot prompt, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. boot_prompt_path is checked before spawning and read after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.",
+      `Spawn a managed AI agent in a terminal surface and return an agent_id plus health for future routing. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot prompt, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Inline prompt is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default; use boot_prompt_path for larger boot prompts. boot_prompt_path is checked before spawning and read after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.`,
       {
         repo: z
           .string()
@@ -4678,7 +4748,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe(
-            "Inline task prompt to send after the agent is ready. Mutually exclusive with boot_prompt_path.",
+            `Inline task prompt to send after the agent is ready. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters by default; use boot_prompt_path for larger prompts. Mutually exclusive with boot_prompt_path.`,
           ),
         boot_prompt_path: z
           .string()
@@ -4748,12 +4818,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "When true, suppress same repo/workspace/role duplicate-lane warnings. Default false so collab leads see reusable existing agents before spawning another lane.",
           ),
+        allow_long_inline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Bypass the inline prompt length cap for a deliberate raw boot-prompt send. Prefer boot_prompt_path for large prompts.",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
         try {
           const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
           assertBootPromptMode(args.prompt, bootPromptPath);
+          assertInlineInputAllowed({
+            tool: "spawn_agent",
+            arg: "prompt",
+            value: args.prompt,
+            allowLongInline: args.allow_long_inline,
+          });
           if (bootPromptPath) {
             await preflightBootPromptFile(bootPromptPath);
           }

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -418,6 +418,7 @@ describe("enter reliability", () => {
     const result = await callTool(server, "send_command", {
       surface: client.surface,
       command: "y".repeat(2000),
+      allow_long_inline: true,
     });
     const parsed = parseResult(result);
     const events = readEventLog();

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const previousMaxInlineChars = process.env.CMUXLAYER_MAX_INLINE_CHARS;
+let testDir = "";
+
+async function loadServerModule() {
+  vi.resetModules();
+  return import("../src/server.js");
+}
+
+function parseToolResult(result: any) {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+function makeLifecycleExec(): ExecFn {
+  let readyText = "codex> ";
+  let promptPending = false;
+
+  return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+    if (args.includes("send-key") && args.includes("return")) {
+      if (promptPending) {
+        readyText =
+          "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+        promptPending = false;
+      }
+      return { stdout: "{}", stderr: "" };
+    }
+
+    if (args.includes("send")) {
+      const text = String(args.at(-1) ?? "");
+      if (text.trim() && !/Codex\b/.test(text)) {
+        promptPending = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:new",
+          text: readyText,
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:new"],
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:new",
+              title: "agent-pane",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
+describe("pane input pointer discipline", () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "cmuxlayer-pointer-discipline-"));
+    delete process.env.CMUXLAYER_MAX_INLINE_CHARS;
+  });
+
+  afterEach(() => {
+    if (previousMaxInlineChars === undefined) {
+      delete process.env.CMUXLAYER_MAX_INLINE_CHARS;
+    } else {
+      process.env.CMUXLAYER_MAX_INLINE_CHARS = previousMaxInlineChars;
+    }
+    rmSync(testDir, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it("send_input refuses over-threshold text with file-pointer guidance and opt-out naming", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: "x".repeat(601) },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("send_input.text");
+    expect(parsed.error).toContain("allow_long_inline");
+    expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS");
+    expect(parsed.error).toContain("Read and follow <path>");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("send_input allow_long_inline preserves chunked delivery", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+    expect(tool.inputSchema.shape.allow_long_inline).toBeDefined();
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text: "x".repeat(2_000),
+        chunk_size: 120,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("set-buffer"),
+    );
+    expect(parsed.ok).toBe(true);
+    expect(setBufferCalls.length).toBeGreaterThan(1);
+  });
+
+  it("CMUXLAYER_MAX_INLINE_CHARS changes the cap and invalid values fall back to the default", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "700";
+    let module = await loadServerModule();
+    let mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    let server = module.createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+    });
+    let tool = (server as any)._registeredTools["send_input"];
+
+    let result = await tool.handler(
+      { surface: "surface:1", text: "x".repeat(701) },
+      {} as any,
+    );
+
+    let parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(mockExec).not.toHaveBeenCalled();
+
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "not-a-number";
+    module = await loadServerModule();
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    server = module.createServer({ exec: mockExec, skipAgentLifecycle: true });
+    tool = (server as any)._registeredTools["send_input"];
+
+    result = await tool.handler(
+      { surface: "surface:1", text: "x".repeat(1_700) },
+      {} as any,
+    );
+
+    parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalled();
+  });
+
+  it("short send_input text stays allowed", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: "x".repeat(600) },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1"]),
+    );
+  });
+
+  it("send_command refuses over-threshold command text unless explicitly opted out", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+    expect(tool.inputSchema.shape.allow_long_inline).toBeDefined();
+
+    let result = await tool.handler(
+      { surface: "surface:1", command: "x".repeat(601) },
+      {} as any,
+    );
+
+    let parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("send_command.command");
+    expect(parsed.error).toContain("boot_prompt_path");
+    expect(mockExec).not.toHaveBeenCalled();
+
+    result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "x".repeat(601),
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer"))
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("send-key"))
+        .length,
+    ).toBe(1);
+  });
+
+  it("spawn_agent refuses an over-threshold inline prompt and points to boot_prompt_path", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+    mockExec.mockClear();
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "x".repeat(601),
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("spawn_agent.prompt");
+    expect(parsed.error).toContain("boot_prompt_path");
+    expect(parsed.error).toContain("allow_long_inline");
+    expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it("spawn_agent allow_long_inline bypasses the inline prompt cap", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+    expect(tool.inputSchema.shape.allow_long_inline).toBeDefined();
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "x".repeat(2_000),
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["set-buffer"]),
+    );
+    context.dispose();
+  });
+
+  it("spawn_agent keeps boot_prompt_path allowed regardless of prompt file size", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const promptPath = join(testDir, "large-boot-prompt.md");
+    writeFileSync(promptPath, "x".repeat(2_400), "utf8");
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    context.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- Add parse-once `CMUXLAYER_MAX_INLINE_CHARS` defaulting to 1800, with invalid or sub-500 values falling back to the default.
- Refuse oversized inline pane-keystroke payloads by default for `send_input.text`, `send_command.command`, and `spawn_agent.prompt` with actionable file-pointer guidance.
- Add `allow_long_inline:true` as the explicit raw-send opt-out while preserving existing chunked delivery for opted-out/allowed sends.
- Keep `boot_prompt_path` file-backed boot prompts allowed regardless of size and document the new env var in `CLAUDE.md`.

## Test plan
- [x] RED: `bunx vitest run tests/pointer-discipline.test.ts` failed before implementation on missing guard/schema behavior.
- [x] Focused: `bunx vitest run tests/pointer-discipline.test.ts` passed 8/8.
- [x] Related: `bunx vitest run tests/server.test.ts tests/server-agent-tools.test.ts` passed 168/168.
- [x] Regression: `bunx vitest run tests/enter-reliability.test.ts -t "retries Enter for send_command"` passed 1/1.
- [x] Required full sequence: `bun run typecheck && bun run test` exited 0 with 66 test files and 1109 tests passing.
- [x] Push hook reran regression scripts plus `vitest run`; hook finished with exit status 0.

## Notes
- Default is loud refusal, not auto-divert, to avoid changing delivery semantics unexpectedly.
- `graphify query` failed in this worktree because `graphify-out/graph.json` is absent; rerunning from the main checkout returned only stale model-policy/spawn-agent recon nodes, not this pointer-discipline path.
- Local `docs.local/reports/issue-6-report.md` was written and ends with `DONE_ISSUE_6`; `docs.local/` is gitignored.
- Pre-commit `coderabbit review --agent` was started and reached review heartbeats but did not complete within the bounded window, so it was stopped and this PR relies on fresh local verification plus PR-level bot review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior for long inline sends on core terminal tools (send_input, send_command, spawn_agent); callers must use files or allow_long_inline, which could break automation that relied on silent chunking.
> 
> **Overview**
> Adds a **default 1800-character cap** on raw inline pane input (`send_input.text`, `send_command.command`, `spawn_agent.prompt`), tunable via **`CMUXLAYER_MAX_INLINE_CHARS`** (minimum 500; invalid values fall back to default).
> 
> Oversized inline payloads **fail with explicit errors** that steer callers toward file-backed delivery (`Read and follow <path>`) or **`boot_prompt_path`** for launchers, instead of silently chunking huge strings into the terminal.
> 
> Each of those tools gains **`allow_long_inline:true`** to opt out deliberately; opted-out sends keep existing chunked delivery. **`boot_prompt_path`** remains uncapped by file size.
> 
> Tool descriptions and **`CLAUDE.md`** document the env var. New **`tests/pointer-discipline.test.ts`** covers refusal, env parsing, opt-out, and file boot prompts; **`enter-reliability`** sets `allow_long_inline` for a long-command Enter retry test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78c44726a605ae298c406859552a885bc547f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard oversized inline inputs in `send_input`, `send_command`, and `spawn_agent` with file-pointer guidance
> - Adds `assertInlineInputAllowed` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/210/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that rejects inline payloads exceeding a configurable character cap (default 1800, set via `CMUXLAYER_MAX_INLINE_CHARS`), throwing an error with guidance to write payloads to a file or use `boot_prompt_path`.
> - All three tool handlers (`send_input.text`, `send_command.command`, `spawn_agent.prompt`) now call this guard before processing; callers can bypass it by passing `allow_long_inline: true`.
> - `boot_prompt_path` is always allowed regardless of file size.
> - Behavioral Change: previously, oversized `send_input` text was chunked and sent automatically; it now throws unless `allow_long_inline: true` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d78c447.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->