### PR TITLE
feat(phase-0): control-plane invariant contract + painpoint replay corpus

### DIFF
--- a/docs/control-plane-invariants.md
+++ b/docs/control-plane-invariants.md
@@ -1,0 +1,71 @@
+# Control-Plane Invariants
+
+Status: Phase 0 contract. This document is the canonical state-machine target for later painpoint
+fixes; it does not claim current source already implements every state.
+
+## Current Vocabulary Split
+
+The current codebase has three related but non-equivalent vocabularies:
+
+- Persisted lifecycle: `creating | booting | ready | working | idle | done | error`
+  (`src/agent-types.ts:6-13`), with transitions in `src/agent-types.ts:199-206`.
+- Parsed screen status: `frozen | thinking | working | idle | done`
+  (`src/types.ts:124-129`).
+- Delivery status: `delivering | delivered | failed` (`src/server.ts:219-225`).
+
+The canonical classifier unifies these into states that are safe for routing, delivery, spawning,
+recovery, and sidebar/reporting decisions.
+
+## Canonical States
+
+| State | Entry evidence | Exit evidence | Current representation |
+| --- | --- | --- | --- |
+| `unknown` | No reliable agent identity, no live-shell evidence, or unreadable/degraded evidence channel. | A stronger state-specific detector fires. | Parser agent type includes `unknown` and `detectAgentType()` falls back to it (`src/types.ts:118-123`, `src/screen-parser.ts:277-319`). Not a persisted lifecycle state (`src/agent-types.ts:6-13`). |
+| `shell` | Shell prompt such as `$`, `%`, `#`, or a bare `>` without an agent identity. | Agent identity plus ready/busy/booting evidence, or dead/stale evidence. | Not modelled. Shell-like prompts currently parse as `idle` (`src/screen-parser.ts:803-807`); launch shell readiness only matches `$%#` (`src/server.ts:786-787`). |
+| `agent_booting` | Managed record is `booting`, or boot prompt delivery/readiness is in progress. | Ready evidence after boot prompt submission, explicit boot failure, or dead/stale evidence. | Current name is lifecycle `booting` (`src/agent-types.ts:6-13`), with initial spawn state at `src/agent-engine.ts:2000-2007` and `boot_prompt_pending` at `src/agent-types.ts:56-57`, `src/agent-engine.ts:2030`. |
+| `ready` | Agent identity plus ready prompt or proven idle/interactive state for that CLI. | Delivery starts, working/thinking marker appears, overlay/prompt appears, or route becomes dead/stale/poisoned. | Persisted as `ready` (`src/agent-types.ts:6-13`), allowed after `booting` (`src/agent-types.ts:199-204`), set after boot delivery (`src/server.ts:5064-5068`) and sweeps (`src/agent-engine.ts:1359-1374`). |
+| `busy` | Working/thinking markers, active execution banners, or lifecycle `working`. | Ready/done/dead/stale evidence. | Not modelled under this name. Parsed `thinking`/`working` exist (`src/types.ts:124-129`); send routing treats non-`ready`/`idle` as non-interactive unless `allow_busy` (`src/server.ts:201`, `src/server.ts:4785-4790`). |
+| `interactive_overlay` | AskUserQuestion, model picker, generic confirmation menu, or other modal/picker that captures keystrokes. | Overlay is dismissed and normal ready/busy state returns. | Not modelled. Permission is partially detected, but generic overlays are absent from current parser/patterns (`src/screen-parser.ts:168-169`, `src/screen-parser.ts:509-523`, `src/pattern-registry.ts:52-75`). |
+| `permission_prompt` | Permission/approval strings such as `do you want to allow`, `allow for this session`, or `[y/n]`. | Explicit allow/deny outcome and prompt disappears. | Partially modelled as parser error `permission_prompt` and status `frozen` (`src/screen-parser.ts:168-169`, `src/screen-parser.ts:509-523`, `src/screen-parser.ts:739-741`), with parser test coverage (`tests/screen-parser.test.ts:85-99`). |
+| `composer_dirty` | Submitted text tail remains visible in the composer, or long/multiline delivery was partially typed/refused before clear evidence. | Composer clear evidence plus agent identity, or explicit refusal/failure. | Not modelled as a state. Current private helper checks the submitted tail (`src/server.ts:850-860`) and submit/boot verification consumes it (`src/server.ts:1694-1735`, `src/server.ts:1989-1997`). |
+| `dead` | Surface read says gone, pane closed, empty dead pane, or process/surface disappearance is positively known. | Respawn/recovery creates a new live route, or the record is terminally archived. | Partially modelled as lifecycle `error` and `pane_died` errors (`src/agent-registry.ts:101-110`, `src/server.ts:279-338`), not a distinct state. Empty submit verification returns null, not true (`src/server.ts:1686-1688`). |
+| `stale_surface` | Registry route points to a surface not in the live list, or live surface has a different occupant/session. | Route is repaired from session index or resync, or delivery refuses clearly. | Partially modelled as delivery-time stale-ref guard (`src/server.ts:4703-4745`) plus durable surface/session index (`src/state-manager.ts:34-45`, `src/state-manager.ts:83-130`). |
+| `poisoned_registry` | Registry records conflict, duplicate routes disagree, ghosts remain after vanished surfaces, or stale `error` state would suppress wakeups. | Reconcile/evict repairs to one route per agent, or poisoned records are isolated/refused. | Not modelled as a state. `dispatch_to_agent` bypasses lifecycle because stale `error` records previously killed wakeups (`src/server.ts:4278-4286`, `src/server.ts:4307-4313`); duplicate route rejection exists in tests (`tests/agent-facade.test.ts:95-111`). |
+
+## Allowed Transitions
+
+Allowed transitions are intentionally narrower than current ad hoc state movement:
+
+- `unknown -> shell | agent_booting | ready | busy | interactive_overlay | permission_prompt | dead | stale_surface | poisoned_registry`
+- `shell -> agent_booting | ready | dead`
+- `agent_booting -> ready | busy | composer_dirty | permission_prompt | interactive_overlay | dead | stale_surface | poisoned_registry`
+- `ready -> busy | interactive_overlay | permission_prompt | composer_dirty | dead | stale_surface | poisoned_registry`
+- `busy -> ready | interactive_overlay | permission_prompt | dead | stale_surface | poisoned_registry`
+- `interactive_overlay -> ready | busy | permission_prompt | dead | stale_surface`
+- `permission_prompt -> ready | busy | interactive_overlay | dead | stale_surface`
+- `composer_dirty -> ready | busy | permission_prompt | interactive_overlay | dead | stale_surface`
+- `dead -> agent_booting | poisoned_registry`
+- `stale_surface -> ready | agent_booting | dead | poisoned_registry`
+- `poisoned_registry -> unknown | ready | dead | stale_surface`
+
+Terminal lifecycle states such as `done` remain lifecycle/reporting outcomes; delivery must still
+classify their backing control-plane route before sending or closing.
+
+## Fixture Pass/Fail Criteria
+
+| Fixture | Desired state/refusal | Pass criterion |
+| --- | --- | --- |
+| `claude-ask-user-question-overlay.txt` | `interactive_overlay`, `blocked_by_interactive_prompt` | Normal delivery refuses, does not send keystrokes, and never reports `submit_verified:true`. |
+| `claude-permission-confirmation.txt` | `permission_prompt`, `blocked_by_permission_prompt` | Parser preserves Claude identity and permission evidence; delivery refuses as permission-blocked, not generic frozen/idle. |
+| `boot-prompt-typed-not-submitted.json` | `composer_dirty` plus `agent_booting` | Pending text remains visible, boot prompt is not silently marked delivered, and record does not transition to `ready`. |
+| `bare-shell-and-bare-gemini-prompt.txt` | `shell` | Bare shell/`>` prompts never become `ready` without agent identity, including sweep ready patterns. |
+| `empty-dead-pane-submit.json` | `dead` | Empty/gone pane submit verification returns null/false or `pane_died`, never `submit_verified:true`. |
+| `stale-surface-after-respawn.json` | `stale_surface` | Route is repaired from session index or refused after rescan; no send targets the stale surface. |
+| `registry-ghost-duplicate-surface.json` | `poisoned_registry` | Ghosts are evicted/isolated and duplicate conflicting routes are rejected before delivery. |
+| `wrong-workspace-spawn.json` | `ready` only in intended workspace | Same-repo child inherits parent workspace; any wrong-workspace route is rejected or marked stale/poisoned. |
+| `long-inline-prompt-wedge.json` | preflight refusal or `composer_dirty` | Oversized inline prompt is refused before typing unless explicitly allowed; no partial send or false submit success. |
+| `multiline-payload-premature-submit.json` | paste-as-one-message or refusal | Multiline payload is pasted/chunked as one composer message with one final Enter, or refuses before typing if paste is unavailable. |
+
+The executable Phase 0 contract lives in `tests/painpoint-replay.test.ts`. It keeps fixture loading
+green and registers the desired canonical classifier assertions as `todo` until later phases add the
+classifier and delivery gates.

