### PR TITLE
fix: accept cleared boot prompt submit evidence

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -993,6 +993,34 @@ function screenHasAnyAgentIdentity(
   );
 }
 
+type RawSubmitEvidenceMetrics = {
+  tokenCount: number | null;
+  cost: number | null;
+};
+
+const COMPOSER_PROMPT_LINE_RE =
+  /^\s*(?:codex>|cursor>|kiro>|>>>|❯|>)\s?(.*)$/i;
+const RAW_SCREEN_TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/gi;
+const RAW_SCREEN_COST_RE = /(?:💰\s*)?\$\s*([0-9]+(?:\.[0-9]+)?)/g;
+
+function normalizeTerminalText(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function extractComposerInputRegion(screenText: string): string | null {
+  const lines = normalizeTerminalText(screenText).split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const match = lines[index]?.match(COMPOSER_PROMPT_LINE_RE);
+    if (!match) {
+      continue;
+    }
+
+    return [match[1] ?? "", ...lines.slice(index + 1)].join("\n").trimEnd();
+  }
+
+  return null;
+}
+
 function screenShowsPendingInput(
   screenText: string,
   submittedText: string,
@@ -1003,7 +1031,46 @@ function screenShowsPendingInput(
   }
 
   const tail = trimmed.slice(-Math.min(80, trimmed.length));
-  return screenText.includes(tail);
+  const composerInput = extractComposerInputRegion(screenText);
+  return composerInput !== null && composerInput.includes(tail);
+}
+
+function parseRawSubmitEvidenceMetrics(
+  screenText: string,
+): RawSubmitEvidenceMetrics {
+  const normalized = normalizeTerminalText(screenText);
+  let tokenCount: number | null = null;
+  for (const match of normalized.matchAll(RAW_SCREEN_TOKENS_RE)) {
+    tokenCount = Number.parseInt(match[1].replaceAll(",", ""), 10);
+  }
+
+  let cost: number | null = null;
+  for (const match of normalized.matchAll(RAW_SCREEN_COST_RE)) {
+    cost = Number.parseFloat(match[1]);
+  }
+
+  return { tokenCount, cost };
+}
+
+function hasRawSubmitEvidenceIncrease(
+  current: RawSubmitEvidenceMetrics,
+  baseline: RawSubmitEvidenceMetrics | null | undefined,
+): boolean {
+  if (
+    current.tokenCount !== null &&
+    (baseline?.tokenCount === null || baseline?.tokenCount === undefined
+      ? current.tokenCount > 0
+      : current.tokenCount > baseline.tokenCount)
+  ) {
+    return true;
+  }
+
+  return (
+    current.cost !== null &&
+    (baseline?.cost === null || baseline?.cost === undefined
+      ? current.cost > 0
+      : current.cost > baseline.cost)
+  );
 }
 
 type MonitorBootResult = {
@@ -2135,7 +2202,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     cli?: CliType;
     timeout_ms: number;
     onUpdateShellRelaunch?: () => Promise<void>;
-  }): Promise<void> => {
+  }): Promise<RawSubmitEvidenceMetrics | null> => {
     let deadline = Date.now() + opts.timeout_ms;
     let lastText = "";
     const consecutiveMatches = new Map<CliType, number>();
@@ -2265,7 +2332,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : 0;
           consecutiveMatches.set(candidate, count);
           if (count >= match.consecutive) {
-            return;
+            return parseRawSubmitEvidenceMetrics(screen.text);
           }
         }
       } catch (error) {
@@ -2299,9 +2366,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     workspace?: string;
     text: string;
     timeout_ms: number;
+    baseline_metrics?: RawSubmitEvidenceMetrics | null;
   }): Promise<void> => {
     const start = Date.now();
     let lastText = "";
+    let lastClearedComposerInput: string | null = null;
+    let stableClearedComposerPolls = 0;
 
     while (Date.now() - start < opts.timeout_ms) {
       const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
@@ -2311,6 +2381,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         lastText = snapshot.text;
         if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
           return;
+        }
+
+        if (
+          hasRawSubmitEvidenceIncrease(
+            parseRawSubmitEvidenceMetrics(snapshot.text),
+            opts.baseline_metrics,
+          )
+        ) {
+          return;
+        }
+
+        const composerInput = extractComposerInputRegion(snapshot.text);
+        const composerCleared =
+          composerInput !== null &&
+          composerInput.trim() === "" &&
+          !screenShowsPendingInput(snapshot.text, opts.text);
+        if (
+          composerCleared &&
+          screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed)
+        ) {
+          if (composerInput === lastClearedComposerInput) {
+            stableClearedComposerPolls += 1;
+          } else {
+            lastClearedComposerInput = composerInput;
+            stableClearedComposerPolls = 1;
+          }
+
+          if (stableClearedComposerPolls >= 2) {
+            return;
+          }
+        } else {
+          lastClearedComposerInput = null;
+          stableClearedComposerPolls = 0;
         }
       }
 
