### PR TITLE
feat(spawn): auto-skip Codex update menu with structured refusal fallback

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -174,6 +174,7 @@ const INTERACTIVE_PROMPT_CLARIFICATION_RE =
 const MENU_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
 const MENU_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
 const BARE_READY_PROMPT_RE = /^\s*(?:[>❯›]|codex\s*>)\s*$/i;
+const CODEX_UPDATE_MENU_WINDOW_LINES = 12;
 const PERMISSION_PROMPT_PRIMARY_RE = /approve command\?|do you want to allow/i;
 const PERMISSION_PROMPT_MARKER_RE =
   /approve command\?|do you want to allow|allow for this session|\[y\/n\]/i;
@@ -253,7 +254,7 @@ function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-function isCodexUpdateMenuScreenNormalized(normalized: string): boolean {
+function hasCodexUpdateMenuMarkers(normalized: string): boolean {
   return (
     (CODEX_BOOT_PANEL_RE.test(normalized) || CODEX_HEADER_RE.test(normalized)) &&
     CODEX_UPDATE_MENU_RE.test(normalized) &&
@@ -262,8 +263,52 @@ function isCodexUpdateMenuScreenNormalized(normalized: string): boolean {
   );
 }
 
+function isCodexUpdateMenuScreenNormalized(
+  normalized: string,
+  opts?: { tailOnly?: boolean },
+): boolean {
+  if (!hasCodexUpdateMenuMarkers(normalized)) {
+    return false;
+  }
+  if (!opts?.tailOnly) {
+    return true;
+  }
+
+  const lines = normalized.split("\n");
+  const lastMeaningfulIndex = lines.reduce(
+    (last, line, index) => (line.trim() ? index : last),
+    -1,
+  );
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const block = lines
+      .slice(index, index + CODEX_UPDATE_MENU_WINDOW_LINES)
+      .join("\n");
+    if (!hasCodexUpdateMenuMarkers(block)) {
+      continue;
+    }
+    if (
+      lines
+        .slice(index + 1)
+        .some((line) => BARE_READY_PROMPT_RE.test(line))
+    ) {
+      continue;
+    }
+    if (lastMeaningfulIndex <= index + CODEX_UPDATE_MENU_WINDOW_LINES - 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function isCodexUpdateMenuScreen(text: string): boolean {
-  return isCodexUpdateMenuScreenNormalized(normalizeText(text));
+  return isCodexUpdateMenuScreenNormalized(normalizeText(text), {
+    tailOnly: true,
+  });
+}
+
+function hasActiveCodexUpdateMenuScreen(text: string): boolean {
+  return isCodexUpdateMenuScreenNormalized(text, { tailOnly: true });
 }
 
 function stripOrphanTtyControlTrailer(line: string): string {
@@ -328,7 +373,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (
     CODEX_HEADER_RE.test(text) ||
     (CODEX_BOOT_PANEL_RE.test(text) && CODEX_PANEL_MODEL_RE.test(text)) ||
-    isCodexUpdateMenuScreenNormalized(text) ||
+    hasActiveCodexUpdateMenuScreen(text) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {
@@ -617,7 +662,7 @@ function parseErrors(text: string): string[] {
   if (
     !errors.includes("permission_prompt") &&
     !errors.includes("interactive_prompt") &&
-    isCodexUpdateMenuScreenNormalized(text)
+    hasActiveCodexUpdateMenuScreen(text)
   ) {
     errors.push("interactive_prompt");
   }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -188,7 +188,8 @@ const CODEX_WORKING_RE =
   /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
 const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
 const CODEX_ACTION_RE = /^\s*[•·]\s+(.+)$/gm;
-const CODEX_UPDATE_MENU_RE = /(?:^|\n)\s*Update available!\s*(?:\n|$)/i;
+const CODEX_UPDATE_MENU_RE =
+  /(?:^|\n)\s*(?:\u2728\s*)?Update available!\s*(?:\n|$)/i;
 const CODEX_UPDATE_MENU_SKIP_RE =
   /(?:^|\n)\s*(?:[>❯]\s*)?Skip until next version\s*(?:\n|$)/i;
 const CODEX_UPDATE_MENU_RELEASE_NOTES_RE =
@@ -252,14 +253,17 @@ function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-export function isCodexUpdateMenuScreen(text: string): boolean {
-  const normalized = normalizeText(text);
+function isCodexUpdateMenuScreenNormalized(normalized: string): boolean {
   return (
     (CODEX_BOOT_PANEL_RE.test(normalized) || CODEX_HEADER_RE.test(normalized)) &&
     CODEX_UPDATE_MENU_RE.test(normalized) &&
     CODEX_UPDATE_MENU_SKIP_RE.test(normalized) &&
     CODEX_UPDATE_MENU_RELEASE_NOTES_RE.test(normalized)
   );
+}
+
+export function isCodexUpdateMenuScreen(text: string): boolean {
+  return isCodexUpdateMenuScreenNormalized(normalizeText(text));
 }
 
 function stripOrphanTtyControlTrailer(line: string): string {
@@ -324,7 +328,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (
     CODEX_HEADER_RE.test(text) ||
     (CODEX_BOOT_PANEL_RE.test(text) && CODEX_PANEL_MODEL_RE.test(text)) ||
-    isCodexUpdateMenuScreen(text) ||
+    isCodexUpdateMenuScreenNormalized(text) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {
@@ -613,7 +617,7 @@ function parseErrors(text: string): string[] {
   if (
     !errors.includes("permission_prompt") &&
     !errors.includes("interactive_prompt") &&
-    isCodexUpdateMenuScreen(text)
+    isCodexUpdateMenuScreenNormalized(text)
   ) {
     errors.push("interactive_prompt");
   }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -255,6 +255,7 @@ function normalizeText(text: string): string {
 export function isCodexUpdateMenuScreen(text: string): boolean {
   const normalized = normalizeText(text);
   return (
+    (CODEX_BOOT_PANEL_RE.test(normalized) || CODEX_HEADER_RE.test(normalized)) &&
     CODEX_UPDATE_MENU_RE.test(normalized) &&
     CODEX_UPDATE_MENU_SKIP_RE.test(normalized) &&
     CODEX_UPDATE_MENU_RELEASE_NOTES_RE.test(normalized)

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -188,6 +188,11 @@ const CODEX_WORKING_RE =
   /Working\s*\(([0-9]+m\s*[0-9]+s)\s*[•·]\s*esc to interrupt\)/i;
 const CODEX_RESUME_RE = /To continue this session,\s*run\s+codex\s+resume/i;
 const CODEX_ACTION_RE = /^\s*[•·]\s+(.+)$/gm;
+const CODEX_UPDATE_MENU_RE = /(?:^|\n)\s*Update available!\s*(?:\n|$)/i;
+const CODEX_UPDATE_MENU_SKIP_RE =
+  /(?:^|\n)\s*(?:[>❯]\s*)?Skip until next version\s*(?:\n|$)/i;
+const CODEX_UPDATE_MENU_RELEASE_NOTES_RE =
+  /(?:^|\n)\s*(?:See full release notes:|https:\/\/github\.com\/openai\/codex\/releases(?:\/latest)?)\s*(?:\n|$)/i;
 const GEMINI_MODEL_RE =
   /(?:^|\n)\s*(?:-\s*)?(?:Model:\s*)?(gemini-[0-9][0-9a-z.-]*)\b/im;
 const GEMINI_WORKING_RE = /^\s*(?:✦\s*)?Working(?:\.\.\.|…)?\s*$/im;
@@ -245,6 +250,15 @@ function stripAnsi(text: string): string {
 
 function normalizeText(text: string): string {
   return stripAnsi(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function isCodexUpdateMenuScreen(text: string): boolean {
+  const normalized = normalizeText(text);
+  return (
+    CODEX_UPDATE_MENU_RE.test(normalized) &&
+    CODEX_UPDATE_MENU_SKIP_RE.test(normalized) &&
+    CODEX_UPDATE_MENU_RELEASE_NOTES_RE.test(normalized)
+  );
 }
 
 function stripOrphanTtyControlTrailer(line: string): string {
@@ -309,6 +323,7 @@ function detectAgentType(text: string): ParsedScreenAgentType {
   if (
     CODEX_HEADER_RE.test(text) ||
     (CODEX_BOOT_PANEL_RE.test(text) && CODEX_PANEL_MODEL_RE.test(text)) ||
+    isCodexUpdateMenuScreen(text) ||
     CODEX_WORKING_RE.test(text) ||
     CODEX_RESUME_RE.test(text)
   ) {
@@ -591,6 +606,14 @@ function parseErrors(text: string): string[] {
   }
 
   if (!errors.includes("permission_prompt") && hasInteractivePromptBlock(text)) {
+    errors.push("interactive_prompt");
+  }
+
+  if (
+    !errors.includes("permission_prompt") &&
+    !errors.includes("interactive_prompt") &&
+    isCodexUpdateMenuScreen(text)
+  ) {
     errors.push("interactive_prompt");
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2066,7 +2066,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         }
       } catch (error) {
-        if (error instanceof BootPromptTimeoutError) {
+        if (
+          error instanceof BootPromptTimeoutError ||
+          error instanceof BootPromptUpdateMenuBlockedError
+        ) {
           throw error;
         }
         if (isSurfaceGoneReadFailure(error, opts.surface)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1988,15 +1988,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
           updateWasSeen = true;
-          codexUpdateMenuDismissed = true;
           consecutiveMatches.clear();
-          await client.sendKey(opts.surface, "down", {
-            workspace: opts.workspace,
-          });
+          await sendKeyWithRetry(opts.surface, "down", opts.workspace);
           await delay(SEND_INPUT_ENTER_DELAY_MS);
-          await client.sendKey(opts.surface, "return", {
-            workspace: opts.workspace,
-          });
+          await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+          codexUpdateMenuDismissed = true;
           const dismissedAt = Date.now();
           deadline = Math.max(deadline, dismissedAt + postUpdateReadyBudgetMs());
           await delay(BOOT_PROMPT_READY_POLL_MS);

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import {
 import {
   cleanScreenText,
   inferContextWindow,
+  isCodexUpdateMenuScreen,
   parseScreen,
 } from "./screen-parser.js";
 import {
@@ -317,6 +318,20 @@ class BootPromptDeliveryError extends Error {
   ) {
     super(message);
     this.name = "BootPromptDeliveryError";
+  }
+}
+
+class BootPromptUpdateMenuBlockedError extends Error {
+  readonly error_code = "blocked_by_update_menu";
+  readonly recovery =
+    "Codex is showing the interactive update menu. Select 'Skip until next version' and rerun the spawn, or launch Codex once manually and dismiss the menu.";
+
+  constructor(
+    message: string,
+    readonly last_10_lines: string[],
+  ) {
+    super(message);
+    this.name = "BootPromptUpdateMenuBlockedError";
   }
 }
 
@@ -839,6 +854,13 @@ function matchesCliUpdateContinuationMarker(text: string): boolean {
   return /(?:^|\n)[^\n]*(?:Update ran successfully|Please restart)[^\n]*/i.test(
     text,
   );
+}
+
+function shouldHandleCodexUpdateMenu(
+  cli: CliType | undefined,
+  text: string,
+): boolean {
+  return (cli === undefined || cli === "codex") && isCodexUpdateMenuScreen(text);
 }
 
 function readyPatternCandidates(cli?: CliType): CliType[] {
@@ -1938,6 +1960,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateElapsedMs = 0;
     let updateWasSeen = false;
     let updateShellRelaunches = 0;
+    let codexUpdateMenuDismissed = false;
     const updateMaxMs = bootPromptUpdateMaxMs();
     const postUpdateReadyBudgetMs = () =>
       Math.max(opts.timeout_ms, BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS);
@@ -1956,6 +1979,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           matchesCliUpdateMarker(screen.text) ||
           (matchesCliUpdateContinuationMarker(screen.text) &&
             !matchesShellPrompt(screen.text));
+
+        if (shouldHandleCodexUpdateMenu(opts.cli, screen.text)) {
+          if (codexUpdateMenuDismissed) {
+            throw new BootPromptUpdateMenuBlockedError(
+              `Boot prompt delivery blocked by Codex update menu on ${opts.surface}`,
+              tailLines(lastText, 10),
+            );
+          }
+          updateWasSeen = true;
+          codexUpdateMenuDismissed = true;
+          consecutiveMatches.clear();
+          await client.sendKey(opts.surface, "down", {
+            workspace: opts.workspace,
+          });
+          await delay(SEND_INPUT_ENTER_DELAY_MS);
+          await client.sendKey(opts.surface, "return", {
+            workspace: opts.workspace,
+          });
+          const dismissedAt = Date.now();
+          deadline = Math.max(deadline, dismissedAt + postUpdateReadyBudgetMs());
+          await delay(BOOT_PROMPT_READY_POLL_MS);
+          continue;
+        }
 
         if (updateMarker) {
           updateWasSeen = true;
@@ -3289,6 +3335,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             last_10_lines: e.last_10_lines,
           });
         }
+        if (e instanceof BootPromptUpdateMenuBlockedError) {
+          return err(e, {
+            surface: result?.surface,
+            error_code: e.error_code,
+            last_10_lines: e.last_10_lines,
+            recovery: e.recovery,
+          });
+        }
         if (e instanceof BootPromptDeliveryError) {
           return err(e, {
             surface: result?.surface,
@@ -3408,6 +3462,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return err(e, {
             surface: result?.surface,
             last_10_lines: e.last_10_lines,
+          });
+        }
+        if (e instanceof BootPromptUpdateMenuBlockedError) {
+          return err(e, {
+            surface: result?.surface,
+            error_code: e.error_code,
+            last_10_lines: e.last_10_lines,
+            recovery: e.recovery,
           });
         }
         if (e instanceof BootPromptDeliveryError) {
@@ -3797,6 +3859,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, { last_10_lines: e.last_10_lines });
+        }
+        if (e instanceof BootPromptUpdateMenuBlockedError) {
+          return err(e, {
+            error_code: e.error_code,
+            last_10_lines: e.last_10_lines,
+            recovery: e.recovery,
+          });
         }
         if (e instanceof BootPromptDeliveryError) {
           return err(e, { delivered_chars: e.delivered_chars });
@@ -5302,6 +5371,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 // Preserve the original timeout response.
               }
               return err(e, { ...extra, last_10_lines: e.last_10_lines });
+            }
+            if (e instanceof BootPromptUpdateMenuBlockedError) {
+              return err(e, {
+                ...extra,
+                error_code: e.error_code,
+                last_10_lines: e.last_10_lines,
+                recovery: e.recovery,
+              });
             }
             if (e instanceof BootPromptDeliveryError) {
               return err(e, { ...extra, delivered_chars: e.delivered_chars });

--- a/src/server.ts
+++ b/src/server.ts
@@ -209,6 +209,8 @@ const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const BOOT_PROMPT_UPDATE_MAX_MS = 120_000;
 const BOOT_PROMPT_UPDATE_RELAUNCH_MAX = 2;
+const BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS =
+  BOOT_PROMPT_READY_POLL_MS * 3;
 const BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS = BOOT_PROMPT_READY_POLL_MS * 3;
 
 function bootPromptUpdateMaxMs(): number {
@@ -1961,6 +1963,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateWasSeen = false;
     let updateShellRelaunches = 0;
     let codexUpdateMenuDismissed = false;
+    let codexUpdateMenuDismissedAt: number | null = null;
     const updateMaxMs = bootPromptUpdateMaxMs();
     const postUpdateReadyBudgetMs = () =>
       Math.max(opts.timeout_ms, BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS);
@@ -1982,6 +1985,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
         if (shouldHandleCodexUpdateMenu(opts.cli, screen.text)) {
           if (codexUpdateMenuDismissed) {
+            const elapsedSinceDismissMs =
+              codexUpdateMenuDismissedAt === null
+                ? BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS
+                : now - codexUpdateMenuDismissedAt;
+            if (
+              elapsedSinceDismissMs < BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS
+            ) {
+              consecutiveMatches.clear();
+              await delay(BOOT_PROMPT_READY_POLL_MS);
+              continue;
+            }
             throw new BootPromptUpdateMenuBlockedError(
               `Boot prompt delivery blocked by Codex update menu on ${opts.surface}`,
               tailLines(lastText, 10),
@@ -1994,7 +2008,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await sendKeyWithRetry(opts.surface, "return", opts.workspace);
           codexUpdateMenuDismissed = true;
           const dismissedAt = Date.now();
-          deadline = Math.max(deadline, dismissedAt + postUpdateReadyBudgetMs());
+          codexUpdateMenuDismissedAt = dismissedAt;
+          deadline = Math.max(
+            deadline,
+            dismissedAt + postUpdateReadyBudgetMs(),
+            dismissedAt +
+              BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS +
+              BOOT_PROMPT_READY_POLL_MS,
+          );
           await delay(BOOT_PROMPT_READY_POLL_MS);
           continue;
         }

--- a/tests/fixtures/painpoints/codex-update-menu.txt
+++ b/tests/fixtures/painpoints/codex-update-menu.txt
@@ -1,0 +1,16 @@
+# RECONSTRUCTED fixture, 2026-07-05.
+# Source evidence: local Codex CLI 0.142.5 native binary strings include
+# "Update available!", "See full release notes:",
+# "https://github.com/openai/codex/releases/latest",
+# "See https://github.com/openai/codex for installation options.",
+# and "Skip until next version".
+
+>_ OpenAI Codex
+
+Update available!
+See full release notes:
+https://github.com/openai/codex/releases/latest
+See https://github.com/openai/codex for installation options.
+
+> Release notes
+  Skip until next version

--- a/tests/fixtures/painpoints/codex-update-menu.txt
+++ b/tests/fixtures/painpoints/codex-update-menu.txt
@@ -1,10 +1,3 @@
-# RECONSTRUCTED fixture, 2026-07-05.
-# Source evidence: local Codex CLI 0.142.5 native binary strings include
-# "Update available!", "See full release notes:",
-# "https://github.com/openai/codex/releases/latest",
-# "See https://github.com/openai/codex for installation options.",
-# and "Skip until next version".
-
 >_ OpenAI Codex
 
 Update available!

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -57,6 +57,7 @@ function readPainpointFixture(fileName: string): PainpointFixture {
   const expectedById: Record<string, string> = {
     "claude-ask-user-question-overlay": "interactive_overlay",
     "claude-permission-confirmation": "permission_prompt",
+    "codex-update-menu": "interactive_overlay",
     "bare-shell-and-bare-gemini-prompt": "shell",
   };
   return {
@@ -161,6 +162,7 @@ describe("Phase 0 painpoint replay corpus", () => {
       "boot-prompt-typed-not-submitted",
       "claude-ask-user-question-overlay",
       "claude-permission-confirmation",
+      "codex-update-menu",
       "empty-dead-pane-submit",
       "long-inline-prompt-wedge",
       "multiline-payload-premature-submit",

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -64,7 +64,7 @@ function readPainpointFixture(fileName: string): PainpointFixture {
     id,
     expected_state: expectedById[id] ?? "unknown",
     phase_home:
-      id === "bare-shell-and-bare-gemini-prompt"
+      id === "bare-shell-and-bare-gemini-prompt" || id === "codex-update-menu"
         ? "phase-3-spawn-readiness-monitor-boot"
         : "phase-1-delivery-safety-gate",
     source_evidence: [fileName],

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -118,10 +118,28 @@ Select a model for the next worker:
   });
 
   it("recognizes the Codex update menu as an interactive overlay", () => {
+    // Reconstructed from local Codex CLI 0.142.5 binary strings; fixture stays screen-only.
     const parsed = parseScreen(readFixture("painpoints/codex-update-menu.txt"));
 
     expect(parsed.agent_type).toBe("codex");
     expect(parsed.status).toBe("frozen");
+    expect(parsed.errors).toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("interactive_overlay");
+  });
+
+  it("recognizes a Codex update menu with a sparkle-prefixed update line", () => {
+    const parsed = parseScreen(`
+>_ OpenAI Codex
+
+\u2728 Update available!
+See full release notes:
+https://github.com/openai/codex/releases/latest
+
+> Release notes
+  Skip until next version
+`);
+
+    expect(parsed.agent_type).toBe("codex");
     expect(parsed.errors).toContain("interactive_prompt");
     expect(parsed.control_state).toBe("interactive_overlay");
   });

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -182,6 +182,32 @@ This is copied documentation, not a live Codex TUI menu.
     expect(parsed.control_state).toBe("ready");
   });
 
+  it("does not classify a pasted Codex update menu transcript above a Claude prompt as active", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Here is the Codex screen I copied:
+
+>_ OpenAI Codex
+
+Update available!
+See full release notes:
+https://github.com/openai/codex/releases/latest
+See https://github.com/openai/codex for installation options.
+
+> Release notes
+  Skip until next version
+
+This is copied output, not the active TUI.
+
+❯
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
   it("recognizes permission prompts without numbered options", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -144,6 +144,26 @@ This is copied prose, not a live Codex TUI menu.
     expect(parsed.control_state).toBe("ready");
   });
 
+  it("does not classify prose with Codex update release-note lines as an update menu", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Reviewer note:
+Update available!
+See full release notes:
+https://github.com/openai/codex/releases/latest
+Skip until next version
+
+This is copied documentation, not a live Codex TUI menu.
+
+❯
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
   it("recognizes permission prompts without numbered options", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -117,6 +117,33 @@ Select a model for the next worker:
     expect(parsed.control_state).toBe("interactive_overlay");
   });
 
+  it("recognizes the Codex update menu as an interactive overlay", () => {
+    const parsed = parseScreen(readFixture("painpoints/codex-update-menu.txt"));
+
+    expect(parsed.agent_type).toBe("codex");
+    expect(parsed.status).toBe("frozen");
+    expect(parsed.errors).toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("interactive_overlay");
+  });
+
+  it("does not classify prose with isolated Codex update strings as an update menu", () => {
+    const parsed = parseScreen(`
+Claude Code
+
+Standup notes:
+Update available!
+Skip until next version
+
+This is copied prose, not a live Codex TUI menu.
+
+❯
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.errors).not.toContain("interactive_prompt");
+    expect(parsed.control_state).toBe("ready");
+  });
+
   it("recognizes permission prompts without numbered options", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4180,6 +4180,163 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
+  it("spawn_agent skips the interactive Codex update menu before delivering the boot prompt", async () => {
+    vi.useRealTimers();
+    const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
+    process.env.REPOGOLEM_ALLOW_MODEL = "1";
+    const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-state");
+    const promptPath = join(CHANNEL_TEST_DIR, "spawn-update-menu.md");
+    const prompt = "boot after skipping update menu";
+    const updateMenu = [
+      ">_ OpenAI Codex",
+      "",
+      "Update available!",
+      "See full release notes:",
+      "https://github.com/openai/codex/releases/latest",
+      "See https://github.com/openai/codex for installation options.",
+      "",
+      "> Release notes",
+      "  Skip until next version",
+    ].join("\n");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+
+    let launcherSent = false;
+    let updateMenuSkipped = false;
+    let promptSent = false;
+    const sentTexts: string[] = [];
+    const sentKeys: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "cmuxlayer",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key")) {
+        const key = String(args.at(-1) ?? "");
+        sentKeys.push(key);
+        if (key === "return" && sentKeys.at(-2) === "down") {
+          updateMenuSkipped = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        sentTexts.push(text);
+        if (text.includes("cmuxlayerCodex")) {
+          launcherSent = true;
+        } else if (text === prompt) {
+          promptSent = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        let text = "$ ";
+        if (launcherSent && !updateMenuSkipped) {
+          text = updateMenu;
+        } else if (launcherSent && updateMenuSkipped && !promptSent) {
+          text = "codex> ";
+        } else if (promptSent) {
+          text =
+            "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (
+      server as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (
+              args: Record<string, unknown>,
+              context: unknown,
+            ) => Promise<{
+              structuredContent?: Record<string, unknown>;
+              content: Array<{ text: string }>;
+            }>;
+          }
+        >;
+      }
+    )._registeredTools["spawn_agent"];
+
+    try {
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 500,
+        },
+        {},
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.boot_prompt_delivered).toBe(true);
+      expect(sentKeys).toEqual(expect.arrayContaining(["down", "return"]));
+      expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
+    } finally {
+      if (previousAllowModel === undefined) {
+        delete process.env.REPOGOLEM_ALLOW_MODEL;
+      } else {
+        process.env.REPOGOLEM_ALLOW_MODEL = previousAllowModel;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it("new_split times out when a CLI auto-update marker never clears", async () => {
     vi.useFakeTimers();
     const previousUpdateMax = process.env.CMUXLAYER_BOOT_PROMPT_UPDATE_MAX_MS;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4205,6 +4205,7 @@ describe("tool handler integration", () => {
     let launcherSent = false;
     let updateMenuSkipped = false;
     let promptSent = false;
+    let downAttempts = 0;
     const sentTexts: string[] = [];
     const sentKeys: string[] = [];
 
@@ -4249,6 +4250,12 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key")) {
         const key = String(args.at(-1) ?? "");
+        if (key === "down") {
+          downAttempts += 1;
+          if (downAttempts === 1) {
+            throw new Error("socket timeout");
+          }
+        }
         sentKeys.push(key);
         if (key === "return" && sentKeys.at(-2) === "down") {
           updateMenuSkipped = true;
@@ -4325,6 +4332,7 @@ describe("tool handler integration", () => {
         result.structuredContent ?? JSON.parse(result.content[0].text);
       expect(parsed.ok).toBe(true);
       expect(parsed.boot_prompt_delivered).toBe(true);
+      expect(downAttempts).toBe(2);
       expect(sentKeys).toEqual(expect.arrayContaining(["down", "return"]));
       expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
     } finally {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4345,6 +4345,166 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
+  it("spawn_agent keeps polling after a slow Codex update menu dismissal", async () => {
+    vi.useRealTimers();
+    const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
+    process.env.REPOGOLEM_ALLOW_MODEL = "1";
+    const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-slow-state");
+    const promptPath = join(CHANNEL_TEST_DIR, "spawn-update-menu-slow.md");
+    const prompt = "boot after a slow update menu repaint";
+    const updateMenu = [
+      ">_ OpenAI Codex",
+      "",
+      "Update available!",
+      "See full release notes:",
+      "https://github.com/openai/codex/releases/latest",
+      "See https://github.com/openai/codex for installation options.",
+      "",
+      "> Release notes",
+      "  Skip until next version",
+    ].join("\n");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, prompt, "utf8");
+
+    let launcherSent = false;
+    let updateMenuSkipped = false;
+    let promptSent = false;
+    let postDismissMenuReads = 0;
+    const sentTexts: string[] = [];
+    const sentKeys: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "cmuxlayer",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key")) {
+        const key = String(args.at(-1) ?? "");
+        sentKeys.push(key);
+        if (key === "return" && sentKeys.at(-2) === "down") {
+          updateMenuSkipped = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        sentTexts.push(text);
+        if (text.includes("cmuxlayerCodex")) {
+          launcherSent = true;
+        } else if (text === prompt) {
+          promptSent = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        let text = "$ ";
+        if (launcherSent && !updateMenuSkipped) {
+          text = updateMenu;
+        } else if (launcherSent && updateMenuSkipped && !promptSent) {
+          postDismissMenuReads += 1;
+          text = postDismissMenuReads === 1 ? updateMenu : "codex> ";
+        } else if (promptSent) {
+          text =
+            "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (
+      server as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (
+              args: Record<string, unknown>,
+              context: unknown,
+            ) => Promise<{
+              structuredContent?: Record<string, unknown>;
+              content: Array<{ text: string }>;
+            }>;
+          }
+        >;
+      }
+    )._registeredTools["spawn_agent"];
+
+    try {
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 500,
+        },
+        {},
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.boot_prompt_delivered).toBe(true);
+      expect(postDismissMenuReads).toBe(2);
+      expect(sentKeys).toEqual(expect.arrayContaining(["down", "return"]));
+      expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);
+    } finally {
+      if (previousAllowModel === undefined) {
+        delete process.env.REPOGOLEM_ALLOW_MODEL;
+      } else {
+        process.env.REPOGOLEM_ALLOW_MODEL = previousAllowModel;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it("spawn_agent returns blocked_by_update_menu when the Codex update menu remains after dismissal", async () => {
     vi.useRealTimers();
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4345,6 +4345,143 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
+  it("spawn_agent returns blocked_by_update_menu when the Codex update menu remains after dismissal", async () => {
+    vi.useRealTimers();
+    const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
+    process.env.REPOGOLEM_ALLOW_MODEL = "1";
+    const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-blocked-state");
+    const promptPath = join(CHANNEL_TEST_DIR, "spawn-update-menu-blocked.md");
+    const updateMenu = [
+      ">_ OpenAI Codex",
+      "",
+      "Update available!",
+      "See full release notes:",
+      "https://github.com/openai/codex/releases/latest",
+      "See https://github.com/openai/codex for installation options.",
+      "",
+      "> Release notes",
+      "  Skip until next version",
+    ].join("\n");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot that should be blocked", "utf8");
+
+    let launcherSent = false;
+    const sentKeys: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "cmuxlayer",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send-key")) {
+        sentKeys.push(String(args.at(-1) ?? ""));
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        if (text.includes("cmuxlayerCodex")) {
+          launcherSent = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:2",
+            text: launcherSent ? updateMenu : "$ ",
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (
+      server as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (
+              args: Record<string, unknown>,
+              context: unknown,
+            ) => Promise<{
+              structuredContent?: Record<string, unknown>;
+              content: Array<{ text: string }>;
+            }>;
+          }
+        >;
+      }
+    )._registeredTools["spawn_agent"];
+
+    try {
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 500,
+        },
+        {},
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error_code).toBe("blocked_by_update_menu");
+      expect(parsed.recovery).toContain("Skip until next version");
+      expect(sentKeys.slice(-2)).toEqual(["down", "return"]);
+    } finally {
+      if (previousAllowModel === undefined) {
+        delete process.env.REPOGOLEM_ALLOW_MODEL;
+      } else {
+        process.env.REPOGOLEM_ALLOW_MODEL = previousAllowModel;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it("new_split times out when a CLI auto-update marker never clears", async () => {
     vi.useFakeTimers();
     const previousUpdateMax = process.env.CMUXLAYER_BOOT_PROMPT_UPDATE_MAX_MS;


### PR DESCRIPTION
## Summary
- Classify the Codex update menu as an interactive overlay using fixture-backed parser coverage.
- Auto-skip the menu during boot prompt delivery with one guarded `down` + `return`, then continue normal readiness polling.
- Return a structured `blocked_by_update_menu` refusal with recovery guidance if the menu remains after the dismissal attempt.
- Harden the classifier against prose false positives by requiring a release-notes structural anchor in addition to the update and skip lines.

## Test plan
- `bun run typecheck` — exit 0
- `bun run test -- tests/screen-parser.test.ts tests/painpoint-replay.test.ts tests/server.test.ts -t "Codex update menu|isolated Codex update strings|spawn_agent skips|loads every required"` — 3 files passed, 4 tests passed, 213 skipped
- `bun run test` — 67 files passed, 1218 tests passed, 3 todo
- Push hook `run_tests.sh` — exit 0, including full Vitest run with 67 files passed, 1218 tests passed, 3 todo

## Review notes
- Local `coderabbit review --agent` was attempted before commit with a 180s timeout. It connected and emitted reviewing heartbeats but produced no findings before timing out.
- The Skip row selector is intentionally optional to avoid false negatives on legitimate Codex update menus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated boot delivery by sending keys to Codex TUI and new screen heuristics could misclassify edge cases; impact is limited to Codex spawn/boot flows with clear structured failure when auto-dismiss fails.
> 
> **Overview**
> Adds **Codex “Update available!” TUI detection** in the screen parser so live update menus classify as Codex with `interactive_prompt` / `interactive_overlay`, while pasted prose or menus above another agent’s ready prompt are ignored via tail-window and structural anchors (Codex header/boot panel, skip line, release-notes markers).
> 
> During **boot-prompt readiness polling**, when that screen is seen for Codex spawns, the server sends **one `down` + `return`** to choose “Skip until next version”, waits a short grace period for repaint, then continues normal readiness checks. If the menu is still present after that attempt, it fails with **`BootPromptUpdateMenuBlockedError`** (`error_code: blocked_by_update_menu`, `last_10_lines`, recovery text) instead of hanging until timeout.
> 
> **Spawn / split / delivery handlers** map that error to structured API responses. Fixtures and tests cover classification false positives, painpoint replay, auto-skip success, slow dismissal, and blocked-after-dismiss paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2563e1921a05526896cf874af73a4f9e7c2d00aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-skip Codex update menu during spawn with structured refusal fallback
> - Adds detection of an active Codex update menu in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/224/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) using new regexes and windowed tail-position checks; screens showing the menu are classified as `agent_type: 'codex'` with an `interactive_prompt` error.
> - When the update menu is detected during boot polling in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/224/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), the server sends `down` + `return` to select "Skip until next version", then waits a grace period (`BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS`) for the screen to repaint before resuming readiness polling.
> - If the menu persists after the grace period, boot fails with a new `BootPromptUpdateMenuBlockedError` (`error_code: 'blocked_by_update_menu'`) including `last_10_lines` and a recovery message.
> - Risk: the dismissal path sends keystrokes to the terminal unconditionally on first detection; a transient false-positive match would inject `down` + `return` into a live session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2563e19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now recognizes and handles update screens during startup, including automatically skipping them when possible.
  * Update-related screens are now classified more accurately, improving overall state detection.

* **Bug Fixes**
  * Prevents startup from stalling when an update prompt appears.
  * Provides clearer recovery feedback when the update screen blocks progress.

* **Tests**
  * Added coverage for update-screen detection, startup recovery, and related replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->