### PR TITLE
fix(spawn): report pane-died distinctly from submit-verify timeout

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -275,6 +275,70 @@ class BootPromptDeliveryError extends Error {
   }
 }
 
+class SurfaceGoneError extends Error {
+  readonly error_code = "pane_died";
+
+  constructor(
+    readonly surface: string,
+    readonly originalError: unknown,
+  ) {
+    super(`surface ${surface} disappeared - respawn`);
+    this.name = "SurfaceGoneError";
+  }
+}
+
+function readErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    const extra = error as Error & {
+      code?: unknown;
+      stderr?: unknown;
+      stdout?: unknown;
+      cause?: unknown;
+    };
+    return [
+      error.name,
+      error.message,
+      typeof extra.code === "string" ? extra.code : "",
+      typeof extra.stderr === "string" ? extra.stderr : "",
+      typeof extra.stdout === "string" ? extra.stdout : "",
+      extra.cause instanceof Error ? extra.cause.message : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+  return String(error);
+}
+
+function isSurfaceGoneReadFailure(error: unknown, surface: string): boolean {
+  const text = readErrorText(error).toLowerCase();
+  const surfaceLower = surface.toLowerCase();
+  if (
+    text.includes(`unable to resolve workspace for surface ${surfaceLower}`)
+  ) {
+    return true;
+  }
+  if (/\bsurface[-_\s]?not[-_\s]?found\b/.test(text)) {
+    return true;
+  }
+  if (text.includes("surface is not a terminal")) {
+    return true;
+  }
+  return /\bnot_found\b/.test(text) && text.includes("surface");
+}
+
+function surfaceGonePayload(
+  error: SurfaceGoneError,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    error_code: error.error_code,
+    pane_died: true,
+    surface: error.surface,
+    action: "respawn",
+    ...extra,
+  };
+}
+
 function ok(data: Record<string, unknown>): ToolReturn {
   const payload = { ok: true, ...data };
   return {
@@ -1547,6 +1611,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const readParsedSurface = async (
     surface: string,
     workspace?: string,
+    opts?: { throwOnSurfaceGone?: boolean },
   ): Promise<{ text: string; parsed: ParsedScreenResult } | null> => {
     try {
       const screen = await client.readScreen(surface, {
@@ -1563,7 +1628,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         resolveHarnessStateForSurface(stateMgr, surface),
       );
       return { text, parsed };
-    } catch {
+    } catch (error) {
+      if (opts?.throwOnSurfaceGone && isSurfaceGoneReadFailure(error, surface)) {
+        throw new SurfaceGoneError(surface, error);
+      }
       return null;
     }
   };
@@ -1610,7 +1678,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let retryCount = 0;
 
     while (Date.now() - startedAt < SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS) {
-      const snapshot = await readParsedSurface(opts.surface, opts.workspace);
+      const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
+        throwOnSurfaceGone: true,
+      });
       if (!snapshot) {
         return { submit_verified: null, retry_count: retryCount };
       }
@@ -1884,6 +1954,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         if (error instanceof BootPromptTimeoutError) {
           throw error;
         }
+        if (isSurfaceGoneReadFailure(error, opts.surface)) {
+          throw new SurfaceGoneError(opts.surface, error);
+        }
         lastText = error instanceof Error ? error.message : String(error);
       }
 
@@ -1910,7 +1983,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let lastText = "";
 
     while (Date.now() - start < opts.timeout_ms) {
-      const snapshot = await readParsedSurface(opts.surface, opts.workspace);
+      const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
+        throwOnSurfaceGone: true,
+      });
       if (snapshot) {
         lastText = snapshot.text;
         const hasPendingInput = screenShowsPendingInput(
@@ -1965,6 +2040,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return;
         }
       } catch (error) {
+        if (isSurfaceGoneReadFailure(error, opts.surface)) {
+          throw new SurfaceGoneError(opts.surface, error);
+        }
         lastText = error instanceof Error ? error.message : String(error);
       }
 
