### PR TITLE
feat(identity): surface-session route staleness + recycled-surface collision guard (phase 2)

### DIFF
--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -44,6 +44,35 @@ export interface SurfaceSessionLookupKey {
   surface_id: string;
 }
 
+export type SurfaceSessionRouteState = "ready" | "stale_surface";
+
+export function classifySurfaceSessionRoute(input: {
+  agent: AgentRecord;
+  index_entry: SurfaceSessionIndexEntry | null;
+  live_surface_refs: string[];
+}): SurfaceSessionRouteState {
+  if (!input.live_surface_refs.includes(input.agent.surface_id)) {
+    return "stale_surface";
+  }
+
+  const entry = input.index_entry;
+  if (!entry) {
+    return input.agent.cli_session_id ? "stale_surface" : "ready";
+  }
+
+  const agentWorkspaceId = input.agent.workspace_id ?? null;
+  if (
+    entry.agent_id !== input.agent.agent_id ||
+    entry.workspace_id !== agentWorkspaceId ||
+    entry.surface_id !== input.agent.surface_id ||
+    entry.cli_session_id !== input.agent.cli_session_id
+  ) {
+    return "stale_surface";
+  }
+
+  return "ready";
+}
+
 interface SurfaceSessionIndexFile {
   version: 1;
   by_agent_id: Record<string, SurfaceSessionIndexEntry>;
@@ -126,6 +155,20 @@ export class SurfaceSessionIndex {
       (a, b) =>
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
+    if (matches.length > 1) {
+      const newestTime = new Date(matches[0].updated_at).getTime();
+      const tiedNewest = matches.filter(
+        (entry) => new Date(entry.updated_at).getTime() === newestTime,
+      );
+      const distinctNewest = new Set(
+        tiedNewest.map(
+          (entry) => `${entry.agent_id}\u0000${entry.cli_session_id}`,
+        ),
+      );
+      if (distinctNewest.size > 1) {
+        return null;
+      }
+    }
     return matches[0] ?? null;
   }
 }

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -2,6 +2,12 @@ import { readFileSync, readdirSync } from "node:fs";
 import { basename, extname } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseScreen } from "../src/screen-parser.js";