--- a/tests/fixtures/painpoints/bare-shell-and-bare-gemini-prompt.txt
+++ b/tests/fixtures/painpoints/bare-shell-and-bare-gemini-prompt.txt
@@ -1,0 +1,9 @@
+case: bash prompt
+etanheyman cmuxlayer-worker-1783191155415 $
+
+case: bare greater-than prompt
+>
+
+case: repeated bare greater-than prompt without Gemini identity
+>
+>

--- a/tests/fixtures/painpoints/boot-prompt-typed-not-submitted.json
+++ b/tests/fixtures/painpoints/boot-prompt-typed-not-submitted.json
@@ -1,0 +1,27 @@
+{
+  "id": "boot-prompt-typed-not-submitted",
+  "description": "Boot prompt remains visible in the composer after delivery was attempted.",
+  "expected_state": "composer_dirty",
+  "secondary_state": "agent_booting",
+  "phase_home": "phase-3-spawn-readiness-monitor-boot and phase-5-submit-verification-v2",
+  "source_evidence": [
+    "src/agent-types.ts:56-57",
+    "src/server.ts:850-860",
+    "src/server.ts:1974-1997"
+  ],
+  "agent_record": {
+    "agent_id": "agent-booting-1",
+    "surface_id": "surface:boot-1",
+    "workspace_id": "workspace:main",
+    "state": "booting",
+    "boot_prompt_pending": true,
+    "cli": "codex"
+  },
+  "screen_text": "OpenAI Codex\nModel: gpt-5.5\n\ncodex> Read and follow docs.local/plans/phase-0.md",
+  "submitted_text": "Read and follow docs.local/plans/phase-0.md",
+  "assertions": [
+    "pending input remains visible",
+    "boot_prompt_pending is not silently cleared",
+    "agent does not transition to ready"
+  ]
+}

