### PR TITLE
feat(runtime): reaper audit gates + doctor provenance + fail-closed socket demux (phase 9)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -91,6 +91,8 @@ import {
 } from "./surface-topology.js";
 import type { InboxOpts } from "./inbox.js";
 
+type ProcessLiveness = "alive" | "gone" | "unknown";
+
 export interface SpawnAgentParams {
   repo: string;
   model?: string;
@@ -3232,11 +3234,11 @@ export class AgentEngine {
     }
   }
 
-  private isProcessGone(pid: number | null | undefined): boolean {
-    if (!pid) return true;
+  private processLiveness(pid: number | null | undefined): ProcessLiveness {
+    if (!pid) return "gone";
     try {
       process.kill(pid, 0);
-      return false;
+      return "alive";
     } catch (error) {
       if (
         typeof error === "object" &&
@@ -3244,10 +3246,15 @@ export class AgentEngine {
         "code" in error &&
         (error as { code?: unknown }).code === "ESRCH"
       ) {
-        return true;
+        return "gone";
       }
-      return false;
+      return "unknown";
     }
+  }
+
+  private isProcessGone(pid: number | null | undefined): boolean {
+    const liveness = this.processLiveness(pid);
+    return liveness === "gone" || liveness === "unknown";
   }
 
   private isTerminalDeadRegistryGhost(agent: AgentRecord): boolean {
@@ -3266,9 +3273,13 @@ export class AgentEngine {
     const evicted: string[] = [];
 
     for (const agent of this.registry.list()) {
+      const processGone =
+        agent.pid !== null &&
+        agent.pid !== undefined &&
+        this.processLiveness(agent.pid) === "gone";
       if (
         !this.isTerminalDeadRegistryGhost(agent) &&
-        (!agent.pid || !this.isProcessGone(agent.pid))
+        !processGone
       ) {
         continue;
       }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3257,6 +3257,10 @@ export class AgentEngine {
     return liveness === "gone" || liveness === "unknown";
   }
 
+  private isProcessConfirmedGone(pid: number | null | undefined): boolean {
+    return this.processLiveness(pid) === "gone";
+  }
+
   private isTerminalDeadRegistryGhost(agent: AgentRecord): boolean {
     if (!TERMINAL_STATES.has(agent.state)) {
       return false;
@@ -3319,8 +3323,11 @@ export class AgentEngine {
   private async readStopPostCondition(
     agent: AgentRecord,
     paneRef: string | null,
+    treatUnknownProcessAsGone: boolean,
   ): Promise<StopPostConditionResult> {
-    const processGone = this.isProcessGone(agent.pid);
+    const processGone = treatUnknownProcessAsGone
+      ? this.isProcessGone(agent.pid)
+      : this.isProcessConfirmedGone(agent.pid);
     const [surfaceGone, paneGone] = await Promise.all([
       this.isSurfaceGone(agent.surface_id),
       this.isPaneGone(paneRef, agent.workspace_id),
@@ -3332,9 +3339,14 @@ export class AgentEngine {
     agent: AgentRecord,
     paneRef: string | null,
     expectPaneGone: boolean,
+    treatUnknownProcessAsGone: boolean,
   ): Promise<StopPostConditionResult> {
     const deadline = Date.now() + this.stopPostConditionTimeoutMs;
-    let result = await this.readStopPostCondition(agent, paneRef);
+    let result = await this.readStopPostCondition(
+      agent,
+      paneRef,
+      treatUnknownProcessAsGone,
+    );
     while (
       !(
         result.processGone &&
@@ -3346,7 +3358,11 @@ export class AgentEngine {
       await new Promise((resolve) =>
         setTimeout(resolve, STOP_POST_CONDITION_POLL_MS),
       );
-      result = await this.readStopPostCondition(agent, paneRef);
+      result = await this.readStopPostCondition(
+        agent,
+        paneRef,
+        treatUnknownProcessAsGone,
+      );
     }
     return result;
   }
@@ -3437,6 +3453,7 @@ export class AgentEngine {
       agent,
       stopClosePolicy.paneRef,
       stopClosePolicy.collapsePane,
+      force === true,
     );
     if (
       !stopResult.processGone ||

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3252,6 +3252,15 @@ export class AgentEngine {
     }
   }
 
+  private isProcessMissingError(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ESRCH"
+    );
+  }
+
   private isProcessGone(pid: number | null | undefined): boolean {
     const liveness = this.processLiveness(pid);
     return liveness === "gone" || liveness === "unknown";
@@ -3426,11 +3435,14 @@ export class AgentEngine {
       route.workspace_id,
     );
 
+    let forceSignalAccepted = force === true && !agent.pid;
     if (force && agent.pid) {
       try {
         process.kill(agent.pid, "SIGKILL");
-      } catch {
-        // Process may already be dead — that's fine
+        forceSignalAccepted = true;
+      } catch (error) {
+        forceSignalAccepted = this.isProcessMissingError(error);
+        // Process may already be dead; other failures must preserve tracking.
       }
     } else {
       // Graceful: send Ctrl+C
@@ -3453,7 +3465,7 @@ export class AgentEngine {
       agent,
       stopClosePolicy.paneRef,
       stopClosePolicy.collapsePane,
-      force === true,
+      force === true && forceSignalAccepted,
     );
     if (
       !stopResult.processGone ||

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -214,11 +214,37 @@ export class CmuxPersistentSocket {
         } else if (this.pendingV1.length > 0) {
           this.resolveNextV1(line);
         }
-      } catch {
-        if (this.pendingV1.length > 0) {
+      } catch (error) {
+        if (this.isJsonLikeFrame(line)) {
+          this.rejectMalformedFrame(line, error);
+        } else if (this.pendingV1.length > 0) {
           this.resolveNextV1(line);
         }
       }
+    }
+  }
+
+  private isJsonLikeFrame(line: string): boolean {
+    const trimmed = line.trimStart();
+    return trimmed.startsWith("{") || trimmed.startsWith("[");
+  }
+
+  private rejectMalformedFrame(line: string, error: unknown): void {
+    const detail = error instanceof Error ? error.message : String(error);
+    const socketError = new CmuxSocketError(
+      `Malformed cmux socket frame: ${detail}; frame=${line.slice(0, 120)}`,
+      "protocol_error",
+    );
+    const entry = this.pendingV1.shift();
+    if (entry) {
+      clearTimeout(entry.timer);
+      entry.reject(socketError);
+      this.writeNextV1();
+      return;
+    }
+
+    if (this.pending.size > 0) {
+      this.rejectAllPending(socketError);
     }
   }
 

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -213,9 +213,11 @@ export class CmuxPersistentSocket {
 
       try {
         const parsed = JSON.parse(line) as Partial<V2Response>;
-        const entry =
-          typeof parsed.id === "string" ? this.pending.get(parsed.id) : null;
-        if (entry && typeof parsed.id === "string") {
+        if (typeof parsed.id === "string") {
+          const entry = this.pending.get(parsed.id);
+          if (!entry) {
+            continue;
+          }
           clearTimeout(entry.timer);
           this.pending.delete(parsed.id);
           entry.resolve(parsed as V2Response);
@@ -224,6 +226,10 @@ export class CmuxPersistentSocket {
         }
       } catch (error) {
         if (this.isJsonLikeFrame(line)) {
+          if (line.trimStart().startsWith("[") && this.pendingV1.length > 0) {
+            this.resolveNextV1(line);
+            continue;
+          }
           this.rejectMalformedFrame(line, error);
         } else if (this.pendingV1.length > 0) {
           this.resolveNextV1(line);

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -195,6 +195,14 @@ export class CmuxPersistentSocket {
     this.pendingV1 = [];
   }
 
+  private rejectPendingV2(error: CmuxSocketError): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
   private processBuffer(): void {
     let newlineIdx: number;
     while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
@@ -235,6 +243,11 @@ export class CmuxPersistentSocket {
       `Malformed cmux socket frame: ${detail}; frame=${line.slice(0, 120)}`,
       "protocol_error",
     );
+    if (line.trimStart().startsWith("{") && this.pending.size > 0) {
+      this.rejectPendingV2(socketError);
+      return;
+    }
+
     const entry = this.pendingV1.shift();
     if (entry) {
       clearTimeout(entry.timer);
@@ -244,7 +257,7 @@ export class CmuxPersistentSocket {
     }
 
     if (this.pending.size > 0) {
-      this.rejectAllPending(socketError);
+      this.rejectPendingV2(socketError);
     }
   }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -278,7 +278,16 @@ export function detectRuntimeProvenance(
   const normalizedEntrypoint = normalizePathForRuntime(entrypoint);
   const execPath = opts.execPath ?? process.execPath;
   const nodeVersion = opts.nodeVersion ?? process.version;
-  const distEntrypoint = /\/dist\/index\.js$/.test(normalizedEntrypoint);
+  const brewBinEntrypoint =
+    normalizedEntrypoint === "cmuxlayer" ||
+    /\/(?:opt\/homebrew|usr\/local)\/bin\/cmuxlayer$/.test(
+      normalizedEntrypoint,
+    ) ||
+    /\/Cellar\/cmuxlayer\/[^/]+\/(?:libexec\/)?bin\/cmuxlayer$/.test(
+      normalizedEntrypoint,
+    );
+  const distEntrypoint =
+    /\/dist\/index\.js$/.test(normalizedEntrypoint) || brewBinEntrypoint;
   const sourceEntrypoint = /\/src\/index\.ts$/.test(normalizedEntrypoint);
   const launcherEntrypoint =
     normalizedEntrypoint === "cmuxlayer-mcp" ||
@@ -294,7 +303,9 @@ export function detectRuntimeProvenance(
   }
 
   const note =
-    mode === "dist"
+    mode === "dist" && brewBinEntrypoint
+      ? "running brew-installed cmuxlayer bin; verify this path/version is the live MCP child after reconnect"
+      : mode === "dist"
       ? "running dist/index.js; verify this path/version is the live MCP child after reconnect"
       : mode === "source"
         ? "running live source; useful for development but not the pinned dist runtime"

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -296,10 +296,10 @@ export function detectRuntimeProvenance(
   let mode: RuntimeMode = "unknown";
   if (distEntrypoint) {
     mode = "dist";
-  } else if (sourceEntrypoint || env.CMUXLAYER_DEV === "1") {
-    mode = "source";
   } else if (launcherEntrypoint) {
     mode = "launcher";
+  } else if (sourceEntrypoint || env.CMUXLAYER_DEV === "1") {
+    mode = "source";
   }
 
   const note =

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -73,6 +73,30 @@ export interface McpConfigDriftReport {
   note: string;
 }
 
+export type RuntimeMode = "dist" | "source" | "launcher" | "unknown";
+
+export interface RuntimeProvenanceReport {
+  distEntrypoint: boolean;
+  entrypoint: string;
+  execPath: string;
+  mode: RuntimeMode;
+  nodeVersion: string;
+  ok: boolean;
+  note: string;
+}
+
+export interface DetectRuntimeProvenanceOptions {
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  nodeVersion?: string;
+}
+
+export interface McpReconnectProcedureReport {
+  automation: false;
+  note: string;
+}
+
 /** Lists candidate `.mcp.json` paths; best-effort callers may include missing files. */
 export type McpConfigPathLister = () => Promise<string[]> | string[];
 
@@ -108,6 +132,10 @@ export interface DoctorReport {
     durable: boolean;
     note: string;
   };
+  /** Running process provenance: source vs dist path for merged-vs-live checks. */
+  runtimeProvenance: RuntimeProvenanceReport;
+  /** Manual MCP reconnect probe; documented here so doctor output carries the runbook. */
+  mcpReconnectProcedure: McpReconnectProcedureReport;
   /** Read-only `.mcp.json` drift report; does NOT affect health. */
   mcpConfigDrift: McpConfigDriftReport;
 }
@@ -127,6 +155,8 @@ export interface RunDoctorOptions {
   listMcpConfigPaths?: McpConfigPathLister;
   /** Injectable `.mcp.json` file reader for read-only drift checks. */
   readMcpConfigFile?: McpConfigFileReader;
+  /** Injectable runtime provenance probe for tests. */
+  runtimeProvenance?: () => RuntimeProvenanceReport;
 }
 
 /**
@@ -234,6 +264,61 @@ export const realMcpConfigPathLister: McpConfigPathLister = async () => {
 
 export const realMcpConfigFileReader: McpConfigFileReader = (path) =>
   readFile(path, "utf-8");
+
+function normalizePathForRuntime(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+export function detectRuntimeProvenance(
+  opts: DetectRuntimeProvenanceOptions = {},
+): RuntimeProvenanceReport {
+  const argv = opts.argv ?? process.argv;
+  const env = opts.env ?? process.env;
+  const entrypoint = argv[1] ?? "";
+  const normalizedEntrypoint = normalizePathForRuntime(entrypoint);
+  const execPath = opts.execPath ?? process.execPath;
+  const nodeVersion = opts.nodeVersion ?? process.version;
+  const distEntrypoint = /\/dist\/index\.js$/.test(normalizedEntrypoint);
+  const sourceEntrypoint = /\/src\/index\.ts$/.test(normalizedEntrypoint);
+  const launcherEntrypoint =
+    normalizedEntrypoint === "cmuxlayer-mcp" ||
+    normalizedEntrypoint.endsWith("/.golems/bin/cmuxlayer-mcp");
+
+  let mode: RuntimeMode = "unknown";
+  if (distEntrypoint) {
+    mode = "dist";
+  } else if (sourceEntrypoint || env.CMUXLAYER_DEV === "1") {
+    mode = "source";
+  } else if (launcherEntrypoint) {
+    mode = "launcher";
+  }
+
+  const note =
+    mode === "dist"
+      ? "running dist/index.js; verify this path/version is the live MCP child after reconnect"
+      : mode === "source"
+        ? "running live source; useful for development but not the pinned dist runtime"
+        : mode === "launcher"
+          ? "running launcher path; launcher should exec brew dist unless development env overrides it"
+          : "runtime entrypoint is unknown; inspect argv/process manager before trusting live provenance";
+
+  return {
+    distEntrypoint,
+    entrypoint,
+    execPath,
+    mode,
+    nodeVersion,
+    ok: distEntrypoint,
+    note,
+  };
+}
+
+function mcpReconnectProcedure(): McpReconnectProcedureReport {
+  return {
+    automation: false,
+    note: "Manual probe: focus the target surface, run /mcp, choose cmuxlayer, choose Reconnect, verify terminal output, then run cmuxlayer doctor --json to confirm runtime provenance.",
+  };
+}
 
 async function checkTap(brew: BrewRunner): Promise<DoctorReport["tap"]> {
   const tapNote = `tap CASKS need \`brew trust ${TAP_NAME}\`; cmuxlayer is a formula, not gated`;
@@ -403,6 +488,9 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
 
   const tap = await checkTap(brew);
   const sleepGuard = await checkSleepGuard(pmset, launchctl);
+  const runtimeProvenance = (
+    opts.runtimeProvenance ?? (() => detectRuntimeProvenance({ env }))
+  )();
   const mcpConfigDrift = await checkMcpConfigDrift({
     listMcpConfigPaths: opts.listMcpConfigPaths,
     readMcpConfigFile: opts.readMcpConfigFile,
@@ -429,6 +517,8 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
       : { set: false, value: null, note: "unset (auto-discover)" },
     sleepGuard,
+    runtimeProvenance,
+    mcpReconnectProcedure: mcpReconnectProcedure(),
     mcpConfigDrift,
   };
 }
@@ -481,6 +571,13 @@ export function renderDoctorText(report: DoctorReport): string {
   lines.push(
     `│ ${mark(report.sleepGuard.durable)} sleep guard: ${report.sleepGuard.note}`,
   );
+
+  lines.push(
+    `│ ${mark(report.runtimeProvenance.ok)} runtime provenance: ${report.runtimeProvenance.mode} ${report.runtimeProvenance.entrypoint || "(unknown entrypoint)"}`,
+  );
+  lines.push(`│      ${report.runtimeProvenance.note}`);
+
+  lines.push(`│ — MCP reconnect probe: ${report.mcpReconnectProcedure.note}`);
 
   if (report.mcpConfigDrift.drifted.length === 0) {
     lines.push(

--- a/src/mcp-reaper.ts
+++ b/src/mcp-reaper.ts
@@ -29,7 +29,7 @@
 import { execFile } from "node:child_process";
 import { mkdir, appendFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
-import { homedir } from "node:os";
+import { freemem, homedir, totalmem } from "node:os";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
@@ -49,12 +49,29 @@ export interface SelectReapableOptions {
   knownServerNames?: readonly string[];
 }
 
-interface CliOptions {
+export interface RunReaperOptions {
   dryRun: boolean;
   graceSeconds: number;
   logFile: string;
   minAgeSeconds: number;
   knownServerNames: readonly string[];
+}
+
+export interface RamEvidence {
+  processRssBytes: number;
+  systemFreeBytes: number;
+  systemTotalBytes: number;
+}
+
+export interface RunReaperDeps {
+  appendAuditLine?: (line: string) => Promise<void>;
+  isProcessAlive?: IsProcessAlive;
+  killProcess?: KillProcess;
+  readProcessTable?: () => Promise<ProcessInfo[]>;
+  readRamEvidence?: () => RamEvidence;
+  sleep?: (ms: number) => Promise<void>;
+  writeStderr?: (line: string) => void;
+  writeStdout?: (line: string) => void;
 }
 
 export interface SignalAttempt {
@@ -315,7 +332,7 @@ function envDryRun(value: string | undefined): boolean {
   return !["0", "false", "no"].includes(value.trim().toLowerCase());
 }
 
-export function parseCliOptions(argv: readonly string[]): CliOptions {
+export function parseCliOptions(argv: readonly string[]): RunReaperOptions {
   let dryRun = envDryRun(process.env.REAPER_DRY_RUN);
   let minAgeSeconds = parseIntegerEnv(
     process.env.REAPER_MIN_AGE_SECONDS,
@@ -402,16 +419,17 @@ async function appendLogLine(logFile: string, line: string): Promise<void> {
 }
 
 async function logSignalFailures(
-  logFile: string,
   attempts: readonly SignalAttempt[],
+  appendAuditLine: (line: string) => Promise<void>,
+  writeStderr: (line: string) => void,
 ): Promise<void> {
   for (const attempt of attempts) {
     if (attempt.ok) {
       continue;
     }
     const line = `SIGNAL_FAILED signal=${attempt.signal} pid=${attempt.pid} code=${attempt.errorCode ?? "UNKNOWN"} message=${attempt.errorMessage ?? ""}`;
-    console.error(line);
-    await appendLogLine(logFile, line);
+    writeStderr(line);
+    await appendAuditLine(line);
   }
 }
 
@@ -419,57 +437,121 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
-async function runReaper(opts: CliOptions): Promise<void> {
-  const processes = await readProcessTable();
+function readRamEvidence(): RamEvidence {
+  return {
+    processRssBytes: process.memoryUsage().rss,
+    systemFreeBytes: freemem(),
+    systemTotalBytes: totalmem(),
+  };
+}
+
+function selectReapableProcesses(
+  processes: readonly ProcessInfo[],
+  opts: RunReaperOptions,
+): ProcessInfo[] {
   const reapablePids = new Set(
     selectReapablePids(processes, {
       knownServerNames: opts.knownServerNames,
       minAgeSeconds: opts.minAgeSeconds,
     }),
   );
-  const reapable = processes.filter((proc) => reapablePids.has(proc.pid));
+  return processes.filter((proc) => reapablePids.has(proc.pid));
+}
+
+function formatAuditSnapshot(
+  phase: "before" | "after",
+  opts: RunReaperOptions,
+  processes: readonly ProcessInfo[],
+  reapable: readonly ProcessInfo[],
+  ram: RamEvidence,
+): string {
+  const pids = reapable.map((proc) => proc.pid).join(",") || "-";
+  return [
+    "AUDIT",
+    `phase=${phase}`,
+    `dry_run=${opts.dryRun ? "true" : "false"}`,
+    `total_processes=${processes.length}`,
+    `reapable_processes=${reapable.length}`,
+    `reapable_pids=${pids}`,
+    `system_free_bytes=${ram.systemFreeBytes}`,
+    `system_total_bytes=${ram.systemTotalBytes}`,
+    `process_rss_bytes=${ram.processRssBytes}`,
+  ].join(" ");
+}
+
+export async function runReaper(
+  opts: RunReaperOptions,
+  deps: RunReaperDeps = {},
+): Promise<void> {
+  const readTable = deps.readProcessTable ?? readProcessTable;
+  const readRam = deps.readRamEvidence ?? readRamEvidence;
+  const appendAuditLine =
+    deps.appendAuditLine ?? ((line: string) => appendLogLine(opts.logFile, line));
+  const writeStdout = deps.writeStdout ?? ((line: string) => console.log(line));
+  const writeStderr = deps.writeStderr ?? ((line: string) => console.error(line));
+  const sleepFor = deps.sleep ?? sleep;
+  const killProcess = deps.killProcess ?? process.kill;
+  const isAlive = deps.isProcessAlive ?? processAlive;
+
+  const processes = await readTable();
+  const reapable = selectReapableProcesses(processes, opts);
 
   if (reapable.length === 0) {
-    console.log("No reapable ppid=1 idle node MCP orphans found.");
+    writeStdout("No reapable ppid=1 idle node MCP orphans found.");
     return;
   }
 
+  const initialReapablePids = new Set(reapable.map((proc) => proc.pid));
+  await appendAuditLine(
+    formatAuditSnapshot("before", opts, processes, reapable, readRam()),
+  );
+
   for (const proc of reapable) {
     const line = `${opts.dryRun ? "DRY_RUN would terminate" : "SIGTERM"} ${formatProcess(proc)}`;
-    console.log(line);
-    await appendLogLine(opts.logFile, line);
+    writeStdout(line);
+    await appendAuditLine(line);
   }
 
   if (opts.dryRun) {
+    const afterProcesses = await readTable();
+    const afterReapable = selectReapableProcesses(afterProcesses, opts);
+    await appendAuditLine(
+      formatAuditSnapshot("after", opts, afterProcesses, afterReapable, readRam()),
+    );
     return;
   }
 
   await logSignalFailures(
-    opts.logFile,
-    signalProcessBatch(reapable, "SIGTERM"),
+    signalProcessBatch(reapable, "SIGTERM", killProcess),
+    appendAuditLine,
+    writeStderr,
   );
 
-  await sleep(opts.graceSeconds * 1000);
+  await sleepFor(opts.graceSeconds * 1000);
 
-  const afterGrace = await readProcessTable();
-  const stillReapablePids = new Set(
-    selectReapablePids(afterGrace, {
-      knownServerNames: opts.knownServerNames,
-      minAgeSeconds: opts.minAgeSeconds,
-    }),
-  );
+  const afterGrace = await readTable();
+  const stillReapable = selectReapableProcesses(afterGrace, opts);
+  const stillReapablePids = new Set(stillReapable.map((proc) => proc.pid));
   const killable = afterGrace.filter(
-    (proc) => reapablePids.has(proc.pid) && stillReapablePids.has(proc.pid),
+    (proc) =>
+      initialReapablePids.has(proc.pid) && stillReapablePids.has(proc.pid),
   );
 
   for (const proc of killable) {
     const line = `SIGKILL ${formatProcess(proc)}`;
-    console.log(line);
-    await appendLogLine(opts.logFile, line);
+    writeStdout(line);
+    await appendAuditLine(line);
   }
   await logSignalFailures(
-    opts.logFile,
-    signalProcessBatch(killable, "SIGKILL", process.kill, processAlive),
+    signalProcessBatch(killable, "SIGKILL", killProcess, isAlive),
+    appendAuditLine,
+    writeStderr,
+  );
+
+  const finalProcesses = killable.length > 0 ? await readTable() : afterGrace;
+  const finalReapable = selectReapableProcesses(finalProcesses, opts);
+  await appendAuditLine(
+    formatAuditSnapshot("after", opts, finalProcesses, finalReapable, readRam()),
   );
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -505,6 +505,7 @@ export class CmuxLayerProxy {
             "[cmuxlayer-proxy] late daemon response for expired request id dropped",
             { id: message.id },
           );
+          this.expiredRequestKeys.delete(key);
           return;
         }
         void this.writeAgent(message);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -468,8 +468,9 @@ export class CmuxLayerProxy {
     }
   };
 
-  private readonly onDaemonError = () => {
-    // Swallow socket errors; the following "close" event drives reconnection.
+  private readonly onDaemonError = (error: Error) => {
+    this.logger.error("[cmuxlayer-proxy] daemon socket error", error);
+    // The following "close" event still drives reconnection.
   };
 
   private readonly onDaemonClose = () => {
@@ -500,6 +501,10 @@ export class CmuxLayerProxy {
       const pending = this.pendingRequests.get(key);
       if (!pending) {
         if (this.expiredRequestKeys.has(key)) {
+          this.logger.error(
+            "[cmuxlayer-proxy] late daemon response for expired request id dropped",
+            { id: message.id },
+          );
           return;
         }
         void this.writeAgent(message);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -505,7 +505,6 @@ export class CmuxLayerProxy {
             "[cmuxlayer-proxy] late daemon response for expired request id dropped",
             { id: message.id },
           );
-          this.expiredRequestKeys.delete(key);
           return;
         }
         void this.writeAgent(message);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5605,6 +5605,59 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("treats kill(0) permission errors as live during graceful stop", async () => {
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        stopPostConditionTimeoutMs: 20,
+      });
+      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          killCalls.push([pid, signal ?? 0]);
+          if (signal === 0) {
+            throw Object.assign(new Error("operation not permitted"), {
+              code: "EPERM",
+            });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-grace-unknown",
+            state: "working",
+            surface_id: "surface:grace-unknown",
+            pid: 45678,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:grace-unknown")];
+        await engine.getRegistry().reconstitute();
+
+        await expect(engine.stopAgent("agent-grace-unknown")).rejects.toThrow(
+          /process still alive/i,
+        );
+
+        expect(killCalls).toContainEqual([45678, 0]);
+        expect(mockClient.sendKey).toHaveBeenCalledWith(
+          "surface:grace-unknown",
+          "c-c",
+          expect.anything(),
+        );
+        expect(stateMgr.readState("agent-grace-unknown")).toMatchObject({
+          state: "working",
+          quality: "degraded",
+          error: expect.stringMatching(/process still alive/i),
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
     it("does not mark naturally completed agents as user-killed", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5605,6 +5605,55 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("preserves tracking when force SIGKILL is not permitted", async () => {
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        stopPostConditionTimeoutMs: 20,
+      });
+      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          killCalls.push([pid, signal ?? 0]);
+          throw Object.assign(new Error("operation not permitted"), {
+            code: "EPERM",
+          });
+        }) as typeof process.kill);
+
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-force-eperm",
+            state: "working",
+            surface_id: "surface:force-eperm",
+            pid: 56789,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:force-eperm")];
+        await engine.getRegistry().reconstitute();
+
+        await expect(engine.stopAgent("agent-force-eperm", true)).rejects.toThrow(
+          /process still alive/i,
+        );
+
+        expect(killCalls).toContainEqual([56789, "SIGKILL"]);
+        expect(killCalls).toContainEqual([56789, 0]);
+        expect(stateMgr.readState("agent-force-eperm")).toMatchObject({
+          state: "working",
+          quality: "degraded",
+          error: expect.stringMatching(/process still alive/i),
+        });
+        expect(engine.getAgentState("agent-force-eperm")).toMatchObject({
+          state: "working",
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
     it("treats kill(0) permission errors as live during graceful stop", async () => {
       engine.dispose();
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5211,6 +5211,46 @@ To continue this session, run codex resume ${sessionId}`,
     });
   });
 
+  describe("evictDeadProcessAgents", () => {
+    it("keeps active agents registered when passive liveness is unknown", async () => {
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          if (signal === 0) {
+            throw Object.assign(new Error("operation not permitted"), {
+              code: "EPERM",
+            });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-passive-unknown",
+            state: "working",
+            surface_id: "surface:passive-unknown",
+            pid: 34567,
+          }),
+        );
+        await engine.getRegistry().reconstitute();
+
+        expect(engine.evictDeadProcessAgents()).toEqual([]);
+        expect(killSpy).toHaveBeenCalledWith(34567, 0);
+        expect(stateMgr.readState("agent-passive-unknown")).toMatchObject({
+          state: "working",
+          pid: 34567,
+        });
+        expect(engine.getAgentState("agent-passive-unknown")).toMatchObject({
+          state: "working",
+          pid: 34567,
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+  });
+
   describe("stopAgent", () => {
     beforeEach(() => {
       (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementation(
@@ -5523,6 +5563,43 @@ To continue this session, run codex resume ${sessionId}`,
         expect(killCalls).toContainEqual([12345, "SIGKILL"]);
         expect(killCalls).toContainEqual([12345, 0]);
         expect(stateMgr.readState("agent-force-live")?.state).not.toBe("done");
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
+    it("does not treat kill(0) permission errors as proof the process is still alive", async () => {
+      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          killCalls.push([pid, signal ?? 0]);
+          if (signal === 0) {
+            throw Object.assign(new Error("operation not permitted"), {
+              code: "EPERM",
+            });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-force-unknown",
+            state: "working",
+            surface_id: "surface:force-unknown",
+            pid: 23456,
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:force-unknown")];
+        await engine.getRegistry().reconstitute();
+
+        await engine.stopAgent("agent-force-unknown", true);
+
+        expect(killCalls).toContainEqual([23456, "SIGKILL"]);
+        expect(killCalls).toContainEqual([23456, 0]);
+        expect(stateMgr.readState("agent-force-unknown")).toBeNull();
+        expect(engine.getAgentState("agent-force-unknown")).toBeNull();
       } finally {
         killSpy.mockRestore();
       }

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -121,4 +121,32 @@ describe("CmuxPersistentSocket V1 demux", () => {
       socket.disconnect();
     }
   });
+
+  it("rejects every pending V2 request when an uncorrelatable object frame is malformed", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("malformed-v2-only");
+    const received: string[] = [];
+    await startLineServer(path, (line, conn) => {
+      received.push(line);
+      if (received.length === 2) {
+        conn.write('{"id":\n');
+      }
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      const first = socket.call("list_workspaces");
+      const second = socket.call("list_panes");
+
+      await expect(first).rejects.toMatchObject({ code: "protocol_error" });
+      await expect(second).rejects.toMatchObject({ code: "protocol_error" });
+      expect(received).toHaveLength(2);
+    } finally {
+      socket.disconnect();
+    }
+  });
 });

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -122,6 +122,27 @@ describe("CmuxPersistentSocket V1 demux", () => {
     }
   });
 
+  it("passes through bracket-prefixed plain V1 replies", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("bracket-v1");
+    await startLineServer(path, (_line, conn) => {
+      conn.write("[busy] retry later\n");
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      await expect(socket.sendLine("set_status first active")).resolves.toBe(
+        "[busy] retry later",
+      );
+    } finally {
+      socket.disconnect();
+    }
+  });
+
   it("rejects every pending V2 request when an uncorrelatable object frame is malformed", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("malformed-v2-only");
@@ -145,6 +166,44 @@ describe("CmuxPersistentSocket V1 demux", () => {
       await expect(first).rejects.toMatchObject({ code: "protocol_error" });
       await expect(second).rejects.toMatchObject({ code: "protocol_error" });
       expect(received).toHaveLength(2);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("does not let late V2 responses complete a queued V1 request after malformed V2 rejection", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("late-v2-after-malformed");
+    const v2Ids: string[] = [];
+    await startLineServer(path, (line, conn) => {
+      if (line.startsWith("{")) {
+        const parsed = JSON.parse(line) as { id: string };
+        v2Ids.push(parsed.id);
+        if (v2Ids.length === 2) {
+          conn.write('{"id":\n');
+        }
+        return;
+      }
+      conn.write(
+        `${JSON.stringify({ id: v2Ids[0], ok: true, result: { stale: true } })}\n`,
+      );
+      conn.write("OK\n");
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      const first = socket.call("list_workspaces");
+      const second = socket.call("list_panes");
+      await expect(first).rejects.toMatchObject({ code: "protocol_error" });
+      await expect(second).rejects.toMatchObject({ code: "protocol_error" });
+
+      await expect(socket.sendLine("set_status after malformed")).resolves.toBe(
+        "OK",
+      );
     } finally {
       socket.disconnect();
     }

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -87,4 +87,38 @@ describe("CmuxPersistentSocket V1 demux", () => {
       socket.disconnect();
     }
   });
+
+  it("rejects malformed object frames as V2 errors before unrelated queued V1 commands", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("malformed-v2");
+    const received: string[] = [];
+    await startLineServer(path, (line, conn) => {
+      received.push(line);
+      if (received.length === 2) {
+        conn.write('{"id":\n');
+        conn.write("OK\n");
+      }
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      const v1 = socket.sendLine("set_status first active");
+      const v2 = socket.call("list_panes");
+
+      await expect(v2).rejects.toMatchObject({ code: "protocol_error" });
+      await expect(v1).resolves.toBe("OK");
+      expect(received).toHaveLength(2);
+      expect(received).toContain("set_status first active");
+      const v2Request = received.find((line) => line.startsWith("{"));
+      expect(JSON.parse(v2Request ?? "")).toMatchObject({
+        method: "list_panes",
+      });
+    } finally {
+      socket.disconnect();
+    }
+  });
 });

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -1,0 +1,90 @@
+import net from "node:net";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
+
+const TEST_ROOT = join("/tmp", "cmux-persistent-socket-test");
+const servers: net.Server[] = [];
+
+function socketPath(name: string): string {
+  return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);
+}
+
+function stopServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function startLineServer(
+  path: string,
+  onLine: (line: string, conn: net.Socket) => void,
+): Promise<net.Server> {
+  rmSync(path, { force: true });
+  const server = net.createServer((conn) => {
+    let buffer = "";
+    conn.on("data", (chunk) => {
+      buffer += chunk.toString("utf-8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line.trim()) {
+          onLine(line, conn);
+        }
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(path, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  servers.push(server);
+  return server;
+}
+
+describe("CmuxPersistentSocket V1 demux", () => {
+  afterEach(async () => {
+    await Promise.allSettled(servers.splice(0).map(stopServer));
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("rejects a JSON-like malformed frame instead of resolving the pending V1 request", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("malformed-v1");
+    const received: string[] = [];
+    await startLineServer(path, (line, conn) => {
+      received.push(line);
+      if (received.length === 1) {
+        conn.write('{"id":\n');
+        return;
+      }
+      conn.write("OK\n");
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      await expect(socket.sendLine("set_status first active")).rejects.toMatchObject(
+        { code: "protocol_error" },
+      );
+      const second = socket.sendLine("set_status second active");
+
+      await expect(second).resolves.toBe("OK");
+      expect(received).toEqual([
+        "set_status first active",
+        "set_status second active",
+      ]);
+    } finally {
+      socket.disconnect();
+    }
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -305,6 +305,32 @@ describe("runDoctor — report shape", () => {
     expect(report.healthy).toBe(true);
   });
 
+  it("treats the Homebrew cmuxlayer bin entrypoint as trusted dist provenance", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: {},
+      brew: makeBrew({}),
+      runtimeProvenance: () =>
+        detectRuntimeProvenance({
+          argv: [
+            "/opt/homebrew/opt/node/bin/node",
+            "/opt/homebrew/bin/cmuxlayer",
+          ],
+          env: {},
+          execPath: "/opt/homebrew/opt/node/bin/node",
+        }),
+    });
+
+    expect(report.runtimeProvenance).toMatchObject({
+      distEntrypoint: true,
+      entrypoint: "/opt/homebrew/bin/cmuxlayer",
+      mode: "dist",
+      ok: true,
+    });
+    expect(report.runtimeProvenance.note).toMatch(/brew-installed cmuxlayer/i);
+    expect(report.healthy).toBe(true);
+  });
+
   it("surfaces live source runtime provenance without failing the doctor", async () => {
     const report = await runDoctorForTest({
       version: "0.3.1",

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -356,6 +356,58 @@ describe("runDoctor — report shape", () => {
     expect(report.healthy).toBe(true);
   });
 
+  it("keeps launcher runtime provenance ahead of the development env override", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: { CMUXLAYER_DEV: "1" },
+      brew: makeBrew({}),
+      runtimeProvenance: () =>
+        detectRuntimeProvenance({
+          argv: [
+            "/opt/homebrew/opt/node/bin/node",
+            "/Users/etanheyman/.golems/bin/cmuxlayer-mcp",
+          ],
+          env: { CMUXLAYER_DEV: "1" },
+          execPath: "/opt/homebrew/opt/node/bin/node",
+        }),
+    });
+
+    expect(report.runtimeProvenance).toMatchObject({
+      distEntrypoint: false,
+      entrypoint: "/Users/etanheyman/.golems/bin/cmuxlayer-mcp",
+      mode: "launcher",
+      ok: false,
+    });
+    expect(report.runtimeProvenance.note).toMatch(/launcher path/i);
+    expect(report.healthy).toBe(true);
+  });
+
+  it("reports unknown runtime provenance without failing the doctor", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: {},
+      brew: makeBrew({}),
+      runtimeProvenance: () =>
+        detectRuntimeProvenance({
+          argv: [
+            "/opt/homebrew/opt/node/bin/node",
+            "/tmp/cmuxlayer-wrapper",
+          ],
+          env: {},
+          execPath: "/opt/homebrew/opt/node/bin/node",
+        }),
+    });
+
+    expect(report.runtimeProvenance).toMatchObject({
+      distEntrypoint: false,
+      entrypoint: "/tmp/cmuxlayer-wrapper",
+      mode: "unknown",
+      ok: false,
+    });
+    expect(report.runtimeProvenance.note).toMatch(/unknown/i);
+    expect(report.healthy).toBe(true);
+  });
+
   it("includes a manual MCP reconnect probe procedure in the doctor report", async () => {
     const report = await runDoctorForTest({
       version: "0.3.1",

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   checkMcpConfigDrift,
+  detectRuntimeProvenance,
   parseSystemSleepPrevented,
   runDoctor,
   renderDoctorText,
@@ -276,6 +277,71 @@ describe("runDoctor — report shape", () => {
       },
     ]);
   });
+
+  it("reports the running dist entrypoint path as runtime provenance", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: {},
+      brew: makeBrew({}),
+      runtimeProvenance: () =>
+        detectRuntimeProvenance({
+          argv: [
+            "/opt/homebrew/opt/node/bin/node",
+            "/opt/homebrew/Cellar/cmuxlayer/0.3.1/libexec/dist/index.js",
+          ],
+          env: {},
+          execPath: "/opt/homebrew/opt/node/bin/node",
+        }),
+    });
+
+    expect(report.runtimeProvenance).toMatchObject({
+      distEntrypoint: true,
+      entrypoint:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.1/libexec/dist/index.js",
+      mode: "dist",
+      ok: true,
+    });
+    expect(report.runtimeProvenance.note).toMatch(/running dist\/index\.js/i);
+    expect(report.healthy).toBe(true);
+  });
+
+  it("surfaces live source runtime provenance without failing the doctor", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: { CMUXLAYER_DEV: "1" },
+      brew: makeBrew({}),
+      runtimeProvenance: () =>
+        detectRuntimeProvenance({
+          argv: [
+            "/Users/etanheyman/.bun/bin/bun",
+            "/Users/etanheyman/Gits/cmuxlayer/src/index.ts",
+          ],
+          env: { CMUXLAYER_DEV: "1" },
+          execPath: "/Users/etanheyman/.bun/bin/bun",
+        }),
+    });
+
+    expect(report.runtimeProvenance).toMatchObject({
+      distEntrypoint: false,
+      mode: "source",
+      ok: false,
+    });
+    expect(report.runtimeProvenance.note).toMatch(/live source/i);
+    expect(report.healthy).toBe(true);
+  });
+
+  it("includes a manual MCP reconnect probe procedure in the doctor report", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.1",
+      env: {},
+      brew: makeBrew({}),
+    });
+
+    expect(report.mcpReconnectProcedure.automation).toBe(false);
+    expect(report.mcpReconnectProcedure.note).toMatch(/\/mcp/);
+    expect(report.mcpReconnectProcedure.note).toMatch(/Reconnect/);
+    expect(report.mcpReconnectProcedure.note).toMatch(/cmuxlayer doctor/);
+  });
 });
 
 describe("parseSystemSleepPrevented", () => {
@@ -444,6 +510,20 @@ describe("renderDoctorText", () => {
         durable: false,
         note: "not durable; install launchd/cmux-caffeinate/README.md",
       },
+      runtimeProvenance: {
+        distEntrypoint: true,
+        entrypoint:
+          "/opt/homebrew/Cellar/cmuxlayer/0.3.1/libexec/dist/index.js",
+        execPath: "/opt/homebrew/opt/node/bin/node",
+        mode: "dist",
+        nodeVersion: "v22.0.0",
+        ok: true,
+        note: "running dist/index.js",
+      },
+      mcpReconnectProcedure: {
+        automation: false,
+        note: "Manual probe: /mcp -> cmuxlayer -> Reconnect, then run cmuxlayer doctor --json.",
+      },
       mcpConfigDrift: {
         scanned: 0,
         drifted: [],
@@ -483,6 +563,13 @@ describe("renderDoctorText", () => {
     const text = renderDoctorText(baseReport());
     expect(text).toMatch(/sleep guard/i);
     expect(text).toMatch(/launchd\/cmux-caffeinate\/README\.md/);
+  });
+
+  it("prints runtime provenance and the MCP reconnect probe procedure", () => {
+    const text = renderDoctorText(baseReport());
+    expect(text).toMatch(/runtime.*dist\/index\.js/i);
+    expect(text).toMatch(/\/mcp.*Reconnect/i);
+    expect(text).toMatch(/cmuxlayer doctor --json/i);
   });
 
   it("prints a no-drift line when no .mcp.json drift is detected", () => {
@@ -547,6 +634,20 @@ describe("renderDoctorJson", () => {
         durable: true,
         note: "durable",
       },
+      runtimeProvenance: {
+        distEntrypoint: true,
+        entrypoint:
+          "/opt/homebrew/Cellar/cmuxlayer/0.3.1/libexec/dist/index.js",
+        execPath: "/opt/homebrew/opt/node/bin/node",
+        mode: "dist",
+        nodeVersion: "v22.0.0",
+        ok: true,
+        note: "running dist/index.js",
+      },
+      mcpReconnectProcedure: {
+        automation: false,
+        note: "Manual probe: /mcp -> cmuxlayer -> Reconnect, then run cmuxlayer doctor --json.",
+      },
       mcpConfigDrift: {
         scanned: 1,
         drifted: [
@@ -569,6 +670,8 @@ describe("renderDoctorJson", () => {
     expect(parsed.socketPath.set).toBe(true);
     expect(parsed.socketPath.value).toBe("/tmp/x.sock");
     expect(parsed.sleepGuard.durable).toBe(true);
+    expect(parsed.runtimeProvenance.mode).toBe("dist");
+    expect(parsed.mcpReconnectProcedure.automation).toBe(false);
     expect(parsed.mcpConfigDrift.scanned).toBe(1);
     expect(parsed.mcpConfigDrift.drifted[0]?.serverKey).toBe("cmuxlayer");
   });

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   PROCESS_TABLE_PS_ARGS,
   parseElapsedSeconds,
   parseCliOptions,
   parseLaunchdServicePids,
   parseProcessLine,
+  runReaper,
   selectReapablePids,
   signalProcessBatch,
 } from "../src/mcp-reaper.js";
@@ -280,6 +281,140 @@ describe("parseCliOptions", () => {
     expect(() => parseCliOptions(["--grace-seconds"])).toThrow(
       "--grace-seconds requires a value",
     );
+  });
+});
+
+describe("runReaper audit evidence", () => {
+  const reapable: ProcessInfo = {
+    pid: 701,
+    ppid: 1,
+    etimes: 1200,
+    command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+  };
+
+  const baseOptions = {
+    dryRun: true,
+    graceSeconds: 0,
+    knownServerNames: [],
+    logFile: "/tmp/cmuxlayer-reaper-test.log",
+    minAgeSeconds: 600,
+  };
+
+  it("skips audit-log writes when nothing is reapable", async () => {
+    const lines: string[] = [];
+    const outputs: string[] = [];
+    const readProcessTable = vi
+      .fn<() => Promise<ProcessInfo[]>>()
+      .mockResolvedValueOnce([]);
+
+    await runReaper(baseOptions, {
+      appendAuditLine: async (line) => {
+        lines.push(line);
+      },
+      readProcessTable,
+      readRamEvidence: () => ({
+        processRssBytes: 11,
+        systemFreeBytes: 22,
+        systemTotalBytes: 33,
+      }),
+      writeStdout: (line) => {
+        outputs.push(line);
+      },
+    });
+
+    expect(readProcessTable).toHaveBeenCalledTimes(1);
+    expect(lines).toEqual([]);
+    expect(outputs).toEqual(["No reapable ppid=1 idle node MCP orphans found."]);
+  });
+
+  it("records before/after process and RAM evidence for dry-run audits", async () => {
+    const lines: string[] = [];
+    const outputs: string[] = [];
+    const readProcessTable = vi
+      .fn<() => Promise<ProcessInfo[]>>()
+      .mockResolvedValueOnce([reapable])
+      .mockResolvedValueOnce([reapable]);
+
+    await runReaper(baseOptions, {
+      appendAuditLine: async (line) => {
+        lines.push(line);
+      },
+      readProcessTable,
+      readRamEvidence: () => ({
+        processRssBytes: 11,
+        systemFreeBytes: 22,
+        systemTotalBytes: 33,
+      }),
+      writeStdout: (line) => {
+        outputs.push(line);
+      },
+    });
+
+    expect(readProcessTable).toHaveBeenCalledTimes(2);
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /AUDIT phase=before dry_run=true total_processes=1 reapable_processes=1 reapable_pids=701 system_free_bytes=22 system_total_bytes=33 process_rss_bytes=11/,
+      ),
+    );
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /AUDIT phase=after dry_run=true total_processes=1 reapable_processes=1 reapable_pids=701 system_free_bytes=22 system_total_bytes=33 process_rss_bytes=11/,
+      ),
+    );
+    expect(lines).toContainEqual(
+      expect.stringContaining("DRY_RUN would terminate pid=701"),
+    );
+    expect(outputs).toContainEqual(
+      expect.stringContaining("DRY_RUN would terminate pid=701"),
+    );
+  });
+
+  it("records before/after evidence and signal attempts for execute audits", async () => {
+    const lines: string[] = [];
+    const outputs: string[] = [];
+    const killCalls: Array<[number, NodeJS.Signals]> = [];
+    const readProcessTable = vi
+      .fn<() => Promise<ProcessInfo[]>>()
+      .mockResolvedValueOnce([reapable])
+      .mockResolvedValueOnce([]);
+
+    await runReaper(
+      { ...baseOptions, dryRun: false },
+      {
+        appendAuditLine: async (line) => {
+          lines.push(line);
+        },
+        isProcessAlive: () => false,
+        killProcess: (pid, signal) => {
+          killCalls.push([pid, signal]);
+        },
+        readProcessTable,
+        readRamEvidence: () => ({
+          processRssBytes: 44,
+          systemFreeBytes: 55,
+          systemTotalBytes: 66,
+        }),
+        sleep: async () => {},
+        writeStdout: (line) => {
+          outputs.push(line);
+        },
+      },
+    );
+
+    expect(readProcessTable).toHaveBeenCalledTimes(2);
+    expect(killCalls).toEqual([[701, "SIGTERM"]]);
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /AUDIT phase=before dry_run=false total_processes=1 reapable_processes=1 reapable_pids=701 system_free_bytes=55 system_total_bytes=66 process_rss_bytes=44/,
+      ),
+    );
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /AUDIT phase=after dry_run=false total_processes=0 reapable_processes=0 reapable_pids=- system_free_bytes=55 system_total_bytes=66 process_rss_bytes=44/,
+      ),
+    );
+    expect(lines).toContainEqual(expect.stringContaining("SIGTERM pid=701"));
+    expect(outputs).toContainEqual(expect.stringContaining("SIGTERM pid=701"));
   });
 });
 

--- a/tests/mcp-reaper.test.ts
+++ b/tests/mcp-reaper.test.ts
@@ -416,6 +416,53 @@ describe("runReaper audit evidence", () => {
     expect(lines).toContainEqual(expect.stringContaining("SIGTERM pid=701"));
     expect(outputs).toContainEqual(expect.stringContaining("SIGTERM pid=701"));
   });
+
+  it("escalates still-reapable processes to SIGKILL after the grace window", async () => {
+    const lines: string[] = [];
+    const outputs: string[] = [];
+    const killCalls: Array<[number, NodeJS.Signals]> = [];
+    const readProcessTable = vi
+      .fn<() => Promise<ProcessInfo[]>>()
+      .mockResolvedValueOnce([reapable])
+      .mockResolvedValueOnce([reapable])
+      .mockResolvedValueOnce([]);
+
+    await runReaper(
+      { ...baseOptions, dryRun: false },
+      {
+        appendAuditLine: async (line) => {
+          lines.push(line);
+        },
+        isProcessAlive: () => false,
+        killProcess: (pid, signal) => {
+          killCalls.push([pid, signal]);
+        },
+        readProcessTable,
+        readRamEvidence: () => ({
+          processRssBytes: 77,
+          systemFreeBytes: 88,
+          systemTotalBytes: 99,
+        }),
+        sleep: async () => {},
+        writeStdout: (line) => {
+          outputs.push(line);
+        },
+      },
+    );
+
+    expect(readProcessTable).toHaveBeenCalledTimes(3);
+    expect(killCalls).toEqual([
+      [701, "SIGTERM"],
+      [701, "SIGKILL"],
+    ]);
+    expect(lines).toContainEqual(expect.stringContaining("SIGKILL pid=701"));
+    expect(outputs).toContainEqual(expect.stringContaining("SIGKILL pid=701"));
+    expect(lines).toContainEqual(
+      expect.stringMatching(
+        /AUDIT phase=after dry_run=false total_processes=0 reapable_processes=0 reapable_pids=- system_free_bytes=88 system_total_bytes=99 process_rss_bytes=77/,
+      ),
+    );
+  });
 });
 
 describe("PROCESS_TABLE_PS_ARGS", () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -669,7 +669,7 @@ describe("CmuxLayerProxy", () => {
     daemons.push(daemon);
     await daemon.start();
     const logger = { error: vi.fn() };
-    const { input, collector } = createProxy(path, {
+    const { input, collector, proxy } = createProxy(path, {
       logger,
       requestTimeoutMs: 30,
     });
@@ -700,6 +700,13 @@ describe("CmuxLayerProxy", () => {
         String(call[0]).includes("late daemon response"),
       ),
     );
+    expect(
+      (
+        proxy as unknown as {
+          expiredRequestKeys: Set<string>;
+        }
+      ).expiredRequestKeys.has("2"),
+    ).toBe(false);
   });
 
   it("keeps agent stdio open while the daemon is offline", async () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ReadBuffer,
   serializeMessage,
@@ -309,6 +309,7 @@ describe("CmuxLayerProxy", () => {
       input,
       output,
       initialBackoffMs: 5,
+      logger: { error: vi.fn() },
       maxBackoffMs: 20,
       reconnectJitterRatio: 0,
       requestTimeoutMs: 500,
@@ -659,6 +660,48 @@ describe("CmuxLayerProxy", () => {
     });
   });
 
+  it("logs late daemon responses for expired request ids before dropping them", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("late-expired-response");
+    const daemon = new FakeDaemon(path, {
+      holdMethods: new Set(["tools/list"]),
+    });
+    daemons.push(daemon);
+    await daemon.start();
+    const logger = { error: vi.fn() };
+    const { input, collector } = createProxy(path, {
+      logger,
+      requestTimeoutMs: 30,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+    await daemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
+
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 500),
+    ).resolves.toMatchObject({
+      id: 2,
+      error: expect.objectContaining({
+        code: -32001,
+        message: expect.stringMatching(/offline|timeout|retry/i),
+      }),
+    });
+
+    daemon.releaseHeld("tools/list");
+
+    await waitFor(() =>
+      logger.error.mock.calls.some((call) =>
+        String(call[0]).includes("late daemon response"),
+      ),
+    );
+  });
+
   it("keeps agent stdio open while the daemon is offline", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("stdio-open");
@@ -681,6 +724,29 @@ describe("CmuxLayerProxy", () => {
 
     expect(outputEnded).toBe(false);
     expect(input.destroyed).toBe(false);
+    expect(proxy.isRunning()).toBe(true);
+  });
+
+  it("logs daemon socket errors while leaving close-driven reconnect semantics intact", async () => {
+    const logger = { error: vi.fn() };
+    const fakeSocket = new PassThrough() as unknown as net.Socket;
+    const { proxy } = createProxy("unused-fake-socket", {
+      connect: () => {
+        queueMicrotask(() => fakeSocket.emit("connect"));
+        return fakeSocket;
+      },
+      logger,
+    });
+
+    await waitFor(() => fakeSocket.listenerCount("data") > 0);
+
+    const error = new Error("daemon link failed");
+    fakeSocket.emit("error", error);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon socket error",
+      error,
+    );
     expect(proxy.isRunning()).toBe(true);
   });
 });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -660,7 +660,7 @@ describe("CmuxLayerProxy", () => {
     });
   });
 
-  it("logs late daemon responses for expired request ids before dropping them", async () => {
+  it("keeps expired request ids quarantined after repeated late responses", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("late-expired-response");
     const daemon = new FakeDaemon(path, {
@@ -700,13 +700,30 @@ describe("CmuxLayerProxy", () => {
         String(call[0]).includes("late daemon response"),
       ),
     );
+    writeFrame(daemon.connections[0].socket, {
+      jsonrpc: "2.0",
+      id: 2,
+      result: { stale: true },
+    });
+    await waitFor(
+      () =>
+        logger.error.mock.calls.filter((call) =>
+          String(call[0]).includes("late daemon response"),
+        ).length >= 2,
+    );
+    await expect(
+      collector.waitForMessage(
+        (message) => isResponseFor(2)(message) && "result" in message,
+        100,
+      ),
+    ).rejects.toThrow(/timed out/);
     expect(
       (
         proxy as unknown as {
           expiredRequestKeys: Set<string>;
         }
-      ).expiredRequestKeys.has("2"),
-    ).toBe(false);
+      ).expiredRequestKeys.has("number:2"),
+    ).toBe(true);
   });
 
   it("keeps agent stdio open while the daemon is offline", async () => {


### PR DESCRIPTION
## Summary
- Implements Phase 9 MCP reaper audit gates, doctor provenance/reconnect guidance, and runtime safety gates.
- Hardens socket demux fail-closed behavior for malformed V2 frames, bracket-prefixed V1 replies, and stale unknown-id V2 responses.
- Keeps stop/reaper liveness gates fail-closed for unknown process state, with force-stop tolerance limited to accepted/already-gone SIGKILL paths.
- Keeps expired proxy request ids quarantined so repeated late daemon responses cannot leak back to the agent.

## Verification
- `bun run typecheck`
- `bun run test` (`70` files, `1273` passed, `3` todo)
- Push hook passed on `5c68c7e` (`70` files, `1273` passed, `3` todo)
- PR checks: `test` pass, `build-site` pass, CodeRabbit pass, Macroscope pass

## Review Handling
- Addressed Macroscope/Codex socket demux and doctor provenance findings.
- Addressed CodeRabbit stop-liveness, doctor precedence, reaper escalation coverage, and proxy stale-response quarantine findings.
- Cursor Bugbot is skipped by the external service limit.
- PR remains open; not merged.
