### PR TITLE
fix: strip opaque agent progress bar

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -413,6 +413,7 @@ interface AgentEngineClient {
     value: number,
     opts?: { label?: string; workspace?: string; surface?: string },
   ): Promise<void>;
+  clearProgress(opts?: { workspace?: string }): Promise<void>;
   newSplit(
     direction: string,
     opts?: {
@@ -716,7 +717,6 @@ export class AgentEngine {
   private currentSweepScreenSignatures = new Map<string, string>();
   /** agentId → last-pushed status target/value */
   private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
-  private progressSnapshot: string | null = null;
   /** e.g. "a1:spawned", "a1:done", "a1:error" */
   private loggedEvents = new Set<string>();
   /** e.g. "a1:done", "a1:health:unhealthy(...)" */
@@ -2666,17 +2666,6 @@ export class AgentEngine {
         this.clearAgentLifecycleMemory(agentId);
       }
     }
-
-    // Progress bar
-    if (total > 0) {
-      const progressSnapshot = `${done}/${total}`;
-      if (this.progressSnapshot !== progressSnapshot) {
-        await this.client.setProgress(done / total, {
-          label: `agents ${done}/${total}`,
-        });
-        this.progressSnapshot = progressSnapshot;
-      }
-    }
   }
 
   /** Whether a startup purge is pending (opt-in via enableStartupPurge) */
@@ -2704,6 +2693,11 @@ export class AgentEngine {
     if (this.startupPurgePending) {
       this.startupPurgePending = false;
       const purgedIds = this.registry.purgeAllTerminal();
+      try {
+        await this.client.clearProgress();
+      } catch {
+        // Best-effort cleanup of the removed workspace-less progress row.
+      }
       // Seed sidebar snapshot so syncSidebar clears their cmux entries
       for (const purgedAgent of purgedIds) {
         this.sidebarSnapshot.set(purgedAgent.agent_id, {

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -173,6 +173,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       sendKey: (surface, key, keyOpts) =>
         this.withSurfaceWrite(surface, () => this.client.sendKey(surface, key, keyOpts)),
       setProgress: async () => {},
+      clearProgress: async () => {},
       newSplit: (direction, splitOpts) => this.client.newSplit(direction, splitOpts),
       newSurface: (surfaceOpts) => this.client.newSurface(surfaceOpts),
       selectWorkspace: (workspace) => this.client.selectWorkspace(workspace),

--- a/src/server.ts
+++ b/src/server.ts
@@ -5254,6 +5254,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ),
           setProgress: (value, progressOpts) =>
             client.setProgress(value, progressOpts),
+          clearProgress: (progressOpts) => client.clearProgress(progressOpts),
           newSplit: (direction, splitOpts) =>
             client.newSplit(direction, splitOpts),
           newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -210,6 +210,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.clearStatus).toHaveBeenCalledWith("stale-done-agent", {
       workspace: "workspace:previous-session",
     });
+    expect(mockClient.clearProgress).toHaveBeenCalledWith();
     expect(mockClient.setStatus).not.toHaveBeenCalledWith(
       "stale-done-agent",
       expect.any(String),
@@ -694,21 +695,42 @@ describe("Sidebar Sync", () => {
     expect(doneCall).toBeDefined();
   });
 
-  it("calls setProgress with ratio of done to total agents", async () => {
+  it("does not emit an opaque global progress bar while preserving agent status", async () => {
     stateMgr.writeState(
-      makeRecord({ agent_id: "a1", state: "done", surface_id: "surface:1" }),
+      makeRecord({
+        agent_id: "a1",
+        state: "working",
+        surface_id: "surface:1",
+        workspace_id: "workspace:alpha",
+        cli_session_id: "session-a1",
+      }),
     );
     stateMgr.writeState(
-      makeRecord({ agent_id: "a2", state: "working", surface_id: "surface:2" }),
+      makeRecord({
+        agent_id: "a2",
+        state: "done",
+        surface_id: "surface:2",
+        workspace_id: "workspace:beta",
+        cli_session_id: "session-a2",
+      }),
     );
     liveSurfaces = [makeSurface("surface:1"), makeSurface("surface:2")];
+    writeHeartbeat("a1", inboxOpts);
+    writeHeartbeat("a2", inboxOpts);
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
 
-    expect(mockClient.setProgress).toHaveBeenCalledWith(
-      0.5,
-      expect.objectContaining({ label: "agents 1/2" }),
+    expect(mockClient.setProgress).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "a1",
+      expect.stringContaining("state=working"),
+      expect.objectContaining({ workspace: "workspace:alpha" }),
+    );
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "a2",
+      expect.stringContaining("state=done"),
+      expect.objectContaining({ workspace: "workspace:beta" }),
     );
   });
 

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -112,6 +112,7 @@ function makeWorkspaceClient() {
     setStatus: vi.fn().mockResolvedValue(undefined),
     clearStatus: vi.fn().mockResolvedValue(undefined),
     setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),
     identify: vi.fn().mockResolvedValue({}),
     listStatus: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
## Summary
- Remove AgentEngine's workspace-less `setProgress(done/total)` emission and `progressSnapshot` bookkeeping.
- Keep per-agent `setStatus` sidebar sync unchanged.
- Clear the removed workspace-less progress row during startup purge so stale global bars have a cleanup path.

## Test plan
- [x] RED: `bunx vitest run tests/sidebar-sync.test.ts -t "opaque global progress|stale workspace"` failed on the old `setProgress(0.5, { label: "agents 1/2" })` call and missing startup `clearProgress()`.
- [x] GREEN: `bunx vitest run tests/sidebar-sync.test.ts -t "opaque global progress|stale workspace"`
- [x] `bunx vitest run tests/sidebar-sync.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] CodeRabbit pre-commit review: 0 findings
- [x] Pre-push hook reran `bun run test`: 71 files / 1319 tests passed

## Live proof
- Attempted rendered sidebar proof with cmux screenshots at `/tmp/cmuxlayer-strip-proof-before.png`, `/tmp/cmuxlayer-strip-proof-after.png`, and `/tmp/cmuxlayer-clear-progress-direct.png`.
- Result: not claimed as conclusive visual proof. The current running installed runtime still renders `agents N/M` rows, and direct `cmux clear-progress` did not remove those visible rows, so that UI state is not a reliable branch-backed proof of this source change.
- Branch-backed evidence is the TDD regression plus full typecheck/test/build above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar/progress behavior with best-effort clearProgress; no auth, data, or lifecycle logic changes beyond removing setProgress emission.
> 
> **Overview**
> Removes the workspace-less **agents N/M** progress bar that `syncSidebar` pushed on every sweep via `setProgress`, along with the `progressSnapshot` dedupe field. Per-agent sidebar **`setStatus`** sync is unchanged.
> 
> Adds **`clearProgress`** to the engine client contract and invokes it during **startup purge** (`enableStartupPurge` → first `runSweep`) so stale global progress rows can be cleared after terminal agents are purged. **`server.ts`** and **`app-server-runtime`** forward or no-op **`clearProgress`** like other cmux hooks.
> 
> Tests now expect no `setProgress` during normal sweeps and **`clearProgress()`** when startup purge runs on stale workspace agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a2383ad3540c9650cd2cec57a9f75bf197ef5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip opaque agent progress bar by replacing `setProgress` with `clearProgress` in `AgentEngine`
> - Removes the global progress bar update logic (`agents X/Y`) from `AgentEngine`, which previously called `client.setProgress` during sweeps.
> - Adds `clearProgress()` to the `AgentEngineClient` interface and calls it during startup purge of terminal agents to clean up any stale progress UI.
> - Wires `clearProgress` through to the external client in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/235/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and adds a no-op shim in [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/235/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3).
> - Behavioral Change: `setProgress` is no longer called during sweeps; callers that relied on the `agents X/Y` progress label will no longer receive it.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 49a2383. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->