--- a/tests/fixtures/painpoints/claude-ask-user-question-overlay.txt
+++ b/tests/fixtures/painpoints/claude-ask-user-question-overlay.txt
@@ -1,0 +1,11 @@
+Claude Code
+
+AskUserQuestion
+The agent is asking for clarification before continuing.
+
+> Which workspace should I use?
+  1. Current workspace
+  2. New worker split
+
+Simulated attempted send_to payload:
+Read and follow docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/reports/GOAL-phase0-invariant-contract.md

--- a/tests/fixtures/painpoints/claude-permission-confirmation.txt
+++ b/tests/fixtures/painpoints/claude-permission-confirmation.txt
@@ -1,0 +1,9 @@
+Claude Code
+
+Do you want to allow this command?
+
+> 1. Allow for this session
+  2. Allow once
+  3. Deny
+
+[y/n]

--- a/tests/fixtures/painpoints/empty-dead-pane-submit.json
+++ b/tests/fixtures/painpoints/empty-dead-pane-submit.json
@@ -1,0 +1,20 @@
+{
+  "id": "empty-dead-pane-submit",
+  "description": "Empty or gone pane must not produce submit_verified:true.",
+  "expected_state": "dead",
+  "phase_home": "phase-5-submit-verification-v2",
+  "source_evidence": [
+    "src/server.ts:279-338",
+    "src/server.ts:1686-1688"
+  ],
+  "screen_text": "",
+  "read_error": {
+    "message": "surface surface:dead-1 is gone",
+    "error_code": "pane_died"
+  },
+  "assertions": [
+    "verifySubmitAfterEnter returns null or false",
+    "delivery result reports pane_died",
+    "submit_verified is never true"
+  ]
+}

