### PR TITLE
feat(policy): enforce manual-mode gate on mutating tools + honest degradation signals

### DIFF
--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -35,6 +35,7 @@ const MUTATING_TOOLS = new Set([
   "supersede_agent_goal",
   "interact",
   "kill",
+  "agent_engine",
 ]);
 
 const VALID_CONTROL_MODES = new Set<string>(["autonomous", "manual"]);

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -15,11 +15,26 @@ const READ_ONLY_TOOLS = new Set([
 /** Tools that mutate state — blocked in manual mode */
 const MUTATING_TOOLS = new Set([
   "select_workspace",
+  "create_workspace",
+  "new_split",
+  "new_surface",
+  "move_surface",
+  "reorder_surface",
   "send_input",
   "send_command",
   "send_key",
+  "rename_tab",
   "close_surface",
   "browser_surface",
+  "spawn_agent",
+  "new_worktree_split",
+  "spawn_in_workspace",
+  "stop_agent",
+  "send_to",
+  "send_to_agent",
+  "supersede_agent_goal",
+  "interact",
+  "kill",
 ]);
 
 const VALID_CONTROL_MODES = new Set<string>(["autonomous", "manual"]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
-import { parseReservedModeKey } from "./mode-policy.js";
+import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
@@ -90,8 +90,10 @@ import type {
   CmuxNewSurfaceResult,
   CmuxPane,
   CmuxSurface,
+  CmuxStatusEntry,
   CmuxTerminalMetadata,
   CmuxWorkspace,
+  ControlMode,
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
@@ -315,6 +317,22 @@ class DeliverySafetyGateError extends Error {
   }
 }
 
+class ManualModeMutationError extends Error {
+  readonly error_code = "manual_mode";
+  readonly control = "manual";
+
+  constructor(
+    readonly tool: string,
+    readonly surface: string,
+    readonly workspace?: string,
+  ) {
+    super(
+      `Tool "${tool}" is blocked for surface ${surface}: surface is in manual mode`,
+    );
+    this.name = "ManualModeMutationError";
+  }
+}
+
 class BootPromptTimeoutError extends Error {
   constructor(
     message: string,
@@ -383,6 +401,26 @@ function readErrorText(error: unknown): string {
   return String(error);
 }
 
+function controlModeFromStatusEntries(entries: unknown): ControlMode {
+  if (!Array.isArray(entries)) {
+    return "autonomous";
+  }
+  const entry = entries.find((candidate): candidate is CmuxStatusEntry => {
+    if (typeof candidate !== "object" || candidate === null) {
+      return false;
+    }
+    const maybeEntry = candidate as Partial<CmuxStatusEntry>;
+    return maybeEntry.key === "mode.control";
+  });
+  return entry?.value === "manual" || entry?.value === "autonomous"
+    ? entry.value
+    : "autonomous";
+}
+
+function screenUnavailableMessage(error: unknown): string {
+  return readErrorText(error).replace(/^Error\ncmux read-screen failed:\s*/i, "");
+}
+
 function isSurfaceGoneReadFailure(error: unknown, surface: string): boolean {
   const text = readErrorText(error).toLowerCase();
   const surfaceLower = surface.toLowerCase();
@@ -432,7 +470,17 @@ function okFormatted(
 
 function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
   const message = error instanceof Error ? error.message : String(error);
-  const payload = { ok: false, error: message, ...extra };
+  const modeExtra =
+    error instanceof ManualModeMutationError
+      ? {
+          error_code: error.error_code,
+          tool: error.tool,
+          surface: error.surface,
+          ...(error.workspace ? { workspace: error.workspace } : {}),
+          control: error.control,
+        }
+      : {};
+  const payload = { ok: false, error: message, ...modeExtra, ...extra };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
@@ -571,6 +619,15 @@ interface SurfaceWorkingDirectoryMaps {
   workspaceCwdByRef: Map<string, string>;
 }
 
+interface TerminalMetadataLoadResult {
+  terminalBySurface: Map<string, CmuxTerminalMetadata>;
+  degraded?: {
+    terminal_metadata: true;
+    error_code: "terminal_metadata_unavailable";
+    error: string;
+  };
+}
+
 function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
@@ -594,12 +651,12 @@ function paneWorkingDirectoryKey(
 
 async function loadTerminalMetadataBySurface(
   client: CmuxLayerClient,
-): Promise<Map<string, CmuxTerminalMetadata>> {
+): Promise<TerminalMetadataLoadResult> {
   const metadataClient = client as CmuxLayerClient & {
     listTerminalMetadata?: () => Promise<{ terminals: CmuxTerminalMetadata[] }>;
   };
   if (typeof metadataClient.listTerminalMetadata !== "function") {
-    return new Map();
+    return { terminalBySurface: new Map() };
   }
 
   try {
@@ -614,9 +671,16 @@ async function loadTerminalMetadataBySurface(
         bySurface.set(surfaceRef, terminal);
       }
     }
-    return bySurface;
-  } catch {
-    return new Map();
+    return { terminalBySurface: bySurface };
+  } catch (error) {
+    return {
+      terminalBySurface: new Map(),
+      degraded: {
+        terminal_metadata: true,
+        error_code: "terminal_metadata_unavailable",
+        error: readErrorText(error),
+      },
+    };
   }
 }
 
@@ -1394,6 +1458,61 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // Health/read paths should not fail just because a refresh scan failed.
     }
   };
+  const resolveModeWorkspace = async (
+    surface: string,
+    workspace?: string,
+  ): Promise<string | undefined> => {
+    if (workspace) {
+      return workspace;
+    }
+    try {
+      const identified = await client.identify(surface);
+      return (
+        identified.caller?.workspace_ref ?? identified.focused?.workspace_ref
+      );
+    } catch {
+      return undefined;
+    }
+  };
+  const readSurfaceControlMode = async (
+    surface: string,
+    workspace?: string,
+  ): Promise<{ control: ControlMode; workspace?: string }> => {
+    const statusClient = client as CmuxLayerClient & {
+      listStatus?: (opts?: { workspace?: string }) => Promise<unknown>;
+    };
+    if (typeof statusClient.listStatus !== "function") {
+      return { control: "autonomous", workspace };
+    }
+    const modeWorkspace = await resolveModeWorkspace(surface, workspace);
+    if (!modeWorkspace) {
+      return { control: "autonomous" };
+    }
+    try {
+      const entries = await statusClient.listStatus({ workspace: modeWorkspace });
+      return {
+        control: controlModeFromStatusEntries(entries),
+        workspace: modeWorkspace,
+      };
+    } catch {
+      return { control: "autonomous", workspace: modeWorkspace };
+    }
+  };
+  const assertSurfaceMutationAllowed = async (
+    toolName: string,
+    surface: string,
+    workspace?: string,
+  ): Promise<void> => {
+    const mode = await readSurfaceControlMode(surface, workspace);
+    try {
+      assertMutationAllowed(toolName, mode.control);
+    } catch (error) {
+      if (mode.control === "manual") {
+        throw new ManualModeMutationError(toolName, surface, mode.workspace);
+      }
+      throw error;
+    }
+  };
 
   const server = new McpServer(
     {
@@ -1519,8 +1638,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const withSurfaceWrite = async <T>(
     surface: string,
     fn: () => Promise<T>,
-    owner = `surface-write:${randomUUID()}`,
+    opts: {
+      toolName?: string;
+      workspace?: string;
+      owner?: string;
+    } = {},
   ): Promise<T> => {
+    if (opts.toolName) {
+      await assertSurfaceMutationAllowed(opts.toolName, surface, opts.workspace);
+    }
+    const owner = opts.owner ?? `surface-write:${randomUUID()}`;
     acquireSurfaceWrite(surface, owner);
     try {
       return await fn();
@@ -2320,7 +2447,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: opts.workspace,
         });
       }
-    });
+    }, { toolName: "send_command", workspace: opts.workspace });
   };
 
   const deliverBootPrompt = async (opts: {
@@ -2367,23 +2494,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let sentChunks = 0;
 
     try {
-      const delivery = await withSurfaceWrite(opts.surface, async () =>
-        deliverInputChunks({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          chunks,
-          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-          press_enter: true,
-          source_event: "boot_prompt",
-          onChunkDelivered: (count) => {
-            sentChunks = count;
-          },
-          verify_submit: true,
-          submit_verify_timeout_ms: opts.timeout_ms
-            ? Math.min(SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS, opts.timeout_ms)
-            : undefined,
-        }),
+      const delivery = await withSurfaceWrite(
+        opts.surface,
+        async () =>
+          deliverInputChunks({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: true,
+            source_event: "boot_prompt",
+            onChunkDelivered: (count) => {
+              sentChunks = count;
+            },
+            verify_submit: true,
+            submit_verify_timeout_ms: opts.timeout_ms
+              ? Math.min(SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS, opts.timeout_ms)
+              : undefined,
+          }),
+        { toolName: "boot_prompt", workspace: opts.workspace },
       );
       return { ...delivery, prompt_text: rawPrompt };
     } catch (error) {
@@ -2912,9 +3042,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return enrichedSurface;
           }),
         );
-        const terminalBySurface = await loadTerminalMetadataBySurface(client);
+        const terminalMetadata = await loadTerminalMetadataBySurface(client);
         const workingDirectoryMaps: SurfaceWorkingDirectoryMaps = {
-          terminalBySurface,
+          terminalBySurface: terminalMetadata.terminalBySurface,
           paneByWorkspaceAndRef,
           workspaceCwdByRef,
         };
@@ -2950,6 +3080,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         };
         if (args.workspace) {
           data.workspace_ref = args.workspace;
+        }
+        if (terminalMetadata.degraded) {
+          data.metadata_degraded = terminalMetadata.degraded;
         }
         const formatted = formatListSurfaces(
           responseSurfaces as Array<{
@@ -3079,6 +3212,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           (await resolveWorkspaceForRepo(
             inferRepoFromLauncherTitle(args.title),
           ));
+        if (args.surface) {
+          await assertSurfaceMutationAllowed("new_split", args.surface);
+        }
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
             throw new Error(
@@ -3428,6 +3564,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        await assertSurfaceMutationAllowed("move_surface", args.surface);
         const result = await client.moveSurface({
           surface: args.surface,
           pane: args.pane,
@@ -3467,6 +3604,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        await assertSurfaceMutationAllowed("reorder_surface", args.surface);
         const result = await client.reorderSurface({
           surface: args.surface,
           index: args.index,
@@ -3604,7 +3742,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_event: "send_input",
             verify_submit: shouldVerifySubmit,
           });
-        });
+        }, { toolName: "send_input", workspace: args.workspace });
 
         const identity = resolveTargetIdentity(stateMgr, args.surface);
         const data = {
@@ -3726,7 +3864,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_event: "send_command",
             verify_submit: bootPromptPath ? false : shouldVerifySubmit,
           });
-        });
+        }, { toolName: "send_command", workspace: args.workspace });
 
         let bootPromptDelivery:
           | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -3821,7 +3959,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const key = normalizeKeyName(args.key);
         await withSurfaceWrite(args.surface, async () => {
           await sendKeyWithRetry(args.surface, key, args.workspace);
-        });
+        }, { toolName: "send_key", workspace: args.workspace });
         const data = { surface: args.surface, key };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
