### PR TITLE
fix(session): capture cli_session_id via transcript across lifecycle states — resume actually works

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -228,7 +228,6 @@ const WAIT_FOR_SWEEP_INTERVAL_MS = 1000;
 const DEFAULT_SWEEP_ACTIVE_INTERVAL_MS = 5_000;
 const DEFAULT_SWEEP_IDLE_INTERVAL_MS = 15_000;
 const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
-const BOOT_SESSION_TRANSCRIPT_CAPTURE_WINDOW_MS = 30_000;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
 const STOP_POST_CONDITION_POLL_MS = 50;
@@ -249,6 +248,12 @@ const CONTEXTUAL_SESSION_ID_PATTERNS = [
   new RegExp(`resumable\\s+session:\\s*(${SESSION_ID_PATTERN})`, "i"),
 ] as const;
 const JSONL_HARNESSES = new Set<CliType>(["claude", "codex", "cursor"]);
+const TRANSCRIPT_SESSION_CAPTURE_STATES = new Set<AgentState>([
+  "booting",
+  "ready",
+  "working",
+  "idle",
+]);
 
 export { buildResumeCommand } from "./agent-command.js";
 
@@ -701,6 +706,7 @@ export class AgentEngine {
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
   private inboxOpts?: InboxOpts;
   private sessionIdentityResolver: SessionIdentityResolver;
+  private hasCustomSessionIdentityResolver: boolean;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
   private postSpawnLivenessTimers = new Set<ReturnType<typeof setTimeout>>();
   private sweepTiming: SweepTimingOptions | null = null;
@@ -728,6 +734,8 @@ export class AgentEngine {
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
     this.inboxOpts = opts?.inboxOpts;
+    this.hasCustomSessionIdentityResolver =
+      opts?.sessionIdentityResolver !== undefined;
     this.sessionIdentityResolver =
       opts?.sessionIdentityResolver ??
       ((agent) => this.findTranscriptSessionIdentity(agent));
@@ -1583,10 +1591,17 @@ export class AgentEngine {
   }
 
   private canUseTranscriptSessionResolver(agent: AgentRecord): boolean {
-    if (agent.state !== "booting") return false;
-    const since = Date.parse(agent.updated_at);
-    if (Number.isNaN(since)) return false;
-    return Date.now() - since <= BOOT_SESSION_TRANSCRIPT_CAPTURE_WINDOW_MS;
+    if (!TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state)) return false;
+    if (!JSONL_HARNESSES.has(agent.cli)) return false;
+    if (agent.task_summary.trim().length === 0) return false;
+    return (
+      this.hasCustomSessionIdentityResolver ||
+      Boolean(
+        agent.launcher_name ||
+          agent.launch_cwd?.trim() ||
+          agent.worktree_path?.trim(),
+      )
+    );
   }
 
   private screenShowsPendingBootPrompt(
@@ -1834,7 +1849,7 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<AgentRecord> {
-    if (agent.cli_session_id || !this.isBootCaptureWindowOpen(agent)) {
+    if (agent.cli_session_id) {
       return agent;
     }
 
@@ -1847,6 +1862,10 @@ export class AgentEngine {
       } catch {
         return agent;
       }
+    }
+
+    if (!this.isBootCaptureWindowOpen(agent)) {
+      return agent;
     }
 
     try {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1763,6 +1763,61 @@ export class AgentEngine {
     return { session_id: identity.session_id, path: identity.path ?? null };
   }
 
+  private rekeyAgentMapEntry<T>(
+    map: Map<string, T>,
+    previousAgentId: string,
+    nextAgentId: string,
+  ): void {
+    if (!map.has(previousAgentId)) return;
+    const value = map.get(previousAgentId);
+    map.delete(previousAgentId);
+    if (value !== undefined && !map.has(nextAgentId)) {
+      map.set(nextAgentId, value);
+    }
+  }
+
+  private rekeyAgentEventSet(
+    events: Set<string>,
+    previousAgentId: string,
+    nextAgentId: string,
+  ): void {
+    const previousPrefix = `${previousAgentId}:`;
+    const renamedKeys = [...events].filter((key) =>
+      key.startsWith(previousPrefix),
+    );
+    for (const key of renamedKeys) {
+      events.delete(key);
+      events.add(`${nextAgentId}:${key.slice(previousPrefix.length)}`);
+    }
+  }
+
+  private transferAgentRenameMemory(
+    previousAgentId: string,
+    nextAgentId: string,
+  ): void {
+    if (previousAgentId === nextAgentId) return;
+
+    const previousSidebarSnapshot = this.sidebarSnapshot.get(previousAgentId);
+    if (previousSidebarSnapshot && !this.sidebarSnapshot.has(nextAgentId)) {
+      this.sidebarSnapshot.set(nextAgentId, {
+        ...previousSidebarSnapshot,
+        statusValue: "__renamed__",
+      });
+    }
+    this.rekeyAgentMapEntry(
+      this.currentSweepScreenSignatures,
+      previousAgentId,
+      nextAgentId,
+    );
+    this.rekeyAgentMapEntry(
+      this.readyPatternMatches,
+      previousAgentId,
+      nextAgentId,
+    );
+    this.rekeyAgentEventSet(this.loggedEvents, previousAgentId, nextAgentId);
+    this.rekeyAgentEventSet(this.notifiedEvents, previousAgentId, nextAgentId);
+  }
+
   private finalizeCapturedSession(
     agent: AgentRecord,
     capturedIdentity: CapturedSessionIdentity | string,
@@ -1800,6 +1855,7 @@ export class AgentEngine {
         }
         updated = this.stateMgr.renameState(previousAgentId, collisionAgentId);
         this.registry.rename(previousAgentId, collisionAgentId, updated);
+        this.transferAgentRenameMemory(previousAgentId, collisionAgentId);
         return updated;
       }
       const sessionPath =
@@ -1816,6 +1872,7 @@ export class AgentEngine {
       index.removeAgent(updated.agent_id);
       index.persistRecord(canonicalFinal);
       this.registry.rename(updated.agent_id, finalAgentId, canonicalFinal);
+      this.transferAgentRenameMemory(updated.agent_id, finalAgentId);
       this.stateMgr.removeState(updated.agent_id);
       return canonicalFinal;
     }
@@ -1823,6 +1880,7 @@ export class AgentEngine {
     const previousAgentId = updated.agent_id;
     updated = this.stateMgr.renameState(previousAgentId, finalAgentId);
     this.registry.rename(previousAgentId, finalAgentId, updated);
+    this.transferAgentRenameMemory(previousAgentId, finalAgentId);
     return updated;
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1593,15 +1593,15 @@ export class AgentEngine {
   private canUseTranscriptSessionResolver(agent: AgentRecord): boolean {
     if (!TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state)) return false;
     if (!JSONL_HARNESSES.has(agent.cli)) return false;
-    if (agent.task_summary.trim().length === 0) return false;
-    return (
-      this.hasCustomSessionIdentityResolver ||
-      Boolean(
-        agent.launcher_name ||
-          agent.launch_cwd?.trim() ||
-          agent.worktree_path?.trim(),
-      )
+    const hasManagedLaunchContext = Boolean(
+      agent.launcher_name ||
+        agent.launch_cwd?.trim() ||
+        agent.worktree_path?.trim(),
     );
+    if (agent.task_summary.trim().length === 0 && !hasManagedLaunchContext) {
+      return false;
+    }
+    return this.hasCustomSessionIdentityResolver || hasManagedLaunchContext;
   }
 
   private screenShowsPendingBootPrompt(

--- a/src/server.ts
+++ b/src/server.ts
@@ -5347,6 +5347,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (bootPromptPath) {
             await preflightBootPromptFile(bootPromptPath);
           }
+          const bootPromptText = bootPromptPath
+            ? await readFile(bootPromptPath, "utf8")
+            : null;
 
           await refreshManagedMetadataBestEffort(args.parent_agent_id);
           const parentWorkspace = args.parent_agent_id
@@ -5411,7 +5414,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             repo: args.repo,
             model: args.model,
             cli: args.cli,
-            prompt: args.prompt ?? "",
+            prompt: args.prompt ?? bootPromptText ?? "",
             boot_prompt_pending:
               hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: spawnWorkspace,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5410,11 +5410,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             existingSameLaneAgents.length > 0
               ? `Existing same-lane agent(s) are idle/ready in ${comparisonWorkspace ?? "unknown workspace"}; reuse or supersede unless a new lane is intentional. Pass force_new:true to suppress this warning.`
               : undefined;
+          const spawnPrompt = hasInlinePrompt(args.prompt)
+            ? args.prompt
+            : (bootPromptText ?? "");
           const result = await engine.spawnAgent({
             repo: args.repo,
             model: args.model,
             cli: args.cli,
-            prompt: args.prompt ?? bootPromptText ?? "",
+            prompt: spawnPrompt,
             boot_prompt_pending:
               hasInlinePrompt(args.prompt) || Boolean(bootPromptPath),
             workspace: spawnWorkspace,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2250,6 +2250,60 @@ To continue this session, run codex resume ${sessionId}`,
       );
     });
 
+    it("captures transcript session identity after boot has already reached ready", async () => {
+      vi.setSystemTime(new Date("2026-07-05T19:20:30.000Z"));
+      const sessionId = "019f0100-051b-4c8a-b836-28ab64144c85";
+      const sessionPath =
+        "/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-cmuxlayer/019f0100-051b-4c8a-b836-28ab64144c85.jsonl";
+      const transcriptResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: sessionPath,
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: transcriptResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerClaude-pending-ready-jsonl",
+          repo: "cmuxlayer",
+          model: "claude-opus-4-8",
+          cli: "claude",
+          surface_id: "surface:ready-jsonl",
+          state: "ready",
+          task_summary: "Session-capture live probe",
+          created_at: "2026-07-05T19:16:13.285Z",
+          updated_at: "2026-07-05T19:17:17.739Z",
+          launch_cwd: "/Users/etanheyman/Gits/cmuxlayer",
+          worktree_path: "/Users/etanheyman/Gits/cmuxlayer",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:ready-jsonl")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:ready-jsonl",
+        text: "Claude Code\nWhat can I help you with?\n❯ ",
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(transcriptResolver).toHaveBeenCalledTimes(1);
+      expect(engine.getAgentState("cmuxlayerClaude-019f0100")).toMatchObject({
+        agent_id: "cmuxlayerClaude-019f0100",
+        state: "ready",
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+      });
+      expect(engine.resolveAgentRoute("cmuxlayerClaude-019f0100")).toMatchObject({
+        session_id: sessionId,
+        resumable: true,
+      });
+    });
+
     it("captures session identity after the initial boot window for a long-stuck ready pane", async () => {
       vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
       const sessionId = "019f0010-1111-7222-8333-444455556666";
@@ -2341,13 +2395,10 @@ To continue this session, run codex resume ${sessionId}`,
       expect(engine.getAgentState("cmuxlayerCodex-019f0020")).toBeNull();
     });
 
-    it("does not bind a late prompted boot record to an unrelated transcript", async () => {
+    it("does not bind a late prompted boot record to an unattributed transcript", async () => {
       vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
       const sessionId = "019f0021-1111-7222-8333-444455556666";
-      const transcriptResolver = vi.fn(() => ({
-        session_id: sessionId,
-        path: "/Users/etanheyman/.codex/sessions/unrelated-prompted.jsonl",
-      }));
+      const transcriptResolver = vi.fn(() => null);
       engine.dispose();
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
       engine = new AgentEngine(stateMgr, registry, mockClient, {
@@ -2378,7 +2429,7 @@ To continue this session, run codex resume ${sessionId}`,
 
       await engine.runSweep();
 
-      expect(transcriptResolver).not.toHaveBeenCalled();
+      expect(transcriptResolver).toHaveBeenCalledTimes(1);
       expect(
         engine.getAgentState("cmuxlayerCodex-pending-prompted"),
       ).toMatchObject({

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -2395,6 +2395,55 @@ To continue this session, run codex resume ${sessionId}`,
       expect(engine.getAgentState("cmuxlayerCodex-019f0020")).toBeNull();
     });
 
+    it("captures a blank-prompt managed launch when transcript identity is launch-attributed", async () => {
+      vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
+      const sessionId = "019f0022-1111-7222-8333-444455556666";
+      const sessionPath = "/Users/etanheyman/.codex/sessions/promptless.jsonl";
+      const transcriptResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: sessionPath,
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: transcriptResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-promptless",
+          repo: "cmuxlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          surface_id: "surface:promptless-session",
+          state: "ready",
+          task_summary: "",
+          created_at: "2026-06-25T08:00:00.000Z",
+          updated_at: "2026-06-25T08:01:00.000Z",
+          launch_cwd: "/Users/etanheyman/Gits/cmuxlayer",
+          worktree_path: "/Users/etanheyman/Gits/cmuxlayer",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:promptless-session")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:promptless-session",
+        text: ["OpenAI Codex", "Model: gpt-5.4", "", "›"].join("\n"),
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(transcriptResolver).toHaveBeenCalledTimes(1);
+      expect(engine.getAgentState("cmuxlayerCodex-019f0022")).toMatchObject({
+        agent_id: "cmuxlayerCodex-019f0022",
+        state: "ready",
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+      });
+    });
+
     it("does not bind a late prompted boot record to an unattributed transcript", async () => {
       vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
       const sessionId = "019f0021-1111-7222-8333-444455556666";

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1830,6 +1830,7 @@ describe("agent lifecycle tool handlers", () => {
         repo: "brainlayer",
         model: "codex",
         cli: "codex",
+        prompt: "",
         boot_prompt_path: promptPath,
         boot_prompt_timeout_ms: 20,
       },
@@ -1850,6 +1851,7 @@ describe("agent lifecycle tool handlers", () => {
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(["booting", "ready"]).toContain(state.state);
     expect(state.error).toBeNull();
+    expect(state.task_summary).toBe("file prompt body");
     expect(state.cli_session_id).toBe(sessionId);
     expect(state.resumable).toBe(true);
     expect(state.health.issue_codes).not.toContain("missing_cli_session_id");

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -821,4 +821,68 @@ describe("Sidebar Sync", () => {
     const doneChannelCalls = channelCalls.filter((c) => c[0] === "done");
     expect(doneChannelCalls).toHaveLength(0);
   });
+
+  it("does not re-emit spawned lifecycle events when late session capture renames an agent", async () => {
+    const sessionId = "019f0123-1111-7222-8333-444455556666";
+    const pendingId = "brainlayerCodex-pending-late-jsonl";
+    const finalId = "brainlayerCodex-019f0123";
+    let capturedIdentity: { session_id: string; path: string | null } | null =
+      null;
+    const transcriptResolver = vi.fn(() => capturedIdentity);
+    engine.dispose();
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts,
+      sessionIdentityResolver: transcriptResolver,
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingId,
+        state: "ready",
+        surface_id: "surface:late-jsonl",
+        repo: "brainlayer",
+        cli: "codex",
+        model: "gpt-5.4",
+        task_summary: "Fix late lifecycle rename",
+        launch_cwd: "/Users/etanheyman/Gits/brainlayer",
+        worktree_path: "/Users/etanheyman/Gits/brainlayer",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:late-jsonl")];
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.log).toHaveBeenCalledWith(
+      "spawned: brainlayer",
+      expect.objectContaining({ level: "info", source: "cmuxlayer" }),
+    );
+    mockClient.log.mockClear();
+    mockClient.setStatus.mockClear();
+    mockClient.clearStatus.mockClear();
+    capturedIdentity = {
+      session_id: sessionId,
+      path: "/tmp/codex-session.jsonl",
+    };
+
+    await engine.runSweep();
+
+    const spawnedCalls = mockClient.log.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "string" && call[0].startsWith("spawned:"),
+    );
+    expect(spawnedCalls).toHaveLength(0);
+    expect(
+      mockClient.setStatus.mock.calls.some((call) => call[0] === finalId),
+    ).toBe(true);
+    expect(
+      mockClient.clearStatus.mock.calls.some((call) => call[0] === pendingId),
+    ).toBe(true);
+    expect(stateMgr.readState(pendingId)).toBeNull();
+    expect(stateMgr.readState(finalId)).toMatchObject({
+      agent_id: finalId,
+      cli_session_id: sessionId,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Capture JSONL-backed `cli_session_id` from transcript discovery across managed agent lifecycle states (`booting`, `ready`, `working`, `idle`) instead of only during the narrow booting window.
- Keep capture scoped to attributed managed launches so unrelated transcripts are not bound accidentally.
- Preserve `boot_prompt_path` content as `task_summary` before spawn so timeout/error paths still have attribution for transcript discovery.
- Add regression coverage for a real failure shape: Claude reaches `ready`, the screen never shows a UUID, but the transcript exists and should make the agent resumable.

## Live proof
Real throwaway Claude spawn through the rebuilt local MCP server (`dist/index.js`) captured a real session identity and resumable route:

- Agent: `cmuxlayerClaude-e70aa34f`
- `cli_session_id`: `e70aa34f-f6b3-47ea-94ec-601a74d5d91e`
- `resumable`: `true`
- `resume_command`: `cmuxlayerClaude -s --resume e70aa34f-f6b3-47ea-94ec-601a74d5d91e`
- Transcript: `/Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-cmuxlayer/e70aa34f-f6b3-47ea-94ec-601a74d5d91e.jsonl`

Disk proof:

```text
-rw-------  1 etanheyman  staff  66377 Jul  5 22:33 /Users/etanheyman/.claude/projects/-Users-etanheyman-Gits-cmuxlayer/e70aa34f-f6b3-47ea-94ec-601a74d5d91e.jsonl
```

`rg "Session-capture fixed live proof 2026-07-05T19:32:17.602Z" .../e70aa34f-f6b3-47ea-94ec-601a74d5d91e.jsonl` found the exact prompt and matching `sessionId`.

## Separate observation, not fixed here
The final live spawn returned `ok:false` from the boot-prompt submit-evidence waiter even though the real Claude session completed and session capture succeeded. That is a distinct false-negative/false-green class in the boot-prompt submit-evidence path and should be filed/fixed separately from this session-capture PR.

## Verification
- `bun run typecheck` passed.
- `bun run test` passed: 71 files, 1304 tests.
- `bun run build` passed.
- Push hook reran the suite and passed: 71 files, 1304 tests.
- Local CodeRabbit CLI pre-commit review: `findings:0`.

## Notes
- Before-fix live diagnosis reproduced `cli_session_id:null` and `resumable:false` on a real managed Claude pane while the matching JSONL transcript existed on disk.
- The root cause was the transcript resolver being gated by the booting window; Claude screen output did not reliably expose a UUID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session identity, agent renaming, and spawn attribution in the agent engine and MCP spawn path; guards limit wrong transcript binding but resume routing depends on this logic.
> 
> **Overview**
> Fixes managed agents staying **`cli_session_id: null`** and **non-resumable** when the CLI never prints a UUID on screen but the JSONL transcript exists (e.g. Claude already **`ready`**).
> 
> **Agent engine:** Drops the fixed post-boot transcript window. Transcript-based capture now runs in **`booting`**, **`ready`**, **`working`**, and **`idle`** for JSONL harnesses when the agent has managed launch context (launcher/cwd/worktree) or a custom resolver; blank **`task_summary`** agents without that context still skip transcript binding. Screen UUID extraction remains **`booting`**-only, tried after transcript resolution. On rename to the canonical session-based **`agent_id`**, **`transferAgentRenameMemory`** moves sidebar snapshots, sweep signatures, ready-pattern counts, and logged/notified lifecycle keys so late capture does not re-emit **`spawned`**.
> 
> **Spawn path:** When **`spawn_agent`** uses **`boot_prompt_path`** without an inline prompt, the file body is read and passed as the spawn **`prompt`** / **`task_summary`** so transcript discovery can match the boot prompt on timeout/error paths.
> 
> Regression tests cover post-**`ready`** capture, promptless managed launches, unattributed transcript rejection, file-prompt **`task_summary`**, and lifecycle dedup after rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc12d1e4be42cab6cd9dbfa87317bbe5724743e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `cli_session_id` capture via transcript across all agent lifecycle states so resume works
> - Replaces the time-windowed boot capture logic with a state-set approach: transcript-based session resolution is now attempted whenever the agent is in `booting`, `ready`, `working`, or `idle` states, not just within a fixed boot window.
> - Screen-scrape fallback remains restricted to the `booting` state; transcript resolution is further gated to JSONL harnesses and requires either a managed launch context or a custom session identity resolver.
> - Adds `transferAgentRenameMemory` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/231/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) to migrate sidebar snapshots, sweep signatures, and event logs when session capture causes an agent ID rename, preventing duplicate lifecycle events.
> - `spawn_agent` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/231/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now forwards file-based boot prompt content as the agent prompt so `task_summary` reflects it even when no inline prompt is provided.
> - Behavioral Change: agents that previously had session capture skip after the boot window will now attempt transcript resolution in later states, which may bind a `cli_session_id` and rename the agent entry later in its lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcc12d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded session recovery so transcript-based identity can be resolved across more agent states, improving resumability for active sessions.
  * Boot prompt text is now used when starting an agent if no explicit prompt is provided.

* **Bug Fixes**
  * Improved session capture behavior for agents that have already progressed beyond the initial startup phase.
  * Preserved boot-session handling while making the capture flow more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->