### PR TITLE
fix(sidebar): resolve surface-targeted status to the surface's own workspace

### DIFF
--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -788,7 +788,9 @@ export class CmuxSocketClient {
       if (!(error instanceof CmuxSocketError && error.code === "not_found")) {
         throw error;
       }
-      workspace = (await this.identify(opts.surface)).caller?.workspace_ref;
+      const identified = await this.identify(opts.surface);
+      workspace =
+        identified.caller?.workspace_ref ?? identified.focused?.workspace_ref;
     }
 
     if (!workspace) return undefined;

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -575,12 +575,8 @@ export class CmuxSocketClient {
     }
     if (opts?.subtitle) args.push(this.rawV1Arg("--subtitle"), opts.subtitle);
     if (opts?.body) args.push(this.rawV1Arg("--body"), opts.body);
-    if (opts?.workspace) {
-      args.push(this.rawV1Arg("--workspace"), opts.workspace);
-    }
-    if (opts?.surface) {
-      args.push(this.rawV1Arg("--surface"), opts.surface);
-    }
+    const tabId = await this.resolveSidebarTabId(opts);
+    if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
     await this.sendV1Args("notify", args);
   }
 
@@ -782,11 +778,19 @@ export class CmuxSocketClient {
     workspace?: string;
     surface?: string;
   }): Promise<string | undefined> {
-    const workspace =
-      opts?.workspace ??
-      (opts?.surface
-        ? (await this.identify(opts.surface)).caller?.workspace_ref
-        : undefined);
+    if (opts?.workspace) return this.resolveWorkspaceTabId(opts.workspace);
+    if (!opts?.surface) return undefined;
+
+    let workspace: string | undefined;
+    try {
+      workspace = await this.resolveWorkspace(opts.surface);
+    } catch (error) {
+      if (!(error instanceof CmuxSocketError && error.code === "not_found")) {
+        throw error;
+      }
+      workspace = (await this.identify(opts.surface)).caller?.workspace_ref;
+    }
+
     if (!workspace) return undefined;
     return this.resolveWorkspaceTabId(workspace);
   }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -575,8 +575,9 @@ export class CmuxSocketClient {
     }
     if (opts?.subtitle) args.push(this.rawV1Arg("--subtitle"), opts.subtitle);
     if (opts?.body) args.push(this.rawV1Arg("--body"), opts.body);
-    const tabId = await this.resolveSidebarTabId(opts);
-    if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
+    const workspace = await this.resolveSidebarWorkspace(opts);
+    if (workspace) args.push(this.rawV1Arg("--workspace"), workspace);
+    if (opts?.surface) args.push(this.rawV1Arg("--surface"), opts.surface);
     await this.sendV1Args("notify", args);
   }
 