@@ -3999,7 +4137,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await client.renameTab(args.surface, finalTitle, {
             workspace: args.workspace,
           });
-        });
+        }, { toolName: "rename_tab", workspace: args.workspace });
         const data = { surface: args.surface, title: finalTitle };
         return okFormatted(formatOk("rename_tab", data), data);
       } catch (e) {
@@ -4130,6 +4268,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.destructive,
     async (args) => {
       try {
+        await assertSurfaceMutationAllowed(
+          "close_surface",
+          args.surface,
+          args.workspace,
+        );
         let staleRegistryDoneConsolidated:
           | { agent_id: string; previous_state: AgentState; done_signal: string }
           | undefined;
@@ -4407,6 +4550,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             break;
         }
 
+        if (args.surface) {
+          await assertSurfaceMutationAllowed(
+            "browser_surface",
+            args.surface,
+            args.workspace,
+          );
+        }
         const result = await client.browser(browserArgs);
         // browser_surface actions map to cmux browser-surface subcommands
         const data = { action: args.action, surface: args.surface, result };
@@ -4721,12 +4871,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           readScreen: (surface, readOpts) =>
             client.readScreen(surface, readOpts),
           send: (surface, text, sendOpts) =>
-            withSurfaceWrite(surface, () =>
-              client.send(surface, text, sendOpts),
+            withSurfaceWrite(
+              surface,
+              () => client.send(surface, text, sendOpts),
+              { toolName: "agent_engine", workspace: sendOpts?.workspace },
             ),
           sendKey: (surface, key, keyOpts) =>
-            withSurfaceWrite(surface, () =>
-              client.sendKey(surface, key, keyOpts),
+            withSurfaceWrite(
+              surface,
+              () => client.sendKey(surface, key, keyOpts),
+              { toolName: "send_key", workspace: keyOpts?.workspace },
             ),
           setProgress: (value, progressOpts) =>
             client.setProgress(value, progressOpts),
@@ -4738,8 +4892,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           listPaneSurfaces: (surfaceOpts) =>
             client.listPaneSurfaces(surfaceOpts),
           closeSurface: (surface, closeOpts) =>
-            withSurfaceWrite(surface, () =>
-              client.closeSurface(surface, closeOpts),
+            withSurfaceWrite(
+              surface,
+              () => client.closeSurface(surface, closeOpts),
+              { toolName: "close_surface", workspace: closeOpts?.workspace },
             ),
           notifyLifecycleEvent,
         },
@@ -4981,29 +5137,36 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
           : [sanitizedText];
 
-      return withSurfaceWrite(route.surface_id, async () => {
-        await assertDeliveryTargetIsSafe(
-          route.surface_id,
-          route.workspace_id ?? undefined,
-        );
-        return deliverInputChunks({
-          surface: route.surface_id,
+      return withSurfaceWrite(
+        route.surface_id,
+        async () => {
+          await assertDeliveryTargetIsSafe(
+            route.surface_id,
+            route.workspace_id ?? undefined,
+          );
+          return deliverInputChunks({
+            surface: route.surface_id,
+            workspace: route.workspace_id ?? undefined,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: args.press_enter,
+            source_event: args.source_event,
+            source_agent: args.agent_id,
+            // Verify every relay to an interactive agent — not just long ones.
+            // A short relay (the common agent-to-agent case) to a frozen
+            // terminal must be caught, never reported as ok. allow_busy sends to
+            // a non-interactive (working) agent stay unverified to avoid
+            // false-failing a legitimate interjection.
+            verify_submit:
+              args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
+          });
+        },
+        {
+          toolName: args.source_event,
           workspace: route.workspace_id ?? undefined,
-          chunks,
-          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-          press_enter: args.press_enter,
-          source_event: args.source_event,
-          source_agent: args.agent_id,
-          // Verify every relay to an interactive agent — not just long ones.
-          // A short relay (the common agent-to-agent case) to a frozen
-          // terminal must be caught, never reported as ok. allow_busy sends to
-          // a non-interactive (working) agent stay unverified to avoid
-          // false-failing a legitimate interjection.
-          verify_submit:
-            args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
-        });
-      });
+        },
+      );
     };
     // Expose the guarded relay to dispatch_to_agent's nudge (registered above,
     // outside this lifecycle block).
@@ -6021,6 +6184,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.destructive,
       async (args) => {
         try {
+          const current = engine.getAgentState(args.agent_id);
+          if (current) {
+            await assertSurfaceMutationAllowed(
+              "stop_agent",
+              current.surface_id,
+              current.workspace_id ?? undefined,
+            );
+          }
           await engine.stopAgent(args.agent_id, args.force);
           const state = engine.getAgentState(args.agent_id);
           const data = {
@@ -6420,8 +6591,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return okFormatted(formatOk("interact:send", d), d);
             }
             case "interrupt": {
-              await withSurfaceWrite(agent.surface_id, () =>
-                client.sendKey(agent.surface_id, "c-c", {}),
+              await withSurfaceWrite(
+                agent.surface_id,
+                () =>
+                  client.sendKey(agent.surface_id, "c-c", {
+                    workspace: agent.workspace_id ?? undefined,
+                  }),
+                {
+                  toolName: "interact",
+                  workspace: agent.workspace_id ?? undefined,
+                },
               );
               const d = { agent_id: args.agent, action: "interrupt" };
               return okFormatted(formatOk("interact:interrupt", d), d);
@@ -6557,6 +6736,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Kill each agent, collecting results
           for (const agentId of targetIds) {
             try {
+              const current = engine.getAgentState(agentId);
+              if (current) {
+                await assertSurfaceMutationAllowed(
+                  "kill",
+                  current.surface_id,
+                  current.workspace_id ?? undefined,
+                );
+              }
               await engine.stopAgent(agentId, args.force);
               killed.push(agentId);
             } catch (e) {
@@ -6614,6 +6801,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const enriched = await Promise.all(
             agents.map(async (agent) => {
               let screenData: ParsedScreenResult | null = null;
+              let screenFailure:
+                | {
+                    screen_unavailable: true;
+                    error_code: "screen_unavailable";
+                    screen_error: string;
+                  }
+                | null = null;
               try {
                 const screen = await Promise.race([
                   client.readScreen(agent.surface_id, { lines: 20 }),
@@ -6632,8 +6826,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   ),
                   resolveHarnessStateForSurface(stateMgr, agent.surface_id),
                 );
-              } catch {
+              } catch (error) {
                 // Surface may be closed, unavailable, or timed out
+                screenFailure = {
+                  screen_unavailable: true,
+                  error_code: "screen_unavailable",
+                  screen_error: screenUnavailableMessage(error),
+                };
               }
 
               const resumeCommand = resumeCommandForAgent(agent);
@@ -6656,6 +6855,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 spawn_depth: agent.spawn_depth,
                 created_at: agent.created_at,
                 quality: agent.quality,
+                ...(screenFailure ?? {}),
               };
             }),
           );

--- a/src/server.ts
+++ b/src/server.ts
@@ -3181,6 +3181,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        await assertWorkspaceMutationAllowed(
+          "create_workspace",
+          await currentCallerWorkspace(),
+        );
         const result = await client.createWorkspace(args.title);
         const data = {
           workspace: result.workspace,
@@ -5344,12 +5348,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await preflightBootPromptFile(bootPromptPath);
           }
 
-          const worktree = await prepareSpawnWorktree(
-            args.repo,
-            args.worktree,
-            args.mcp_profile as McpProfile | undefined,
-          );
-
           await refreshManagedMetadataBestEffort(args.parent_agent_id);
           const parentWorkspace = args.parent_agent_id
             ? (engine.getAgentState(args.parent_agent_id)?.workspace_id ??
@@ -5360,6 +5358,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             explicitWorkspace ??
             (args.parent_agent_id ? undefined : await currentCallerWorkspace());
           const comparisonWorkspace = spawnWorkspace ?? parentWorkspace;
+          await assertWorkspaceMutationAllowed("spawn_agent", comparisonWorkspace);
+          const worktree = await prepareSpawnWorktree(
+            args.repo,
+            args.worktree,
+            args.mcp_profile as McpProfile | undefined,
+          );
           const requestedRole = inferAgentRole({
             role: args.role,
             cli: args.cli,
@@ -5629,6 +5633,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           assertBootPromptMode(args.prompt, null);
+          const explicitWorkspace = await canonicalWorkspaceRef(args.workspace);
+          const mutationWorkspace =
+            explicitWorkspace ?? (await currentCallerWorkspace());
+          await assertWorkspaceMutationAllowed(
+            "new_worktree_split",
+            mutationWorkspace,
+          );
           const priorFocus = await focusTargetBeforeSplit(args.workspace);
           const worktree = await prepareSpawnWorktree(
             args.repo,
@@ -5769,6 +5780,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
+          await assertWorkspaceMutationAllowed(
+            "spawn_in_workspace",
+            args.reuse_workspace ?? (await currentCallerWorkspace()),
+          );
           const workspaceResult = args.reuse_workspace
             ? { workspace: args.reuse_workspace, title: args.workspace_title }
             : await client.createWorkspace(args.workspace_title);

--- a/src/server.ts
+++ b/src/server.ts
@@ -323,11 +323,13 @@ class ManualModeMutationError extends Error {
 
   constructor(
     readonly tool: string,
-    readonly surface: string,
+    readonly surface?: string,
     readonly workspace?: string,
   ) {
     super(
-      `Tool "${tool}" is blocked for surface ${surface}: surface is in manual mode`,
+      `Tool "${tool}" is blocked${
+        surface ? ` for surface ${surface}` : ""
+      }${workspace ? ` in workspace ${workspace}` : ""}: surface is in manual mode`,
     );
     this.name = "ManualModeMutationError";
   }
@@ -475,7 +477,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
       ? {
           error_code: error.error_code,
           tool: error.tool,
-          surface: error.surface,
+          ...(error.surface ? { surface: error.surface } : {}),
           ...(error.workspace ? { workspace: error.workspace } : {}),
           control: error.control,
         }
@@ -1498,6 +1500,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return { control: "autonomous", workspace: modeWorkspace };
     }
   };
+  const readWorkspaceControlMode = async (
+    workspace?: string,
+  ): Promise<{ control: ControlMode; workspace?: string }> => {
+    const statusClient = client as CmuxLayerClient & {
+      listStatus?: (opts?: { workspace?: string }) => Promise<unknown>;
+    };
+    if (!workspace || typeof statusClient.listStatus !== "function") {
+      return { control: "autonomous", workspace };
+    }
+    try {
+      const entries = await statusClient.listStatus({ workspace });
+      return {
+        control: controlModeFromStatusEntries(entries),
+        workspace,
+      };
+    } catch {
+      return { control: "autonomous", workspace };
+    }
+  };
   const assertSurfaceMutationAllowed = async (
     toolName: string,
     surface: string,
@@ -1509,6 +1530,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     } catch (error) {
       if (mode.control === "manual") {
         throw new ManualModeMutationError(toolName, surface, mode.workspace);
+      }
+      throw error;
+    }
+  };
+  const assertWorkspaceMutationAllowed = async (
+    toolName: string,
+    workspace?: string,
+  ): Promise<void> => {
+    const mode = await readWorkspaceControlMode(workspace);
+    try {
+      assertMutationAllowed(toolName, mode.control);
+    } catch (error) {
+      if (mode.control === "manual") {
+        throw new ManualModeMutationError(toolName, undefined, mode.workspace);
       }
       throw error;
     }
@@ -3212,8 +3247,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           (await resolveWorkspaceForRepo(
             inferRepoFromLauncherTitle(args.title),
           ));
+        const shouldInferRole =
+          Boolean(args.role) ||
+          (!args.pane &&
+            !args.surface &&
+            canInferAgentRole({ title: args.title }));
+        const inferredRole = shouldInferRole
+          ? inferAgentRole({ role: args.role, title: args.title })
+          : null;
+        if (
+          inferredRole &&
+          (args.type ?? "terminal") === "terminal" &&
+          (args.pane || args.surface)
+        ) {
+          throw new Error(
+            "pane/surface cannot be combined with role-based new_split; omit the explicit target or omit role",
+          );
+        }
         if (args.surface) {
           await assertSurfaceMutationAllowed("new_split", args.surface);
+        } else if (targetWorkspace) {
+          await assertWorkspaceMutationAllowed("new_split", targetWorkspace);
         }
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
@@ -3228,22 +3282,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         // pane/surface anchor). Captured right before creation, AFTER all
         // validation, so a rejected request has no focus side effects.
         let priorFocus: string | null = null;
-        const shouldInferRole =
-          Boolean(args.role) ||
-          (!args.pane &&
-            !args.surface &&
-            canInferAgentRole({ title: args.title }));
-        const inferredRole = shouldInferRole
-          ? inferAgentRole({ role: args.role, title: args.title })
-          : null;
         let actualPlacement: "split" | "surface" = "split";
         let actualDirection: string | null = args.direction;
         if (inferredRole && (args.type ?? "terminal") === "terminal") {
-          if (args.pane || args.surface) {
-            throw new Error(
-              "pane/surface cannot be combined with role-based new_split; omit the explicit target or omit role",
-            );
-          }
           const panes = await client.listPanes({ workspace: targetWorkspace });
           const rawPaneSurfaces = await Promise.all(
             panes.panes.map(async (pane) => {
@@ -3691,6 +3732,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
         if (args.background) {
+          await assertSurfaceMutationAllowed(
+            "send_input",
+            args.surface,
+            args.workspace,
+          );
           const record: DeliveryRecord = {
             delivery_id: randomUUID(),
             surface: args.surface,

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -57,6 +57,7 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("send_to_agent")).toBe(true);
     expect(isMutatingTool("stop_agent")).toBe(true);
     expect(isMutatingTool("kill")).toBe(true);
+    expect(isMutatingTool("agent_engine")).toBe(true);
   });
 
   it("returns false for list_surfaces", () => {
@@ -101,6 +102,9 @@ describe("assertMutationAllowed", () => {
       /manual/i,
     );
     expect(() => assertMutationAllowed("send_to", "manual")).toThrow(/manual/i);
+    expect(() => assertMutationAllowed("agent_engine", "manual")).toThrow(
+      /manual/i,
+    );
     expect(() => assertMutationAllowed("kill", "manual")).toThrow(/manual/i);
   });
 

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -49,12 +49,18 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("browser_surface")).toBe(true);
   });
 
-  it("returns false for list_surfaces", () => {
-    expect(isMutatingTool("list_surfaces")).toBe(false);
+  it("returns true for lifecycle and tab mutation tools", () => {
+    expect(isMutatingTool("rename_tab")).toBe(true);
+    expect(isMutatingTool("move_surface")).toBe(true);
+    expect(isMutatingTool("reorder_surface")).toBe(true);
+    expect(isMutatingTool("send_to")).toBe(true);
+    expect(isMutatingTool("send_to_agent")).toBe(true);
+    expect(isMutatingTool("stop_agent")).toBe(true);
+    expect(isMutatingTool("kill")).toBe(true);
   });
 
-  it("returns false for rename_tab (metadata, not mutation)", () => {
-    expect(isMutatingTool("rename_tab")).toBe(false);
+  it("returns false for list_surfaces", () => {
+    expect(isMutatingTool("list_surfaces")).toBe(false);
   });
 });
 
@@ -91,10 +97,14 @@ describe("assertMutationAllowed", () => {
     expect(() => assertMutationAllowed("close_surface", "manual")).toThrow(
       /manual/i,
     );
+    expect(() => assertMutationAllowed("rename_tab", "manual")).toThrow(
+      /manual/i,
+    );
+    expect(() => assertMutationAllowed("send_to", "manual")).toThrow(/manual/i);
+    expect(() => assertMutationAllowed("kill", "manual")).toThrow(/manual/i);
   });
 
   it("allows metadata tools in manual mode", () => {
-    expect(() => assertMutationAllowed("rename_tab", "manual")).not.toThrow();
     expect(() => assertMutationAllowed("set_status", "manual")).not.toThrow();
     expect(() => assertMutationAllowed("set_progress", "manual")).not.toThrow();
   });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2992,6 +2992,48 @@ codex>
     expect(parsed.health.issue_codes).toContain("registry_screen_disagreement");
   });
 
+  it("interact interrupt sends the key in the agent workspace", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const interact = (server as any)._registeredTools["interact"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    mockExec.mockClear();
+
+    const result = await interact.handler(
+      { agent: agentId, action: "interrupt" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const sendKeyCalls = mockExec.mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args.includes("send-key"),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(sendKeyCalls).toHaveLength(1);
+    expect(sendKeyCalls[0][1]).toEqual(
+      expect.arrayContaining([
+        "send-key",
+        "--surface",
+        "surface:new",
+        "--workspace",
+        "workspace:1",
+        "ctrl-c",
+      ]),
+    );
+  });
+
   it("send_to sanitizes and chunks delivery through the agent surface", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -3791,6 +3833,116 @@ codex>
     expect(agent).toHaveProperty("spawn_depth");
     expect(agent).toHaveProperty("created_at");
     expect(agent).toHaveProperty("quality");
+  });
+
+  it("my_agents marks a row when screen data is unavailable", async () => {
+    const readError = new Error("screen read timed out");
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [{ ref: "workspace:1", title: "Main", selected: true }],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:screen-fail"],
+                selected_surface_ref: "surface:screen-fail",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:screen-fail",
+                title: "screen fail",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("read-screen")) {
+        throw readError;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createLifecycleServer(mockExec);
+    const engine = testLifecycleEngine(server);
+    const record: AgentRecord = {
+      agent_id: "screenFailClaude-session1",
+      surface_id: "surface:screen-fail",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "opus",
+      cli: "claude",
+      cli_session_id: null,
+      cli_session_path: null,
+      launcher_name: "cmuxlayerClaude",
+      task_summary: "screen unavailable",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-05T00:00:00.000Z",
+      updated_at: "2026-07-05T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      role: "worker",
+      auto_archive_on_done: false,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+      boot_prompt_pending: false,
+      launch_cwd: null,
+      mcp_profile: null,
+      worktree_path: null,
+      worktree_branch: null,
+    };
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+    const myAgents = registeredTestTool(server, "my_agents");
+
+    const result = await myAgents.handler({}, {});
+    const data = parseToolResult(result);
+    const agents = data.agents as Array<Record<string, unknown>>;
+
+    expect(data.ok).toBe(true);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({
+      agent_id: record.agent_id,
+      screen_unavailable: true,
+      error_code: "screen_unavailable",
+      screen_error: "screen read timed out",
+      token_count: null,
+      context_pct: null,
+      cost: null,
+    });
   });
 
   it("my_agents includes resume_command when a session id is captured", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -433,6 +433,52 @@ describe("agent lifecycle tool handlers", () => {
     expect(persisted.auto_archive_on_done).toBe(false);
   });
 
+  it("spawn_agent refuses a manual-mode caller workspace before spawning", async () => {
+    const baseExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (Array.isArray(args) && args.includes("list-status")) {
+        return {
+          stdout: JSON.stringify([{ key: "mode.control", value: "manual" }]),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec as ExecFn);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect((result as { isError?: boolean }).isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "spawn_agent",
+      workspace: "workspace:1",
+    });
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "list-status",
+        "--workspace",
+        "workspace:1",
+      ]),
+    );
+    expect(
+      exec.mock.calls.some(
+        ([, args]) => Array.isArray(args) && args.includes("new-split"),
+      ),
+    ).toBe(false);
+  });
+
   it("spawn_agent inherits the selected workspace when workspace is omitted", async () => {
     const calls: string[] = [];
     const mockClient = {
@@ -1173,6 +1219,57 @@ describe("agent lifecycle tool handlers", () => {
         `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
+  });
+
+  it("new_worktree_split refuses a manual-mode caller workspace before worktree setup", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "cmuxlayer");
+    mkdirSync(repoRoot, { recursive: true });
+    const baseExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (Array.isArray(args) && args.includes("list-status")) {
+        return {
+          stdout: JSON.stringify([{ key: "mode.control", value: "manual" }]),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const worktreeExec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+    const server = createTrackedServer({
+      exec: exec as ExecFn,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["new_worktree_split"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        worktree: { name: "sterile worker" },
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect((result as { isError?: boolean }).isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "new_worktree_split",
+      workspace: "workspace:1",
+    });
+    expect(worktreeExec).not.toHaveBeenCalled();
+    expect(
+      exec.mock.calls.some(
+        ([, args]) => Array.isArray(args) && args.includes("new-split"),
+      ),
+    ).toBe(false);
   });
 
   it("spawn_agent finalizes a pending Cursor prompt when the state directory is noncanonical", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1900,6 +1900,45 @@ describe("tool handler integration", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
+  it("send_input background refuses a manual-mode target before enqueueing", async () => {
+    const mockClient = {
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:bg-manual",
+        workspace: "workspace:bg-manual",
+        text: "echo no",
+        background: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "send_input",
+      surface: "surface:bg-manual",
+      control: "manual",
+    });
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:bg-manual",
+    });
+    expect(mockClient.send).not.toHaveBeenCalled();
+  });
+
   it("send_input returns delivered + cheap target identity from the state cache (F8)", async () => {
     const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input");
     rmSync(stateDir, { recursive: true, force: true });
@@ -4179,6 +4218,10 @@ describe("tool handler integration", () => {
     mockExec = vi
       .fn()
       .mockResolvedValueOnce({
+        stdout: "[]",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
           window_ref: "window:1",
@@ -4229,6 +4272,10 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBeUndefined();
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["list-status", "--workspace", "workspace:1"]),
+    );
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
@@ -4429,6 +4476,49 @@ describe("tool handler integration", () => {
     expect(mockClient.identify).toHaveBeenCalledWith("surface:source");
     expect(mockClient.listStatus).toHaveBeenCalledWith({
       workspace: "workspace:source",
+    });
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("new_split refuses a manual target workspace before creating a pane", async () => {
+    const mockClient = {
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:manual",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "New",
+        type: "terminal",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        workspace: "workspace:manual",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "new_split",
+      workspace: "workspace:manual",
+      control: "manual",
+    });
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:manual",
     });
     expect(mockClient.newSplit).not.toHaveBeenCalled();
   });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -442,6 +442,42 @@ describe("tool handler integration", () => {
     });
   });
 
+  it("create_workspace refuses a manual-mode caller workspace before creating", async () => {
+    const mockClient = {
+      createWorkspace: vi.fn().mockResolvedValue({
+        workspace: "workspace:7",
+        title: "red-team",
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [{ ref: "workspace:manual", selected: true }],
+      }),
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["create_workspace"];
+
+    const result = await tool.handler({ title: "red-team" }, {} as any);
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "create_workspace",
+      workspace: "workspace:manual",
+    });
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:manual",
+    });
+    expect(mockClient.createWorkspace).not.toHaveBeenCalled();
+  });
+
   it("spawn_in_workspace tool handler creates, selects, then spawns agents", async () => {
     const calls: string[] = [];
     let surfaceIndex = 0;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1288,6 +1288,88 @@ describe("tool handler integration", () => {
     });
   });
 
+  it("list_surfaces reports degraded terminal metadata when debug-terminals fails", async () => {
+    const workspaceCwd = "/Users/etanheyman/Gits/golems";
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "golems",
+                index: 0,
+                selected: true,
+                pinned: false,
+                current_directory: workspaceCwd,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:worker",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:adopted"],
+                selected_surface_ref: "surface:adopted",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:worker",
+            surfaces: [
+              {
+                ref: "surface:adopted",
+                title: "adopted-pane-binding",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("debug-terminals")) {
+        throw new Error("debug-terminals unavailable");
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["list_surfaces"];
+
+    const result = await tool.handler({ verbose: true }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.metadata_degraded).toMatchObject({
+      terminal_metadata: true,
+      error_code: "terminal_metadata_unavailable",
+    });
+    expect(parsed.metadata_degraded.error).toMatch(/debug-terminals unavailable/);
+    expect(parsed.surfaces[0]).toMatchObject({
+      current_directory: workspaceCwd,
+      working_directory_source: "workspace_fallback",
+      working_directory_fallback: true,
+    });
+  });
+
   it("read_screen handler calls cmux read-screen", async () => {
     mockExec = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({
@@ -1722,23 +1804,33 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Should preflight the screen, send text, and press enter. Raw uncached
-    // surfaces do not get submit_verified:true from prompt clearing alone.
-    expect(mockExec).toHaveBeenCalledTimes(3);
+    // Should try to resolve mode scope, fail open when no workspace is known,
+    // preflight the screen, send text, and press enter. Raw uncached surfaces do
+    // not get submit_verified:true from prompt clearing alone.
+    expect(mockExec).toHaveBeenCalledTimes(4);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
-      expect.arrayContaining(["read-screen"]),
+      expect.arrayContaining(["identify", "--surface", "surface:1"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       "cmux",
-      expect.arrayContaining(["send"]),
+      expect.arrayContaining(["read-screen"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
+      expect.arrayContaining(["send"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      4,
+      "cmux",
       expect.arrayContaining(["send-key"]),
+    );
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["list-status"]),
     );
   });
 
@@ -1754,21 +1846,30 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(3);
+    expect(mockExec).toHaveBeenCalledTimes(4);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
-      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
+      expect.arrayContaining(["identify", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       "cmux",
-      expect.arrayContaining(["send", "--surface", "surface:6"]),
+      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      4,
+      "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
+    );
+    expect(mockExec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["list-status"]),
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -2392,6 +2493,129 @@ describe("tool handler integration", () => {
     expect(mockClient.send).not.toHaveBeenCalled();
   });
 
+  it("send_input refuses a manual-mode target before sending", async () => {
+    const mockClient = {
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:manual",
+        text: "$ ",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:manual",
+        workspace: "workspace:manual",
+        text: "echo no",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "send_input",
+      surface: "surface:manual",
+      control: "manual",
+    });
+    expect(parsed.error).toMatch(/manual mode/i);
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:manual",
+    });
+    expect(mockClient.send).not.toHaveBeenCalled();
+  });
+
+  it("send_input allows a no-workspace target when workspace identity is unavailable", async () => {
+    const mockClient = {
+      identify: vi.fn().mockRejectedValue(new Error("identify unavailable")),
+      listStatus: vi
+        .fn()
+        .mockResolvedValue([{ key: "mode.control", value: "manual" }]),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:no-workspace",
+        text: "$ ",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:no-workspace",
+        text: "echo allowed",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.identify).toHaveBeenCalledWith("surface:no-workspace");
+    expect(mockClient.listStatus).not.toHaveBeenCalled();
+    expect(mockClient.send).toHaveBeenCalledWith(
+      "surface:no-workspace",
+      "echo allowed",
+      { workspace: undefined },
+    );
+  });
+
+  it("send_input allows an autonomous-mode target", async () => {
+    const mockClient = {
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "autonomous" },
+      ]),
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:auto",
+        text: "$ ",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      send: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:auto",
+        workspace: "workspace:auto",
+        text: "echo ok",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.send).toHaveBeenCalledWith(
+      "surface:auto",
+      "echo ok",
+      { workspace: "workspace:auto" },
+    );
+  });
+
   it("send_input can deliver long text in the background and expose status via read_screen", async () => {
     vi.useFakeTimers();
     mockExec = vi.fn().mockImplementation((_cmd, args) => {
@@ -2629,6 +2853,27 @@ describe("tool handler integration", () => {
       | ((value: { stdout: string; stderr: string }) => void)
       | null = null;
     mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("identify")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            caller: { workspace_ref: "workspace:1" },
+          }),
+          stderr: "",
+        });
+      }
+      if (args.includes("list-status")) {
+        return Promise.resolve({ stdout: "[]", stderr: "" });
+      }
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:1",
+            text: "$ ",
+            lines: 1,
+          }),
+          stderr: "",
+        });
+      }
       if (args.includes("send") && !releaseSend) {
         return new Promise((resolve) => {
           releaseSend = resolve;
@@ -2645,8 +2890,8 @@ describe("tool handler integration", () => {
       { surface: "surface:1", text: "echo first" },
       {} as any,
     );
-    for (let attempt = 0; attempt < 10 && !releaseSend; attempt += 1) {
-      await Promise.resolve();
+    for (let attempt = 0; attempt < 20 && !releaseSend; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
     expect(releaseSend).toBeTruthy();
 
@@ -4137,6 +4382,55 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("ENOENT");
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("new_split gates a surface anchor by its source workspace", async () => {
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:source" },
+      }),
+      listStatus: vi.fn().mockImplementation(async (opts?: { workspace?: string }) =>
+        opts?.workspace === "workspace:source"
+          ? [{ key: "mode.control", value: "manual" }]
+          : [{ key: "mode.control", value: "autonomous" }],
+      ),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:dest",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "New",
+        type: "terminal",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        surface: "surface:source",
+        workspace: "workspace:dest",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "new_split",
+      surface: "surface:source",
+    });
+    expect(mockClient.identify).toHaveBeenCalledWith("surface:source");
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:source",
+    });
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
   });
 
   it("new_split reports boot prompt timeout with surface and last screen lines", async () => {
@@ -6014,6 +6308,54 @@ describe("tool handler integration", () => {
       pane: "pane:2",
       workspace: "workspace:1",
     });
+  });
+
+  it("move_surface gates the moved surface by its source workspace", async () => {
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({
+        caller: { workspace_ref: "workspace:source" },
+      }),
+      listStatus: vi.fn().mockImplementation(async (opts?: { workspace?: string }) =>
+        opts?.workspace === "workspace:source"
+          ? [{ key: "mode.control", value: "manual" }]
+          : [{ key: "mode.control", value: "autonomous" }],
+      ),
+      moveSurface: vi.fn().mockResolvedValue({
+        ok: true,
+        workspace: "workspace:dest",
+        surface: "surface:source",
+        pane: "pane:dest",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["move_surface"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:source",
+        pane: "pane:dest",
+        workspace: "workspace:dest",
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "move_surface",
+      surface: "surface:source",
+    });
+    expect(mockClient.identify).toHaveBeenCalledWith("surface:source");
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:source",
+    });
+    expect(mockClient.moveSurface).not.toHaveBeenCalled();
   });
 
   it("reorder_surface handler calls cmux reorder-surface", async () => {

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -114,6 +114,7 @@ function makeWorkspaceClient() {
     setProgress: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),
     identify: vi.fn().mockResolvedValue({}),
+    listStatus: vi.fn().mockResolvedValue([]),
     browser: vi.fn().mockResolvedValue({}),
   };
   return client;
@@ -206,6 +207,47 @@ describe("workspace spawn tools", () => {
     ).toEqual(["workspace:grid", "workspace:grid"]);
   });
 
+  it("spawn_in_workspace refuses a manual-mode caller workspace before creating", async () => {
+    const client = makeWorkspaceClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [{ ref: "workspace:manual", title: "Manual", selected: true }],
+    });
+    client.listStatus.mockResolvedValue([
+      { key: "mode.control", value: "manual" },
+    ]);
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_in_workspace"];
+
+    const result = await tool.handler(
+      {
+        workspace_title: "red-team",
+        agents: [
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "spawn_in_workspace",
+      workspace: "workspace:manual",
+    });
+    expect(client.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:manual",
+    });
+    expect(client.createWorkspace).not.toHaveBeenCalled();
+    expect(client.newSplit).not.toHaveBeenCalled();
+  });
+
   it("spawn_in_workspace with reuse_workspace skips workspace creation", async () => {
     const client = makeWorkspaceClient();
     const server = createServer({
@@ -235,6 +277,45 @@ describe("workspace spawn tools", () => {
       workspace: "workspace:existing",
       type: "terminal",
     });
+  });
+
+  it("spawn_in_workspace refuses a manual-mode reused workspace before selecting", async () => {
+    const client = makeWorkspaceClient();
+    client.listStatus.mockResolvedValue([
+      { key: "mode.control", value: "manual" },
+    ]);
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_in_workspace"];
+
+    const result = await tool.handler(
+      {
+        workspace_title: "ignored-title",
+        reuse_workspace: "workspace:existing",
+        agents: [
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "spawn_in_workspace",
+      workspace: "workspace:existing",
+    });
+    expect(client.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:existing",
+    });
+    expect(client.selectWorkspace).not.toHaveBeenCalled();
+    expect(client.newSplit).not.toHaveBeenCalled();
   });
 
   it("same-repo child spawn inherits parent workspace and reports wrong actual workspace as unhealthy", async () => {


### PR DESCRIPTION
## Summary
- Enforce the existing manual-mode mutation gate across MCP mutating surface/lifecycle tools with structured `manual_mode` errors.
- Close F1: when a target surface workspace cannot be resolved, fail open with `{ control: "autonomous" }` and do not issue an unscoped/global `listStatus` read.
- Add honest degradation signals: `my_agents.screen_unavailable` and `list_surfaces.metadata_degraded`.
- Keep `dispatch_to_agent` outside the mutating policy so durable dispatch/nudge delivery is not blocked by manual mode.

## Review follow-up handled
- Fixed source-workspace gating for anchored `new_split` and `move_surface`.
- Scoped `interact(action=interrupt)` key dispatch to the same agent workspace used by the gate.
- Local CodeRabbit pre-commit review rerun after fixes: 0 findings.

## Test plan
- RED: `bun run test tests/server.test.ts -t "send_input allows a no-workspace target when workspace identity is unavailable"` failed before F1 fix.
- RED: `bun run test tests/server.test.ts -t "source workspace"` failed before source-workspace gate fixes.
- RED: `bun run test tests/server-agent-tools.test.ts -t "interact interrupt sends the key in the agent workspace"` failed before workspace-scoped interrupt send.
- GREEN: `bun run typecheck`
- GREEN: `bun run test tests/mode-policy.test.ts tests/server.test.ts tests/server-agent-tools.test.ts` (220 tests)
- GREEN: `bun run test` (71 files / 1293 tests)
- GREEN: `bun run build`
- GREEN: `git diff --check`
- GREEN: push hook reran `bun run test` (71 files / 1293 tests)

## Runtime smoke
- `mcp__cmuxlayer.control_health` returned `ok: true` with socket transport selected.
- `mcp__cmuxlayer.list_surfaces` returned real workspace/surface data.

Do not merge yet: opened for review per Track-T PR loop instruction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to mutation paths add identify/list-status latency and fail-open behavior when workspace mode cannot be resolved; incorrect gating could block legitimate ops or allow mutations in manual mode.
> 
> **Overview**
> **Manual-mode enforcement** is wired through the MCP server so mutating tools are blocked when `mode.control` is `manual`, with structured `manual_mode` errors (`error_code`, `tool`, `surface`/`workspace`, `control`).
> 
> The **mutating tool set** in `mode-policy.ts` is expanded (workspace layout, agent lifecycle, relays, tab rename, etc.); **`rename_tab` is no longer treated as metadata-only**. Handlers and **`withSurfaceWrite`** call **`assertSurfaceMutationAllowed`** / **`assertWorkspaceMutationAllowed`**, which resolve workspace via **`identify`** when needed and read **`list-status`** for `mode.control`. **Surface-anchored** `new_split` and **`move_surface`** gate on the **source** workspace, not only the destination. If workspace identity cannot be resolved, mode checks **fail open** to autonomous (no unscoped global status read).
> 
> **Observability:** `list_surfaces` can return **`metadata_degraded`** when terminal metadata fails; **`my_agents`** rows can include **`screen_unavailable`** when screen reads fail. **`dispatch_to_agent`** stays outside the mutating policy set so inbox dispatch/nudges are not blocked by manual mode (per PR intent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd151ec9cfeefa622e1141f4d1265cfa709b751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce manual-mode gate on mutating tools with structured error signals
> - Expands `MUTATING_TOOLS` in [mode-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/229/files#diff-4a89bc8fb1fcb711b6f2d32068e35805abdfc196e1dfb023834f2d0c042f5884) to include workspace/surface management, agent lifecycle, and relay tools, blocking them when control mode is `manual`.
> - Adds `assertSurfaceMutationAllowed` and `assertWorkspaceMutationAllowed` helpers in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/229/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that query `listStatus` and throw a structured `ManualModeMutationError` (with `error_code`, `tool`, `surface`, `workspace`, `control` fields) on violations.
> - Gates all mutating tool handlers (`spawn_agent`, `new_split`, `send_input`, `send_command`, `kill`, etc.) with preflight mutation checks before any side effects occur.
> - Adds honest degradation signals: `list_surfaces` reports `metadata_degraded` when terminal metadata is unavailable; `my_agents` marks rows with `screen_unavailable` and a cleaned `screen_error` when read-screen fails.
> - Risk: all previously ungated mutating tools will now return errors for callers operating in manual control mode workspaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dd151e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Surface and agent actions now respect manual-mode restrictions more consistently, blocking operations that should not run in that mode.
  * Terminal metadata handling is more resilient when data can’t be loaded, and surface lists can still appear with fallback workspace info.

* **Bug Fixes**
  * Improved error reporting for unavailable screen reads and blocked actions with clearer, structured messages.
  * Fixed several interaction flows so send, move, rename, close, and agent lifecycle actions behave consistently across modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->