### PR TITLE
test: add topology placement health fixture

### DIFF
--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -1,6 +1,10 @@
-import type { AgentRecord, AgentState } from "./agent-types.js";
+import type { AgentRecord, AgentRole, AgentState } from "./agent-types.js";
 import type { WorkerHarvestability } from "./agent-engine.js";
-import { inferRecordRoleOrNull } from "./layout-policy.js";
+import {
+  inferAgentRole,
+  inferRecordRoleOrNull,
+  isAgentRoleInferenceError,
+} from "./layout-policy.js";
 
 export type AgentHealthStatus = "healthy" | "degraded" | "unhealthy";
 export type AgentHealthIssueSeverity = "blocking" | "degraded" | "info";
@@ -171,6 +175,36 @@ function hasAmbiguousRepoOrCwdLabel(agent: AgentRecord): boolean {
   return (
     ambiguousNames.has(repo) ||
     /\/(?:gits|repos|projects|workspaces)\/?$/.test(cwd)
+  );
+}
+
+function inferRoleOrNull(input: {
+  role?: AgentRole;
+  launcherName?: string;
+  title?: string;
+  cli?: string;
+}): AgentRole | null {
+  try {
+    return inferAgentRole(input);
+  } catch (error) {
+    if (isAgentRoleInferenceError(error)) return null;
+    throw error;
+  }
+}
+
+function inferTopologyRole(
+  agent: AgentRecord,
+  input: AgentHealthInput,
+): AgentRole | null {
+  if (agent.role) return agent.role;
+
+  return (
+    inferRoleOrNull({ title: input.surface_title ?? undefined }) ??
+    inferRoleOrNull({
+      launcherName: agent.launcher_name ?? undefined,
+      cli: agent.cli,
+    }) ??
+    inferRecordRoleOrNull(agent)
   );
 }
 
@@ -374,6 +408,7 @@ export function evaluateAgentHealth(
   }
 
   const topology = input.topology;
