### PR TITLE
feat(verify): submit verification v2 — no false greens (phase 5)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -242,22 +242,6 @@ type RefreshedTargetStateEvidenceSource = Exclude<
   "state"
 >;
 
-// AIDEV-NOTE: Cursor has no distinct "done" lifecycle state — it settles to
-// "idle" when a task completes. A wait_for(target="done") on a Cursor agent
-// would otherwise hang the full timeout (R-038(cmuxlayer-code: cursor-idle short-circuit): "300s hang on a done Cursor").
-// AIDEV-NOTE: This is distinct from weave-registry R-038 (wait_for(done) transcript ground-truth) and weave-registry R-039 (delta-wave coverage).
-// Treat a Cursor that has reached idle as satisfying a done wait. Narrowly
-// scoped to cli==="cursor" so Claude/Codex idle (awaiting input ≠ done) is
-// unaffected.
-function isCursorTerminalIdleTarget(
-  agent: AgentRecord,
-  targetState: AgentState,
-): boolean {
-  return (
-    targetState === "done" && agent.cli === "cursor" && agent.state === "idle"
-  );
-}
-
 function tailScreenLines(text: string, lines: number): string {
   return text.split(/\r?\n/).slice(-lines).join("\n");
 }
@@ -831,7 +815,6 @@ export class AgentEngine {
     agent: AgentRecord,
     targetState: AgentState,
   ): Promise<TargetStateEvidenceSource | null> {
-    if (isCursorTerminalIdleTarget(agent, targetState)) return "state";
     if (agent.state !== targetState) return null;
     if (!this.requiresOutputDoneEvidence(targetState)) return "state";
     if (await this.hasGroundTruthDone(agent)) return "transcript";

--- a/src/server.ts
+++ b/src/server.ts
@@ -252,6 +252,9 @@ export interface DeliveryRecord {
   chunk_delay_ms: number;
   chunks: string[];
   press_enter: boolean;
+  verify_submit: boolean;
+  submit_verified: boolean | null;
+  retry_count: number;
   rename_to_task?: string;
   started_at: string;
   completed_at?: string;
@@ -1387,6 +1390,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     completed_at: record.completed_at ?? null,
     failed_chunk: record.failed_chunk ?? null,
     error: record.error ?? null,
+    submit_verified: record.submit_verified,
+    retry_count: record.retry_count,
   });
 
   const collectServerRoleSurfaceIds = (
@@ -1732,8 +1737,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_event: DeliveryEventType;
     source_agent?: string | null;
     verify_submit: boolean;
-    allow_non_agent_clear?: boolean;
     require_working_status?: boolean;
+    timeout_ms?: number;
   }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
@@ -1741,11 +1746,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return { submit_verified: null, retry_count: 0 };
     }
 
+    const timeoutMs = opts.timeout_ms ?? SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS;
     const startedAt = Date.now();
     let retried = false;
     let retryCount = 0;
+    let sawClearedInput = false;
 
-    while (Date.now() - startedAt < SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS) {
+    while (Date.now() - startedAt < timeoutMs) {
       const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
         throwOnSurfaceGone: true,
       });
