### PR TITLE
fix(spawn): warn when cmux returns a placement-mismatched workspace

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -110,6 +110,10 @@ export interface SpawnAgentResult {
   mcp_env?: string;
 }
 
+type CreatedAgentSurface = (CmuxNewSplitResult | CmuxNewSurfaceResult) & {
+  warnings?: string[];
+};
+
 export interface CapturedSessionIdentity {
   session_id: string;
   path?: string | null;
@@ -942,7 +946,7 @@ export class AgentEngine {
       parentAgent?: AgentRecord | null;
       repo?: string;
     },
-  ): Promise<CmuxNewSplitResult | CmuxNewSurfaceResult> {
+  ): Promise<CreatedAgentSurface> {
     // Pin a child worker to the parent orchestrator's ACTUAL workspace before
     // falling back to repo-name resolution. Without this a worker re-resolves
     // its workspace purely from the repo directory name, which fails for
@@ -1030,26 +1034,47 @@ export class AgentEngine {
           childWorkerSurfaceIds,
         },
       );
-      return placement.kind === "surface"
-        ? this.client.newSurface({
-            pane: placement.pane,
-            type: "terminal",
-            workspace,
-          })
-        : this.client.newSplit(placement.direction, {
-            ...(placement.pane ? { pane: placement.pane } : {}),
-            workspace,
-            type: "terminal",
-          });
+      const surface =
+        placement.kind === "surface"
+          ? await this.client.newSurface({
+              pane: placement.pane,
+              type: "terminal",
+              workspace,
+            })
+          : await this.client.newSplit(placement.direction, {
+              ...(placement.pane ? { pane: placement.pane } : {}),
+              workspace,
+              type: "terminal",
+            });
+      return this.withWorkspacePlacementWarning(surface, workspace);
     } catch (error) {
       if (isAgentRoleInferenceError(error)) {
         throw error;
       }
-      return this.client.newSplit("right", {
+      const surface = await this.client.newSplit("right", {
         workspace,
         type: "terminal",
       });
+      return this.withWorkspacePlacementWarning(surface, workspace);
     }
+  }
+
+  private withWorkspacePlacementWarning<T extends CreatedAgentSurface>(
+    surface: T,
+    requestedWorkspace: string | undefined,
+  ): T {
+    if (
+      !requestedWorkspace ||
+      !surface.workspace ||
+      surface.workspace === requestedWorkspace
+    ) {
+      return surface;
+    }
+    const warning = `Spawn placement mismatch: requested ${requestedWorkspace} but cmux returned ${surface.workspace} for surface ${surface.surface}`;
+    return {
+      ...surface,
+      warnings: [...(surface.warnings ?? []), warning],
+    };
   }
 
   private async resolveWorkspaceForRepo(
@@ -2057,7 +2082,7 @@ export class AgentEngine {
       state: "booting",
       model: modelPolicy.effective_model,
       requested_model: modelPolicy.requested_model,
-      warnings: modelPolicy.warnings,
+      warnings: [...modelPolicy.warnings, ...(surface.warnings ?? [])],
       model_policy: modelPolicy,
       cwd: spawnParams.cwd,
       mcp_env: spawnParams.mcp_env,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -512,6 +512,48 @@ describe("AgentEngine", () => {
       );
     });
 
+    it("warns when cmux returns a spawned surface in a different workspace than requested", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:interactive"],
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        workspace_ref: "workspace:intended",
+        window_ref: "window:1",
+        pane_ref: "pane:left",
+        surfaces: [makeSurface("surface:interactive")],
+      });
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "workspace:wrong",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "",
+        type: "terminal",
+      });
+
+      const result = await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix placement",
+        workspace: "workspace:intended",
+      });
+
+      expect(result.workspace_id).toBe("workspace:wrong");
+      expect(result.warnings).toContain(
+        "Spawn placement mismatch: requested workspace:intended but cmux returned workspace:wrong for surface surface:new",
+      );
+    });
+
     it("inherits the workspace whose current directory matches the target repo", async () => {
       (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue(
         {


### PR DESCRIPTION
## Summary
- Add a post-create placement check for `spawn_agent` surface creation.
- Warn when cmux returns a surface in a different workspace than the requested target workspace.
- Preserve the actual returned workspace and keep same-workspace/default focus behavior unchanged.

## Root-cause boundary
The MCP already resolves and pins a target workspace before surface creation. The remaining drift appears to be app/socket state after stale refs or window consolidation. This PR closes the MCP observability gap by surfacing the mismatch as a structured warning instead of silently reporting a normal spawn.

## Test plan
- `bun run test tests/agent-engine.test.ts --testNamePattern "warns when cmux returns"` RED before fix, GREEN after fix.
- `bun run typecheck && bun run test` passed locally: 66 files / 1117 tests.
- `coderabbit review --agent` completed locally with `findings:0`.
- `git push -u origin fix/spawn-workspace-placement` ran pre-push hooks without `--no-verify`; hook finished with exit status 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only check after existing surface creation; spawn outcomes and workspace ids are unchanged except for optional warning strings on the result.
> 
> **Overview**
> **Spawn observability:** After cmux creates a terminal surface for `spawn_agent`, the engine compares the **requested** workspace to the workspace cmux reports on the new surface. If they differ, it appends a structured **Spawn placement mismatch** warning on the surface result; spawn still uses cmux’s actual `workspace_id` and does not change focus or placement logic when they match.
> 
> **Caller-facing warnings:** `spawnAgent` now merges those surface warnings with existing model-policy warnings in the returned `warnings` array, so MCP/clients can see drift without treating the spawn as failed.
> 
> **Tests:** A unit test covers the mismatch path (requested `workspace:intended`, cmux returns `workspace:wrong`) and asserts the warning text while preserving the returned workspace id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c3c314d9700d89e8cc737553e72fec20585d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn when cmux returns a surface in a different workspace than requested
> - Adds `withWorkspacePlacementWarning` helper in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/214/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) that compares the requested workspace to the one cmux actually placed the surface in, appending a mismatch message to `warnings` on the result if they differ.
> - `spawnAgent` merges these surface warnings into the existing `modelPolicy.warnings` array so callers see the full warning set.
> - Adds a test covering the mismatch case, verifying the returned `workspace_id` and warning message are correct.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08c3c31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->