### PR TITLE
fix: post-update boot readiness budget + tolerate malformed surface enumeration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -82,6 +82,7 @@ import {
 import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
+  CmuxPane,
   CmuxSurface,
   CmuxTerminalMetadata,
   CmuxWorkspace,
@@ -113,6 +114,27 @@ type ToolReturn = {
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
+
+class SurfaceEnumerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SurfaceEnumerationError";
+  }
+}
+
+function requireSurfaceEnumerationArray<T>(
+  value: unknown,
+  label: string,
+): T[] {
+  if (Array.isArray(value)) return value as T[];
+  throw new SurfaceEnumerationError(
+    `Malformed cmux surface enumeration: ${label} is not an array`,
+  );
+}
+
+function isSurfaceEnumerationError(error: unknown): boolean {
+  return error instanceof SurfaceEnumerationError;
+}
 
 /** ToolAnnotations for MCP spec compliance */
 const ANNOTATIONS = {
@@ -4562,11 +4584,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // --- Agent Lifecycle Tools (Phase 5) ---
 
   if (!skipAgentLifecycle) {
-    const surfaceProvider = async () => {
+    let registry: AgentRegistry | null = null;
+    let lastLifecycleSurfaces: CmuxSurface[] | null = null;
+    const readLifecycleSurfaces = async () => {
       const workspaces = await client.listWorkspaces();
-      const workspaceList = Array.isArray(workspaces.workspaces)
-        ? workspaces.workspaces
-        : [];
+      const workspaceList = requireSurfaceEnumerationArray<CmuxWorkspace>(
+        workspaces.workspaces,
+        "workspaces.workspaces",
+      );
       const panesByWorkspace = await Promise.all(
         workspaceList.map(async (ws) => ({
           ref: ws.ref,
@@ -4575,7 +4600,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       const surfaceGroupsByWorkspace = await Promise.all(
         panesByWorkspace.map(async ({ ref, panes }) => {
-          const paneList = Array.isArray(panes.panes) ? panes.panes : [];
+          const paneList = requireSurfaceEnumerationArray<CmuxPane>(
+            panes.panes,
+            `panes.panes for ${ref}`,
+          );
           const rawGroups = await Promise.all(
             paneList.map((p) =>
               client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
@@ -4596,7 +4624,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         })),
       );
     };
-    const registry =
+    const surfaceProvider = async () => {
+      try {
+        const surfaces = await readLifecycleSurfaces();
+        lastLifecycleSurfaces = surfaces;
+        return surfaces;
+      } catch (error) {
+        if (!isSurfaceEnumerationError(error)) {
+          throw error;
+        }
+        if (lastLifecycleSurfaces) {
+          return lastLifecycleSurfaces;
+        }
+        if (!registry || registry.list().length === 0) {
+          return [];
+        }
+        throw error;
+      }
+    };
+    registry =
       context.lifecycleRegistry ?? new AgentRegistry(stateMgr, surfaceProvider);
     context.lifecycleRegistry = registry;
     const discovery = new AgentDiscovery({
@@ -5805,17 +5851,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.readOnly,
       async (args) => {
-        try {
-          const merged = await registry.listMerged(discovery, {
-            filter: {
-              state: args.state,
-              repo: args.repo,
-              model: args.model,
-            },
-          });
+        const filter = {
+          state: args.state,
+          repo: args.repo,
+          model: args.model,
+        };
+        const buildListAgentsResponse = async (records: AgentRecord[]) => {
           const topology = await collectSurfaceTopology();
           const agents = await Promise.all(
-            merged.map(async (agent) => ({
+            records.map(async (agent) => ({
               ...toPublicAgent(agent),
               health: await evaluateServerAgentHealth(agent, {
                 ...healthTopologyOverrides(agent, topology),
@@ -5828,7 +5872,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           const formatted = formatListAgents(agents, agents.length);
           return okFormatted(formatted, data);
+        };
+
+        try {
+          const merged = await registry.listMerged(discovery, {
+            filter,
+          });
+          return await buildListAgentsResponse(merged);
         } catch (e) {
+          if (isSurfaceEnumerationError(e)) {
+            try {
+              return await buildListAgentsResponse(registry.list(filter));
+            } catch (fallbackError) {
+              return err(fallbackError);
+            }
+          }
           return err(e);
         }
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,6 +186,7 @@ const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const BOOT_PROMPT_UPDATE_MAX_MS = 120_000;
 const BOOT_PROMPT_UPDATE_RELAUNCH_MAX = 2;
+const BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS = BOOT_PROMPT_READY_POLL_MS * 3;
 
 function bootPromptUpdateMaxMs(): number {
   const raw = Number(process.env.CMUXLAYER_BOOT_PROMPT_UPDATE_MAX_MS);
@@ -1920,6 +1921,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateWasSeen = false;
     let updateShellRelaunches = 0;
     const updateMaxMs = bootPromptUpdateMaxMs();
+    const postUpdateReadyBudgetMs = () =>
+      Math.max(opts.timeout_ms, BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS);
 
     while (Date.now() < deadline || updateStartedAt !== null) {
       try {
@@ -1955,7 +1958,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         if (updateStartedAt !== null) {
-          deadline += Math.max(now - updateStartedAt, updateElapsedMs);
+          const updateDuration = Math.max(now - updateStartedAt, updateElapsedMs);
+          deadline = Math.max(
+            deadline + updateDuration,
+            now + postUpdateReadyBudgetMs(),
+          );
           updateStartedAt = null;
           updateElapsedMs = 0;
         }
@@ -1978,7 +1985,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           consecutiveMatches.clear();
           const relaunchStartedAt = Date.now();
           await opts.onUpdateShellRelaunch();
-          deadline += Date.now() - relaunchStartedAt;
+          const relaunchEndedAt = Date.now();
+          deadline = Math.max(
+            deadline + (relaunchEndedAt - relaunchStartedAt),
+            relaunchEndedAt + postUpdateReadyBudgetMs(),
+          );
           continue;
         }
 
@@ -4553,20 +4564,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   if (!skipAgentLifecycle) {
     const surfaceProvider = async () => {
       const workspaces = await client.listWorkspaces();
+      const workspaceList = Array.isArray(workspaces.workspaces)
+        ? workspaces.workspaces
+        : [];
       const panesByWorkspace = await Promise.all(
-        workspaces.workspaces.map(async (ws) => ({
+        workspaceList.map(async (ws) => ({
           ref: ws.ref,
           panes: await client.listPanes({ workspace: ws.ref }),
         })),
       );
       const surfaceGroupsByWorkspace = await Promise.all(
         panesByWorkspace.map(async ({ ref, panes }) => {
+          const paneList = Array.isArray(panes.panes) ? panes.panes : [];
           const rawGroups = await Promise.all(
-            panes.panes.map((p) =>
+            paneList.map((p) =>
               client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
             ),
           );
-          return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+          return partitionPaneSurfacesByMembership(paneList, rawGroups, {
             workspace_ref: panes.workspace_ref ?? ref,
             window_ref: panes.window_ref,
           });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6164,6 +6164,86 @@ describe("tool handler integration", () => {
       await server.close();
     }
   });
+
+  it("list_agents does not mark persisted agents disappeared when workspace enumeration is malformed", async () => {
+    const stateDir = join(CHANNEL_TEST_DIR, "malformed-workspaces-persisted");
+    rmSync(stateDir, { recursive: true, force: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-1",
+      surface_id: "surface:kept",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "keep me registered",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      role: "worker",
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({}),
+      listPanes: vi.fn(),
+      listPaneSurfaces: vi.fn(),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:kept",
+        text: "Codex\n>",
+        lines: 30,
+        scrollback_used: false,
+      }),
+      log: vi.fn(),
+      setStatus: vi.fn(),
+      clearStatus: vi.fn(),
+      setProgress: vi.fn(),
+      send: vi.fn(),
+      sendKey: vi.fn(),
+      newSplit: vi.fn(),
+      newSurface: vi.fn(),
+      closeSurface: vi.fn(),
+      selectWorkspace: vi.fn(),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      controlHealthIntervalMs: 0,
+    });
+    const tool = (server as any)._registeredTools["list_agents"];
+
+    try {
+      const result = await tool.handler({}, {} as any);
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.count).toBe(1);
+      expect(parsed.agents[0]).toMatchObject({
+        agent_id: "worker-1",
+        repo: "cmuxlayer",
+        model: "gpt-5.4",
+        state: "working",
+      });
+      expect(stateMgr.readState("worker-1")).toMatchObject({
+        state: "working",
+        error: null,
+      });
+      expect(mockClient.listPanes).toHaveBeenCalledWith({
+        workspace: "workspace:1",
+      });
+    } finally {
+      await server.close();
+    }
+  });
 });
 
 describe("registry reconstitution error logging", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4396,6 +4396,138 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBeGreaterThanOrEqual(2);
   }, 10_000);
 
+  it("new_split preserves enough post-update time for low-confidence ready prompts", async () => {
+    vi.useRealTimers();
+    const promptPath = join(CHANNEL_TEST_DIR, "split-update-gemini.md");
+    const prompt = "boot after gemini update";
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+
+    let launcherSends = 0;
+    let promptSent = false;
+    let returnPresses = 0;
+    let reads = 0;
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "cmuxlayer",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "cmuxlayerGemini",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 0,
+                surface_refs: [],
+                selected_surface_ref: null,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        if (text.includes("cmuxlayerGemini")) {
+          launcherSends += 1;
+        } else if (text === prompt) {
+          promptSent = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        reads += 1;
+        const text =
+          launcherSends === 0 && reads === 1
+            ? "Updating Gemini via npm install -g @google/gemini-cli"
+            : launcherSends === 0 && reads === 2
+              ? "Please restart Gemini\netan@mac % "
+              : promptSent
+                ? "Gemini CLI\n✦ Working..."
+                : "Gemini CLI\n>\n";
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    try {
+      const result = await tool.handler(
+        {
+          direction: "right",
+          title: "cmuxlayerGemini",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 50,
+        },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.boot_prompt_delivered).toBe(true);
+      expect(launcherSends).toBe(1);
+      expect(returnPresses).toBeGreaterThanOrEqual(2);
+    } finally {
+      await server.close();
+    }
+  }, 10_000);
+
   it("new_surface relaunches a launcher-title terminal after update drops to shell", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "surface-update-relaunch.md");
@@ -5993,6 +6125,44 @@ describe("tool handler integration", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/selector.*required/i);
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("list_agents tolerates malformed workspace enumeration instead of throwing", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({}),
+      listPanes: vi.fn(),
+      listPaneSurfaces: vi.fn(),
+      readScreen: vi.fn(),
+      log: vi.fn(),
+      setStatus: vi.fn(),
+      clearStatus: vi.fn(),
+      setProgress: vi.fn(),
+      send: vi.fn(),
+      sendKey: vi.fn(),
+      newSplit: vi.fn(),
+      newSurface: vi.fn(),
+      closeSurface: vi.fn(),
+      selectWorkspace: vi.fn(),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      stateDir: join(CHANNEL_TEST_DIR, "malformed-workspaces"),
+      controlHealthIntervalMs: 0,
+    });
+    const tool = (server as any)._registeredTools["list_agents"];
+
+    try {
+      const result = await tool.handler({}, {} as any);
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.agents).toEqual([]);
+      expect(parsed.count).toBe(0);
+      expect(mockClient.listPanes).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserves a fresh ready-prompt budget after CLI auto-update completion or update-triggered shell relaunch, preventing short `boot_prompt_timeout_ms` calls from exhausting all post-update readiness time before the final low-confidence prompt can stabilize.
- Normalizes malformed workspace and pane enumeration responses to empty arrays before lifecycle surface discovery maps over them, so `list_agents` returns an empty result instead of throwing on partial cmux CLI output.
- Adds regressions for the post-update `new_split` readiness path and malformed workspace enumeration; also closes the local CodeRabbit test cleanup finding with `server.close()` in `finally`.

## Root Causes
- `src/server.ts`: `waitForBootPromptReady` extended the deadline by update duration only. When the caller supplied a tiny boot prompt timeout, the loop could restart after update with no usable post-update readiness budget, racing the final ready prompt and skipping prompt delivery.
- `src/server.ts`: lifecycle surface enumeration assumed `workspaces.workspaces` and `panes.panes` were arrays. Malformed or partial CLI JSON made `.map` throw, which surfaced through `server.test`/`list_agents` instead of returning an empty agent list.

## Verification
- `bun run test` on rebased branch before CodeRabbit fix: 67 files passed, 1203 passed, 5 todo.
- `bun run typecheck` on rebased branch before CodeRabbit fix: exit 0.
- `coderabbit review --agent` before commit: 1 MAJOR test cleanup finding, fixed.
- `bun run test` after CodeRabbit fix: 67 files passed, 1203 passed, 5 todo.
- `bun run typecheck` after CodeRabbit fix: exit 0.
- `coderabbit review --agent` after CodeRabbit fix: 0 findings.
- Pre-push hook: `run_tests.sh finished with exit status 0`; full Vitest suite reported 67 files passed, 1203 passed, 5 todo.

## Merge
- Do not merge from this worker; lead requested PR loop only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes boot-prompt timing for splits/surfaces and agent discovery fallbacks; behavior is defensive but affects agent lifecycle and `list_agents` when cmux returns partial data.
> 
> **Overview**
> Fixes two reliability issues in **boot prompt delivery** and **agent lifecycle surface discovery**.
> 
> **Post-update boot readiness:** After a CLI auto-update or update-triggered shell relaunch, `waitForBootPromptReady` now extends the deadline with a floor of `postUpdateReadyBudgetMs()` (at least the caller timeout or `BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS`), not only elapsed update/relaunch time. That stops tiny `boot_prompt_timeout_ms` values from leaving no post-update window before low-confidence ready prompts can stabilize (e.g. `new_split` with Gemini update flows).
> 
> **Malformed cmux enumeration:** Workspace/pane lists are validated as arrays via `requireSurfaceEnumerationError`; bad shapes throw a typed error instead of failing on `.map`. The lifecycle `surfaceProvider` caches the last good surface list and can reuse it or return `[]` when the registry is empty. **`list_agents`** catches enumeration failures and responds from persisted **`registry.list()`** with filters instead of erroring, so partial CLI JSON does not break listing or incorrectly ghost agents.
> 
> Tests cover the post-update `new_split` path, empty/malformed workspace responses, and persisted agents staying registered when enumeration is bad.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f021de2cf0818d493e9d1e09f57827a5e31245b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-update boot readiness budget and tolerate malformed surface enumeration
> - Adds `BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS` (3× the poll interval) as a minimum grace budget after CLI updates or relaunches, so the readiness loop no longer times out prematurely before late-emerging boot prompts arrive.
> - Introduces `SurfaceEnumerationError` and `requireSurfaceEnumerationArray` to tag and validate malformed workspace/pane data from cmux; the `surfaceProvider` closure now falls back to cached surfaces or an empty list on enumeration failure instead of throwing.
> - The `list_agents` tool handler falls back to registry data when surface enumeration is malformed, returning a successful response instead of an error.
> - Three integration tests cover: sufficient post-update time for low-confidence prompts, `list_agents` tolerating malformed workspaces, and persisted agent state surviving malformed enumeration.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0f021de. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot prompt readiness handling during updates and relaunches, reducing cases where the app could proceed too early.
  * Made workspace and pane discovery more resilient when data is incomplete, helping prevent crashes or empty results from malformed responses.

* **Tests**
  * Added coverage for update/relaunch readiness behavior and for handling invalid workspace listings without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->