@@ -1762,17 +1769,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
-      const hasClearedAgentComposer =
-        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
-        !hasPendingInput;
+      if (!hasPendingInput) {
+        sawClearedInput = true;
+      }
       if (opts.require_working_status) {
-        if (retried && hasClearedAgentComposer) {
-          // Slow-to-stream boot prompts can clear the composer before the CLI
-          // renders a parsed working marker; identity + cleared input is enough
-          // evidence after the recovery Return has been attempted.
-          return { submit_verified: true, retry_count: retryCount };
-        }
-
         if (!retried) {
           await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
           await sendKeyWithRetry(opts.surface, "return", opts.workspace);
@@ -1794,20 +1794,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         continue;
       }
 
-      if (
-        hasClearedAgentComposer ||
-        (opts.allow_non_agent_clear === true && !hasPendingInput)
-      ) {
-        // The submitted text is no longer echoed in the input box: the terminal
-        // accepted it and cleared the prompt. For agent surfaces this catches
-        // the common idle-after-submit case; raw shell clears are only accepted
-        // when the caller explicitly allows non-agent verification.
-        return { submit_verified: true, retry_count: retryCount };
-      }
-
-      // The submitted text is still pending in the input box. Retry Enter once,
-      // then keep polling; if it never clears (a frozen terminal) we fall
-      // through to the timeout below and report the relay as unverified.
+      // Pending input and cleared-but-idle composers are both ambiguous: the
+      // first Return may have been missed, or the CLI may have cleared input
+      // without starting the task. Retry Enter once, then keep polling for real
+      // working/thinking evidence. Cleared input alone is not submit proof.
       if (!retried) {
         await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
         await sendKeyWithRetry(opts.surface, "return", opts.workspace);
@@ -1827,7 +1817,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
-    return { submit_verified: false, retry_count: retryCount };
+    return {
+      submit_verified:
+        sawClearedInput && !opts.require_working_status ? null : false,
+      retry_count: retryCount,
+    };
   };
 
   const deliverInputChunks = async (opts: {
@@ -1842,7 +1836,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_event?: DeliveryEventType;
     source_agent?: string | null;
     verify_submit?: boolean;
-    allow_non_agent_clear?: boolean;
+    submit_verify_timeout_ms?: number;
   }): Promise<{
     bytes: number;
     retry_count: number;
@@ -1892,7 +1886,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         source_event: opts.source_event ?? "send_command",
         source_agent: opts.source_agent,
         verify_submit: opts.verify_submit ?? false,
-        allow_non_agent_clear: opts.allow_non_agent_clear,
+        timeout_ms: opts.submit_verify_timeout_ms,
         require_working_status: opts.source_event === "boot_prompt",
       });
       submit_verified = verification.submit_verified;
@@ -1918,8 +1912,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     if (submit_verified === false) {
+      const timeoutMs =
+        opts.submit_verify_timeout_ms ?? SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS;
       throw new SubmitVerificationError(
-        `Enter submit could not be verified for ${opts.surface} within ${SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS}ms`,
+        `Enter submit could not be verified for ${opts.surface} within ${timeoutMs}ms`,
         retry_count,
       );
     }
@@ -1958,8 +1954,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const now = Date.now();
         const updateMarker =
           matchesCliUpdateMarker(screen.text) ||
-          (updateStartedAt !== null &&
-            matchesCliUpdateContinuationMarker(screen.text) &&
+          (matchesCliUpdateContinuationMarker(screen.text) &&
             !matchesShellPrompt(screen.text));
 
         if (updateMarker) {
@@ -2066,15 +2061,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       });
       if (snapshot) {
         lastText = snapshot.text;
-        const hasPendingInput = screenShowsPendingInput(
-          snapshot.text,
-          opts.text,
-        );
-        if (
-          isSubmitVerifiedStatus(snapshot.parsed.status) ||
-          (screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
-            !hasPendingInput)
-        ) {
+        if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
           return;
         }
       }
@@ -2181,6 +2168,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
   };
 
