### PR TITLE
fix: alert on lead monitor death

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2440,7 +2440,7 @@ export class AgentEngine {
     }
 
     if (healthInput.monitor_alive === false) {
-      return true;
+      return readLastAgentHeartbeat(agent.agent_id, this.inboxOpts) !== null;
     }
 
     if (

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -83,14 +83,18 @@ import {
   DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY,
   evaluateAgentHealth,
   type AgentHealth,
+  type AgentHealthInput,
 } from "./agent-health.js";
-import { buildAgentHealthInput } from "./agent-health-input.js";
+import {
+  AGENT_HEALTH_MONITOR_MAX_AGE_MS,
+  buildAgentHealthInput,
+} from "./agent-health-input.js";
 import {
   collectSurfaceTopology,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
 } from "./surface-topology.js";
-import type { InboxOpts } from "./inbox.js";
+import { readLastAgentHeartbeat, type InboxOpts } from "./inbox.js";
 
 type ProcessLiveness = "alive" | "gone" | "unknown";
 
@@ -263,6 +267,11 @@ interface SidebarStatusSnapshot {
   surfaceId: string | null;
   workspaceId: string | null;
   healthSignature: string;
+}
+
+interface LeadMonitorDeathTimer {
+  timer: ReturnType<typeof setTimeout>;
+  dueAtMs: number;
 }
 
 export interface SweepTimingOptions {
@@ -446,6 +455,13 @@ interface AgentEngineClient {
     surface: string,
     opts?: { workspace?: string; collapsePane?: boolean },
   ): Promise<void>;
+  notify?(opts?: {
+    title?: string;
+    subtitle?: string;
+    body?: string;
+    workspace?: string;
+    surface?: string;
+  }): Promise<void>;
   notifyLifecycleEvent(
     event: AgentLifecycleEvent,
     agent: AgentRecord,
@@ -721,6 +737,10 @@ export class AgentEngine {
   private loggedEvents = new Set<string>();
   /** e.g. "a1:done", "a1:health:unhealthy(...)" */
   private notifiedEvents = new Set<string>();
+  /** agentId values whose current lead monitor-death alert was delivered. */
+  private deliveredLeadMonitorDeathAlerts = new Set<string>();
+  /** agentId → wake-on-timeout timer for lead monitor-death detection. */
+  private leadMonitorDeathTimers = new Map<string, LeadMonitorDeathTimer>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
   constructor(
@@ -1817,6 +1837,10 @@ export class AgentEngine {
     );
     this.rekeyAgentEventSet(this.loggedEvents, previousAgentId, nextAgentId);
     this.rekeyAgentEventSet(this.notifiedEvents, previousAgentId, nextAgentId);
+    if (this.deliveredLeadMonitorDeathAlerts.delete(previousAgentId)) {
+      this.deliveredLeadMonitorDeathAlerts.add(nextAgentId);
+    }
+    this.transferLeadMonitorDeathTimer(previousAgentId, nextAgentId);
   }
 
   private finalizeCapturedSession(
@@ -2363,6 +2387,146 @@ export class AgentEngine {
         this.notifiedEvents.delete(key);
       }
     }
+    this.deliveredLeadMonitorDeathAlerts.delete(agentId);
+    this.clearLeadMonitorDeathTimer(agentId);
+  }
+
+  private clearLeadMonitorDeathTimer(agentId: string): void {
+    const entry = this.leadMonitorDeathTimers.get(agentId);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    this.leadMonitorDeathTimers.delete(agentId);
+  }
+
+  private armLeadMonitorDeathTimer(
+    agentId: string,
+    delayMs: number,
+    dueAtMs: number,
+  ): void {
+    const timer = setTimeout(() => {
+      this.leadMonitorDeathTimers.delete(agentId);
+      void this.fireLeadMonitorDeathDeadman(agentId);
+    }, delayMs);
+    this.leadMonitorDeathTimers.set(agentId, { timer, dueAtMs });
+  }
+
+  private transferLeadMonitorDeathTimer(
+    previousAgentId: string,
+    nextAgentId: string,
+  ): void {
+    const entry = this.leadMonitorDeathTimers.get(previousAgentId);
+    if (!entry) return;
+
+    clearTimeout(entry.timer);
+    this.leadMonitorDeathTimers.delete(previousAgentId);
+    if (this.leadMonitorDeathTimers.has(nextAgentId)) {
+      return;
+    }
+
+    const now = (this.inboxOpts?.now ?? Date.now)();
+    this.armLeadMonitorDeathTimer(
+      nextAgentId,
+      Math.max(0, entry.dueAtMs - now),
+      entry.dueAtMs,
+    );
+  }
+
+  private isLeadWatchBlind(
+    agent: AgentRecord,
+    healthInput: AgentHealthInput,
+  ): boolean {
+    if (inferRecordRoleOrNull(agent) !== "orchestrator") {
+      return false;
+    }
+
+    if (healthInput.monitor_alive === false) {
+      return true;
+    }
+
+    if (
+      agent.pid !== null &&
+      agent.pid !== undefined &&
+      this.processLiveness(agent.pid) === "gone"
+    ) {
+      return true;
+    }
+
+    return (
+      agent.state === "error" &&
+      /\b(?:pty|session|process|pane|surface|disappeared)\b/i.test(
+        agent.error ?? "",
+      )
+    );
+  }
+
+  private async maybeNotifyLeadMonitorDeath(
+    agent: AgentRecord,
+    healthInput: AgentHealthInput,
+  ): Promise<void> {
+    if (inferRecordRoleOrNull(agent) !== "orchestrator") {
+      this.clearLeadMonitorDeathTimer(agent.agent_id);
+      this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
+      return;
+    }
+
+    if (!this.isLeadWatchBlind(agent, healthInput)) {
+      this.scheduleLeadMonitorDeathDeadman(agent);
+      this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
+      return;
+    }
+
+    this.clearLeadMonitorDeathTimer(agent.agent_id);
+    if (this.deliveredLeadMonitorDeathAlerts.has(agent.agent_id)) {
+      return;
+    }
+
+    if (!this.client.notify) {
+      return;
+    }
+
+    const workspace = agent.workspace_id ?? "unknown";
+    try {
+      await this.client.notify({
+        title: "Lead monitor/session ended",
+        subtitle: `${agent.repo} lead ${agent.agent_id}`,
+        body: `Lead seat ${agent.agent_id} in workspace ${workspace} is watch-blind: monitor/session ended - lead is watch-blind. Last-known state: ${agent.state}.`,
+        workspace: agent.workspace_id ?? undefined,
+        surface: agent.surface_id,
+      });
+      this.deliveredLeadMonitorDeathAlerts.add(agent.agent_id);
+    } catch {
+      // Notification delivery is best-effort; do not break sweeps. Retry next sweep.
+    }
+  }
+
+  private scheduleLeadMonitorDeathDeadman(agent: AgentRecord): void {
+    this.clearLeadMonitorDeathTimer(agent.agent_id);
+
+    const heartbeat = readLastAgentHeartbeat(agent.agent_id, this.inboxOpts);
+    if (!heartbeat) {
+      return;
+    }
+
+    const now = (this.inboxOpts?.now ?? Date.now)();
+    const ageMs = Math.max(0, now - heartbeat.ts_ms);
+    const delayMs = Math.max(
+      0,
+      AGENT_HEALTH_MONITOR_MAX_AGE_MS - ageMs + 1,
+    );
+    this.armLeadMonitorDeathTimer(agent.agent_id, delayMs, now + delayMs);
+  }
+
+  private async fireLeadMonitorDeathDeadman(agentId: string): Promise<void> {
+    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    if (!agent) {
+      this.clearLeadMonitorDeathTimer(agentId);
+      return;
+    }
+
+    const healthInput = await buildAgentHealthInput(agent, {
+      inboxOpts: this.inboxOpts,
+    });
+    await this.maybeNotifyLeadMonitorDeath(agent, healthInput);
   }
 
   private async logLifecycleEvent(
@@ -2505,6 +2669,7 @@ export class AgentEngine {
         },
       );
       const health = evaluateAgentHealth(agent, healthInput);
+      await this.maybeNotifyLeadMonitorDeath(agent, healthInput);
       const healthSignature = this.healthSignature(health);
       const statusValue = this.buildSidebarStatusValue(
         agent,
@@ -2807,6 +2972,10 @@ export class AgentEngine {
       clearTimeout(timer);
     }
     this.postSpawnLivenessTimers.clear();
+    for (const entry of this.leadMonitorDeathTimers.values()) {
+      clearTimeout(entry.timer);
+    }
+    this.leadMonitorDeathTimers.clear();
     this.sweepTiming = null;
     this.lastSweepSignature = null;
     this.unchangedSweepCount = 0;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -182,6 +182,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         this.withSurfaceWrite(surface, () =>
           this.client.closeSurface(surface, closeOpts),
         ),
+      notify: (notifyOpts) => this.client.notify(notifyOpts),
       notifyLifecycleEvent: async () => {},
     }, {
       launchCommandSender: async ({ surface, workspace, command }) => {

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -273,7 +273,7 @@ export function readLastHeartbeat(
   return last ? parseHeartbeatLine(last) : null;
 }
 
-function readLastAgentHeartbeat(
+export function readLastAgentHeartbeat(
   agentId: string,
   opts?: InboxOpts,
 ): MonitorHeartbeat | null {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5267,6 +5267,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               () => client.closeSurface(surface, closeOpts),
               { toolName: "close_surface", workspace: closeOpts?.workspace },
             ),
+          notify: (notifyOpts) => client.notify(notifyOpts),
           notifyLifecycleEvent,
         },
         {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -10,13 +10,15 @@ import { AgentEngine } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { ack, dispatch, writeHeartbeat } from "../src/inbox.js";
+import { AGENT_HEALTH_MONITOR_MAX_AGE_MS } from "../src/agent-health-input.js";
 import type { CmuxClient } from "../src/cmux-client.js";
-import type { AgentRecord } from "../src/agent-types.js";
+import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-sidebar");
 
 type MockClient = CmuxClient & {
+  notify: ReturnType<typeof vi.fn>;
   notifyLifecycleEvent: ReturnType<typeof vi.fn>;
 };
 
@@ -49,6 +51,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): MockClient {
     identify: vi.fn().mockResolvedValue({}),
     browser: vi.fn().mockResolvedValue({}),
     log: vi.fn().mockResolvedValue(undefined),
+    notify: vi.fn().mockResolvedValue(undefined),
     notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as MockClient;
@@ -116,6 +119,7 @@ describe("Sidebar Sync", () => {
 
   afterEach(() => {
     engine.dispose();
+    vi.useRealTimers();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
@@ -555,6 +559,244 @@ describe("Sidebar Sync", () => {
       expect.objectContaining({ agent_id: agentId }),
       healthSummary,
     ]);
+  });
+
+  it("fires one proactive alert when a lead monitor heartbeat goes stale", async () => {
+    const inboxDir = join(TEST_DIR, "lead-stale-monitor-inbox");
+    const agentId = "cmuxlayer-lead-stale-monitor";
+    let now = 1_000_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:lead-stale",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-lead-stale",
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:lead-stale")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    now += 61_000;
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+    await engine.runSweep();
+
+    expect(mockClient.notify).toHaveBeenCalledTimes(1);
+    expect(mockClient.notify).toHaveBeenCalledWith({
+      title: "Lead monitor/session ended",
+      subtitle: "cmuxlayer lead cmuxlayer-lead-stale-monitor",
+      body: "Lead seat cmuxlayer-lead-stale-monitor in workspace workspace:cmuxlayer is watch-blind: monitor/session ended - lead is watch-blind. Last-known state: working.",
+      workspace: "workspace:cmuxlayer",
+      surface: "surface:lead-stale",
+    });
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalledWith(
+      "health",
+      expect.objectContaining({ agent_id: agentId }),
+      expect.stringContaining("inbox_monitor_not_alive"),
+    );
+  });
+
+  it("does not fire the proactive monitor-death alert for a worker", async () => {
+    const inboxDir = join(TEST_DIR, "worker-stale-monitor-inbox");
+    const agentId = "cmuxlayer-worker-stale-monitor";
+    let now = 2_000_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:worker-stale",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-worker-stale",
+        role: "worker",
+        repo: "cmuxlayer",
+        task_summary: "Worker remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:worker-stale")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    now += 61_000;
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notify).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      agentId,
+      expect.stringContaining(
+        "health=degraded(inbox_monitor_not_alive:degraded)",
+      ),
+      expect.any(Object),
+    );
+  });
+
+  it("re-arms the lead monitor-death alert after heartbeat recovery", async () => {
+    const inboxDir = join(TEST_DIR, "lead-monitor-rearm-inbox");
+    const agentId = "cmuxlayer-lead-monitor-rearm";
+    let now = 3_000_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:lead-rearm",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-lead-rearm",
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:lead-rearm")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    now += 61_000;
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    now += 1_000;
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await engine.runSweep();
+
+    now += 61_000;
+    await engine.runSweep();
+
+    expect(mockClient.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it("deadman timeout fires a lead monitor-death alert without a follow-up sweep", async () => {
+    vi.useFakeTimers();
+    const inboxDir = join(TEST_DIR, "lead-monitor-deadman-inbox");
+    const agentId = "cmuxlayer-lead-monitor-deadman";
+    let now = 4_000_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:lead-deadman",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-lead-deadman",
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:lead-deadman")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+    });
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notify).not.toHaveBeenCalled();
+
+    now += AGENT_HEALTH_MONITOR_MAX_AGE_MS + 1;
+    const advanceTimersByTimeAsync = (
+      vi as unknown as {
+        advanceTimersByTimeAsync?: (ms: number) => Promise<void>;
+      }
+    ).advanceTimersByTimeAsync;
+    if (advanceTimersByTimeAsync) {
+      await advanceTimersByTimeAsync.call(
+        vi,
+        AGENT_HEALTH_MONITOR_MAX_AGE_MS + 1,
+      );
+    } else {
+      vi.advanceTimersByTime(AGENT_HEALTH_MONITOR_MAX_AGE_MS + 1);
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    expect(mockClient.notify).toHaveBeenCalledTimes(1);
+    expect(mockClient.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Lead monitor/session ended",
+        surface: "surface:lead-deadman",
+        workspace: "workspace:cmuxlayer",
+      }),
+    );
+  });
+
+  it("lead monitor-death delivery memory follows session-capture rename", async () => {
+    const inboxDir = join(TEST_DIR, "lead-monitor-rename-deadman-inbox");
+    const pendingAgentId = "claude-cmuxlayer-pending-lead";
+    const sessionId = "12345678-1234-1234-1234-123456789abc";
+    const finalAgentId = generateAgentId("claude", "cmuxlayer", sessionId);
+    let now = 5_000_000;
+    let capturedSessionId: string | null = null;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: pendingAgentId,
+        state: "working",
+        surface_id: "surface:lead-rename",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: null,
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:lead-rename")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+      sessionIdentityResolver: () => capturedSessionId,
+    });
+    writeHeartbeat(pendingAgentId, { baseDir: inboxDir, now: () => now });
+    now += AGENT_HEALTH_MONITOR_MAX_AGE_MS + 1;
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notify).toHaveBeenCalledTimes(1);
+    expect(mockClient.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subtitle: `cmuxlayer lead ${pendingAgentId}`,
+        body: expect.stringContaining(`Lead seat ${pendingAgentId}`),
+      }),
+    );
+
+    capturedSessionId = sessionId;
+    await engine.runSweep();
+
+    expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    expect(stateMgr.readState(finalAgentId)).not.toBeNull();
+    expect(mockClient.notify).toHaveBeenCalledTimes(1);
   });
 
   it("does not emit done notifications until a worker has verified terminal evidence", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -608,6 +608,45 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("does not alert when a lead monitor was never armed", async () => {
+    const inboxDir = join(TEST_DIR, "lead-never-armed-monitor-inbox");
+    const agentId = "cmuxlayer-lead-never-armed-monitor";
+    let now = 1_500_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:lead-never-armed",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-lead-never-armed",
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:lead-never-armed")];
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+    });
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notify).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      agentId,
+      expect.stringContaining(
+        "health=degraded(inbox_monitor_not_alive:degraded)",
+      ),
+      expect.any(Object),
+    );
+  });
+
   it("does not fire the proactive monitor-death alert for a worker", async () => {
     const inboxDir = join(TEST_DIR, "worker-stale-monitor-inbox");
     const agentId = "cmuxlayer-worker-stale-monitor";


### PR DESCRIPTION
## Summary
- Add proactive cmux `notify` alerts when an orchestrator/lead becomes watch-blind from stale monitor heartbeat, ended PTY/process, or ended session signal.
- Add a wake-on-timeout DEADMAN timer keyed from the last agent heartbeat so a stale lead monitor can alert without waiting for a later sweep.
- Dedup one alert per death, re-arm on heartbeat recovery, and preserve alert/timer memory through session-capture agent ID renames.

## Test plan
- [x] RED observed: new sidebar-sync tests failed before implementation for missing lead alert / re-arm / deadman behavior.
- [x] `bun run typecheck`
- [x] `bun run test` (71 files, 1324 tests)
- [x] Push hook `run_tests.sh` completed with exit status 0.

## Live-proof payload
For the predecessor `surface:13` lead death, the alert payload would be:

```json
{
  "title": "Lead monitor/session ended",
  "subtitle": "<repo> lead <lead-agent-id>",
  "body": "Lead seat <lead-agent-id> in workspace <workspace-ref> is watch-blind: monitor/session ended - lead is watch-blind. Last-known state: <state>.",
  "workspace": "<workspace-ref>",
  "surface": "surface:13"
}
```

## Reviewer note
- Local CodeRabbit pre-commit review surfaced one MAJOR rename-cache issue; fixed in this branch with regression coverage.
- A second local CodeRabbit run hit the free OSS rate limit (`waitTime: 48 minutes`), so PR-level bot review is still requested.

Do not merge from this worker; lead owns merge post-review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator lifecycle monitoring and timed notifications during sweeps; misclassification could alert late or duplicate, but scope is limited to orchestrators and delivery is best-effort.
> 
> **Overview**
> Adds **proactive cmux notifications** when an orchestrator (lead) becomes **watch-blind**—stale inbox monitor heartbeat (only if a prior agent heartbeat existed), dead process, or session/pane error signals—via optional `client.notify` on `AgentEngineClient`.
> 
> During sweeps, **`maybeNotifyLeadMonitorDeath`** runs after health input is built. It sends a **one-time** “Lead monitor/session ended” alert per death, clears/re-arms on recovery, and **does not** alert workers or leads that never had a monitor heartbeat. A **deadman timer** keyed off `AGENT_HEALTH_MONITOR_MAX_AGE_MS` and `readLastAgentHeartbeat` (newly exported from `inbox.ts`) can fire the same path **without waiting for the next sweep**. Alert and timer state **transfer on session-capture agent ID renames** and are cleared on dispose/agent cleanup.
> 
> **`notify`** is wired through the `AgentEngine` client adapters in **`server.ts`** and **`app-server-runtime.ts`**. **`sidebar-sync.test.ts`** adds coverage for stale heartbeat, never-armed monitor, worker exclusion, re-arm after recovery, deadman timeout, and rename dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52446a47d4342a5afc424789a810983842be3d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Alert on lead monitor death in `AgentEngine`
> - Adds `maybeNotifyLeadMonitorDeath` to [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/237/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) that fires a single `client.notify` alert when an orchestrator agent becomes watch-blind (monitor stopped, process gone, or heartbeat aged out).
> - Introduces deadman timers (`scheduleLeadMonitorDeathDeadman`) that fire the alert after `AGENT_HEALTH_MONITOR_MAX_AGE_MS` even without a subsequent sweep; timers re-arm after heartbeat recovery and transfer across agent ID renames.
> - Extends `AgentEngineClient` with an optional `notify` method, wired through in [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/237/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/237/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595).
> - Exports `readLastAgentHeartbeat` from [inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/237/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) to support heartbeat staleness checks.
> - Behavioral Change: orchestrators that are watch-blind will now trigger a notification; duplicate alerts are suppressed via a delivery memory set that is cleared on record purge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52446a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->