### PR TITLE
fix: tier agent health severity

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -80,6 +80,7 @@ import {
   type SpawnModelPolicy,
 } from "./model-policy.js";
 import {
+  DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY,
   evaluateAgentHealth,
   type AgentHealth,
 } from "./agent-health.js";
@@ -2274,7 +2275,15 @@ export class AgentEngine {
 
   private formatHealthSummary(health: AgentHealth): string {
     if (health.issue_codes.length === 0) return health.status;
-    return `${health.status}(${health.issue_codes.join(",")})`;
+    const issueSummary = health.issue_codes
+      .map((code) => {
+        const severity =
+          health.issue_severities?.[code] ??
+          DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code];
+        return `${code}:${severity}`;
+      })
+      .join(",");
+    return `${health.status}(${issueSummary})`;
   }
 
   private formatReportSummary(harvestability: WorkerHarvestability): string {
@@ -2393,18 +2402,22 @@ export class AgentEngine {
         await this.client.notifyLifecycleEvent(event, agent, signature);
       }
       if (event === "health") {
-        const healthPrefix = `${agent.agent_id}:health:`;
-        for (const key of this.notifiedEvents) {
-          if (key.startsWith(healthPrefix)) {
-            this.notifiedEvents.delete(key);
-          }
-        }
+        this.clearHealthNotificationMemory(agent.agent_id);
       }
       this.notifiedEvents.add(eventKey);
       return true;
     } catch {
       // Ignore Claude channel push failures; logs and sidebar state remain canonical.
       return false;
+    }
+  }
+
+  private clearHealthNotificationMemory(agentId: string): void {
+    const healthPrefix = `${agentId}:health:`;
+    for (const key of this.notifiedEvents) {
+      if (key.startsWith(healthPrefix)) {
+        this.notifiedEvents.delete(key);
+      }
     }
   }
 