+  const probeAgentLaunchReadyOnce = async (opts: {
+    surface: string;
+    workspace?: string;
+  }): Promise<void> => {
+    try {
+      await client.readScreen(opts.surface, {
+        workspace: opts.workspace,
+        lines: 80,
+        scrollback: false,
+      });
+    } catch (error) {
+      if (isSurfaceGoneReadFailure(error, opts.surface)) {
+        throw new SurfaceGoneError(opts.surface, error);
+      }
+    }
+  };
+
   const sendLauncherCommandToSurface = async (opts: {
     surface: string;
     workspace?: string;
@@ -2198,7 +2202,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
     await withSurfaceWrite(opts.surface, async () => {
       try {
-        await deliverInputChunks({
+        const delivery = await deliverInputChunks({
           surface: opts.surface,
           workspace: opts.workspace,
           chunks,
@@ -2207,7 +2211,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           press_enter: true,
           source_event: "spawn_agent",
           verify_submit: true,
+          submit_verify_timeout_ms: SEND_INPUT_RECOVERY_ENTER_DELAY_MS,
         });
+        if (delivery.submit_verified !== true) {
+          // The command can clear from the shell without proving the launcher
+          // accepted it. Probe once to consume transient ready evidence, then
+          // let boot-prompt readiness own update/relaunch monitoring.
+          await probeAgentLaunchReadyOnce({
+            surface: opts.surface,
+            workspace: opts.workspace,
+          });
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!/Enter submit could not be verified/.test(message)) {
@@ -2280,6 +2294,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             sentChunks = count;
           },
           verify_submit: true,
+          submit_verify_timeout_ms: opts.timeout_ms
+            ? Math.min(SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS, opts.timeout_ms)
+            : undefined,
         }),
       );
       return { ...delivery, prompt_text: rawPrompt };
@@ -2442,7 +2459,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const run = async () => {
       try {
         await assertDeliveryTargetIsSafe(record.surface, record.workspace);
-        await deliverInputChunks({
+        const delivery = await deliverInputChunks({
           surface: record.surface,
           workspace: record.workspace,
           chunks: record.chunks,
@@ -2450,12 +2467,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           chunk_delay_ms: record.chunk_delay_ms,
           press_enter: record.press_enter,
           rename_to_task: record.rename_to_task,
+          source_event: "send_input",
+          verify_submit: record.verify_submit,
           onChunkDelivered: (sentChunks) => {
             record.sent_chunks = sentChunks;
           },
         });
+        record.submit_verified = delivery.submit_verified;
+        record.retry_count = delivery.retry_count;
         finishDelivery(record, "delivered");
       } catch (error) {
+        if (error instanceof SubmitVerificationError) {
+          record.submit_verified = false;
+          record.retry_count = error.retry_count;
+        } else if (error instanceof DeliverySafetyGateError) {
+          record.submit_verified = error.submit_verified;
+        }
         const message = error instanceof Error ? error.message : String(error);
         const failedChunk =
           error instanceof DeliveryError ? error.failed_chunk : undefined;
@@ -3528,6 +3555,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
             ? chunkTerminalInput(sanitizedText, args.chunk_size)
             : [sanitizedText];
+        const targetRecord = resolveLatestSurfaceAgentRecord(
+          stateMgr,
+          args.surface,
+        );
+        const shouldVerifySubmit =
+          args.press_enter &&
+          !!targetRecord &&
+          INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
         if (args.background) {
           const record: DeliveryRecord = {
@@ -3541,6 +3576,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             chunks,
             press_enter: args.press_enter,
+            verify_submit: shouldVerifySubmit,
+            submit_verified: null,
+            retry_count: 0,
             rename_to_task: args.rename_to_task,
             started_at: new Date().toISOString(),
           };
@@ -3552,6 +3590,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             delivered: false,
             delivery_id: record.delivery_id,
             status: record.status,
+            submit_verified: record.submit_verified,
+            retry_count: record.retry_count,
           };
           return okFormatted(
             formatDelivery("send_input", {
@@ -3563,13 +3603,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
 
-        const targetRecord = resolveLatestSurfaceAgentRecord(
-          stateMgr,
-          args.surface,
-        );
-        const shouldVerifySubmit =
-          args.press_enter &&
-          (!targetRecord || INTERACTIVE_AGENT_STATES.has(targetRecord.state));
         const delivery = await withSurfaceWrite(args.surface, async () => {
           await assertDeliveryTargetIsSafe(args.surface, args.workspace);
           return deliverInputChunks({
@@ -3582,7 +3615,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             rename_to_task: args.rename_to_task,
             source_event: "send_input",
             verify_submit: shouldVerifySubmit,
-            allow_non_agent_clear: !targetRecord,
           });
         });
 
@@ -5478,6 +5510,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               screen: e.screen,
             });
           }
+          if (e instanceof SubmitVerificationError) {
+            return err(e, {
+              submit_verified: false,
+              retry_count: e.retry_count,
+            });
+          }
           return err(e);
         }
       },
@@ -5656,6 +5694,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               screen: e.screen,
             });
           }
+          if (e instanceof SubmitVerificationError) {
+            return err(e, {
+              submit_verified: false,
+              retry_count: e.retry_count,
+            });
+          }
           return err(e);
         }
       },
@@ -5721,6 +5765,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               error_code: e.error_code,
               submit_verified: e.submit_verified,
               screen: e.screen,
+            });
+          }
+          if (e instanceof SubmitVerificationError) {
+            return err(e, {
+              submit_verified: false,
+              retry_count: e.retry_count,
             });
           }
           return err(e);
