### PR TITLE
feat(layout): deterministic role-zone rehydration + workspace-mismatch health (phase 4)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -101,6 +101,7 @@ export interface SpawnAgentResult {
   agent_id: string;
   surface_id: string;
   workspace_id?: string;
+  actual_workspace_id?: string;
   state: AgentState;
   model?: string;
   requested_model?: string;
@@ -2106,6 +2107,7 @@ export class AgentEngine {
       agent_id: agentId,
       surface_id: surface.surface,
       workspace_id: surface.workspace,
+      actual_workspace_id: surface.actual_workspace,
       state: "booting",
       model: modelPolicy.effective_model,
       requested_model: modelPolicy.requested_model,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1587,7 +1587,7 @@ export class AgentEngine {
         );
         await this.sendLaunchCommand(
           surface.surface,
-          surface.workspace,
+          surface.actual_workspace ?? surface.workspace,
           resumeCmd,
         );
         await this.client.log(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1999,11 +1999,15 @@ export class AgentEngine {
       }
       const childrenById = new Map<string, AgentRecord>();
       for (const child of this.stateMgr.listStates()) {
-        if (child.parent_agent_id === parent.agent_id) {
+        if (
+          child.parent_agent_id === parent.agent_id &&
+          !TERMINAL_STATES.has(child.state)
+        ) {
           childrenById.set(child.agent_id, child);
         }
       }
       for (const child of this.registry.getChildren(parent.agent_id)) {
+        if (TERMINAL_STATES.has(child.state)) continue;
         childrenById.set(child.agent_id, child);
       }
       if (childrenById.size >= MAX_CHILDREN) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -111,6 +111,7 @@ export interface SpawnAgentResult {
 }
 
 type CreatedAgentSurface = (CmuxNewSplitResult | CmuxNewSurfaceResult) & {
+  actual_workspace?: string;
   warnings?: string[];
 };
 
@@ -1002,7 +1003,18 @@ export class AgentEngine {
           group.surfaces.map((surface) => surface.ref),
         ),
       );
-      const roleSurfaceIds = collectRoleSurfaceIds(this.registry.list());
+      const knownAgentsById = new Map(
+        this.stateMgr
+          .listStates()
+          .map((agent) => [agent.agent_id, agent] as const),
+      );
+      for (const agent of this.registry.list()) {
+        knownAgentsById.set(agent.agent_id, agent);
+      }
+      const liveKnownAgents = [...knownAgentsById.values()].filter((agent) =>
+        liveSurfaceIds.has(agent.surface_id),
+      );
+      const roleSurfaceIds = collectRoleSurfaceIds(liveKnownAgents);
       const extraRoleSurfaceIds =
         this.roleSurfaceIdsProvider?.(liveSurfaceIds, workspace) ?? null;
       if (extraRoleSurfaceIds) {
@@ -1014,8 +1026,8 @@ export class AgentEngine {
       }
       const childWorkerSurfaceIds = new Set(
         parentAgent
-          ? this.registry
-              .getChildren(parentAgent.agent_id)
+          ? liveKnownAgents
+              .filter((agent) => agent.parent_agent_id === parentAgent.agent_id)
               .filter((agent) => inferRecordRoleOrNull(agent) === "worker")
               .map((agent) => agent.surface_id)
           : [],
@@ -1073,6 +1085,8 @@ export class AgentEngine {
     const warning = `Spawn placement mismatch: requested ${requestedWorkspace} but cmux returned ${surface.workspace} for surface ${surface.surface}`;
     return {
       ...surface,
+      workspace: requestedWorkspace,
+      actual_workspace: surface.workspace,
       warnings: [...(surface.warnings ?? []), warning],
     };
   }
@@ -1968,17 +1982,30 @@ export class AgentEngine {
     });
 
     if (spawnParams.parent_agent_id) {
-      const parent = this.registry.get(spawnParams.parent_agent_id);
+      const parent =
+        this.registry.get(spawnParams.parent_agent_id) ??
+        this.stateMgr.readState(spawnParams.parent_agent_id);
       if (!parent) {
         throw new Error(
           `Parent agent not found: ${spawnParams.parent_agent_id}`,
         );
       }
+      if (!this.registry.get(parent.agent_id)) {
+        this.registry.set(parent.agent_id, parent);
+      }
       if (parent.spawn_depth >= MAX_SPAWN_DEPTH) {
         throw new Error(`Max spawn depth exceeded: ${MAX_SPAWN_DEPTH}`);
       }
-      const children = this.registry.getChildren(parent.agent_id);
-      if (children.length >= MAX_CHILDREN) {
+      const childrenById = new Map<string, AgentRecord>();
+      for (const child of this.stateMgr.listStates()) {
+        if (child.parent_agent_id === parent.agent_id) {
+          childrenById.set(child.agent_id, child);
+        }
+      }
+      for (const child of this.registry.getChildren(parent.agent_id)) {
+        childrenById.set(child.agent_id, child);
+      }
+      if (childrenById.size >= MAX_CHILDREN) {
         throw new Error(`Max children exceeded: ${MAX_CHILDREN}`);
       }
       spawnDepth = parent.spawn_depth + 1;
@@ -2051,7 +2078,7 @@ export class AgentEngine {
     try {
       await this.sendLaunchCommand(
         surface.surface,
-        surface.workspace,
+        surface.actual_workspace ?? surface.workspace,
         launchCmd,
       );
     } catch (error) {

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -8,18 +8,31 @@ function repoIdentityToken(input: string): string {
   const normalized = input.trim().replace(/\/+$/, "");
   if (!normalized) return "";
   const segments = normalized.split("/").filter(Boolean);
-  const worktreeSegment = segments.find((segment) =>
-    segment.toLowerCase().endsWith(".wt"),
-  );
-  if (worktreeSegment) return worktreeSegment.slice(0, -3);
   const worktreesIndex = segments.findIndex(
     (segment) => segment.toLowerCase() === ".worktrees",
   );
   if (worktreesIndex > 0) return segments[worktreesIndex - 1] ?? "";
   const baseName = pathBaseName(normalized);
-  return baseName.toLowerCase().endsWith(".wt")
-    ? baseName.slice(0, -3)
-    : baseName;
+  if (baseName.toLowerCase().endsWith(".wt")) {
+    return baseName.slice(0, -3);
+  }
+  const worktreeSegment = segments.find((segment) =>
+    segment.toLowerCase().endsWith(".wt"),
+  );
+  if (worktreeSegment) {
+    const worktreeRepo = worktreeSegment.slice(0, -3);
+    const normalizedBase = baseName.toLowerCase().replace(/[-_]/g, "");
+    const normalizedWorktreeRepo = worktreeRepo
+      .toLowerCase()
+      .replace(/[-_]/g, "");
+    if (
+      normalizedBase === normalizedWorktreeRepo ||
+      normalizedBase.startsWith(`${normalizedWorktreeRepo}worker`)
+    ) {
+      return worktreeRepo;
+    }
+  }
+  return baseName;
 }
 
 function tokenMatchesRepo(token: string, repo: string): boolean {

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -4,10 +4,28 @@ export function pathBaseName(path: string): string {
   return index >= 0 ? normalized.slice(index + 1) : normalized;
 }
 
+function repoIdentityToken(input: string): string {
+  const normalized = input.trim().replace(/\/+$/, "");
+  if (!normalized) return "";
+  const segments = normalized.split("/").filter(Boolean);
+  const worktreeSegment = segments.find((segment) =>
+    segment.toLowerCase().endsWith(".wt"),
+  );
+  if (worktreeSegment) return worktreeSegment.slice(0, -3);
+  const worktreesIndex = segments.findIndex(
+    (segment) => segment.toLowerCase() === ".worktrees",
+  );
+  if (worktreesIndex > 0) return segments[worktreesIndex - 1] ?? "";
+  const baseName = pathBaseName(normalized);
+  return baseName.toLowerCase().endsWith(".wt")
+    ? baseName.slice(0, -3)
+    : baseName;
+}
+
 function tokenMatchesRepo(token: string, repo: string): boolean {
-  const normalizedRepo = repo.toLowerCase();
+  const normalizedRepo = repoIdentityToken(repo).toLowerCase();
   const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");
-  const normalizedToken = token.toLowerCase();
+  const normalizedToken = repoIdentityToken(token).toLowerCase();
   return (
     normalizedToken === normalizedRepo ||
     normalizedToken.replace(/-/g, "") === normalizedRepoNoHyphen

--- a/src/server.ts
+++ b/src/server.ts
@@ -2636,6 +2636,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
   };
 
+  const agentForSpawnHealth = (
+    agent: AgentRecord,
+    result: { workspace_id?: string; warnings?: string[] },
+  ): AgentRecord => {
+    const placementMismatch =
+      result.warnings?.some((warning) =>
+        warning.startsWith("Spawn placement mismatch:"),
+      ) ?? false;
+    if (!placementMismatch || !result.workspace_id) return agent;
+    return { ...agent, workspace_id: result.workspace_id };
+  };
+
   const isLeadLikeSurfaceTitle = (title: string): boolean =>
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
 
@@ -5207,9 +5219,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : undefined;
           const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
-            ? await evaluateServerAgentHealth(currentAgent, {
-                ...healthTopologyOverrides(currentAgent, topology),
-              })
+            ? await evaluateServerAgentHealth(
+                agentForSpawnHealth(currentAgent, result),
+                {
+                  ...healthTopologyOverrides(currentAgent, topology),
+                },
+              )
             : undefined;
 
           return okFormatted(
@@ -5350,9 +5365,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const currentAgent = engine.getAgentState(result.agent_id);
           const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
-            ? await evaluateServerAgentHealth(currentAgent, {
-                ...healthTopologyOverrides(currentAgent, topology),
-              })
+            ? await evaluateServerAgentHealth(
+                agentForSpawnHealth(currentAgent, result),
+                {
+                  ...healthTopologyOverrides(currentAgent, topology),
+                },
+              )
             : undefined;
 
           return okFormatted(
@@ -5509,9 +5527,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 : undefined;
             const topology = currentAgent ? await collectSurfaceTopology() : null;
             const health = currentAgent
-              ? await evaluateServerAgentHealth(currentAgent, {
-                  ...healthTopologyOverrides(currentAgent, topology),
-                })
+              ? await evaluateServerAgentHealth(
+                  agentForSpawnHealth(currentAgent, result),
+                  {
+                    ...healthTopologyOverrides(currentAgent, topology),
+                  },
+                )
               : undefined;
 
             spawnedAgents.push({

--- a/src/server.ts
+++ b/src/server.ts
@@ -2648,6 +2648,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return { ...agent, workspace_id: result.workspace_id };
   };
 
+  const spawnDeliveryWorkspace = (
+    result: { actual_workspace_id?: string; workspace_id?: string },
+    fallback?: string,
+  ): string | undefined =>
+    result.actual_workspace_id ?? result.workspace_id ?? fallback;
+
   const isLeadLikeSurfaceTitle = (title: string): boolean =>
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
 
@@ -5114,7 +5120,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             | undefined;
           try {
             if (hasInlinePrompt(args.prompt) || bootPromptPath) {
-              const deliveryWorkspace = result.workspace_id ?? spawnWorkspace;
+              const deliveryWorkspace = spawnDeliveryWorkspace(
+                result,
+                spawnWorkspace,
+              );
               bootPromptDelivery = await deliverBootPrompt({
                 surface: result.surface_id,
                 workspace: deliveryWorkspace,
@@ -5333,9 +5342,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             | Awaited<ReturnType<typeof deliverBootPrompt>>
             | undefined;
           if (hasPrompt) {
+            const deliveryWorkspace = spawnDeliveryWorkspace(
+              result,
+              args.workspace,
+            );
             bootPromptDelivery = await deliverBootPrompt({
               surface: result.surface_id,
-              workspace: result.workspace_id ?? args.workspace,
+              workspace: deliveryWorkspace,
               cli: args.cli,
               prompt: args.prompt,
               timeout_ms: args.boot_prompt_timeout_ms,
@@ -5343,7 +5356,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 relaunchSpawnAgentAfterUpdate({
                   agentId: result.agent_id,
                   surface: result.surface_id,
-                  workspace: result.workspace_id ?? args.workspace,
+                  workspace: deliveryWorkspace,
                   model: result.model ?? args.model,
                   mcpEnv: result.mcp_env,
                 }),
@@ -5359,7 +5372,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await restoreFocusAfterRender(
             priorFocus,
             result.surface_id,
-            result.workspace_id ?? args.workspace,
+            spawnDeliveryWorkspace(result, args.workspace),
           );
           await refreshManagedMetadataBestEffort(result.agent_id);
           const currentAgent = engine.getAgentState(result.agent_id);
@@ -5478,9 +5491,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               | undefined;
 
             if (hasPrompt) {
+              const deliveryWorkspace = spawnDeliveryWorkspace(
+                result,
+                workspace,
+              );
               bootPromptDelivery = await deliverBootPrompt({
                 surface: result.surface_id,
-                workspace,
+                workspace: deliveryWorkspace,
                 cli: agent.cli,
                 prompt: agent.prompt,
                 timeout_ms: BOOT_PROMPT_TIMEOUT_MS,
@@ -5488,7 +5505,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   relaunchSpawnAgentAfterUpdate({
                     agentId: result.agent_id,
                     surface: result.surface_id,
-                    workspace,
+                    workspace: deliveryWorkspace,
                     model: result.model ?? agent.model,
                     mcpEnv: result.mcp_env,
                   }),

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -284,6 +284,42 @@ describe("AgentEngine", () => {
       expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
 
+    it("does not count terminal children against max children after disk rehydration", async () => {
+      const parent = makeRecord({
+        agent_id: "parent-with-terminal-children",
+        surface_id: "surface:parent",
+        state: "ready",
+        cli: "claude",
+        spawn_depth: 0,
+      });
+      stateMgr.writeState(parent);
+      for (let i = 0; i < MAX_CHILDREN; i++) {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `terminal-child-${i}`,
+            surface_id: `surface:terminal-child-${i}`,
+            state: i % 2 === 0 ? "done" : "error",
+            cli: "codex",
+            parent_agent_id: parent.agent_id,
+            spawn_depth: parent.spawn_depth + 1,
+          }),
+        );
+      }
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          prompt: "Fix gap F",
+          parent_agent_id: parent.agent_id,
+        }),
+      ).resolves.toMatchObject({
+        surface_id: "surface:new",
+        state: "booting",
+      });
+    });
+
     it("captures session identity before surfacing launch command failures", async () => {
       const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1771,6 +1771,46 @@ describe("AgentEngine", () => {
       expect(recovered?.respawn_attempts).toBe(1);
     });
 
+    it("sends crash recovery resume commands to the actual cmux workspace on placement mismatch", async () => {
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "workspace:wrong",
+        surface: "surface:new",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      } satisfies CmuxNewSplitResult);
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-crash-mismatch",
+          state: "working",
+          surface_id: "surface:dead",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+          workspace_id: "workspace:intended",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:dead")];
+      await engine.getRegistry().reconstitute();
+
+      liveSurfaces = [];
+      await engine.runSweep();
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        "surface:new",
+        "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        { workspace: "workspace:wrong" },
+      );
+      expect(mockClient.sendKey).toHaveBeenCalledWith("surface:new", "return", {
+        workspace: "workspace:wrong",
+      });
+      expect(engine.getAgentState("agent-crash-mismatch")?.workspace_id).toBe(
+        "workspace:intended",
+      );
+    });
+
     it("respawns launcher CLI agents with their resolved launcher name", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -29,7 +29,11 @@ import {
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
-import { MAX_RESPAWN_ATTEMPTS, type AgentRecord } from "../src/agent-types.js";
+import {
+  MAX_CHILDREN,
+  MAX_RESPAWN_ATTEMPTS,
+  type AgentRecord,
+} from "../src/agent-types.js";
 import { SpawnGuard, SpawnRateLimitedError } from "../src/spawn-guard.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
@@ -243,6 +247,41 @@ describe("AgentEngine", () => {
       );
       expect(result.surface_id).toBe("surface:new");
       expect(result.state).toBe("booting");
+    });
+
+    it("enforces max children when parent and children are rehydrated from disk", async () => {
+      const parent = makeRecord({
+        agent_id: "parent-claude",
+        surface_id: "surface:parent",
+        state: "ready",
+        cli: "claude",
+        spawn_depth: 0,
+      });
+      stateMgr.writeState(parent);
+      for (let i = 0; i < MAX_CHILDREN; i++) {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `child-${i}`,
+            surface_id: `surface:child-${i}`,
+            state: "ready",
+            cli: "codex",
+            parent_agent_id: parent.agent_id,
+            spawn_depth: parent.spawn_depth + 1,
+          }),
+        );
+      }
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          prompt: "Fix gap F",
+          parent_agent_id: parent.agent_id,
+        }),
+      ).rejects.toThrow(`Max children exceeded: ${MAX_CHILDREN}`);
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
 
     it("captures session identity before surfacing launch command failures", async () => {
@@ -548,7 +587,7 @@ describe("AgentEngine", () => {
         workspace: "workspace:intended",
       });
 
-      expect(result.workspace_id).toBe("workspace:wrong");
+      expect(result.workspace_id).toBe("workspace:intended");
       expect(result.warnings).toContain(
         "Spawn placement mismatch: requested workspace:intended but cmux returned workspace:wrong for surface surface:new",
       );
@@ -888,6 +927,54 @@ describe("AgentEngine", () => {
 
       expect(mockClient.newSurface).toHaveBeenCalledWith({
         pane: "pane:right",
+        type: "terminal",
+        workspace: "ws:1",
+      });
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+    });
+
+    it("rehydrates persisted role surfaces before placing after reconnect", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "existing-worker",
+          state: "ready",
+          surface_id: "surface:worker-existing",
+          workspace_id: "ws:1",
+          role: "worker",
+        }),
+      );
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:worker",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:worker-existing"],
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: "pane:worker",
+        surfaces: [makeSurface("surface:worker-existing")],
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix gap F",
+        workspace: "ws:1",
+      });
+
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:worker",
         type: "terminal",
         workspace: "ws:1",
       });

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { basename, extname } from "node:path";
 import { describe, expect, it } from "vitest";
+import { evaluateAgentHealth } from "../src/agent-health.js";
+import { reposEquivalent } from "../src/repo-workspace.js";
 import { parseScreen } from "../src/screen-parser.js";
 import { classifySurfaceSessionRoute } from "../src/state-manager.js";
 import type {
@@ -24,6 +26,15 @@ type PainpointFixture = {
     surface_id: string;
     cli_session_id: string;
     updated_at?: string;
+  };
+  parent_agent?: {
+    repo: string;
+    workspace_id: string;
+  };
+  spawn_request?: {
+    repo: string;
+    focused_workspace: string;
+    explicit_workspace: string | null;
   };
 };
 
@@ -144,6 +155,41 @@ describe("Phase 0 painpoint replay corpus", () => {
               fixture.live_surfaces?.map((surface) => surface.ref) ?? [],
           }),
         ).toBe(fixture.expected_state);
+      });
+      continue;
+    }
+
+    if (fixture.id === "wrong-workspace-spawn") {
+      it(`${fixture.id} inherits the same-repo parent workspace and flags wrong actual placement`, () => {
+        expect(fixture.parent_agent).toBeTruthy();
+        expect(fixture.spawn_request).toBeTruthy();
+        const parent = fixture.parent_agent!;
+        const spawn = fixture.spawn_request!;
+        expect(reposEquivalent(parent.repo, spawn.repo)).toBe(true);
+        expect(spawn.explicit_workspace).toBeNull();
+
+        const child = recordFromFixture({
+          agent_id: "child-worker",
+          surface_id: "surface:child",
+          workspace_id: parent.workspace_id,
+          repo: spawn.repo,
+          cli: "codex",
+          role: "worker",
+          state: "ready",
+        });
+
+        expect(
+          evaluateAgentHealth(child, {
+            monitor_alive: true,
+            surface_workspace_id: parent.workspace_id,
+          }).issue_codes,
+        ).not.toContain("registry_surface_workspace_mismatch");
+        expect(
+          evaluateAgentHealth(child, {
+            monitor_alive: true,
+            surface_workspace_id: spawn.focused_workspace,
+          }).issue_codes,
+        ).toContain("registry_surface_workspace_mismatch");
       });
       continue;
     }

--- a/tests/repo-workspace.test.ts
+++ b/tests/repo-workspace.test.ts
@@ -58,6 +58,21 @@ describe("workspaceDirectoryRepoMatchScore", () => {
     ).toBe(2);
   });
 
+  it("treats a path under an unrelated .wt ancestor as the final repo basename", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "/Users/x/outer.wt/nestedrepo",
+        "/Users/x/outer.wt/nestedrepo",
+      ),
+    ).toBe(2);
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "/Users/x/outer.wt/nestedrepo",
+        "/Users/x/Gits/outer",
+      ),
+    ).toBe(0);
+  });
+
   it("does not match an unrelated sibling repo (no substring/prefix match)", () => {
     expect(
       workspaceDirectoryRepoMatchScore(
@@ -212,5 +227,14 @@ describe("reposEquivalent", () => {
         "/example/workspaces/cmuxlayer.wt/cmuxlayer-worker-1",
       ),
     ).toBe(true);
+  });
+
+  it("does not let an unrelated .wt ancestor replace the repo basename", () => {
+    expect(
+      reposEquivalent("/Users/x/outer.wt/nestedrepo", "nestedrepo"),
+    ).toBe(true);
+    expect(reposEquivalent("/Users/x/outer.wt/nestedrepo", "outer")).toBe(
+      false,
+    );
   });
 });

