### PR TITLE
feat(sidebar): diffed sync truth + discriminating health + wedge-aware notifications (phase 8)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1258,6 +1258,7 @@ export class AgentEngine {
         ? await this.readSweepScreen(agent, ctx)
         : await this.client.readScreen(agent.surface_id, {
             lines: BOOT_SESSION_CAPTURE_LINES,
+            workspace: agent.workspace_id ?? undefined,
           });
       return !this.screenContradictsTranscriptDone(agent.cli, screen.text);
     } catch {
@@ -1271,6 +1272,7 @@ export class AgentEngine {
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
+        workspace: agent.workspace_id ?? undefined,
       });
       return this.hasOutputDoneEvidence(agent.cli, screen.text);
     } catch {
@@ -1339,6 +1341,7 @@ export class AgentEngine {
     try {
       const screen = await this.client.readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
+        workspace: agent.workspace_id ?? undefined,
       });
       const evidence = this.readReadyEvidence(agent, screen.text);
       if (
@@ -1813,6 +1816,7 @@ export class AgentEngine {
     ctx.screen ??= this.client
       .readScreen(agent.surface_id, {
         lines: BOOT_SESSION_CAPTURE_LINES,
+        workspace: agent.workspace_id ?? undefined,
       })
       .then((screen) => {
         this.currentSweepScreenSignatures.set(
@@ -2514,7 +2518,12 @@ export class AgentEngine {
         try {
           const screenText =
             taskDoneResult.screenText ??
-            (await this.client.readScreen(surface_id, { lines: 5 })).text;
+            (
+              await this.client.readScreen(surface_id, {
+                lines: 5,
+                workspace: agent.workspace_id ?? undefined,
+              })
+            ).text;
           const parsed = parseScreen(tailScreenLines(screenText, 5));
           const contextPct = parsed.context_pct;
           if (

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -79,6 +79,12 @@ import {
   resolveSpawnModelPolicy,
   type SpawnModelPolicy,
 } from "./model-policy.js";
+import {
+  evaluateAgentHealth,
+  type AgentHealth,
+} from "./agent-health.js";
+import { buildAgentHealthInput } from "./agent-health-input.js";
+import type { InboxOpts } from "./inbox.js";
 
 export interface SpawnAgentParams {
   repo: string;
@@ -204,9 +210,10 @@ export interface AgentEngineOptions {
     workspace?: string;
     command: string;
   }) => Promise<void>;
+  inboxOpts?: InboxOpts;
 }
 
-export type AgentLifecycleEvent = "spawned" | "done" | "errored";
+export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
 
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
@@ -242,6 +249,7 @@ interface SidebarStatusSnapshot {
   statusValue: string;
   surfaceId: string | null;
   workspaceId: string | null;
+  healthSignature: string;
 }
 
 export interface SweepTimingOptions {
@@ -428,6 +436,7 @@ interface AgentEngineClient {
   notifyLifecycleEvent(
     event: AgentLifecycleEvent,
     agent: AgentRecord,
+    healthSummary?: string,
   ): Promise<void>;
 }
 
@@ -446,6 +455,7 @@ const LIFECYCLE_LOGS = {
   spawned: { message: "spawned", level: "info" },
   done: { message: "done", level: "success" },
   errored: { message: "errored", level: "error" },
+  health: { message: "health", level: "warning" },
 } as const;
 
 /**
@@ -682,6 +692,7 @@ export class AgentEngine {
     workspace?: string,
   ) => RoleSurfaceIds;
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
+  private inboxOpts?: InboxOpts;
   private sessionIdentityResolver: SessionIdentityResolver;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
   private postSpawnLivenessTimers = new Set<ReturnType<typeof setTimeout>>();
@@ -694,6 +705,8 @@ export class AgentEngine {
   private progressSnapshot: string | null = null;
   /** e.g. "a1:spawned", "a1:done", "a1:error" */
   private loggedEvents = new Set<string>();
+  /** e.g. "a1:done", "a1:health:unhealthy(...)" */
+  private notifiedEvents = new Set<string>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
   constructor(
@@ -707,6 +720,7 @@ export class AgentEngine {
     this.client = client;
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
+    this.inboxOpts = opts?.inboxOpts;
     this.sessionIdentityResolver =
       opts?.sessionIdentityResolver ??
       ((agent) => this.findTranscriptSessionIdentity(agent));
@@ -2160,7 +2174,101 @@ export class AgentEngine {
     }
   }
 
-  private async emitLifecycleEvent(
+  private compactSidebarValue(value: string | null | undefined): string {
+    const normalized = (value ?? "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!normalized) return "-";
+    return normalized.length > 160
+      ? `${normalized.slice(0, 157).trimEnd()}...`
+      : normalized;
+  }
+
+  private formatHealthSummary(health: AgentHealth): string {
+    if (health.issue_codes.length === 0) return health.status;
+    return `${health.status}(${health.issue_codes.join(",")})`;
+  }
+
+  private formatReportSummary(harvestability: WorkerHarvestability): string {
+    if (!harvestability.report_path) return "n/a";
+    if (harvestability.closure_artifact_verified === true) return "verified";
+    if (harvestability.report_exists === false) return "missing";
+    if (harvestability.report_fresh === false) return "stale";
+    return "unverified";
+  }
+
+  private formatPrSummary(harvestability: WorkerHarvestability): string {
+    if (!harvestability.pr_loop_required) return "n/a";
+    return harvestability.pr_loop_satisfied === true
+      ? "satisfied"
+      : "incomplete";
+  }
+
+  private extractNamedBlocker(agent: AgentRecord): string | null {
+    const text = [agent.error, agent.task_summary]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join(" ");
+    const match = text.match(
+      /\b(?:blocked by|blocked on|waiting on|waits on)\s+([A-Za-z0-9_.:@/-]+)/i,
+    );
+    return match?.[1]?.replace(/[),.;:]+$/g, "") ?? null;
+  }
+
+  private formatBlockedSummary(
+    agent: AgentRecord,
+    health: AgentHealth,
+  ): string {
+    const namedBlocker = this.extractNamedBlocker(agent);
+    if (namedBlocker) return namedBlocker;
+    if (health.issue_codes.includes("agent_wedged")) {
+      return "self:agent_wedged";
+    }
+    if (health.issue_codes.includes("recoverable_blocker_requires_action")) {
+      return "recoverable_action";
+    }
+    return "-";
+  }
+
+  private buildSidebarStatusValue(
+    agent: AgentRecord,
+    health: AgentHealth,
+    harvestability: WorkerHarvestability,
+  ): string {
+    const role = inferRecordRoleOrNull(agent) ?? "unknown";
+    const worktree = agent.worktree_path ?? agent.launch_cwd ?? null;
+    return [
+      agent.repo,
+      `role=${role}`,
+      `state=${agent.state}`,
+      `health=${this.formatHealthSummary(health)}`,
+      `blocked=${this.formatBlockedSummary(agent, health)}`,
+      `last_prompt=${this.compactSidebarValue(agent.task_summary)}`,
+      `worktree=${this.compactSidebarValue(worktree)}`,
+      `branch=${this.compactSidebarValue(agent.worktree_branch)}`,
+      `report=${this.formatReportSummary(harvestability)}`,
+      `pr=${this.formatPrSummary(harvestability)}`,
+    ].join(" | ");
+  }
+
+  private healthSignature(health: AgentHealth): string {
+    return this.formatHealthSummary(health);
+  }
+
+  private clearAgentLifecycleMemory(agentId: string): void {
+    const prefix = `${agentId}:`;
+    for (const key of this.loggedEvents) {
+      if (key.startsWith(prefix)) {
+        this.loggedEvents.delete(key);
+      }
+    }
+    for (const key of this.notifiedEvents) {
+      if (key.startsWith(prefix)) {
+        this.notifiedEvents.delete(key);
+      }
+    }
+  }
+
+  private async logLifecycleEvent(
     agent: AgentRecord,
     event: AgentLifecycleEvent,
   ): Promise<void> {
@@ -2175,14 +2283,56 @@ export class AgentEngine {
       source: "cmuxlayer",
     });
 
+    this.loggedEvents.add(eventKey);
+  }
+
+  private async notifyLifecycleEvent(
+    agent: AgentRecord,
+    event: AgentLifecycleEvent,
+    signature?: string,
+  ): Promise<void> {
+    const eventSuffix = signature === undefined ? "" : `:${signature}`;
+    const eventKey = `${agent.agent_id}:${event}${eventSuffix}`;
+    if (this.notifiedEvents.has(eventKey)) {
+      return;
+    }
+
     try {
       // Channel delivery is best-effort and must not break the sweep loop.
-      await this.client.notifyLifecycleEvent(event, agent);
+      if (signature === undefined) {
+        await this.client.notifyLifecycleEvent(event, agent);
+      } else {
+        await this.client.notifyLifecycleEvent(event, agent, signature);
+      }
+      if (event === "health") {
+        const healthPrefix = `${agent.agent_id}:health:`;
+        for (const key of this.notifiedEvents) {
+          if (key.startsWith(healthPrefix)) {
+            this.notifiedEvents.delete(key);
+          }
+        }
+      }
+      this.notifiedEvents.add(eventKey);
     } catch {
       // Ignore Claude channel push failures; logs and sidebar state remain canonical.
     }
+  }
 
-    this.loggedEvents.add(eventKey);
+  private shouldNotifyDone(harvestability: WorkerHarvestability): boolean {
+    return harvestability.closeable;
+  }
+
+  private shouldNotifyHealthChange(
+    prev: SidebarStatusSnapshot | undefined,
+    health: AgentHealth,
+  ): boolean {
+    if (!prev) return false;
+    const nextSignature = this.healthSignature(health);
+    if (prev.healthSignature === nextSignature) return false;
+    return (
+      health.status === "unhealthy" ||
+      prev.healthSignature.startsWith("unhealthy")
+    );
   }
 
   /**
@@ -2203,28 +2353,79 @@ export class AgentEngine {
       const readyAgent = await this.maybeMarkBootReady(capturedAgent, sweepCtx);
       const taskDoneResult = await this.maybeMarkTaskDone(readyAgent, sweepCtx);
       const agent = taskDoneResult.agent;
-      const { agent_id: agentId, repo, state, surface_id } = agent;
-      const statusValue =
-        state === "error" ? `${repo}: error` : `${repo}: ${state}`;
+      const { agent_id: agentId, state, surface_id } = agent;
+      const harvestability = this.assessHarvestability(agent);
+      const healthScreenContexts = new Map<string, SweepAgentContext>();
+      const healthScreenContextFor = (
+        targetAgent: AgentRecord,
+      ): SweepAgentContext => {
+        if (targetAgent.agent_id === agent.agent_id) return sweepCtx;
+        const existing = healthScreenContexts.get(targetAgent.agent_id);
+        if (existing) return existing;
+        const next: SweepAgentContext = {};
+        healthScreenContexts.set(targetAgent.agent_id, next);
+        return next;
+      };
+      const healthInput = await buildAgentHealthInput(
+        agent,
+        {
+          inboxOpts: this.inboxOpts,
+          readParsedSurface: async (targetAgent) => {
+            const screenText =
+              targetAgent.agent_id === agent.agent_id &&
+              taskDoneResult.screenText !== undefined
+                ? taskDoneResult.screenText
+                : (
+                    await this.readSweepScreen(
+                      targetAgent,
+                      healthScreenContextFor(targetAgent),
+                    )
+                  ).text;
+            const parsed = parseScreen(screenText);
+            return {
+              status: parsed.status,
+              actions: parsed.actions,
+            };
+          },
+        },
+        { harvestability },
+      );
+      const health = evaluateAgentHealth(agent, healthInput);
+      const healthSignature = this.healthSignature(health);
+      const statusValue = this.buildSidebarStatusValue(
+        agent,
+        health,
+        harvestability,
+      );
       const statusSnapshot: SidebarStatusSnapshot = {
         statusValue,
         surfaceId: surface_id,
         workspaceId: agent.workspace_id ?? null,
+        healthSignature,
       };
+      const prev = this.sidebarSnapshot.get(agentId);
 
       // Lifecycle log: spawned (first encounter)
-      if (!this.sidebarSnapshot.has(agentId)) {
-        await this.emitLifecycleEvent(agent, "spawned");
+      if (!prev) {
+        await this.logLifecycleEvent(agent, "spawned");
       }
 
       // Lifecycle log: done
       if (state === "done") {
-        await this.emitLifecycleEvent(agent, "done");
+        await this.logLifecycleEvent(agent, "done");
+        if (this.shouldNotifyDone(harvestability)) {
+          await this.notifyLifecycleEvent(agent, "done");
+        }
       }
 
       // Lifecycle log: error
       if (state === "error") {
-        await this.emitLifecycleEvent(agent, "errored");
+        await this.logLifecycleEvent(agent, "errored");
+        await this.notifyLifecycleEvent(agent, "errored");
+      }
+
+      if (this.shouldNotifyHealthChange(prev, health)) {
+        await this.notifyLifecycleEvent(agent, "health", healthSignature);
       }
 
       const archived = await this.maybeArchiveDoneAgent(agent);
@@ -2240,11 +2441,11 @@ export class AgentEngine {
         this.registry.remove(agentId);
         this.stateMgr.removeState(agentId);
         this.sidebarSnapshot.delete(agentId);
+        this.clearAgentLifecycleMemory(agentId);
         continue;
       }
 
       // Status diff — only push if changed
-      const prev = this.sidebarSnapshot.get(agentId);
       const statusChanged =
         !prev ||
         prev.statusValue !== statusSnapshot.statusValue ||
@@ -2300,7 +2501,7 @@ export class AgentEngine {
               await this.client.sendKey(surface_id, "return", {});
             } else {
               await this.client.log(
-                `context-limit: depth ${agent.spawn_depth} agent ${repo} degraded; leaving pane running for orchestrator decision`,
+                `context-limit: depth ${agent.spawn_depth} agent ${agent.repo} degraded; leaving pane running for orchestrator decision`,
                 { level: "warning", source: "cmuxlayer" },
               );
             }
@@ -2325,6 +2526,7 @@ export class AgentEngine {
           // Best-effort sidebar cleanup
         }
         this.sidebarSnapshot.delete(agentId);
+        this.clearAgentLifecycleMemory(agentId);
       }
     }
 
@@ -2366,11 +2568,12 @@ export class AgentEngine {
       this.startupPurgePending = false;
       const purgedIds = this.registry.purgeAllTerminal();
       // Seed sidebar snapshot so syncSidebar clears their cmux entries
-      for (const id of purgedIds) {
-        this.sidebarSnapshot.set(id, {
+      for (const purgedAgent of purgedIds) {
+        this.sidebarSnapshot.set(purgedAgent.agent_id, {
           statusValue: "__purged__",
-          surfaceId: null,
-          workspaceId: null,
+          surfaceId: purgedAgent.surface_id,
+          workspaceId: purgedAgent.workspace_id ?? null,
+          healthSignature: "__purged__",
         });
       }
     }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2371,21 +2371,25 @@ export class AgentEngine {
         {
           inboxOpts: this.inboxOpts,
           readParsedSurface: async (targetAgent) => {
-            const screenText =
-              targetAgent.agent_id === agent.agent_id &&
-              taskDoneResult.screenText !== undefined
-                ? taskDoneResult.screenText
-                : (
-                    await this.readSweepScreen(
-                      targetAgent,
-                      healthScreenContextFor(targetAgent),
-                    )
-                  ).text;
-            const parsed = parseScreen(screenText);
-            return {
-              status: parsed.status,
-              actions: parsed.actions,
-            };
+            try {
+              const screenText =
+                targetAgent.agent_id === agent.agent_id &&
+                taskDoneResult.screenText !== undefined
+                  ? taskDoneResult.screenText
+                  : (
+                      await this.readSweepScreen(
+                        targetAgent,
+                        healthScreenContextFor(targetAgent),
+                      )
+                    ).text;
+              const parsed = parseScreen(screenText);
+              return {
+                status: parsed.status,
+                actions: parsed.actions,
+              };
+            } catch {
+              return null;
+            }
           },
         },
         { harvestability },

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2326,7 +2326,7 @@ export class AgentEngine {
     prev: SidebarStatusSnapshot | undefined,
     health: AgentHealth,
   ): boolean {
-    if (!prev) return false;
+    if (!prev) return health.status === "unhealthy";
     const nextSignature = this.healthSignature(health);
     if (prev.healthSignature === nextSignature) return false;
     return (
@@ -2475,8 +2475,8 @@ export class AgentEngine {
           surface: surface_id,
           workspace: agent.workspace_id ?? undefined,
         });
-        this.sidebarSnapshot.set(agentId, statusSnapshot);
       }
+      this.sidebarSnapshot.set(agentId, statusSnapshot);
 
       // Quality tracking: check context usage for non-terminal agents
       // AIDEV-NOTE: Uses parseScreen for model-aware context_pct (handles Claude, Codex, Gemini).

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -84,6 +84,11 @@ import {
   type AgentHealth,
 } from "./agent-health.js";
 import { buildAgentHealthInput } from "./agent-health-input.js";
+import {
+  collectSurfaceTopology,
+  EMPTY_SURFACE_TOPOLOGY,
+  healthTopologyOverrides,
+} from "./surface-topology.js";
 import type { InboxOpts } from "./inbox.js";
 
 export interface SpawnAgentParams {
@@ -2290,11 +2295,11 @@ export class AgentEngine {
     agent: AgentRecord,
     event: AgentLifecycleEvent,
     signature?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const eventSuffix = signature === undefined ? "" : `:${signature}`;
     const eventKey = `${agent.agent_id}:${event}${eventSuffix}`;
     if (this.notifiedEvents.has(eventKey)) {
-      return;
+      return true;
     }
 
     try {
@@ -2313,8 +2318,10 @@ export class AgentEngine {
         }
       }
       this.notifiedEvents.add(eventKey);
+      return true;
     } catch {
       // Ignore Claude channel push failures; logs and sidebar state remain canonical.
+      return false;
     }
   }
 
@@ -2343,6 +2350,7 @@ export class AgentEngine {
     const agents = this.registry.list();
     const total = agents.length;
     const done = agents.filter((a) => a.state === "done").length;
+    const surfaceTopology = await collectSurfaceTopology(this.client);
 
     for (const originalAgent of agents) {
       const sweepCtx: SweepAgentContext = {};
@@ -2370,6 +2378,9 @@ export class AgentEngine {
         agent,
         {
           inboxOpts: this.inboxOpts,
+          resolveTopology: async (targetAgent) =>
+            surfaceTopology?.topologyBySurface.get(targetAgent.surface_id) ??
+            EMPTY_SURFACE_TOPOLOGY,
           readParsedSurface: async (targetAgent) => {
             try {
               const screenText =
@@ -2391,8 +2402,14 @@ export class AgentEngine {
               return null;
             }
           },
+          resolveSurfaceWorkspace: async (targetAgent) =>
+            surfaceTopology?.workspaceBySurface.get(targetAgent.surface_id) ??
+            null,
         },
-        { harvestability },
+        {
+          ...healthTopologyOverrides(agent, surfaceTopology),
+          harvestability,
+        },
       );
       const health = evaluateAgentHealth(agent, healthInput);
       const healthSignature = this.healthSignature(health);
@@ -2428,8 +2445,14 @@ export class AgentEngine {
         await this.notifyLifecycleEvent(agent, "errored");
       }
 
-      if (this.shouldNotifyHealthChange(prev, health)) {
-        await this.notifyLifecycleEvent(agent, "health", healthSignature);
+      const shouldNotifyHealth = this.shouldNotifyHealthChange(prev, health);
+      let healthNotificationDelivered = true;
+      if (shouldNotifyHealth) {
+        healthNotificationDelivered = await this.notifyLifecycleEvent(
+          agent,
+          "health",
+          healthSignature,
+        );
       }
 
       const archived = await this.maybeArchiveDoneAgent(agent);
@@ -2476,7 +2499,13 @@ export class AgentEngine {
           workspace: agent.workspace_id ?? undefined,
         });
       }
-      this.sidebarSnapshot.set(agentId, statusSnapshot);
+      this.sidebarSnapshot.set(agentId, {
+        ...statusSnapshot,
+        healthSignature:
+          shouldNotifyHealth && !healthNotificationDelivered
+            ? (prev?.healthSignature ?? "pending_health_notification")
+            : statusSnapshot.healthSignature,
+      });
 
       // Quality tracking: check context usage for non-terminal agents
       // AIDEV-NOTE: Uses parseScreen for model-aware context_pct (handles Claude, Codex, Gemini).

--- a/src/agent-health-input.ts
+++ b/src/agent-health-input.ts
@@ -66,15 +66,17 @@ export async function buildAgentHealthInput(
       ? overrides.topology
       : (await deps.resolveTopology?.(agent)) ?? null;
   const alive =
-    overrides.monitor_alive ??
-    monitorAlive(
-      agent.agent_id,
-      deps.monitorMaxAgeMs ?? AGENT_HEALTH_MONITOR_MAX_AGE_MS,
-      deps.inboxOpts,
-    );
+    overrides.monitor_alive !== undefined
+      ? overrides.monitor_alive
+      : monitorAlive(
+          agent.agent_id,
+          deps.monitorMaxAgeMs ?? AGENT_HEALTH_MONITOR_MAX_AGE_MS,
+          deps.inboxOpts,
+        );
   const inboxChannelDirDeleted =
-    overrides.inbox_channel_dir_deleted ??
-    (!alive && channelDirDeletedAfterCreate(agent.agent_id, deps.inboxOpts));
+    overrides.inbox_channel_dir_deleted !== undefined
+      ? overrides.inbox_channel_dir_deleted
+      : !alive && channelDirDeletedAfterCreate(agent.agent_id, deps.inboxOpts);
   const staleCount =
     overrides.stale_count ??
     pendingDispatches(
@@ -85,9 +87,14 @@ export async function buildAgentHealthInput(
   const needsScreen =
     overrides.screen_status === undefined ||
     overrides.screen_actions === undefined;
-  const parsedScreen = needsScreen
-    ? await deps.readParsedSurface?.(agent)
-    : null;
+  let parsedScreen: ParsedSurfaceHealthInput | null | undefined = null;
+  if (needsScreen) {
+    try {
+      parsedScreen = await deps.readParsedSurface?.(agent);
+    } catch {
+      parsedScreen = null;
+    }
+  }
   const screenStatus =
     overrides.screen_status !== undefined
       ? overrides.screen_status

--- a/src/agent-health-input.ts
+++ b/src/agent-health-input.ts
@@ -1,0 +1,116 @@
+import type { AgentRecord } from "./agent-types.js";
+import type {
+  AgentHealthInput,
+  AgentTopologyHealthInput,
+} from "./agent-health.js";
+import type { WorkerHarvestability } from "./agent-engine.js";
+import {
+  channelDirDeletedAfterCreate,
+  monitorAlive,
+  pendingDispatches,
+  type InboxOpts,
+} from "./inbox.js";
+
+export const AGENT_HEALTH_MONITOR_MAX_AGE_MS = 60_000;
+export const AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS = 120_000;
+
+export interface ParsedSurfaceHealthInput {
+  status?: string | null;
+  actions?: string[] | null;
+}
+
+export interface AgentHealthInputOverrides {
+  monitor_alive?: boolean | null;
+  stale_count?: number;
+  screen_status?: string | null;
+  screen_actions?: string[] | null;
+  surface_workspace_id?: string | null;
+  surface_title?: string | null;
+  topology?: AgentTopologyHealthInput | null;
+  closure_artifact_verified?: boolean | null;
+  harvestability?: WorkerHarvestability | null;
+  inbox_channel_dir_deleted?: boolean | null;
+}
+
+export interface AgentHealthInputDeps {
+  inboxOpts?: InboxOpts;
+  monitorMaxAgeMs?: number;
+  dispatchAckTimeoutMs?: number;
+  assessHarvestability?: (
+    agent: AgentRecord,
+  ) => WorkerHarvestability | null | undefined;
+  resolveTopology?: (
+    agent: AgentRecord,
+  ) => Promise<AgentTopologyHealthInput | null>;
+  readParsedSurface?: (
+    agent: AgentRecord,
+  ) => Promise<ParsedSurfaceHealthInput | null>;
+  resolveSurfaceWorkspace?: (agent: AgentRecord) => Promise<string | null>;
+}
+
+export async function buildAgentHealthInput(
+  agent: AgentRecord,
+  deps: AgentHealthInputDeps = {},
+  overrides: AgentHealthInputOverrides = {},
+): Promise<AgentHealthInput> {
+  const harvestability =
+    overrides.harvestability !== undefined
+      ? overrides.harvestability
+      : deps.assessHarvestability?.(agent) ?? null;
+  const closureArtifactVerified =
+    overrides.closure_artifact_verified !== undefined
+      ? overrides.closure_artifact_verified
+      : harvestability?.closure_artifact_verified ?? null;
+  const topology =
+    overrides.topology !== undefined
+      ? overrides.topology
+      : (await deps.resolveTopology?.(agent)) ?? null;
+  const alive =
+    overrides.monitor_alive ??
+    monitorAlive(
+      agent.agent_id,
+      deps.monitorMaxAgeMs ?? AGENT_HEALTH_MONITOR_MAX_AGE_MS,
+      deps.inboxOpts,
+    );
+  const inboxChannelDirDeleted =
+    overrides.inbox_channel_dir_deleted ??
+    (!alive && channelDirDeletedAfterCreate(agent.agent_id, deps.inboxOpts));
+  const staleCount =
+    overrides.stale_count ??
+    pendingDispatches(
+      agent.agent_id,
+      deps.dispatchAckTimeoutMs ?? AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
+      deps.inboxOpts,
+    ).length;
+  const needsScreen =
+    overrides.screen_status === undefined ||
+    overrides.screen_actions === undefined;
+  const parsedScreen = needsScreen
+    ? await deps.readParsedSurface?.(agent)
+    : null;
+  const screenStatus =
+    overrides.screen_status !== undefined
+      ? overrides.screen_status
+      : parsedScreen?.status;
+  const screenActions =
+    overrides.screen_actions !== undefined
+      ? overrides.screen_actions
+      : parsedScreen?.actions;
+  const surfaceWorkspaceId =
+    overrides.surface_workspace_id !== undefined
+      ? overrides.surface_workspace_id
+      : await deps.resolveSurfaceWorkspace?.(agent);
+
+  return {
+    monitor_alive: alive,
+    inbox_channel_dir_deleted: inboxChannelDirDeleted,
+    stale_count: staleCount,
+    screen_status: screenStatus,
+    screen_actions: screenActions,
+    surface_workspace_id: surfaceWorkspaceId,
+    surface_title: overrides.surface_title,
+    topology,
+    closure_artifact_verified: closureArtifactVerified,
+    harvestability,
+  };
+}

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -610,23 +610,23 @@ export class AgentRegistry {
    * Non-terminal agents with dead surfaces are already handled by reconcileSurfaces()
    * (marked as error during reconstitute), then caught here as terminal.
    *
-   * Returns the IDs of purged agents for sidebar cleanup.
+   * Returns purged agent records for sidebar cleanup.
    */
-  purgeAllTerminal(): string[] {
-    const purgedIds: string[] = [];
+  purgeAllTerminal(): AgentRecord[] {
+    const purgedAgents: AgentRecord[] = [];
 
     for (const [id, agent] of this.agents) {
       if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
       if (TERMINAL_STATES.has(agent.state)) {
+        purgedAgents.push(agent);
         const removedAgentId = this.deleteAgentAndAliases(id);
         this.stateMgr.removeState(removedAgentId);
-        purgedIds.push(removedAgentId);
       }
     }
 
-    return purgedIds;
+    return purgedAgents;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,12 @@ import {
   toPublicAgent,
 } from "./agent-facade.js";
 import { evaluateAgentHealth } from "./agent-health.js";
+import {
+  AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
+  AGENT_HEALTH_MONITOR_MAX_AGE_MS,
+  buildAgentHealthInput,
+  type AgentHealthInputOverrides,
+} from "./agent-health-input.js";
 import type {
   AgentRecord,
   AgentRole,
@@ -54,7 +60,6 @@ import {
   parseScreen,
 } from "./screen-parser.js";
 import {
-  channelDirDeletedAfterCreate,
   dispatch,
   ensureInboxFile,
   inboxPath,
@@ -223,7 +228,8 @@ const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 /** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
-const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = 60_000;
+const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS =
+  AGENT_HEALTH_MONITOR_MAX_AGE_MS;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 /** Agent states that are safe to close without `force`: the task is over. */
 const TERMINAL_AGENT_STATES = new Set<AgentState>(["done", "error"]);
@@ -1262,6 +1268,7 @@ export function createServerContext(
 function formatLifecycleChannelContent(
   event: AgentLifecycleEvent,
   agent: AgentRecord,
+  healthSummary?: string,
 ): string {
   switch (event) {
     case "spawned":
@@ -1272,12 +1279,15 @@ function formatLifecycleChannelContent(
       return agent.error
         ? `cmux agent errored: ${agent.repo} (${agent.agent_id}) - ${agent.error}`
         : `cmux agent errored: ${agent.repo} (${agent.agent_id})`;
+    case "health":
+      return `cmux agent health changed: ${agent.repo} (${agent.agent_id}) health=${healthSummary ?? "unknown"} state=${agent.state}`;
   }
 }
 
 function buildLifecycleChannelMeta(
   event: AgentLifecycleEvent,
   agent: AgentRecord,
+  healthSummary?: string,
 ): Record<string, string> {
   const meta: Record<string, string> = {
     source: "cmux-agent-status",
@@ -1299,6 +1309,9 @@ function buildLifecycleChannelMeta(
   }
   if (agent.cli_session_path) {
     meta.cli_session_path = agent.cli_session_path;
+  }
+  if (event === "health" && healthSummary) {
+    meta.health_summary = healthSummary;
   }
 
   return meta;
@@ -2701,72 +2714,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   const evaluateServerAgentHealth = async (
     agent: AgentRecord,
-    overrides?: {
-      monitor_alive?: boolean | null;
-      stale_count?: number;
-      screen_status?: string | null;
-      screen_actions?: string[] | null;
-      surface_workspace_id?: string | null;
-      surface_title?: string | null;
-      topology?: { column: number | null; column_count: number | null } | null;
-      closure_artifact_verified?: boolean | null;
-      harvestability?: ReturnType<AgentEngine["assessHarvestability"]> | null;
-      inbox_channel_dir_deleted?: boolean | null;
-    },
+    overrides?: AgentHealthInputOverrides,
   ) => {
-    const harvestability =
-      overrides?.harvestability !== undefined
-        ? overrides.harvestability
-        : lifecycleHealthEngine?.assessHarvestability(agent) ?? null;
-    const closureArtifactVerified =
-      overrides?.closure_artifact_verified !== undefined
-        ? overrides.closure_artifact_verified
-        : harvestability?.closure_artifact_verified ?? null;
-    const topology =
-      overrides?.topology !== undefined
-        ? overrides.topology
-        : await resolveSurfaceColumn(
-            agent.surface_id,
-            agent.workspace_id ?? undefined,
+    const input = await buildAgentHealthInput(
+      agent,
+      {
+        inboxOpts,
+        monitorMaxAgeMs: INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS,
+        dispatchAckTimeoutMs: AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
+        assessHarvestability: (target) =>
+          lifecycleHealthEngine?.assessHarvestability(target),
+        resolveTopology: (target) =>
+          resolveSurfaceColumn(
+            target.surface_id,
+            target.workspace_id ?? undefined,
+          ),
+        readParsedSurface: async (target) => {
+          const screen = await readParsedSurface(
+            target.surface_id,
+            target.workspace_id ?? undefined,
           );
-    const alive =
-      overrides?.monitor_alive ??
-      monitorAlive(agent.agent_id, INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS, inboxOpts);
-    const inboxChannelDirDeleted =
-      overrides?.inbox_channel_dir_deleted ??
-      (!alive && channelDirDeletedAfterCreate(agent.agent_id, inboxOpts));
-    const staleCount =
-      overrides?.stale_count ??
-      pendingDispatches(agent.agent_id, 120000, inboxOpts).length;
-    const parsedScreen =
-      overrides?.screen_status === undefined ||
-      overrides?.screen_actions === undefined
-        ? await readParsedSurface(agent.surface_id, agent.workspace_id ?? undefined)
-        : null;
-    const screenStatus =
-      overrides?.screen_status !== undefined
-        ? overrides.screen_status
-        : parsedScreen?.parsed.status;
-    const screenActions =
-      overrides?.screen_actions !== undefined
-        ? overrides.screen_actions
-        : parsedScreen?.parsed.actions;
-    const surfaceWorkspaceId =
-      overrides?.surface_workspace_id !== undefined
-        ? overrides.surface_workspace_id
-        : await resolveSurfaceWorkspace(agent.surface_id);
-    return evaluateAgentHealth(agent, {
-      monitor_alive: alive,
-      inbox_channel_dir_deleted: inboxChannelDirDeleted,
-      stale_count: staleCount,
-      screen_status: screenStatus,
-      screen_actions: screenActions,
-      surface_workspace_id: surfaceWorkspaceId,
-      surface_title: overrides?.surface_title,
-      topology,
-      closure_artifact_verified: closureArtifactVerified,
-      harvestability,
-    });
+          return screen
+            ? {
+                status: screen.parsed.status,
+                actions: screen.parsed.actions,
+              }
+            : null;
+        },
+        resolveSurfaceWorkspace: (target) =>
+          resolveSurfaceWorkspace(target.surface_id),
+      },
+      overrides,
+    );
+    return evaluateAgentHealth(agent, input);
   };
 
   const agentForSpawnHealth = (
@@ -4571,7 +4551,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS,
           inboxOpts,
         );
-        const pending = pendingDispatches(args.agent_id, 120000, inboxOpts);
+        const pending = pendingDispatches(
+          args.agent_id,
+          AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
+          inboxOpts,
+        );
         const nudge: {
           attempted: boolean;
           sent: boolean;
@@ -4657,14 +4641,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .int()
         .min(1000)
         .optional()
-        .default(120000)
+        .default(AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS)
         .describe("Treat un-acked dispatches older than this as stale/wedged"),
       heartbeat_max_age_ms: z
         .number()
         .int()
         .min(1000)
         .optional()
-        .default(60000)
+        .default(AGENT_HEALTH_MONITOR_MAX_AGE_MS)
         .describe(
           "Monitor is considered alive if it heartbeated within this window",
         ),
@@ -4786,6 +4770,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const notifyLifecycleEvent = async (
       event: AgentLifecycleEvent,
       agent: AgentRecord,
+      healthSummary?: string,
     ): Promise<void> => {
       if (!enableClaudeChannels || !server.server.transport) {
         return;
@@ -4795,8 +4780,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       await server.server.notification({
         method: CLAUDE_CHANNEL_NOTIFICATION,
         params: {
-          content: formatLifecycleChannelContent(event, agent),
-          meta: buildLifecycleChannelMeta(event, agent),
+          content: formatLifecycleChannelContent(event, agent, healthSummary),
+          meta: buildLifecycleChannelMeta(event, agent, healthSummary),
         },
       });
     };
@@ -4842,6 +4827,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             (disableSpawnPreflight ? async () => {} : undefined),
           sessionIdentityResolver: context.sessionIdentityResolver,
           roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
+          inboxOpts,
           launchCommandSender: async ({ surface, workspace, command }) => {
             await sendLauncherCommandToSurface({ surface, workspace, command });
           },

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,12 @@ import {
   type ControlHealth,
 } from "./control-health.js";
 import {
+  collectSurfaceTopology as collectCmuxSurfaceTopology,
+  EMPTY_SURFACE_TOPOLOGY,
+  healthTopologyOverrides,
+  type SurfaceTopology,
+} from "./surface-topology.js";
+import {
   formatMcpProfileEnv,
   prepareWorktree,
   type McpProfile,
@@ -2606,93 +2612,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return null;
   };
 
-  type SurfaceTopology = { column: number | null; column_count: number | null };
-  type SurfaceTopologySnapshot = {
-    workspaceBySurface: Map<string, string>;
-    titleBySurface: Map<string, string>;
-    topologyBySurface: Map<string, SurfaceTopology>;
-  };
-  const emptySurfaceTopology: SurfaceTopology = {
-    column: null,
-    column_count: null,
-  };
-
   const collectSurfaceTopology = async (
     workspace?: string,
-  ): Promise<SurfaceTopologySnapshot | null> => {
-    try {
-      const workspaceRefs = workspace
-        ? [workspace]
-        : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
-      const snapshot: SurfaceTopologySnapshot = {
-        workspaceBySurface: new Map(),
-        titleBySurface: new Map(),
-        topologyBySurface: new Map(),
-      };
-
-      for (const workspaceRef of workspaceRefs) {
-        const panes = await client.listPanes({ workspace: workspaceRef });
-        if (!panes.panes || panes.panes.length === 0) {
-          continue;
-        }
-        const columnIndex = deriveColumnIndex(panes.panes);
-        const columnCount = new Set(columnIndex.values()).size;
-        const rawGroups = await Promise.all(
-          panes.panes.map(async (pane) => {
-            const group = await client.listPaneSurfaces({
-              workspace: workspaceRef,
-              pane: pane.ref,
-            });
-            return {
-              ...group,
-              workspace_ref: group.workspace_ref ?? workspaceRef,
-              pane_ref: group.pane_ref ?? pane.ref,
-            };
-          }),
-        );
-        const partitioned = partitionPaneSurfacesByMembership(
-          panes.panes,
-          rawGroups,
-          {
-            workspace_ref: panes.workspace_ref ?? workspaceRef,
-            window_ref: panes.window_ref,
-          },
-        );
-        for (const group of partitioned) {
-          for (const surface of group.surfaces) {
-            snapshot.workspaceBySurface.set(
-              surface.ref,
-              group.workspace_ref ?? workspaceRef,
-            );
-            snapshot.titleBySurface.set(surface.ref, surface.title);
-            snapshot.topologyBySurface.set(surface.ref, {
-              column: columnIndex.get(group.pane_ref) ?? null,
-              column_count: columnCount,
-            });
-          }
-        }
-      }
-
-      return snapshot;
-    } catch {
-      return null;
-    }
-  };
-
-  const healthTopologyOverrides = (
-    agent: AgentRecord,
-    snapshot: SurfaceTopologySnapshot | null,
-  ) =>
-    snapshot
-      ? {
-          topology:
-            snapshot.topologyBySurface.get(agent.surface_id) ??
-            emptySurfaceTopology,
-          surface_workspace_id:
-            snapshot.workspaceBySurface.get(agent.surface_id) ?? null,
-          surface_title: snapshot.titleBySurface.get(agent.surface_id) ?? null,
-        }
-      : {};
+  ) => collectCmuxSurfaceTopology(client, workspace);
 
   // Resolve a surface's 0-based column + the workspace column_count using the
   // SAME reliable post-F5 logic as list_surfaces: derive columns from pane
@@ -2705,7 +2627,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): Promise<SurfaceTopology> =>
     (await collectSurfaceTopology(workspace))?.topologyBySurface.get(
       surfaceRef,
-    ) ?? emptySurfaceTopology;
+    ) ?? EMPTY_SURFACE_TOPOLOGY;
 
   const resolveSurfaceWorkspace = async (
     surfaceRef: string,

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -1,0 +1,107 @@
+import type { AgentRecord } from "./agent-types.js";
+import type { AgentTopologyHealthInput } from "./agent-health.js";
+import type { AgentHealthInputOverrides } from "./agent-health-input.js";
+import { deriveColumnIndex } from "./layout-policy.js";
+import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
+import type { CmuxPane, CmuxPaneSurfaces, CmuxWorkspace } from "./types.js";
+
+export type SurfaceTopology = AgentTopologyHealthInput;
+
+export interface SurfaceTopologySnapshot {
+  workspaceBySurface: Map<string, string>;
+  titleBySurface: Map<string, string>;
+  topologyBySurface: Map<string, SurfaceTopology>;
+}
+
+export interface SurfaceTopologyClient {
+  listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }>;
+  listPanes(opts?: { workspace?: string }): Promise<{
+    workspace_ref?: string;
+    window_ref?: string;
+    panes: CmuxPane[];
+  }>;
+  listPaneSurfaces(opts?: {
+    workspace?: string;
+    pane?: string;
+  }): Promise<CmuxPaneSurfaces>;
+}
+
+export const EMPTY_SURFACE_TOPOLOGY: SurfaceTopology = {
+  column: null,
+  column_count: null,
+};
+
+export async function collectSurfaceTopology(
+  client: SurfaceTopologyClient,
+  workspace?: string,
+): Promise<SurfaceTopologySnapshot | null> {
+  try {
+    const workspaceRefs = workspace
+      ? [workspace]
+      : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+    const snapshot: SurfaceTopologySnapshot = {
+      workspaceBySurface: new Map(),
+      titleBySurface: new Map(),
+      topologyBySurface: new Map(),
+    };
+
+    for (const workspaceRef of workspaceRefs) {
+      const panes = await client.listPanes({ workspace: workspaceRef });
+      if (!panes.panes || panes.panes.length === 0) {
+        continue;
+      }
+      const columnIndex = deriveColumnIndex(panes.panes);
+      const columnCount = new Set(columnIndex.values()).size;
+      const rawGroups = await Promise.all(
+        panes.panes.map(async (pane) => {
+          const group = await client.listPaneSurfaces({
+            workspace: workspaceRef,
+            pane: pane.ref,
+          });
+          return {
+            ...group,
+            workspace_ref: group.workspace_ref ?? workspaceRef,
+            pane_ref: group.pane_ref ?? pane.ref,
+          };
+        }),
+      );
+      const partitioned = partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
+        workspace_ref: panes.workspace_ref ?? workspaceRef,
+        window_ref: panes.window_ref,
+      });
+      for (const group of partitioned) {
+        for (const surface of group.surfaces) {
+          snapshot.workspaceBySurface.set(
+            surface.ref,
+            group.workspace_ref ?? workspaceRef,
+          );
+          snapshot.titleBySurface.set(surface.ref, surface.title);
+          snapshot.topologyBySurface.set(surface.ref, {
+            column: columnIndex.get(group.pane_ref) ?? null,
+            column_count: columnCount,
+          });
+        }
+      }
+    }
+
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function healthTopologyOverrides(
+  agent: AgentRecord,
+  snapshot: SurfaceTopologySnapshot | null,
+): AgentHealthInputOverrides {
+  return snapshot
+    ? {
+        topology:
+          snapshot.topologyBySurface.get(agent.surface_id) ??
+          EMPTY_SURFACE_TOPOLOGY,
+        surface_workspace_id:
+          snapshot.workspaceBySurface.get(agent.surface_id) ?? null,
+        surface_title: snapshot.titleBySurface.get(agent.surface_id) ?? null,
+      }
+    : {};
+}

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -35,36 +35,45 @@ export async function collectSurfaceTopology(
   client: SurfaceTopologyClient,
   workspace?: string,
 ): Promise<SurfaceTopologySnapshot | null> {
+  let workspaceRefs: string[];
   try {
-    const workspaceRefs = workspace
+    workspaceRefs = workspace
       ? [workspace]
       : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
-    const snapshot: SurfaceTopologySnapshot = {
-      workspaceBySurface: new Map(),
-      titleBySurface: new Map(),
-      topologyBySurface: new Map(),
-    };
+  } catch {
+    return null;
+  }
 
-    for (const workspaceRef of workspaceRefs) {
+  const snapshot: SurfaceTopologySnapshot = {
+    workspaceBySurface: new Map(),
+    titleBySurface: new Map(),
+    topologyBySurface: new Map(),
+  };
+
+  for (const workspaceRef of workspaceRefs) {
+    try {
       const panes = await client.listPanes({ workspace: workspaceRef });
-      if (!panes.panes || panes.panes.length === 0) {
-        continue;
-      }
+      if (!panes.panes || panes.panes.length === 0) continue;
+
       const columnIndex = deriveColumnIndex(panes.panes);
       const columnCount = new Set(columnIndex.values()).size;
-      const rawGroups = await Promise.all(
-        panes.panes.map(async (pane) => {
+      const rawGroups: CmuxPaneSurfaces[] = [];
+      for (const pane of panes.panes) {
+        try {
           const group = await client.listPaneSurfaces({
             workspace: workspaceRef,
             pane: pane.ref,
           });
-          return {
+          rawGroups.push({
             ...group,
             workspace_ref: group.workspace_ref ?? workspaceRef,
             pane_ref: group.pane_ref ?? pane.ref,
-          };
-        }),
-      );
+          });
+        } catch {
+          // Panes can close between listPanes and listPaneSurfaces. Keep the
+          // rest of the snapshot usable instead of dropping every agent's health input.
+        }
+      }
       const partitioned = partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
         workspace_ref: panes.workspace_ref ?? workspaceRef,
         window_ref: panes.window_ref,
@@ -82,12 +91,12 @@ export async function collectSurfaceTopology(
           });
         }
       }
+    } catch {
+      // A single bad workspace should not erase topology already collected for others.
     }
-
-    return snapshot;
-  } catch {
-    return null;
   }
+
+  return snapshot;
 }
 
 export function healthTopologyOverrides(

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1472,7 +1472,7 @@ describe("AgentEngine", () => {
         expect(mockClient.clearStatus).not.toHaveBeenCalled();
         expect(mockClient.setStatus).toHaveBeenCalledWith(
           "worker-archived-before-status",
-          "brainlayer: done",
+          "brainlayer | role=worker | state=done | health=unhealthy(inbox_monitor_not_alive,closure_without_artifact) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
           expect.objectContaining({
             surface: "surface:archived-before-status",
           }),

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2970,7 +2970,7 @@ To continue this session, run codex resume ${sessionId}`,
         expect(mockClient.moveSurface).not.toHaveBeenCalled();
         expect(mockClient.readScreen).toHaveBeenCalledWith(
           "surface:claude-screen-ready",
-          { lines: 80 },
+          { lines: 80, workspace: "ws:screen-ready" },
         );
       } finally {
         vi.useRealTimers();

--- a/tests/agent-health-input.test.ts
+++ b/tests/agent-health-input.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildAgentHealthInput } from "../src/agent-health-input.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+function makeAgent(overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "agent-health-input-test",
+    surface_id: "surface:1",
+    state: "working",
+    repo: "brainlayer",
+    model: "codex",
+    cli: "codex",
+    cli_session_id: "session-1",
+    task_summary: "Test helper",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-05T12:00:00Z",
+    updated_at: "2026-07-05T12:00:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    ...overrides,
+  };
+}
+
+describe("buildAgentHealthInput", () => {
+  it("preserves explicit null monitor overrides", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "cmux-agent-health-input-"));
+    try {
+      const input = await buildAgentHealthInput(
+        makeAgent(),
+        { inboxOpts: { baseDir: tmp } },
+        {
+          monitor_alive: null,
+          inbox_channel_dir_deleted: null,
+        },
+      );
+
+      expect(input.monitor_alive).toBeNull();
+      expect(input.inbox_channel_dir_deleted).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("treats parsed surface read failures as absent screen input", async () => {
+    const input = await buildAgentHealthInput(makeAgent(), {
+      readParsedSurface: async () => {
+        throw new Error("cmux read failed");
+      },
+    });
+
+    expect(input.screen_status).toBeUndefined();
+    expect(input.screen_actions).toBeUndefined();
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,6 +7,7 @@ import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
+import { dispatch, writeHeartbeat } from "../src/inbox.js";
 
 // Core low-level and metadata tools.
 const EXPECTED_TOOLS = [
@@ -93,7 +94,7 @@ describe("Claude channels", () => {
     rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
   });
 
-  it("emits lifecycle notifications over the MCP transport when enabled", async () => {
+  it("emits attention-worthy lifecycle notifications over the MCP transport when enabled", async () => {
     vi.useFakeTimers();
     rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -179,19 +180,171 @@ describe("Claude channels", () => {
       await advanceTimers(5000);
     }
 
+    stateMgr.transition("a1", "error", { error: "crashed" });
+
+    if (typeof advanceAsync === "function") {
+      await advanceAsync.call(vi, 5000);
+    } else {
+      await advanceTimers(5000);
+    }
+
     const notifications = messages.filter(
       (message) =>
         "method" in message &&
         message.method === "notifications/claude/channel",
     );
-    expect(notifications).toHaveLength(1);
-    expect(notifications[0]).toEqual(
+    const events = notifications.map((message) => {
+      const params = message.params as { meta?: { event?: string } };
+      return params.meta?.event;
+    });
+    expect(events).toContain("errored");
+    expect(events).toContain("health");
+    expect(events).not.toContain("spawned");
+    const erroredNotification = notifications.find((message) => {
+      const params = message.params as { meta?: { event?: string } };
+      return params.meta?.event === "errored";
+    });
+    expect(erroredNotification).toEqual(
       expect.objectContaining({
         params: expect.objectContaining({
           meta: expect.objectContaining({
-            event: "spawned",
+            event: "errored",
             agent_id: "a1",
             repo: "brainlayer",
+            state: "error",
+          }),
+        }),
+      }),
+    );
+
+    await server.close();
+    await clientTransport.close();
+  });
+
+  it("includes health issue summary in health channel notifications", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00.000Z"));
+    rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    const inboxDir = join(CHANNEL_TEST_DIR, "inbox");
+    const stateMgr = new StateManager(CHANNEL_TEST_DIR);
+    stateMgr.writeState({
+      agent_id: "wedged-holder",
+      surface_id: "surface:42",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "session-wedged",
+      task_summary: "Drain the inbox",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-05T12:00:00Z",
+      updated_at: "2026-07-05T12:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      role: "worker",
+    });
+
+    const mockClient = {
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            ref: "surface:42",
+            title: "agent",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+      log: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue(undefined),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:42",
+        text: "$ ",
+        lines: 5,
+        scrollback_used: false,
+      }),
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      setProgress: vi.fn().mockResolvedValue(undefined),
+      newSplit: vi.fn(),
+    };
+    writeHeartbeat("wedged-holder", { baseDir: inboxDir });
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir: CHANNEL_TEST_DIR,
+      inboxBaseDir: inboxDir,
+      enableClaudeChannels: true,
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const messages: any[] = [];
+    clientTransport.onmessage = (message) => {
+      messages.push(message);
+    };
+
+    await server.connect(serverTransport);
+    const advanceAsync = (vi as any).advanceTimersByTimeAsync;
+    if (typeof advanceAsync === "function") {
+      await advanceAsync.call(vi, 5000);
+    } else {
+      await advanceTimers(5000);
+    }
+
+    dispatch(
+      "wedged-holder",
+      {
+        id: "stale-dispatch",
+        ts_ms: Date.now() - 180_000,
+        from: "lead",
+        tag: "dispatch",
+        task: "stale work item",
+      },
+      { baseDir: inboxDir },
+    );
+
+    if (typeof advanceAsync === "function") {
+      await advanceAsync.call(vi, 5000);
+    } else {
+      await advanceTimers(5000);
+    }
+
+    const healthNotification = messages.find((message) => {
+      const params = message.params as { meta?: { event?: string } };
+      return (
+        "method" in message &&
+        message.method === "notifications/claude/channel" &&
+        params.meta?.event === "health"
+      );
+    });
+    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    expect(healthNotification).toEqual(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          content: expect.stringContaining(healthSummary),
+          meta: expect.objectContaining({
+            event: "health",
+            agent_id: "wedged-holder",
+            health_summary: healthSummary,
           }),
         }),
       }),

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -336,6 +336,28 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("scopes sidebar health screen reads to the agent workspace", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "scoped-read",
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-scoped-read",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("scoped-read", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.readScreen).toHaveBeenCalledWith(
+      "surface:42",
+      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    );
+  });
+
   it("notifies when a wedged holder is already unhealthy on the first sweep", async () => {
     const inboxDir = join(TEST_DIR, "initial-wedged-inbox");
     const agentId = "initial-wedged-holder";

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -3,19 +3,24 @@
  * Tests syncSidebar(), runSweep(), and lifecycle log events.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AgentEngine } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
+import { ack, dispatch, writeHeartbeat } from "../src/inbox.js";
 import type { CmuxClient } from "../src/cmux-client.js";
 import type { AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-sidebar");
 
-function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
+type MockClient = CmuxClient & {
+  notifyLifecycleEvent: ReturnType<typeof vi.fn>;
+};
+
+function makeMockClient(overrides?: Partial<CmuxClient>): MockClient {
   return {
     newSplit: vi.fn().mockResolvedValue({
       workspace: "ws:1",
@@ -46,7 +51,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
     log: vi.fn().mockResolvedValue(undefined),
     notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
     ...overrides,
-  } as unknown as CmuxClient;
+  } as unknown as MockClient;
 }
 
 function makeSurface(ref: string): CmuxSurface {
@@ -79,9 +84,10 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
 
 describe("Sidebar Sync", () => {
   let stateMgr: StateManager;
-  let mockClient: CmuxClient;
+  let mockClient: MockClient;
   let engine: AgentEngine;
   let liveSurfaces: CmuxSurface[];
+  let inboxOpts: { baseDir: string };
 
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
@@ -89,10 +95,12 @@ describe("Sidebar Sync", () => {
     stateMgr = new StateManager(TEST_DIR);
     mockClient = makeMockClient();
     liveSurfaces = [];
+    inboxOpts = { baseDir: join(TEST_DIR, "inbox") };
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
+      inboxOpts,
     });
   });
 
@@ -101,29 +109,261 @@ describe("Sidebar Sync", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("calls setStatus for an active agent with state-derived icon and color", async () => {
+  it("calls setStatus with compact sidebar truth for an active agent", async () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: "a1",
         state: "working",
         surface_id: "surface:42",
         workspace_id: "workspace:coach",
+        cli_session_id: "session-a1",
+        task_summary: "Read and follow GOAL-p8-sidebar.md",
+        role: "worker",
+        worktree_path:
+          "/Users/etanheyman/Gits/cmuxlayer.wt/cmuxlayer-worker-p8",
+        worktree_branch: "p8-sidebar",
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
 
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       "a1",
-      "brainlayer: working",
+      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Read and follow GOAL-p8-sidebar.md | worktree=/Users/etanheyman/Gits/cmuxlayer.wt/cmuxlayer-worker-p8 | branch=p8-sidebar | report=n/a | pr=n/a",
       expect.objectContaining({
         icon: "bolt.fill",
         color: "#3B82F6",
         workspace: "workspace:coach",
         surface: "surface:42",
       }),
+    );
+  });
+
+  it("discriminates health by state instead of marking every missing-session row unhealthy", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "booting-agent",
+        state: "booting",
+        surface_id: "surface:1",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: null,
+        task_summary: "Boot worker",
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "working-agent",
+        state: "working",
+        surface_id: "surface:2",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: null,
+        task_summary: "Run worker",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:1"), makeSurface("surface:2")];
+    writeHeartbeat("booting-agent", inboxOpts);
+    writeHeartbeat("working-agent", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "booting-agent",
+      "brainlayer | role=worker | state=booting | health=healthy | blocked=- | last_prompt=Boot worker | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    );
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "working-agent",
+      "brainlayer | role=worker | state=working | health=unhealthy(missing_cli_session_id,non_resumable) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    );
+  });
+
+  it("clears stale workspace-scoped sidebar rows during startup purge after restart", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "stale-done-agent",
+        state: "done",
+        surface_id: "surface:recycled",
+        workspace_id: "workspace:previous-session",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:recycled")];
+    await engine.getRegistry().reconstitute();
+    engine.enableStartupPurge();
+
+    await engine.runSweep();
+
+    expect(mockClient.clearStatus).toHaveBeenCalledWith("stale-done-agent", {
+      workspace: "workspace:previous-session",
+    });
+    expect(mockClient.setStatus).not.toHaveBeenCalledWith(
+      "stale-done-agent",
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it("does not emit channel notifications for initial spawned rows", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "a1",
+        state: "working",
+        surface_id: "surface:42",
+        cli_session_id: "session-a1",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
+  });
+
+  it("marks a wedged holder unhealthy and notifies with the health issue summary", async () => {
+    const inboxDir = join(TEST_DIR, "wedged-inbox");
+    const agentId = "wedged-holder";
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-wedged",
+        role: "worker",
+        task_summary: "Keep draining inbox dispatches",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir });
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      agentId,
+      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Keep draining inbox dispatches | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    );
+
+    (mockClient.setStatus as ReturnType<typeof vi.fn>).mockClear();
+    mockClient.notifyLifecycleEvent.mockClear();
+    dispatch(
+      agentId,
+      {
+        id: "stale-dispatch",
+        ts_ms: Date.now() - 180_000,
+        from: "lead",
+        tag: "dispatch",
+        task: "stale work item",
+      },
+      { baseDir: inboxDir },
+    );
+
+    await engine.runSweep();
+
+    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      agentId,
+      `brainlayer | role=worker | state=working | health=${healthSummary} | blocked=self:agent_wedged | last_prompt=Keep draining inbox dispatches | worktree=- | branch=- | report=n/a | pr=n/a`,
+      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    );
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      healthSummary,
+    );
+
+    mockClient.notifyLifecycleEvent.mockClear();
+    ack(agentId, "stale-dispatch", "done", { baseDir: inboxDir });
+
+    await engine.runSweep();
+
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      "healthy",
+    );
+
+    mockClient.notifyLifecycleEvent.mockClear();
+    dispatch(
+      agentId,
+      {
+        id: "stale-dispatch-2",
+        ts_ms: Date.now() - 180_000,
+        from: "lead",
+        tag: "dispatch",
+        task: "second stale work item",
+      },
+      { baseDir: inboxDir },
+    );
+
+    await engine.runSweep();
+
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      healthSummary,
+    );
+  });
+
+  it("does not emit done notifications until a worker has verified terminal evidence", async () => {
+    const goalPath = join(TEST_DIR, "phase-8-goal.md");
+    const reportPath = join(TEST_DIR, "phase-8-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Phase 8 Goal",
+        "",
+        "Write the report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "The final report line must be exactly:",
+        "",
+        "`DONE_P8_WORKER`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "done-worker",
+        state: "done",
+        surface_id: "surface:42",
+        goal_file: goalPath,
+        role: "worker",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("done-worker", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalledWith(
+      "done",
+      expect.objectContaining({ agent_id: "done-worker" }),
+    );
+
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_P8_WORKER\n", "utf8");
+
+    await engine.runSweep();
+
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "done",
+      expect.objectContaining({ agent_id: "done-worker" }),
     );
   });
 
@@ -137,6 +377,7 @@ describe("Sidebar Sync", () => {
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -153,7 +394,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.setStatus).toHaveBeenCalledTimes(2);
     expect(mockClient.setStatus).toHaveBeenLastCalledWith(
       "a1",
-      "brainlayer: working",
+      "brainlayer | role=worker | state=working | health=unhealthy(missing_cli_session_id,non_resumable) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
       expect.objectContaining({
         workspace: "workspace:coach",
         surface: "surface:99",
@@ -245,14 +486,7 @@ describe("Sidebar Sync", () => {
       "spawned: brainlayer",
       expect.objectContaining({ level: "info", source: "cmuxlayer" }),
     );
-    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
-      "spawned",
-      expect.objectContaining({
-        agent_id: "a1",
-        repo: "brainlayer",
-        state: "working",
-      }),
-    );
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
   });
 
   it("logs done event when agent reaches done state", async () => {
@@ -279,13 +513,9 @@ describe("Sidebar Sync", () => {
       "done: brainlayer",
       expect.objectContaining({ level: "success", source: "cmuxlayer" }),
     );
-    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalledWith(
       "done",
-      expect.objectContaining({
-        agent_id: "a1",
-        repo: "brainlayer",
-        state: "done",
-      }),
+      expect.objectContaining({ agent_id: "a1" }),
     );
   });
 
@@ -307,7 +537,7 @@ describe("Sidebar Sync", () => {
       "errored: brainlayer",
       expect.objectContaining({ level: "error", source: "cmuxlayer" }),
     );
-    expect((mockClient as any).notifyLifecycleEvent).toHaveBeenCalledWith(
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
       "errored",
       expect.objectContaining({
         agent_id: "a1",
@@ -340,12 +570,10 @@ describe("Sidebar Sync", () => {
     );
     expect(doneCalls).toHaveLength(1);
 
-    const channelCalls = (
-      (mockClient as any).notifyLifecycleEvent as ReturnType<typeof vi.fn>
-    ).mock.calls;
+    const channelCalls = mockClient.notifyLifecycleEvent.mock.calls;
     const spawnedChannelCalls = channelCalls.filter((c) => c[0] === "spawned");
-    expect(spawnedChannelCalls).toHaveLength(1);
+    expect(spawnedChannelCalls).toHaveLength(0);
     const doneChannelCalls = channelCalls.filter((c) => c[0] === "done");
-    expect(doneChannelCalls).toHaveLength(1);
+    expect(doneChannelCalls).toHaveLength(0);
   });
 });

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -264,6 +264,51 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("notifies when a wedged holder is already unhealthy on the first sweep", async () => {
+    const inboxDir = join(TEST_DIR, "initial-wedged-inbox");
+    const agentId = "initial-wedged-holder";
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-wedged",
+        role: "worker",
+        task_summary: "Drain existing stale dispatch",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir });
+    dispatch(
+      agentId,
+      {
+        id: "already-stale-dispatch",
+        ts_ms: Date.now() - 180_000,
+        from: "lead",
+        tag: "dispatch",
+        task: "stale work item",
+      },
+      { baseDir: inboxDir },
+    );
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      healthSummary,
+    );
+  });
+
   it("marks a wedged holder unhealthy and notifies with the health issue summary", async () => {
     const inboxDir = join(TEST_DIR, "wedged-inbox");
     const agentId = "wedged-holder";
@@ -447,9 +492,11 @@ describe("Sidebar Sync", () => {
         agent_id: "a1",
         state: "working",
         surface_id: "surface:42",
+        cli_session_id: "session-a1",
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -470,9 +517,11 @@ describe("Sidebar Sync", () => {
         agent_id: "a1",
         state: "working",
         surface_id: "surface:42",
+        cli_session_id: "session-a1",
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -514,9 +563,11 @@ describe("Sidebar Sync", () => {
         agent_id: "a1",
         state: "working",
         surface_id: "surface:42",
+        cli_session_id: "session-a1",
       }),
     );
     liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("a1", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -225,6 +225,45 @@ describe("Sidebar Sync", () => {
     expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
   });
 
+  it("continues sidebar sync when health screen reads fail", async () => {
+    mockClient.readScreen.mockRejectedValue(new Error("cmux read failed"));
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "a1",
+        state: "working",
+        surface_id: "surface:1",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-a1",
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "a2",
+        state: "working",
+        surface_id: "surface:2",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-a2",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:1"), makeSurface("surface:2")];
+    writeHeartbeat("a1", inboxOpts);
+    writeHeartbeat("a2", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await expect(engine.runSweep()).resolves.toBeUndefined();
+
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "a1",
+      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({ surface: "surface:1" }),
+    );
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "a2",
+      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({ surface: "surface:2" }),
+    );
+  });
+
   it("marks a wedged holder unhealthy and notifies with the health issue summary", async () => {
     const inboxDir = join(TEST_DIR, "wedged-inbox");
     const agentId = "wedged-holder";

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -58,6 +58,16 @@ function makeSurface(ref: string): CmuxSurface {
   return { ref, title: "", type: "terminal", index: 0, selected: false };
 }
 
+function makeWorkspace(ref: string) {
+  return {
+    ref,
+    title: ref,
+    index: 0,
+    selected: false,
+    pinned: false,
+  };
+}
+
 function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
   return {
     agent_id: "codex-brainlayer-1710388800",
@@ -264,6 +274,68 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("feeds topology and surface workspace truth into sidebar health", async () => {
+    mockClient.listWorkspaces.mockResolvedValue({
+      workspaces: [makeWorkspace("workspace:actual")],
+    });
+    mockClient.listPanes.mockResolvedValue({
+      workspace_ref: "workspace:actual",
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: "pane:actual",
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: ["surface:42"],
+        },
+      ],
+    });
+    mockClient.listPaneSurfaces.mockResolvedValue({
+      workspace_ref: "workspace:actual",
+      window_ref: "window:1",
+      pane_ref: "pane:actual",
+      surfaces: [
+        {
+          ref: "surface:42",
+          title: "worker lane",
+          type: "terminal",
+          index: 0,
+          selected: false,
+        },
+      ],
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "workspace-drift",
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:registry",
+        cli_session_id: "session-workspace-drift",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    writeHeartbeat("workspace-drift", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    const healthSummary = "unhealthy(registry_surface_workspace_mismatch)";
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "workspace-drift",
+      `brainlayer | role=worker | state=working | health=${healthSummary} | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a`,
+      expect.objectContaining({
+        surface: "surface:42",
+        workspace: "workspace:registry",
+      }),
+    );
+    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: "workspace-drift" }),
+      healthSummary,
+    );
+  });
+
   it("notifies when a wedged holder is already unhealthy on the first sweep", async () => {
     const inboxDir = join(TEST_DIR, "initial-wedged-inbox");
     const agentId = "initial-wedged-holder";
@@ -400,6 +472,67 @@ describe("Sidebar Sync", () => {
       expect.objectContaining({ agent_id: agentId }),
       healthSummary,
     );
+  });
+
+  it("retries health notifications when channel delivery fails", async () => {
+    const inboxDir = join(TEST_DIR, "wedged-retry-inbox");
+    const agentId = "wedged-retry-holder";
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:42",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-wedged-retry",
+        role: "worker",
+        task_summary: "Retry health channel",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:42")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir });
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    dispatch(
+      agentId,
+      {
+        id: "stale-dispatch",
+        ts_ms: Date.now() - 180_000,
+        from: "lead",
+        tag: "dispatch",
+        task: "stale work item",
+      },
+      { baseDir: inboxDir },
+    );
+    mockClient.notifyLifecycleEvent.mockRejectedValueOnce(
+      new Error("channel down"),
+    );
+
+    await engine.runSweep();
+    await engine.runSweep();
+
+    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    const healthCalls = mockClient.notifyLifecycleEvent.mock.calls.filter(
+      (call) => call[0] === "health",
+    );
+    expect(healthCalls).toHaveLength(2);
+    expect(healthCalls[0]).toEqual([
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      healthSummary,
+    ]);
+    expect(healthCalls[1]).toEqual([
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      healthSummary,
+    ]);
   });
 
   it("does not emit done notifications until a worker has verified terminal evidence", async () => {

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { collectSurfaceTopology } from "../src/surface-topology.js";
+import type {
+  CmuxPane,
+  CmuxPaneSurfaces,
+  CmuxSurface,
+  CmuxWorkspace,
+} from "../src/types.js";
+
+function workspace(ref: string): CmuxWorkspace {
+  return {
+    ref,
+    title: ref,
+    index: 0,
+    selected: false,
+    pinned: false,
+  };
+}
+
+function pane(ref: string, index: number, surfaceRefs: string[]): CmuxPane {
+  return {
+    ref,
+    index,
+    focused: index === 0,
+    surface_count: surfaceRefs.length,
+    surface_refs: surfaceRefs,
+  };
+}
+
+function surface(ref: string): CmuxSurface {
+  return {
+    ref,
+    title: ref,
+    type: "terminal",
+    index: 0,
+    selected: false,
+  };
+}
+
+describe("collectSurfaceTopology", () => {
+  it("keeps usable pane topology when another pane surface lookup fails", async () => {
+    const panes = [pane("pane:ok", 0, ["surface:ok"]), pane("pane:gone", 1, [])];
+    const client = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [workspace("workspace:1")],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes,
+      }),
+      listPaneSurfaces: vi.fn(
+        async (opts: { workspace?: string; pane?: string }) => {
+          if (opts.pane === "pane:gone") {
+            throw new Error("pane closed");
+          }
+          return {
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:ok",
+            surfaces: [surface("surface:ok")],
+          } satisfies CmuxPaneSurfaces;
+        },
+      ),
+    };
+
+    const snapshot = await collectSurfaceTopology(client);
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.workspaceBySurface.get("surface:ok")).toBe("workspace:1");
+    expect(snapshot?.topologyBySurface.get("surface:ok")).toEqual({
+      column: 0,
+      column_count: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Feed sidebar health through the same shared inbox/screen/topology input builder used by `control_health`.
- Emit compact diffed sidebar truth with discriminating health, per-agent worktree/branch/last-prompt/report/PR status, stale-row purge, and attention-worthy notifications only.
- Surface wedged inbox holders as `unhealthy(stale_inbox_dispatches,agent_wedged)` with `blocked=self:agent_wedged`, and include health summaries in channel notifications.
- Addressed local CodeRabbit findings before commit: health notification dedupe is last-state based, health screen reads use per-agent sweep contexts, and lifecycle notification/log memory is cleared when agents leave the sidebar registry.

## Test plan
- `bun run typecheck`
- `bun run test tests/sidebar-sync.test.ts tests/server.test.ts tests/agent-engine.test.ts`
- `bun run test`
- `git diff --check`
- Push hook: `run_tests.sh` completed with exit status 0

## Local review notes
- `coderabbit review --agent` produced two MAJOR findings before timing out at 180s; both were fixed and verified locally.
- A second pass produced one MINOR cleanup finding before timing out; it was fixed and verified locally.
- A third bounded pass timed out with no new findings emitted; red/blue fallback review found no additional concrete blockers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sweep-loop sidebar formatting, health evaluation inputs, and external channel notification semantics; the sidebar string format is a breaking change for any parser expecting `repo: state`.
> 
> **Overview**
> **Phase 8 sidebar sync** replaces the old `repo: state` sidebar line with a **pipe-delimited status string** (role, state, health, blocked, worktree, branch, report, PR) built each sweep from **`evaluateAgentHealth`** plus worker **harvestability**.
> 
> Health signals are assembled through a new shared **`buildAgentHealthInput`** (inbox monitor, stale dispatches, parsed screen, topology/harvestability overrides) used by both the **agent engine** and **server**, with **surface topology** moved into **`surface-topology.ts`** for reuse.
> 
> **Lifecycle channels** are split from logs: **`spawned`** still logs only; **`done`** notifies only when harvestability is **closeable**; **`errored`** always notifies; new **`health`** notifies on unhealthy transitions (including recovery), with signature-based dedupe and **retry** if delivery fails. Startup purge now returns full agent records so sidebar cleanup can clear **workspace-scoped** stale rows; **`readScreen`** calls pass **`workspace`** for correct multi-workspace reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eafa2dad45913df5a4d4f598ad723b94b98b770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add health-discriminating sidebar status and wedge-aware lifecycle notifications to the agent engine
> - The agent engine now evaluates per-agent health each sweep using `evaluateAgentHealth` and builds a rich sidebar status string covering role, state, health, blocked reason, last prompt, worktree, branch, and report/PR summaries.
> - Health channel notifications fire when the health signature changes and either the new or previous health is unhealthy; failed notifications are retried on subsequent sweeps.
> - `done` lifecycle notifications are now gated on `assessHarvestability().closeable` rather than firing unconditionally; `error` events always trigger a notification.
> - All `readScreen` calls for done/readiness detection and sidebar health parsing now include the agent workspace scope.
> - `AgentRegistry.purgeAllTerminal` returns full `AgentRecord` objects so startup purge can clear workspace-scoped sidebar rows and reset per-agent lifecycle memory.
> - Surface topology collection is extracted into a shared [surface-topology.ts](https://github.com/EtanHey/cmuxlayer/pull/226/files#diff-a861838bd88c600f492d934ff6bd5df4c2c8e61e24dda1dcd88f71ec123fd667) module used by both the engine and server.
> - Risk: Behavioral change — `done` notifications are suppressed for non-closeable agents, and a new `health` lifecycle event type is emitted; clients must accept the optional `healthSummary` third argument on `notifyLifecycleEvent`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eafa2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar and lifecycle updates now surface agent health alongside status, including clearer indicators for unhealthy, blocked, and completed agents.
  * Notifications can now include a health summary when an agent’s condition changes.
  * Sidebar rows now retain richer status details such as worktree, branch, report, and PR info.

* **Bug Fixes**
  * Improved handling of stale or wedged agents so health updates refresh more reliably.
  * Startup cleanup now preserves clearer state for removed terminal agents.
  * Lifecycle notifications are more consistent for done and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->