### PR TITLE
test(replay): end-to-end painpoint replay suite (phase10)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -183,8 +183,8 @@ const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
-const SEND_INPUT_CHUNK_THRESHOLD = 500;
-const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
+export const SEND_INPUT_CHUNK_THRESHOLD = 500;
+export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
@@ -202,7 +202,7 @@ const SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = parsePositiveIntegerMs(
   process.env.CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS,
   DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
 );
-function parseMaxInlineChars(
+export function parseMaxInlineChars(
   value: string | undefined,
   fallback: number,
 ): number {
@@ -211,7 +211,7 @@ function parseMaxInlineChars(
     ? parsed
     : fallback;
 }
-const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
+export const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
   process.env.CMUXLAYER_MAX_INLINE_CHARS,
   DEFAULT_SEND_INPUT_MAX_INLINE_CHARS,
 );

--- a/tests/helpers/mcp-tool-harness.ts
+++ b/tests/helpers/mcp-tool-harness.ts
@@ -1,0 +1,63 @@
+import type { AgentEngine } from "../../src/agent-engine.js";
+
+export type ToolCallResult = {
+  structuredContent?: unknown;
+  content: Array<{ text: string }>;
+  isError?: boolean;
+};
+
+export type RegisteredTool = {
+  handler(
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+  ): Promise<ToolCallResult>;
+  _engine?: AgentEngine;
+};
+
+export type ServerWithRegisteredTools = {
+  close?: () => Promise<void>;
+  _registeredTools: Record<string, RegisteredTool | undefined>;
+};
+
+export function asToolServer(server: unknown): ServerWithRegisteredTools {
+  return server as ServerWithRegisteredTools;
+}
+
+export function getTool(server: unknown, name: string): RegisteredTool {
+  const tool = asToolServer(server)._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+export function getEngine(server: unknown): AgentEngine {
+  const engine = getTool(server, "interact")._engine;
+  if (!engine) throw new Error("Lifecycle engine not registered");
+  return engine;
+}
+
+function parsePayload<T>(result: ToolCallResult): T {
+  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
+}
+
+export function parseToolResult<T>(result: ToolCallResult): T {
+  if (result.isError) {
+    throw new Error(
+      result.content.map((entry) => entry.text).join("\n") ||
+        "Tool returned an error",
+    );
+  }
+  return parsePayload<T>(result);
+}
+
+export function parseErroredToolResult<T>(result: ToolCallResult): T {
+  if (!result.isError) {
+    throw new Error("Tool result was expected to be an error");
+  }
+  return parsePayload<T>(result);
+}
+
+export async function closeToolServer(server: unknown): Promise<void> {
+  const close = asToolServer(server).close;
+  if (!close) throw new Error("Tool server does not expose close()");
+  await close();
+}

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -9,7 +9,6 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentEngine } from "../src/agent-engine.js";
 import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import {
@@ -17,28 +16,15 @@ import {
   selectReapablePids,
   type ProcessInfo,
 } from "../src/mcp-reaper.js";
-import { createServer } from "../src/server.js";
+import { createServer, type CreateServerOptions } from "../src/server.js";
 import { StateManager } from "../src/state-manager.js";
 import type { AgentRecord, AgentState, CliType } from "../src/agent-types.js";
-
-type ToolCallResult = {
-  structuredContent?: unknown;
-  content: Array<{ text: string }>;
-  isError?: boolean;
-};
-
-type RegisteredTool = {
-  handler(
-    args: Record<string, unknown>,
-    extra: Record<string, unknown>,
-  ): Promise<ToolCallResult>;
-  _engine?: AgentEngine;
-};
-
-type ServerWithRegisteredTools = {
-  close(): Promise<void>;
-  _registeredTools: Record<string, RegisteredTool | undefined>;
-};
+import {
+  closeToolServer,
+  getEngine,
+  getTool,
+  parseToolResult,
+} from "./helpers/mcp-tool-harness.js";
 
 type StatusCall = {
   key: string;
@@ -69,32 +55,6 @@ afterEach(async () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
-
-function asToolServer(server: unknown): ServerWithRegisteredTools {
-  return server as ServerWithRegisteredTools;
-}
-
-function getTool(server: unknown, name: string): RegisteredTool {
-  const tool = asToolServer(server)._registeredTools[name];
-  if (!tool) throw new Error(`Tool not found: ${name}`);
-  return tool;
-}
-
-function getEngine(server: unknown): AgentEngine {
-  const engine = getTool(server, "interact")._engine;
-  if (!engine) throw new Error("Lifecycle engine not registered");
-  return engine;
-}
-
-function parseToolResult<T>(result: ToolCallResult): T {
-  if (result.isError) {
-    throw new Error(
-      result.content.map((entry) => entry.text).join("\n") ||
-        "Tool returned an error",
-    );
-  }
-  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
-}
 
 function makeRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
   return {
@@ -138,6 +98,7 @@ function paneArg(args: string[]): string {
 }
 
 function makeLifecycleExec(surfaceRefs: string[], opts?: {
+  emptyPanes?: boolean;
   screenBySurface?: Map<string, string>;
 }): {
   exec: ExecFn;
@@ -167,6 +128,16 @@ function makeLifecycleExec(surfaceRefs: string[], opts?: {
       };
     }
     if (command === "list-panes") {
+      if (opts?.emptyPanes) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
       const liveWorkerSurfaces = [...liveSurfaces].filter(
         (surface) => surface !== "surface:lead",
       );
@@ -289,7 +260,22 @@ function makeLifecycleExec(surfaceRefs: string[], opts?: {
 }
 
 async function closeServer(server: unknown): Promise<void> {
-  await asToolServer(server).close();
+  await closeToolServer(server);
+}
+
+function startEngineServer(
+  exec: ExecFn,
+  stateDir: string,
+  overrides: Omit<Partial<CreateServerOptions>, "exec" | "stateDir"> = {},
+) {
+  return createServer({
+    exec,
+    stateDir,
+    controlHealthIntervalMs: 0,
+    disableSpawnPreflight: true,
+    sessionIdentityResolver: () => null,
+    ...overrides,
+  });
 }
 
 describe("Phase 10 painpoint e2e replay", () => {
@@ -314,13 +300,7 @@ describe("Phase 10 painpoint e2e replay", () => {
       "surface:lead",
       ...agentIds.map((_agentId, index) => `surface:worker-${index}`),
     ]);
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -482,13 +462,7 @@ describe("Phase 10 painpoint e2e replay", () => {
       "surface:lead",
       "surface:pr-loop-worker",
     ]);
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -560,43 +534,8 @@ describe("Phase 10 painpoint e2e replay", () => {
         state: "done",
       }),
     );
-    const exec: ExecFn = async (_cmd, args) => {
-      const command = args[1];
-      if (command === "list-workspaces") {
-        return {
-          stdout: JSON.stringify({
-            workspaces: [
-              {
-                ref: "workspace:1",
-                title: "Main",
-                index: 0,
-                selected: true,
-                pinned: false,
-              },
-            ],
-          }),
-          stderr: "",
-        };
-      }
-      if (command === "list-panes") {
-        return {
-          stdout: JSON.stringify({
-            workspace_ref: "workspace:1",
-            window_ref: "window:1",
-            panes: [],
-          }),
-          stderr: "",
-        };
-      }
-      return { stdout: "{}", stderr: "" };
-    };
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const { exec } = makeLifecycleExec([], { emptyPanes: true });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -639,13 +578,7 @@ describe("Phase 10 painpoint e2e replay", () => {
         ],
       ]),
     });
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -704,13 +637,7 @@ describe("Phase 10 painpoint e2e replay", () => {
     const { exec } = makeLifecycleExec([
       "surface:worker-without-artifact",
     ]);
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -761,13 +688,7 @@ describe("Phase 10 painpoint e2e replay", () => {
         }
         return true;
       }) as typeof process.kill);
-    const server = createServer({
-      exec,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = startEngineServer(exec, dir);
 
     try {
       const engine = getEngine(server);
@@ -819,12 +740,7 @@ describe("Phase 10 painpoint e2e replay", () => {
       }
       return { stdout: "{}", stderr: "" };
     };
-    const server = createServer({
-      exec,
-      skipAgentLifecycle: true,
-      stateDir: dir,
-      controlHealthIntervalMs: 0,
-    });
+    const server = startEngineServer(exec, dir, { skipAgentLifecycle: true });
 
     try {
       const send = getTool(server, "send_input");

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -1,0 +1,926 @@
+import net from "node:net";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentEngine } from "../src/agent-engine.js";
+import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import {
+  runReaper,
+  selectReapablePids,
+  type ProcessInfo,
+} from "../src/mcp-reaper.js";
+import { createServer } from "../src/server.js";
+import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord, AgentState, CliType } from "../src/agent-types.js";
+
+type ToolCallResult = {
+  structuredContent?: unknown;
+  content: Array<{ text: string }>;
+  isError?: boolean;
+};
+
+type RegisteredTool = {
+  handler(
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+  ): Promise<ToolCallResult>;
+  _engine?: AgentEngine;
+};
+
+type ServerWithRegisteredTools = {
+  close(): Promise<void>;
+  _registeredTools: Record<string, RegisteredTool | undefined>;
+};
+
+type StatusCall = {
+  key: string;
+  value: string;
+  args: string[];
+};
+
+const tempDirs: string[] = [];
+const servers: net.Server[] = [];
+
+function tempDir(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `cmuxlayer-p10-${label}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.allSettled(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function asToolServer(server: unknown): ServerWithRegisteredTools {
+  return server as ServerWithRegisteredTools;
+}
+
+function getTool(server: unknown, name: string): RegisteredTool {
+  const tool = asToolServer(server)._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+function getEngine(server: unknown): AgentEngine {
+  const engine = getTool(server, "interact")._engine;
+  if (!engine) throw new Error("Lifecycle engine not registered");
+  return engine;
+}
+
+function parseToolResult<T>(result: ToolCallResult): T {
+  if (result.isError) {
+    throw new Error(
+      result.content.map((entry) => entry.text).join("\n") ||
+        "Tool returned an error",
+    );
+  }
+  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
+}
+
+function makeRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    agent_id: "codex-cmuxlayer-p10",
+    surface_id: "surface:p10",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "cmuxlayer",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "Phase 10 replay fixture",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-05T00:00:00.000Z",
+    updated_at: "2026-07-05T00:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+}
+
+function surfaceArg(args: string[]): string {
+  const index = args.indexOf("--surface");
+  return index >= 0 ? (args[index + 1] ?? "") : "";
+}
+
+function paneArg(args: string[]): string {
+  const index = args.indexOf("--pane");
+  return index >= 0 ? (args[index + 1] ?? "") : "";
+}
+
+function makeLifecycleExec(surfaceRefs: string[], opts?: {
+  screenBySurface?: Map<string, string>;
+}): {
+  exec: ExecFn;
+  statusCalls: StatusCall[];
+  closeCalls: string[];
+} {
+  const liveSurfaces = new Set(surfaceRefs);
+  const statusCalls: StatusCall[] = [];
+  const closeCalls: string[] = [];
+  const screenBySurface = opts?.screenBySurface ?? new Map<string, string>();
+  const exec: ExecFn = async (_cmd, args) => {
+    const command = args[1];
+    if (command === "list-workspaces") {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "list-panes") {
+      const liveWorkerSurfaces = [...liveSurfaces].filter(
+        (surface) => surface !== "surface:lead",
+      );
+      const panes = [
+        {
+          ref: "pane:lead",
+          index: 0,
+          focused: liveWorkerSurfaces.length === 0,
+          surface_count: liveSurfaces.has("surface:lead") ? 1 : 0,
+          surface_refs: liveSurfaces.has("surface:lead")
+            ? ["surface:lead"]
+            : [],
+          selected_surface_ref: liveSurfaces.has("surface:lead")
+            ? "surface:lead"
+            : undefined,
+          pixel_frame: { x: 0, y: 0, width: 400, height: 900 },
+        },
+        ...(liveWorkerSurfaces.length > 0
+          ? [
+              {
+                ref: "pane:workers",
+                index: 1,
+                focused: true,
+                surface_count: liveWorkerSurfaces.length,
+                surface_refs: liveWorkerSurfaces,
+                selected_surface_ref: liveWorkerSurfaces[0],
+                pixel_frame: { x: 400, y: 0, width: 800, height: 900 },
+              },
+            ]
+          : []),
+      ];
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes,
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "list-pane-surfaces") {
+      const pane = paneArg(args);
+      const surfaces =
+        pane === "pane:lead"
+          ? liveSurfaces.has("surface:lead")
+            ? [
+                {
+                  ref: "surface:lead",
+                  title: "cmuxlayerClaude",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : []
+          : [...liveSurfaces]
+              .filter((surface) => surface !== "surface:lead")
+              .map((surface, index) => ({
+                ref: surface,
+                title: `cmuxlayerCodex ${index}`,
+                type: "terminal",
+                index,
+                selected: index === 0,
+              }));
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces,
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "read-screen") {
+      const surface = surfaceArg(args);
+      return {
+        stdout: JSON.stringify({
+          surface_ref: surface,
+          text:
+            screenBySurface.get(surface) ??
+            "OpenAI Codex\nModel: gpt-5.5\n\ncodex> ",
+          lines: 20,
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "identify") {
+      return {
+        stdout: JSON.stringify({
+          caller: { workspace_ref: "workspace:1" },
+          focused: { workspace_ref: "workspace:1" },
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "set-status") {
+      statusCalls.push({
+        key: args[2] ?? "",
+        value: args[3] ?? "",
+        args: [...args],
+      });
+      return { stdout: "{}", stderr: "" };
+    }
+    if (command === "clear-status") {
+      return { stdout: "{}", stderr: "" };
+    }
+    if (command === "close-surface") {
+      const surface = surfaceArg(args);
+      closeCalls.push(surface);
+      liveSurfaces.delete(surface);
+      return { stdout: "{}", stderr: "" };
+    }
+    if (command === "log" || command === "notify") {
+      return { stdout: "{}", stderr: "" };
+    }
+    return { stdout: "{}", stderr: "" };
+  };
+  return { exec, statusCalls, closeCalls };
+}
+
+async function closeServer(server: unknown): Promise<void> {
+  await asToolServer(server).close();
+}
+
+describe("Phase 10 painpoint e2e replay", () => {
+  it("sidebar-scale sweeps many agents with bounded, diffed status emissions", async () => {
+    const dir = tempDir("sidebar-scale");
+    const stateMgr = new StateManager(dir);
+    const agentCount = 25;
+    const agentIds = Array.from({ length: agentCount }, (_entry, index) => {
+      const agentId = `codex-cmuxlayer-sidebar-${index}`;
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          surface_id: `surface:worker-${index}`,
+          state: "ready",
+          task_summary: `sidebar scale worker ${index}`,
+          cli_session_id: `session-${index}`,
+        }),
+      );
+      return agentId;
+    });
+    const { exec, statusCalls } = makeLifecycleExec([
+      "surface:lead",
+      ...agentIds.map((_agentId, index) => `surface:worker-${index}`),
+    ]);
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      statusCalls.length = 0;
+
+      await engine.runSweep();
+
+      expect(statusCalls).toHaveLength(agentCount);
+      expect(statusCalls.map((call) => call.key).sort()).toEqual(
+        [...agentIds].sort(),
+      );
+      expect(
+        statusCalls.every(
+          (call) =>
+            call.value.includes("role=worker") &&
+            call.value.includes("state=ready"),
+        ),
+      ).toBe(true);
+
+      statusCalls.length = 0;
+      await engine.runSweep();
+
+      expect(statusCalls).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("MCP reaper matches only orphan MCP node servers and writes before/after audit evidence", async () => {
+    const processes: ProcessInfo[] = [
+      {
+        pid: 701,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/cmuxlayer/dist/index.js",
+      },
+      {
+        pid: 702,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/acme-mcp/scripts/dev.js",
+      },
+      {
+        pid: 703,
+        ppid: 2,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/brainlayer-mcp/dist/index.js",
+      },
+      {
+        pid: 704,
+        ppid: 1,
+        etimes: 60,
+        command: "node /Users/etanheyman/Gits/voicelayer-mcp/dist/index.js",
+      },
+      {
+        pid: 705,
+        ppid: 1,
+        etimes: 1200,
+        command: "node /Users/etanheyman/Gits/context7-mcp/dist/index.js",
+        launchdManaged: true,
+      },
+    ];
+    expect(selectReapablePids(processes, { minAgeSeconds: 600 })).toEqual([
+      701,
+    ]);
+
+    const lines: string[] = [];
+    const outputs: string[] = [];
+    const readProcessTable = vi
+      .fn<() => Promise<ProcessInfo[]>>()
+      .mockResolvedValueOnce(processes)
+      .mockResolvedValueOnce(processes);
+
+    await runReaper(
+      {
+        dryRun: true,
+        graceSeconds: 0,
+        knownServerNames: [],
+        logFile: join(tempDir("reaper"), "audit.log"),
+        minAgeSeconds: 600,
+      },
+      {
+        appendAuditLine: async (line) => {
+          lines.push(line);
+        },
+        readProcessTable,
+        readRamEvidence: () => ({
+          processRssBytes: 11,
+          systemFreeBytes: 22,
+          systemTotalBytes: 33,
+        }),
+        writeStdout: (line) => {
+          outputs.push(line);
+        },
+      },
+    );
+
+    expect(outputs).toContainEqual(
+      expect.stringContaining("DRY_RUN would terminate pid=701"),
+    );
+    expect(lines).toContainEqual(
+      expect.stringContaining(
+        "AUDIT phase=before dry_run=true total_processes=5 reapable_processes=1 reapable_pids=701",
+      ),
+    );
+    expect(lines).toContainEqual(
+      expect.stringContaining(
+        "AUDIT phase=after dry_run=true total_processes=5 reapable_processes=1 reapable_pids=701",
+      ),
+    );
+  });
+
+  it("PR-loop worker retention blocks unmerged reports and allows verified merged artifacts", async () => {
+    const dir = tempDir("pr-loop-retention");
+    const reportsDir = join(dir, "reports");
+    mkdirSync(reportsDir, { recursive: true });
+    const goalPath = join(dir, "GOAL-pr-worker.md");
+    const reportPath = join(reportsDir, "pr-worker-report.md");
+    const doneMarker = "DONE_PR_LOOP_WORKER";
+    writeFileSync(
+      goalPath,
+      [
+        "# Goal",
+        "",
+        `Write report path: \`${reportPath}\`.`,
+        "Open a PR for the implementation and run `/pr-loop`.",
+        `End with \`${doneMarker}\`.`,
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      reportPath,
+      [
+        "# Worker Report",
+        "PR: https://github.com/EtanHey/cmuxlayer/pull/999",
+        "PR status: open",
+        doneMarker,
+      ].join("\n"),
+      "utf8",
+    );
+    const now = new Date("2026-07-05T12:00:00.000Z");
+    const later = new Date("2026-07-05T12:01:00.000Z");
+    utimesSync(goalPath, now, now);
+    utimesSync(reportPath, later, later);
+
+    const stateMgr = new StateManager(dir);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "codex-pr-loop-worker",
+        surface_id: "surface:pr-loop-worker",
+        state: "done",
+        goal_file: goalPath,
+        task_summary: "PR deliverable: true",
+        task_done_detected_at: later.toISOString(),
+      }),
+    );
+    const { exec } = makeLifecycleExec([
+      "surface:lead",
+      "surface:pr-loop-worker",
+    ]);
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      const getState = getTool(server, "get_agent_state");
+      const first = parseToolResult<{
+        harvestability: {
+          closeable: boolean;
+          closure_artifact_verified: boolean;
+          pr_loop_required: boolean;
+          pr_loop_satisfied: boolean;
+        };
+        health: { issue_codes: string[] };
+      }>(
+        await getState.handler({ agent_id: "codex-pr-loop-worker" }, {}),
+      );
+
+      expect(first.harvestability).toMatchObject({
+        closeable: false,
+        closure_artifact_verified: true,
+        pr_loop_required: true,
+        pr_loop_satisfied: false,
+      });
+      expect(first.health.issue_codes).toContain("pr_loop_incomplete");
+
+      writeFileSync(
+        reportPath,
+        [
+          "# Worker Report",
+          "PR: https://github.com/EtanHey/cmuxlayer/pull/999",
+          "PR status: merged",
+          "Reviewed complete.",
+          doneMarker,
+        ].join("\n"),
+        "utf8",
+      );
+      utimesSync(reportPath, later, later);
+
+      const second = parseToolResult<{
+        harvestability: {
+          closeable: boolean;
+          closure_artifact_verified: boolean;
+          pr_loop_required: boolean;
+          pr_loop_satisfied: boolean;
+        };
+        health: { issue_codes: string[] };
+      }>(
+        await getState.handler({ agent_id: "codex-pr-loop-worker" }, {}),
+      );
+
+      expect(second.harvestability).toMatchObject({
+        closeable: true,
+        closure_artifact_verified: true,
+        pr_loop_required: true,
+        pr_loop_satisfied: true,
+      });
+      expect(second.health.issue_codes).not.toContain("pr_loop_incomplete");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 14: public resync/list keeps terminal workers on empty surface enumeration", async () => {
+    const dir = tempDir("candidate-14");
+    new StateManager(dir).writeState(
+      makeRecord({
+        agent_id: "terminal-worker-empty-scan",
+        surface_id: "surface:maybe-live",
+        state: "done",
+      }),
+    );
+    const exec: ExecFn = async (_cmd, args) => {
+      const command = args[1];
+      if (command === "list-workspaces") {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (command === "list-panes") {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    };
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      const resync = parseToolResult<{ ok: boolean; count: number }>(
+        await getTool(server, "resync_agents").handler({}, {}),
+      );
+      const listed = parseToolResult<{
+        agents: Array<{ agent_id: string; state: AgentState }>;
+      }>(await getTool(server, "list_agents").handler({}, {}));
+
+      expect(resync.ok).toBe(true);
+      expect(resync.count).toBe(1);
+      expect(listed.agents).toEqual([
+        expect.objectContaining({
+          agent_id: "terminal-worker-empty-scan",
+          state: "done",
+        }),
+      ]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 15: public wait_for(done) requires output evidence, not registry done alone", async () => {
+    vi.useFakeTimers();
+    const dir = tempDir("candidate-15");
+    new StateManager(dir).writeState(
+      makeRecord({
+        agent_id: "worker-registry-done",
+        surface_id: "surface:worker-registry-done",
+        state: "done",
+      }),
+    );
+    const { exec } = makeLifecycleExec(["surface:worker-registry-done"], {
+      screenBySurface: new Map([
+        [
+          "surface:worker-registry-done",
+          "gpt-5.5\nWorking (1m 02s - esc to interrupt)",
+        ],
+      ]),
+    });
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      const pending = getTool(server, "wait_for").handler(
+        {
+          agent_id: "worker-registry-done",
+          target_state: "done",
+          timeout_ms: 2_500,
+        },
+        {},
+      );
+      await vi.advanceTimersByTimeAsync(3_000);
+      const result = parseToolResult<{
+        matched: boolean;
+        source: string;
+        state: AgentState;
+      }>(await pending);
+
+      expect(result).toMatchObject({
+        matched: false,
+        source: "timeout",
+        state: "done",
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 16: public get_agent_state reports closure artifacts as unverified without a final DONE artifact", async () => {
+    const dir = tempDir("candidate-16");
+    const goalPath = join(dir, "GOAL-worker.md");
+    const reportPath = join(dir, "reports", "worker-report.md");
+    mkdirSync(join(dir, "reports"), { recursive: true });
+    writeFileSync(
+      goalPath,
+      [`Report path: \`${reportPath}\`.`, "End with `DONE_WORKER_REPORT`."].join(
+        "\n",
+      ),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: stopped before final marker\n", "utf8");
+    const now = new Date("2026-07-05T12:00:00.000Z");
+    const later = new Date("2026-07-05T12:01:00.000Z");
+    utimesSync(goalPath, now, now);
+    utimesSync(reportPath, later, later);
+    new StateManager(dir).writeState(
+      makeRecord({
+        agent_id: "worker-without-artifact",
+        surface_id: "surface:worker-without-artifact",
+        state: "done",
+        goal_file: goalPath,
+        task_done_detected_at: later.toISOString(),
+      }),
+    );
+    const { exec } = makeLifecycleExec([
+      "surface:worker-without-artifact",
+    ]);
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      const state = parseToolResult<{
+        harvestability: { closure_artifact_verified: boolean; closeable: boolean };
+        health: { issue_codes: string[] };
+      }>(
+        await getTool(server, "get_agent_state").handler(
+          { agent_id: "worker-without-artifact" },
+          {},
+        ),
+      );
+
+      expect(state.harvestability).toMatchObject({
+        closure_artifact_verified: false,
+        closeable: false,
+      });
+      expect(state.health.issue_codes).toContain("closure_without_artifact");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 19: public stop_agent force treats kill(0) EPERM as unknown/gone after SIGKILL", async () => {
+    const dir = tempDir("candidate-19");
+    new StateManager(dir).writeState(
+      makeRecord({
+        agent_id: "agent-force-unknown",
+        surface_id: "surface:force-unknown",
+        state: "working",
+        pid: 23_456,
+      }),
+    );
+    const { exec, closeCalls } = makeLifecycleExec([
+      "surface:lead",
+      "surface:force-unknown",
+    ]);
+    const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+        killCalls.push([pid, signal ?? 0]);
+        if (signal === 0) {
+          throw Object.assign(new Error("operation not permitted"), {
+            code: "EPERM",
+          });
+        }
+        return true;
+      }) as typeof process.kill);
+    const server = createServer({
+      exec,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+
+    try {
+      const engine = getEngine(server);
+      await engine.getRegistry().reconstitute();
+      const stopped = parseToolResult<{ state: AgentState }>(
+        await getTool(server, "stop_agent").handler(
+          { agent_id: "agent-force-unknown", force: true },
+          {},
+        ),
+      );
+
+      expect(stopped.state).toBe("done");
+      expect(killCalls).toContainEqual([23_456, "SIGKILL"]);
+      expect(killCalls).toContainEqual([23_456, 0]);
+      expect(closeCalls).toEqual(["surface:force-unknown"]);
+      expect(new StateManager(dir).readState("agent-force-unknown")).toBeNull();
+    } finally {
+      killSpy.mockRestore();
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 21: public background send_input records submit verification evidence after completion", async () => {
+    vi.useFakeTimers();
+    const dir = tempDir("candidate-21");
+    new StateManager(dir).writeState(
+      makeRecord({
+        agent_id: "agent-background-submit",
+        surface_id: "surface:agent-bg",
+        state: "idle",
+        cli: "claude",
+        model: "Opus 4.8",
+      }),
+    );
+    const exec: ExecFn = async (_cmd, args) => {
+      const command = args[1];
+      if (command === "read-screen") {
+        return {
+          stdout: JSON.stringify({
+            surface_ref: "surface:agent-bg",
+            text: "Claude Code\n> \nCLAUDE_COUNTER:1\n",
+            lines: 3,
+          }),
+          stderr: "",
+        };
+      }
+      if (command === "list-workspaces") {
+        return { stdout: JSON.stringify({ workspaces: [] }), stderr: "" };
+      }
+      return { stdout: "{}", stderr: "" };
+    };
+    const server = createServer({
+      exec,
+      skipAgentLifecycle: true,
+      stateDir: dir,
+      controlHealthIntervalMs: 0,
+    });
+
+    try {
+      const send = getTool(server, "send_input");
+      const read = getTool(server, "read_screen");
+      const accepted = parseToolResult<{
+        status: string;
+        submit_verified: boolean | null;
+        delivery_id: string;
+      }>(
+        await send.handler(
+          {
+            surface: "surface:agent-bg",
+            text: "ping",
+            background: true,
+            press_enter: true,
+          },
+          {},
+        ),
+      );
+
+      expect(accepted).toMatchObject({
+        status: "delivering",
+        submit_verified: null,
+      });
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      const after = parseToolResult<{
+        delivery: {
+          delivery_id: string;
+          status: string;
+          submit_verified: boolean | null;
+          retry_count: number;
+        };
+      }>(
+        await read.handler(
+          { surface: "surface:agent-bg", parsed_only: true },
+          {},
+        ),
+      );
+
+      expect(after.delivery).toMatchObject({
+        delivery_id: accepted.delivery_id,
+        status: "delivered",
+        submit_verified: null,
+        retry_count: 1,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("candidate 23: malformed socket frames reject pending requests instead of completing the wrong operation", async () => {
+    const root = tempDir("candidate-23");
+    const socketPath = join(root, "cmux.sock");
+    const received: string[] = [];
+    const server = net.createServer((conn) => {
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          if (line.trim()) {
+            received.push(line);
+            if (received.length === 1) {
+              conn.write('{"id":\n');
+            } else {
+              conn.write("OK\n");
+            }
+          }
+          newlineIndex = buffer.indexOf("\n");
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    servers.push(server);
+
+    const socket = new CmuxPersistentSocket({
+      socketPath,
+      timeoutMs: 500,
+    });
+    try {
+      await expect(socket.sendLine("set_status first")).rejects.toMatchObject({
+        code: "protocol_error",
+      });
+      await expect(socket.sendLine("set_status second")).resolves.toBe("OK");
+      expect(received).toEqual(["set_status first", "set_status second"]);
+    } finally {
+      socket.disconnect();
+    }
+  });
+});

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -3,11 +3,16 @@ import { basename, extname } from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildRouteTable } from "../src/agent-facade.js";
 import { evaluateAgentHealth } from "../src/agent-health.js";
-import { createServer } from "../src/server.js";
+import { createServer, SEND_INPUT_MAX_INLINE_CHARS } from "../src/server.js";
 import { reposEquivalent } from "../src/repo-workspace.js";
 import { parseScreen } from "../src/screen-parser.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { classifySurfaceSessionRoute } from "../src/state-manager.js";
+import {
+  getTool,
+  parseErroredToolResult,
+  parseToolResult,
+} from "./helpers/mcp-tool-harness.js";
 import type {
   AgentRecord,
   AgentState,
@@ -50,37 +55,7 @@ type PainpointFixture = {
   payload?: string;
 };
 
-type ToolCallResult = {
-  structuredContent?: unknown;
-  content: Array<{ text: string }>;
-  isError?: boolean;
-};
-
-type RegisteredTool = {
-  handler(
-    args: Record<string, unknown>,
-    extra: Record<string, unknown>,
-  ): Promise<ToolCallResult>;
-};
-
-type ServerWithRegisteredTools = {
-  _registeredTools: Record<string, RegisteredTool | undefined>;
-};
-
-const SEND_INPUT_CHUNK_THRESHOLD = 500;
-const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
-const SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT = parseMaxInlineCharsForTest(
-  process.env.CMUXLAYER_MAX_INLINE_CHARS,
-);
-
 const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
-
-function parseMaxInlineCharsForTest(value: string | undefined): number {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed >= SEND_INPUT_CHUNK_THRESHOLD
-    ? parsed
-    : DEFAULT_SEND_INPUT_MAX_INLINE_CHARS;
-}
 
 function readPainpointFixture(fileName: string): PainpointFixture {
   const raw = readFileSync(new URL(fileName, fixtureDir), "utf8");
@@ -112,29 +87,6 @@ const fixtureNames = readdirSync(fixtureDir)
   .sort();
 
 const fixtures = fixtureNames.map(readPainpointFixture);
-
-function getTool(server: unknown, name: string): RegisteredTool {
-  const tool = (server as ServerWithRegisteredTools)._registeredTools[name];
-  if (!tool) throw new Error(`Tool not found: ${name}`);
-  return tool;
-}
-
-function parseToolResult<T>(result: ToolCallResult): T {
-  if (result.isError) {
-    throw new Error(
-      result.content.map((entry) => entry.text).join("\n") ||
-        "Tool returned an error",
-    );
-  }
-  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
-}
-
-function parseErroredToolResult<T>(result: ToolCallResult): T {
-  if (!result.isError) {
-    throw new Error("Tool result was expected to be an error");
-  }
-  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
-}
 
 function legacyClassifierShape(fixture: PainpointFixture): string {
   if (fixture.read_error?.error_code === "pane_died") {
@@ -316,7 +268,7 @@ describe("Phase 0 painpoint replay corpus", () => {
         const overCapText = "x".repeat(
           Math.max(
             fixture.inline_length ?? 0,
-            SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT + 1,
+            SEND_INPUT_MAX_INLINE_CHARS + 1,
           ),
         );
         const calls: string[][] = [];
@@ -342,7 +294,7 @@ describe("Phase 0 painpoint replay corpus", () => {
 
         expect(parsed.ok).toBe(false);
         expect(parsed.error).toContain(
-          `CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT}`,
+          `CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}`,
         );
         expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS");
         expect(calls).toEqual([]);

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -67,7 +67,20 @@ type ServerWithRegisteredTools = {
   _registeredTools: Record<string, RegisteredTool | undefined>;
 };
 
+const SEND_INPUT_CHUNK_THRESHOLD = 500;
+const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
+const SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT = parseMaxInlineCharsForTest(
+  process.env.CMUXLAYER_MAX_INLINE_CHARS,
+);
+
 const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
+
+function parseMaxInlineCharsForTest(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= SEND_INPUT_CHUNK_THRESHOLD
+    ? parsed
+    : DEFAULT_SEND_INPUT_MAX_INLINE_CHARS;
+}
 
 function readPainpointFixture(fileName: string): PainpointFixture {
   const raw = readFileSync(new URL(fileName, fixtureDir), "utf8");
@@ -300,6 +313,12 @@ describe("Phase 0 painpoint replay corpus", () => {
 
     if (fixture.id === "long-inline-prompt-wedge") {
       it(`${fixture.id} refuses over-cap inline input before keystrokes are sent`, async () => {
+        const overCapText = "x".repeat(
+          Math.max(
+            fixture.inline_length ?? 0,
+            SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT + 1,
+          ),
+        );
         const calls: string[][] = [];
         const exec: ExecFn = async (_cmd, args) => {
           calls.push([...args]);
@@ -313,7 +332,7 @@ describe("Phase 0 painpoint replay corpus", () => {
         const result = await getTool(server, "send_input").handler(
           {
             surface: "surface:long-inline",
-            text: "x".repeat(fixture.inline_length ?? 1801),
+            text: overCapText,
           },
           {},
         );
@@ -322,6 +341,9 @@ describe("Phase 0 painpoint replay corpus", () => {
         );
 
         expect(parsed.ok).toBe(false);
+        expect(parsed.error).toContain(
+          `CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS_AT_IMPORT}`,
+        );
         expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS");
         expect(calls).toEqual([]);
       });

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -3,8 +3,10 @@ import { basename, extname } from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildRouteTable } from "../src/agent-facade.js";
 import { evaluateAgentHealth } from "../src/agent-health.js";
+import { createServer } from "../src/server.js";
 import { reposEquivalent } from "../src/repo-workspace.js";
 import { parseScreen } from "../src/screen-parser.js";
+import type { ExecFn } from "../src/cmux-client.js";
 import { classifySurfaceSessionRoute } from "../src/state-manager.js";
 import type {
   AgentRecord,
@@ -44,6 +46,25 @@ type PainpointFixture = {
     explicit_workspace: string | null;
   };
   records?: Partial<AgentRecord>[];
+  inline_length?: number;
+  payload?: string;
+};
+
+type ToolCallResult = {
+  structuredContent?: unknown;
+  content: Array<{ text: string }>;
+  isError?: boolean;
+};
+
+type RegisteredTool = {
+  handler(
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+  ): Promise<ToolCallResult>;
+};
+
+type ServerWithRegisteredTools = {
+  _registeredTools: Record<string, RegisteredTool | undefined>;
 };
 
 const fixtureDir = new URL("./fixtures/painpoints/", import.meta.url);
@@ -78,6 +99,29 @@ const fixtureNames = readdirSync(fixtureDir)
   .sort();
 
 const fixtures = fixtureNames.map(readPainpointFixture);
+
+function getTool(server: unknown, name: string): RegisteredTool {
+  const tool = (server as ServerWithRegisteredTools)._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+function parseToolResult<T>(result: ToolCallResult): T {
+  if (result.isError) {
+    throw new Error(
+      result.content.map((entry) => entry.text).join("\n") ||
+        "Tool returned an error",
+    );
+  }
+  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
+}
+
+function parseErroredToolResult<T>(result: ToolCallResult): T {
+  if (!result.isError) {
+    throw new Error("Tool result was expected to be an error");
+  }
+  return (result.structuredContent ?? JSON.parse(result.content[0]!.text)) as T;
+}
 
 function legacyClassifierShape(fixture: PainpointFixture): string {
   if (fixture.read_error?.error_code === "pane_died") {
@@ -254,15 +298,96 @@ describe("Phase 0 painpoint replay corpus", () => {
       continue;
     }
 
-    const testFn =
-      fixture.id === "claude-ask-user-question-overlay" ||
-      fixture.id === "claude-permission-confirmation" ||
-      fixture.id === "bare-shell-and-bare-gemini-prompt" ||
-      fixture.id === "empty-dead-pane-submit" ||
-      fixture.id === "boot-prompt-typed-not-submitted"
-        ? it
-        : it.todo;
-    testFn(
+    if (fixture.id === "long-inline-prompt-wedge") {
+      it(`${fixture.id} refuses over-cap inline input before keystrokes are sent`, async () => {
+        const calls: string[][] = [];
+        const exec: ExecFn = async (_cmd, args) => {
+          calls.push([...args]);
+          return { stdout: "{}", stderr: "" };
+        };
+        const server = createServer({
+          exec,
+          skipAgentLifecycle: true,
+        });
+
+        const result = await getTool(server, "send_input").handler(
+          {
+            surface: "surface:long-inline",
+            text: "x".repeat(fixture.inline_length ?? 1801),
+          },
+          {},
+        );
+        const parsed = parseErroredToolResult<{ ok: boolean; error?: string }>(
+          result,
+        );
+
+        expect(parsed.ok).toBe(false);
+        expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS");
+        expect(calls).toEqual([]);
+      });
+      continue;
+    }
+
+    if (fixture.id === "multiline-payload-premature-submit") {
+      it(`${fixture.id} pastes multiline payload as one message and presses Enter once`, async () => {
+        const pastedTexts: string[] = [];
+        const keys: string[] = [];
+        const sentTexts: string[] = [];
+        const exec: ExecFn = async (_cmd, args) => {
+          const command = args[1];
+          if (command === "read-screen") {
+            return {
+              stdout: JSON.stringify({
+                surface_ref: "surface:multiline",
+                text: "OpenAI Codex\nModel: gpt-5.5\n\ncodex> ",
+                lines: 4,
+              }),
+              stderr: "",
+            };
+          }
+          if (command === "set-buffer") {
+            pastedTexts.push(args.at(-1) ?? "");
+            return { stdout: "{}", stderr: "" };
+          }
+          if (command === "paste-buffer") {
+            return { stdout: "{}", stderr: "" };
+          }
+          if (command === "send-key") {
+            keys.push(args.at(-1) ?? "");
+            return { stdout: "{}", stderr: "" };
+          }
+          if (command === "send") {
+            sentTexts.push(args.at(-1) ?? "");
+            return { stdout: "{}", stderr: "" };
+          }
+          return { stdout: "{}", stderr: "" };
+        };
+        const server = createServer({
+          exec,
+          skipAgentLifecycle: true,
+        });
+
+        const result = await getTool(server, "send_input").handler(
+          {
+            surface: "surface:multiline",
+            text: fixture.payload ?? "line one\nline two\nline three",
+            press_enter: true,
+          },
+          {},
+        );
+        const parsed = parseToolResult<{ ok: boolean }>(result);
+
+        expect(parsed.ok).toBe(true);
+        expect(pastedTexts).toEqual([
+          fixture.payload ?? "line one\nline two\nline three",
+        ]);
+        expect(sentTexts).toEqual([]);
+        expect(keys).toEqual(["return"]);
+      });
+      continue;
+    }
+
+    it(
       `${fixture.id} classifies as ${fixture.expected_state} via the canonical control-plane state machine`,
       () => {
         expect(legacyClassifierShape(fixture)).toBe(fixture.expected_state);


### PR DESCRIPTION
## Summary
- Adds Phase 10 production-wired E2E painpoint replay coverage in `tests/painpoint-e2e.test.ts`.
- Flips the remaining flippable replay corpus todos in `tests/painpoint-replay.test.ts`.
- Covers sidebar-scale status emission, MCP reaper audit selection, PR-loop retention, and candidates 14/15/16/19/21/23.
- Incorporates pre-commit CodeRabbit feedback by making success-path tool parsing fail fast on MCP error results while keeping intentional-error assertions explicit.

## Test plan
- `rg -n "\\bany\\b|it\\.todo|todo\\(" tests/painpoint-replay.test.ts tests/painpoint-e2e.test.ts` -> no matches
- `bun run typecheck` -> passed
- `bunx vitest run tests/painpoint-replay.test.ts tests/painpoint-e2e.test.ts` -> 22 passed
- `bun run test` -> 71 files / 1285 tests passed
- Push hook `run_tests.sh` -> passed, including 71 files / 1285 tests
- `coderabbit review --agent` pre-commit pass 1 -> 1 minor finding, fixed
- `coderabbit review --agent` pre-commit pass 2 -> 0 findings

## Coverage
- Replay fixtures: overlays, permission prompts, update menu, shell/dead/composer-dirty states, stale surfaces, wrong workspace, duplicate registry routes, long inline refusal, multiline paste/submit.
- E2E spot checks: sidebar-scale, MCP-reaper, PR-loop-retention, candidate 14, candidate 15, candidate 16, candidate 19, candidate 21, candidate 23.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus public exports of existing send-input constants; no production logic paths altered beyond visibility for tests.
> 
> **Overview**
> Adds **Phase 10 production-wired replay tests** that exercise MCP tools and the lifecycle engine with mocked cmux `exec`, plus shared helpers to invoke registered tools and parse success vs error payloads.
> 
> **`tests/painpoint-e2e.test.ts`** covers sidebar-scale status sweeps (diffed `set-status` only on change), MCP reaper dry-run audit lines, PR-loop harvestability before/after merge, empty-pane resync retention, `wait_for(done)` timing out without screen evidence, unverified closure artifacts, force `stop_agent` when `kill(0)` returns EPERM, background `send_input` delivery metadata, and malformed socket frames rejecting the wrong pending request.
> 
> **`tests/painpoint-replay.test.ts`** promotes previously skipped painpoint fixtures to real classifier tests and adds **`send_input`** replay cases for over-cap inline refusal and multiline paste with a single Enter.
> 
> **`tests/helpers/mcp-tool-harness.ts`** centralizes `getTool` / `getEngine` / `parseToolResult` / server teardown. **`src/server.ts`** exports `SEND_INPUT_*` limits and `parseMaxInlineChars` so replay tests assert the same caps as production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1fd7c49c0ad732a4677e81778e46a092c0b879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add end-to-end painpoint replay test suite (phase 10) with MCP tool test harness
> - Adds [tests/painpoint-e2e.test.ts](https://github.com/EtanHey/cmuxlayer/pull/228/files#diff-bc90ffb33b06a54a1563b0e95a9978eaa86c922be83f2f321774545177a5dc8c) covering nine new scenarios: status emission sweep limits, MCP reaper audit/evidence, PR loop retention, resync/list with empty surface enumeration, `wait_for(done)` output evidence, closure artifact verification, forced stop with EPERM handling, background `send_input` submit verification, and malformed socket frame handling.
> - Adds [tests/helpers/mcp-tool-harness.ts](https://github.com/EtanHey/cmuxlayer/pull/228/files#diff-0468e97eaff5d53f6dc922ba83a4c9ee5bf9b4899b6e6fb229f23b47fb96ef02) with utilities (`asToolServer`, `getTool`, `getEngine`, `parseToolResult`, `parseErroredToolResult`, `closeToolServer`) to simplify MCP tool interaction in tests.
> - Extends [tests/painpoint-replay.test.ts](https://github.com/EtanHey/cmuxlayer/pull/228/files#diff-3b0b93f895437253e2c9db5345c95afbe302205f9c362419fb82867f30153a1b) with fixture-specific branches for `long-inline-prompt-wedge` (verifies `send_input` rejects over-cap inline input) and `multiline-payload-premature-submit` (verifies paste-buffer path with a single Enter keypress).
> - Exports `SEND_INPUT_CHUNK_THRESHOLD`, `DEFAULT_SEND_INPUT_MAX_INLINE_CHARS`, `SEND_INPUT_MAX_INLINE_CHARS`, and `parseMaxInlineChars` from [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/228/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to support test assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f1fd7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader end-to-end coverage for server and agent workflows, including status updates, cleanup, recovery, and error handling.
  * Added replay coverage for long inline inputs and multiline message submission behavior.
  * Improved validation for malformed socket messages and timeout-based completion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->