### PR TITLE
fix(registry): empty surface enumeration is inconclusive — no mass-purge (phase 6)

### DIFF
--- a/docs/control-plane-invariants.md
+++ b/docs/control-plane-invariants.md
@@ -32,6 +32,11 @@ recovery, and sidebar/reporting decisions.
 | `stale_surface` | Registry route points to a surface not in the live list, or live surface has a different occupant/session. | Route is repaired from session index or resync, or delivery refuses clearly. | Partially modelled as delivery-time stale-ref guard (`src/server.ts:4703-4745`) plus durable surface/session index (`src/state-manager.ts:34-45`, `src/state-manager.ts:83-130`). |
 | `poisoned_registry` | Registry records conflict, duplicate routes disagree, ghosts remain after vanished surfaces, or stale `error` state would suppress wakeups. | Reconcile/evict repairs to one route per agent, or poisoned records are isolated/refused. | Not modelled as a state. `dispatch_to_agent` bypasses lifecycle because stale `error` records previously killed wakeups (`src/server.ts:4278-4286`, `src/server.ts:4307-4313`); duplicate route rejection exists in tests (`tests/agent-facade.test.ts:95-111`). |
 
+## Surface Topology Evidence
+
+An empty/failed surface listing is inconclusive (`unknown`); only a non-empty topology lacking a
+specific surface proves absence; stale records reap on the next non-empty scan.
+
 ## Allowed Transitions
 
 Allowed transitions are intentionally narrower than current ad hoc state movement:

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -96,6 +96,12 @@ export class AgentRegistry {
       // socket/listing failure must not mark every active agent as disappeared.
       return;
     }
+    if (surfaces.length === 0) {
+      // An empty topology is indistinguishable from a degraded cmux/app-server
+      // listing path. Do not mass-mark agents dead until a non-empty scan proves
+      // their specific surfaces are absent.
+      return;
+    }
     const liveSurfaceRefs = new Set(surfaces.map((s) => s.ref));
 
     // Phase 1: Mark agents with disappeared surfaces as error
@@ -197,7 +203,17 @@ export class AgentRegistry {
   }
 
   async hasLiveSurface(surfaceId: string): Promise<boolean> {
-    const surfaces = await this.surfaceProvider();
+    let surfaces: CmuxSurface[];
+    try {
+      surfaces = await this.surfaceProvider();
+    } catch {
+      // "Live" here means "not proven absent" for liveness guards.
+      return true;
+    }
+    if (surfaces.length === 0) {
+      // Empty enumeration is inconclusive until a non-empty scan proves absence.
+      return true;
+    }
     return surfaces.some((surface) => surface.ref === surfaceId);
   }
 
@@ -619,7 +635,15 @@ export class AgentRegistry {
    * Agents whose surface is still alive are kept (user may want to inspect output).
    */
   async purgeTerminal(): Promise<number> {
-    const surfaces = await this.surfaceProvider();
+    let surfaces: CmuxSurface[];
+    try {
+      surfaces = await this.surfaceProvider();
+    } catch {
+      return 0;
+    }
+    if (surfaces.length === 0) {
+      return 0;
+    }
     const liveSurfaceRefs = new Set(surfaces.map((s) => s.ref));
     let purged = 0;
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -131,38 +131,34 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     );
 
     const surfaceProvider = async () => {
-      try {
-        const workspaces = await this.client.listWorkspaces();
-        const panesByWorkspace = await Promise.all(
-          workspaces.workspaces.map(async (ws) => ({
-            ref: ws.ref,
-            panes: await this.client.listPanes({ workspace: ws.ref }),
-          })),
-        );
-        const surfaceGroupsByWorkspace = await Promise.all(
-          panesByWorkspace.map(async ({ ref, panes }) => {
-            const rawGroups = await Promise.all(
-              panes.panes.map((pane) =>
-                this.client.listPaneSurfaces({ workspace: ref, pane: pane.ref }),
-              ),
-            );
-            return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
-              workspace_ref: panes.workspace_ref ?? ref,
-              window_ref: panes.window_ref,
-            });
-          }),
-        );
-        const surfaceGroups = surfaceGroupsByWorkspace.flat();
-        return surfaceGroups.flatMap((group) =>
-          group.surfaces.map((surface) => ({
-            ...surface,
-            workspace_ref: group.workspace_ref,
-            pane_ref: group.pane_ref,
-          })),
-        );
-      } catch {
-        return [];
-      }
+      const workspaces = await this.client.listWorkspaces();
+      const panesByWorkspace = await Promise.all(
+        workspaces.workspaces.map(async (ws) => ({
+          ref: ws.ref,
+          panes: await this.client.listPanes({ workspace: ws.ref }),
+        })),
+      );
+      const surfaceGroupsByWorkspace = await Promise.all(
+        panesByWorkspace.map(async ({ ref, panes }) => {
+          const rawGroups = await Promise.all(
+            panes.panes.map((pane) =>
+              this.client.listPaneSurfaces({ workspace: ref, pane: pane.ref }),
+            ),
+          );
+          return partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+            workspace_ref: panes.workspace_ref ?? ref,
+            window_ref: panes.window_ref,
+          });
+        }),
+      );
+      const surfaceGroups = surfaceGroupsByWorkspace.flat();
+      return surfaceGroups.flatMap((group) =>
+        group.surfaces.map((surface) => ({
+          ...surface,
+          workspace_ref: group.workspace_ref,
+          pane_ref: group.pane_ref,
+        })),
+      );
     };
 
     this.registry = new AgentRegistry(this.stateMgr, surfaceProvider);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -392,6 +392,7 @@ describe("AgentEngine", () => {
         });
 
         expect(stateMgr.readState(result.agent_id)?.state).toBe("booting");