+import { classifySurfaceSessionRoute } from "../src/state-manager.js";
+import type {
+  AgentRecord,
+  AgentState,
+  CliType,
+} from "../src/agent-types.js";
 
 type PainpointFixture = {
   id: string;
@@ -10,6 +16,15 @@ type PainpointFixture = {
   source_evidence: string[];
   screen_text?: string;
   assertions?: string[];
+  agent_record?: Partial<AgentRecord>;
+  live_surfaces?: Array<{ ref: string }>;
+  surface_session_index?: {
+    agent_id: string;
+    workspace_id: string | null;
+    surface_id: string;
+    cli_session_id: string;
+    updated_at?: string;
+  };
 };
 
 const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
@@ -52,6 +67,36 @@ function legacyClassifierShape(fixture: PainpointFixture): string {
   return "legacy:no-canonical-control-plane-classifier";
 }
 
+function recordFromFixture(record: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: record.agent_id ?? "fixture-agent",
+    surface_id: record.surface_id ?? "surface:fixture",
+    workspace_id: record.workspace_id ?? null,
+    state: (record.state as AgentState | undefined) ?? "ready",
+    repo: record.repo ?? "cmuxlayer",
+    model: record.model ?? "unknown",
+    cli: (record.cli as CliType | undefined) ?? "claude",
+    cli_session_id: record.cli_session_id ?? null,
+    cli_session_path: record.cli_session_path ?? null,
+    task_summary: record.task_summary ?? "fixture replay",
+    pid: record.pid ?? null,
+    version: record.version ?? 1,
+    created_at: record.created_at ?? "2026-07-04T00:00:00.000Z",
+    updated_at: record.updated_at ?? "2026-07-04T00:00:00.000Z",
+    error: record.error ?? null,
+    parent_agent_id: record.parent_agent_id ?? null,
+    spawn_depth: record.spawn_depth ?? 0,
+    role: record.role ?? "worker",
+    auto_archive_on_done: record.auto_archive_on_done ?? false,
+    deletion_intent: record.deletion_intent ?? false,
+    quality: record.quality ?? "unknown",
+    max_cost_per_agent: record.max_cost_per_agent ?? null,
+    crash_recover: record.crash_recover ?? false,
+    respawn_attempts: record.respawn_attempts ?? 0,
+    user_killed: record.user_killed ?? false,
+  };
+}
+
 describe("Phase 0 painpoint replay corpus", () => {
   it("loads every required painpoint fixture", () => {
     expect(fixtures.map((fixture) => fixture.id)).toEqual([
@@ -77,6 +122,32 @@ describe("Phase 0 painpoint replay corpus", () => {
   });
 
   for (const fixture of fixtures) {
+    if (fixture.id === "stale-surface-after-respawn") {
+      it(`${fixture.id} classifies as ${fixture.expected_state} via the surface session index`, () => {
+        expect(fixture.agent_record).toBeTruthy();
+        expect(fixture.surface_session_index).toBeTruthy();
+        const agent = recordFromFixture(fixture.agent_record ?? {});
+        const indexEntry = fixture.surface_session_index
+          ? {
+              ...fixture.surface_session_index,
+              updated_at:
+                fixture.surface_session_index.updated_at ??
+                "2026-07-04T00:00:00.000Z",
+            }
+          : null;
+
+        expect(
+          classifySurfaceSessionRoute({
+            agent,
+            index_entry: indexEntry,
+            live_surface_refs:
+              fixture.live_surfaces?.map((surface) => surface.ref) ?? [],
+          }),
+        ).toBe(fixture.expected_state);
+      });
+      continue;
+    }
+
     it.todo(
       `${fixture.id} classifies as ${fixture.expected_state} via the canonical control-plane state machine`,
       () => {

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { StateManager } from "../src/state-manager.js";
+import {
+  classifySurfaceSessionRoute,
+  StateManager,
+} from "../src/state-manager.js";
 import type { AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-state");
@@ -188,6 +197,104 @@ describe("StateManager", () => {
     it("does not throw for non-existent agent", () => {
       const mgr = new StateManager(TEST_DIR);
       expect(() => mgr.removeState("nonexistent")).not.toThrow();
+    });
+  });
+
+  describe("surface session route classification", () => {
+    it("classifies an indexed old surface as stale after respawn moves the agent", () => {
+      const mgr = new StateManager(TEST_DIR);
+      const record = makeRecord({
+        agent_id: "agent-stale-1",
+        surface_id: "surface:old",
+        workspace_id: "workspace:main",
+        state: "ready",
+        cli: "claude",
+        cli_session_id: "claude-session-old",
+      });
+      mgr.writeState(record);
+      const entry = mgr.getSurfaceSessionIndex().lookup({
+        workspace_id: record.workspace_id,
+        surface_id: record.surface_id,
+      });
+
+      expect(
+        classifySurfaceSessionRoute({
+          agent: record,
+          index_entry: entry,
+          live_surface_refs: ["surface:new"],
+        }),
+      ).toBe("stale_surface");
+    });
+
+    it("classifies a recycled surface as stale when the index occupant differs", () => {
+      const mgr = new StateManager(TEST_DIR);
+      const oldAgent = makeRecord({
+        agent_id: "agent-old",
+        surface_id: "surface:reused",
+        workspace_id: "workspace:main",
+        state: "ready",
+        cli_session_id: "session-old",
+      });
+      const newAgent = makeRecord({
+        agent_id: "agent-new",
+        surface_id: "surface:reused",
+        workspace_id: "workspace:main",
+        state: "ready",
+        cli_session_id: "session-new",
+      });
+      mgr.writeState(oldAgent);
+      mgr.writeState(newAgent);
+      const entry = mgr.getSurfaceSessionIndex().lookup({
+        workspace_id: oldAgent.workspace_id,
+        surface_id: oldAgent.surface_id,
+      });
+
+      expect(
+        classifySurfaceSessionRoute({
+          agent: oldAgent,
+          index_entry: entry,
+          live_surface_refs: ["surface:reused"],
+        }),
+      ).toBe("stale_surface");
+    });
+
+    it("returns null when newest lookup entries tie with distinct identities", () => {
+      const mgr = new StateManager(TEST_DIR);
+      const updatedAt = "2026-07-04T12:00:00.000Z";
+      writeFileSync(
+        join(TEST_DIR, "surface-session-index.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            by_agent_id: {
+              "agent-a": {
+                agent_id: "agent-a",
+                workspace_id: "workspace:main",
+                surface_id: "surface:reused",
+                cli_session_id: "session-a",
+                updated_at: updatedAt,
+              },
+              "agent-b": {
+                agent_id: "agent-b",
+                workspace_id: "workspace:main",
+                surface_id: "surface:reused",
+                cli_session_id: "session-b",
+                updated_at: updatedAt,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      expect(
+        mgr.getSurfaceSessionIndex().lookup({
+          workspace_id: "workspace:main",
+          surface_id: "surface:reused",
+        }),
+      ).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Phase 2 Identity + Surface Index hardening for the cmuxlayer painpoint remediation plan.
- Adds `classifySurfaceSessionRoute()` so absent or ambiguous surface/session routes classify as `stale_surface` instead of silently routing to a stale or recycled surface.
- Hardens `SurfaceSessionIndex.lookup()` to return `null` on same-`updated_at` ties with distinct `(agent_id, cli_session_id)` identities.
- Flips the `stale-surface-after-respawn` replay fixture from todo to a real assertion.

## Plan Context
- Local plan README: `docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/README.md`
- Phase: P2 Identity + Surface Index
- Reviewer status before PR loop: SHIP 9/10; fast-follow unit coverage applied.

## Test Plan
- `bun run typecheck`
- `bun run test`
- Pre-push hook also ran `run_tests.sh` and exited 0.

## Notes
- No edits to `src/server.ts` or `src/screen-parser.ts`.
- No merge requested here; lead owns merge after checks/review.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing identity logic for agent/surface/session binding; misclassification could block valid routes or still allow stale ones, though behavior is scoped to new helpers and lookup with broad test coverage.
> 
> **Overview**
> Adds **`classifySurfaceSessionRoute()`** in `state-manager.ts`, returning **`ready`** vs **`stale_surface`** by comparing the agent record to live surface refs and an optional index entry (missing index with a CLI session, surface not live, or agent/workspace/surface/session mismatch → stale).
> 
> **`SurfaceSessionIndex.lookup()`** now returns **`null`** when multiple newest entries share the same `updated_at` but differ in `(agent_id, cli_session_id)`, so recycled surfaces are not resolved to an arbitrary occupant.
> 
> Tests cover respawn/stale surface, recycled-surface mismatch, ambiguous lookup ties, and the **`stale-surface-after-respawn`** painpoint fixture (replacing a todo with a real assertion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087b90cc0e5a6797a37479ad2357cbaf20867b87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add surface session route staleness classification and tie-breaking collision guard
> - Adds `classifySurfaceSessionRoute` to [state-manager.ts](https://github.com/EtanHey/cmuxlayer/pull/216/files#diff-48f5aae831d763ad62d5e44527c3e96d45cfccfa451f8f81674c26e9bb0448a8), which returns `"stale_surface"` when the agent's surface is no longer live, no index entry exists for a CLI session, or any identity field in the index entry mismatches the agent's current record.
> - Fixes `SurfaceSessionIndex.lookup` to return `null` instead of an arbitrary entry when the two newest matches share the same `updated_at` timestamp but represent distinct `agent_id`/`cli_session_id` identities (recycled-surface collision guard).
> - Adds tests covering stale-surface-after-respawn, recycled surface staleness, and the tie-breaking null return in [state-manager.test.ts](https://github.com/EtanHey/cmuxlayer/pull/216/files#diff-561ea8741f2e375b8dac80a5c80c012c41375bd99a072cc4d8d738351e88e475) and [painpoint-replay.test.ts](https://github.com/EtanHey/cmuxlayer/pull/216/files#diff-3b0b93f895437253e2c9db5345c95afbe302205f9c362419fb82867f30153a1b).
> - Behavioral Change: `lookup` previously returned an arbitrary entry on timestamp ties; it now returns `null`, so callers that relied on a non-null result in this edge case will need to handle `null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 087b90c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->