@@ -2419,10 +2432,7 @@ export class AgentEngine {
     if (!prev) return health.status === "unhealthy";
     const nextSignature = this.healthSignature(health);
     if (prev.healthSignature === nextSignature) return false;
-    return (
-      health.status === "unhealthy" ||
-      prev.healthSignature.startsWith("unhealthy")
-    );
+    return health.status === "unhealthy";
   }
 
   /**
@@ -2536,6 +2546,12 @@ export class AgentEngine {
           "health",
           healthSignature,
         );
+      } else if (
+        prev &&
+        prev.healthSignature !== healthSignature &&
+        health.status !== "unhealthy"
+      ) {
+        this.clearHealthNotificationMemory(agentId);
       }
 
       const archived = await this.maybeArchiveDoneAgent(agent);

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -1,8 +1,9 @@
-import type { AgentRecord } from "./agent-types.js";
+import type { AgentRecord, AgentState } from "./agent-types.js";
 import type { WorkerHarvestability } from "./agent-engine.js";
 import { inferRecordRoleOrNull } from "./layout-policy.js";
 
-export type AgentHealthStatus = "healthy" | "unhealthy";
+export type AgentHealthStatus = "healthy" | "degraded" | "unhealthy";
+export type AgentHealthIssueSeverity = "blocking" | "degraded" | "info";
 
 export type AgentHealthIssueCode =
   | "auto_discovered_agent"
@@ -26,6 +27,32 @@ export type AgentHealthIssueCode =
   | "orchestrator_not_leftmost"
   | "worker_in_leftmost_column";
 
+export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
+  AgentHealthIssueCode,
+  AgentHealthIssueSeverity
+> = {
+  agent_wedged: "blocking",
+  closure_without_artifact: "blocking",
+  pr_loop_incomplete: "blocking",
+  kept_open_contract_incomplete: "blocking",
+  degraded_evidence_channel: "blocking",
+  recoverable_blocker_requires_action: "blocking",
+  registry_surface_workspace_mismatch: "blocking",
+  topology_three_or_more_columns: "blocking",
+  orchestrator_not_leftmost: "blocking",
+  worker_in_leftmost_column: "blocking",
+  non_claude_orchestrator: "blocking",
+  inbox_channel_dir_deleted: "blocking",
+  stale_inbox_dispatches: "blocking",
+  missing_managed_lead_agent_id: "degraded",
+  missing_cli_session_id: "degraded",
+  non_resumable: "degraded",
+  inbox_monitor_not_alive: "degraded",
+  auto_discovered_agent: "degraded",
+  ambiguous_repo_cwd_label: "info",
+  registry_screen_disagreement: "degraded",
+};
+
 export interface AgentTopologyHealthInput {
   column: number | null;
   column_count: number | null;
@@ -48,6 +75,10 @@ export interface AgentHealth {
   status: AgentHealthStatus;
   issue_codes: AgentHealthIssueCode[];
   issues: string[];
+  issue_severities?: Partial<
+    Record<AgentHealthIssueCode, AgentHealthIssueSeverity>
+  >;
+  reconciled_state?: AgentState;
   recommended_actions?: string[];
 }
 
@@ -69,6 +100,39 @@ const RECOVERABLE_ACTION_RECOMMENDATIONS: Record<string, string> = {
 
 function addRecommendedAction(actions: string[], action: string): void {
   if (!actions.includes(action)) actions.push(action);
+}
+
+function issueSeverity(
+  code: AgentHealthIssueCode,
+  context: { screenActive: boolean },
+): AgentHealthIssueSeverity {
+  if (code === "registry_screen_disagreement" && context.screenActive) {
+    return "info";
+  }
+  return DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code];
+}
+
+function deriveIssueSeverities(
+  codes: AgentHealthIssueCode[],
+  context: { screenActive: boolean },
+): Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>> {
+  const severities: Partial<
+    Record<AgentHealthIssueCode, AgentHealthIssueSeverity>
+  > = {};
+  for (const code of codes) {
+    severities[code] = issueSeverity(code, context);
+  }
+  return severities;
+}
+
+function deriveStatus(
+  codes: AgentHealthIssueCode[],
+  severities: Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>>,
+): AgentHealthStatus {
+  if (codes.length === 0) return "healthy";
+  return codes.some((code) => severities[code] === "blocking")
+    ? "unhealthy"
+    : "degraded";
 }
 
 function isLongRunning(agent: AgentRecord): boolean {
@@ -198,6 +262,7 @@ export function evaluateAgentHealth(
   const screenActive =
     input.screen_status === "working" || input.screen_status === "thinking";
   const screenDone = input.screen_status === "done";
+  let reconciledState: AgentState | undefined;
   const registryActive =
     agent.state === "creating" ||
     agent.state === "booting" ||
@@ -208,6 +273,9 @@ export function evaluateAgentHealth(
     agent.state === "done" ||
     agent.state === "error";
   if ((screenActive && registryInactive) || (screenDone && registryActive)) {
+    if (screenActive && registryInactive) {
+      reconciledState = "working";
+    }
     addIssue(
       issueCodes,
       issues,
@@ -333,10 +401,15 @@ export function evaluateAgentHealth(
     }
   }
 
+  const issueSeverities = deriveIssueSeverities(issueCodes, { screenActive });
+  const status = deriveStatus(issueCodes, issueSeverities);
+
   return {
-    status: issueCodes.length === 0 ? "healthy" : "unhealthy",
+    status,
     issue_codes: issueCodes,
     issues,
+    ...(issueCodes.length > 0 ? { issue_severities: issueSeverities } : {}),
+    ...(reconciledState ? { reconciled_state: reconciledState } : {}),
     ...(recommendedActions.length > 0
       ? { recommended_actions: recommendedActions }
       : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,7 +29,11 @@ import {
   toAgentStatePayload,
   toPublicAgent,
 } from "./agent-facade.js";
-import { evaluateAgentHealth } from "./agent-health.js";
+import {
+  DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY,
+  evaluateAgentHealth,
+  type AgentHealthIssueCode,
+} from "./agent-health.js";
 import {
   AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
   AGENT_HEALTH_MONITOR_MAX_AGE_MS,
@@ -1392,10 +1396,8 @@ const LIVE_HEALTHY_STATE: Partial<
 
 /**
  * Reconcile a registry AgentState with the live read_screen parse for my_agents.
- * The registry can hold a STALE "error" for an agent that is actually alive (idle/working);
- * read_screen is ground truth for liveness. When the registry says "error" but the live screen
- * still parses a healthy running status, surface the live state instead. All other cases keep
- * the registry state (we never downgrade a healthy registry state on a transient screen blip).
+ * An active agent screen is ground truth for liveness, so working/thinking screens win
+ * over stale inactive registry states. A healthy idle screen only clears a stale error.
  */
 export function reconcileAgentLiveState(
   registryState: AgentState,
@@ -1404,9 +1406,10 @@ export function reconcileAgentLiveState(
   // Only a REAL agent screen can clear an error. parseScreen reports status:"idle" for a
   // plain shell prompt (agent_type:"unknown"), so a crashed agent fallen back to a shell must
   // keep its registry error instead of being masked as healthy idle.
-  if (registryState === "error" && screen && screen.agent_type !== "unknown") {
+  if (screen && screen.agent_type !== "unknown") {
     const live = LIVE_HEALTHY_STATE[screen.status];
-    if (live) return live;
+    if (live === "working") return live;
+    if (registryState === "error" && live) return live;
   }
   return registryState;
 }
@@ -3163,7 +3166,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
 
   const buildOrphanSurfaceHealth = (surface: DiscoveredAgent) => {
-    const issueCodes: string[] = [];
+    const issueCodes: AgentHealthIssueCode[] = [];
     const issues: string[] = [];
     if (isLeadLikeSurfaceTitle(surface.surface_title)) {
       issueCodes.push("missing_managed_lead_agent_id");
@@ -3187,13 +3190,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
     }
 
+    const issueSeverities = Object.fromEntries(
+      issueCodes.map((code) => [code, DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code]]),
+    );
+    const hasBlockingIssue = issueCodes.some(
+      (code) => DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code] === "blocking",
+    );
     return {
       surface_id: surface.surface_id,
       surface_title: surface.surface_title,
       workspace_id: surface.workspace_id ?? null,
-      status: issueCodes.length > 0 ? "unhealthy" : "unknown",
+      status:
+        issueCodes.length === 0
+          ? "unknown"
+          : hasBlockingIssue
+            ? "unhealthy"
+            : "degraded",
       issue_codes: issueCodes,
       issues,
+      ...(issueCodes.length > 0 ? { issue_severities: issueSeverities } : {}),
     };
   };
 