+  const topologyRole = inferTopologyRole(agent, input) ?? role;
   if (topology && topology.column_count !== null) {
     if (topology.column_count >= 3) {
       addIssue(
@@ -383,7 +418,11 @@ export function evaluateAgentHealth(
         `workspace has ${topology.column_count} columns; expected at most two lead/worker columns`,
       );
     }
-    if (role === "orchestrator" && topology.column !== null && topology.column > 0) {
+    if (
+      topologyRole === "orchestrator" &&
+      topology.column !== null &&
+      topology.column > 0
+    ) {
       addIssue(
         issueCodes,
         issues,
@@ -391,7 +430,11 @@ export function evaluateAgentHealth(
         `orchestrator is in column ${topology.column}; expected leftmost column 0`,
       );
     }
-    if (role === "worker" && topology.column === 0 && topology.column_count >= 2) {
+    if (
+      topologyRole === "worker" &&
+      topology.column === 0 &&
+      topology.column_count >= 2
+    ) {
       addIssue(
         issueCodes,
         issues,

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { collectSurfaceTopology } from "../src/surface-topology.js";
+import { evaluateAgentHealth } from "../src/agent-health.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import {
+  collectSurfaceTopology,
+  healthTopologyOverrides,
+} from "../src/surface-topology.js";
 import type {
   CmuxPane,
   CmuxPaneSurfaces,
@@ -27,14 +32,98 @@ function pane(ref: string, index: number, surfaceRefs: string[]): CmuxPane {
   };
 }
 
-function surface(ref: string): CmuxSurface {
+function positionedPane(
+  ref: string,
+  index: number,
+  surfaceRefs: string[],
+  x: number,
+): CmuxPane {
+  return {
+    ...pane(ref, index, surfaceRefs),
+    pixel_frame: { x, y: 0, width: 500, height: 900 },
+  };
+}
+
+function surface(ref: string, title = ref): CmuxSurface {
   return {
     ref,
-    title: ref,
+    title,
     type: "terminal",
     index: 0,
     selected: false,
   };
+}
+
+function makeRecord(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "cmuxlayerCodex-topology-fixture",
+    surface_id: "surface:worker-right",
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "cmuxlayer",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: "019f0001-1111-7222-8333-444455556666",
+    cli_session_path: null,
+    launcher_name: null,
+    task_summary: "Topology fixture",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-06T12:00:00.000Z",
+    updated_at: "2026-07-06T12:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    boot_prompt_pending: false,
+    launch_cwd: null,
+    mcp_profile: null,
+    worktree_path: null,
+    worktree_branch: null,
+    ...overrides,
+  };
+}
+
+function makeTopologyClient(
+  panes: CmuxPane[],
+  groups: CmuxPaneSurfaces[],
+) {
+  return {
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [workspace("workspace:1")],
+    }),
+    listPanes: vi.fn().mockResolvedValue({
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      panes,
+    }),
+    listPaneSurfaces: vi.fn(
+      async (opts: { workspace?: string; pane?: string }) =>
+        groups.find((group) => group.pane_ref === opts.pane) ??
+        ({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: opts.pane ?? "pane:unknown",
+          surfaces: [],
+        } satisfies CmuxPaneSurfaces),
+    ),
+  };
+}
+
+function healthFor(
+  agent: AgentRecord,
+  snapshot: Awaited<ReturnType<typeof collectSurfaceTopology>>,
+) {
+  return evaluateAgentHealth(agent, {
+    monitor_alive: true,
+    ...healthTopologyOverrides(agent, snapshot),
+  });
 }
 
 describe("collectSurfaceTopology", () => {
@@ -71,6 +160,117 @@ describe("collectSurfaceTopology", () => {
     expect(snapshot?.topologyBySurface.get("surface:ok")).toEqual({
       column: 0,
       column_count: 2,
+    });
+  });
+
+  it("turns live pane placement into blocking role-zone health", async () => {
+    const panes = [
+      positionedPane("pane:left", 0, ["surface:worker-left"], 0),
+      positionedPane("pane:center", 1, ["surface:lead-center"], 500),
+      positionedPane("pane:right", 2, ["surface:worker-right"], 1000),
+    ];
+    const groups: CmuxPaneSurfaces[] = [
+      {
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:left",
+        surfaces: [surface("surface:worker-left", "cmuxlayerCodex W-A1")],
+      },
+      {
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:center",
+        surfaces: [surface("surface:lead-center", "cmuxlayerClaude-LEAD")],
+      },
+      {
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:right",
+        surfaces: [surface("surface:worker-right", "cmuxlayerCodex W-A2")],
+      },
+    ];
+    const snapshot = await collectSurfaceTopology(
+      makeTopologyClient(panes, groups),
+      "workspace:1",
+    );
+    expect(snapshot).not.toBeNull();
+
+    const centerLeadHealth = healthFor(
+      makeRecord({ surface_id: "surface:lead-center", role: undefined }),
+      snapshot,
+    );
+    expect(centerLeadHealth.status).toBe("unhealthy");
+    expect(centerLeadHealth.issue_codes).toEqual(
+      expect.arrayContaining([
+        "topology_three_or_more_columns",
+        "orchestrator_not_leftmost",
+      ]),
+    );
+    expect(centerLeadHealth.issue_severities).toMatchObject({
+      topology_three_or_more_columns: "blocking",
+      orchestrator_not_leftmost: "blocking",
+    });
+
+    const leftWorkerHealth = healthFor(
+      makeRecord({ surface_id: "surface:worker-left", role: undefined }),
+      snapshot,
+    );
+    expect(leftWorkerHealth.status).toBe("unhealthy");
+    expect(leftWorkerHealth.issue_codes).toEqual(
+      expect.arrayContaining([
+        "topology_three_or_more_columns",
+        "worker_in_leftmost_column",
+      ]),
+    );
+    expect(leftWorkerHealth.issue_severities).toMatchObject({
+      topology_three_or_more_columns: "blocking",
+      worker_in_leftmost_column: "blocking",
+    });
+  });
+
+  it("keeps the correct lead-left worker-right fixture healthy", async () => {
+    const panes = [
+      positionedPane("pane:left", 0, ["surface:lead-left"], 0),
+      positionedPane("pane:right", 1, ["surface:worker-right"], 500),
+    ];
+    const groups: CmuxPaneSurfaces[] = [
+      {
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:left",
+        surfaces: [surface("surface:lead-left", "cmuxlayerClaude-LEAD")],
+      },
+      {
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:right",
+        surfaces: [surface("surface:worker-right", "cmuxlayerCodex W-A1")],
+      },
+    ];
+    const snapshot = await collectSurfaceTopology(
+      makeTopologyClient(panes, groups),
+      "workspace:1",
+    );
+    expect(snapshot).not.toBeNull();
+    const lead = makeRecord({ surface_id: "surface:lead-left", role: undefined });
+    const worker = makeRecord({
+      surface_id: "surface:worker-right",
+      role: undefined,
+    });
+
+    expect(
+      healthFor(lead, snapshot),
+    ).toEqual({
+      status: "healthy",
+      issue_codes: [],
+      issues: [],
+    });
+    expect(
+      healthFor(worker, snapshot),
+    ).toEqual({
+      status: "healthy",
+      issue_codes: [],
+      issues: [],
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added a surface-topology fixture that converts live pane geometry into health checks for role-zone placement.
- Covers a bad layout where a visible `cmuxlayerClaude` lead is stranded in the center and a worker is in the leftmost column.
- Covers the good layout where the lead is in column 0 and worker is in the right column.
- Uses live surface launcher titles for topology role inference when the registry role is missing, so visual `*Claude` lead panes are checked with `orchestrator_not_leftmost`.

## Test plan
- RED: `bun test tests/surface-topology.test.ts` failed before the fix with missing `orchestrator_not_leftmost` and a false `worker_in_leftmost_column` on the correct fixture.
- GREEN: `bun test tests/surface-topology.test.ts`
- `bun test tests/agent-health.test.ts tests/surface-topology.test.ts`
- `bun run typecheck`
- `bun run typecheck && bun run test`
- Pre-push hook reran tests and ended with `run_tests.sh finished with exit status 0`.

## Review note
- Local `coderabbit review --agent` was attempted before commit and hit the free OSS rate limit: wait time 48 minutes. Proceeded on fresh local verification evidence per PR-loop fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how blocking topology health issues are raised for agents without explicit roles; behavior is test-covered but affects operational health signals.
> 
> **Overview**
> **Topology health checks now use a richer role guess** when `agent.role` is unset, so column placement rules apply to visually labeled lead/worker panes—not only registry-backed roles.
> 
> `evaluateAgentHealth` introduces `inferTopologyRole`, which prefers the stored role, then tries `inferAgentRole` from **surface title**, launcher/cli, and finally `inferRecordRoleOrNull`. **Orchestrator/worker column violations** (`orchestrator_not_leftmost`, `worker_in_leftmost_column`) and the three-column rule now key off this `topologyRole` instead of record-only inference.
> 
> **Tests** in `surface-topology.test.ts` wire live pane geometry through `collectSurfaceTopology` + `healthTopologyOverrides` into health: a bad three-column layout flags a center Claude lead and left worker; a correct lead-left / worker-right layout stays healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d826b3b4ec7db2db6c1841952de86dc85fad1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add topology placement health fixture with role inference from surface title and launcher
> - Adds `inferTopologyRole` in [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/236/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3) to determine an agent's role for topology checks by priority: explicit `agent.role`, then surface title inference, then launcher/CLI inference, then record-based fallback.
> - Updates `evaluateAgentHealth` to use this inferred topology role for `orchestrator_not_leftmost` and `worker_in_leftmost_column` checks, while keeping other checks (e.g. `non_claude_orchestrator`) on the original record-inferred role.
> - Adds integration tests in [surface-topology.test.ts](https://github.com/EtanHey/cmuxlayer/pull/236/files#diff-7eeb9cf3fee910feac78b564eddc884ef47f21236bac5a9a55622e270da07a8d) covering a three-column layout (yields blocking issues) and a correct two-column layout (yields healthy status).
> - Behavioral Change: agents without an explicit role but with a matching surface title or launcher/CLI may now trigger or clear topology health issue codes that previously required an explicit role.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 03d826b. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->