### PR TITLE
feat(lifecycle): worker harvestability assessment + verified closure artifacts (phase 7)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -805,7 +805,7 @@ export class AgentEngine {
       Boolean(goal.reportPath) &&
       Boolean(goal.doneMarker) &&
       reportText !== null &&
-      reportFresh !== false &&
+      reportFresh === true &&
       reportFinalLine === goal.doneMarker;
     const keptOpen = reportText ? this.extractKeptOpenContract(reportText) : null;
     const prLoopRequired = this.isPrLoopRequired(
@@ -1027,7 +1027,7 @@ export class AgentEngine {
         .find(
           (candidate) =>
             /^[A-Z0-9_:-]+$/.test(candidate) &&
-            /(?:DONE|NOT_GREEN|BLOCKED|KEPT_OPEN)/.test(candidate),
+            /^DONE(?:[_:-]|$)/.test(candidate),
         ) ?? null
     );
   }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4,9 +4,9 @@
  */
 
 import { spawn } from "node:child_process";
-import { statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
 import {
@@ -110,6 +110,38 @@ export interface SpawnAgentResult {
   model_policy?: SpawnModelPolicy;
   cwd?: string;
   mcp_env?: string;
+}
+
+export type HarvestabilityDoneSource = "transcript" | "screen" | "none";
+
+export interface HarvestabilityEvidenceChannel {
+  done_source: HarvestabilityDoneSource;
+  degraded: boolean;
+  reason: string | null;
+}
+
+export interface KeptOpenContract {
+  present: boolean;
+  reason: string | null;
+  owner: string | null;
+  next_check: string | null;
+  complete: boolean;
+}
+
+export interface WorkerHarvestability {
+  closeable: boolean;
+  closure_artifact_verified: boolean | null;
+  report_path: string | null;
+  done_marker: string | null;
+  report_exists: boolean | null;
+  report_fresh: boolean | null;
+  report_final_line: string | null;
+  pr_loop_required: boolean;
+  pr_loop_satisfied: boolean | null;
+  kept_open: KeptOpenContract | null;
+  evidence_channel: HarvestabilityEvidenceChannel;
+  issue_codes: string[];
+  issues: string[];
 }
 
 type CreatedAgentSurface = (CmuxNewSplitResult | CmuxNewSurfaceResult) & {
@@ -719,6 +751,377 @@ export class AgentEngine {
 
   getRegistry(): AgentRegistry {
     return this.registry;
+  }
+
+  assessHarvestability(agent: AgentRecord): WorkerHarvestability {
+    const evidenceChannel = this.readHarvestabilityEvidenceChannel(agent);
+    const issueCodes: string[] = [];
+    const issues: string[] = [];
+    const addIssue = (code: string, message: string): void => {
+      if (!issueCodes.includes(code)) issueCodes.push(code);
+      if (!issues.includes(message)) issues.push(message);
+    };
+
+    const role = agent.role ?? inferRecordRoleOrNull(agent);
+    if (agent.state !== "done" || role === "orchestrator") {
+      if (evidenceChannel.degraded) {
+        addIssue(
+          "degraded_evidence_channel",
+          evidenceChannel.reason ?? "done evidence channel is degraded",
+        );
+      }
+      return {
+        closeable: false,
+        closure_artifact_verified: null,
+        report_path: null,
+        done_marker: null,
+        report_exists: null,
+        report_fresh: null,
+        report_final_line: null,
+        pr_loop_required: false,
+        pr_loop_satisfied: null,
+        kept_open: null,
+        evidence_channel: evidenceChannel,
+        issue_codes: issueCodes,
+        issues,
+      };
+    }
+
+    const goal = this.readClosureGoalContract(agent.goal_file ?? null);
+    const reportText = goal.reportPath
+      ? this.readTextFile(goal.reportPath)
+      : null;
+    const reportExists = goal.reportPath ? reportText !== null : null;
+    const reportFresh =
+      goal.reportPath && reportText !== null
+        ? this.reportIsFreshForDoneDetection(
+            goal.reportPath,
+            agent.task_done_detected_at ?? null,
+          )
+        : null;
+    const reportFinalLine = reportText
+      ? this.extractFinalNonEmptyLine(reportText)
+      : null;
+    const closureArtifactVerified =
+      Boolean(goal.reportPath) &&
+      Boolean(goal.doneMarker) &&
+      reportText !== null &&
+      reportFresh !== false &&
+      reportFinalLine === goal.doneMarker;
+    const keptOpen = reportText ? this.extractKeptOpenContract(reportText) : null;
+    const prLoopRequired = this.isPrLoopRequired(
+      agent,
+      goal.goalText,
+      reportText,
+    );
+    const prLoopSatisfied = prLoopRequired
+      ? this.isPrLoopSatisfied(reportText ?? "")
+      : null;
+
+    if (!agent.goal_file || goal.goalReadFailed) {
+      addIssue(
+        "terminal_contract_missing",
+        "worker has no readable file-backed terminal contract",
+      );
+    }
+    if (!goal.reportPath || !goal.doneMarker) {
+      addIssue(
+        "terminal_contract_missing",
+        "worker terminal contract does not name a report path and DONE marker",
+      );
+    } else if (!reportExists) {
+      addIssue(
+        "report_missing",
+        `worker report file is missing: ${goal.reportPath}`,
+      );
+    } else if (reportFresh === false) {
+      addIssue(
+        "report_stale",
+        "worker report was last modified before task_done_detected_at",
+      );
+    } else if (!closureArtifactVerified) {
+      addIssue(
+        "done_marker_mismatch",
+        `worker report final line is ${reportFinalLine ?? "empty"}, expected ${goal.doneMarker}`,
+      );
+    }
+    if (keptOpen?.present) {
+      addIssue(
+        "kept_open",
+        `worker requested KEPT_OPEN${keptOpen.reason ? `: ${keptOpen.reason}` : ""}`,
+      );
+      if (!keptOpen.complete) {
+        addIssue(
+          "kept_open_contract_incomplete",
+          "KEPT_OPEN requires reason, owner, and next check",
+        );
+      }
+    }
+    if (prLoopRequired && prLoopSatisfied === false) {
+      addIssue(
+        "pr_loop_incomplete",
+        "PR-loop worker did not record merged/reviewed status or an explicit handoff",
+      );
+    }
+    if (evidenceChannel.degraded) {
+      addIssue(
+        "degraded_evidence_channel",
+        evidenceChannel.reason ?? "done evidence channel is degraded",
+      );
+    }
+
+    return {
+      closeable:
+        closureArtifactVerified &&
+        !keptOpen?.present &&
+        (!prLoopRequired || prLoopSatisfied === true),
+      closure_artifact_verified: closureArtifactVerified,
+      report_path: goal.reportPath,
+      done_marker: goal.doneMarker,
+      report_exists: reportExists,
+      report_fresh: reportFresh,
+      report_final_line: reportFinalLine,
+      pr_loop_required: prLoopRequired,
+      pr_loop_satisfied: prLoopSatisfied,
+      kept_open: keptOpen,
+      evidence_channel: evidenceChannel,
+      issue_codes: issueCodes,
+      issues,
+    };
+  }
+
+  private readHarvestabilityEvidenceChannel(
+    agent: AgentRecord,
+  ): HarvestabilityEvidenceChannel {
+    const session = this.loadGroundTruthSession(agent);
+    if (session?.state.done) {
+      return { done_source: "transcript", degraded: false, reason: null };
+    }
+    const expectsHarness =
+      harnessJsonlEnabled() &&
+      JSONL_HARNESSES.has(agent.cli) &&
+      Boolean(agent.cli_session_path || agent.cli_session_id);
+    const doneSource: HarvestabilityDoneSource = agent.task_done_detected_at
+      ? "screen"
+      : "none";
+    if (expectsHarness && !session) {
+      return {
+        done_source: doneSource,
+        degraded: true,
+        reason:
+          "harness JSONL session is missing or unreadable; done evidence fell back to screen parsing",
+      };
+    }
+    return { done_source: doneSource, degraded: false, reason: null };
+  }
+
+  private readClosureGoalContract(goalFile: string | null): {
+    goalText: string | null;
+    reportPath: string | null;
+    doneMarker: string | null;
+    goalReadFailed: boolean;
+  } {
+    if (!goalFile) {
+      return {
+        goalText: null,
+        reportPath: null,
+        doneMarker: null,
+        goalReadFailed: false,
+      };
+    }
+    const goalText = this.readTextFile(goalFile);
+    if (goalText === null) {
+      return {
+        goalText: null,
+        reportPath: null,
+        doneMarker: null,
+        goalReadFailed: true,
+      };
+    }
+    return {
+      goalText,
+      reportPath: this.extractReportPath(goalText, goalFile),
+      doneMarker: this.extractDoneMarker(goalText),
+      goalReadFailed: false,
+    };
+  }
+
+  private readTextFile(path: string): string | null {
+    try {
+      return readFileSync(path, "utf8");
+    } catch {
+      return null;
+    }
+  }
+
+  private extractCodeSpans(text: string): string[] {
+    return [...text.matchAll(/`([^`\r\n]+)`/g)]
+      .map((match) => match[1]?.trim() ?? "")
+      .filter((candidate) => candidate.length > 0);
+  }
+
+  private extractReportPath(goalText: string, goalFile: string): string | null {
+    const rawPath = this.extractCodeSpans(goalText).find(
+      (candidate) =>
+        /\.md$/i.test(candidate) ||
+        /(?:^|[/\\])reports[/\\].+\.md$/i.test(candidate),
+    );
+    if (!rawPath) return null;
+    return this.resolveContractPath(rawPath, goalFile);
+  }
+
+  private resolveContractPath(rawPath: string, goalFile: string): string {
+    const stripped = rawPath.trim().replace(/^file:\/\//, "");
+    if (isAbsolute(stripped)) return stripped;
+
+    const candidates: string[] = [];
+    let currentDir = dirname(goalFile);
+    for (let i = 0; i < 6; i += 1) {
+      candidates.push(resolve(currentDir, stripped));
+      const parent = dirname(currentDir);
+      if (parent === currentDir) break;
+      currentDir = parent;
+    }
+    candidates.push(resolve(process.cwd(), stripped));
+
+    return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+  }
+
+  private extractDoneMarker(goalText: string): string | null {
+    return (
+      this.extractCodeSpans(goalText)
+        .reverse()
+        .find(
+          (candidate) =>
+            /^[A-Z0-9_:-]+$/.test(candidate) &&
+            /(?:DONE|NOT_GREEN|BLOCKED|KEPT_OPEN)/.test(candidate),
+        ) ?? null
+    );
+  }
+
+  private extractFinalNonEmptyLine(text: string): string {
+    return (
+      text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .at(-1) ?? ""
+    );
+  }
+
+  private reportIsFreshForDoneDetection(
+    reportPath: string,
+    taskDoneDetectedAt: string | null,
+  ): boolean | null {
+    if (!taskDoneDetectedAt) return null;
+    const doneDetectedMs = Date.parse(taskDoneDetectedAt);
+    if (Number.isNaN(doneDetectedMs)) return null;
+    const reportMtimeMs = safeMtimeMs(reportPath);
+    if (reportMtimeMs <= 0) return null;
+    return reportMtimeMs >= doneDetectedMs;
+  }
+
+  private extractLineValue(lines: string[], label: string): string | null {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`^\\s*${escaped}\\s*:\\s*(.+)$`, "i");
+    for (const line of lines) {
+      const match = line.match(re);
+      if (match) return match[1]?.trim() ?? null;
+    }
+    return null;
+  }
+
+  private extractKeptOpenContract(text: string): KeptOpenContract | null {
+    const lines = text.split(/\r?\n/);
+    const keptOpenIndex = lines.findIndex((line) =>
+      /^\s*KEPT_OPEN:[^\r\n]+$/i.test(line),
+    );
+    if (keptOpenIndex < 0) return null;
+    const keptOpenLine = lines[keptOpenIndex] ?? "";
+    const reason =
+      keptOpenLine.match(/^\s*KEPT_OPEN:([^\r\n]+)$/i)?.[1]?.trim() || null;
+    const blockLines: string[] = [];
+    for (const line of lines.slice(keptOpenIndex + 1)) {
+      const trimmed = line.trim();
+      if (!trimmed) break;
+      if (
+        /^[A-Z0-9_:-]+$/.test(trimmed) &&
+        /(?:DONE|NOT_GREEN|BLOCKED)/.test(trimmed)
+      ) {
+        break;
+      }
+      blockLines.push(line);
+    }
+    const owner = this.extractLineValue(blockLines, "owner");
+    const nextCheck =
+      this.extractLineValue(blockLines, "next check") ??
+      this.extractLineValue(blockLines, "next_check");
+    return {
+      present: true,
+      reason,
+      owner,
+      next_check: nextCheck,
+      complete: Boolean(reason && owner && nextCheck),
+    };
+  }
+
+  private isPrLoopRequired(
+    agent: AgentRecord,
+    goalText: string | null,
+    reportText: string | null,
+  ): boolean {
+    return [agent.task_summary, goalText, reportText]
+      .filter(Boolean)
+      .join("\n")
+      .split(/\r?\n/)
+      .some((line) => this.isPrDeliverableEvidenceLine(line));
+  }
+
+  private isPrDeliverableEvidenceLine(line: string): boolean {
+    const normalized = line.trim().toLowerCase();
+    if (!normalized || this.isPrDeliverableExcludedLine(normalized)) {
+      return false;
+    }
+    return [
+      /\bpr_deliverable\s*:\s*(?:true|yes|required|1)\b/i,
+      /\bpr deliverable\s*:\s*(?:true|yes|required)\b/i,
+      /\brun\s+`?\/pr-loop`?\b/i,
+      /\b(?:open|create)\s+(?:a\s+)?pr\b/i,
+      /\bpush,?\s+(?:and\s+)?open\s+(?:a\s+)?pr\b/i,
+      /\byour\s+pr\b/i,
+    ].some((pattern) => pattern.test(line));
+  }
+
+  private isPrDeliverableExcludedLine(normalizedLine: string): boolean {
+    return (
+      /\breviewer\s+pairs?\s+before\s+pr[-_ ]?loop\b/.test(normalizedLine) ||
+      /\bbefore\s+pr[-_ ]?loop\b/.test(normalizedLine) ||
+      /\b(?:no|not|never|without|do\s+not|don't|does\s+not|doesn't)\b.{0,80}\b(?:pr[-_ ]?loop|\/pr-loop|pr\b)\b/.test(
+        normalizedLine,
+      ) ||
+      /\b(?:pr[-_ ]?loop|\/pr-loop|pr\b)\b.{0,80}\b(?:not\s+required|not\s+needed|unnecessary|not\s+a\s+deliverable|phrase)\b/.test(
+        normalizedLine,
+      )
+    );
+  }
+
+  private isPrLoopSatisfied(reportText: string): boolean {
+    if (!reportText.trim()) return false;
+    const explicitlyHandedOff =
+      /\b(?:handoff|handed off|successor transfer|explicitly handed off)\b/i.test(
+        reportText,
+      );
+    if (explicitlyHandedOff) return true;
+
+    const hasPrReference =
+      /github\.com\/\S+\/pull\/\d+/i.test(reportText) ||
+      /\bPR\s*#?\d+\b/i.test(reportText) ||
+      /\bPR\s+(?:url|status|state)\s*:/i.test(reportText);
+    const reviewOrMergeComplete =
+      /\b(?:merged|review(?:ed)?\s+(?:complete|passed|done)|review\/merge loop complete)\b/i.test(
+        reportText,
+      ) || /\bPR\s+(?:status|state)\s*:\s*(?:merged|closed)\b/i.test(reportText);
+    return hasPrReference && reviewOrMergeComplete;
   }
 
   private hasOutputDoneEvidence(cli: CliType, text: string): boolean {
@@ -2031,7 +2434,13 @@ export class AgentEngine {
     }
 
     const registered = this.registry.get(agentId) !== null;
-    const surfaceLive = await this.registry.hasLiveSurface(agent.surface_id);
+    let surfaceLive = true;
+    try {
+      surfaceLive = await this.registry.hasLiveSurface(agent.surface_id);
+    } catch {
+      // A failed topology read is inconclusive, not proof the spawn is dead.
+      return;
+    }
     if (registered && surfaceLive) {
       return;
     }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -754,7 +754,6 @@ export class AgentEngine {
   }
 
   assessHarvestability(agent: AgentRecord): WorkerHarvestability {
-    const evidenceChannel = this.readHarvestabilityEvidenceChannel(agent);
     const issueCodes: string[] = [];
     const issues: string[] = [];
     const addIssue = (code: string, message: string): void => {
@@ -763,13 +762,12 @@ export class AgentEngine {
     };
 
     const role = agent.role ?? inferRecordRoleOrNull(agent);
-    if (agent.state !== "done" || role === "orchestrator") {
-      if (evidenceChannel.degraded) {
-        addIssue(
-          "degraded_evidence_channel",
-          evidenceChannel.reason ?? "done evidence channel is degraded",
-        );
-      }
+    const neutralEvidenceChannel: HarvestabilityEvidenceChannel = {
+      done_source: agent.task_done_detected_at ? "screen" : "none",
+      degraded: false,
+      reason: null,
+    };
+    if (agent.state !== "done" || role === "orchestrator" || role === "ic") {
       return {
         closeable: false,
         closure_artifact_verified: null,
@@ -781,12 +779,13 @@ export class AgentEngine {
         pr_loop_required: false,
         pr_loop_satisfied: null,
         kept_open: null,
-        evidence_channel: evidenceChannel,
+        evidence_channel: neutralEvidenceChannel,
         issue_codes: issueCodes,
         issues,
       };
     }
 
+    const evidenceChannel = this.readHarvestabilityEvidenceChannel(agent);
     const goal = this.readClosureGoalContract(agent.goal_file ?? null);
     const reportText = goal.reportPath
       ? this.readTextFile(goal.reportPath)
@@ -794,9 +793,9 @@ export class AgentEngine {
     const reportExists = goal.reportPath ? reportText !== null : null;
     const reportFresh =
       goal.reportPath && reportText !== null
-        ? this.reportIsFreshForDoneDetection(
+        ? this.reportIsFreshForGoalContract(
             goal.reportPath,
-            agent.task_done_detected_at ?? null,
+            agent.goal_file ?? null,
           )
         : null;
     const reportFinalLine = reportText
@@ -837,7 +836,7 @@ export class AgentEngine {
     } else if (reportFresh === false) {
       addIssue(
         "report_stale",
-        "worker report was last modified before task_done_detected_at",
+        "worker report was last modified before the goal contract file",
       );
     } else if (!closureArtifactVerified) {
       addIssue(
@@ -961,13 +960,47 @@ export class AgentEngine {
   }
 
   private extractReportPath(goalText: string, goalFile: string): string | null {
-    const rawPath = this.extractCodeSpans(goalText).find(
-      (candidate) =>
-        /\.md$/i.test(candidate) ||
-        /(?:^|[/\\])reports[/\\].+\.md$/i.test(candidate),
-    );
+    const lines = goalText.split(/\r?\n/);
+    const candidates: Array<{ rawPath: string; score: number; index: number }> =
+      [];
+    let index = 0;
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex] ?? "";
+      for (const rawPath of this.extractCodeSpans(line)) {
+        if (!this.isMarkdownContractPath(rawPath)) continue;
+        const context = lines
+          .slice(Math.max(0, lineIndex - 3), lineIndex + 1)
+          .join("\n");
+        const reportsSegment = /(?:^|[/\\])reports[/\\].+\.md$/i.test(rawPath);
+        const reportContext =
+          /\breport(?:[_ -]?path)?\b/i.test(context) ||
+          /\bwrite\s+(?:the\s+)?report\b/i.test(context);
+        const basenameIncludesReport = /(?:^|[/\\])[^/\\]*report[^/\\]*\.md$/i.test(
+          rawPath,
+        );
+        candidates.push({
+          rawPath,
+          score:
+            (reportContext ? 100 : 0) +
+            (reportsSegment ? 20 : 0) +
+            (basenameIncludesReport ? 10 : 0),
+          index,
+        });
+        index += 1;
+      }
+    }
+    const rawPath = candidates
+      .sort((a, b) => b.score - a.score || b.index - a.index)
+      .at(0)?.rawPath;
     if (!rawPath) return null;
     return this.resolveContractPath(rawPath, goalFile);
+  }
+
+  private isMarkdownContractPath(rawPath: string): boolean {
+    return (
+      /\.md$/i.test(rawPath) ||
+      /(?:^|[/\\])reports[/\\].+\.md$/i.test(rawPath)
+    );
   }
 
   private resolveContractPath(rawPath: string, goalFile: string): string {
@@ -1009,16 +1042,16 @@ export class AgentEngine {
     );
   }
 
-  private reportIsFreshForDoneDetection(
+  private reportIsFreshForGoalContract(
     reportPath: string,
-    taskDoneDetectedAt: string | null,
+    goalFile: string | null,
   ): boolean | null {
-    if (!taskDoneDetectedAt) return null;
-    const doneDetectedMs = Date.parse(taskDoneDetectedAt);
-    if (Number.isNaN(doneDetectedMs)) return null;
+    if (!goalFile) return null;
     const reportMtimeMs = safeMtimeMs(reportPath);
+    const goalMtimeMs = safeMtimeMs(goalFile);
     if (reportMtimeMs <= 0) return null;
-    return reportMtimeMs >= doneDetectedMs;
+    if (goalMtimeMs <= 0) return null;
+    return reportMtimeMs >= goalMtimeMs;
   }
 
   private extractLineValue(lines: string[], label: string): string | null {
@@ -1107,11 +1140,7 @@ export class AgentEngine {
 
   private isPrLoopSatisfied(reportText: string): boolean {
     if (!reportText.trim()) return false;
-    const explicitlyHandedOff =
-      /\b(?:handoff|handed off|successor transfer|explicitly handed off)\b/i.test(
-        reportText,
-      );
-    if (explicitlyHandedOff) return true;
+    if (this.hasCompletedPrLoopHandoff(reportText)) return true;
 
     const hasPrReference =
       /github\.com\/\S+\/pull\/\d+/i.test(reportText) ||
@@ -1122,6 +1151,31 @@ export class AgentEngine {
         reportText,
       ) || /\bPR\s+(?:status|state)\s*:\s*(?:merged|closed)\b/i.test(reportText);
     return hasPrReference && reviewOrMergeComplete;
+  }
+
+  private hasCompletedPrLoopHandoff(reportText: string): boolean {
+    return reportText
+      .split(/\r?\n/)
+      .some((line) => this.isCompletedPrLoopHandoffLine(line));
+  }
+
+  private isCompletedPrLoopHandoffLine(line: string): boolean {
+    const normalized = line.trim().toLowerCase();
+    if (
+      !/\b(?:handoff|handed off|successor transfer)\b/.test(normalized) ||
+      /\b(?:no|not|never|without|none|pending|todo|missing|incomplete|not yet)\b/.test(
+        normalized,
+      )
+    ) {
+      return false;
+    }
+    return [
+      /\b(?:explicitly\s+)?handed off\b/,
+      /\bsuccessor transfer\s*:\s*(?:complete|completed|done|recorded|sent|posted|delivered)\b/,
+      /\bhandoff\s*:\s*(?:complete|completed|done|recorded|sent|posted|delivered)\b/,
+      /\bhandoff\b.*\b(?:complete|completed|done|recorded|sent|posted|delivered)\b/,
+      /\bhandoff\b.*\bto\s+[-\w ]+\b/,
+    ].some((pattern) => pattern.test(normalized));
   }
 
   private hasOutputDoneEvidence(cli: CliType, text: string): boolean {

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -259,7 +259,12 @@ export function evaluateAgentHealth(
       "KEPT_OPEN requires reason, owner, and next check",
     );
   }
-  if (input.harvestability?.evidence_channel.degraded === true) {
+  if (
+    agent.state === "done" &&
+    role !== "orchestrator" &&
+    role !== "ic" &&
+    input.harvestability?.evidence_channel.degraded === true
+  ) {
     addIssue(
       issueCodes,
       issues,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -1,4 +1,5 @@
 import type { AgentRecord } from "./agent-types.js";
+import type { WorkerHarvestability } from "./agent-engine.js";
 import { inferRecordRoleOrNull } from "./layout-policy.js";
 
 export type AgentHealthStatus = "healthy" | "unhealthy";
@@ -14,6 +15,9 @@ export type AgentHealthIssueCode =
   | "registry_screen_disagreement"
   | "registry_surface_workspace_mismatch"
   | "closure_without_artifact"
+  | "pr_loop_incomplete"
+  | "kept_open_contract_incomplete"
+  | "degraded_evidence_channel"
   | "recoverable_blocker_requires_action"
   | "missing_managed_lead_agent_id"
   | "ambiguous_repo_cwd_label"
@@ -35,6 +39,7 @@ export interface AgentHealthInput {
   surface_workspace_id?: string | null;
   surface_title?: string | null;
   closure_artifact_verified?: boolean | null;
+  harvestability?: WorkerHarvestability | null;
   screen_actions?: string[] | null;
   topology?: AgentTopologyHealthInput | null;
 }
@@ -230,6 +235,37 @@ export function evaluateAgentHealth(
       issues,
       "closure_without_artifact",
       "worker closure is not backed by a verified DONE marker, BLOCKED/NOT_GREEN handoff, or successor transfer",
+    );
+  }
+  if (
+    input.harvestability?.pr_loop_required === true &&
+    input.harvestability.pr_loop_satisfied === false
+  ) {
+    addIssue(
+      issueCodes,
+      issues,
+      "pr_loop_incomplete",
+      "PR-loop worker did not record merged/reviewed status or an explicit handoff",
+    );
+  }
+  if (
+    input.harvestability?.kept_open?.present === true &&
+    input.harvestability.kept_open.complete === false
+  ) {
+    addIssue(
+      issueCodes,
+      issues,
+      "kept_open_contract_incomplete",
+      "KEPT_OPEN requires reason, owner, and next check",
+    );
+  }
+  if (input.harvestability?.evidence_channel.degraded === true) {
+    addIssue(
+      issueCodes,
+      issues,
+      "degraded_evidence_channel",
+      input.harvestability.evidence_channel.reason ??
+        "done evidence channel is degraded",
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1365,6 +1365,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   let lifecycleRefreshManagedMetadata:
     | ((agentId?: string) => Promise<void>)
     | null = null;
+  let lifecycleHealthEngine: AgentEngine | null = null;
   const refreshManagedMetadataBestEffort = async (
     agentId?: string,
   ): Promise<void> => {
@@ -2709,16 +2710,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_title?: string | null;
       topology?: { column: number | null; column_count: number | null } | null;
       closure_artifact_verified?: boolean | null;
+      harvestability?: ReturnType<AgentEngine["assessHarvestability"]> | null;
       inbox_channel_dir_deleted?: boolean | null;
     },
   ) => {
+    const harvestability =
+      overrides?.harvestability !== undefined
+        ? overrides.harvestability
+        : lifecycleHealthEngine?.assessHarvestability(agent) ?? null;
     const closureArtifactVerified =
       overrides?.closure_artifact_verified !== undefined
         ? overrides.closure_artifact_verified
-        : agent.state === "done" &&
-            (agent.role ?? "worker") !== "orchestrator"
-          ? Boolean(agent.task_done_detected_at)
-          : null;
+        : harvestability?.closure_artifact_verified ?? null;
     const topology =
       overrides?.topology !== undefined
         ? overrides.topology
@@ -2762,6 +2765,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_title: overrides?.surface_title,
       topology,
       closure_artifact_verified: closureArtifactVerified,
+      harvestability,
     });
   };
 
@@ -4844,6 +4848,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       );
     context.lifecycleSweepEngine = engine;
+    lifecycleHealthEngine = engine;
 
     const resolveSpawnRecord = (
       agentId: string,
@@ -5805,7 +5810,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 12. wait_for
     server.tool(
       "wait_for",
-      "Block until an agent reaches a target registry state and return health. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography. This does not yet watch report files or DONE markers; if a collab goal defines a report path/DONE marker, verify that file separately and treat registry/file or registry/screen disagreement as health evidence.",
+      "Block until an agent reaches a target registry state and return health. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography. When the agent has a file-backed goal contract, returned health includes artifact-backed harvestability by reading the referenced report and DONE marker.",
       {
         agent_id: z.string().describe("Agent ID from spawn_agent"),
         target_state: z
@@ -5878,7 +5883,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 13. wait_for_all
     server.tool(
       "wait_for_all",
-      "Block until ALL agents reach a target registry state OR any agent errors, returning per-agent health with partial results. This does not yet watch report files or DONE markers; collab leads must verify required output files separately.",
+      "Block until ALL agents reach a target registry state OR any agent errors, returning per-agent health with partial results. When agents have file-backed goal contracts, returned health includes artifact-backed harvestability by reading referenced reports and DONE markers.",
       {
         agent_ids: z.array(z.string()).describe("Array of agent IDs"),
         target_state: z
@@ -5943,7 +5948,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 14. get_agent_state
     server.tool(
       "get_agent_state",
-      "Get the full registry state of an agent, including cli_session_id/resume data and health. Health may flag missing sessions, dead inbox monitors, topology drift, or registry/screen disagreement.",
+      "Get the full registry state of an agent, including cli_session_id/resume data, health, and artifact-backed harvestability. Health may flag missing sessions, dead inbox monitors, topology drift, registry/screen disagreement, or unverified worker closure artifacts.",
       {
         agent_id: z.string().describe("Agent ID"),
       },
@@ -5955,17 +5960,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
           const topology = await collectSurfaceTopology();
+          const harvestability = engine.assessHarvestability(state);
           const health = await evaluateServerAgentHealth(state, {
             ...healthTopologyOverrides(state, topology),
+            harvestability,
           });
           const formatted =
             formatAgentState(state) +
+            `\nharvestability: ${
+              harvestability.closeable ? "closeable" : "not closeable"
+            }` +
             `\nhealth: ${health.status}${
               health.issues.length > 0
                 ? ` (${health.issues.join("; ")})`
                 : ""
             }`;
-          const payload = { ...toAgentStatePayload(state), health };
+          const payload = {
+            ...toAgentStatePayload(state),
+            harvestability,
+            health,
+          };
           return okFormatted(
             formatted,
             payload as unknown as Record<string, unknown>,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1278,6 +1278,46 @@ describe("AgentEngine", () => {
       }
     });
 
+    it("treats post-spawn live-surface listing failures as inconclusive", async () => {
+      const guardedRegistry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:post-spawn"),
+      ]);
+      vi.spyOn(guardedRegistry, "hasLiveSurface").mockRejectedValue(
+        new Error("surface listing failed"),
+      );
+      const guardedEngine = new AgentEngine(stateMgr, guardedRegistry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+      });
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "worker-post-spawn",
+            state: "booting",
+            surface_id: "surface:post-spawn",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        guardedRegistry.set(
+          "worker-post-spawn",
+          stateMgr.readState("worker-post-spawn")!,
+        );
+
+        const engineInternals = guardedEngine as unknown as {
+          assertPostSpawnLiveness(agentId: string): Promise<void>;
+        };
+        await expect(
+          engineInternals.assertPostSpawnLiveness("worker-post-spawn"),
+        ).resolves.toBeUndefined();
+        expect(
+          guardedEngine.getAgentState("worker-post-spawn")?.error ?? null,
+        ).toBeNull();
+      } finally {
+        guardedEngine.dispose();
+      }
+    });
+
     it("marks TASK_DONE for any cli and role without using the auto-archive gate", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -224,6 +224,33 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("closure_without_artifact");
   });
 
+  it("does not mark non-done agents unhealthy for degraded closure evidence", () => {
+    const health = evaluateAgentHealth(makeRecord({ state: "working" }), {
+      monitor_alive: true,
+      harvestability: {
+        closeable: false,
+        closure_artifact_verified: null,
+        report_path: null,
+        done_marker: null,
+        report_exists: null,
+        report_fresh: null,
+        report_final_line: null,
+        pr_loop_required: false,
+        pr_loop_satisfied: null,
+        kept_open: null,
+        evidence_channel: {
+          done_source: "none",
+          degraded: true,
+          reason: "missing completion transcript",
+        },
+        issue_codes: ["degraded_evidence_channel"],
+        issues: ["missing completion transcript"],
+      },
+    });
+
+    expect(health.issue_codes).not.toContain("degraded_evidence_channel");
+  });
+
   it("marks recoverable permission-parking blockers as action-required health failures", () => {
     const health = evaluateAgentHealth(makeRecord(), {
       monitor_alive: true,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -282,7 +282,7 @@ function makeServerAgentRecord(
     role: "worker",
     auto_archive_on_done: false,
     task_done_candidate_at: null,
-    task_done_detected_at: "2026-07-05T07:00:00.000Z",
+    task_done_detected_at: "2000-01-01T00:00:00.000Z",
     deletion_intent: false,
     quality: "unknown",
     max_cost_per_agent: null,
@@ -2349,6 +2349,50 @@ describe("agent lifecycle tool handlers", () => {
     expect(
       (parsed.harvestability as { issue_codes: string[] }).issue_codes,
     ).toContain("report_stale");
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state does not treat non-DONE terminal markers as closeable", async () => {
+    const goalPath = join(TEST_DIR, "not-green-goal.md");
+    const reportPath = join(TEST_DIR, "not-green-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Not Green Goal",
+        "",
+        "Write report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`NOT_GREEN_P7`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: NOT_GREEN\nNOT_GREEN_P7\n", "utf8");
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-not-green";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: false,
+      done_marker: null,
+    });
     expect(
       (parsed.health as { issue_codes: string[] }).issue_codes,
     ).toContain("closure_without_artifact");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10,6 +10,7 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -255,6 +256,84 @@ function resolveCurrentTestAgentId(
     .filter((name) => name !== "events" && !name.startsWith("Gits"));
   expect(entries).toHaveLength(1);
   return entries[0]!;
+}
+
+function makeServerAgentRecord(
+  overrides: Partial<AgentRecord> = {},
+): AgentRecord {
+  return {
+    agent_id: "codex-golems-000000",
+    surface_id: "surface:new",
+    workspace_id: "ws:1",
+    state: "done",
+    repo: "golems",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "fixture worker",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-05T07:00:00.000Z",
+    updated_at: "2026-07-05T07:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    auto_archive_on_done: false,
+    task_done_candidate_at: null,
+    task_done_detected_at: "2026-07-05T07:00:00.000Z",
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    boot_prompt_pending: false,
+    goal_file: null,
+    launch_cwd: null,
+    mcp_profile: null,
+    worktree_path: null,
+    worktree_branch: null,
+    ...overrides,
+  };
+}
+
+type TestToolResult = {
+  structuredContent?: Record<string, unknown>;
+  content: Array<{ text: string }>;
+};
+
+type RegisteredTestTool = {
+  handler(args: Record<string, unknown>, context: unknown): Promise<TestToolResult>;
+};
+
+type TestLifecycleEngine = {
+  stateMgr: { writeState(record: AgentRecord): void };
+  getRegistry(): { set(agentId: string, record: AgentRecord): void };
+};
+
+function registeredTestTool(server: unknown, name: string): RegisteredTestTool {
+  const registry = (
+    server as {
+      _registeredTools: Record<string, RegisteredTestTool>;
+    }
+  )._registeredTools;
+  return registry[name]!;
+}
+
+function testLifecycleEngine(server: unknown): TestLifecycleEngine {
+  const interact = registeredTestTool(server, "interact") as RegisteredTestTool & {
+    _engine: TestLifecycleEngine;
+  };
+  return interact._engine;
+}
+
+function parseToolResult(result: TestToolResult): Record<string, unknown> {
+  return (
+    result.structuredContent ??
+    (JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>)
+  );
 }
 
 describe("agent lifecycle tool registration", () => {
@@ -1904,6 +1983,332 @@ describe("agent lifecycle tool handlers", () => {
       status: "unhealthy",
       issue_codes: expect.arrayContaining(["closure_without_artifact"]),
     });
+  });
+
+  it("get_agent_state verifies the report artifact before marking a done worker closeable", async () => {
+    const goalPath = join(TEST_DIR, "phase-7-goal.md");
+    const reportPath = join(TEST_DIR, "phase-7-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Phase 7 Goal",
+        "",
+        "Write the report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "The final report line must be exactly:",
+        "",
+        "`DONE_P7_HARVESTABILITY`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-harvestability";
+    const doneWithTimestamp = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(doneWithTimestamp);
+    engine.getRegistry().set(agentId, doneWithTimestamp);
+
+    const missingResult = await getState.handler({ agent_id: agentId }, {});
+    const missing = parseToolResult(missingResult);
+    expect(missing.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: false,
+      report_path: reportPath,
+      done_marker: "DONE_P7_HARVESTABILITY",
+    });
+    expect(
+      (missing.health as { issue_codes: string[] }).issue_codes,
+    ).toContain("closure_without_artifact");
+
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nDONE_P7_HARVESTABILITY\n",
+      "utf8",
+    );
+    const verifiedResult = await getState.handler(
+      { agent_id: agentId },
+      {},
+    );
+    const verified = parseToolResult(verifiedResult);
+    expect(verified.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      report_path: reportPath,
+      done_marker: "DONE_P7_HARVESTABILITY",
+    });
+    expect(
+      (verified.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state keeps PR-loop workers uncloseable until PR status or handoff is recorded", async () => {
+    const goalPath = join(TEST_DIR, "pr-loop-goal.md");
+    const reportPath = join(TEST_DIR, "pr-loop-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# PR Loop Goal",
+        "",
+        "Report:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "End with:",
+        "",
+        "`DONE_PR_LOOP_WORKER`",
+        "",
+        "Run `/pr-loop` after implementation.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_PR_LOOP_WORKER\n", "utf8");
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-pr-loop";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      task_summary: "pr-loop implementation worker",
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: true,
+      pr_loop_required: true,
+    });
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "pr_loop_incomplete",
+    );
+  });
+
+  it("get_agent_state ignores reviewer-pairing boilerplate and negated PR-loop mentions", async () => {
+    const goalPath = join(TEST_DIR, "non-pr-loop-goal.md");
+    const reportPath = join(TEST_DIR, "non-pr-loop-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Non PR Deliverable Goal",
+        "",
+        "Report:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "End with:",
+        "",
+        "`DONE_NO_PR_WORKER`",
+        "",
+        "Claude reviewer pairs before pr-loop.",
+        "No pr loop deliverable for this worker.",
+        "Do not open a PR in this lane.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_NO_PR_WORKER\n", "utf8");
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-no-pr-loop";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      task_summary: "worker with no pr loop phrase in the title",
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      pr_loop_required: false,
+      pr_loop_satisfied: null,
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("pr_loop_incomplete");
+  });
+
+  it("get_agent_state rejects stale reports written before task_done_detected_at", async () => {
+    const goalPath = join(TEST_DIR, "stale-report-goal.md");
+    const reportPath = join(TEST_DIR, "stale-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Stale Report Goal",
+        "",
+        "Write report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`DONE_STALE_REPORT`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_STALE_REPORT\n", "utf8");
+    const olderThanDone = new Date("2026-07-05T06:59:00.000Z");
+    utimesSync(reportPath, olderThanDone, olderThanDone);
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-stale-report";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      task_done_detected_at: "2026-07-05T07:00:00.000Z",
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: false,
+      report_fresh: false,
+    });
+    expect(
+      (parsed.harvestability as { issue_codes: string[] }).issue_codes,
+    ).toContain("report_stale");
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state anchors KEPT_OPEN owner and next check to the KEPT_OPEN block", async () => {
+    const goalPath = join(TEST_DIR, "kept-open-block-goal.md");
+    const reportPath = join(TEST_DIR, "kept-open-block-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Kept Open Goal",
+        "",
+        "Write report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`DONE_KEEP_OPEN_BLOCK`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      [
+        "owner: stale lead metadata",
+        "next check: not part of kept-open",
+        "",
+        "Status: needs human follow-up",
+        "KEPT_OPEN: waiting for reviewer handoff",
+        "DONE_KEEP_OPEN_BLOCK",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-kept-open-block";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: true,
+      kept_open: {
+        present: true,
+        reason: "waiting for reviewer handoff",
+        owner: null,
+        next_check: null,
+        complete: false,
+      },
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).toContain("kept_open_contract_incomplete");
+  });
+
+  it("get_agent_state reports degraded evidence when done relies on screen fallback after harness read failure", async () => {
+    const goalPath = join(TEST_DIR, "degraded-goal.md");
+    const reportPath = join(TEST_DIR, "degraded-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Degraded Evidence Goal",
+        "",
+        "Write report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final report line:",
+        "",
+        "`DONE_DEGRADED_EVIDENCE`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nDONE_DEGRADED_EVIDENCE\n",
+      "utf8",
+    );
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-degraded";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      cli_session_id: "019eab06-57d6-72b1-b3a8-6cf98a30a3f6",
+      cli_session_path: join(TEST_DIR, "missing-codex-session.jsonl"),
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      evidence_channel: {
+        done_source: "screen",
+        degraded: true,
+      },
+    });
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "degraded_evidence_channel",
+    );
   });
 
   it("get_agent_state does not require closure artifacts for errored workers", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2049,6 +2049,106 @@ describe("agent lifecycle tool handlers", () => {
     ).not.toContain("closure_without_artifact");
   });
 
+  it("get_agent_state accepts a report written before done detection when it is newer than the goal file", async () => {
+    const goalPath = join(TEST_DIR, "pre-done-report-goal.md");
+    const reportPath = join(TEST_DIR, "pre-done-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Pre Done Report Goal",
+        "",
+        "Write the report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`DONE_PRE_DETECTION_REPORT`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nDONE_PRE_DETECTION_REPORT\n",
+      "utf8",
+    );
+    const goalTime = new Date("2026-07-05T06:00:00.000Z");
+    const reportTime = new Date("2026-07-05T06:30:00.000Z");
+    utimesSync(goalPath, goalTime, goalTime);
+    utimesSync(reportPath, reportTime, reportTime);
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-pre-done-report";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      task_done_detected_at: "2026-07-05T07:00:00.000Z",
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      report_fresh: true,
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state prefers report-path context over unrelated markdown code spans", async () => {
+    const goalPath = join(TEST_DIR, "report-path-context-goal.md");
+    const reportPath = join(TEST_DIR, "report-path-context-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Report Path Context Goal",
+        "",
+        "Read `README.md` and `docs/design.md` before implementation.",
+        "",
+        "Report:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "End with:",
+        "",
+        "`DONE_REPORT_PATH_CONTEXT`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nDONE_REPORT_PATH_CONTEXT\n",
+      "utf8",
+    );
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-report-path-context";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      report_path: reportPath,
+    });
+  });
+
   it("get_agent_state keeps PR-loop workers uncloseable until PR status or handoff is recorded", async () => {
     const goalPath = join(TEST_DIR, "pr-loop-goal.md");
     const reportPath = join(TEST_DIR, "pr-loop-report.md");
@@ -2070,7 +2170,11 @@ describe("agent lifecycle tool handlers", () => {
       ].join("\n"),
       "utf8",
     );
-    writeFileSync(reportPath, "Status: COMPLETE\nDONE_PR_LOOP_WORKER\n", "utf8");
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nhandoff: none\nDONE_PR_LOOP_WORKER\n",
+      "utf8",
+    );
 
     const server = createLifecycleServer(mockExec);
     const getState = registeredTestTool(server, "get_agent_state");
@@ -2094,6 +2198,58 @@ describe("agent lifecycle tool handlers", () => {
     expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
       "pr_loop_incomplete",
     );
+  });
+
+  it("get_agent_state accepts completed handoff evidence for PR-loop workers", async () => {
+    const goalPath = join(TEST_DIR, "pr-loop-handoff-goal.md");
+    const reportPath = join(TEST_DIR, "pr-loop-handoff-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# PR Loop Handoff Goal",
+        "",
+        "Report:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "End with:",
+        "",
+        "`DONE_PR_LOOP_HANDOFF`",
+        "",
+        "Run `/pr-loop` after implementation.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      "Status: COMPLETE\nhandoff: complete to lead for merge ownership\nDONE_PR_LOOP_HANDOFF\n",
+      "utf8",
+    );
+
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-pr-loop-handoff";
+    const done = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      task_summary: "pr-loop implementation worker",
+    });
+    engine.stateMgr.writeState(done);
+    engine.getRegistry().set(agentId, done);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: true,
+      closure_artifact_verified: true,
+      pr_loop_required: true,
+      pr_loop_satisfied: true,
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("pr_loop_incomplete");
   });
 
   it("get_agent_state ignores reviewer-pairing boilerplate and negated PR-loop mentions", async () => {
@@ -2146,7 +2302,7 @@ describe("agent lifecycle tool handlers", () => {
     ).not.toContain("pr_loop_incomplete");
   });
 
-  it("get_agent_state rejects stale reports written before task_done_detected_at", async () => {
+  it("get_agent_state rejects stale reports written before the goal contract file", async () => {
     const goalPath = join(TEST_DIR, "stale-report-goal.md");
     const reportPath = join(TEST_DIR, "stale-report.md");
     writeFileSync(
@@ -2166,8 +2322,10 @@ describe("agent lifecycle tool handlers", () => {
       "utf8",
     );
     writeFileSync(reportPath, "Status: COMPLETE\nDONE_STALE_REPORT\n", "utf8");
-    const olderThanDone = new Date("2026-07-05T06:59:00.000Z");
-    utimesSync(reportPath, olderThanDone, olderThanDone);
+    const goalTime = new Date("2026-07-05T07:00:00.000Z");
+    const staleReportTime = new Date("2026-07-05T06:59:00.000Z");
+    utimesSync(goalPath, goalTime, goalTime);
+    utimesSync(reportPath, staleReportTime, staleReportTime);
 
     const server = createLifecycleServer(mockExec);
     const getState = registeredTestTool(server, "get_agent_state");
@@ -2194,6 +2352,61 @@ describe("agent lifecycle tool handlers", () => {
     expect(
       (parsed.health as { issue_codes: string[] }).issue_codes,
     ).toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state does not require worker closure artifacts for done IC agents", async () => {
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "claude-cmuxlayer-ic-done";
+    const doneIc = makeServerAgentRecord({
+      agent_id: agentId,
+      cli: "claude",
+      role: "ic",
+      task_summary: "integration coordinator",
+    });
+    engine.stateMgr.writeState(doneIc);
+    engine.getRegistry().set(agentId, doneIc);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: null,
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("closure_without_artifact");
+  });
+
+  it("get_agent_state does not mark non-done workers unhealthy for missing completion evidence", async () => {
+    const server = createLifecycleServer(mockExec);
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-working-no-session-file";
+    const working = makeServerAgentRecord({
+      agent_id: agentId,
+      state: "working",
+      cli_session_id: "019eab06-57d6-72b1-b3a8-6cf98a30a3f6",
+      cli_session_path: join(TEST_DIR, "missing-working-codex-session.jsonl"),
+      task_done_detected_at: null,
+    });
+    engine.stateMgr.writeState(working);
+    engine.getRegistry().set(agentId, working);
+
+    const result = await getState.handler({ agent_id: agentId }, {});
+    const parsed = parseToolResult(result);
+    expect(parsed.harvestability).toMatchObject({
+      closeable: false,
+      closure_artifact_verified: null,
+      evidence_channel: {
+        done_source: "none",
+        degraded: false,
+      },
+    });
+    expect(
+      (parsed.health as { issue_codes: string[] }).issue_codes,
+    ).not.toContain("degraded_evidence_channel");
   });
 
   it("get_agent_state anchors KEPT_OPEN owner and next check to the KEPT_OPEN block", async () => {


### PR DESCRIPTION
## Summary
- Adds artifact-backed worker harvestability assessment for done workers with report path, DONE marker, freshness, KEPT_OPEN contract, PR-loop handoff/review status, and degraded evidence-channel reporting.
- Threads harvestability through lifecycle health, `get_agent_state`, `wait_for`, and `wait_for_all` so worker closure is based on file-backed evidence instead of screen-only done detection.
- Keeps post-spawn live-surface listing failures inconclusive so transient topology read failures do not mark a valid spawn as dead.

## Test plan
- `coderabbit review --agent` -> `findings: 0`
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit`
- `bun run test` -> 67 files passed; 1230 tests passed; 3 todo
- push hook `run_tests.sh` -> exit status 0; 67 files passed; 1230 tests passed; 3 todo

## Review notes
- Macroscope local CLI was not installed in this environment.
- This PR intentionally stops at review/PR handoff; do not merge from this worker.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle closure and health semantics for done workers (file reads, heuristics for PR-loop and goal parsing); incorrect parsing could block closeability or miss real issues, but scope is worker harvest/health rather than auth or data stores.
> 
> **Overview**
> Adds **worker harvestability** for done workers: the engine reads goal contracts, resolves report paths and DONE markers from markdown, checks report freshness and final line, parses **KEPT_OPEN** blocks, and gates **PR-loop** workers on merge/review or explicit handoff evidence. Done evidence is classified as transcript vs screen, with a **degraded** flag when harness JSONL is expected but unreadable.
> 
> **Health and MCP tools** now derive `closure_artifact_verified` from harvestability instead of inferring closure from `task_done_detected_at` alone. `evaluateAgentHealth` adds issues for incomplete PR loops, incomplete KEPT_OPEN contracts, and degraded done evidence on done workers. `get_agent_state` returns a structured `harvestability` payload and a closeable/not closeable line; `wait_for` / `wait_for_all` tool descriptions reflect artifact-backed health.
> 
> **Post-spawn liveness** treats failures from `hasLiveSurface` as inconclusive so transient topology errors do not mark spawns dead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa73c6e2eac740776a06e2f98fce99cf26b4be94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add worker harvestability assessment and verified closure artifacts to agent lifecycle
> - Adds `AgentEngine.assessHarvestability` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/225/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to evaluate whether a 'done' worker is closeable by reading its goal contract, verifying report freshness, extracting the DONE marker, parsing KEPT_OPEN blocks, and checking PR-loop obligation and satisfaction.
> - Adds `AgentEngine.readHarvestabilityEvidenceChannel` to detect whether the 'done' evidence came from a ground-truth harness session or a degraded screen-parsing fallback.
> - Extends `evaluateAgentHealth` in [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/225/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3) with three new issue codes: `pr_loop_incomplete`, `kept_open_contract_incomplete`, and `degraded_evidence_channel`.
> - Updates the `get_agent_state` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/225/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to call `assessHarvestability`, include the result in health evaluation, and surface a `closeable|not closeable` status in the formatted output.
> - Fixes `assertPostSpawnLiveness` to treat a `hasLiveSurface` read failure as inconclusive rather than a liveness failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa73c6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added harvestability checks to agent health and state reporting, including support for file-backed goal contracts and evidence-based completion status.
  * `get_agent_state` now includes harvestability details in its output.

* **Bug Fixes**
  * Improved closure detection so completed work depends on verified report markers and fresh artifacts.
  * Added clearer handling for PR-loop requirements, kept-open contracts, and degraded evidence channels.
  * Topology lookup failures during post-spawn checks are now treated as inconclusive instead of causing failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->