### PR TITLE
fix: report package version in server info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,28 +19,11 @@
  *                         wait_for_all, stop_agent, kill, interact
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
 import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";
-
-function readVersion(): string {
-  // package.json sits one level above the compiled entrypoint (dist/index.js
-  // → ../package.json, and likewise libexec/dist/index.js → libexec/package.json
-  // for a brew install). Best-effort; never throw from a --version probe.
-  try {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(
-      readFileSync(join(here, "..", "package.json"), "utf-8"),
-    ) as { version?: string };
-    return pkg.version ?? "unknown";
-  } catch {
-    return "unknown";
-  }
-}
+import { readVersion } from "./version.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
+import { readVersion } from "./version.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
@@ -1820,7 +1821,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const server = new McpServer(
     {
       name: "cmuxlayer",
-      version: "0.1.0",
+      version: readVersion(),
     },
     enableClaudeChannels
       ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function readVersion(): string {
+  // package.json sits one level above the compiled entrypoint (dist/version.js
+  // -> ../package.json, and likewise libexec/dist/version.js -> libexec/package.json
+  // for a brew install). Best-effort; never throw from a --version probe.
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "package.json"), "utf-8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer, __submitEvidenceTestHooks } from "../src/server.js";
@@ -65,6 +66,28 @@ describe("createServer", () => {
     const server = createServer({ skipAgentLifecycle: true });
     expect(server).toBeDefined();
     expect(typeof server.connect).toBe("function");
+  });
+
+  it("reports the package version in MCP serverInfo", async () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    ) as { version?: string };
+    const server = createServer({ skipAgentLifecycle: true });
+    const client = new Client({ name: "test-client", version: "0.1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    expect(client.getServerVersion()).toEqual({
+      name: "cmuxlayer",
+      version: packageJson.version,
+    });
+
+    await client.close();
   });
 
   it("registers Claude channel capability when enabled", () => {


### PR DESCRIPTION
## Summary
- Extract `readVersion()` into `src/version.ts` so CLI and MCP server metadata share the package-version source.
- Use the package-derived version for `McpServer` `serverInfo.version` instead of the stale hardcoded `0.1.0`.
- Add an MCP initialize regression test that asserts `serverInfo.version` matches `package.json`.

## Test plan
- RED: `bun run test -- tests/server.test.ts -t "reports the package version in MCP serverInfo"` failed with `version: "0.1.0"` vs `"0.3.6"`.
- GREEN: `bun run test -- tests/server.test.ts -t "reports the package version in MCP serverInfo"` passed.
- Full: `bun run typecheck && bun run test` passed: 71 test files, 1320 tests.
- Push hook reran the full suite and ended with `run_tests.sh finished with exit status 0`.

Supersedes stale PR #203; this branch is based after the phase-7 harvestability/topology work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and a small refactor only; no runtime behavior, auth, or workspace mutation paths change.
> 
> **Overview**
> MCP clients now see the real **`package.json` version** in initialize **`serverInfo`**, matching **`cmuxlayer --version`** and doctor output.
> 
> **`readVersion()`** moves from the CLI entrypoint into **`src/version.js`**, and **`createServer`** passes that value into **`McpServer`** metadata instead of the stale **`0.1.0`** constant. A new **`createServer`** test connects an in-memory MCP client and asserts **`getServerVersion()`** matches **`package.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985a21a25f18d1b120779f0f55663424edc26010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report actual package version in server info instead of hardcoded '0.1.0'
> Extracts version reading into a shared [`version.ts`](https://github.com/EtanHey/cmuxlayer/pull/234/files#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087) module that reads `../package.json` relative to the compiled file, returning `'unknown'` on any error. The `createServer` factory in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/234/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now calls `readVersion()` to set the `McpServer` version, and [`index.ts`](https://github.com/EtanHey/cmuxlayer/pull/234/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) imports from the same module instead of duplicating the logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 985a21a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server and CLI version information now comes from the app’s package version at runtime.
  * Added a best-effort version reader that falls back to `unknown` if the version can’t be determined.

* **Bug Fixes**
  * Replaced the previously hardcoded server version with a dynamic value to keep reported version details accurate.

* **Tests**
  * Added coverage to verify the server reports the expected version over the MCP connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->