### PR TITLE
feat(input): extend inline-length guard to send_to/send_to_agent

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -212,6 +212,7 @@ const SendToArgsSchema = z.object({
   text: z.string(),
   press_enter: z.boolean().optional().default(true),
   allow_busy: z.boolean().optional().default(false),
+  allow_long_inline: z.boolean().optional().default(false),
 });
 
 type DeliveryStatus = "delivering" | "delivered" | "failed";
@@ -620,7 +621,12 @@ function hasInlinePrompt(value: string | undefined): value is string {
 }
 
 function assertInlineInputAllowed(opts: {
-  tool: "send_input" | "send_command" | "spawn_agent";
+  tool:
+    | "send_input"
+    | "send_command"
+    | "spawn_agent"
+    | "send_to"
+    | "send_to_agent";
   arg: "text" | "command" | "prompt";
   value: string | undefined;
   allowLongInline?: boolean;
@@ -5645,14 +5651,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      "Preferred path for sending text to a tracked agent by agent_id. Resolves the current backing surface internally so clients do not need pane or surface references, and should be used instead of send_input whenever an agent_id is available. For collab supersession, send a short `/goal Read and follow <absolute goal file>` reference rather than a long lossy paste. Returns submission evidence plus registry state, parsed screen status, state_conflict, and health; submit_verified means the input was submitted/cleared, not that the agent accepted, started, or completed the task.",
+      `Preferred path for sending text to a tracked agent by agent_id. Resolves the current backing surface internally so clients do not need pane or surface references, and should be used instead of send_input whenever an agent_id is available. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); write large payloads to a file and send one line: "Read and follow <path>". For collab supersession, send a short \`/goal Read and follow <absolute goal file>\` reference rather than a long lossy paste. For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path through spawn_agent/send_command instead of routing raw long text through the agent composer. Pass allow_long_inline:true only for deliberate raw sends. Returns submission evidence plus registry state, parsed screen status, state_conflict, and health; submit_verified means the input was submitted/cleared, not that the agent accepted, started, or completed the task.`,
       {
         ...SendToArgsSchema.shape,
+        text: SendToArgsSchema.shape.text.describe(
+          `Text to send. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters by default; for large payloads write a file and send "Read and follow <path>" instead.`,
+        ),
         press_enter: SendToArgsSchema.shape.press_enter.describe(
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
           "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior). Use to interject while an agent is working — e.g., to cancel, steer, or stack an instruction.",
+        ),
+        allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
+          "Bypass the inline length cap for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
         ),
       },
       ANNOTATIONS.mutating,
@@ -5666,6 +5678,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           const args = parsedArgs.data;
+          assertInlineInputAllowed({
+            tool: "send_to",
+            arg: "text",
+            value: args.text,
+            allowLongInline: args.allow_long_inline,
+          });
           const delivery = await deliverAgentInput({
             agent_id: args.agent_id,
             text: args.text,
@@ -5690,14 +5708,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 18. send_to_agent
     server.tool(
       "send_to_agent",
-      "Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state. Returns the same post-delivery registry/screen health evidence as send_to.",
+      `Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); write large payloads to a file and send one line: "Read and follow <path>". For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path through spawn_agent/send_command instead of routing raw long text through the agent composer. Pass allow_long_inline:true only for deliberate raw sends. Returns the same post-delivery registry/screen health evidence as send_to.`,
       {
         ...SendToArgsSchema.shape,
+        text: SendToArgsSchema.shape.text.describe(
+          `Text to send. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters by default; for large payloads write a file and send "Read and follow <path>" instead.`,
+        ),
         press_enter: SendToArgsSchema.shape.press_enter.describe(
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
           "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior).",
+        ),
+        allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
+          "Bypass the inline length cap for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
         ),
       },
       ANNOTATIONS.mutating,
@@ -5713,6 +5737,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           const args = parsedArgs.data;
+          assertInlineInputAllowed({
+            tool: "send_to_agent",
+            arg: "text",
+            value: args.text,
+            allowLongInline: args.allow_long_inline,
+          });
           const delivery = await deliverAgentInput({
             agent_id: args.agent_id,
             text: args.text,

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -364,6 +364,7 @@ describe("enter reliability", () => {
       agent_id: "agent-1",
       text: "x".repeat(2000),
       press_enter: true,
+      allow_long_inline: true,
     });
     const parsed = parseResult(result);
     const events = readEventLog();
@@ -584,11 +585,13 @@ describe("enter reliability", () => {
       agent_id: "agent-1",
       text: "first\n".repeat(300),
       press_enter: true,
+      allow_long_inline: true,
     });
     await callTool(server, "send_to", {
       agent_id: "agent-1",
       text: "second\n".repeat(300),
       press_enter: true,
+      allow_long_inline: true,
     });
 
     const events = readEventLog().filter(

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -16,6 +16,28 @@ function parseToolResult(result: any) {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
+function getLifecycleEngine(server: any) {
+  return server._registeredTools.interact._engine;
+}
+
+async function spawnReadyAgent(server: any) {
+  const spawn = server._registeredTools["spawn_agent"];
+  const spawnResult = await spawn.handler(
+    {
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+    },
+    {} as any,
+  );
+  const agentId = parseToolResult(spawnResult).agent_id;
+  const engine = getLifecycleEngine(server);
+  const registry = engine.getRegistry();
+  const agent = registry.get(agentId);
+  registry.set(agentId, { ...agent, state: "ready" });
+  return agentId;
+}
+
 function makeLifecycleExec(): ExecFn {
   let readyText = "codex> ";
   let promptPending = false;
@@ -375,6 +397,191 @@ describe("pane input pointer discipline", () => {
     const parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
+    context.dispose();
+  });
+
+  it("send_to refuses over-threshold text with file-pointer guidance and opt-out naming", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendTo = (server as any)._registeredTools["send_to"];
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(601),
+        press_enter: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("send_to.text");
+    expect(parsed.error).toContain("allow_long_inline");
+    expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS");
+    expect(parsed.error).toContain("Read and follow <path>");
+    expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it("send_to allow_long_inline bypasses the inline text cap", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendTo = (server as any)._registeredTools["send_to"];
+    expect(sendTo.inputSchema.shape.allow_long_inline).toBeDefined();
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(2_000),
+        press_enter: true,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("set-buffer"),
+    );
+    expect(parsed.ok).toBe(true);
+    expect(setBufferCalls.length).toBeGreaterThan(1);
+    context.dispose();
+  });
+
+  it("short send_to text stays allowed at the configured cap", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendTo = (server as any)._registeredTools["send_to"];
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(600),
+        press_enter: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send-key", "--surface", "surface:new"]),
+    );
+    context.dispose();
+  });
+
+  it("send_to_agent refuses over-threshold text unless explicitly opted out", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendToAgent = (server as any)._registeredTools["send_to_agent"];
+    expect(sendToAgent.inputSchema.shape.allow_long_inline).toBeDefined();
+    mockExec.mockClear();
+
+    let result = await sendToAgent.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(601),
+        press_enter: true,
+      },
+      {} as any,
+    );
+
+    let parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("send_to_agent.text");
+    expect(parsed.error).toContain("allow_long_inline");
+    expect(mockExec).not.toHaveBeenCalled();
+
+    result = await sendToAgent.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(2_000),
+        press_enter: true,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("set-buffer"))
+        .length,
+    ).toBeGreaterThan(1);
+    context.dispose();
+  });
+
+  it("CMUXLAYER_MAX_INLINE_CHARS changes the send_to cap", async () => {
+    process.env.CMUXLAYER_MAX_INLINE_CHARS = "700";
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendTo = (server as any)._registeredTools["send_to"];
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      {
+        agent_id: agentId,
+        text: "x".repeat(701),
+        press_enter: true,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS=700");
+    expect(mockExec).not.toHaveBeenCalled();
     context.dispose();
   });
 });