+        liveSurfaces = [makeSurface("surface:other-live")];
 
         await vi.runOnlyPendingTimersAsync();
 
@@ -1788,7 +1789,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(mockClient.newSplit).toHaveBeenCalled();
@@ -1831,7 +1832,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(mockClient.send).toHaveBeenCalledWith(
@@ -1864,7 +1865,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(mockClient.send).toHaveBeenCalledWith(
@@ -1895,7 +1896,7 @@ describe("AgentEngine", () => {
         user_killed: true,
       });
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(mockClient.newSplit).not.toHaveBeenCalled();
@@ -1946,7 +1947,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
       await engine.runSweep();
 
@@ -1980,7 +1981,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(mockClient.send).not.toHaveBeenCalled();
@@ -2010,7 +2011,7 @@ describe("AgentEngine", () => {
       liveSurfaces = [makeSurface("surface:dead")];
       await engine.getRegistry().reconstitute();
 
-      liveSurfaces = [];
+      liveSurfaces = [makeSurface("surface:other")];
       await engine.runSweep();
 
       expect(engine.getAgentState("agent-preflight")).toMatchObject({
@@ -4142,7 +4143,7 @@ To continue this session, run codex resume ${sessionId}`,
         liveSurfaces = [makeSurface("surface:gone-during-wait")];
         await engine.getRegistry().reconstitute();
 
-        liveSurfaces = [];
+        liveSurfaces = [makeSurface("surface:other")];
         const pending = engine.waitFor(
           "agent-surface-gone",
           "done",
@@ -5175,6 +5176,9 @@ To continue this session, run codex resume ${sessionId}`,
       (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementation(
         async (surface: string) => {
           liveSurfaces = liveSurfaces.filter((item) => item.ref !== surface);
+          if (liveSurfaces.length === 0) {
+            liveSurfaces = [makeSurface("surface:post-close-witness")];
+          }
         },
       );
     });

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -77,8 +77,8 @@ describe("AgentRegistry", () => {
         }),
       );
 
-      // Surface provider returns no surfaces — surface:99 is gone
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      // Non-empty surface enumeration proves surface:99 is gone.
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
 
@@ -97,7 +97,7 @@ describe("AgentRegistry", () => {
         }),
       );
 
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
 
@@ -120,7 +120,7 @@ describe("AgentRegistry", () => {
     });
 
     it("returns null for unknown agent", async () => {
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
 
@@ -213,7 +213,7 @@ describe("AgentRegistry", () => {
       await registry.reconstitute();
 
       // Surface disappears
-      surfaces = [];
+      surfaces = [makeSurface("surface:2")];
       await registry.reconcile();
 
       const agent = registry.get("agent-alive");
@@ -244,6 +244,28 @@ describe("AgentRegistry", () => {
       await registry.reconcile();
 
       const agent = registry.get("agent-live");
+      expect(agent!.state).toBe("working");
+      expect(agent!.error).toBeNull();
+    });
+
+    it("does not mark live agents disappeared when surface enumeration is empty", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-live-empty-scan",
+          surface_id: "surface:1",
+          state: "working",
+        }),
+      );
+
+      let surfaces = [makeSurface("surface:1")];
+      const surfaceProvider = async () => surfaces;
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+
+      surfaces = [];
+      await registry.reconcile();
+
+      const agent = registry.get("agent-live-empty-scan");
       expect(agent!.state).toBe("working");
       expect(agent!.error).toBeNull();
     });
@@ -393,7 +415,63 @@ describe("AgentRegistry", () => {
     });
   });
 
+  describe("hasLiveSurface", () => {
+    it("treats empty surface enumeration as inconclusive", async () => {
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => [] as CmuxSurface[],
+      );
+
+      await expect(registry.hasLiveSurface("surface:maybe-live")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("treats surface enumeration failures as inconclusive", async () => {
+      const registry = new AgentRegistry(stateMgr, async () => {
+        throw new Error("socket unavailable");
+      });
+
+      await expect(registry.hasLiveSurface("surface:maybe-live")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false only when a non-empty topology lacks the surface", async () => {
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:other"),
+      ]);
+
+      await expect(registry.hasLiveSurface("surface:missing")).resolves.toBe(
+        false,
+      );
+    });
+  });
+
   describe("purgeTerminal", () => {
+    it("does not purge terminal workers when surface enumeration is empty", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "terminal-worker-empty-scan",
+          state: "done",
+          surface_id: "surface:maybe-live",
+          role: "worker",
+        }),
+      );
+
+      const surfaceProvider = async () => [] as CmuxSurface[];
+      const registry = new AgentRegistry(stateMgr, surfaceProvider);
+      await registry.reconstitute();
+
+      const purged = await registry.purgeTerminal();
+
+      expect(purged).toBe(0);
+      expect(registry.get("terminal-worker-empty-scan")).toMatchObject({
+        agent_id: "terminal-worker-empty-scan",
+        state: "done",
+      });
+    });
+
     it("keeps absent terminal lead roles while purging absent terminal workers", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -420,7 +498,7 @@ describe("AgentRegistry", () => {
         }),
       );
 
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
 