--- a/tests/repo-workspace.test.ts
+++ b/tests/repo-workspace.test.ts
@@ -43,6 +43,21 @@ describe("workspaceDirectoryRepoMatchScore", () => {
     ).toBe(2);
   });
 
+  it("scores path-shaped repo roots and their worktree directories", () => {
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "/example/workspaces/cmuxlayer",
+        "/example/workspaces/cmuxlayer",
+      ),
+    ).toBe(2);
+    expect(
+      workspaceDirectoryRepoMatchScore(
+        "/example/workspaces/cmuxlayer.wt/cmuxlayer-worker-1",
+        "/example/workspaces/cmuxlayer",
+      ),
+    ).toBe(2);
+  });
+
   it("does not match an unrelated sibling repo (no substring/prefix match)", () => {
     expect(
       workspaceDirectoryRepoMatchScore(
@@ -188,5 +203,14 @@ describe("reposEquivalent", () => {
     expect(reposEquivalent("cmuxlayer", "cmux-layer")).toBe(true);
     expect(reposEquivalent("Brainlayer", "brainlayer")).toBe(true);
     expect(reposEquivalent("brainlayer", "voicelayer")).toBe(false);
+  });
+
+  it("treats a repo root path and a same-repo worktree path as equivalent", () => {
+    expect(
+      reposEquivalent(
+        "/example/workspaces/cmuxlayer",
+        "/example/workspaces/cmuxlayer.wt/cmuxlayer-worker-1",
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -821,6 +821,38 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
+  it("spawn_agent delivers inline prompts to the actual workspace after placement mismatch", async () => {
+    const server = createLifecycleServer(mockExec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+    const prompt = "fix placement mismatch prompt delivery";
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.workspace_id).toBe("workspace:1");
+    expect(parsed.actual_workspace_id).toBe("ws:1");
+
+    const promptSendCall = mockExec.mock.calls.find(([, args]) => {
+      const argv = args as string[];
+      return argv.includes("send") && argv.includes(prompt);
+    });
+    expect(promptSendCall).toBeDefined();
+    const argv = promptSendCall![1] as string[];
+    const workspaceIndex = argv.indexOf("--workspace");
+    expect(workspaceIndex).toBeGreaterThanOrEqual(0);
+    expect(argv[workspaceIndex + 1]).toBe("ws:1");
+  });
+
   it("spawn_agent delivers inline prompts with blank lines without empty chunks", async () => {
     const baseExec = makeLifecycleExec();
     const prompt = `${"a".repeat(500)}\n\n${"b".repeat(600)}`;

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -1,11 +1,66 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
 import { inboxPath, monitorAlive } from "../src/inbox.js";
 
 const TEST_DIR = join(tmpdir(), "cmuxlayer-spawn-workspace-test");
+const wrongWorkspaceFixtureUrl = new URL(
+  "./fixtures/painpoints/wrong-workspace-spawn.json",
+  import.meta.url,
+);
+
+type RegisteredTool = {
+  handler(
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+  ): Promise<{
+    structuredContent?: unknown;
+    content: Array<{ text: string }>;
+  }>;
+};
+
+type ServerWithRegisteredTools = {
+  _registeredTools: Record<string, RegisteredTool>;
+};
+
+type WrongWorkspaceFixture = {
+  parent_agent: {
+    repo: string;
+    workspace_id: string;
+  };
+  spawn_request: {
+    repo: string;
+    explicit_workspace: string | null;
+  };
+};
+
+function getTool(server: unknown, name: string): RegisteredTool {
+  return (server as ServerWithRegisteredTools)._registeredTools[name]!;
+}
+
+function parseStructuredResult<T>(result: {
+  structuredContent?: unknown;
+  content: Array<{ text: string }>;
+}): T {
+  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
+}
+
+function readWrongWorkspaceFixture(): WrongWorkspaceFixture {
+  return JSON.parse(
+    readFileSync(wrongWorkspaceFixtureUrl, "utf8"),
+  ) as WrongWorkspaceFixture;
+}
+
+function repoLabelFromFixturePath(path: string): string {
+  const segments = path.split("/").filter(Boolean);
+  const worktreeSegment = segments.find((segment) =>
+    segment.endsWith(".wt"),
+  );
+  if (worktreeSegment) return worktreeSegment.slice(0, -3);
+  return segments.at(-1) ?? path;
+}
 
 function makeWorkspaceClient() {
   let surfaceIndex = 0;
@@ -178,6 +233,144 @@ describe("workspace spawn tools", () => {
     expect(client.newSplit).toHaveBeenCalledWith("right", {
       workspace: "workspace:existing",
       type: "terminal",
+    });
+  });
+
+  it("same-repo child spawn inherits parent workspace and reports wrong actual workspace as unhealthy", async () => {
+    const fixture = readWrongWorkspaceFixture();
+    const repo = repoLabelFromFixturePath(fixture.parent_agent.repo);
+    const childRepo = repoLabelFromFixturePath(fixture.spawn_request.repo);
+    let surfaceIndex = 0;
+    const surfaceWorkspace = new Map<string, string>();
+    const surfacePane = new Map<string, string>();
+    const client = makeWorkspaceClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          ref: fixture.parent_agent.workspace_id,
+          current_directory: fixture.parent_agent.repo,
+        },
+        {
+          ref: "workspace:B",
+          current_directory: "/example/workspaces/other",
+          selected: true,
+        },
+      ],
+    });
+    client.listPanes.mockImplementation(async ({ workspace } = {}) => {
+      const workspaceRef =
+        typeof workspace === "string" ? workspace : "workspace:B";
+      const paneRefs = [...surfacePane.entries()]
+        .filter(([surface]) => surfaceWorkspace.get(surface) === workspaceRef)
+        .map(([, pane]) => pane);
+      return {
+        workspace_ref: workspaceRef,
+        window_ref: `window:${workspaceRef}`,
+        panes: [...new Set(paneRefs)].map((pane, index) => ({
+          ref: pane,
+          index,
+          focused: index === 0,
+          surface_count: [...surfacePane.values()].filter(
+            (candidate) => candidate === pane,
+          ).length,
+          surface_refs: [...surfacePane.entries()]
+            .filter(([, candidate]) => candidate === pane)
+            .map(([surface]) => surface),
+        })),
+      };
+    });
+    client.listPaneSurfaces.mockImplementation(
+      async ({ workspace, pane } = {}) => {
+        const workspaceRef =
+          typeof workspace === "string" ? workspace : "workspace:B";
+        const paneRef = typeof pane === "string" ? pane : "pane:focused";
+        return {
+          workspace_ref: workspaceRef,
+          window_ref: `window:${workspaceRef}`,
+          pane_ref: paneRef,
+          surfaces: [...surfacePane.entries()]
+            .filter(
+              ([surface, candidatePane]) =>
+                candidatePane === paneRef &&
+                surfaceWorkspace.get(surface) === workspaceRef,
+            )
+            .map(([surface], index) => ({
+              ref: surface,
+              title:
+                surface === "surface:1" ? "cmuxlayerClaude" : "cmuxlayerCodex",
+              type: "terminal" as const,
+              index,
+              selected: index === 0,
+            })),
+        };
+      },
+    );
+    client.newSplit.mockImplementation(async (_direction, opts) => {
+      surfaceIndex += 1;
+      const surface = `surface:${surfaceIndex}`;
+      const pane = `pane:${surfaceIndex}`;
+      const actualWorkspace =
+        surfaceIndex > 1 ? "workspace:B" : opts.workspace;
+      surfaceWorkspace.set(surface, actualWorkspace ?? "workspace:B");
+      surfacePane.set(surface, pane);
+      return {
+        workspace: actualWorkspace,
+        surface,
+        pane,
+        title: "",
+        type: "terminal",
+      };
+    });
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const spawnAgent = getTool(server, "spawn_agent");
+
+    const parentResult = await spawnAgent.handler(
+      {
+        repo,
+        cli: "claude",
+        role: "orchestrator",
+        workspace: fixture.parent_agent.workspace_id,
+        force_new: true,
+      },
+      {},
+    );
+    const parent = parseStructuredResult<{ agent_id: string }>(parentResult);
+    expect(parent.agent_id).toEqual(expect.any(String));
+    const childResult = await spawnAgent.handler(
+      {
+        repo: childRepo,
+        cli: "codex",
+        role: "worker",
+        workspace: fixture.spawn_request.explicit_workspace ?? undefined,
+        parent_agent_id: parent.agent_id,
+        force_new: true,
+      },
+      {},
+    );
+    const child = parseStructuredResult<{
+      ok: boolean;
+      workspace_id?: string;
+      warnings?: string[];
+      health?: { status: string; issue_codes: string[] };
+    }>(childResult);
+
+    expect(client.newSplit.mock.calls[1]?.[1]?.workspace).toBe(
+      fixture.parent_agent.workspace_id,
+    );
+    expect(child.ok).toBe(true);
+    expect(child.workspace_id).toBe(fixture.parent_agent.workspace_id);
+    expect(child.warnings).toEqual([
+      expect.stringMatching(/Spawn placement mismatch/),
+    ]);
+    expect(child.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining([
+        "registry_surface_workspace_mismatch",
+      ]),
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rehydrate persisted role-zone state before layout placement so fresh reconnects keep worker panes deterministic.
- Normalize repo/worktree/path identities so same-repo child spawns inherit the parent workspace.
- Preserve intended workspace on placement mismatch, track actual_workspace for launch routing, and surface registry_surface_workspace_mismatch health.

## Plan Context
- Phase 4: layout/workspace determinism.
- Local plan README: docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/README.md
- lead-approved real-green.

## Review Notes
- Local CodeRabbit agent pass timed out after 180s with no findings emitted; fallback red/blue-team review found a persisted-child MAX_CHILDREN edge case, which is fixed in this PR before commit.
- Do not merge; lead owns merge.

## Verification
- graphify update . --no-cluster; graphify query over workspace placement area.
- git diff --check
- bun run typecheck
- bun run test: 67 files passed, 1149 tests passed, 6 todo
- push hook run_tests.sh finished with exit status 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn, layout, and workspace routing paths; regressions could misplace agents or block spawns, though coverage is broad in tests.
> 
> **Overview**
> Improves **spawn layout determinism** after reconnect and when cmux assigns a different workspace than requested.
> 
> **Placement mismatch:** When cmux returns a different workspace than requested, the engine keeps the **intended** `workspace_id` on the agent record and spawn result, adds `actual_workspace_id` / `actual_workspace`, and still sends launch, resume, and boot prompts to the **cmux-assigned** workspace. Health checks use the intended workspace so **`registry_surface_workspace_mismatch`** can fire when live topology disagrees.
> 
> **Rehydration:** Role-surface IDs and sibling worker placement now merge **persisted state** with the in-memory registry, limited to surfaces that are still live—so layout placement stays stable after reconnect. Parent lookup and **max-children** enforcement also consider disk-backed agents (terminal children excluded).
> 
> **Repo identity:** `repo-workspace` normalizes `.worktrees` and `.wt` paths so same-repo parent/child spawns inherit the parent workspace and path-shaped repo labels match correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c786ac42a7151839736326d965f6119b1ddabda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic role-zone rehydration and workspace-mismatch health detection to agent spawning
> - `AgentEngine.spawnAgent` now merges children from both disk state (`stateMgr.listStates()`) and the in-memory registry to enforce `MAX_CHILDREN`, excluding terminal-state children from the count.
> - When cmux places an agent in a different workspace than requested, the surface records both the requested workspace (public) and the actual cmux workspace (`actual_workspace`), and `spawnAgent` returns `actual_workspace_id` to callers.
> - Boot prompt delivery and relaunch commands in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/218/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now target the actual cmux workspace on placement mismatch; agent health evaluation uses the spawn-time workspace override to detect `registry_surface_workspace_mismatch`.
> - `repoIdentityToken` in [repo-workspace.ts](https://github.com/EtanHey/cmuxlayer/pull/218/files#diff-53d8fefee7e992adc9fdb6abf96bf6397197686ef114234c74632c022f4e70e0) normalizes `.worktrees` and `.wt` worktree path shapes so `tokenMatchesRepo` correctly equates worktree paths with their repo root.
> - Crash recovery resume commands in `runSweep` also target the actual cmux workspace when a mismatch occurred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c786ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent spawning now better respects the actual workspace placement, including cases where the requested and assigned workspaces differ.
  * Repo and workspace matching is more consistent across root and worktree-style paths.

* **Bug Fixes**
  * Improved child-agent spawning to handle persisted state more reliably and enforce child limits correctly.
  * Health status now reflects workspace placement mismatches more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->