### PR DESCRIPTION
## Summary
- Extend the existing #210 inline-length guard to `send_to.text` and `send_to_agent.text` before agent delivery.
- Add `allow_long_inline` to the shared relay schema and document the cap/file-pointer/boot_prompt_path guidance on both tools.
- Keep allowed long sends on the existing chunked delivery path; update deliberate long-send reliability tests to opt out explicitly.

## Test plan
- `bun run test -- tests/pointer-discipline.test.ts`
- `bun run test -- tests/server-agent-tools.test.ts tests/enter-reliability.test.ts tests/verified-relay.test.ts tests/stale-surface-ref.test.ts tests/recycled-surface-identity.test.ts`
- `bun run typecheck && bun run test`
- Normal `git push -u origin feat/pointer-discipline-send-to` pre-push hook: regression checks plus full Vitest suite, ending `run_tests.sh finished with exit status 0`

## Notes
- `graphify query "send_to send_to_agent assertInlineInputAllowed"` could not run because this worktree lacks `graphify-out/graph.json`; I proceeded from source/tests and recorded that in `docs.local/reports/issue-10-report.md`.
- Do not merge; lead owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default behavior of primary agent messaging tools by rejecting long inline text unless explicitly opted out, which could break clients that relied on uncapped sends.
> 
> **Overview**
> **`send_to` and `send_to_agent` now enforce the same inline text cap** as `send_input` (via `CMUXLAYER_MAX_INLINE_CHARS` / `SEND_INPUT_MAX_INLINE_CHARS`) before any agent delivery runs. Oversized `text` is rejected with file-pointer guidance unless the caller passes **`allow_long_inline: true`**.
> 
> The shared **`SendToArgsSchema`** gains `allow_long_inline` (default `false`). **`assertInlineInputAllowed`** is extended to cover `send_to` / `send_to_agent`, and both tool handlers invoke it up front. Tool descriptions and parameter `.describe()` text document the cap, “Read and follow &lt;path&gt;”, and **`boot_prompt_path`** for launcher prompts.
> 
> Deliberate long sends still use **existing chunked delivery** when opted in. Reliability tests that send multi-kilobyte inline text now set **`allow_long_inline: true`**; **`pointer-discipline.test.ts`** adds coverage for refusal, opt-out, at-cap success, and env-driven limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19fb337b35f1c63294dd2d3792e4613aa2940859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend inline-length guard to `send_to` and `send_to_agent` tools
> - Adds `allow_long_inline` boolean (default `false`) to `SendToArgsSchema`, shared by both `send_to` and `send_to_agent`.
> - Both tools now call `assertInlineInputAllowed` before delivering text, rejecting payloads over the threshold unless `allow_long_inline: true` is passed.
> - The cap is configurable via the `CMUXLAYER_MAX_INLINE_CHARS` environment variable.
> - Existing tests in [enter-reliability.test.ts](https://github.com/EtanHey/cmuxlayer/pull/211/files#diff-5e89c52026fcdfee326f57b1efc91920f9bc47ec7a580591cebc889ffb9a21fb) that send large payloads are updated to pass `allow_long_inline: true`.
> - Behavioral Change: `send_to` and `send_to_agent` now error on over-threshold inline text by default; callers sending large payloads must opt in with `allow_long_inline: true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 19fb337. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->