@@ -450,7 +528,7 @@ describe("AgentRegistry", () => {
         }),
       );
 
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
 
@@ -469,7 +547,7 @@ describe("AgentRegistry", () => {
         }),
       );
 
-      const surfaceProvider = async () => [] as CmuxSurface[];
+      const surfaceProvider = async () => [makeSurface("surface:live")];
       const registry = new AgentRegistry(stateMgr, surfaceProvider);
       await registry.reconstitute();
       const renamed = stateMgr.renameState("agent-pending", "agent-final");

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -63,6 +63,21 @@ function makeRecord(): AgentRecord {
 }
 
 describe("CmuxAppServerRuntime", () => {
+  it("does not collapse surface listing failures into an absent surface", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWorkspaces.mockRejectedValueOnce(new Error("socket unavailable"));
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+
+    await expect((runtime as any).registry.hasLiveSurface("surface:1")).resolves.toBe(
+      true,
+    );
+
+    runtime.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
   it("scopes bridge turns, interrupts, and screen reads to the agent workspace", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/mcp-quality.test.ts
+++ b/tests/mcp-quality.test.ts
@@ -117,8 +117,8 @@ describe("close_surface cleans up agent registry", () => {
     const before = registry.get("agent-on-closed-surface");
     expect(before?.state).toBe("working");
 
-    // Simulate surface being closed — remove from live surfaces
-    liveSurfaces = [];
+    // Simulate surface being closed with a successful non-empty topology scan.
+    liveSurfaces = [makeSurface("surface:live")];
 
     // After reconcile, agent should be marked error
     await registry.reconcile();
@@ -144,7 +144,7 @@ describe("close_surface cleans up agent registry", () => {
     stateMgr.writeState(doneRecord);
     stateMgr.writeState(errorRecord);
 
-    const surfaceProvider = async () => [] as CmuxSurface[];
+    const surfaceProvider = async () => [makeSurface("surface:live")];
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
     await registry.reconstitute();
 

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { basename, extname } from "node:path";
 import { describe, expect, it } from "vitest";
+import { buildRouteTable } from "../src/agent-facade.js";
 import { evaluateAgentHealth } from "../src/agent-health.js";
 import { reposEquivalent } from "../src/repo-workspace.js";
 import { parseScreen } from "../src/screen-parser.js";
@@ -42,6 +43,7 @@ type PainpointFixture = {
     focused_workspace: string;
     explicit_workspace: string | null;
   };
+  records?: Partial<AgentRecord>[];
 };
 
 const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
@@ -126,6 +128,32 @@ function recordFromFixture(record: Partial<AgentRecord>): AgentRecord {
   };
 }
 
+function classifyRegistryGhostDuplicateFixture(
+  fixture: PainpointFixture,
+): string {
+  const records = fixture.records?.map(recordFromFixture) ?? [];
+  const liveSurfaceRefs = new Set(
+    records
+      .map((record) => record.surface_id)
+      .filter((surfaceId) => surfaceId !== "surface:missing"),
+  );
+
+  const hasMissingSurfaceRecord = records.some(
+    (record) => !liveSurfaceRefs.has(record.surface_id),
+  );
+  let hasConflictingRoutes = false;
+  try {
+    buildRouteTable(records);
+  } catch (error) {
+    hasConflictingRoutes =
+      error instanceof Error && /Conflicting routes/.test(error.message);
+  }
+
+  return hasMissingSurfaceRecord || hasConflictingRoutes
+    ? "poisoned_registry"
+    : "unknown";
+}
+
 describe("Phase 0 painpoint replay corpus", () => {
   it("loads every required painpoint fixture", () => {
     expect(fixtures.map((fixture) => fixture.id)).toEqual([
@@ -208,6 +236,18 @@ describe("Phase 0 painpoint replay corpus", () => {
             surface_workspace_id: spawn.focused_workspace,
           }).issue_codes,
         ).toContain("registry_surface_workspace_mismatch");
+      });
+      continue;
+    }
+
+    if (fixture.id === "registry-ghost-duplicate-surface") {
+      it(`${fixture.id} classifies as ${fixture.expected_state} via registry route guards`, () => {
+        const records = fixture.records?.map(recordFromFixture) ?? [];
+        expect(records.length).toBeGreaterThan(0);
+        expect(() => buildRouteTable(records)).toThrow(/Conflicting routes/);
+        expect(classifyRegistryGhostDuplicateFixture(fixture)).toBe(
+          fixture.expected_state,
+        );
       });
       continue;
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -50,6 +50,18 @@ function makeLifecycleExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
   let surfaceLive = true;
   let promptPending = false;
   let activeCli: "claude" | "codex" | "cursor" = "claude";
+  const listedSurface = () =>
+    surfaceLive
+      ? {
+          paneRef: "pane:1",
+          surfaceRef: "surface:new",
+          title: "agent-pane",
+        }
+      : {
+          paneRef: "pane:witness",
+          surfaceRef: "surface:post-close-witness",
+          title: "witness-pane",
+        };
   const workingText = () => {
     if (activeCli === "codex") {
       return "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)";
@@ -114,44 +126,42 @@ function makeLifecycleExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
     }
 
     if (args.includes("list-panes")) {
+      const listed = listedSurface();
       return {
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
           window_ref: "window:1",
-          panes: surfaceLive
-            ? [
-                {
-                  ref: "pane:1",
-                  index: 0,
-                  focused: true,
-                  surface_count: 1,
-                  surface_refs: ["surface:new"],
-                  selected_surface_ref: "surface:new",
-                },
-              ]
-            : [],
+          panes: [
+            {
+              ref: listed.paneRef,
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: [listed.surfaceRef],
+              selected_surface_ref: listed.surfaceRef,
+            },
+          ],
         }),
         stderr: "",
       };
     }
 
     if (args.includes("list-pane-surfaces")) {
+      const listed = listedSurface();
       return {
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
           window_ref: "window:1",
-          pane_ref: "pane:1",
-          surfaces: surfaceLive
-            ? [
-                {
-                  ref: "surface:new",
-                  title: "agent-pane",
-                  type: "terminal",
-                  index: 0,
-                  selected: true,
-                },
-              ]
-            : [],
+          pane_ref: listed.paneRef,
+          surfaces: [
+            {
+              ref: listed.surfaceRef,
+              title: listed.title,
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
         }),
         stderr: "",
       };

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -34,6 +34,18 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
   let launchSent = false;
   let agentMessageSubmitted = false;
   let surfaceLive = true;
+  const listedSurface = () =>
+    surfaceLive
+      ? {
+          paneRef: "pane:1",
+          surfaceRef: "surface:new",
+          title: "agent-pane",
+        }
+      : {
+          paneRef: "pane:witness",
+          surfaceRef: "surface:post-close-witness",
+          title: "witness-pane",
+        };
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("new-split") || args.includes("new-surface")) {
       surfaceLive = true;
@@ -51,46 +63,57 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
       }
     }
     if (args.includes("list-workspaces")) {
-      return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "ws:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
     }
     if (args.includes("list-panes")) {
+      const listed = listedSurface();
       return {
         stdout: JSON.stringify({
           workspace_ref: "ws:1",
           window_ref: "window:1",
-          panes: surfaceLive
-            ? [
-                {
-                  ref: "pane:1",
-                  index: 0,
-                  focused: true,
-                  surface_count: 1,
-                  surface_refs: ["surface:new"],
-                  selected_surface_ref: "surface:new",
-                },
-              ]
-            : [],
+          panes: [
+            {
+              ref: listed.paneRef,
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: [listed.surfaceRef],
+              selected_surface_ref: listed.surfaceRef,
+            },
+          ],
         }),
         stderr: "",
       };
     }
     if (args.includes("list-pane-surfaces")) {
+      const listed = listedSurface();
       return {
         stdout: JSON.stringify({
           workspace_ref: "ws:1",
           window_ref: "window:1",
-          pane_ref: "pane:1",
-          surfaces: surfaceLive
-            ? [
-                {
-                  ref: "surface:new",
-                  title: "agent-pane",
-                  type: "terminal",
-                  index: 0,
-                  selected: true,
-                },
-              ]
-            : [],
+          pane_ref: listed.paneRef,
+          surfaces: [
+            {
+              ref: listed.surfaceRef,
+              title: listed.title,
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
         }),
         stderr: "",
       };


### PR DESCRIPTION
## Summary
- Treat empty cmux surface enumerations as inconclusive in registry reconciliation/reaper paths instead of proof that every managed surface disappeared.
- Let failed surface enumeration remain an unknown state at the runtime boundary so callers do not synthesize `[]` and mass-purge live agents.
- Add regression coverage for candidate #14 plus the documented control-plane invariant.

## Verification
- `git fetch origin main && git rebase origin/main`
- `bun run typecheck`
- `git diff --check`
- `bun run test` (67 passed, 1208 passed, 4 todo)
- pre-push hook: `run_tests.sh` exited 0, including full `vitest run` (67 passed, 1208 passed, 4 todo)

## Review Notes
- Local `coderabbit review --agent` was attempted before commit and returned a recoverable OSS rate limit (`waitTime: 30 minutes`), not a code finding.
- Do not merge yet; main-fix lane landed first and this PR is ready for Claude/reviewer pairing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent registry liveness, reconciliation, and terminal purge behavior; incorrect semantics could delay detecting truly dead surfaces or retain stale terminal records, but the change reduces a known mass false-error path during degraded listing.
> 
> **Overview**
> **Registry reconciliation and terminal purge** no longer treat an empty cmux surface list as proof that every managed surface is gone. `reconcileSurfaces`, `hasLiveSurface`, and `purgeTerminal` now bail out or treat liveness as inconclusive when enumeration fails or returns zero surfaces; absence is only inferred when a **non-empty** topology omits the specific surface ref.
> 
> **App-server runtime** stops swallowing listing errors in the `surfaceProvider` (no more `catch { return [] }`), so degraded cmux scans propagate as failures instead of being converted into a synthetic empty topology that could drive mass purge.
> 
> **Docs** add a **Surface Topology Evidence** invariant aligned with the above. **Tests** across registry, engine, MCP, server mocks, and painpoint replay are updated to prove “surface gone” via a non-empty witness list that excludes the target, plus new coverage for empty scans and listing failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53453f35ab67247c7d0c0cae7ffc6228889467d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat empty surface enumeration as inconclusive to prevent mass-purge in agent registry
> - `AgentRegistry.reconcileSurfaces` now skips state changes when the surface provider returns an empty list, waiting for a subsequent non-empty scan before marking agents as disappeared.
> - `AgentRegistry.hasLiveSurface` returns `true` on empty enumeration or provider error; only returns `false` when a non-empty topology confirms the surface is absent.
> - `AgentRegistry.purgeTerminal` returns 0 without purging when enumeration fails or is empty.
> - `CmuxAppServerRuntime`'s surface provider now throws on failure instead of collapsing errors into an empty array, so callers can distinguish failure from a genuinely empty topology.
> - Tests updated throughout to use non-empty witness surfaces when asserting absence of a specific surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d53453f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->