@@ -2510,7 +2613,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       };
     }
 
-    await waitForBootPromptReady({
+    const baselineSubmitMetrics = await waitForBootPromptReady({
       surface: opts.surface,
       workspace: opts.workspace,
       cli: opts.cli,
@@ -2566,6 +2669,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: opts.workspace,
             text: sanitizedText,
             timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
+            baseline_metrics: baselineSubmitMetrics,
           });
           return {
             bytes: Buffer.byteLength(sanitizedText, "utf8"),

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,7 @@ import type {
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import {
+  CLI_INPUT_PROMPT_PREFIXES,
   matchReadyPattern,
   screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
@@ -998,24 +999,203 @@ type RawSubmitEvidenceMetrics = {
   cost: number | null;
 };
 
-const COMPOSER_PROMPT_LINE_RE =
-  /^\s*(?:codex>|cursor>|kiro>|>>>|❯|>)\s?(.*)$/i;
-const RAW_SCREEN_TOKENS_RE = /\b([0-9][0-9,]*)\s+tokens\b/gi;
-const RAW_SCREEN_COST_RE = /(?:💰\s*)?\$\s*([0-9]+(?:\.[0-9]+)?)/g;
+type ComposerPromptLineMatch = {
+  input: string;
+};
+
+const COMPOSER_PROMPT_PREFIXES = Array.from(
+  new Set(Object.values(CLI_INPUT_PROMPT_PREFIXES).flat()),
+).sort((a, b) => b.length - a.length);
+const RAW_SCREEN_TOKENS_LINE_RE =
+  /(?:^\s*|.*\s{2,})([0-9][0-9,]*)\s+tokens\s*$/i;
+const RAW_SCREEN_COST_LINE_RE =
+  /(?:^|\s)🤖\s*[^|\n]+?\s*\|\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)(?:\s|$)|^\s*💰\s*\$([0-9]+(?:\.[0-9]+)?)(?:\s|$)/i;
 
 function normalizeTerminalText(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
+function matchComposerPromptLine(line: string): ComposerPromptLineMatch | null {
+  const trimmedStart = line.trimStart();
+  for (const prefix of COMPOSER_PROMPT_PREFIXES) {
+    if (!trimmedStart.toLowerCase().startsWith(prefix.toLowerCase())) {
+      continue;
+    }
+    return { input: trimmedStart.slice(prefix.length).replace(/^\s/, "") };
+  }
+
+  return null;
+}
+
+function inferComposerCli(
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): CliType | null {
+  if (parsed.agent_type !== "unknown") {
+    return parsed.agent_type;
+  }
+  if (/(?:^|\n)\s*(?:Kiro\b|kiro>)/i.test(screenText)) {
+    return "kiro";
+  }
+  if (/(?:^|\n)\s*Gemini CLI\b|(?:^|\n)\s*gemini>/i.test(screenText)) {
+    return "gemini";
+  }
+  if (/(?:^|\n)\s*Cursor Agent\b|(?:^|\n)\s*cursor>/i.test(screenText)) {
+    return "cursor";
+  }
+  if (
+    /\bOpenAI\s+Codex\b/i.test(screenText) ||
+    /(?:^|\n)\s*(?:Model:\s*)?gpt-[0-9]/i.test(screenText)
+  ) {
+    return "codex";
+  }
+  if (
+    /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?/i.test(
+      screenText,
+    )
+  ) {
+    return "claude";
+  }
+
+  return null;
+}
+
+function lineIsCurrentComposerRegionAnchor(
+  cli: CliType | null,
+  line: string,
+): boolean {
+  const trimmed = line.trim();
+  switch (cli) {
+    case "claude":
+      return /Claude Code|bypass permissions on|What can I help you with\?/i.test(
+        trimmed,
+      );
+    case "codex":
+      return (
+        /\bOpenAI\s+Codex\b/i.test(trimmed) ||
+        /\bModel:\s*gpt-/i.test(trimmed)
+      );
+    case "cursor":
+      return /^Cursor Agent$/i.test(trimmed) || /^cursor>\s*$/i.test(trimmed);
+    case "gemini":
+      return /^Gemini CLI$/i.test(trimmed) || /^gemini>\s*$/i.test(trimmed);
+    case "kiro":
+      return /^Kiro\b/i.test(trimmed) || /^kiro>\s*$/i.test(trimmed);
+    case null:
+      return (
+        /Claude Code|bypass permissions on|What can I help you with\?/i.test(
+          trimmed,
+        ) ||
+        /\bOpenAI\s+Codex\b/i.test(trimmed) ||
+        /\bModel:\s*gpt-/i.test(trimmed) ||
+        /^Cursor Agent$/i.test(trimmed) ||
+        /^cursor>\s*$/i.test(trimmed) ||
+        /^Gemini CLI$/i.test(trimmed) ||
+        /^gemini>\s*$/i.test(trimmed) ||
+        /^Kiro\b/i.test(trimmed) ||
+        /^kiro>\s*$/i.test(trimmed)
+      );
+  }
+}
+
+function currentComposerRegionStart(
+  cli: CliType | null,
+  lines: string[],
+): number {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lineIsCurrentComposerRegionAnchor(cli, lines[index] ?? "")) {
+      return index + 1;
+    }
+  }
+  return 0;
+}
+
+function isComposerFooterOrChromeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return true;
+  }
+  return (
+    /^(?:⎇|🤖)(?:\s|$)/.test(trimmed) ||
+    /^CLAUDE_COUNTER:/i.test(trimmed) ||
+    /^gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?\s*[·•]\s*/i.test(trimmed) ||
+    /^\d+(?:\.\d+)?%\s+(?:context\s+)?left\b/i.test(trimmed) ||
+    /^\/ commands\b/i.test(trimmed) ||
+    /^(?:Auto|Agent)(?:\s*·|$)/i.test(trimmed) ||
+    /^ctrl\+c to stop\b/i.test(trimmed) ||
+    /^bypass permissions on\b/i.test(trimmed) ||
+    /^⬡\s+Idle\b/i.test(trimmed) ||
+    /^v20\d{2}\.\d{2}\.\d{2}-[a-f0-9]+$/i.test(trimmed)
+  );
+}
+
+function isEligibleBareReadyPromptLine(
+  cli: CliType | null,
+  line: string,
+): boolean {
+  if (!/^\s*(?:>|>>>)\s*$/.test(line)) {
+    return false;
+  }
+  return cli === "claude" || cli === "gemini" || cli === "kiro";
+}
+
+function matchLegacyClaudePromptLine(
+  cli: CliType | null,
+  line: string,
+): ComposerPromptLineMatch | null {
+  if (cli !== "claude") {
+    return null;
+  }
+  const match = line.trimStart().match(/^>(?!>)\s?(.*)$/);
+  return match ? { input: match[1] ?? "" } : null;
+}
+
 function extractComposerInputRegion(screenText: string): string | null {
   const lines = normalizeTerminalText(screenText).split("\n");
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const match = lines[index]?.match(COMPOSER_PROMPT_LINE_RE);
+  const cli = inferComposerCli(screenText);
+  const start = currentComposerRegionStart(cli, lines);
+  let end = lines.length;
+  while (end > start && isComposerFooterOrChromeLine(lines[end - 1] ?? "")) {
+    end -= 1;
+  }
+
+  for (let index = end - 1; index >= start; index -= 1) {
+    const match = matchComposerPromptLine(lines[index] ?? "");
     if (!match) {
       continue;
     }
 
-    return [match[1] ?? "", ...lines.slice(index + 1)].join("\n").trimEnd();
+    const inputLines = [match.input];
+    for (const line of lines.slice(index + 1, end)) {
+      if (isComposerFooterOrChromeLine(line)) {
+        break;
+      }
+      inputLines.push(line);
+    }
+
+    return inputLines.join("\n").trimEnd();
+  }
+
+  for (let index = end - 1; index >= start; index -= 1) {
+    const match = matchLegacyClaudePromptLine(cli, lines[index] ?? "");
+    if (!match) {
+      continue;
+    }
+
+    const inputLines = [match.input];
+    for (const line of lines.slice(index + 1, end)) {
+      if (isComposerFooterOrChromeLine(line)) {
+        break;
+      }
+      inputLines.push(line);
+    }
+
+    return inputLines.join("\n").trimEnd();
+  }
+
+  const lastActiveLine = lines[end - 1] ?? "";
+  if (end > start && isEligibleBareReadyPromptLine(cli, lastActiveLine)) {
+    return "";
   }
 
   return null;
@@ -1031,8 +1211,14 @@ function screenShowsPendingInput(
   }
 
   const tail = trimmed.slice(-Math.min(80, trimmed.length));
+  const compactTail = tail.replace(/\s+/g, "");
   const composerInput = extractComposerInputRegion(screenText);
-  return composerInput !== null && composerInput.includes(tail);
+  return (
+    composerInput !== null &&
+    (composerInput.includes(tail) ||
+      (compactTail.length > 0 &&
+        composerInput.replace(/\s+/g, "").includes(compactTail)))
+  );
 }
 
 function parseRawSubmitEvidenceMetrics(
@@ -1040,13 +1226,21 @@ function parseRawSubmitEvidenceMetrics(
 ): RawSubmitEvidenceMetrics {
   const normalized = normalizeTerminalText(screenText);
   let tokenCount: number | null = null;
-  for (const match of normalized.matchAll(RAW_SCREEN_TOKENS_RE)) {
-    tokenCount = Number.parseInt(match[1].replaceAll(",", ""), 10);
-  }
-
   let cost: number | null = null;
-  for (const match of normalized.matchAll(RAW_SCREEN_COST_RE)) {
-    cost = Number.parseFloat(match[1]);
+
+  for (const line of normalized.split("\n")) {
+    const tokenMatch = line.match(RAW_SCREEN_TOKENS_LINE_RE);
+    if (tokenMatch) {
+      tokenCount = Number.parseInt(tokenMatch[1].replaceAll(",", ""), 10);
+    }
+
+    const costMatch = line.match(RAW_SCREEN_COST_LINE_RE);
+    if (costMatch) {
+      const rawCost = costMatch[1] ?? costMatch[2];
+      if (rawCost !== undefined) {
+        cost = Number.parseFloat(rawCost);
+      }
+    }
   }
 
   return { tokenCount, cost };
@@ -2383,7 +2577,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return;
         }
 
+        const composerInput = extractComposerInputRegion(snapshot.text);
+        const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
         if (
+          composerInput !== null &&
+          !hasPendingInput &&
           hasRawSubmitEvidenceIncrease(
             parseRawSubmitEvidenceMetrics(snapshot.text),
             opts.baseline_metrics,
@@ -2392,11 +2590,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return;
         }
 
-        const composerInput = extractComposerInputRegion(snapshot.text);
         const composerCleared =
           composerInput !== null &&
           composerInput.trim() === "" &&
-          !screenShowsPendingInput(snapshot.text, opts.text);
+          !hasPendingInput;
         if (
           composerCleared &&
           screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1067,9 +1067,7 @@ function lineIsCurrentComposerRegionAnchor(
   const trimmed = line.trim();
   switch (cli) {
     case "claude":
-      return /Claude Code|bypass permissions on|What can I help you with\?/i.test(
-        trimmed,
-      );
+      return /Claude Code|What can I help you with\?/i.test(trimmed);
     case "codex":
       return (
         /\bOpenAI\s+Codex\b/i.test(trimmed) ||
@@ -1083,9 +1081,7 @@ function lineIsCurrentComposerRegionAnchor(
       return /^Kiro\b/i.test(trimmed) || /^kiro>\s*$/i.test(trimmed);
     case null:
       return (
-        /Claude Code|bypass permissions on|What can I help you with\?/i.test(
-          trimmed,
-        ) ||
+        /Claude Code|What can I help you with\?/i.test(trimmed) ||
         /\bOpenAI\s+Codex\b/i.test(trimmed) ||
         /\bModel:\s*gpt-/i.test(trimmed) ||
         /^Cursor Agent$/i.test(trimmed) ||
@@ -1116,7 +1112,10 @@ function isComposerFooterOrChromeLine(line: string): boolean {
     return true;
   }
   return (
+    /^─{8,}$/.test(trimmed) ||
     /^(?:⎇|🤖)(?:\s|$)/.test(trimmed) ||
+    /^⏵+.*\bbypass permissions on\b/i.test(trimmed) ||
+    /^[✻✢✳✶]\s+Cogitated\s+for\s+\d+s\b/i.test(trimmed) ||
     /^CLAUDE_COUNTER:/i.test(trimmed) ||
     /^gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?\s*[·•]\s*/i.test(trimmed) ||
     /^\d+(?:\.\d+)?%\s+(?:context\s+)?left\b/i.test(trimmed) ||
@@ -1245,6 +1244,11 @@ function parseRawSubmitEvidenceMetrics(
 
   return { tokenCount, cost };
 }
+
+export const __submitEvidenceTestHooks = {
+  extractComposerInputRegion,
+  screenShowsPendingInput,
+};
 
 function hasRawSubmitEvidenceIncrease(
   current: RawSubmitEvidenceMetrics,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3,7 +3,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer } from "../src/server.js";
+import { createServer, __submitEvidenceTestHooks } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
@@ -35,6 +35,22 @@ const EXPECTED_TOOLS = [
 
 const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
 const BOOT_PROMPT_READY_POLL_MS_FOR_TESTS = 250;
+const REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN = [
+  "✻ Cogitated for 15s",
+  "                                                                                51784 tokens",
+  "─────────────────────────────────────────────────────────────────────────────────────────────",
+  "❯ ",
+  "─────────────────────────────────────────────────────────────────────────────────────────────",
+  "  ⎇ main | +16,-0 | 🔧 13",
+  "  🤖 Opus 4.8 (1M context) | 💰 $0.50 | ⏱️  0m | 🧠 27.6% | 📚 89%",
+  "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents",
+].join("\n");
+const REAL_CLAUDE_READY_BASELINE_SCREEN =
+  REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN.replace("51784 tokens", "0 tokens")
+    .replace("$0.50", "$0.00")
+    .replace("✻ Cogitated for 15s", "Claude Code");
+const REAL_CLAUDE_DIRTY_COMPOSER_SCREEN =
+  REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN.replace("\n❯ \n", "\n❯ still typing\n");
 
 async function advanceTimers(ms: number): Promise<void> {
   await Promise.resolve();
@@ -70,6 +86,34 @@ describe("createServer", () => {
 
     expect(rawServer._capabilities.experimental).toBeUndefined();
     expect(rawServer._instructions).toBeUndefined();
+  });
+});
+
+describe("submit evidence parser", () => {
+  it("extracts an empty composer from the real Claude submit-evidence screen", () => {
+    expect(
+      __submitEvidenceTestHooks.extractComposerInputRegion(
+        REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN,
+      ),
+    ).toBe("");
+  });
+
+  it("does not report pending input for the real Claude screen with an empty composer", () => {
+    expect(
+      __submitEvidenceTestHooks.screenShowsPendingInput(
+        REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN,
+        "any submitted text",
+      ),
+    ).toBe(false);
+  });
+
+  it("reports pending input for the real Claude screen when the composer is dirty", () => {
+    expect(
+      __submitEvidenceTestHooks.screenShowsPendingInput(
+        REAL_CLAUDE_DIRTY_COMPOSER_SCREEN,
+        "still typing",
+      ),
+    ).toBe(true);
   });
 });
 
@@ -2456,6 +2500,101 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
+  it("send_command verifies the real Claude cleared-composer screen using token evidence", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "real-claude-cleared.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN
+              : REAL_CLAUDE_READY_BASELINE_SCREEN,
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 700,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
+  it("send_command rejects the real Claude layout when the composer is still dirty", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "real-claude-dirty.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "still typing", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? REAL_CLAUDE_DIRTY_COMPOSER_SCREEN
+              : REAL_CLAUDE_READY_BASELINE_SCREEN,
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "still typing"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 100,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Boot prompt delivery failed");
     expect(promptSent).toBe(true);
   }, 10_000);
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2203,7 +2203,7 @@ describe("tool handler integration", () => {
     );
   });
 
-  it("send_command does not verify a cleared Claude boot prompt without a working marker", async () => {
+  it("send_command verifies a cleared stable Claude boot prompt without a working marker", async () => {
     const promptPath = join(CHANNEL_TEST_DIR, "slow-claude.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
@@ -2241,6 +2241,54 @@ describe("tool handler integration", () => {
         surface: "surface:1",
         command: "brainlayerClaude -s",
         boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 700,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
+    expect(returnPresses).toBeGreaterThanOrEqual(1);
+  }, 10_000);
+
+  it("send_command rejects a Claude boot prompt that remains visible in the composer", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "dirty-composer.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? "Claude Code\nWhat can I help you with?\n❯ boot prompt"
+              : "Claude Code\nWhat can I help you with?\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
         boot_prompt_timeout_ms: 100,
       },
       {} as any,
@@ -2250,9 +2298,55 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("boot prompt submit evidence");
+    expect(parsed.error).toContain("Boot prompt delivery failed");
     expect(promptSent).toBe(true);
-    expect(returnPresses).toBe(3);
+  }, 10_000);
+
+  it("send_command ignores transcript echoes when checking if a boot prompt is still pending", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "echoed-prompt.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? "Claude Code\n❯ boot prompt\n\nWhat can I help you with?\n❯"
+              : "Claude Code\nWhat can I help you with?\n>",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 700,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
   }, 10_000);
 
   it("send_command reports timeout with last screen lines and leaves launcher surface alive", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2349,6 +2349,228 @@ describe("tool handler integration", () => {
     expect(promptSent).toBe(true);
   }, 10_000);
 
+  it("send_command treats a Codex › composer line as still pending", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "codex-pending.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "still typed here", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? [
+                  "OpenAI Codex",
+                  "Model: gpt-5.5 xhigh",
+                  "› still typed here",
+                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+                ].join("\n")
+              : [
+                  "OpenAI Codex",
+                  "Model: gpt-5.5 xhigh",
+                  "›",
+                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+                ].join("\n"),
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "still typed here"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerCodex -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 100,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
+  it("send_command verifies a cleared Claude composer with footer chrome and no token evidence", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "claude-footer-cleared.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot prompt", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? [
+                  "Claude Code",
+                  "What can I help you with?",
+                  "❯",
+                  "  ⎇ cmuxlayer/fix-submit | 🔧 13",
+                ].join("\n")
+              : "Claude Code\nWhat can I help you with?\n❯",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "boot prompt"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 700,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_submit_verified).toBe(true);
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
+  it("send_command rejects a pending prompt whose payload ends with a bare blockquote marker", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "blockquote-pending.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "Review this\n>", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? "Claude Code\nWhat can I help you with?\n❯ Review this\n>"
+              : "Claude Code\nWhat can I help you with?\n❯",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "Review this\n>"
+      ) {
+        promptSent = true;
+      }
+      if (
+        args.includes("set-buffer") &&
+        String(args.at(-1) ?? "") === "Review this\n>"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerClaude -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 700,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
+  it("send_command rejects a pending metric-looking boot prompt instead of treating prompt text as submit evidence", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "metric-looking-pending.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "Use 500 tokens and budget $5.00", "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? [
+                  "OpenAI Codex",
+                  "Model: gpt-5.5 xhigh",
+                  "› Use 500 tokens and budget $5.00",
+                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+                ].join("\n")
+              : [
+                  "OpenAI Codex",
+                  "Model: gpt-5.5 xhigh",
+                  "›",
+                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+                ].join("\n"),
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "") === "Use 500 tokens and budget $5.00"
+      ) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerCodex -s",
+        boot_prompt_path: promptPath,
+        boot_prompt_timeout_ms: 100,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(promptSent).toBe(true);
+  }, 10_000);
+
   it("send_command reports timeout with last screen lines and leaves launcher surface alive", async () => {
     const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- Fix D1: broaden boot-prompt submit recovery evidence beyond parsed `working`/`thinking`. `waitForBootPromptSubmitEvidence` now also accepts raw token/cost growth versus the pre-submit readiness frame, or a cleared composer that is stable across two consecutive polls with an agent identity present.
- Fix D2: make `screenShowsPendingInput` composer-region scoped by checking text after the final prompt marker instead of matching the submitted prompt tail anywhere in the screen. This prevents transcript echoes from looking like pending composer input.
- Re-specify the existing cleared-Claude/no-working-marker test to expect `ok:true`, and add the false-green guard where the prompt remains visible in the composer and still returns `ok:false`.

## Painpoint doc
- Local lead handoff/spec: `/Users/etanheyman/Gits/cmuxlayer/docs.local/plans/2026-07-04-cmuxlayer-painpoint-remediation/reports/painpoint-submit-evidence-false-red.md`
- The doc is under `docs.local` and is not GitHub-visible, so the D1/D2 root cause and test changes are summarized inline above.

## TDD evidence
- RED: `bun run test -- tests/server.test.ts -t "send_command verifies a cleared stable|send_command rejects a Claude boot prompt|send_command ignores transcript echoes"`
  - Result before implementation: `2 failed | 1 passed | 115 skipped`; failures were `expected false to be true` for the cleared-composer and transcript-echo success cases.
- GREEN targeted: same command after implementation: `3 passed | 115 skipped`.
- Regression/read-count check: `bun run test -- tests/server.test.ts -t "send_command verifies a cleared stable|send_command rejects a Claude boot prompt|send_command ignores transcript echoes|send_command requires consecutive low-confidence ready matches|spawn_agent keeps polling after a slow Codex update menu dismissal"`
  - Result: `5 passed | 113 skipped`.

## Verification
- `bun run typecheck` -> exit 0.
- `bun run test` -> `71 passed (71)` test files, `1308 passed (1308)` tests.
- Push hook reran `bun run test` -> `71 passed (71)` test files, `1308 passed (1308)` tests, `run_tests.sh finished with exit status 0`.
- `coderabbit review --agent` -> `findings: 0`.

## Notes
- `verifySubmitAfterEnter` was not changed; the behavioral change is scoped to the boot-prompt recovery path plus the shared pending-input predicate.
- LIVE-PROOF is intentionally not performed here per the worker brief; lead owns real spawn proof, review, merge, and release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes boot-prompt delivery success criteria in `send_command`, which affects agent launch reliability; behavior is well covered by tests but alters production verification paths.
> 
> **Overview**
> **Boot prompt submit verification** no longer relies only on parsed `working`/`thinking` status. After send, `waitForBootPromptSubmitEvidence` can succeed when token/cost on the screen rises versus a baseline captured at ready time, or when the composer input region is empty, stable for two polls, and an agent identity is present.
> 
> **Pending-input detection** is narrowed so `screenShowsPendingInput` compares the submitted text only against the extracted composer region (with whitespace normalization), not the full screen. That avoids treating transcript echoes or metric-like prompt text as “still typing.”
> 
> New helpers parse multi-CLI prompt prefixes, footer/chrome lines, and raw token/cost lines from terminal output; `__submitEvidenceTestHooks` exposes composer extraction for tests. **`send_command` boot-prompt tests** are expanded for cleared Claude, dirty composer, Codex `›`, transcript echoes, and metric-looking pending prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126a9a94e99ef7897a0c903375370cfea195d61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix boot prompt submit verification to accept cleared composer as evidence
> - `waitForBootPromptSubmitEvidence` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/232/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now succeeds when the composer is observed empty and stable (2 consecutive polls) with an agent identity present, in addition to the existing token/cost metric increase path.
> - `screenShowsPendingInput` is reworked to extract only the active composer region (via `extractComposerInputRegion`) and match against it, preventing false positives from transcript echoes elsewhere on screen.
> - `waitForBootPromptReady` now returns baseline token/cost metrics captured at readiness; these are passed into submit verification to detect increases vs. the post-submission state.
> - Behavioral Change: pending input detection no longer uses a raw `includes()` over the full screen — it matches only the current composer region, whitespace-insensitively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 126a9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced boot prompt verification with evidence parsing (token/cost) and baseline comparisons.
  * Improved detection of composer “pending” vs “cleared” states to reduce false positives.
  * Added stability gating so prompts that clear reliably are treated as successfully submit-verified, even without “working” markers.
  * Improved handling for delayed confirmation based on terminal output changes.
* **Tests**
  * Updated and added scenarios to validate success and failure outcomes for cleared, pending, and delayed boot prompt states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->