--- a/tests/fixtures/painpoints/long-inline-prompt-wedge.json
+++ b/tests/fixtures/painpoints/long-inline-prompt-wedge.json
@@ -1,0 +1,18 @@
+{
+  "id": "long-inline-prompt-wedge",
+  "description": "Long inline prompt must be refused before keystrokes or left as composer_dirty if already typed.",
+  "expected_state": "composer_dirty",
+  "phase_home": "phase-1-delivery-safety-gate",
+  "source_evidence": [
+    "src/server.ts:153-183",
+    "src/server.ts:685-711"
+  ],
+  "inline_length": 1801,
+  "limit_env": "CMUXLAYER_MAX_INLINE_CHARS",
+  "screen_text": "OpenAI Codex\nModel: gpt-5.5\n\ncodex> " ,
+  "assertions": [
+    "assertInlineInputAllowed rejects before delivery unless allow_long_inline is true",
+    "large payload guidance points to file-pointer delivery",
+    "no partial send and no submit_verified:true"
+  ]
+}

--- a/tests/fixtures/painpoints/multiline-payload-premature-submit.json
+++ b/tests/fixtures/painpoints/multiline-payload-premature-submit.json
@@ -1,0 +1,20 @@
+{
+  "id": "multiline-payload-premature-submit",
+  "description": "Multiline Codex payload must paste as one composer message or refuse instead of submitting line by line.",
+  "expected_state": "composer_dirty",
+  "phase_home": "phase-1-delivery-safety-gate",
+  "source_evidence": [
+    "src/server.ts:607-619",
+    "src/server.ts:658-660",
+    "src/sanitize.ts:1-17"
+  ],
+  "payload": "line one\nline two\nline three",
+  "target_cli": "codex",
+  "observed_symptom": "Codex receives newline-delimited text as separate submitted messages.",
+  "root_cause_status": "unconfirmed; fixture covers symptom and candidate newline chunking path",
+  "assertions": [
+    "multiline text uses paste delivery as one composer message",
+    "press_enter occurs once after final chunk",
+    "if paste is unavailable, delivery refuses before typing"
+  ]
+}

--- a/tests/fixtures/painpoints/registry-ghost-duplicate-surface.json
+++ b/tests/fixtures/painpoints/registry-ghost-duplicate-surface.json
@@ -1,0 +1,39 @@
+{
+  "id": "registry-ghost-duplicate-surface",
+  "description": "Registry contains a stale error/booting ghost and conflicting duplicate routes.",
+  "expected_state": "poisoned_registry",
+  "phase_home": "phase-6-registry-resync-ghost-reaper",
+  "source_evidence": [
+    "src/server.ts:4278-4286",
+    "src/server.ts:4307-4313",
+    "tests/agent-facade.test.ts:95-111"
+  ],
+  "records": [
+    {
+      "agent_id": "agent-ghost",
+      "surface_id": "surface:missing",
+      "workspace_id": "workspace:main",
+      "state": "error",
+      "cli": "codex"
+    },
+    {
+      "agent_id": "agent-dup",
+      "surface_id": "surface:1",
+      "workspace_id": "workspace:main",
+      "state": "ready",
+      "cli": "claude"
+    },
+    {
+      "agent_id": "agent-dup",
+      "surface_id": "surface:2",
+      "workspace_id": "workspace:main",
+      "state": "ready",
+      "cli": "claude"
+    }
+  ],
+  "assertions": [
+    "conflicting routes are rejected",
+    "ghost records are evicted or marked poisoned",
+    "dispatch_to_agent does not rely on poisoned lifecycle state"
+  ]
+}

--- a/tests/fixtures/painpoints/stale-surface-after-respawn.json
+++ b/tests/fixtures/painpoints/stale-surface-after-respawn.json
@@ -1,0 +1,38 @@
+{
+  "id": "stale-surface-after-respawn",
+  "description": "Agent record points at an old surface after respawn; live surface list omits it.",
+  "expected_state": "stale_surface",
+  "phase_home": "phase-2-agent-identity-surface-index and phase-6-registry-resync-ghost-reaper",
+  "source_evidence": [
+    "src/state-manager.ts:34-45",
+    "src/state-manager.ts:83-130",
+    "src/server.ts:4703-4745",
+    "tests/stale-surface-ref.test.ts:178-195"
+  ],
+  "agent_record": {
+    "agent_id": "agent-stale-1",
+    "surface_id": "surface:old",
+    "workspace_id": "workspace:main",
+    "state": "ready",
+    "cli": "claude",
+    "cli_session_id": "claude-session-old"
+  },
+  "live_surfaces": [
+    {
+      "ref": "surface:new",
+      "workspace_ref": "workspace:main",
+      "title": "claude replacement"
+    }
+  ],
+  "surface_session_index": {
+    "agent_id": "agent-stale-1",
+    "surface_id": "surface:old",
+    "workspace_id": "workspace:main",
+    "cli_session_id": "claude-session-old"
+  },
+  "assertions": [
+    "send_to rescans before delivery",
+    "no send occurs to surface:old",
+    "route is repaired or refused as stale"
+  ]
+}