@@ -6456,20 +6471,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.readOnly,
       async (args) => {
         const filter = {
-          state: args.state,
           repo: args.repo,
           model: args.model,
         };
+        const requestedState = args.state;
         const buildListAgentsResponse = async (records: AgentRecord[]) => {
           const topology = await collectSurfaceTopology();
-          const agents = await Promise.all(
-            records.map(async (agent) => ({
-              ...toPublicAgent(agent),
-              health: await evaluateServerAgentHealth(agent, {
+          const enrichedAgents = await Promise.all(
+            records.map(async (agent) => {
+              const health = await evaluateServerAgentHealth(agent, {
                 ...healthTopologyOverrides(agent, topology),
-              }),
-            })),
+              });
+              return {
+                ...toPublicAgent(agent),
+                state: health.reconciled_state ?? agent.state,
+                health,
+              };
+            }),
           );
+          const agents = requestedState
+            ? enrichedAgents.filter((agent) => agent.state === requestedState)
+            : enrichedAgents;
           const data = {
             agents: agents as unknown as Record<string, unknown>[],
             count: agents.length,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1472,7 +1472,7 @@ describe("AgentEngine", () => {
         expect(mockClient.clearStatus).not.toHaveBeenCalled();
         expect(mockClient.setStatus).toHaveBeenCalledWith(
           "worker-archived-before-status",
-          "brainlayer | role=worker | state=done | health=unhealthy(inbox_monitor_not_alive,closure_without_artifact) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+          "brainlayer | role=worker | state=done | health=unhealthy(inbox_monitor_not_alive:degraded,closure_without_artifact:blocking) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
           expect.objectContaining({
             surface: "surface:archived-before-status",
           }),

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -40,21 +40,30 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
 }
 
 describe("agent lifecycle health", () => {
-  it("marks a ready managed agent without a CLI session or monitor as unhealthy", () => {
+  it("degrades a working-screen agent without a CLI session or monitor without marking it unhealthy", () => {
     const health = evaluateAgentHealth(
-      makeRecord({ cli_session_id: null, cli_session_path: null }),
-      { monitor_alive: false },
+      makeRecord({
+        state: "working",
+        cli_session_id: null,
+        cli_session_path: null,
+      }),
+      { monitor_alive: false, screen_status: "working" },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toEqual([
       "missing_cli_session_id",
       "non_resumable",
       "inbox_monitor_not_alive",
     ]);
+    expect(health.issue_severities).toMatchObject({
+      missing_cli_session_id: "degraded",
+      non_resumable: "degraded",
+      inbox_monitor_not_alive: "degraded",
+    });
   });
 
-  it("marks auto-discovered agents as unhealthy even if they look ready", () => {
+  it("marks auto-discovered agents as degraded even if they look ready", () => {
     const health = evaluateAgentHealth(
       makeRecord({
         agent_id: "auto-codex-surface-306",
@@ -64,9 +73,13 @@ describe("agent lifecycle health", () => {
       { monitor_alive: false },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toContain("auto_discovered_agent");
     expect(health.issue_codes).toContain("missing_cli_session_id");
+    expect(health.issue_severities).toMatchObject({
+      auto_discovered_agent: "degraded",
+      missing_cli_session_id: "degraded",
+    });
   });
 
   it("distinguishes a deleted inbox channel dir from a never-armed monitor", () => {
@@ -95,12 +108,15 @@ describe("agent lifecycle health", () => {
       { monitor_alive: false, surface_title: "M1 LEAD VoiceLayerCodex" },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toContain("auto_discovered_agent");
     expect(health.issue_codes).toContain("missing_managed_lead_agent_id");
+    expect(health.issue_severities?.missing_managed_lead_agent_id).toBe(
+      "degraded",
+    );
   });
 
-  it("marks ambiguous auto-discovered repo labels as unhealthy", () => {
+  it("marks ambiguous auto-discovered repo labels as degraded label hygiene", () => {
     const health = evaluateAgentHealth(
       makeRecord({
         agent_id: "auto-codex-surface-999",
@@ -111,8 +127,9 @@ describe("agent lifecycle health", () => {
       { monitor_alive: false },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toContain("ambiguous_repo_cwd_label");
+    expect(health.issue_severities?.ambiguous_repo_cwd_label).toBe("info");
   });
 
   it("marks non-Claude orchestrators as role health failures", () => {
@@ -135,7 +152,7 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("topology_three_or_more_columns");
   });
 
-  it("marks registry done while the screen is working as unhealthy", () => {
+  it("treats registry done while the screen is working as a screen-liveness signal", () => {
     const health = evaluateAgentHealth(
       makeRecord({
         state: "done",
@@ -147,11 +164,13 @@ describe("agent lifecycle health", () => {
       },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
+    expect(health.reconciled_state).toBe("working");
     expect(health.issue_codes).toContain("registry_screen_disagreement");
+    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
   });
 
-  it("marks registry working while the screen parses done as unhealthy", () => {
+  it("marks registry working while the screen parses done as degraded registry lag", () => {
     const health = evaluateAgentHealth(
       makeRecord({
         state: "working",
@@ -163,8 +182,11 @@ describe("agent lifecycle health", () => {
       },
     );
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toContain("registry_screen_disagreement");
+    expect(health.issue_severities?.registry_screen_disagreement).toBe(
+      "degraded",
+    );
   });
 
   it("marks stale dispatches on a live monitor as wedged, not dead", () => {
@@ -192,14 +214,14 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).not.toContain("inbox_monitor_not_alive");
   });
 
-  it("marks an absent monitor as dead evidence, not a wedged live pane", () => {
+  it("marks an absent monitor as degraded evidence, not a wedged live pane", () => {
     const health = evaluateAgentHealth(makeRecord({ state: "working" }), {
       monitor_alive: false,
       stale_count: 0,
       screen_status: "working",
     });
 
-    expect(health.status).toBe("unhealthy");
+    expect(health.status).toBe("degraded");
     expect(health.issue_codes).toContain("inbox_monitor_not_alive");
     expect(health.issue_codes).not.toContain("agent_wedged");
   });

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -8,14 +8,70 @@ import {
 } from "../src/control-health.js";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ControlHealth } from "../src/control-health.js";
+import { AgentEngine } from "../src/agent-engine.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { StateManager } from "../src/state-manager.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-control-health-test");
+
+function createHealthNotificationEngine() {
+  const stateDir = join(TEST_ROOT, `engine-${Date.now()}-${Math.random()}`);
+  mkdirSync(stateDir, { recursive: true });
+  const stateMgr = new StateManager(stateDir);
+  const registry = new AgentRegistry(stateMgr, async () => []);
+  const engine = new AgentEngine(stateMgr, registry, {} as any, {
+    spawnPreflight: async () => {},
+    sessionIdentityResolver: () => null,
+  });
+  return { engine, stateDir };
+}
 
 afterEach(() => {
   vi.useRealTimers();
 });
 
 describe("control health", () => {
+  it("only notifies on blocking health and records code severity in signatures", () => {
+    const { engine, stateDir } = createHealthNotificationEngine();
+    try {
+      const healthSignature = (engine as any).healthSignature.bind(engine);
+      const shouldNotifyHealthChange = (
+        engine as any
+      ).shouldNotifyHealthChange.bind(engine);
+      const degradedHealth = {
+        status: "degraded",
+        issue_codes: ["missing_cli_session_id"],
+        issues: ["managed long-running agent has no cli_session_id"],
+        issue_severities: { missing_cli_session_id: "degraded" },
+      };
+      const blockingHealth = {
+        status: "unhealthy",
+        issue_codes: ["agent_wedged"],
+        issues: ["agent monitor is alive but dispatches remain unacked"],
+        issue_severities: { agent_wedged: "blocking" },
+      };
+
+      expect(healthSignature(degradedHealth)).toBe(
+        "degraded(missing_cli_session_id:degraded)",
+      );
+      expect(
+        shouldNotifyHealthChange(
+          { healthSignature: "unhealthy(agent_wedged:blocking)" },
+          degradedHealth,
+        ),
+      ).toBe(false);
+      expect(
+        shouldNotifyHealthChange(
+          { healthSignature: "degraded(missing_cli_session_id:degraded)" },
+          blockingHealth,
+        ),
+      ).toBe(true);
+    } finally {
+      engine.dispose();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("reports prod/nightly sockets and warns on Nightly env with prod-resolving cmux", async () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home");

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -1244,12 +1244,14 @@ describe("resync_agents tool", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.diff.orphaned).toEqual(["surface:325"]);
-    expect(parsed.diff.health_failures).toEqual([
+    expect(parsed.diff.health_failures).toEqual([]);
+    expect(parsed.diff.orphaned_health).toEqual([
       expect.objectContaining({
         surface_id: "surface:325",
         surface_title: "M1 LEAD VoiceLayerCodex",
-        status: "unhealthy",
+        status: "degraded",
         issue_codes: ["missing_managed_lead_agent_id"],
+        issue_severities: { missing_managed_lead_agent_id: "degraded" },
       }),
     ]);
   });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -416,7 +416,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
     expect(parsed.health).toMatchObject({
-      status: "unhealthy",
+      status: "degraded",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
@@ -903,7 +903,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("ic");
-    expect(parsed.health.status).toBe("unhealthy");
+    expect(parsed.health.status).toBe("degraded");
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -1974,11 +1974,48 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agents[0].resume_command).toBeUndefined();
     expect(parsed.agents[0].surface_id).toBeUndefined();
     expect(parsed.agents[0].health).toMatchObject({
-      status: "unhealthy",
+      status: "degraded",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
       ]),
+    });
+  });
+
+  it("list_agents state filter uses the reconciled screen-active state", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const list = (server as any)._registeredTools["list_agents"];
+
+    await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "begin work",
+      },
+      {} as any,
+    );
+
+    const result = await list.handler({ state: "working" }, {} as any);
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.agents[0]).toMatchObject({
+      repo: "brainlayer",
+      state: "working",
+      health: {
+        status: "degraded",
+        issue_codes: expect.arrayContaining([
+          "registry_screen_disagreement",
+        ]),
+        issue_severities: {
+          registry_screen_disagreement: "info",
+        },
+        reconciled_state: "working",
+      },
     });
   });
 
@@ -2044,7 +2081,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.cli).toBe("codex");
     expect(parsed.resume_command).toBeUndefined();
     expect(parsed.health).toMatchObject({
-      status: "unhealthy",
+      status: "degraded",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
@@ -2843,7 +2880,7 @@ codex>
       pid: null,
       resumable: false,
       health: {
-        status: "unhealthy",
+        status: "degraded",
         issue_codes: expect.arrayContaining([
           "auto_discovered_agent",
           "missing_cli_session_id",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -380,7 +380,8 @@ describe("Claude channels", () => {
         params.meta?.event === "health"
       );
     });
-    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    const healthSummary =
+      "unhealthy(stale_inbox_dispatches:blocking,agent_wedged:blocking)";
     expect(healthNotification).toEqual(
       expect.objectContaining({
         params: expect.objectContaining({

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -187,7 +187,7 @@ describe("Sidebar Sync", () => {
     );
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       "working-agent",
-      "brainlayer | role=worker | state=working | health=unhealthy(missing_cli_session_id,non_resumable) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
+      "brainlayer | role=worker | state=working | health=degraded(missing_cli_session_id:degraded,non_resumable:degraded) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
       expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
     );
   });
@@ -320,7 +320,8 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    const healthSummary = "unhealthy(registry_surface_workspace_mismatch)";
+    const healthSummary =
+      "unhealthy(registry_surface_workspace_mismatch:blocking)";
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       "workspace-drift",
       `brainlayer | role=worker | state=working | health=${healthSummary} | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a`,
@@ -395,7 +396,8 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    const healthSummary =
+      "unhealthy(stale_inbox_dispatches:blocking,agent_wedged:blocking)";
     expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
       "health",
       expect.objectContaining({ agent_id: agentId }),
@@ -451,7 +453,8 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    const healthSummary =
+      "unhealthy(stale_inbox_dispatches:blocking,agent_wedged:blocking)";
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       agentId,
       `brainlayer | role=worker | state=working | health=${healthSummary} | blocked=self:agent_wedged | last_prompt=Keep draining inbox dispatches | worktree=- | branch=- | report=n/a | pr=n/a`,
@@ -468,11 +471,7 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    expect(mockClient.notifyLifecycleEvent).toHaveBeenCalledWith(
-      "health",
-      expect.objectContaining({ agent_id: agentId }),
-      "healthy",
-    );
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
 
     mockClient.notifyLifecycleEvent.mockClear();
     dispatch(
@@ -540,7 +539,8 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
     await engine.runSweep();
 
-    const healthSummary = "unhealthy(stale_inbox_dispatches,agent_wedged)";
+    const healthSummary =
+      "unhealthy(stale_inbox_dispatches:blocking,agent_wedged:blocking)";
     const healthCalls = mockClient.notifyLifecycleEvent.mock.calls.filter(
       (call) => call[0] === "health",
     );
@@ -633,7 +633,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.setStatus).toHaveBeenCalledTimes(2);
     expect(mockClient.setStatus).toHaveBeenLastCalledWith(
       "a1",
-      "brainlayer | role=worker | state=working | health=unhealthy(missing_cli_session_id,non_resumable) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+      "brainlayer | role=worker | state=working | health=degraded(missing_cli_session_id:degraded,non_resumable:degraded) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
       expect.objectContaining({
         workspace: "workspace:coach",
         surface: "surface:99",


### PR DESCRIPTION
## Summary
- Add DEFAULT health issue severity tiering and derive `healthy | degraded | unhealthy` from blocking vs non-blocking issue codes.
- Treat active screen status as liveness: registry/screen disagreement is `info`, reports `reconciled_state: "working"`, and `list_agents` state filtering runs after reconciliation.
- Gate health notifications on blocking `unhealthy` only while clearing dedupe when an agent recovers so later blocking regressions still notify.

## Test plan
- [x] RED: `bunx vitest run tests/agent-health.test.ts tests/control-health.test.ts` failed on old binary status/signature behavior.
- [x] Review RED: `bunx vitest run tests/server-agent-tools.test.ts -t "list_agents state filter uses the reconciled screen-active state"` failed before moving state filtering post-reconciliation.
- [x] `bun run typecheck && bun run test`
- [x] Pre-push hook reran full suite successfully.

## Live proof
Ran this branch's `list_agents({ state: "working" })` handler against the live cmux fleet without restarting the installed MCP. It returned 2 working agents, both `health.status: "degraded"` rather than `"unhealthy"`:
- `brainlayerCodex-pending-1783302301-dbsp`: `missing_cli_session_id/non_resumable/inbox_monitor_not_alive = degraded`, `registry_screen_disagreement = info`, `reconciled_state = working`.
- `cmuxlayerCodex-pending-1783302792-ef6f`: same degraded/info tiering and `reconciled_state = working`.

## Review notes
- First bounded CodeRabbit pre-commit pass emitted one valid major finding: `list_agents` filtered by registry state before reconciliation. Fixed with a failing regression test.
- Second bounded CodeRabbit pass timed out after 180s with no findings emitted.

Do not merge until Etan confirms the tiering table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how operators and tools interpret agent health, state filters, and alert noise across sweeps and MCP list APIs; tiering table still pending product confirmation per PR notes.
> 
> **Overview**
> Agent health moves from binary **healthy/unhealthy** to **healthy | degraded | unhealthy**, driven by per-issue severities (`blocking`, `degraded`, `info`) and a default tier table. Sidebar and notification signatures now include `code:severity` (e.g. `missing_cli_session_id:degraded`).
> 
> **Liveness and API behavior:** When the screen shows working/thinking but the registry is inactive, health emits `reconciled_state: "working"` and treats registry/screen disagreement as **info** (not blocking). `reconcileAgentLiveState` always prefers a live working/thinking screen over stale registry state; idle only clears a stale **error**. **`list_agents`** applies the `state` filter **after** enrichment so `state=working` matches reconciled agents.
> 
> **Notifications:** Channel health alerts fire only for **blocking unhealthy** status. Dedupe memory clears when health improves to non-unhealthy (including recovery from wedged → healthy without a new notification). Orphan surface health in resync uses the same degraded/unhealthy split and exposes `orphaned_health` separately from blocking `health_failures`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0471c31a5711bc35b0b82ab848fa2d184ec99c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tier agent health severity to distinguish degraded vs unhealthy states
> - `evaluateAgentHealth` now returns `'degraded'` for non-blocking issues and `'unhealthy'` only when at least one blocking issue exists, replacing the previous binary healthy/unhealthy result.
> - Per-issue severities are added to `AgentHealth` via `issue_severities` and surfaced in health summary strings (e.g. `unhealthy(code:blocking,other:degraded)`).
> - `reconciled_state` is set to `'working'` when screen activity contradicts an inactive registry state; `list_agents` now filters and returns agent state using this reconciled value.
> - Health lifecycle notifications are sent only when transitioning *to* `'unhealthy'`; recoveries no longer emit notifications but do clear prior health notification memory.
> - Behavioral Change: agents with only non-blocking issues now report `'degraded'` instead of `'unhealthy'`, which affects `list_agents` state filtering and sidebar/notification content.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dc0471c. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->