### PR TITLE
fix: improve worktree naming and MCP config copy

### DIFF
--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  realpathSync,
   symlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -75,6 +76,14 @@ function safeName(input: string): string {
 function defaultWorkerName(repo: string): string {
   const shortId = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
   return safeName(`${repo}-worker-${shortId}`);
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 function assertInside(root: string, path: string): void {
@@ -159,6 +168,21 @@ function copyMcpJson(repoRoot: string, worktreePath: string): boolean {
   return true;
 }
 
+async function branchExists(
+  repoRoot: string,
+  branch: string,
+  exec: WorktreeExec,
+): Promise<boolean> {
+  const result = await exec("git", [
+    "-C",
+    repoRoot,
+    "branch",
+    "--list",
+    branch,
+  ]);
+  return result.stdout.trim().length > 0;
+}
+
 function parseWorktreeListPaths(stdout: string): string[] {
   return stdout
     .split("\n")
@@ -187,9 +211,9 @@ async function assertExistingWorktree(
     "list",
     "--porcelain",
   ]);
-  const expectedPath = resolve(path);
+  const expectedPath = canonicalPath(path);
   const belongsToRepo = parseWorktreeListPaths(worktreeList.stdout).some(
-    (worktreePath) => resolve(worktreePath) === expectedPath,
+    (worktreePath) => canonicalPath(worktreePath) === expectedPath,
   );
   if (!belongsToRepo) {
     throw new Error(`Existing path is not a worktree of ${repoRoot}: ${path}`);
@@ -203,23 +227,35 @@ export async function prepareWorktree(
   const homeGitsDir = resolve(input.homeGitsDir ?? join(homedir(), "Gits"));
   const repoRoot = resolve(input.repoRoot ?? join(homeGitsDir, repo));
   assertInside(homeGitsDir, repoRoot);
+  const exec = input.exec ?? defaultExec;
 
   const spec = normalizeWorktreeRequest(repo, input.worktree);
   let worktreePath = spec.path
     ? resolve(spec.path)
     : join(homeGitsDir, `${repo}.wt`, spec.name);
   if (spec.generatedName && !spec.path) {
-    for (let attempts = 0; existsSync(worktreePath) && attempts < 10; attempts++) {
+    for (let attempts = 0; attempts < 10; attempts++) {
+      const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+      const pathExists = existsSync(worktreePath);
+      const branchTaken = pathExists
+        ? false
+        : await branchExists(repoRoot, branch, exec);
+      if (!pathExists && !branchTaken) {
+        break;
+      }
       spec.name = defaultWorkerName(repo);
       worktreePath = join(homeGitsDir, `${repo}.wt`, spec.name);
     }
-    if (existsSync(worktreePath)) {
+    const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+    if (
+      existsSync(worktreePath) ||
+      (await branchExists(repoRoot, branch, exec))
+    ) {
       throw new Error(`Unable to generate a unique worktree path for ${repo}`);
     }
   }
   assertInside(homeGitsDir, worktreePath);
 
-  const exec = input.exec ?? defaultExec;
   if (existsSync(worktreePath)) {
     if (!spec.reuse) {
       throw new Error(`Worktree already exists: ${worktreePath}`);

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -150,7 +150,18 @@ function copyMcpJson(repoRoot: string, worktreePath: string): boolean {
   return true;
 }
 
-async function assertExistingWorktree(path: string, exec: WorktreeExec) {
+function parseWorktreeListPaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length));
+}
+
+async function assertExistingWorktree(
+  path: string,
+  repoRoot: string,
+  exec: WorktreeExec,
+) {
   const result = await exec("git", [
     "-C",
     path,
@@ -159,6 +170,20 @@ async function assertExistingWorktree(path: string, exec: WorktreeExec) {
   ]);
   if (result.stdout.trim() !== "true") {
     throw new Error(`Existing path is not a git worktree: ${path}`);
+  }
+  const worktreeList = await exec("git", [
+    "-C",
+    repoRoot,
+    "worktree",
+    "list",
+    "--porcelain",
+  ]);
+  const expectedPath = resolve(path);
+  const belongsToRepo = parseWorktreeListPaths(worktreeList.stdout).some(
+    (worktreePath) => resolve(worktreePath) === expectedPath,
+  );
+  if (!belongsToRepo) {
+    throw new Error(`Existing path is not a worktree of ${repoRoot}: ${path}`);
   }
 }
 
@@ -185,7 +210,7 @@ export async function prepareWorktree(
     if (!stat.isDirectory()) {
       throw new Error(`Worktree path exists but is not a directory: ${worktreePath}`);
     }
-    await assertExistingWorktree(worktreePath, exec);
+    await assertExistingWorktree(worktreePath, repoRoot, exec);
     return {
       path: worktreePath,
       name: basename(worktreePath),

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import {
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -51,6 +52,7 @@ export interface PreparedWorktree {
   created: boolean;
   reused: boolean;
   node_modules_linked: boolean;
+  mcp_json_copied: boolean;
 }
 
 function defaultExec(cmd: string, args: string[]) {
@@ -86,7 +88,8 @@ function normalizeWorktreeRequest(
   Omit<WorktreeRequest, "create" | "reuse" | "base"> & { name: string } {
   const spec: WorktreeRequest =
     request === true || request === false || request === undefined ? {} : request;
-  const name = safeName(spec.name ?? `${repo}-worker-${Date.now()}`);
+  const shortId = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
+  const name = safeName(spec.name ?? `${repo}-worker-${shortId}`);
   return {
     create: spec.create ?? true,
     reuse: spec.reuse ?? true,
@@ -137,6 +140,16 @@ function linkNodeModules(repoRoot: string, worktreePath: string): boolean {
   return true;
 }
 
+function copyMcpJson(repoRoot: string, worktreePath: string): boolean {
+  const source = join(repoRoot, ".mcp.json");
+  const target = join(worktreePath, ".mcp.json");
+  if (!existsSync(source) || existsSync(target)) {
+    return false;
+  }
+  copyFileSync(source, target);
+  return true;
+}
+
 async function assertExistingWorktree(path: string, exec: WorktreeExec) {
   const result = await exec("git", [
     "-C",
@@ -181,6 +194,7 @@ export async function prepareWorktree(
       created: false,
       reused: true,
       node_modules_linked: linkNodeModules(repoRoot, worktreePath),
+      mcp_json_copied: copyMcpJson(repoRoot, worktreePath),
     };
   }
 
@@ -209,5 +223,6 @@ export async function prepareWorktree(
     created: true,
     reused: false,
     node_modules_linked: linkNodeModules(repoRoot, worktreePath),
+    mcp_json_copied: copyMcpJson(repoRoot, worktreePath),
   };
 }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -72,6 +72,11 @@ function safeName(input: string): string {
   return normalized;
 }
 
+function defaultWorkerName(repo: string): string {
+  const shortId = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
+  return safeName(`${repo}-worker-${shortId}`);
+}
+
 function assertInside(root: string, path: string): void {
   const resolvedRoot = resolve(root);
   const resolvedPath = resolve(path);
@@ -85,15 +90,19 @@ function normalizeWorktreeRequest(
   repo: string,
   request: boolean | WorktreeRequest | undefined,
 ): Required<Pick<WorktreeRequest, "create" | "reuse" | "base">> &
-  Omit<WorktreeRequest, "create" | "reuse" | "base"> & { name: string } {
+  Omit<WorktreeRequest, "create" | "reuse" | "base"> & {
+    generatedName: boolean;
+    name: string;
+  } {
   const spec: WorktreeRequest =
     request === true || request === false || request === undefined ? {} : request;
-  const shortId = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
-  const name = safeName(spec.name ?? `${repo}-worker-${shortId}`);
+  const generatedName = spec.name === undefined;
+  const name = generatedName ? defaultWorkerName(repo) : safeName(spec.name ?? "");
   return {
     create: spec.create ?? true,
     reuse: spec.reuse ?? true,
     base: spec.base ?? "HEAD",
+    generatedName,
     name,
     ...(spec.path ? { path: spec.path } : {}),
     ...(spec.branch ? { branch: spec.branch } : {}),
@@ -196,9 +205,18 @@ export async function prepareWorktree(
   assertInside(homeGitsDir, repoRoot);
 
   const spec = normalizeWorktreeRequest(repo, input.worktree);
-  const worktreePath = spec.path
+  let worktreePath = spec.path
     ? resolve(spec.path)
     : join(homeGitsDir, `${repo}.wt`, spec.name);
+  if (spec.generatedName && !spec.path) {
+    for (let attempts = 0; existsSync(worktreePath) && attempts < 10; attempts++) {
+      spec.name = defaultWorkerName(repo);
+      worktreePath = join(homeGitsDir, `${repo}.wt`, spec.name);
+    }
+    if (existsSync(worktreePath)) {
+      throw new Error(`Unable to generate a unique worktree path for ${repo}`);
+    }
+  }
   assertInside(homeGitsDir, worktreePath);
 
   const exec = input.exec ?? defaultExec;

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -15,6 +15,10 @@ import {
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-worktree-test");
 
+function worktreeListOutput(paths: string[]): string {
+  return paths.map((path) => `worktree ${path}\n`).join("");
+}
+
 describe("worktree helpers", () => {
   beforeEach(() => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
@@ -99,7 +103,15 @@ describe("worktree helpers", () => {
     const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "existing");
     mkdirSync(repoRoot, { recursive: true });
     mkdirSync(worktreePath, { recursive: true });
-    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([repoRoot, worktreePath]),
+          stderr: "",
+        };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
 
     const result = await prepareWorktree({
       repo: "cmuxlayer",
@@ -178,7 +190,15 @@ describe("worktree helpers", () => {
     mkdirSync(repoRoot, { recursive: true });
     mkdirSync(worktreePath, { recursive: true });
     writeFileSync(join(repoRoot, ".mcp.json"), mcpConfig);
-    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([repoRoot, worktreePath]),
+          stderr: "",
+        };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
 
     const result = await prepareWorktree({
       repo: "cmuxlayer",
@@ -203,7 +223,15 @@ describe("worktree helpers", () => {
     mkdirSync(worktreePath, { recursive: true });
     writeFileSync(join(repoRoot, ".mcp.json"), sourceConfig);
     writeFileSync(join(worktreePath, ".mcp.json"), existingConfig);
-    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([repoRoot, worktreePath]),
+          stderr: "",
+        };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
 
     const result = await prepareWorktree({
       repo: "cmuxlayer",
@@ -217,6 +245,36 @@ describe("worktree helpers", () => {
     expect(readFileSync(join(worktreePath, ".mcp.json"), "utf8")).toBe(
       existingConfig,
     );
+  });
+
+  it("rejects reuse when an existing git worktree does not belong to the repo root", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "other.wt", "foreign");
+    const foreignRepoRoot = join(TEST_ROOT, "foreign-repo");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(worktreePath, { recursive: true });
+    writeFileSync(join(repoRoot, ".mcp.json"), '{"mcpServers":{"cmux":{}}}\n');
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([repoRoot, foreignRepoRoot]),
+          stderr: "",
+        };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
+
+    await expect(
+      prepareWorktree({
+        repo: "cmuxlayer",
+        repoRoot,
+        homeGitsDir: TEST_ROOT,
+        worktree: { path: worktreePath, reuse: true },
+        exec,
+      }),
+    ).rejects.toThrow(/not a worktree of/);
+
+    expect(existsSync(join(worktreePath, ".mcp.json"))).toBe(false);
   });
 
   it("skips .mcp.json copy when the source file is missing", async () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -74,6 +75,9 @@ describe("worktree helpers", () => {
     mkdirSync(collidingPath, { recursive: true });
     vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
     const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("branch") && args.includes("--list")) {
+        return { stdout: "", stderr: "" };
+      }
       if (args.includes("worktree") && args.includes("list")) {
         return {
           stdout: worktreeListOutput([repoRoot, collidingPath]),
@@ -111,6 +115,51 @@ describe("worktree helpers", () => {
       nextPath,
       "HEAD",
     ]);
+  });
+
+  it("retries generated default names when the generated branch already exists", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const firstId = (0.5).toString(36).slice(2, 8).padEnd(6, "0");
+    const secondId = (0.25).toString(36).slice(2, 8).padEnd(6, "0");
+    const collidingName = `cmuxlayer-worker-${firstId}`;
+    const nextName = `cmuxlayer-worker-${secondId}`;
+    const collidingBranch = `cmuxlayer/${collidingName}`;
+    const nextPath = join(TEST_ROOT, "cmuxlayer.wt", nextName);
+    mkdirSync(repoRoot, { recursive: true });
+    vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("branch") && args.includes("--list")) {
+        const branch = args.at(-1);
+        return {
+          stdout: branch === collidingBranch ? `  ${collidingBranch}\n` : "",
+          stderr: "",
+        };
+      }
+      if (args.includes("worktree") && args.includes("add")) {
+        if (args.includes(collidingBranch)) {
+          throw new Error("fatal: a branch named already exists");
+        }
+        mkdirSync(nextPath, { recursive: true });
+        return { stdout: "", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: true,
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      path: nextPath,
+      name: nextName,
+      branch: `cmuxlayer/${nextName}`,
+      created: true,
+      reused: false,
+    });
   });
 
   it("creates a named git worktree with a deterministic default path", async () => {
@@ -199,6 +248,41 @@ describe("worktree helpers", () => {
       "git",
       expect.arrayContaining(["worktree", "add"]),
     );
+  });
+
+  it("reuses a repo worktree when git reports canonical paths through a symlink", async () => {
+    const actualGitsDir = join(TEST_ROOT, "actual-gits");
+    const linkedGitsDir = join(TEST_ROOT, "linked-gits");
+    const repoRoot = join(linkedGitsDir, "repo");
+    const worktreePath = join(linkedGitsDir, "cmuxlayer.wt", "linked");
+    const actualRepoRoot = join(actualGitsDir, "repo");
+    const actualWorktreePath = join(actualGitsDir, "cmuxlayer.wt", "linked");
+    mkdirSync(actualRepoRoot, { recursive: true });
+    mkdirSync(actualWorktreePath, { recursive: true });
+    symlinkSync(actualGitsDir, linkedGitsDir, "dir");
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([actualRepoRoot, actualWorktreePath]),
+          stderr: "",
+        };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: linkedGitsDir,
+      worktree: { name: "linked", reuse: true },
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      path: worktreePath,
+      created: false,
+      reused: true,
+    });
   });
 
   it("symlinks node_modules from the main checkout when present", async () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -62,6 +62,57 @@ describe("worktree helpers", () => {
     expect(second.path).toBe(join(TEST_ROOT, "cmuxlayer.wt", second.name));
   });
 
+  it("retries generated default names instead of reusing a colliding worktree", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const firstId = (0.5).toString(36).slice(2, 8).padEnd(6, "0");
+    const secondId = (0.25).toString(36).slice(2, 8).padEnd(6, "0");
+    const collidingName = `cmuxlayer-worker-${firstId}`;
+    const nextName = `cmuxlayer-worker-${secondId}`;
+    const collidingPath = join(TEST_ROOT, "cmuxlayer.wt", collidingName);
+    const nextPath = join(TEST_ROOT, "cmuxlayer.wt", nextName);
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(collidingPath, { recursive: true });
+    vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return {
+          stdout: worktreeListOutput([repoRoot, collidingPath]),
+          stderr: "",
+        };
+      }
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(nextPath, { recursive: true });
+        return { stdout: "", stderr: "" };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: true,
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      path: nextPath,
+      name: nextName,
+      created: true,
+      reused: false,
+    });
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "add",
+      "-b",
+      `cmuxlayer/${nextName}`,
+      nextPath,
+      "HEAD",
+    ]);
+  });
+
   it("creates a named git worktree with a deterministic default path", async () => {
     const repoRoot = join(TEST_ROOT, "repo");
     mkdirSync(repoRoot, { recursive: true });
@@ -96,6 +147,18 @@ describe("worktree helpers", () => {
       join(TEST_ROOT, "cmuxlayer.wt", "skill-eval"),
       "origin/main",
     ]);
+  });
+
+  it("rejects an empty explicit worktree name", async () => {
+    await expect(
+      prepareWorktree({
+        repo: "cmuxlayer",
+        repoRoot: join(TEST_ROOT, "repo"),
+        homeGitsDir: TEST_ROOT,
+        worktree: { name: "" },
+        exec: vi.fn(),
+      }),
+    ).rejects.toThrow(/Invalid worktree name/);
   });
 
   it("reuses an existing worktree when reuse is enabled", async () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -16,7 +22,40 @@ describe("worktree helpers", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("generates distinct parseable default worker names for the same repo", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+    vi.spyOn(Date, "now").mockReturnValue(1783204101457);
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0.123456789)
+      .mockReturnValueOnce(0.987654321);
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    const first = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: true,
+      exec,
+    });
+    const second = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: true,
+      exec,
+    });
+
+    expect(first.name).toMatch(/^cmuxlayer-worker-[a-z0-9]{6}$/);
+    expect(second.name).toMatch(/^cmuxlayer-worker-[a-z0-9]{6}$/);
+    expect(first.name).not.toBe(second.name);
+    expect(first.name).not.toContain("1783204101457");
+    expect(first.path).toBe(join(TEST_ROOT, "cmuxlayer.wt", first.name));
+    expect(second.path).toBe(join(TEST_ROOT, "cmuxlayer.wt", second.name));
   });
 
   it("creates a named git worktree with a deterministic default path", async () => {
@@ -105,6 +144,100 @@ describe("worktree helpers", () => {
     });
 
     expect(result.node_modules_linked).toBe(true);
+  });
+
+  it("copies .mcp.json byte-for-byte into a newly created worktree", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "with-mcp");
+    const mcpConfig = '{\n  "mcpServers": {\n    "cmuxlayer": {}\n  }\n}\n';
+    mkdirSync(repoRoot, { recursive: true });
+    writeFileSync(join(repoRoot, ".mcp.json"), mcpConfig);
+    const exec = vi.fn().mockImplementation(async () => {
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "with-mcp" },
+      exec,
+    });
+
+    expect(result.mcp_json_copied).toBe(true);
+    expect(readFileSync(join(worktreePath, ".mcp.json"), "utf8")).toBe(
+      mcpConfig,
+    );
+  });
+
+  it("copies .mcp.json when reusing an existing worktree", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "existing-mcp");
+    const mcpConfig = '{\n  "mcpServers": {\n    "brainlayer": {}\n  }\n}\n';
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(worktreePath, { recursive: true });
+    writeFileSync(join(repoRoot, ".mcp.json"), mcpConfig);
+    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "existing-mcp", reuse: true },
+      exec,
+    });
+
+    expect(result.mcp_json_copied).toBe(true);
+    expect(readFileSync(join(worktreePath, ".mcp.json"), "utf8")).toBe(
+      mcpConfig,
+    );
+  });
+
+  it("does not overwrite an existing worktree .mcp.json", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "keeps-mcp");
+    const sourceConfig = '{"mcpServers":{"cmuxlayer":{}}}\n';
+    const existingConfig = '{"mcpServers":{"local":{}}}\n';
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(worktreePath, { recursive: true });
+    writeFileSync(join(repoRoot, ".mcp.json"), sourceConfig);
+    writeFileSync(join(worktreePath, ".mcp.json"), existingConfig);
+    const exec = vi.fn().mockResolvedValue({ stdout: "true\n", stderr: "" });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "keeps-mcp", reuse: true },
+      exec,
+    });
+
+    expect(result.mcp_json_copied).toBe(false);
+    expect(readFileSync(join(worktreePath, ".mcp.json"), "utf8")).toBe(
+      existingConfig,
+    );
+  });
+
+  it("skips .mcp.json copy when the source file is missing", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "missing-mcp");
+    mkdirSync(repoRoot, { recursive: true });
+    const exec = vi.fn().mockImplementation(async () => {
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "missing-mcp" },
+      exec,
+    });
+
+    expect(result.mcp_json_copied).toBe(false);
+    expect(existsSync(join(worktreePath, ".mcp.json"))).toBe(false);
   });
 
   it("rejects a path outside the allowed Gits root", async () => {


### PR DESCRIPTION
## Summary
- replace timestamp-tail default worktree names with six-character base36 short IDs so worker names remain distinguishable when truncated
- copy parent `.mcp.json` into created or reused worktrees only when the source exists and the target is absent
- add TDD coverage for default-name uniqueness and `.mcp.json` copy/no-overwrite/missing-source behavior

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `coderabbit review --agent` local gate: `findings: 0`
- [x] push hook `run_tests.sh` finished with exit status 0

## Notes
- Worker endpoint only; do not merge until lead does the final merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worktree creation/reuse behavior and rejects foreign paths on reuse; empty explicit names now fail validation, which could break callers that relied on old defaults.
> 
> **Overview**
> **Default worker worktrees** no longer use timestamp-based names; they get `{repo}-worker-{6-char base36}` IDs with up to 10 retries when the path or `cmuxlayer/{name}` branch already exists. Explicit empty names are rejected.
> 
> **On create or reuse**, parent `.mcp.json` is copied into the worktree when the source exists and the target does not; `PreparedWorktree` adds **`mcp_json_copied`**.
> 
> **Reuse validation** now requires the path to appear in `git worktree list --porcelain` for the repo root, comparing **canonical** paths (symlink-safe), so foreign git checkouts cannot be reused by mistake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb899d4d910932234c336b219843d7cf62fd535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree naming to use random base36 IDs and copy `.mcp.json` into new worktrees
> - Replaces time-based default worktree names with short random base36 suffixes via `defaultWorkerName()`, with a collision-avoidance retry loop (up to 10 attempts) that checks both path and branch existence before accepting a name.
> - Copies `.mcp.json` from the repo root into the worktree on create or reuse if the source exists and the target does not; `PreparedWorktree` now includes an `mcp_json_copied` boolean.
> - Hardens `assertExistingWorktree` to verify that a reused path is actually listed by `git worktree list --porcelain` for the specified repo root, rejecting paths that belong to a different repo.
> - Adds `canonicalPath()` using `realpathSync` so path comparisons work correctly through symlinks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cb899d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->