@@ -778,23 +779,29 @@ export class CmuxSocketClient {
     workspace?: string;
     surface?: string;
   }): Promise<string | undefined> {
-    if (opts?.workspace) return this.resolveWorkspaceTabId(opts.workspace);
+    const workspace = await this.resolveSidebarWorkspace(opts);
+    if (!workspace) return undefined;
+    return this.resolveWorkspaceTabId(workspace);
+  }
+
+  private async resolveSidebarWorkspace(opts?: {
+    workspace?: string;
+    surface?: string;
+  }): Promise<string | undefined> {
+    if (opts?.workspace) return opts.workspace;
     if (!opts?.surface) return undefined;
 
-    let workspace: string | undefined;
     try {
-      workspace = await this.resolveWorkspace(opts.surface);
+      return await this.resolveWorkspace(opts.surface);
     } catch (error) {
       if (!(error instanceof CmuxSocketError && error.code === "not_found")) {
         throw error;
       }
       const identified = await this.identify(opts.surface);
-      workspace =
-        identified.caller?.workspace_ref ?? identified.focused?.workspace_ref;
+      return (
+        identified.caller?.workspace_ref ?? identified.focused?.workspace_ref
+      );
     }
-
-    if (!workspace) return undefined;
-    return this.resolveWorkspaceTabId(workspace);
   }
 
   private async resolveWorkspaceTabId(workspace: string): Promise<string> {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -810,7 +810,12 @@ export class CmuxSocketClient {
     try {
       return await this.resolveWorkspace(opts.surface);
     } catch (error) {
-      if (!(error instanceof CmuxSocketError && error.code === "not_found")) {
+      if (
+        !(
+          error instanceof CmuxSocketError &&
+          (error.code === "not_found" || error.code === "method_not_found")
+        )
+      ) {
         throw error;
       }
       return undefined;

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -575,7 +575,7 @@ export class CmuxSocketClient {
     }
     if (opts?.subtitle) args.push(this.rawV1Arg("--subtitle"), opts.subtitle);
     if (opts?.body) args.push(this.rawV1Arg("--body"), opts.body);
-    const workspace = await this.resolveSidebarWorkspace(opts);
+    const workspace = await this.resolveMappedSidebarWorkspace(opts);
     if (workspace) args.push(this.rawV1Arg("--workspace"), workspace);
     if (opts?.surface) args.push(this.rawV1Arg("--surface"), opts.surface);
     await this.sendV1Args("notify", args);
@@ -791,16 +791,29 @@ export class CmuxSocketClient {
     if (opts?.workspace) return opts.workspace;
     if (!opts?.surface) return undefined;
 
+    const mapped = await this.resolveMappedSidebarWorkspace(opts);
+    if (mapped) return mapped;
+
+    const identified = await this.identify(opts.surface);
+    return (
+      identified.caller?.workspace_ref ?? identified.focused?.workspace_ref
+    );
+  }
+
+  private async resolveMappedSidebarWorkspace(opts?: {
+    workspace?: string;
+    surface?: string;
+  }): Promise<string | undefined> {
+    if (opts?.workspace) return opts.workspace;
+    if (!opts?.surface) return undefined;
+
     try {
       return await this.resolveWorkspace(opts.surface);
     } catch (error) {
       if (!(error instanceof CmuxSocketError && error.code === "not_found")) {
         throw error;
       }
-      const identified = await this.identify(opts.surface);
-      return (
-        identified.caller?.workspace_ref ?? identified.focused?.workspace_ref
-      );
+      return undefined;
     }
   }
 

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -793,7 +793,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     }
   });
 
-  it("falls back to the focused workspace when a surface cannot be mapped", async () => {
+  it("falls back to the focused workspace for tab commands when a surface cannot be mapped", async () => {
     const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
     const savedSurfaceList = MOCK_RESPONSES["surface.list"];
     const savedIdentify = MOCK_RESPONSES["system.identify"];
@@ -835,13 +835,20 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     try {
       const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 
+      await client.setStatus("agent", "active", {
+        surface: "surface:unmapped",
+      });
+      expect(lastV1Command).toBe(
+        `set_status agent active --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+
       await client.notify({
         title: "Done",
         surface: "surface:unmapped",
       });
 
       expect(lastV1Command).toBe(
-        "notify --title Done --workspace workspace:2 --surface surface:unmapped",
+        "notify --title Done --surface surface:unmapped",
       );
     } finally {
       MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -857,6 +857,26 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     }
   });
 
+  it("preserves surface-only notify when workspace mapping is unsupported", async () => {
+    const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
+    MOCK_RESPONSES["workspace.list"] = undefined;
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.notify({
+        title: "Done",
+        surface: "surface:legacy",
+      });
+
+      expect(lastV1Command).toBe(
+        "notify --title Done --surface surface:legacy",
+      );
+    } finally {
+      MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
+    }
+  });
+
   it("renameTab sends V2 tab.action with rename params", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -793,6 +793,63 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     }
   });
 
+  it("falls back to the focused workspace when a surface cannot be mapped", async () => {
+    const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
+    const savedSurfaceList = MOCK_RESPONSES["surface.list"];
+    const savedIdentify = MOCK_RESPONSES["system.identify"];
+
+    MOCK_RESPONSES["workspace.list"] = {
+      workspaces: [
+        {
+          id: MOCK_WORKSPACE_ID,
+          ref: "workspace:1",
+          title: "Caller WS",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+        {
+          id: MOCK_SECOND_WORKSPACE_ID,
+          ref: "workspace:2",
+          title: "Focused WS",
+          index: 1,
+          selected: false,
+          pinned: false,
+        },
+      ],
+    };
+    MOCK_RESPONSES["surface.list"] = (req) => ({
+      workspace_ref: String(req.params.workspace_id ?? ""),
+      window_ref: "window:1",
+      pane_ref: "pane:1",
+      surfaces: [],
+    });
+    MOCK_RESPONSES["system.identify"] = {
+      focused: {
+        workspace_ref: "workspace:2",
+        surface_ref: "surface:focused",
+        pane_ref: "pane:focused",
+      },
+    };
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.notify({
+        title: "Done",
+        surface: "surface:unmapped",
+      });
+
+      expect(lastV1Command).toBe(
+        `notify --title Done --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+    } finally {
+      MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
+      MOCK_RESPONSES["surface.list"] = savedSurfaceList;
+      MOCK_RESPONSES["system.identify"] = savedIdentify;
+    }
+  });
+
   it("renameTab sends V2 tab.action with rename params", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -30,6 +30,15 @@ import { createCmuxClient } from "../src/cmux-client-factory.js";
 const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
 const MOCK_SOCKET_PATH = "/tmp/cmux-test-mock.sock";
 const MOCK_WORKSPACE_ID = "8481D6A0-CE17-4B7C-8695-7A722D30FEE2";
+const MOCK_SECOND_WORKSPACE_ID = "7335E54B-6E88-4B19-BE8C-71C39F4E9D10";
+
+interface MockV2Request {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+type MockResponseHandler = (req: MockV2Request) => unknown;
 
 const MOCK_RESPONSES: Record<string, unknown> = {
   "system.ping": { pong: true },
@@ -114,6 +123,10 @@ const MOCK_RESPONSES: Record<string, unknown> = {
   },
 };
 
+function isMockResponseHandler(response: unknown): response is MockResponseHandler {
+  return typeof response === "function";
+}
+
 let mockServer: net.Server;
 let lastV1Command = "";
 let lastV2Request: { method: string; params: Record<string, unknown> } | null =
@@ -149,7 +162,7 @@ function startMockServer(): Promise<void> {
           if (!line.trim()) continue;
 
           try {
-            const req = JSON.parse(line);
+            const req = JSON.parse(line) as MockV2Request;
             const method = req.method as string;
             lastV2Request = { method, params: req.params ?? {} };
             mockEvents.push({
@@ -157,7 +170,11 @@ function startMockServer(): Promise<void> {
               method,
               params: req.params ?? {},
             });
-            const result = MOCK_RESPONSES[method];
+            const mockResponse = MOCK_RESPONSES[method];
+            const result =
+              isMockResponseHandler(mockResponse)
+                ? mockResponse(req)
+                : mockResponse;
 
             if (result !== undefined) {
               const resp =
@@ -187,6 +204,7 @@ function startMockServer(): Promise<void> {
                 "clear_status",
                 "set_progress",
                 "clear_progress",
+                "notify",
                 "log",
                 "list_status",
               ].includes(cmd)
@@ -680,6 +698,99 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(lastV1Command).toBe(
       `set_status agent active --tab=${MOCK_WORKSPACE_ID}`,
     );
+  });
+
+  it("resolves surface-targeted sidebar commands to the target surface workspace", async () => {
+    const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
+    const savedSurfaceList = MOCK_RESPONSES["surface.list"];
+    const savedIdentify = MOCK_RESPONSES["system.identify"];
+
+    MOCK_RESPONSES["workspace.list"] = {
+      workspaces: [
+        {
+          id: MOCK_WORKSPACE_ID,
+          ref: "workspace:1",
+          title: "Caller WS",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+        {
+          id: MOCK_SECOND_WORKSPACE_ID,
+          ref: "workspace:2",
+          title: "Target WS",
+          index: 1,
+          selected: false,
+          pinned: false,
+        },
+      ],
+    };
+    MOCK_RESPONSES["surface.list"] = (req) => {
+      const workspace = String(req.params.workspace_id ?? "");
+      return {
+        workspace_ref: workspace,
+        window_ref: workspace === "workspace:2" ? "window:2" : "window:1",
+        pane_ref: workspace === "workspace:2" ? "pane:2" : "pane:1",
+        surfaces:
+          workspace === "workspace:2"
+            ? [
+                {
+                  ref: "surface:target",
+                  title: "target",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [
+                {
+                  ref: "surface:caller",
+                  title: "caller",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ],
+      };
+    };
+    MOCK_RESPONSES["system.identify"] = {
+      caller: {
+        workspace_ref: "workspace:1",
+        surface_ref: "surface:caller",
+        pane_ref: "pane:1",
+      },
+    };
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.setStatus("agent", "active", {
+        surface: "surface:target",
+      });
+      expect(lastV1Command).toBe(
+        `set_status agent active --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+
+      await client.setProgress(0.5, {
+        label: "halfway",
+        surface: "surface:target",
+      });
+      expect(lastV1Command).toBe(
+        `set_progress 0.5 --label halfway --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+
+      await client.notify({
+        title: "Done",
+        surface: "surface:target",
+      });
+      expect(lastV1Command).toBe(
+        `notify --title Done --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+    } finally {
+      MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
+      MOCK_RESPONSES["surface.list"] = savedSurfaceList;
+      MOCK_RESPONSES["system.identify"] = savedIdentify;
+    }
   });
 
   it("renameTab sends V2 tab.action with rename params", async () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -784,7 +784,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
         surface: "surface:target",
       });
       expect(lastV1Command).toBe(
-        `notify --title Done --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+        "notify --title Done --workspace workspace:2 --surface surface:target",
       );
     } finally {
       MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
@@ -841,7 +841,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
       });
 
       expect(lastV1Command).toBe(
-        `notify --title Done --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+        "notify --title Done --workspace workspace:2 --surface surface:unmapped",
       );
     } finally {
       MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;


### PR DESCRIPTION
## Summary
- Resolve socket-client sidebar `surface:` targets via the target surface's owning workspace before falling back to caller workspace.
- Route `notify` through the same tab resolution path as `set_status` and `set_progress`.
- Add a regression test where caller workspace A targets a surface in workspace B and all three V1 sidebar commands emit workspace B's tab id.

## Verification
- `bun run typecheck` → `tsc -p tsconfig.json --noEmit` exit 0
- `bun run test -- tests/cmux-socket-client.test.ts -t "resolves surface-targeted sidebar commands"` → 1 passed, 52 skipped
- `bun run test` → 71 files passed, 1286 tests passed
- `bash scripts/run_tests.sh` → fixture tests passed; Vitest 71 files passed, 1286 tests passed
- Pre-push hook reran `scripts/run_tests.sh` and passed before branch push
- Live cmux MCP availability probe: `list_surfaces(verbose=true)` returned real workspace/surface topology including this worker surface in `workspace:2`

## Review Notes
- Local `coderabbit review --agent` was attempted before commit and returned a recoverable free OSS rate-limit response: wait time 37 minutes. PR-level reviewers requested below after PR creation.
- This PR touches socket/sidebar routing code but is not deployed by this branch; no live deployment claim is made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing for status, progress, and notifications across workspaces; behavior shifts when surfaces cannot be mapped (focused vs caller workspace), but scope is limited to socket client sidebar resolution with regression tests.
> 
> **Overview**
> Surface-targeted V1 sidebar commands (`setStatus`, `setProgress`, `log`, and now **`notify`**) no longer assume the **caller's** workspace when only a `surface` is given. Resolution first maps the surface to its owning workspace via `resolveWorkspace`, then falls back to **`system.identify`** (caller, then **focused** workspace) when mapping fails.
> 
> **`notify`** now adds `--workspace` only when that mapping succeeds; if mapping is unsupported or returns `not_found` / `method_not_found`, it keeps a **surface-only** command (no `--workspace`).
> 
> Tests extend the mock socket server (dynamic V2 handlers, multi-workspace fixtures) and cover cross-workspace targeting, unmapped-surface fallback, and legacy notify behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b65595aab81fd128d8698c9a9686c52667833d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar status commands to resolve workspace from the target surface
> - Adds `resolveMappedSidebarWorkspace` to map a surface directly to its workspace, and `resolveSidebarWorkspace` to orchestrate fallback logic (mapped workspace → caller workspace → focused workspace).
> - `notify` (v1) now includes `--workspace <workspace>` when a surface can be mapped to a workspace, previously only when `opts.workspace` was supplied directly.
> - `resolveSidebarTabId` delegates to `resolveSidebarWorkspace` instead of using inline logic, enabling the focused-workspace fallback for tab resolution.
> - Servers that don't support workspace mapping (`not_found`/`method_not_found`) are handled gracefully by skipping the mapping step rather than throwing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6b6559.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar commands now better resolve the target workspace and tab from the current surface, improving behavior for `setStatus`, `setProgress`, and `notify`.
  * When a surface cannot be mapped, tab-targeted commands now fall back more reliably to the focused workspace.

* **Bug Fixes**
  * Improved handling for workspace selection in notification and sidebar command flows, reducing mismatches between the active surface and the destination workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->