### PR TITLE
fix: harden spawn readiness monitor boot

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -54,8 +54,9 @@ import {
   type RoleSurfaceIds,
 } from "./layout-policy.js";
 import {
+  CLI_INPUT_PROMPT_PREFIXES,
+  lineStartsWithCliInputPrompt,
   matchReadyPattern,
-  readyPatternRequiresAgentIdentity,
   screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
@@ -181,7 +182,7 @@ const WAIT_FOR_SWEEP_INTERVAL_MS = 1000;
 const DEFAULT_SWEEP_ACTIVE_INTERVAL_MS = 5_000;
 const DEFAULT_SWEEP_IDLE_INTERVAL_MS = 15_000;
 const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
-const BOOT_SESSION_CAPTURE_WINDOW_MS = 30_000;
+const BOOT_SESSION_TRANSCRIPT_CAPTURE_WINDOW_MS = 30_000;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
 const STOP_POST_CONDITION_POLL_MS = 50;
@@ -876,25 +877,16 @@ export class AgentEngine {
       waitForReadyPatternMatches.delete(agent.agent_id);
       return { agent };
     }
-    if (agent.boot_prompt_pending) {
-      waitForReadyPatternMatches.delete(agent.agent_id);
-      return { agent };
-    }
-
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
       });
-      const match = matchReadyPattern(agent.cli, screen.text);
-      const hasReadyIdentity =
-        !readyPatternRequiresAgentIdentity(agent.cli) ||
-        screenHasReadyAgentIdentity(
-          agent.cli,
-          screen.text,
-          parseScreen(screen.text),
-        );
-      const ready = match.matched && hasReadyIdentity;
-      if (!ready) {
+      const evidence = this.readReadyEvidence(agent, screen.text);
+      if (
+        !evidence.ready ||
+        (targetState === "ready" &&
+          this.screenShowsPendingBootPrompt(agent, screen.text))
+      ) {
         waitForReadyPatternMatches.delete(agent.agent_id);
         return { agent };
       }
@@ -902,16 +894,23 @@ export class AgentEngine {
       const count =
         (waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
       waitForReadyPatternMatches.set(agent.agent_id, count);
-      if (count < Math.max(1, match.consecutive)) {
+      if (count < Math.max(1, evidence.consecutive)) {
         return { agent };
       }
 
-      const transitionAgent =
+      let transitionAgent =
         targetState === "ready"
           ? await this.maybeCaptureBootSessionId(agent, {
               screen: Promise.resolve(screen),
             })
           : agent;
+      if (targetState === "ready" && transitionAgent.boot_prompt_pending) {
+        transitionAgent = this.stateMgr.updateRecord(
+          transitionAgent.agent_id,
+          { boot_prompt_pending: false },
+        );
+        this.registry.set(transitionAgent.agent_id, transitionAgent);
+      }
       let updated = this.stateMgr.transition(
         transitionAgent.agent_id,
         targetState,
@@ -1116,10 +1115,130 @@ export class AgentEngine {
   }
 
   private isBootCaptureWindowOpen(agent: AgentRecord): boolean {
+    return agent.state === "booting";
+  }
+
+  private canUseTranscriptSessionResolver(agent: AgentRecord): boolean {
     if (agent.state !== "booting") return false;
     const since = Date.parse(agent.updated_at);
     if (Number.isNaN(since)) return false;
-    return Date.now() - since <= BOOT_SESSION_CAPTURE_WINDOW_MS;
+    return Date.now() - since <= BOOT_SESSION_TRANSCRIPT_CAPTURE_WINDOW_MS;
+  }
+
+  private screenShowsPendingBootPrompt(
+    agent: AgentRecord,
+    screenText: string,
+  ): boolean {
+    if (!agent.boot_prompt_pending) {
+      return false;
+    }
+    const prompt = agent.task_summary.trim();
+    if (!prompt) {
+      return !this.isBootPromptPendingStale(agent);
+    }
+    const promptLines = prompt
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const promptTailSource = promptLines.at(-1) ?? prompt;
+    const tail = promptTailSource.slice(
+      -Math.min(80, promptTailSource.length),
+    );
+    return this.screenInputRegionContainsPromptTail(
+      agent.cli,
+      screenText,
+      tail,
+    );
+  }
+
+  private screenInputRegionContainsPromptTail(
+    cli: CliType,
+    screenText: string,
+    tail: string,
+  ): boolean {
+    if (!tail) return false;
+
+    const lines = screenText
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (lines.length === 0) return false;
+
+    const start = this.currentScreenRegionStart(cli, lines);
+
+    const region = lines.slice(start);
+    const compactTail = tail.replace(/\s+/g, "");
+
+    return region.some((line, index) => {
+      if (!this.lineCanSeedInputPromptScan(cli, line)) return false;
+      const candidate = region.slice(index).join("\n");
+      return (
+        candidate.includes(tail) ||
+        (compactTail.length > 0 &&
+          candidate.replace(/\s+/g, "").includes(compactTail))
+      );
+    });
+  }
+
+  private currentScreenRegionStart(cli: CliType, lines: string[]): number {
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (this.lineIsCurrentScreenRegionAnchor(cli, lines[index] ?? "")) {
+        return index + 1;
+      }
+    }
+    return 0;
+  }
+
+  private lineIsCurrentScreenRegionAnchor(cli: CliType, line: string): boolean {
+    const trimmed = line.trim();
+    switch (cli) {
+      case "claude":
+        return /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
+          trimmed,
+        );
+      case "codex":
+        return (
+          /\bOpenAI\s+Codex\b/i.test(trimmed) ||
+          /\bModel:\s*gpt-/i.test(trimmed)
+        );
+      case "cursor":
+        return /^Cursor Agent$/i.test(trimmed) || /^cursor>\s*$/i.test(trimmed);
+      case "gemini":
+        return /^Gemini CLI$/i.test(trimmed) || /^gemini>\s*$/i.test(trimmed);
+      case "kiro":
+        return /^Kiro\b/i.test(trimmed) || /^kiro>\s*$/i.test(trimmed);
+    }
+  }
+
+  private lineCanSeedInputPromptScan(cli: CliType, line: string): boolean {
+    if (lineStartsWithCliInputPrompt(cli, line)) return true;
+    const trimmed = line.trim();
+    return (CLI_INPUT_PROMPT_PREFIXES[cli] ?? []).some(
+      (prefix) => trimmed === prefix,
+    );
+  }
+
+  private isBootPromptPendingStale(agent: AgentRecord): boolean {
+    const since = Date.parse(agent.updated_at);
+    if (Number.isNaN(since)) return false;
+    return Date.now() - since >= BOOT_PROMPT_PENDING_STALE_MS;
+  }
+
+  private readReadyEvidence(
+    agent: AgentRecord,
+    screenText: string,
+  ): {
+    ready: boolean;
+    consecutive: number;
+  } {
+    const parsed = parseScreen(screenText);
+    const match = matchReadyPattern(agent.cli, screenText);
+    return {
+      ready:
+        match.matched &&
+        screenHasReadyAgentIdentity(agent.cli, screenText, parsed),
+      consecutive: match.consecutive,
+    };
   }
 
   private harnessCwdForAgent(agent: AgentRecord): string {
@@ -1254,13 +1373,15 @@ export class AgentEngine {
       return agent;
     }
 
-    try {
-      const transcriptSessionId = this.sessionIdentityResolver(agent);
-      if (transcriptSessionId) {
-        return this.finalizeCapturedSession(agent, transcriptSessionId);
+    if (this.canUseTranscriptSessionResolver(agent)) {
+      try {
+        const transcriptSessionId = this.sessionIdentityResolver(agent);
+        if (transcriptSessionId) {
+          return this.finalizeCapturedSession(agent, transcriptSessionId);
+        }
+      } catch {
+        return agent;
       }
-    } catch {
-      return agent;
     }
 
     try {
@@ -1296,27 +1417,16 @@ export class AgentEngine {
       return agent;
     }
     if (agent.boot_prompt_pending) {
-      const since = Date.parse(agent.updated_at);
-      if (
-        Number.isNaN(since) ||
-        Date.now() - since < BOOT_PROMPT_PENDING_STALE_MS
-      ) {
-        this.readyPatternMatches.delete(agent.agent_id);
-        return agent;
-      }
-
       try {
         const screen = await this.readSweepScreen(agent, ctx);
-        const parsed = parseScreen(screen.text);
-        const match = matchReadyPattern(agent.cli, screen.text);
+        const evidence = this.readReadyEvidence(agent, screen.text);
         if (
-          match.matched &&
-          (!readyPatternRequiresAgentIdentity(agent.cli) ||
-            screenHasReadyAgentIdentity(agent.cli, screen.text, parsed))
+          evidence.ready &&
+          !this.screenShowsPendingBootPrompt(agent, screen.text)
         ) {
           const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
           this.readyPatternMatches.set(agent.agent_id, count);
-          if (count < Math.max(1, match.consecutive)) {
+          if (count < Math.max(1, evidence.consecutive)) {
             return agent;
           }
 
@@ -1343,6 +1453,14 @@ export class AgentEngine {
         // Fall through to the explicit interrupted-delivery error below.
       }
 
+      const since = Date.parse(agent.updated_at);
+      if (
+        !Number.isNaN(since) &&
+        Date.now() - since < BOOT_PROMPT_PENDING_STALE_MS
+      ) {
+        return agent;
+      }
+
       try {
         this.stateMgr.updateRecord(agent.agent_id, {
           boot_prompt_pending: false,
@@ -1359,15 +1477,15 @@ export class AgentEngine {
 
     try {
       const screen = await this.readSweepScreen(agent, ctx);
-      const match = matchReadyPattern(agent.cli, screen.text);
-      if (!match.matched) {
+      const evidence = this.readReadyEvidence(agent, screen.text);
+      if (!evidence.ready) {
         this.readyPatternMatches.delete(agent.agent_id);
         return agent;
       }
 
       const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
       this.readyPatternMatches.set(agent.agent_id, count);
-      if (count < Math.max(1, match.consecutive)) {
+      if (count < Math.max(1, evidence.consecutive)) {
         return agent;
       }
 

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -10,6 +10,7 @@ export type AgentHealthIssueCode =
   | "inbox_channel_dir_deleted"
   | "inbox_monitor_not_alive"
   | "stale_inbox_dispatches"
+  | "agent_wedged"
   | "registry_screen_disagreement"
   | "registry_surface_workspace_mismatch"
   | "closure_without_artifact"
@@ -171,13 +172,22 @@ export function evaluateAgentHealth(
     );
   }
 
-  if ((input.stale_count ?? 0) > 0) {
+  const staleCount = input.stale_count ?? 0;
+  if (staleCount > 0) {
     addIssue(
       issueCodes,
       issues,
       "stale_inbox_dispatches",
       "agent has unacked inbox dispatches past the ACK timeout",
     );
+    if (input.monitor_alive === true) {
+      addIssue(
+        issueCodes,
+        issues,
+        "agent_wedged",
+        "agent monitor is alive but dispatches remain unacked past the ACK timeout; treat as wedged rather than dead",
+      );
+    }
   }
 
   const screenActive =

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -20,6 +20,14 @@ export interface PatternMatch {
   consecutive: number;
 }
 
+export const CLI_INPUT_PROMPT_PREFIXES: Record<CliType, readonly string[]> = {
+  claude: ["❯"],
+  codex: ["codex>", "›", "❯"],
+  cursor: ["cursor>", "→"],
+  gemini: ["gemini>"],
+  kiro: ["kiro>"],
+};
+
 const CLAUDE_READY_RE =
   /What can I help you with\?|╭─|(?=[\s\S]*(?:Claude Code|CLAUDE_COUNTER|bypass permissions on|🤖))(?=[\s\S]*(?:^|\n)\s*(?:>|❯)\s*$)/m;
 const CLAUDE_ACTIVE_RE =
@@ -48,6 +56,11 @@ const CODEX_READY_RE = new RegExp(
   "im",
 );
 const CODEX_ACTIVE_RE = /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b|Working\s*\(/i;
+const GEMINI_ACTIVE_RE =
+  /(?:^|\n)\s*(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?\s*$/im;
+const GEMINI_ACTIVE_LINE_RE =
+  /^(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?$/i;
+const GEMINI_READY_PROMPT_LINE_RE = /^>\s*$/;
 
 export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {
   claude: {
@@ -90,10 +103,39 @@ export function matchReadyPattern(
       entry.pattern.test(screenContent) &&
       (cli !== "claude" || !CLAUDE_ACTIVE_RE.test(screenContent)) &&
       (cli !== "codex" || !CODEX_ACTIVE_RE.test(screenContent)) &&
+      (cli !== "gemini" ||
+        !hasGeminiActiveMarkerAfterLastPrompt(screenContent)) &&
       (cli !== "cursor" || !CURSOR_ACTIVE_RE.test(screenContent)),
     confidence: entry.confidence,
     consecutive: entry.consecutive,
   };
+}
+
+function hasGeminiActiveMarkerAfterLastPrompt(screenContent: string): boolean {
+  const lines = screenContent.split(/\r?\n/).map((line) => line.trim());
+  let lastPromptIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (GEMINI_READY_PROMPT_LINE_RE.test(lines[index] ?? "")) {
+      lastPromptIndex = index;
+      break;
+    }
+  }
+  if (lastPromptIndex === -1) return GEMINI_ACTIVE_RE.test(screenContent);
+  return lines
+    .slice(lastPromptIndex + 1)
+    .some((line) => GEMINI_ACTIVE_LINE_RE.test(line));
+}
+
+export function lineStartsWithCliInputPrompt(
+  cli: CliType,
+  line: string,
+): boolean {
+  const trimmed = line.trimStart();
+  const prefixes = CLI_INPUT_PROMPT_PREFIXES[cli] ?? [];
+  return prefixes.some((prefix) => {
+    if (!trimmed.startsWith(prefix)) return false;
+    return trimmed.slice(prefix.length).trim().length > 0;
+  });
 }
 
 export function screenHasActiveAgentMarker(
@@ -119,9 +161,7 @@ export function screenHasActiveAgentMarker(
     case "cursor":
       return CURSOR_ACTIVE_RE.test(screenText);
     case "gemini":
-      return /(?:^|\n)\s*(?:✦\s*)?Working(?:\.\.\.|…)?\s*$/im.test(
-        screenText,
-      );
+      return GEMINI_ACTIVE_RE.test(screenText);
     case "kiro":
       return false;
   }
@@ -152,10 +192,11 @@ export function screenHasReadyAgentIdentity(
     case "kiro":
       return /(?:^|\n)\s*kiro>\s*$/im.test(screenText);
     case "gemini":
-      return false;
+      return /(?:^|\n)\s*(?:Gemini CLI|gemini>)\s*$/im.test(screenText);
   }
 }
 
 export function readyPatternRequiresAgentIdentity(cli: CliType): boolean {
-  return cli !== "gemini" && cli !== "kiro";
+  void cli;
+  return true;
 }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -612,6 +612,7 @@ function inferControlState(
   status: ParsedScreenStatus,
   errors: string[],
   agentType: ParsedScreenAgentType,
+  text: string,
 ): ParsedScreenResult["control_state"] {
   if (errors.includes("permission_prompt")) {
     return "permission_prompt";
@@ -625,7 +626,20 @@ function inferControlState(
   if (status === "idle" && agentType !== "unknown") {
     return "ready";
   }
+  if (status === "idle" && agentType === "unknown" && hasShellPrompt(text)) {
+    return "shell";
+  }
   return "unknown";
+}
+
+function hasShellPrompt(text: string): boolean {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const last = lines.at(-1);
+  if (!last) return false;
+  return /^(?:>|❯|>>>|[$%#])$/.test(last) || /[$#]$/.test(last);
 }
 
 function parseModelAndCost(
@@ -948,7 +962,7 @@ export function parseScreen(text: string): ParsedScreenResult {
   const result: ParsedScreenResult = {
     agent_type: agentType,
     status,
-    control_state: inferControlState(status, errors, agentType),
+    control_state: inferControlState(status, errors, agentType, normalized),
     token_count: tokenCount,
     context_pct: contextPct,
     context_window: contextWindow,

--- a/src/server.ts
+++ b/src/server.ts
@@ -879,6 +879,7 @@ function screenShowsPendingInput(
 }
 
 type MonitorBootResult = {
+  status: "bootstrapped" | "monitor-not-ready";
   heartbeat_written: boolean;
   heartbeat_source: "server_boot";
   monitor_command: string;
@@ -1283,12 +1284,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ensureInboxFile(agentId, inboxOpts);
       writeHeartbeat(agentId, inboxOpts, "server_boot");
       return {
+        status: "bootstrapped",
         heartbeat_written: true,
         heartbeat_source: "server_boot",
         monitor_command: monitorCommand,
       };
     } catch (e) {
       return {
+        status: "monitor-not-ready",
         heartbeat_written: false,
         heartbeat_source: "server_boot",
         monitor_command: monitorCommand,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2209,6 +2209,145 @@ To continue this session, run codex resume ${sessionId}`,
       );
     });
 
+    it("captures session identity after the initial boot window for a long-stuck ready pane", async () => {
+      vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
+      const sessionId = "019f0010-1111-7222-8333-444455556666";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-late",
+          repo: "cmuxlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          surface_id: "surface:late-session",
+          state: "booting",
+          task_summary: "Fix late session capture",
+          created_at: "2026-06-25T08:00:00.000Z",
+          updated_at: "2026-06-25T08:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:late-session")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:late-session",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.4",
+          `To continue this session, run codex resume ${sessionId}`,
+          "",
+          "›",
+        ].join("\n"),
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("cmuxlayerCodex-019f0010")).toMatchObject({
+        agent_id: "cmuxlayerCodex-019f0010",
+        state: "ready",
+        cli_session_id: sessionId,
+        cli_session_path: null,
+      });
+      expect(engine.resolveAgentRoute("cmuxlayerCodex-019f0010")).toMatchObject({
+        session_id: sessionId,
+        resumable: true,
+      });
+    });
+
+    it("does not bind a late blank-prompt boot record to an unattributed transcript", async () => {
+      vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
+      const sessionId = "019f0020-1111-7222-8333-444455556666";
+      const transcriptResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: "/Users/etanheyman/.codex/sessions/unrelated.jsonl",
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: transcriptResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-blank",
+          repo: "cmuxlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          surface_id: "surface:blank-session",
+          state: "booting",
+          task_summary: "",
+          created_at: "2026-06-25T08:00:00.000Z",
+          updated_at: "2026-06-25T08:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:blank-session")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:blank-session",
+        text: ["OpenAI Codex", "Model: gpt-5.4", "", "›"].join("\n"),
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(transcriptResolver).not.toHaveBeenCalled();
+      expect(engine.getAgentState("cmuxlayerCodex-pending-blank")).toMatchObject({
+        agent_id: "cmuxlayerCodex-pending-blank",
+        state: "ready",
+        cli_session_id: null,
+      });
+      expect(engine.getAgentState("cmuxlayerCodex-019f0020")).toBeNull();
+    });
+
+    it("does not bind a late prompted boot record to an unrelated transcript", async () => {
+      vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
+      const sessionId = "019f0021-1111-7222-8333-444455556666";
+      const transcriptResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: "/Users/etanheyman/.codex/sessions/unrelated-prompted.jsonl",
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: transcriptResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-prompted",
+          repo: "cmuxlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          surface_id: "surface:prompted-session",
+          state: "booting",
+          task_summary: "Fix launcher resumability",
+          created_at: "2026-06-25T08:00:00.000Z",
+          updated_at: "2026-06-25T08:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:prompted-session")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:prompted-session",
+        text: ["OpenAI Codex", "Model: gpt-5.4", "", "›"].join("\n"),
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(transcriptResolver).not.toHaveBeenCalled();
+      expect(
+        engine.getAgentState("cmuxlayerCodex-pending-prompted"),
+      ).toMatchObject({
+        agent_id: "cmuxlayerCodex-pending-prompted",
+        state: "ready",
+        cli_session_id: null,
+      });
+      expect(engine.getAgentState("cmuxlayerCodex-019f0021")).toBeNull();
+    });
+
     it("uses the saved launch cwd when capturing worktree transcript sessions", async () => {
       vi.setSystemTime(new Date("2026-06-19T05:00:30.000Z"));
       const home = join(TEST_DIR, "home");
@@ -2854,7 +2993,52 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
-    it("resolves Gemini ready from consecutive screen-truth prompts", async () => {
+    it("resolves a prompt-pending booting agent once a real ready screen no longer shows the prompt", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "codex-pending-ready",
+            state: "booting",
+            surface_id: "surface:codex-pending-ready",
+            workspace_id: "ws:codex-pending-ready",
+            cli: "codex",
+            role: "worker",
+            boot_prompt_pending: true,
+            task_summary: "Read and follow the phase 3 plan",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:codex-pending-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:codex-pending-ready",
+          text: [
+            "OpenAI Codex",
+            "Model: gpt-5.5",
+            "",
+            "›",
+          ].join("\n"),
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("codex-pending-ready", "ready", 1_500);
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.state).toBe("ready");
+        expect(engine.getAgentState("codex-pending-ready")).toMatchObject({
+          state: "ready",
+          boot_prompt_pending: false,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve Gemini ready from bare prompt screen truth without identity", async () => {
       vi.useFakeTimers();
       try {
         stateMgr.writeState(
@@ -2875,15 +3059,131 @@ To continue this session, run codex resume ${sessionId}`,
         });
         await engine.getRegistry().reconstitute();
 
-        const pending = engine.waitFor("gemini-screen-ready", "ready", 2_500);
+        const pending = engine.waitFor("gemini-screen-ready", "ready", 1_000);
+        await vi.advanceTimersByTimeAsync(1_500);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("booting");
+        expect(engine.getAgentState("gemini-screen-ready")?.state).toBe(
+          "booting",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resolves Gemini ready from consecutive identity-backed screen-truth prompts", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "gemini-identity-screen-ready",
+            state: "booting",
+            surface_id: "surface:gemini-identity-screen-ready",
+            cli: "gemini",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:gemini-identity-screen-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-identity-screen-ready",
+          text: "Gemini CLI\nready\n> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "gemini-identity-screen-ready",
+          "ready",
+          2_500,
+        );
         await vi.advanceTimersByTimeAsync(3_000);
         const result = await pending;
 
         expect(result.matched).toBe(true);
         expect(result.source).toBe("screen");
         expect(result.state).toBe("ready");
-        expect(engine.getAgentState("gemini-screen-ready")?.state).toBe(
+        expect(
+          engine.getAgentState("gemini-identity-screen-ready")?.state,
+        ).toBe("ready");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve Gemini ready from identity-backed active screen truth", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "gemini-thinking-screen-ready",
+            state: "booting",
+            surface_id: "surface:gemini-thinking-screen-ready",
+            cli: "gemini",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:gemini-thinking-screen-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:gemini-thinking-screen-ready",
+          text: "Gemini CLI\n> \nThinking...",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "gemini-thinking-screen-ready",
           "ready",
+          1_000,
+        );
+        await vi.advanceTimersByTimeAsync(1_500);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("booting");
+        expect(
+          engine.getAgentState("gemini-thinking-screen-ready")?.state,
+        ).toBe("booting");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resolve Kiro ready from a bare prompt without Kiro identity", async () => {
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "kiro-bare-screen-ready",
+            state: "booting",
+            surface_id: "surface:kiro-bare-screen-ready",
+            cli: "kiro",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:kiro-bare-screen-ready")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:kiro-bare-screen-ready",
+          text: "ready\n> ",
+          lines: 80,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor("kiro-bare-screen-ready", "ready", 1_000);
+        await vi.advanceTimersByTimeAsync(1_500);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("booting");
+        expect(engine.getAgentState("kiro-bare-screen-ready")?.state).toBe(
+          "booting",
         );
       } finally {
         vi.useRealTimers();
@@ -3023,7 +3323,7 @@ To continue this session, run codex resume ${sessionId}`,
         liveSurfaces = [makeSurface("surface:gemini-sweep-progress")];
         (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
           surface: "surface:gemini-sweep-progress",
-          text: "ready\n> ",
+          text: "Gemini CLI\nready\n> ",
           lines: 80,
           scrollback_used: false,
         });
@@ -3051,7 +3351,7 @@ To continue this session, run codex resume ${sessionId}`,
 
         (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
           surface: "surface:gemini-sweep-progress",
-          text: "ready\n> ",
+          text: "Gemini CLI\nready\n> ",
           lines: 80,
           scrollback_used: false,
         });
@@ -3993,13 +4293,19 @@ To continue this session, run codex resume ${sessionId}`,
           surface_id: "surface:42",
           cli: "codex",
           boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
           updated_at: new Date().toISOString(),
         }),
       );
       liveSurfaces = [makeSurface("surface:42")];
       (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
         surface: "surface:42",
-        text: "codex> ",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "codex> Read and follow docs.local/phase-3.md",
+        ].join("\n"),
         lines: 20,
         scrollback_used: false,
       });
@@ -4008,6 +4314,421 @@ To continue this session, run codex resume ${sessionId}`,
       await engine.runSweep();
 
       expect(engine.getAgentState("agent-boot")?.state).toBe("booting");
+    });
+
+    it("does not clear prompt-pending when the Codex composer line is above the footer", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-composer-footer",
+          state: "booting",
+          surface_id: "surface:composer-footer",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:composer-footer")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:composer-footer",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "› Read and follow docs.local/phase-3.md",
+          "gpt-5.5 xhigh · ~/Gits/cmuxlayer",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-composer-footer")).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+      });
+    });
+
+    it("does not clear prompt-pending when the visible prompt tail wraps onto continuation lines", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-wrapped-composer",
+          state: "booting",
+          surface_id: "surface:wrapped-composer",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:wrapped-composer")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:wrapped-composer",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "› Read and follow docs.local/",
+          "phase-3.md",
+          "gpt-5.5 xhigh · ~/Gits/cmuxlayer",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-wrapped-composer")).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+      });
+    });
+
+    it("does not clear prompt-pending when a narrow pane wraps the prompt outside the tail window", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-narrow-wrapped-composer",
+          state: "booting",
+          surface_id: "surface:narrow-wrapped-composer",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:narrow-wrapped-composer")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:narrow-wrapped-composer",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "› Read",
+          "and follow",
+          "docs.local/",
+          "phase-3.md",
+          "gpt-5.5 xhigh",
+          "~/Gits/cmuxlayer",
+          "99% context left",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(
+        engine.getAgentState("agent-boot-narrow-wrapped-composer"),
+      ).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+      });
+    });
+
+    it("does not clear prompt-pending when the composer marker wraps before the prompt text", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-marker-only-wrapped-composer",
+          state: "booting",
+          surface_id: "surface:marker-only-wrapped-composer",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:marker-only-wrapped-composer")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:marker-only-wrapped-composer",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "›",
+          "Read and follow",
+          "docs.local/phase-3.md",
+          "gpt-5.5 xhigh",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(
+        engine.getAgentState("agent-boot-marker-only-wrapped-composer"),
+      ).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+      });
+    });
+
+    it.each([
+      ["cursor", "Cursor Agent\ncursor> Read and follow docs.local/phase-3.md"],
+      [
+        "cursor",
+        "Cursor Agent\nAuto\n→ Read and follow docs.local/phase-3.md",
+      ],
+      [
+        "gemini",
+        "Gemini CLI\ngemini> Read and follow docs.local/phase-3.md\n> ",
+      ],
+      ["kiro", "Kiro\nkiro> Read and follow docs.local/phase-3.md"],
+    ] as const)(
+      "does not clear prompt-pending for %s composer prefixes",
+      async (cli, screenText) => {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `agent-boot-${cli}-composer`,
+            state: "booting",
+            surface_id: `surface:${cli}-composer`,
+            cli,
+            boot_prompt_pending: true,
+            task_summary: "Read and follow docs.local/phase-3.md",
+            updated_at: new Date().toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface(`surface:${cli}-composer`)];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: `surface:${cli}-composer`,
+          text: screenText,
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+        await engine.runSweep();
+
+        expect(engine.getAgentState(`agent-boot-${cli}-composer`)).toMatchObject(
+          {
+            state: "booting",
+            boot_prompt_pending: true,
+          },
+        );
+      },
+    );
+
+    it.each([
+      [
+        "claude",
+        [
+          "❯ Read and follow docs.local/phase-3.md",
+          "Prompt accepted.",
+          "Claude Code",
+          "What can I help you with?",
+          "❯",
+        ].join("\n"),
+      ],
+      [
+        "cursor",
+        [
+          "cursor> Read and follow docs.local/phase-3.md",
+          "Prompt accepted.",
+          "Cursor Agent",
+          "→ Plan, search, build anything",
+          "Auto",
+        ].join("\n"),
+      ],
+      [
+        "gemini",
+        [
+          "gemini> Read and follow docs.local/phase-3.md",
+          "Prompt accepted.",
+          "Gemini CLI",
+          ">",
+        ].join("\n"),
+      ],
+      [
+        "kiro",
+        [
+          "kiro> Read and follow docs.local/phase-3.md",
+          "Prompt accepted.",
+          "kiro>",
+        ].join("\n"),
+      ],
+    ] as const)(
+      "treats stale %s prompt text before the latest identity marker as cleared",
+      async (cli, screenText) => {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `agent-boot-${cli}-scrollback-ready`,
+            state: "booting",
+            surface_id: `surface:${cli}-scrollback-ready`,
+            cli,
+            boot_prompt_pending: true,
+            task_summary: "Read and follow docs.local/phase-3.md",
+            updated_at: new Date().toISOString(),
+          }),
+        );
+        liveSurfaces = [makeSurface(`surface:${cli}-scrollback-ready`)];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: `surface:${cli}-scrollback-ready`,
+          text: screenText,
+          lines: 20,
+          scrollback_used: false,
+        });
+        await engine.getRegistry().reconstitute();
+
+        await engine.runSweep();
+        await engine.runSweep();
+
+        expect(
+          engine.getAgentState(`agent-boot-${cli}-scrollback-ready`),
+        ).toMatchObject({
+          state: "ready",
+          boot_prompt_pending: false,
+        });
+      },
+    );
+
+    it("promotes prompt-pending booting agents once a real ready prompt shows the prompt is gone", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-prompt-cleared",
+          state: "booting",
+          surface_id: "surface:cleared",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:cleared")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:cleared",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-prompt-cleared")).toMatchObject({
+        state: "ready",
+        boot_prompt_pending: false,
+      });
+    });
+
+    it("does not clear fresh prompt-pending agents when stored prompt text is unknown", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-empty-summary-fresh",
+          state: "booting",
+          surface_id: "surface:empty-summary-fresh",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:empty-summary-fresh")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:empty-summary-fresh",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-empty-summary-fresh")).toMatchObject(
+        {
+          state: "booting",
+          boot_prompt_pending: true,
+        },
+      );
+    });
+
+    it("recovers stale prompt-pending booting agents with no stored prompt text once ready evidence is visible", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-empty-summary-ready",
+          state: "booting",
+          surface_id: "surface:empty-summary-ready",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "",
+          updated_at: new Date(Date.now() - 6 * 60_000).toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:empty-summary-ready")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:empty-summary-ready",
+        text: [
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-empty-summary-ready")).toMatchObject(
+        {
+          state: "ready",
+          boot_prompt_pending: false,
+        },
+      );
+    });
+
+    it("does not treat old scrollback prompt text as pending once the current prompt is ready", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-boot-prompt-scrollback",
+          state: "booting",
+          surface_id: "surface:scrollback",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/phase-3.md",
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:scrollback")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:scrollback",
+        text: [
+          "OpenAI Codex",
+          "codex> Read and follow docs.local/phase-3.md",
+          "Task accepted.",
+          "",
+          "OpenAI Codex",
+          "Model: gpt-5.5",
+          "",
+          "›",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(engine.getAgentState("agent-boot-prompt-scrollback")).toMatchObject(
+        {
+          state: "ready",
+          boot_prompt_pending: false,
+        },
+      );
     });
 
     it("marks stale pending boot prompt agents as errored", async () => {
@@ -4112,7 +4833,7 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
-    it("recovers stale pending Gemini boot prompt without requiring identity parsing", async () => {
+    it("recovers stale pending Gemini boot prompt with identity-backed readiness", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-gemini-boot-ready",
@@ -4126,7 +4847,7 @@ To continue this session, run codex resume ${sessionId}`,
       liveSurfaces = [makeSurface("surface:gemini")];
       (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
         surface: "surface:gemini",
-        text: "> ",
+        text: "Gemini CLI\n> ",
         lines: 20,
         scrollback_used: false,
       });
@@ -4146,7 +4867,7 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
-    it("promotes low-confidence CLI prompts after consecutive matches", async () => {
+    it("does not promote low-confidence bare prompts without agent identity", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-gemini",
@@ -4169,7 +4890,37 @@ To continue this session, run codex resume ${sessionId}`,
       expect(engine.getAgentState("agent-gemini")?.state).toBe("booting");
 
       await engine.runSweep();
-      expect(engine.getAgentState("agent-gemini")?.state).toBe("ready");
+      expect(engine.getAgentState("agent-gemini")?.state).toBe("booting");
+    });
+
+    it("promotes low-confidence CLI prompts after consecutive identity-backed matches", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-gemini-identity",
+          state: "booting",
+          surface_id: "surface:gemini-identity",
+          cli: "gemini",
+          task_summary: "",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:gemini-identity")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:gemini-identity",
+        text: "Gemini CLI\nready\n> ",
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+      expect(engine.getAgentState("agent-gemini-identity")?.state).toBe(
+        "booting",
+      );
+
+      await engine.runSweep();
+      expect(engine.getAgentState("agent-gemini-identity")?.state).toBe(
+        "ready",
+      );
     });
 
     it("throws for non-existent agent", async () => {

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -167,6 +167,43 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("registry_screen_disagreement");
   });
 
+  it("marks stale dispatches on a live monitor as wedged, not dead", () => {
+    const health = evaluateAgentHealth(makeRecord({ state: "working" }), {
+      monitor_alive: true,
+      stale_count: 2,
+      screen_status: "working",
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("stale_inbox_dispatches");
+    expect(health.issue_codes).toContain("agent_wedged");
+    expect(health.issue_codes).not.toContain("inbox_monitor_not_alive");
+  });
+
+  it("does not mark stale dispatches as wedged when monitor liveness is unknown", () => {
+    const health = evaluateAgentHealth(makeRecord({ state: "working" }), {
+      stale_count: 2,
+      screen_status: "working",
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("stale_inbox_dispatches");
+    expect(health.issue_codes).not.toContain("agent_wedged");
+    expect(health.issue_codes).not.toContain("inbox_monitor_not_alive");
+  });
+
+  it("marks an absent monitor as dead evidence, not a wedged live pane", () => {
+    const health = evaluateAgentHealth(makeRecord({ state: "working" }), {
+      monitor_alive: false,
+      stale_count: 0,
+      screen_status: "working",
+    });
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("inbox_monitor_not_alive");
+    expect(health.issue_codes).not.toContain("agent_wedged");
+  });
+
   it("marks registry workspace mismatch against the live surface as unhealthy", () => {
     const health = evaluateAgentHealth(makeRecord({ workspace_id: "workspace:5" }), {
       monitor_alive: true,

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -196,7 +196,8 @@ describe("Phase 0 painpoint replay corpus", () => {
 
     const testFn =
       fixture.id === "claude-ask-user-question-overlay" ||
-      fixture.id === "claude-permission-confirmation"
+      fixture.id === "claude-permission-confirmation" ||
+      fixture.id === "bare-shell-and-bare-gemini-prompt"
         ? it
         : it.todo;
     testFn(

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import {
+  CLI_INPUT_PROMPT_PREFIXES,
   CLI_READY_PATTERNS,
+  lineStartsWithCliInputPrompt,
   matchReadyPattern,
   screenHasActiveAgentMarker,
   type PatternMatch,
@@ -50,6 +52,41 @@ describe("CLI_READY_PATTERNS", () => {
         ).toBeGreaterThanOrEqual(2);
       }
     }
+  });
+});
+
+describe("CLI_INPUT_PROMPT_PREFIXES", () => {
+  it("recognizes typed composer lines for each supported CLI", () => {
+    expect(lineStartsWithCliInputPrompt("claude", "❯ Do the task")).toBe(true);
+    expect(lineStartsWithCliInputPrompt("codex", "› Do the task")).toBe(true);
+    expect(lineStartsWithCliInputPrompt("cursor", "cursor> Do the task")).toBe(
+      true,
+    );
+    expect(lineStartsWithCliInputPrompt("cursor", "→ Do the task")).toBe(true);
+    expect(lineStartsWithCliInputPrompt("gemini", "gemini> Do the task")).toBe(
+      true,
+    );
+    expect(lineStartsWithCliInputPrompt("kiro", "kiro> Do the task")).toBe(
+      true,
+    );
+  });
+
+  it("keeps every supported CLI in the input prompt prefix map", () => {
+    expect(Object.keys(CLI_INPUT_PROMPT_PREFIXES).sort()).toEqual(
+      Object.keys(CLI_READY_PATTERNS).sort(),
+    );
+  });
+
+  it("does not treat an empty ready prompt as typed composer text", () => {
+    expect(lineStartsWithCliInputPrompt("gemini", "> ")).toBe(false);
+    expect(lineStartsWithCliInputPrompt("codex", "›")).toBe(false);
+  });
+
+  it("does not treat Markdown blockquotes as typed composer text", () => {
+    expect(lineStartsWithCliInputPrompt("claude", "> Do the task")).toBe(false);
+    expect(lineStartsWithCliInputPrompt("codex", "> Do the task")).toBe(false);
+    expect(lineStartsWithCliInputPrompt("gemini", "> Do the task")).toBe(false);
+    expect(lineStartsWithCliInputPrompt("kiro", "> Do the task")).toBe(false);
   });
 });
 
@@ -103,6 +140,24 @@ describe("matchReadyPattern", () => {
         "CLAUDE_COUNTER:1",
       ].join("\n"),
     );
+    expect(result.matched).toBe(false);
+  });
+
+  it("matches Gemini ready when stale active text is above the current prompt", () => {
+    const result = matchReadyPattern(
+      "gemini",
+      ["Gemini CLI", "Thinking...", "Previous response", ">"].join("\n"),
+    );
+
+    expect(result.matched).toBe(true);
+  });
+
+  it("does not match Gemini ready when active text follows the prompt", () => {
+    const result = matchReadyPattern(
+      "gemini",
+      ["Gemini CLI", ">", "Thinking..."].join("\n"),
+    );
+
     expect(result.matched).toBe(false);
   });
 

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -827,6 +827,38 @@ etanheyman ~ [master] $
 
     expect(parsed.agent_type).toBe("unknown");
     expect(parsed.status).toBe("idle");
+    expect(parsed.control_state).toBe("shell");
+    expect(parsed.errors).toEqual([]);
+  });
+
+  it("detects shell prompts without whitespace before the prompt marker", () => {
+    const parsed = parseScreen("etanheyman@mac ~/repo5$");
+
+    expect(parsed.agent_type).toBe("unknown");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.control_state).toBe("shell");
+    expect(parsed.errors).toEqual([]);
+  });
+
+  it("does not classify stale shell prompts above current output as shell", () => {
+    const parsed = parseScreen(`
+etanheyman@mac ~/repo5$
+running local setup output
+still printing logs
+`);
+
+    expect(parsed.agent_type).toBe("unknown");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.control_state).toBe("unknown");
+    expect(parsed.errors).toEqual([]);
+  });
+
+  it("does not classify percentage status lines as shell prompts", () => {
+    const parsed = parseScreen("Auto · 16.1%");
+
+    expect(parsed.agent_type).toBe("unknown");
+    expect(parsed.status).toBe("idle");
+    expect(parsed.control_state).toBe("unknown");
     expect(parsed.errors).toEqual([]);
   });
 

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -143,6 +143,7 @@ describe("spawn monitor boot", () => {
     const parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.monitor_boot).toEqual({
+      status: "bootstrapped",
       heartbeat_written: true,
       heartbeat_source: "server_boot",
       monitor_command: expect.stringContaining(parsed.agent_id),
@@ -206,6 +207,7 @@ describe("spawn monitor boot", () => {
       const parsed = parseToolResult(result);
       expect(parsed.ok).toBe(true);
       expect(parsed.monitor_boot).toEqual({
+        status: "monitor-not-ready",
         heartbeat_written: false,
         heartbeat_source: "server_boot",
         monitor_command: expect.stringContaining(parsed.agent_id),
@@ -246,6 +248,7 @@ describe("spawn monitor boot", () => {
     const parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.monitor_alive).toBe(false);
+    expect(parsed.health.issue_codes).toContain("inbox_monitor_not_alive");
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(true);
     expect(sendCalls(exec)).toHaveLength(beforeDispatchSendCount + 1);

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -180,6 +180,7 @@ describe("workspace spawn tools", () => {
         repo: "brainlayer",
         cli: "claude",
         monitor_boot: {
+          status: "bootstrapped",
           heartbeat_written: true,
           heartbeat_source: "server_boot",
           monitor_command: expect.any(String),


### PR DESCRIPTION
## Summary
- Harden spawn readiness so booting agents only transition ready from CLI identity-backed screen evidence.
- Keep boot-prompt-pending agents booting while the prompt text is still visible, then clear the pending bit once the prompt disappears and real readiness is visible.
- Preserve late `cli_session_id` capture during boot, add wedged-vs-dead health classification, and expose monitor boot status.

## Test plan
- `bun run typecheck` -> exit 0 (`tsc -p tsconfig.json --noEmit`).
- `bun run test` -> exit 0, 67 files passed, 1163 passed, 5 todo.
- Push hook reran tests and ended `run_tests.sh finished with exit status 0`.
- Local CodeRabbit CLI gate attempted with `/opt/homebrew/bin/timeout 180s coderabbit review --agent`; skipped due free OSS rate limit (`waitTime: 11 minutes`). Fallback red/blue prompt review checked the actual diff, spawn prompt state flow, bare prompt fixture, and Gemini identity path; no evidence-backed findings.

## Reviewer focus
- CodeRabbit/Bugbot/Macroscope should focus on false-ready regressions, prompt-pending state transitions, session capture behavior, and wedged health semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core boot→ready state machine, session binding, and CLI heuristics; misclassification can delay spawns, bind wrong sessions, or mislabel wedged agents.
> 
> **Overview**
> **Spawn readiness** now gates `ready` on identity-backed screen evidence plus, when `boot_prompt_pending` is set, confirmation that the boot prompt is no longer visible in the current input region (CLI-specific anchors, composer prefixes, wrapped tails)—instead of blocking all booting agents or promoting on bare prompts.
> 
> **Pattern and parser updates:** all CLIs require identity for ready; Gemini ignores stale `Working`/`Thinking` above the current `>` prompt; shared `CLI_INPUT_PROMPT_PREFIXES` / `readReadyEvidence`; idle unknown panes with a shell prompt get `control_state: shell`.
> 
> **Session capture:** transcript resolver runs only inside a 30s boot window while still booting; after that, screen UUID extraction continues; resolver errors no longer skip screen fallback.
> 
> **Ops:** new `agent_wedged` when stale inbox dispatches meet a live monitor; monitor boot responses include `status: bootstrapped` | `monitor-not-ready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524cd58ebaa7de58b919978f423c0eeb2e769766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden spawn readiness monitor boot to prevent premature or missed ready-state transitions
> - Readiness promotion in `AgentEngine.waitFor` now requires both a ready-pattern match and a confirmed agent identity on screen; promotion is deferred while a boot prompt is still visible, and `boot_prompt_pending` is cleared on success.
> - Adds `screenShowsPendingBootPrompt` and `screenInputRegionContainsPromptTail` to detect whether the boot prompt is still present by scanning the current input region, tolerating wrapped and whitespace-varied lines.
> - Adds `canUseTranscriptSessionResolver` to gate transcript-based session ID resolution to a bounded early-boot window; late-stuck cases fall back to on-screen extraction.
> - Stale `boot_prompt_pending` agents that are not yet ready transition to an error state with a message indicating the boot prompt was not delivered.
> - Extends Gemini readiness detection so active markers appearing after the last prompt negate readiness, and adds Gemini support to `screenHasReadyAgentIdentity`.
> - Adds `agent_wedged` health issue code to distinguish a live-but-stuck monitor from a dead monitor when stale inbox dispatches are present.
> - Adds shell `control_state` detection in `inferControlState` for idle unknown panes that show a shell prompt on the last line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 524cd58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved boot and readiness detection for agent sessions, including better handling of shell prompts and pending prompt states.
  * Added clearer monitor boot status values so startup outcomes are easier to distinguish.

* **Bug Fixes**
  * Reduced false “ready” states when an agent is still active, thinking, or waiting on a prompt.
  * Improved health reporting to identify when an agent appears wedged versus simply stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->