@@ -6024,6 +6074,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               screen: e.screen,
             });
           }
+          if (e instanceof SubmitVerificationError) {
+            return err(e, {
+              submit_verified: false,
+              retry_count: e.retry_count,
+            });
+          }
           return err(e);
         }
       },
@@ -6088,6 +6144,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               error_code: e.error_code,
               submit_verified: e.submit_verified,
               screen: e.screen,
+            });
+          }
+          if (e instanceof SubmitVerificationError) {
+            return err(e, {
+              submit_verified: false,
+              retry_count: e.retry_count,
             });
           }
           return err(e);

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -387,7 +387,7 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
-  it("verifies short send_to submissions once the input clears", async () => {
+  it("keeps cleared short send_to submissions uncertain without a hard error", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
     client.completionMode = "idle";
@@ -403,12 +403,12 @@ describe("enter reliability", () => {
     const events = readEventLog().filter((event) => event.event_type === "send_to");
 
     expect(parsed.ok).toBe(true);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(parsed.submit_verified).toBeNull();
+    expect(parsed.retry_count).toBe(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(2);
     expect(events).toHaveLength(1);
-    // A short relay is now verified: the input cleared from the prompt, so the
-    // submit landed even though Claude settled straight back to idle.
-    expect(events[0]?.submit_verified).toBe(true);
-    expect(events[0]?.retry_count).toBe(0);
+    expect(events[0]?.submit_verified).toBeNull();
+    expect(events[0]?.retry_count).toBe(1);
   });
 
   it("retries Enter for send_command on a Claude surface", async () => {
@@ -525,7 +525,7 @@ describe("enter reliability", () => {
     expect(events[0]?.submit_verified).toBeNull();
   });
 
-  it("verifies send_input to an uncached shell when the prompt clears", async () => {
+  it("does not verify send_input to an uncached shell from prompt clearing", async () => {
     const client = new FakeShellSurfaceClient();
     server = createReliabilityServer(client as any);
 
@@ -540,13 +540,13 @@ describe("enter reliability", () => {
     );
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
     expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBe(true);
+    expect(events[0]?.submit_verified).toBeNull();
   });
 
   it("uses the verified send path for interact(action=send)", async () => {

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -207,9 +207,8 @@ describe("false-green empty surface protection", () => {
     const result = await resultPromise;
 
     const parsed = parseToolResult(result);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
-    expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBeNull();
     expect(
       (mockExec as any).mock.calls.some(([, args]: [string, string[]]) =>
         args.includes("read-screen"),

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -14,9 +14,15 @@ import type {
 type PainpointFixture = {
   id: string;
   expected_state: string;
+  secondary_state?: string;
   phase_home: string;
   source_evidence: string[];
   screen_text?: string;
+  submitted_text?: string;
+  read_error?: {
+    message: string;
+    error_code: string;
+  };
   assertions?: string[];
   agent_record?: Partial<AgentRecord>;
   live_surfaces?: Array<{ ref: string }>;
@@ -71,7 +77,19 @@ const fixtureNames = readdirSync(fixtureDir)
 const fixtures = fixtureNames.map(readPainpointFixture);
 
 function legacyClassifierShape(fixture: PainpointFixture): string {
+  if (fixture.read_error?.error_code === "pane_died") {
+    return "dead";
+  }
+
   if (fixture.screen_text !== undefined) {
+    if (
+      fixture.agent_record?.boot_prompt_pending === true &&
+      fixture.submitted_text !== undefined &&
+      fixture.screen_text.includes(fixture.submitted_text)
+    ) {
+      return "composer_dirty";
+    }
+
     const parsed = parseScreen(fixture.screen_text);
     return parsed.control_state ?? `legacy:${parsed.agent_type}:${parsed.status}:${parsed.errors.join(",")}`;
   }
@@ -197,7 +215,9 @@ describe("Phase 0 painpoint replay corpus", () => {
     const testFn =
       fixture.id === "claude-ask-user-question-overlay" ||
       fixture.id === "claude-permission-confirmation" ||
-      fixture.id === "bare-shell-and-bare-gemini-prompt"
+      fixture.id === "bare-shell-and-bare-gemini-prompt" ||
+      fixture.id === "empty-dead-pane-submit" ||
+      fixture.id === "boot-prompt-typed-not-submitted"
         ? it
         : it.todo;
     testFn(

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -72,6 +72,11 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
       return { stdout: "{}", stderr: "" };
     }
 
+    if (args.includes("paste-buffer")) {
+      promptPending = true;
+      return { stdout: "{}", stderr: "" };
+    }
+
     if (args.includes("read-screen")) {
       return {
         stdout: JSON.stringify({

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1569,8 +1569,9 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Should preflight the screen, then send, press enter, and verify submit.
-    expect(mockExec).toHaveBeenCalledTimes(4);
+    // Should preflight the screen, send text, and press enter. Raw uncached
+    // surfaces do not get submit_verified:true from prompt clearing alone.
+    expect(mockExec).toHaveBeenCalledTimes(3);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -1585,11 +1586,6 @@ describe("tool handler integration", () => {
       3,
       "cmux",
       expect.arrayContaining(["send-key"]),
-    );
-    expect(mockExec).toHaveBeenNthCalledWith(
-      4,
-      "cmux",
-      expect.arrayContaining(["read-screen"]),
     );
   });
 
@@ -1878,7 +1874,7 @@ describe("tool handler integration", () => {
     );
   });
 
-  it("send_command accepts a cleared Claude boot prompt before a working marker streams", async () => {
+  it("send_command does not verify a cleared Claude boot prompt without a working marker", async () => {
     const promptPath = join(CHANNEL_TEST_DIR, "slow-claude.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
@@ -1916,15 +1912,16 @@ describe("tool handler integration", () => {
         surface: "surface:1",
         command: "brainlayerClaude -s",
         boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 100,
       },
       {} as any,
     );
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.boot_prompt_delivered).toBe(true);
-    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("boot prompt submit evidence");
     expect(promptSent).toBe(true);
     expect(returnPresses).toBe(3);
   }, 10_000);
@@ -2337,6 +2334,92 @@ describe("tool handler integration", () => {
       status: "delivered",
       sent_chunks: 5,
       total_chunks: 5,
+    });
+  });
+
+  it("send_input background press_enter surfaces uncertain cleared submits", async () => {
+    vi.useFakeTimers();
+    const stateDir = join(tmpdir(), "cmuxlayer-background-submit-verify");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "agent-background-submit",
+      surface_id: "surface:agent-bg",
+      workspace_id: null,
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "Opus 4.8",
+      cli: "claude",
+      cli_session_id: null,
+      task_summary: "background submit verification",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-05T00:00:00.000Z",
+      updated_at: "2026-07-05T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+    mockExec = vi.fn().mockImplementation((_cmd, args: string[]) => {
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:agent-bg",
+            text: "Claude Code\n> \nCLAUDE_COUNTER:1\n",
+            lines: 3,
+          }),
+          stderr: "",
+        });
+      }
+      if (args.includes("list-workspaces")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({ workspaces: [] }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true, stateDir });
+    const registeredTools = (server as any)._registeredTools;
+    const sendTool = registeredTools["send_input"];
+    const readTool = registeredTools["read_screen"];
+
+    const result = await sendTool.handler(
+      {
+        surface: "surface:agent-bg",
+        text: "ping",
+        background: true,
+        press_enter: true,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.status).toBe("delivering");
+    expect(parsed.submit_verified).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const readAfterDelivery = await readTool.handler(
+      { surface: "surface:agent-bg", parsed_only: true },
+      {} as any,
+    );
+    const readAfterDeliveryParsed =
+      readAfterDelivery.structuredContent ??
+      JSON.parse(readAfterDelivery.content[0].text);
+    expect(readAfterDeliveryParsed.delivery).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      status: "delivered",
+      submit_verified: null,
+      retry_count: 1,
     });
   });
 

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -32,6 +32,7 @@ function parseResult(result: any): any {
 
 function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
   let launchSent = false;
+  let agentMessageSubmitted = false;
   let surfaceLive = true;
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("new-split") || args.includes("new-surface")) {
@@ -42,7 +43,12 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
       return { stdout: "{}", stderr: "" };
     }
     if (args.includes("send")) {
-      launchSent = true;
+      const text = String(args.at(-1) ?? "");
+      if (text.includes("Claude") || text.includes("Codex") || text.includes("Cursor")) {
+        launchSent = true;
+      } else {
+        agentMessageSubmitted = true;
+      }
     }
     if (args.includes("list-workspaces")) {
       return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
@@ -93,7 +99,11 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: launchSent ? "What can I help you with?\n>" : "$ ",
+          text: agentMessageSubmitted
+            ? "Claude Code\n✻ Working\n"
+            : launchSent
+              ? "What can I help you with?\n>"
+              : "$ ",
           lines: 20,
           scrollback_used: false,
         }),

--- a/tests/wait-for-cursor.test.ts
+++ b/tests/wait-for-cursor.test.ts
@@ -15,6 +15,10 @@ const CURSOR_IDLE_SCREEN = readFileSync(
   join(process.cwd(), "tests/fixtures/cursor-2026-06-04-boot-ready.txt"),
   "utf8",
 );
+const CURSOR_DONE_SCREEN = readFileSync(
+  join(process.cwd(), "tests/fixtures/cursor-2026-06-04-task-done.txt"),
+  "utf8",
+);
 
 function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
   return {
@@ -95,11 +99,13 @@ describe("wait_for Cursor terminal idle", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     engine.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("resolves done promptly when a Cursor agent reaches its terminal idle state", async () => {
+  it("does not resolve done from Cursor idle registry state without output evidence", async () => {
+    vi.useFakeTimers();
     const parsed = parseScreen(CURSOR_IDLE_SCREEN);
     expect(parsed.agent_type).toBe("cursor");
     expect(parsed.status).toBe("idle");
@@ -107,14 +113,65 @@ describe("wait_for Cursor terminal idle", () => {
     stateMgr.writeState(makeRecord({ state: parsed.status }));
     await engine.getRegistry().reconstitute();
 
-    const result = await engine.waitFor("cmuxlayerCursor-idle", "done", 50);
+    const pending = engine.waitFor("cmuxlayerCursor-idle", "done", 1_500);
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await pending;
 
-    expect(result.matched).toBe(true);
+    expect(result.matched).toBe(false);
     expect(result.state).toBe("idle");
-    expect(result.source).toBe("immediate");
+    expect(result.source).toBe("timeout");
     expect(result.agent).toMatchObject({
       agent_id: "cmuxlayerCursor-idle",
       state: "idle",
+    });
+  });
+
+  it("resolves done from a Cursor screen with a done signal", async () => {
+    vi.useFakeTimers();
+    const candidateAt = new Date("2026-06-04T22:01:10.000Z");
+    vi.setSystemTime(new Date(candidateAt.getTime() + 5_001));
+    const parsed = parseScreen(CURSOR_DONE_SCREEN);
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("done");
+    expect(parsed.done_signal).toBe("TASK_DONE");
+
+    engine.dispose();
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine = new AgentEngine(
+      stateMgr,
+      registry,
+      makeMockClient({
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:cursor-idle",
+          text: CURSOR_DONE_SCREEN,
+          lines: 80,
+          scrollback_used: false,
+        }),
+      }),
+      {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+      },
+    );
+
+    stateMgr.writeState(
+      makeRecord({
+        state: "idle",
+        task_done_candidate_at: candidateAt.toISOString(),
+      }),
+    );
+    await engine.getRegistry().reconstitute();
+
+    const pending = engine.waitFor("cmuxlayerCursor-idle", "done", 1_500);
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await pending;
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("done");
+    expect(result.source).toBe("screen");
+    expect(result.agent).toMatchObject({
+      agent_id: "cmuxlayerCursor-idle",
+      state: "done",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add submit verification v2 metadata and tri-state outcomes for interactive and background deliveries.
- Treat cleared composers without working/thinking evidence as uncertain (`submit_verified:null`) instead of a false green or hard failure while the pane is alive.
- Require real done-signal output for Cursor `wait_for(done)` so idle alone cannot resolve the wait.
- Preserve launcher update/relaunch readiness after uncertain submit evidence.

## Verification
- `bun run typecheck`
- `bun run test` (67 files passed, 1208 tests passed, 3 todo)
- `git diff --check`
- Push hook reran the full suite cleanly.
- CodeRabbit CLI pre-commit review attempted; CLI returned a recoverable rate limit with waitTime=29 minutes.

## Notes
- Do not merge yet; reviewer pass requested next.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input delivery and wait-for-done semantics used by orchestration; mis-tuned timeouts could leave submits uncertain or boot paths stricter, but the goal is fewer false-positive “verified” submits.
> 
> **Overview**
> **Submit verification v2** tightens Enter/submit proof across `send_input`, boot prompts, and launcher delivery. Cleared composers and idle-after-submit no longer count as verified; only parsed **working** or **thinking** status confirms submit. When input clears but the CLI never shows that evidence, callers get **`submit_verified: null`** instead of a false green or, in some alive-pane cases, a hard failure. **`allow_non_agent_clear`** is removed; background deliveries carry **`verify_submit`**, **`submit_verified`**, and **`retry_count`**, and interactive **`send_input`** verifies only when the surface has a registry agent in **ready/idle**.
> 
> Launcher and boot flows get shorter or bounded verify timeouts, a one-shot launch probe when submit stays unproven, and boot readiness that no longer treats cleared input as submit evidence. MCP tools return structured **`SubmitVerificationError`** payloads where applicable.
> 
> **Cursor `wait_for(done)`** drops the idle short-circuit: **`isCursorTerminalIdleTarget`** is removed, so **done** waits need transcript or screen **done-signal** evidence like other agents. Tests and painpoint fixtures are updated for the new tri-state behavior and stricter boot/Cursor expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005d8f0814c7c5af741a4f8331f295c1c4425d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Eliminate false-green submit verification by requiring explicit working evidence
> - Removes the Cursor-idle-as-done shortcut in `AgentEngine.getTargetStateEvidenceSource`; waiting for `done` now requires actual output evidence or an explicit `done` state.
> - Tightens `verifySubmitAfterEnter` so cleared input without a working/thinking status yields `submit_verified=null` (uncertain) or `false` rather than `true`.
> - Adds `verify_submit`, `submit_verified`, and `retry_count` fields to `DeliveryRecord` and surfaces them in API responses and tool results across `send_to`, `send_command`, `spawn_in_workspace`, `wait_for`, and `wait_for_all`.
> - Boot prompt readiness (`waitForBootPromptReady`) now requires explicit working evidence; a cleared prompt alone no longer satisfies readiness.
> - Launcher commands (`sendLauncherCommandToSurface`) tolerate ambiguous clears by probing readiness once before escalating to a full `waitForAgentLaunchReady` cycle.
> - Risk: callers that previously treated a cleared input as a verified submit will now receive `submit_verified=null` and must handle the uncertain outcome explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 005d8f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->