### PR TITLE
fix(inbox): self-heal a deleted channel dir on write

### DIFF
--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -7,6 +7,7 @@ export type AgentHealthIssueCode =
   | "auto_discovered_agent"
   | "missing_cli_session_id"
   | "non_resumable"
+  | "inbox_channel_dir_deleted"
   | "inbox_monitor_not_alive"
   | "stale_inbox_dispatches"
   | "registry_screen_disagreement"
@@ -27,6 +28,7 @@ export interface AgentTopologyHealthInput {
 
 export interface AgentHealthInput {
   monitor_alive?: boolean | null;
+  inbox_channel_dir_deleted?: boolean | null;
   stale_count?: number;
   screen_status?: string | null;
   surface_workspace_id?: string | null;
@@ -153,7 +155,14 @@ export function evaluateAgentHealth(
     );
   }
 
-  if (input.monitor_alive === false) {
+  if (input.monitor_alive === false && input.inbox_channel_dir_deleted === true) {
+    addIssue(
+      issueCodes,
+      issues,
+      "inbox_channel_dir_deleted",
+      "agent inbox channel dir was deleted after creation; next inbox write will recreate it",
+    );
+  } else if (input.monitor_alive === false) {
     addIssue(
       issueCodes,
       issues,

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -20,7 +20,7 @@
 //
 // send_input is KEPT as the fallback path — this channel is additive (belt-and-suspenders) until
 // proven in production.
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -90,12 +90,36 @@ export function heartbeatPath(agentId: string, opts?: InboxOpts): string {
   return join(agentDir(agentId, opts), "monitor.heartbeat");
 }
 
-function ensureDir(agentId: string, opts?: InboxOpts): void {
+function channelMarkerDir(opts?: InboxOpts): string {
+  return join(baseDirOf(opts), ".channel-dirs");
+}
+
+function channelMarkerPath(agentId: string, opts?: InboxOpts): string {
+  return join(channelMarkerDir(opts), `${encodeURIComponent(agentId)}.created`);
+}
+
+function ensureChannelDirForWrite(agentId: string, opts?: InboxOpts): void {
   mkdirSync(agentDir(agentId, opts), { recursive: true });
+  mkdirSync(channelMarkerDir(opts), { recursive: true });
+  appendFileSync(channelMarkerPath(agentId, opts), "");
+}
+
+export function channelDirExists(agentId: string, opts?: InboxOpts): boolean {
+  return existsSync(agentDir(agentId, opts));
+}
+
+export function channelDirDeletedAfterCreate(
+  agentId: string,
+  opts?: InboxOpts,
+): boolean {
+  return (
+    existsSync(channelMarkerPath(agentId, opts)) &&
+    !channelDirExists(agentId, opts)
+  );
 }
 
 export function ensureInboxFile(agentId: string, opts?: InboxOpts): string {
-  ensureDir(agentId, opts);
+  ensureChannelDirForWrite(agentId, opts);
   const path = inboxPath(agentId, opts);
   appendFileSync(path, "");
   return path;
@@ -146,7 +170,7 @@ export function dispatch(
   input: DispatchInput,
   opts?: InboxOpts,
 ): InboxMessage {
-  ensureDir(agentId, opts);
+  ensureChannelDirForWrite(agentId, opts);
   const ts = input.ts_ms ?? nowOf(opts);
   const msg: InboxMessage = {
     id: input.id ?? genId(ts),
@@ -194,7 +218,7 @@ export function ack(
   status: string,
   opts?: InboxOpts,
 ): InboxAck {
-  ensureDir(agentId, opts);
+  ensureChannelDirForWrite(agentId, opts);
   const record: InboxAck = {
     ts_ms: nowOf(opts),
     agent: agentId,
@@ -228,7 +252,7 @@ export function writeHeartbeat(
   opts?: InboxOpts,
   source: MonitorHeartbeatSource = "agent",
 ): number {
-  ensureDir(agentId, opts);
+  ensureChannelDirForWrite(agentId, opts);
   const ts = nowOf(opts);
   const sourceSuffix = source === "agent" ? "" : ` ${source}`;
   appendFileSync(heartbeatPath(agentId, opts), `${ts}${sourceSuffix}\n`);
@@ -313,5 +337,6 @@ export function recommendedCodexWatch(
   agentId: string,
   opts?: InboxOpts,
 ): string {
+  ensureChannelDirForWrite(agentId, opts);
   return `tail -n0 -F ${inboxPath(agentId, opts)} >> ${surfacedLogPath(agentId, opts)}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import {
   parseScreen,
 } from "./screen-parser.js";
 import {
+  channelDirDeletedAfterCreate,
   dispatch,
   ensureInboxFile,
   inboxPath,
@@ -2534,6 +2535,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_title?: string | null;
       topology?: { column: number | null; column_count: number | null } | null;
       closure_artifact_verified?: boolean | null;
+      inbox_channel_dir_deleted?: boolean | null;
     },
   ) => {
     const closureArtifactVerified =
@@ -2553,6 +2555,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const alive =
       overrides?.monitor_alive ??
       monitorAlive(agent.agent_id, INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS, inboxOpts);
+    const inboxChannelDirDeleted =
+      overrides?.inbox_channel_dir_deleted ??
+      (!alive && channelDirDeletedAfterCreate(agent.agent_id, inboxOpts));
     const staleCount =
       overrides?.stale_count ??
       pendingDispatches(agent.agent_id, 120000, inboxOpts).length;
@@ -2575,6 +2580,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         : await resolveSurfaceWorkspace(agent.surface_id);
     return evaluateAgentHealth(agent, {
       monitor_alive: alive,
+      inbox_channel_dir_deleted: inboxChannelDirDeleted,
       stale_count: staleCount,
       screen_status: screenStatus,
       screen_actions: screenActions,

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -69,6 +69,21 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("missing_cli_session_id");
   });
 
+  it("distinguishes a deleted inbox channel dir from a never-armed monitor", () => {
+    const deleted = evaluateAgentHealth(makeRecord(), {
+      monitor_alive: false,
+      inbox_channel_dir_deleted: true,
+    });
+    const neverArmed = evaluateAgentHealth(makeRecord(), {
+      monitor_alive: false,
+    });
+
+    expect(deleted.issue_codes).toContain("inbox_channel_dir_deleted");
+    expect(deleted.issue_codes).not.toContain("inbox_monitor_not_alive");
+    expect(neverArmed.issue_codes).toContain("inbox_monitor_not_alive");
+    expect(neverArmed.issue_codes).not.toContain("inbox_channel_dir_deleted");
+  });
+
   it("marks auto-discovered lead surfaces as missing managed lead ids", () => {
     const health = evaluateAgentHealth(
       makeRecord({

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -18,7 +18,7 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
-import { writeHeartbeat, readInbox } from "../src/inbox.js";
+import { agentDir, writeHeartbeat, readInbox } from "../src/inbox.js";
 import type { ExecFn } from "../src/cmux-client.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-inbox-nudge");
@@ -489,5 +489,25 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.undelivered_count).toBe(1);
+  });
+
+  it("get_agent_state reports a deleted inbox channel dir distinctly from a never-armed monitor", async () => {
+    const agentId = await spawnTestAgent(server);
+    writeHeartbeat(agentId, { baseDir: inboxDir });
+    rmSync(agentDir(agentId, { baseDir: inboxDir }), {
+      recursive: true,
+      force: true,
+    });
+
+    const getState = server._registeredTools["get_agent_state"];
+    const result = await getState.handler({ agent_id: agentId }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining(["inbox_channel_dir_deleted"]),
+    });
+    expect(parsed.health.issue_codes).not.toContain("inbox_monitor_not_alive");
   });
 });

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   ack,
   ackedIds,
+  agentDir,
   dispatch,
   inboxPath,
   monitorAlive,
@@ -154,6 +155,19 @@ describe("inbox write-channel", () => {
     const cmd = recommendedCodexWatch("a10", opts);
     expect(cmd).toBe(
       `tail -n0 -F ${inboxPath("a10", opts)} >> ${surfacedLogPath("a10", opts)}`,
+    );
+  });
+
+  it("Codex watch recreates a deleted channel dir before returning a surfaced-log write command", () => {
+    const dir = agentDir("a10-deleted", opts);
+    writeHeartbeat("a10-deleted", opts);
+    rmSync(dir, { recursive: true, force: true });
+
+    const cmd = recommendedCodexWatch("a10-deleted", opts);
+
+    expect(existsSync(dir)).toBe(true);
+    expect(cmd).toBe(
+      `tail -n0 -F ${inboxPath("a10-deleted", opts)} >> ${surfacedLogPath("a10-deleted", opts)}`,
     );
   });
 


### PR DESCRIPTION
## Summary
- Recreate inbox channel dirs through a single write-prep helper before inbox/ack/heartbeat writes and the Codex surfaced-log watch command.
- Track channel creation outside the per-agent channel dir so health can report `inbox_channel_dir_deleted` separately from `inbox_monitor_not_alive`.
- Wire the deleted-dir detector through server health and add temp-baseDir regression coverage.

## Test plan
- [x] RED: `bun run test -- tests/inbox.test.ts tests/agent-health.test.ts` failed on the deleted-dir watch command and deleted-dir health distinction before implementation.
- [x] `bun run test -- tests/inbox.test.ts tests/agent-health.test.ts tests/inbox-nudge.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Pre-push hook: race fixtures + full `vitest run` passed.

## Notes
- `docs.local/reports/issue-11-report.md` was written locally and ends with `DONE_ISSUE_11`; `docs.local/` is gitignored, so it is not included in this PR.
- The brief said `graphify-out/graph.json` existed in the worktree, but it was absent there. I ran `graphify query` successfully from the main checkout where `graphify-out/graph.json` exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local filesystem coordination and health labeling only; no auth, registry, or dispatch semantics changes beyond mkdir-on-write.
> 
> **Overview**
> Inbox channel directories that were removed after first use are **recreated on the next write** (dispatch, ack, heartbeat, Codex watch setup) via a shared `ensureChannelDirForWrite` helper. Creation is tracked with **persistent markers** under `.channel-dirs` so the system can tell “dir was deleted” from “monitor never armed.”
> 
> Agent health now reports **`inbox_channel_dir_deleted`** instead of **`inbox_monitor_not_alive`** when the marker exists but the per-agent channel dir is missing and the heartbeat looks dead. **`get_agent_state`** passes that signal through from `channelDirDeletedAfterCreate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1879cac498ed991ff7b1770da0921800f8c86451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inbox channel dir deletion by self-healing on write and reporting a distinct health issue
> - Write-path functions (`dispatch`, `ack`, `writeHeartbeat`, `ensureInboxFile`, `recommendedCodexWatch`) now call `ensureChannelDirForWrite` before operating, which recreates a deleted channel directory and writes a marker file under `.channel-dirs/` to record that the channel was created.
> - A new `channelDirDeletedAfterCreate` helper in [inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/213/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) detects when a creation marker exists but the channel directory is gone.
> - `evaluateAgentHealth` in [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/213/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3) now emits `inbox_channel_dir_deleted` instead of `inbox_monitor_not_alive` when the monitor is not alive and the channel dir was deleted after creation.
> - `get_agent_state` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/213/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) passes the result of `channelDirDeletedAfterCreate` into `evaluateAgentHealth` to surface the new issue code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1879cac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for deleted inbox channel directories so agent health can report this condition separately.
  - Improved inbox/channel setup to recreate missing channel directories before watch and logging operations.

- **Bug Fixes**
  - Health checks now distinguish between “monitor not alive” and “channel directory deleted after creation,” giving more accurate status reporting.
  - Recommended watch behavior now works even if the channel directory was removed, and confirms the directory is restored before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->