### PR TITLE
feat(delivery): block send into interactive overlay / permission prompt (phase 1)

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -173,6 +173,7 @@ const INTERACTIVE_PROMPT_CLARIFICATION_RE =
   /agent is asking for clarification/i;
 const MENU_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
 const MENU_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
+const BARE_READY_PROMPT_RE = /^\s*[>❯]\s*$/;
 const PERMISSION_PROMPT_PRIMARY_RE = /approve command\?|do you want to allow/i;
 const PERMISSION_PROMPT_SECONDARY_RE = /allow for this session|\[y\/n\]/i;
 const PERMISSION_PROMPT_MARKER_RE =
@@ -516,16 +517,32 @@ function parseResponse(text: string): string | null {
   return response || extractClaudeResponseTail(text);
 }
 
-function hasMenuBlock(text: string): boolean {
+function hasMenuBlock(text: string, opts?: { tailOnly?: boolean }): boolean {
   const lines = text.split("\n");
+  const lastMeaningfulIndex = lines.reduce(
+    (last, line, index) => (line.trim() ? index : last),
+    -1,
+  );
   for (let index = 0; index < lines.length; index += 1) {
     if (!MENU_SELECTOR_RE.test(lines[index])) {
       continue;
     }
+    if (
+      opts?.tailOnly &&
+      lines
+        .slice(index + 1)
+        .some((line) => BARE_READY_PROMPT_RE.test(line))
+    ) {
+      continue;
+    }
     const block = lines
-      .slice(index, index + PROMPT_BLOCK_WINDOW_LINES + 1)
+      .slice(index + 1, index + PROMPT_BLOCK_WINDOW_LINES + 1)
       .join("\n");
-    if (MENU_OPTION_RE.test(block)) {
+    if (
+      MENU_OPTION_RE.test(block) &&
+      (!opts?.tailOnly ||
+        lastMeaningfulIndex <= index + PROMPT_BLOCK_WINDOW_LINES)
+    ) {
       return true;
     }
   }
@@ -566,7 +583,7 @@ function hasInteractivePromptBlock(text: string): boolean {
       return true;
     }
   }
-  return hasMenuBlock(text) && !PERMISSION_PROMPT_MARKER_RE.test(text);
+  return hasMenuBlock(text, { tailOnly: true }) && !PERMISSION_PROMPT_MARKER_RE.test(text);
 }
 
 function parseErrors(text: string): string[] {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -167,10 +167,13 @@ const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CLAUDE_PERMISSION_APPROVAL_RE =
   /allow for this session|do you want to allow|\[y\/n\]/i;
-const INTERACTIVE_PROMPT_TOOL_RE =
-  /\bAskUserQuestion\b|\bask-tool\b|agent is asking for clarification/i;
+const INTERACTIVE_PROMPT_TOOL_RE = /^\s*(AskUserQuestion|ask-tool)\s*$/i;
+const INTERACTIVE_PROMPT_CLARIFICATION_RE =
+  /agent is asking for clarification/i;
 const INTERACTIVE_PROMPT_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
-const INTERACTIVE_PROMPT_OPTION_RE = /^\s*\d+\.\s+\S.+$/gm;
+const INTERACTIVE_PROMPT_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
+const PERMISSION_PROMPT_MARKER_RE =
+  /approve command\?|do you want to allow|allow for this session|\[y\/n\]/i;
 const CODEX_HEADER_RE =
   /^\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)(?:\s*[·•]\s*[^\n]*)?\s*$/m;
 const CODEX_BOOT_PANEL_RE = /(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)/i;
@@ -510,28 +513,52 @@ function parseResponse(text: string): string | null {
   return response || extractClaudeResponseTail(text);
 }
 
+function hasPromptBlock(
+  text: string,
+  markerRe: RegExp,
+  windowSize = 8,
+): boolean {
+  const lines = text.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!markerRe.test(lines[index])) {
+      continue;
+    }
+    const block = lines.slice(index, index + windowSize + 1).join("\n");
+    const hasSelector = INTERACTIVE_PROMPT_SELECTOR_RE.test(block);
+    const hasOption = INTERACTIVE_PROMPT_OPTION_RE.test(block);
+    if (hasSelector && hasOption) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasInteractivePromptBlock(text: string): boolean {
+  const lines = text.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!INTERACTIVE_PROMPT_TOOL_RE.test(lines[index])) {
+      continue;
+    }
+    const block = lines.slice(index, index + 7).join("\n");
+    const hasClarification =
+      INTERACTIVE_PROMPT_CLARIFICATION_RE.test(block);
+    const hasSelector = INTERACTIVE_PROMPT_SELECTOR_RE.test(block);
+    const hasOption = INTERACTIVE_PROMPT_OPTION_RE.test(block);
+    if (hasClarification && hasSelector && hasOption) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function parseErrors(text: string): string[] {
   const errors: string[] = [];
-  const lowered = text.toLowerCase();
-  const permissionPatterns = [
-    "approve command?",
-    "permission denied",
-    "permission prompt",
-    "do you want to allow",
-    "allow for this session",
-    "[y/n]",
-  ];
 
-  if (permissionPatterns.some((pattern) => lowered.includes(pattern))) {
+  if (hasPromptBlock(text, PERMISSION_PROMPT_MARKER_RE)) {
     errors.push("permission_prompt");
   }
 
-  const optionCount = [...text.matchAll(INTERACTIVE_PROMPT_OPTION_RE)].length;
-  if (
-    INTERACTIVE_PROMPT_TOOL_RE.test(text) &&
-    INTERACTIVE_PROMPT_SELECTOR_RE.test(text) &&
-    optionCount > 0
-  ) {
+  if (hasInteractivePromptBlock(text)) {
     errors.push("interactive_prompt");
   }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -173,9 +173,8 @@ const INTERACTIVE_PROMPT_CLARIFICATION_RE =
   /agent is asking for clarification/i;
 const MENU_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
 const MENU_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
-const BARE_READY_PROMPT_RE = /^\s*[>❯]\s*$/;
+const BARE_READY_PROMPT_RE = /^\s*(?:[>❯›]|codex\s*>)\s*$/i;
 const PERMISSION_PROMPT_PRIMARY_RE = /approve command\?|do you want to allow/i;
-const PERMISSION_PROMPT_SECONDARY_RE = /allow for this session|\[y\/n\]/i;
 const PERMISSION_PROMPT_MARKER_RE =
   /approve command\?|do you want to allow|allow for this session|\[y\/n\]/i;
 const CODEX_HEADER_RE =
@@ -559,9 +558,7 @@ function hasPermissionPromptBlock(text: string): boolean {
     const block = lines
       .slice(index, index + PROMPT_BLOCK_WINDOW_LINES + 1)
       .join("\n");
-    const hasPrimaryMarker = PERMISSION_PROMPT_PRIMARY_RE.test(block);
-    const hasSecondaryMarker = PERMISSION_PROMPT_SECONDARY_RE.test(block);
-    if (hasPrimaryMarker || (hasSecondaryMarker && hasMenuBlock(block))) {
+    if (PERMISSION_PROMPT_PRIMARY_RE.test(block)) {
       return true;
     }
   }
@@ -583,7 +580,7 @@ function hasInteractivePromptBlock(text: string): boolean {
       return true;
     }
   }
-  return hasMenuBlock(text, { tailOnly: true }) && !PERMISSION_PROMPT_MARKER_RE.test(text);
+  return hasMenuBlock(text, { tailOnly: true });
 }
 
 function parseErrors(text: string): string[] {
@@ -593,7 +590,7 @@ function parseErrors(text: string): string[] {
     errors.push("permission_prompt");
   }
 
-  if (hasInteractivePromptBlock(text)) {
+  if (!errors.includes("permission_prompt") && hasInteractivePromptBlock(text)) {
     errors.push("interactive_prompt");
   }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -167,11 +167,14 @@ const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CLAUDE_PERMISSION_APPROVAL_RE =
   /allow for this session|do you want to allow|\[y\/n\]/i;
+const PROMPT_BLOCK_WINDOW_LINES = 8;
 const INTERACTIVE_PROMPT_TOOL_RE = /^\s*(AskUserQuestion|ask-tool)\s*$/i;
 const INTERACTIVE_PROMPT_CLARIFICATION_RE =
   /agent is asking for clarification/i;
-const INTERACTIVE_PROMPT_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
-const INTERACTIVE_PROMPT_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
+const MENU_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
+const MENU_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
+const PERMISSION_PROMPT_PRIMARY_RE = /approve command\?|do you want to allow/i;
+const PERMISSION_PROMPT_SECONDARY_RE = /allow for this session|\[y\/n\]/i;
 const PERMISSION_PROMPT_MARKER_RE =
   /approve command\?|do you want to allow|allow for this session|\[y\/n\]/i;
 const CODEX_HEADER_RE =
@@ -513,20 +516,35 @@ function parseResponse(text: string): string | null {
   return response || extractClaudeResponseTail(text);
 }
 
-function hasPromptBlock(
-  text: string,
-  markerRe: RegExp,
-  windowSize = 8,
-): boolean {
+function hasMenuBlock(text: string): boolean {
   const lines = text.split("\n");
   for (let index = 0; index < lines.length; index += 1) {
-    if (!markerRe.test(lines[index])) {
+    if (!MENU_SELECTOR_RE.test(lines[index])) {
       continue;
     }
-    const block = lines.slice(index, index + windowSize + 1).join("\n");
-    const hasSelector = INTERACTIVE_PROMPT_SELECTOR_RE.test(block);
-    const hasOption = INTERACTIVE_PROMPT_OPTION_RE.test(block);
-    if (hasSelector && hasOption) {
+    const block = lines
+      .slice(index, index + PROMPT_BLOCK_WINDOW_LINES + 1)
+      .join("\n");
+    if (MENU_OPTION_RE.test(block)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasPermissionPromptBlock(text: string): boolean {
+  const lines = text.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!PERMISSION_PROMPT_MARKER_RE.test(line)) {
+      continue;
+    }
+    const block = lines
+      .slice(index, index + PROMPT_BLOCK_WINDOW_LINES + 1)
+      .join("\n");
+    const hasPrimaryMarker = PERMISSION_PROMPT_PRIMARY_RE.test(block);
+    const hasSecondaryMarker = PERMISSION_PROMPT_SECONDARY_RE.test(block);
+    if (hasPrimaryMarker || (hasSecondaryMarker && hasMenuBlock(block))) {
       return true;
     }
   }
@@ -539,22 +557,22 @@ function hasInteractivePromptBlock(text: string): boolean {
     if (!INTERACTIVE_PROMPT_TOOL_RE.test(lines[index])) {
       continue;
     }
-    const block = lines.slice(index, index + 7).join("\n");
+    const block = lines
+      .slice(index, index + PROMPT_BLOCK_WINDOW_LINES + 1)
+      .join("\n");
     const hasClarification =
       INTERACTIVE_PROMPT_CLARIFICATION_RE.test(block);
-    const hasSelector = INTERACTIVE_PROMPT_SELECTOR_RE.test(block);
-    const hasOption = INTERACTIVE_PROMPT_OPTION_RE.test(block);
-    if (hasClarification && hasSelector && hasOption) {
+    if (hasClarification && hasMenuBlock(block)) {
       return true;
     }
   }
-  return false;
+  return hasMenuBlock(text) && !PERMISSION_PROMPT_MARKER_RE.test(text);
 }
 
 function parseErrors(text: string): string[] {
   const errors: string[] = [];
 
-  if (hasPromptBlock(text, PERMISSION_PROMPT_MARKER_RE)) {
+  if (hasPermissionPromptBlock(text)) {
     errors.push("permission_prompt");
   }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -167,6 +167,10 @@ const MODEL_KEYWORD_RE = /🤖\s*(Opus|Sonnet|Haiku)\b/i;
 const EXIT_CODE_RE = /(?:exit(?:ed)?\s+with\s+code|code)\s+(\d+)/gi;
 const CLAUDE_PERMISSION_APPROVAL_RE =
   /allow for this session|do you want to allow|\[y\/n\]/i;
+const INTERACTIVE_PROMPT_TOOL_RE =
+  /\bAskUserQuestion\b|\bask-tool\b|agent is asking for clarification/i;
+const INTERACTIVE_PROMPT_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
+const INTERACTIVE_PROMPT_OPTION_RE = /^\s*\d+\.\s+\S.+$/gm;
 const CODEX_HEADER_RE =
   /^\s*(gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?)(?:\s*[·•]\s*[^\n]*)?\s*$/m;
 const CODEX_BOOT_PANEL_RE = /(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)/i;
@@ -522,6 +526,15 @@ function parseErrors(text: string): string[] {
     errors.push("permission_prompt");
   }
 
+  const optionCount = [...text.matchAll(INTERACTIVE_PROMPT_OPTION_RE)].length;
+  if (
+    INTERACTIVE_PROMPT_TOOL_RE.test(text) &&
+    INTERACTIVE_PROMPT_SELECTOR_RE.test(text) &&
+    optionCount > 0
+  ) {
+    errors.push("interactive_prompt");
+  }
+
   if (text.includes("SQLITE_BUSY")) {
     errors.push("SQLITE_BUSY");
   }
@@ -534,6 +547,26 @@ function parseErrors(text: string): string[] {
   }
 
   return errors;
+}
+
+function inferControlState(
+  status: ParsedScreenStatus,
+  errors: string[],
+  agentType: ParsedScreenAgentType,
+): ParsedScreenResult["control_state"] {
+  if (errors.includes("permission_prompt")) {
+    return "permission_prompt";
+  }
+  if (errors.includes("interactive_prompt")) {
+    return "interactive_overlay";
+  }
+  if (status === "thinking" || status === "working") {
+    return "busy";
+  }
+  if (status === "idle" && agentType !== "unknown") {
+    return "ready";
+  }
+  return "unknown";
 }
 
 function parseModelAndCost(
@@ -852,9 +885,11 @@ export function parseScreen(text: string): ParsedScreenResult {
     actions.push(...parseCodexActions(normalized));
   }
 
+  const status = inferStatus(normalized, doneSignal, errors, agentType);
   const result: ParsedScreenResult = {
     agent_type: agentType,
-    status: inferStatus(normalized, doneSignal, errors, agentType),
+    status,
+    control_state: inferControlState(status, errors, agentType),
     token_count: tokenCount,
     context_pct: contextPct,
     context_window: contextWindow,

--- a/src/server.ts
+++ b/src/server.ts
@@ -256,6 +256,24 @@ class SubmitVerificationError extends Error {
   }
 }
 
+class DeliverySafetyGateError extends Error {
+  readonly submit_verified = false;
+
+  constructor(
+    readonly error_code:
+      | "blocked_by_interactive_prompt"
+      | "blocked_by_permission_prompt",
+    readonly screen: ParsedScreenResult,
+  ) {
+    super(
+      error_code === "blocked_by_permission_prompt"
+        ? "delivery blocked by active permission prompt"
+        : "delivery blocked by active interactive prompt",
+    );
+    this.name = "DeliverySafetyGateError";
+  }
+}
+
 class BootPromptTimeoutError extends Error {
   constructor(
     message: string,
@@ -1631,6 +1649,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         throw new SurfaceGoneError(surface, error);
       }
       return null;
+    }
+  };
+
+  const assertDeliveryTargetIsSafe = async (
+    surface: string,
+    workspace?: string,
+  ): Promise<void> => {
+    const snapshot = await readParsedSurface(surface, workspace, {
+      throwOnSurfaceGone: true,
+    });
+    if (!snapshot) {
+      return;
+    }
+
+    if (snapshot.parsed.control_state === "permission_prompt") {
+      throw new DeliverySafetyGateError(
+        "blocked_by_permission_prompt",
+        snapshot.parsed,
+      );
+    }
+
+    if (snapshot.parsed.control_state === "interactive_overlay") {
+      throw new DeliverySafetyGateError(
+        "blocked_by_interactive_prompt",
+        snapshot.parsed,
+      );
     }
   };
 
@@ -3430,6 +3474,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? chunkTerminalInput(sanitizedText, args.chunk_size)
             : [sanitizedText];
 
+        await assertDeliveryTargetIsSafe(args.surface, args.workspace);
+
         if (args.background) {
           const record: DeliveryRecord = {
             delivery_id: randomUUID(),
@@ -3504,6 +3550,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       } catch (e) {
         if (e instanceof SurfaceGoneError) {
           return err(e, surfaceGonePayload(e));
+        }
+        if (e instanceof DeliverySafetyGateError) {
+          return err(e, {
+            error_code: e.error_code,
+            submit_verified: e.submit_verified,
+            screen: e.screen,
+          });
         }
         if (e instanceof SubmitVerificationError) {
           return err(e, {
@@ -4332,7 +4385,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           inboxOpts,
         );
         const pending = pendingDispatches(args.agent_id, 120000, inboxOpts);
-        const nudge = { attempted: false, sent: false, reason: "" };
+        const nudge: {
+          attempted: boolean;
+          sent: boolean;
+          reason: string;
+          error_code?: string;
+        } = { attempted: false, sent: false, reason: "" };
         if (args.nudge === "never") {
           nudge.reason = "nudge disabled by caller";
         } else if (monitor_alive) {
@@ -4371,6 +4429,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               nudge.sent = true;
               nudge.reason = `heartbeat stale/absent — typed inbox pointer into ${record.surface_id} (state: ${record.state})`;
             } catch (e) {
+              if (e instanceof DeliverySafetyGateError) {
+                nudge.error_code = e.error_code;
+              }
               nudge.reason = `nudge failed (dispatch still durable in inbox file): ${
                 e instanceof Error ? e.message : String(e)
               }`;
@@ -4790,6 +4851,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
       }
 
+      await assertDeliveryTargetIsSafe(
+        route.surface_id,
+        route.workspace_id ?? undefined,
+      );
+
       const sanitizedText = sanitizeTerminalInput(args.text);
       const chunks =
         sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
@@ -5172,6 +5238,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },
@@ -5296,6 +5369,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },
@@ -5460,6 +5540,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },
@@ -5520,6 +5607,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },
@@ -5802,6 +5896,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           return okFormatted(formatOk("send_to", data), data);
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },
@@ -5861,6 +5962,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           return okFormatted(formatOk("send_to_agent", data), data);
         } catch (e) {
+          if (e instanceof DeliverySafetyGateError) {
+            return err(e, {
+              error_code: e.error_code,
+              submit_verified: e.submit_verified,
+              screen: e.screen,
+            });
+          }
           return err(e);
         }
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -2405,6 +2405,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const run = async () => {
       try {
+        await assertDeliveryTargetIsSafe(record.surface, record.workspace);
         await deliverInputChunks({
           surface: record.surface,
           workspace: record.workspace,
@@ -3474,8 +3475,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? chunkTerminalInput(sanitizedText, args.chunk_size)
             : [sanitizedText];
 
-        await assertDeliveryTargetIsSafe(args.surface, args.workspace);
-
         if (args.background) {
           const record: DeliveryRecord = {
             delivery_id: randomUUID(),
@@ -3518,6 +3517,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           args.press_enter &&
           (!targetRecord || INTERACTIVE_AGENT_STATES.has(targetRecord.state));
         const delivery = await withSurfaceWrite(args.surface, async () => {
+          await assertDeliveryTargetIsSafe(args.surface, args.workspace);
           return deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
@@ -3640,10 +3640,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const shouldVerifySubmit =
           !!targetRecord && INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
-        await assertDeliveryTargetIsSafe(args.surface, args.workspace);
-
-        const delivery = await withSurfaceWrite(args.surface, async () =>
-          deliverInputChunks({
+        const delivery = await withSurfaceWrite(args.surface, async () => {
+          await assertDeliveryTargetIsSafe(args.surface, args.workspace);
+          return deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
             chunks,
@@ -3652,8 +3651,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             press_enter: true,
             source_event: "send_command",
             verify_submit: bootPromptPath ? false : shouldVerifySubmit,
-          }),
-        );
+          });
+        });
 
         let bootPromptDelivery:
           | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -4860,19 +4859,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
       }
 
-      await assertDeliveryTargetIsSafe(
-        route.surface_id,
-        route.workspace_id ?? undefined,
-      );
-
       const sanitizedText = sanitizeTerminalInput(args.text);
       const chunks =
         sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
           ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
           : [sanitizedText];
 
-      return withSurfaceWrite(route.surface_id, async () =>
-        deliverInputChunks({
+      return withSurfaceWrite(route.surface_id, async () => {
+        await assertDeliveryTargetIsSafe(
+          route.surface_id,
+          route.workspace_id ?? undefined,
+        );
+        return deliverInputChunks({
           surface: route.surface_id,
           workspace: route.workspace_id ?? undefined,
           chunks,
@@ -4888,8 +4886,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // false-failing a legitimate interjection.
           verify_submit:
             args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
-        }),
-      );
+        });
+      });
     };
     // Expose the guarded relay to dispatch_to_agent's nudge (registered above,
     // outside this lifecycle block).

--- a/src/server.ts
+++ b/src/server.ts
@@ -3640,6 +3640,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const shouldVerifySubmit =
           !!targetRecord && INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
+        await assertDeliveryTargetIsSafe(args.surface, args.workspace);
+
         const delivery = await withSurfaceWrite(args.surface, async () =>
           deliverInputChunks({
             surface: args.surface,
@@ -3694,6 +3696,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       } catch (e) {
         if (e instanceof SurfaceGoneError) {
           return err(e, surfaceGonePayload(e));
+        }
+        if (e instanceof DeliverySafetyGateError) {
+          return err(e, {
+            error_code: e.error_code,
+            submit_verified: e.submit_verified,
+            screen: e.screen,
+          });
         }
         if (e instanceof SubmitVerificationError) {
           return err(e, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,10 +127,23 @@ export type ParsedScreenStatus =
   | "working"
   | "idle"
   | "done";
+export type ParsedControlPlaneState =
+  | "unknown"
+  | "shell"
+  | "agent_booting"
+  | "ready"
+  | "busy"
+  | "interactive_overlay"
+  | "permission_prompt"
+  | "composer_dirty"
+  | "dead"
+  | "stale_surface"
+  | "poisoned_registry";
 
 export interface ParsedScreenResult {
   agent_type: ParsedScreenAgentType;
   status: ParsedScreenStatus;
+  control_state: ParsedControlPlaneState;
   token_count: number | null;
   context_pct: number | null;
   context_window: number | null;

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -257,7 +257,7 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     expect(readInbox("ghost-agent", { baseDir: inboxDir })).toHaveLength(1);
   });
 
-  it("discovers and registers a launcher-spawned Claude agent before nudging", async () => {
+  it("discovers a launcher-spawned Claude permission prompt but does not type a nudge into it", async () => {
     exec = makeExec(
       [
         "Do you want to allow this command?",
@@ -296,8 +296,9 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.nudge.attempted).toBe(true);
-    expect(parsed.nudge.sent).toBe(true);
-    expect(sendCalls(exec).length).toBeGreaterThan(before);
+    expect(parsed.nudge.sent).toBe(false);
+    expect(parsed.nudge.error_code).toBe("blocked_by_permission_prompt");
+    expect(sendCalls(exec).length).toBe(before);
     expect(
       readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
     ).toContain("GO");

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -47,7 +47,7 @@ const fixtures = fixtureNames.map(readPainpointFixture);
 function legacyClassifierShape(fixture: PainpointFixture): string {
   if (fixture.screen_text !== undefined) {
     const parsed = parseScreen(fixture.screen_text);
-    return `legacy:${parsed.agent_type}:${parsed.status}:${parsed.errors.join(",")}`;
+    return parsed.control_state ?? `legacy:${parsed.agent_type}:${parsed.status}:${parsed.errors.join(",")}`;
   }
   return "legacy:no-canonical-control-plane-classifier";
 }
@@ -77,7 +77,12 @@ describe("Phase 0 painpoint replay corpus", () => {
   });
 
   for (const fixture of fixtures) {
-    it.todo(
+    const testFn =
+      fixture.id === "claude-ask-user-question-overlay" ||
+      fixture.id === "claude-permission-confirmation"
+        ? it
+        : it.todo;
+    testFn(
       `${fixture.id} classifies as ${fixture.expected_state} via the canonical control-plane state machine`,
       () => {
         expect(legacyClassifierShape(fixture)).toBe(fixture.expected_state);

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ExecFn } from "../src/cmux-client.js";
@@ -38,8 +44,12 @@ async function spawnReadyAgent(server: any) {
   return agentId;
 }
 
-function makeLifecycleExec(): ExecFn {
-  let readyText = "codex> ";
+const readPainpointFixture = (name: string) =>
+  readFileSync(new URL(`./fixtures/painpoints/${name}`, import.meta.url), "utf8");
+
+function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "): ExecFn {
+  let readyText =
+    typeof initialReadyText === "function" ? initialReadyText() : initialReadyText;
   let promptPending = false;
 
   return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
@@ -64,7 +74,10 @@ function makeLifecycleExec(): ExecFn {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: readyText,
+          text:
+            typeof initialReadyText === "function"
+              ? initialReadyText()
+              : readyText,
           lines: 20,
           scrollback_used: false,
         }),
@@ -259,6 +272,131 @@ describe("pane input pointer discipline", () => {
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1"]),
     );
+  });
+
+  it("send_input refuses while a Claude AskUserQuestion overlay is active", async () => {
+    const overlayText = readPainpointFixture("claude-ask-user-question-overlay.txt");
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: overlayText,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: "new task", press_enter: true },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("blocked_by_interactive_prompt");
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.screen).toMatchObject({
+      control_state: "interactive_overlay",
+      errors: expect.arrayContaining(["interactive_prompt"]),
+    });
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send")),
+    ).toBe(false);
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send-key")),
+    ).toBe(false);
+  });
+
+  it("send_input allows prose that only mentions AskUserQuestion", async () => {
+    const proseText = [
+      "Claude Code",
+      "",
+      "Reviewer note: AskUserQuestion is a tool name mentioned in this plan.",
+      "There is no modal overlay, selected response line, or numbered choice box.",
+      "",
+      "❯ ",
+    ].join("\n");
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: proseText,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: "new task", press_enter: false },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(result.isError).toBeUndefined();
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send")),
+    ).toBe(true);
+  });
+
+  it("send_to refuses while a Claude permission prompt is active", async () => {
+    const permissionText = readPainpointFixture("claude-permission-confirmation.txt");
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "codex> ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const tool = (server as any)._registeredTools["send_to"];
+    screenText = permissionText;
+    mockExec.mockClear();
+
+    const result = await tool.handler(
+      { agent_id: agentId, text: "continue", press_enter: true },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("blocked_by_permission_prompt");
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.screen).toMatchObject({
+      control_state: "permission_prompt",
+      errors: expect.arrayContaining(["permission_prompt"]),
+    });
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send")),
+    ).toBe(false);
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("paste-buffer")),
+    ).toBe(false);
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send-key")),
+    ).toBe(false);
+    context.dispose();
   });
 
   it("send_command refuses over-threshold command text unless explicitly opted out", async () => {

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -399,6 +399,48 @@ describe("pane input pointer discipline", () => {
     context.dispose();
   });
 
+  it("send_command refuses while a Claude permission prompt is active", async () => {
+    const permissionText = readPainpointFixture("claude-permission-confirmation.txt");
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: permissionText,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", command: "codex resume 123" },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("blocked_by_permission_prompt");
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.screen).toMatchObject({
+      control_state: "permission_prompt",
+      errors: expect.arrayContaining(["permission_prompt"]),
+    });
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send")),
+    ).toBe(false);
+    expect(
+      mockExec.mock.calls.some(([, args]) => args.includes("send-key")),
+    ).toBe(false);
+  });
+
   it("send_command refuses over-threshold command text unless explicitly opted out", async () => {
     process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
     const { createServer } = await loadServerModule();

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -48,6 +48,8 @@ const readPainpointFixture = (name: string) =>
   readFileSync(new URL(`./fixtures/painpoints/${name}`, import.meta.url), "utf8");
 
 function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "): ExecFn {
+  // Function mode is caller-driven and intentionally bypasses the internal
+  // promptPending -> readyText simulation used by static string mode.
   let readyText =
     typeof initialReadyText === "function" ? initialReadyText() : initialReadyText;
   let promptPending = false;
@@ -152,6 +154,23 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
       }),
       stderr: "",
     };
+  });
+}
+
+function makeStaticScreenExec(text: string): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:1",
+          text,
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
   });
 }
 
@@ -277,20 +296,7 @@ describe("pane input pointer discipline", () => {
   it("send_input refuses while a Claude AskUserQuestion overlay is active", async () => {
     const overlayText = readPainpointFixture("claude-ask-user-question-overlay.txt");
     const { createServer } = await loadServerModule();
-    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
-      if (args.includes("read-screen")) {
-        return {
-          stdout: JSON.stringify({
-            surface: "surface:1",
-            text: overlayText,
-            lines: 20,
-            scrollback_used: false,
-          }),
-          stderr: "",
-        };
-      }
-      return { stdout: "{}", stderr: "" };
-    });
+    const mockExec = makeStaticScreenExec(overlayText);
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_input"];
 
@@ -326,20 +332,7 @@ describe("pane input pointer discipline", () => {
       "❯ ",
     ].join("\n");
     const { createServer } = await loadServerModule();
-    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
-      if (args.includes("read-screen")) {
-        return {
-          stdout: JSON.stringify({
-            surface: "surface:1",
-            text: proseText,
-            lines: 20,
-            scrollback_used: false,
-          }),
-          stderr: "",
-        };
-      }
-      return { stdout: "{}", stderr: "" };
-    });
+    const mockExec = makeStaticScreenExec(proseText);
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_input"];
 
@@ -402,20 +395,7 @@ describe("pane input pointer discipline", () => {
   it("send_command refuses while a Claude permission prompt is active", async () => {
     const permissionText = readPainpointFixture("claude-permission-confirmation.txt");
     const { createServer } = await loadServerModule();
-    const mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
-      if (args.includes("read-screen")) {
-        return {
-          stdout: JSON.stringify({
-            surface: "surface:1",
-            text: permissionText,
-            lines: 20,
-            scrollback_used: false,
-          }),
-          stderr: "",
-        };
-      }
-      return { stdout: "{}", stderr: "" };
-    });
+    const mockExec = makeStaticScreenExec(permissionText);
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_command"];
 

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -83,19 +83,38 @@ Token usage: total=12,345 input=10,000 output=2,345
   });
 
   it("recognizes Claude permission approval dialogs as Claude", () => {
-    const parsed = parseScreen(`
-Do you want to allow this command?
-
-❯ 1. Allow for this session
-  2. Allow once
-  3. Deny
-
-[y/n]
-`);
+    const parsed = parseScreen(readFixture("painpoints/claude-permission-confirmation.txt"));
 
     expect(parsed.agent_type).toBe("claude");
     expect(parsed.status).toBe("frozen");
     expect(parsed.errors).toContain("permission_prompt");
+    expect(parsed.control_state).toBe("permission_prompt");
+  });
+
+  it("recognizes Claude AskUserQuestion overlays as interactive overlays", () => {
+    const parsed = parseScreen(
+      readFixture("painpoints/claude-ask-user-question-overlay.txt"),
+    );
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("frozen");
+    expect(parsed.errors).toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("interactive_overlay");
+  });
+
+  it("does not treat prose mentioning AskUserQuestion as an interactive overlay", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Reviewer note: AskUserQuestion is a tool name mentioned in this plan.
+There is no modal overlay, no selected response line, and no numbered choice box.
+
+❯ 
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
   });
 
   it("detects recoverable pr-loop parking as an action instead of plain idle text", () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -198,6 +198,41 @@ Applied pnpm.
     expect(parsed.control_state).toBe("ready");
   });
 
+  it("does not treat stale menu history above a Codex prompt as active", () => {
+    const parsed = parseScreen(`
+OpenAI Codex
+Model: gpt-5.5
+
+Earlier selection:
+> 1. Use pnpm
+  2. Use npm
+
+Applied pnpm.
+
+codex>
+`);
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
+  it("detects an active menu despite stale permission fragments above it", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Earlier transcript mentioned [y/n].
+
+Choose routing mode:
+> 1. Current worker
+  2. New worker
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("interactive_overlay");
+  });
+
   it("does not treat stale permission denied output as an active permission prompt", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -102,6 +102,35 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.control_state).toBe("interactive_overlay");
   });
 
+  it("recognizes generic active choice menus as interactive overlays", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Select a model for the next worker:
+> 1. Opus
+  2. Sonnet
+  3. Haiku
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("interactive_overlay");
+  });
+
+  it("recognizes permission prompts without numbered options", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Do you want to allow this command?
+
+[y/n]
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).toContain("permission_prompt");
+    expect(parsed.control_state).toBe("permission_prompt");
+  });
+
   it("does not treat prose mentioning AskUserQuestion as an interactive overlay", () => {
     const parsed = parseScreen(`
 Claude Code
@@ -142,6 +171,21 @@ Claude Code
 
 $ cat ./private.txt
 bash: ./private.txt: Permission denied
+
+❯ 
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("permission_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
+  it("does not treat stale bracketed y/n text as an active permission prompt", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Notes from the previous run:
+[y/n] appeared in an old command transcript.
 
 ❯ 
 `);

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -117,6 +117,40 @@ There is no modal overlay, no selected response line, and no numbered choice box
     expect(parsed.control_state).toBe("ready");
   });
 
+  it("does not combine separated AskUserQuestion prose, numbered lists, and prompts into an overlay", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Reviewer note: AskUserQuestion is mentioned in a plan paragraph.
+
+Implementation checklist:
+1. Read the plan
+2. Run the tests
+
+Done reading.
+> unrelated shell prompt
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
+  it("does not treat stale permission denied output as an active permission prompt", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+$ cat ./private.txt
+bash: ./private.txt: Permission denied
+
+❯ 
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("permission_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
   it("detects recoverable pr-loop parking as an action instead of plain idle text", () => {
     const parsed = parseScreen(`
 OpenAI Codex

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -165,6 +165,39 @@ Done reading.
     expect(parsed.control_state).toBe("ready");
   });
 
+  it("does not treat one selected numbered line as a menu overlay", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Done:
+> 1. Read the plan
+
+❯ 
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
+  it("does not treat stale menu history above a fresh prompt as active", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Earlier selection:
+> 1. Use pnpm
+  2. Use npm
+
+Applied pnpm.
+
+❯ 
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
   it("does not treat stale permission denied output as an active permission prompt", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2409,7 +2409,10 @@ describe("tool handler integration", () => {
       { surface: "surface:1", text: "echo first" },
       {} as any,
     );
-    await Promise.resolve();
+    for (let attempt = 0; attempt < 10 && !releaseSend; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(releaseSend).toBeTruthy();
 
     const second = await tool.handler(
       { surface: "surface:1", text: "echo second" },

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1569,20 +1569,25 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Should have called send, then send-key, then the submit verification read.
-    expect(mockExec).toHaveBeenCalledTimes(3);
+    // Should preflight the screen, then send, press enter, and verify submit.
+    expect(mockExec).toHaveBeenCalledTimes(4);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
-      expect.arrayContaining(["send"]),
+      expect.arrayContaining(["read-screen"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       "cmux",
-      expect.arrayContaining(["send-key"]),
+      expect.arrayContaining(["send"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
+      "cmux",
+      expect.arrayContaining(["send-key"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      4,
       "cmux",
       expect.arrayContaining(["read-screen"]),
     );

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1605,14 +1605,19 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenCalledTimes(3);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
+      "cmux",
+      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      2,
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
-      2,
+      3,
       "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
     );
@@ -2060,8 +2065,8 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(readsWhenBootPromptSent).toBe(2);
-    expect(reads).toBe(3);
+    expect(readsWhenBootPromptSent).toBe(3);
+    expect(reads).toBe(4);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),


### PR DESCRIPTION
## Summary
- Implements Phase 1 of the cmuxlayer painpoint-remediation plan: Delivery Safety Gate.
- Adds canonical parser `control_state` for the Phase 1 states and blocks delivery into active `interactive_overlay` / `permission_prompt` screens with structured `blocked_by_interactive_prompt` / `blocked_by_permission_prompt` refusals.
- Anchors AskUserQuestion overlay detection to structural markers: tool/clarification marker + selected `>`/`❯` line + numbered options, so panes merely displaying `AskUserQuestion` in prose/source are not blocked.
- Keeps multiline delivery atomic via existing paste-or-refuse behavior; no `dist/` changes included.

## Plan / Review Context
- Plan README: `docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/README.md`
- Phase 1 report: `docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/reports/p1-implementer-report.md`
- Reviewer status before PR loop: SHIP 9/10, with pre-merge fast-follow applied and re-greened.
- Lead noted live-`dist/` E2E review gate as part of the Phase 1 lane.

## Test Plan
- [x] `bun run typecheck`
- [x] `bun run test` — 67 files passed, 1129 tests passed, 8 later-phase todos
- [x] Local CodeRabbit CLI attempted before commit; timed out after 180s while still heartbeating, with no findings returned.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delivery paths with an extra read-screen preflight; false positives could block legitimate sends, but detection is tightened to reduce prose/stale-menu mistakes.
> 
> **Overview**
> **Phase 1 delivery safety gate:** terminal input is no longer sent when the screen shows an active permission prompt or interactive overlay (menus, AskUserQuestion).
> 
> **Screen parsing** adds `control_state` on parsed screens and replaces broad substring checks with windowed detection for permission prompts, choice menus, and AskUserQuestion-style overlays—while ignoring stale transcript text and prose that only mentions tool names.
> 
> **Server delivery** preflights with `read-screen` on every send path (`send_input`, `send_command`, background delivery, agent relay, spawn-related flows). Blocked attempts return structured errors (`blocked_by_permission_prompt` / `blocked_by_interactive_prompt`) with parsed screen context; dispatch inbox nudges no longer type into permission prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2d1c5cea10d46c872dcb767fcd5d3945875982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block input delivery into interactive overlays and permission prompts in screen parser and server
> - Adds regex-based detection in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/217/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) for active permission prompts and interactive overlays (e.g. Claude `AskUserQuestion` menus), exposing a new `control_state` field on `ParsedScreenResult`.
> - Introduces `assertDeliveryTargetIsSafe` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/217/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that preflights the target surface before any input delivery and throws a typed `DeliverySafetyGateError` when `control_state` is `permission_prompt` or `interactive_overlay`.
> - All delivery paths (`send_input`, `send_command`, background deliveries, agent nudges, relayed agent input) now call the safety gate and return structured errors with `error_code` and screen evidence on block.
> - Risk: every delivery now incurs an extra `read-screen` call for the preflight check, increasing total read counts by 1 per delivery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a2d1c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer screen-state detection, including permission prompts, interactive overlays, busy, ready, and unknown states.
  - Tool responses now include a visible control-state status for affected screens.

- **Bug Fixes**
  - Blocked input delivery when a terminal surface is covered by permission or interactive prompts.
  - Improved error reporting so blocked actions return structured details instead of proceeding.
  - Tightened screen parsing to avoid mistaking regular text for active prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->