@@ -2006,6 +2084,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return;
         }
       } catch (error) {
+        if (isSurfaceGoneReadFailure(error, opts.surface)) {
+          throw new SurfaceGoneError(opts.surface, error);
+        }
         lastText = error instanceof Error ? error.message : String(error);
       }
 
@@ -2125,6 +2206,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       return { ...delivery, prompt_text: rawPrompt };
     } catch (error) {
+      if (error instanceof SurfaceGoneError) {
+        throw error;
+      }
       if (error instanceof SubmitVerificationError) {
         const snapshot = await readParsedSurface(opts.surface, opts.workspace);
         if (
@@ -3067,6 +3151,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof SurfaceGoneError) {
+          return err(e, surfaceGonePayload(e));
+        }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, {
             surface: result?.surface,
@@ -3185,6 +3272,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof SurfaceGoneError) {
+          return err(e, surfaceGonePayload(e));
+        }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, {
             surface: result?.surface,
@@ -3409,6 +3499,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof SurfaceGoneError) {
+          return err(e, surfaceGonePayload(e));
+        }
         if (e instanceof SubmitVerificationError) {
           return err(e, {
             submit_verified: false,
@@ -3543,6 +3636,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        if (e instanceof SurfaceGoneError) {
+          return err(e, surfaceGonePayload(e));
+        }
         if (e instanceof SubmitVerificationError) {
           return err(e, {
             submit_verified: false,
@@ -5003,6 +5099,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               agent_id: result.agent_id,
               surface_id: result.surface_id,
             };
+            if (e instanceof SurfaceGoneError) {
+              return err(e, surfaceGonePayload(e, extra));
+            }
             if (e instanceof BootPromptTimeoutError) {
               try {
                 clearBootPromptPending();

--- a/src/server.ts
+++ b/src/server.ts
@@ -320,9 +320,6 @@ function isSurfaceGoneReadFailure(error: unknown, surface: string): boolean {
   if (/\bsurface[-_\s]?not[-_\s]?found\b/.test(text)) {
     return true;
   }
-  if (text.includes("surface is not a terminal")) {
-    return true;
-  }
   return /\bnot_found\b/.test(text) && text.includes("surface");
 }
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4491,7 +4491,7 @@ describe("tool handler integration", () => {
         returnPresses += 1;
         return { stdout: "{}", stderr: "" };
       }
-      if (args.includes("send")) {
+      if (args.includes("send") || args.includes("set-buffer")) {
         promptSent = true;
         return { stdout: "{}", stderr: "" };
       }
@@ -4529,6 +4529,153 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
     expect(returnPresses).toBe(2);
+  }, 10_000);
+
+  it("new_split reports pane_died when the new surface disappears during boot prompt submit verification", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-pane-died.md");
+    const prompt = "short boot prompt";
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+    let promptSent = false;
+    let returnPresses = 0;
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send") || args.includes("set-buffer")) {
+        promptSent = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        if (promptSent && returnPresses > 0) {
+          throw Object.assign(new Error("Command failed"), {
+            code: 1,
+            stderr: "not_found: Surface not found for the given surface_id",
+          });
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: "codex> ",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 50,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("pane_died");
+    expect(parsed.error).toContain("surface surface:2 disappeared");
+    expect(parsed.surface).toBe("surface:2");
+  }, 10_000);
+
+  it("new_split does not classify transient read errors as pane_died during boot prompt fallback", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-transient-read.md");
+    const prompt = "short boot prompt";
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+    let promptSent = false;
+    let returnPresses = 0;
+    let transientFailureThrown = false;
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send") || args.includes("set-buffer")) {
+        promptSent = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        if (!transientFailureThrown) {
+          transientFailureThrown = true;
+          throw Object.assign(new Error("temporary read unavailable"), {
+            stderr: "pty read temporarily unavailable",
+          });
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text:
+              promptSent && returnPresses >= 2
+                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                : promptSent
+                  ? `codex> ${prompt}`
+                  : "codex> ",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(parsed.error_code).toBeUndefined();
+    expect(transientFailureThrown).toBe(true);
   }, 10_000);
 
   it("new_split fails when the boot prompt clears after retry without agent identity", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4637,7 +4637,7 @@ describe("tool handler integration", () => {
         if (!transientFailureThrown) {
           transientFailureThrown = true;
           throw Object.assign(new Error("temporary read unavailable"), {
-            stderr: "pty read temporarily unavailable",
+            stderr: "Surface is not a terminal",
           });
         }
         return {


### PR DESCRIPTION
## Summary
- Detect genuine surface-gone read failures inside boot/readiness polling loops and throw a distinct `pane_died` error instead of falling through to generic timeouts.
- Return structured `error_code: "pane_died"`, `pane_died: true`, and `action: "respawn"` from the affected tool boundaries.
- Keep transient read hiccups tolerant so slow-but-alive surfaces can still succeed through the existing boot-submit readiness fallback.

## Investigation
- Live cmux probe on a disposable closed tab confirmed:
  - with workspace: `not_found: Surface not found for the given surface_id`
  - without workspace: `Unable to resolve workspace for surface surface:53`
- Socket path trace confirmed missing surfaces can fail during workspace resolution before `surface.read_text`; CLI fallback preserves `surface not found` stderr strings.

## Test plan
- [x] `bun test tests/server.test.ts -t "pane_died|transient read errors"`
- [x] `bun run typecheck && bun run test`
- [x] pre-push hook completed successfully during `git push`
- [x] `coderabbit review --agent` (rerun after local fix): 0 findings

## Notes
- Required local report written at `docs.local/reports/issue-7-report.md` and ends with `DONE_ISSUE_7`.
- Do not merge here; lead owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling across multiple MCP tool paths and boot/submit polling loops; misclassification could either hide real pane death or falsely abort healthy flows, though new tests target those cases.
> 
> **Overview**
> When a terminal **surface disappears** during boot prompt, submit verification, or readiness polling, the server now raises **`SurfaceGoneError`** instead of treating the failure as a generic timeout or silent `null` read.
> 
> **Detection** uses `readErrorText` plus `isSurfaceGoneReadFailure` to match cmux-style messages (e.g. surface not found, unable to resolve workspace). **`readParsedSurface`** gains optional **`throwOnSurfaceGone`**; polling paths that need a hard signal enable it, while other reads still return `null` on failure.
> 
> **Tool boundaries** (`new_split`, `new_surface`, `send_input`, `send_command`, agent spawn boot flows) catch `SurfaceGoneError` and return structured errors: **`error_code: "pane_died"`**, **`pane_died: true`**, **`action: "respawn"`**, and the surface id. Transient read errors that do not match the surface-gone heuristics are **not** classified as pane died.
> 
> Tests cover **`new_split`** returning `pane_died` when read-screen fails after submit, and success when a one-off transient read error occurs during boot fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9921d22310bc224f2e286fa430d70d01e7a168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report pane-died distinctly from submit-verify timeout in spawn handlers
> - Introduces `SurfaceGoneError`, a custom error subclass with `error_code: 'pane_died'`, thrown when read-screen calls detect a disappeared surface during polling loops.
> - Adds `isSurfaceGoneReadFailure` to classify errors by inspecting stderr/stdout for patterns like `'unable to resolve workspace for surface'` or `'surface not found'`.
> - Updates `readParsedSurface` to accept `{ throwOnSurfaceGone: true }`, converting qualifying read failures into `SurfaceGoneError` instead of returning `null`.
> - Tool handlers (`new_split`, `new_tab`, `send_input`, `send_command`) now catch `SurfaceGoneError` and return a structured payload with `pane_died: true`, `action: 'respawn'`, and the affected surface id.
> - Behavioral Change: callers that previously received a timeout or generic error when a pane died during boot prompt delivery or submit verification will now receive `error_code: 'pane_died'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b9921d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a terminal surface disappears during interactive actions.
  * Readiness checks now return a clearer “pane died” error with respawn guidance instead of failing inconsistently or timing out.
  * Added more reliable behavior for boot prompt delivery and surface creation so temporary read failures don’t interrupt successful flows.
  * Error responses now include more consistent details about the affected surface, helping clients recover automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->