--- a/tests/fixtures/painpoints/wrong-workspace-spawn.json
+++ b/tests/fixtures/painpoints/wrong-workspace-spawn.json
@@ -1,0 +1,28 @@
+{
+  "id": "wrong-workspace-spawn",
+  "description": "Same-repo child spawn must inherit the parent workspace instead of the focused workspace.",
+  "expected_state": "ready",
+  "phase_home": "phase-4-layout-workspace-determinism",
+  "source_evidence": [
+    "src/agent-engine.ts:950-970",
+    "src/repo-workspace.ts:76-105"
+  ],
+  "parent_agent": {
+    "agent_id": "parent-orchestrator",
+    "repo": "/example/workspaces/cmuxlayer",
+    "workspace_id": "workspace:A",
+    "surface_id": "surface:parent",
+    "state": "ready",
+    "role": "orchestrator"
+  },
+  "spawn_request": {
+    "repo": "/example/workspaces/cmuxlayer.wt/cmuxlayer-worker-1",
+    "focused_workspace": "workspace:B",
+    "explicit_workspace": null
+  },
+  "assertions": [
+    "same-repo child spawn selects workspace:A",
+    "no split is created in workspace:B",
+    "ready is valid only when the child occupies the intended workspace"
+  ]
+}

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, extname } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseScreen } from "../src/screen-parser.js";
+
+type PainpointFixture = {
+  id: string;
+  expected_state: string;
+  phase_home: string;
+  source_evidence: string[];
+  screen_text?: string;
+  assertions?: string[];
+};
+
+const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
+
+function readPainpointFixture(fileName: string): PainpointFixture {
+  const raw = readFileSync(new URL(fileName, fixtureDir), "utf8");
+  if (fileName.endsWith(".json")) {
+    return JSON.parse(raw) as PainpointFixture;
+  }
+  const id = basename(fileName, extname(fileName));
+  const expectedById: Record<string, string> = {
+    "claude-ask-user-question-overlay": "interactive_overlay",
+    "claude-permission-confirmation": "permission_prompt",
+    "bare-shell-and-bare-gemini-prompt": "shell",
+  };
+  return {
+    id,
+    expected_state: expectedById[id] ?? "unknown",
+    phase_home:
+      id === "bare-shell-and-bare-gemini-prompt"
+        ? "phase-3-spawn-readiness-monitor-boot"
+        : "phase-1-delivery-safety-gate",
+    source_evidence: [fileName],
+    screen_text: raw,
+    assertions: ["canonical classifier emits the expected control-plane state"],
+  };
+}
+
+const fixtureNames = readdirSync(fixtureDir)
+  .filter((name) => name.endsWith(".json") || name.endsWith(".txt"))
+  .sort();
+
+const fixtures = fixtureNames.map(readPainpointFixture);
+
+function legacyClassifierShape(fixture: PainpointFixture): string {
+  if (fixture.screen_text !== undefined) {
+    const parsed = parseScreen(fixture.screen_text);
+    return `legacy:${parsed.agent_type}:${parsed.status}:${parsed.errors.join(",")}`;
+  }
+  return "legacy:no-canonical-control-plane-classifier";
+}
+
+describe("Phase 0 painpoint replay corpus", () => {
+  it("loads every required painpoint fixture", () => {
+    expect(fixtures.map((fixture) => fixture.id)).toEqual([
+      "bare-shell-and-bare-gemini-prompt",
+      "boot-prompt-typed-not-submitted",
+      "claude-ask-user-question-overlay",
+      "claude-permission-confirmation",
+      "empty-dead-pane-submit",
+      "long-inline-prompt-wedge",
+      "multiline-payload-premature-submit",
+      "registry-ghost-duplicate-surface",
+      "stale-surface-after-respawn",
+      "wrong-workspace-spawn",
+    ]);
+  });
+
+  it("documents phase ownership and source evidence for every fixture", () => {
+    for (const fixture of fixtures) {
+      expect(fixture.phase_home).toBeTruthy();
+      expect(fixture.source_evidence.length).toBeGreaterThan(0);
+      expect(fixture.assertions?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  for (const fixture of fixtures) {
+    it.todo(
+      `${fixture.id} classifies as ${fixture.expected_state} via the canonical control-plane state machine`,
+      () => {
+        expect(legacyClassifierShape(fixture)).toBe(fixture.expected_state);
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Phase 0 foundation for the cmuxlayer painpoint-remediation plan.
- Adds the tracked canonical control-plane invariant contract at `docs/control-plane-invariants.md`.
- Adds 10 painpoint replay fixtures under `tests/fixtures/painpoints/`.
- Adds `tests/painpoint-replay.test.ts`, which keeps fixture loading green and registers canonical classifier assertions as `todo` for later phases.
- No source behavior change.

## Plan Context
- Local lead plan path: `docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/README.md`
- Tracked spec for reviewers: `docs/control-plane-invariants.md`

## Test Plan
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit` exited 0
- `bun run test` -> 67 files passed; 1122 passed, 10 todo
- push hook `run_tests.sh` -> exit status 0

## Review Notes
- Local `coderabbit review --agent` initially found 2 issues: URL path handling in the fixture reader and personal absolute paths in one fixture.
- Both were fixed before commit.
- Second local `coderabbit review --agent` returned 0 findings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only additions; no changes to delivery, registry, or parser behavior in application code.
> 
> **Overview**
> Introduces **Phase 0** of the painpoint-remediation work: a written target state machine and a replay corpus, without changing runtime behavior in `src/`.
> 
> **`docs/control-plane-invariants.md`** defines canonical control-plane states (e.g. `shell`, `interactive_overlay`, `composer_dirty`, `stale_surface`, `poisoned_registry`), allowed transitions, and how they relate to today’s split vocabularies (lifecycle, parsed screen status, delivery). It maps each of **10** painpoint scenarios to desired classification or delivery refusal and pass criteria for later phases.
> 
> **`tests/fixtures/painpoints/`** adds JSON/txt fixtures for those scenarios (overlays, permissions, boot/composer dirt, dead panes, stale routes, registry ghosts, workspace spawn, long/multiline delivery).
> 
> **`tests/painpoint-replay.test.ts`** loads the corpus, asserts metadata and fixture inventory, and registers **10 `it.todo`** cases for future canonical classifier assertions; it only calls existing `parseScreen` today to document the legacy shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66f721a77e412528926d21c7a78cee3e7ed6999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Phase 0 control-plane invariant contract and painpoint replay test corpus
> - Adds [docs/control-plane-invariants.md](https://github.com/EtanHey/cmuxlayer/pull/215/files#diff-5fc959fb4a65147841e47c15330128a21d474b6d08e8b39193d6a511bd7124be) defining the canonical control-plane state machine: vocabularies, allowed transitions, and fixture pass/fail criteria for Phase 0.
> - Adds 10 fixture files under [tests/fixtures/painpoints/](https://github.com/EtanHey/cmuxlayer/pull/215/files#diff-9bb02f6d0761f30843e0b4985b22d5bd7222171508212d4e1213f482792478d0) covering edge cases such as stale surfaces, registry ghosts, multiline payload delivery, and wrong-workspace spawns.
> - Adds [tests/painpoint-replay.test.ts](https://github.com/EtanHey/cmuxlayer/pull/215/files#diff-3b0b93f895437253e2c9db5345c95afbe302205f9c362419fb82867f30153a1b) which loads all fixtures, validates their structure (phase_home, source_evidence, assertions), and registers per-fixture classification checks as `it.todo` for future phases.
> - The `readPainpointFixture` helper normalises both `.json` and `.txt` fixtures into a common `PainpointFixture` shape; `.txt` fixtures default to `expected_state: 'unknown'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c66f721.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a control-plane contract document describing the supported state vocabulary, valid transitions, and expected outcomes for key replay scenarios.

* **Tests**
  * Added a new replay test suite and a set of fixture cases covering prompt handling, stale sessions, workspace selection, permission flows, and delivery edge cases.
  * Established baseline expectations for state classification, with some checks currently marked as pending for later phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->