### PR TITLE
fix: assert spawned agent seat identity

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -90,6 +90,11 @@ import {
   buildAgentHealthInput,
 } from "./agent-health-input.js";
 import {
+  assertSeatIdentity,
+  loadSeatRegistryFromConfig,
+  type SeatRegistry,
+} from "./seat-identity.js";
+import {
   collectSurfaceTopology,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
@@ -223,6 +228,8 @@ export interface AgentEngineOptions {
     command: string;
   }) => Promise<void>;
   inboxOpts?: InboxOpts;
+  seatRegistry?: SeatRegistry | null;
+  seatRegistryPath?: string;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
@@ -725,6 +732,7 @@ export class AgentEngine {
   private inboxOpts?: InboxOpts;
   private sessionIdentityResolver: SessionIdentityResolver;
   private hasCustomSessionIdentityResolver: boolean;
+  private seatRegistry: SeatRegistry | null;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
   private postSpawnLivenessTimers = new Set<ReturnType<typeof setTimeout>>();
   private sweepTiming: SweepTimingOptions | null = null;
@@ -755,6 +763,10 @@ export class AgentEngine {
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
     this.inboxOpts = opts?.inboxOpts;
+    this.seatRegistry =
+      opts?.seatRegistry !== undefined
+        ? opts.seatRegistry
+        : this.loadSeatRegistry(opts?.seatRegistryPath);
     this.hasCustomSessionIdentityResolver =
       opts?.sessionIdentityResolver !== undefined;
     this.sessionIdentityResolver =
@@ -797,6 +809,14 @@ export class AgentEngine {
           };
         }
       });
+  }
+
+  private loadSeatRegistry(configPath: string | undefined): SeatRegistry | null {
+    try {
+      return loadSeatRegistryFromConfig(configPath);
+    } catch {
+      return null;
+    }
   }
 
   getRegistry(): AgentRegistry {
@@ -2360,6 +2380,8 @@ export class AgentEngine {
     return [
       agent.repo,
       `role=${role}`,
+      agent.seat_id ? `seat=${agent.seat_id}` : null,
+      agent.seat_lane ? `lane=${agent.seat_lane}` : null,
       `state=${agent.state}`,
       `health=${this.formatHealthSummary(health)}`,
       `blocked=${this.formatBlockedSummary(agent, health)}`,
@@ -2368,7 +2390,9 @@ export class AgentEngine {
       `branch=${this.compactSidebarValue(agent.worktree_branch)}`,
       `report=${this.formatReportSummary(harvestability)}`,
       `pr=${this.formatPrSummary(harvestability)}`,
-    ].join(" | ");
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join(" | ");
   }
 
   private healthSignature(health: AgentHealth): string {
@@ -3088,6 +3112,12 @@ export class AgentEngine {
     this.spawnGuard.check(spawnParams.workspace);
 
     const preflight = await this.spawnPreflight(spawnParams);
+    const seatIdentity = assertSeatIdentity({
+      repo: spawnParams.repo,
+      cli: spawnParams.cli,
+      launcherName: preflight?.launcherName ?? null,
+      registry: this.seatRegistry,
+    });
 
     // 1. Create cmux surface using the deterministic worker layout policy.
     const surface = await this.createAgentSurface(spawnParams.workspace, {
@@ -3109,6 +3139,11 @@ export class AgentEngine {
       cli_session_id: null,
       cli_session_path: null,
       launcher_name: preflight?.launcherName ?? null,
+      seat_id: seatIdentity.seat_id,
+      seat_lane: seatIdentity.seat_lane,
+      seat_role: seatIdentity.seat_role,
+      seat_identity_status: seatIdentity.seat_identity_status,
+      seat_identity_error: seatIdentity.seat_identity_error,
       task_summary: spawnParams.prompt,
       pid: null,
       version: 1,
@@ -3173,6 +3208,11 @@ export class AgentEngine {
       throw error;
     }
     this.schedulePostSpawnLivenessAssertion(agentId);
+    const seatWarnings =
+      seatIdentity.seat_identity_status === "mismatch" &&
+      seatIdentity.seat_identity_error
+        ? [`Seat identity mismatch: ${seatIdentity.seat_identity_error}`]
+        : [];
 
     return {
       agent_id: agentId,
@@ -3182,7 +3222,11 @@ export class AgentEngine {
       state: "booting",
       model: modelPolicy.effective_model,
       requested_model: modelPolicy.requested_model,
-      warnings: [...modelPolicy.warnings, ...(surface.warnings ?? [])],
+      warnings: [
+        ...modelPolicy.warnings,
+        ...(surface.warnings ?? []),
+        ...seatWarnings,
+      ],
       model_policy: modelPolicy,
       cwd: spawnParams.cwd,
       mcp_env: spawnParams.mcp_env,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -26,6 +26,7 @@ export type AgentHealthIssueCode =
   | "recoverable_blocker_requires_action"
   | "missing_managed_lead_agent_id"
   | "ambiguous_repo_cwd_label"
+  | "seat_identity_mismatch"
   | "non_claude_orchestrator"
   | "topology_three_or_more_columns"
   | "orchestrator_not_leftmost"
@@ -42,6 +43,7 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   degraded_evidence_channel: "blocking",
   recoverable_blocker_requires_action: "blocking",
   registry_surface_workspace_mismatch: "blocking",
+  seat_identity_mismatch: "blocking",
   topology_three_or_more_columns: "blocking",
   orchestrator_not_leftmost: "blocking",
   worker_in_leftmost_column: "blocking",
@@ -216,6 +218,16 @@ export function evaluateAgentHealth(
   const issues: string[] = [];
   const recommendedActions: string[] = [];
   const role = inferRecordRoleOrNull(agent);
+
+  if (agent.seat_identity_status === "mismatch") {
+    addIssue(
+      issueCodes,
+      issues,
+      "seat_identity_mismatch",
+      agent.seat_identity_error ??
+        "spawned agent seat identity does not match the registry",
+    );
+  }
 
   if (isAutoDiscovered(agent)) {
     addIssue(

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -16,6 +16,7 @@ export type CliType = "claude" | "codex" | "gemini" | "kiro" | "cursor";
 
 export type AgentQuality = "unknown" | "verified" | "suspect" | "degraded";
 export type AgentRole = "orchestrator" | "ic" | "worker";
+export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
 
 export const MAX_SPAWN_DEPTH = 2;
 export const MAX_CHILDREN = 10;
@@ -32,6 +33,11 @@ export interface AgentRecord {
   cli_session_id: string | null;
   cli_session_path?: string | null;
   launcher_name?: string | null;
+  seat_id?: string | null;
+  seat_lane?: string | null;
+  seat_role?: string | null;
+  seat_identity_status?: SeatIdentityStatus;
+  seat_identity_error?: string | null;
   task_summary: string;
   pid: number | null;
   version: number;

--- a/src/seat-identity.ts
+++ b/src/seat-identity.ts
@@ -1,0 +1,238 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { CliType } from "./agent-types.js";
+import { reposEquivalent } from "./repo-workspace.js";
+
+export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
+
+export interface SeatRegistryEntry {
+  repo: string;
+  launchers: Partial<Record<CliType, string>>;
+  lane: string;
+  aliases?: string[];
+  role?: string;
+}
+
+export type SeatRegistry = Record<string, SeatRegistryEntry>;
+
+export interface SeatIdentityAssertion {
+  seat_id: string | null;
+  seat_lane: string | null;
+  seat_role: string | null;
+  seat_identity_status: SeatIdentityStatus;
+  seat_identity_error: string | null;
+}
+
+export interface AssertSeatIdentityInput {
+  repo: string;
+  cli: CliType;
+  launcherName?: string | null;
+  lane?: string | null;
+  registry?: SeatRegistry | null;
+}
+
+const REPO_ALIASES: Record<string, string[]> = {
+  orchestrator: ["orc"],
+  orc: ["orchestrator"],
+};
+
+function cleanScalar(value: string): string {
+  const withoutComment = value.replace(/\s+#.*$/, "").trim();
+  if (
+    (withoutComment.startsWith('"') && withoutComment.endsWith('"')) ||
+    (withoutComment.startsWith("'") && withoutComment.endsWith("'"))
+  ) {
+    return withoutComment.slice(1, -1);
+  }
+  return withoutComment;
+}
+
+export function parseSeatRegistryConfig(raw: string): SeatRegistry {
+  const lines = raw.split(/\r?\n/);
+  const registry: SeatRegistry = {};
+  const startIndex = lines.findIndex((line) => /^seatRegistry:\s*$/.test(line));
+  if (startIndex === -1) return registry;
+
+  let currentSeatId: string | null = null;
+  let inLaunchers = false;
+
+  for (const line of lines.slice(startIndex + 1)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent === 0) break;
+
+    const seatMatch = line.match(/^  ([^:\s][^:]*):\s*$/);
+    if (seatMatch) {
+      currentSeatId = seatMatch[1].trim();
+      registry[currentSeatId] = {
+        repo: "",
+        launchers: {},
+        lane: "",
+      };
+      inLaunchers = false;
+      continue;
+    }
+
+    if (!currentSeatId) continue;
+    const entry = registry[currentSeatId];
+    if (!entry) continue;
+
+    if (/^    launchers:\s*$/.test(line)) {
+      inLaunchers = true;
+      continue;
+    }
+
+    const fieldMatch = line.match(/^    ([^:\s][^:]*):\s*(.*)$/);
+    if (fieldMatch) {
+      inLaunchers = false;
+      const [, key, rawValue] = fieldMatch;
+      if (key === "repo") entry.repo = cleanScalar(rawValue);
+      if (key === "lane") entry.lane = cleanScalar(rawValue);
+      if (key === "role") entry.role = cleanScalar(rawValue);
+      continue;
+    }
+
+    if (inLaunchers) {
+      const launcherMatch = line.match(/^      ([^:\s][^:]*):\s*(.*)$/);
+      if (launcherMatch) {
+        const [, key, rawValue] = launcherMatch;
+        if (isCliType(key)) {
+          entry.launchers[key] = cleanScalar(rawValue);
+        }
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(registry).filter(
+      ([, entry]) =>
+        entry.repo && entry.lane && Object.keys(entry.launchers).length > 0,
+    ),
+  );
+}
+
+export function defaultSeatRegistryPath(): string {
+  return join(homedir(), ".golems", "config.yaml");
+}
+
+export function loadSeatRegistryFromConfig(
+  configPath = defaultSeatRegistryPath(),
+): SeatRegistry | null {
+  if (!existsSync(configPath)) return null;
+  return parseSeatRegistryConfig(readFileSync(configPath, "utf8"));
+}
+
+function isCliType(value: string): value is CliType {
+  return (
+    value === "claude" ||
+    value === "codex" ||
+    value === "gemini" ||
+    value === "kiro" ||
+    value === "cursor"
+  );
+}
+
+function entryAssertion(
+  seatId: string,
+  entry: SeatRegistryEntry,
+  status: SeatIdentityStatus,
+  error: string | null,
+): SeatIdentityAssertion {
+  return {
+    seat_id: seatId,
+    seat_lane: entry.lane || null,
+    seat_role: entry.role ?? null,
+    seat_identity_status: status,
+    seat_identity_error: error,
+  };
+}
+
+function unknownAssertion(reason: string | null = null): SeatIdentityAssertion {
+  return {
+    seat_id: null,
+    seat_lane: null,
+    seat_role: null,
+    seat_identity_status: "unknown",
+    seat_identity_error: reason,
+  };
+}
+
+function launcherFor(entry: SeatRegistryEntry, cli: CliType): string | null {
+  return entry.launchers[cli] ?? null;
+}
+
+function seatReposEquivalent(a: string, b: string): boolean {
+  if (reposEquivalent(a, b)) return true;
+  const left = a.trim().toLowerCase();
+  const right = b.trim().toLowerCase();
+  return (
+    (REPO_ALIASES[left] ?? []).includes(right) ||
+    (REPO_ALIASES[right] ?? []).includes(left)
+  );
+}
+
+export function assertSeatIdentity(
+  input: AssertSeatIdentityInput,
+): SeatIdentityAssertion {
+  const registryEntries = Object.entries(input.registry ?? {});
+  if (registryEntries.length === 0) return unknownAssertion();
+
+  const launcherName = input.launcherName?.trim() || null;
+  const lane = input.lane?.trim() || null;
+  const repoEntries = registryEntries.filter(([, entry]) =>
+    seatReposEquivalent(entry.repo, input.repo),
+  );
+  const launcherEntries = launcherName
+    ? registryEntries.filter(
+        ([, entry]) => launcherFor(entry, input.cli) === launcherName,
+      )
+    : [];
+
+  const exactMatch = registryEntries.find(
+    ([, entry]) =>
+      launcherName &&
+      seatReposEquivalent(entry.repo, input.repo) &&
+      launcherFor(entry, input.cli) === launcherName &&
+      (!lane || entry.lane === lane),
+  );
+  if (exactMatch) {
+    const [seatId, entry] = exactMatch;
+    return entryAssertion(seatId, entry, "ok", null);
+  }
+
+  const launcherMatch = launcherEntries[0];
+  if (launcherMatch) {
+    const [seatId, entry] = launcherMatch;
+    const reasons = [
+      seatReposEquivalent(entry.repo, input.repo)
+        ? null
+        : `repo=${entry.repo} expected ${input.repo}`,
+      lane && entry.lane !== lane ? `lane=${entry.lane} expected ${lane}` : null,
+    ].filter((reason): reason is string => Boolean(reason));
+    return entryAssertion(
+      seatId,
+      entry,
+      "mismatch",
+      `launcher ${launcherName} belongs to seat ${seatId} ${reasons.join(", ")}`,
+    );
+  }
+
+  const repoMatch = repoEntries[0];
+  if (repoMatch && launcherName) {
+    const [seatId, entry] = repoMatch;
+    const expectedLauncher = launcherFor(entry, input.cli);
+    return entryAssertion(
+      seatId,
+      entry,
+      "mismatch",
+      `repo ${input.repo} expects ${input.cli} launcher ${expectedLauncher ?? "unregistered"}, got ${launcherName}`,
+    );
+  }
+
+  return unknownAssertion(
+    launcherName
+      ? `no seat registry entry matched repo=${input.repo} launcher=${launcherName}`
+      : `no seat registry entry matched repo=${input.repo}`,
+  );
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -477,6 +477,83 @@ describe("AgentEngine", () => {
       resolvingEngine.dispose();
     });
 
+    it("records the resolved registry seat identity when repo and launcher match", async () => {
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => ({ launcherName: "cmuxlayerCodex" }),
+        sessionIdentityResolver: () => null,
+        seatRegistry: {
+          cmuxlayerClaude: {
+            repo: "cmuxlayer",
+            launchers: {
+              claude: "cmuxlayerClaude",
+              codex: "cmuxlayerCodex",
+              cursor: "cmuxlayerCursor",
+              gemini: "cmuxlayerGemini",
+              kiro: "cmuxlayerKiro",
+            },
+            lane: "cmuxlayer",
+            aliases: [],
+            role: "worker",
+            orgTree: { parent: "cmuxlayerLead", directReports: [] },
+          },
+        },
+      });
+
+      const result = await engine.spawnAgent({
+        repo: "cmuxlayer",
+        cli: "codex",
+        prompt: "Fix seat identity",
+      });
+
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        seat_id: "cmuxlayerClaude",
+        seat_lane: "cmuxlayer",
+        seat_role: "worker",
+        seat_identity_status: "ok",
+        seat_identity_error: null,
+      });
+    });
+
+    it("treats orchestrator repo spawns through orc launchers as the same registry seat", async () => {
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => ({ launcherName: "orcCodex" }),
+        sessionIdentityResolver: () => null,
+        seatRegistry: {
+          orcClaude: {
+            repo: "orc",
+            launchers: {
+              claude: "orcClaude",
+              codex: "orcCodex",
+              cursor: "orcCursor",
+              gemini: "orcGemini",
+              kiro: "orcKiro",
+            },
+            lane: "orc",
+            aliases: [],
+            role: "orc",
+          },
+        },
+      });
+
+      const result = await engine.spawnAgent({
+        repo: "orchestrator",
+        cli: "codex",
+        prompt: "Coordinate fleet",
+      });
+
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        seat_id: "orcClaude",
+        seat_lane: "orc",
+        seat_role: "orc",
+        seat_identity_status: "ok",
+        seat_identity_error: null,
+      });
+    });
+
     it("writes initial state file", async () => {
       const result = await engine.spawnAgent({
         repo: "brainlayer",

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -196,6 +196,45 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("surfaces a registry seat identity mismatch as blocking health", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "seat-mismatch",
+        state: "working",
+        surface_id: "surface:seat-mismatch",
+        workspace_id: "workspace:cmuxlayer",
+        repo: "cmuxlayer",
+        cli: "codex",
+        cli_session_id: "session-seat-mismatch",
+        launcher_name: "golemsCodex",
+        task_summary: "Fix seat assertion",
+        role: "worker",
+        seat_id: "golemsClaude",
+        seat_lane: "golems",
+        seat_role: "worker",
+        seat_identity_status: "mismatch",
+        seat_identity_error:
+          "launcher golemsCodex belongs to seat golemsClaude repo=golems lane=golems, not requested repo=cmuxlayer",
+      } as Partial<AgentRecord>),
+    );
+    liveSurfaces = [makeSurface("surface:seat-mismatch")];
+    writeHeartbeat("seat-mismatch", inboxOpts);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "seat-mismatch",
+      "cmuxlayer | role=worker | seat=golemsClaude | lane=golems | state=working | health=unhealthy(seat_identity_mismatch:blocking) | blocked=- | last_prompt=Fix seat assertion | worktree=- | branch=- | report=n/a | pr=n/a",
+      expect.objectContaining({
+        icon: "bolt.fill",
+        color: "#3B82F6",
+        workspace: "workspace:cmuxlayer",
+        surface: "surface:seat-mismatch",
+      }),
+    );
+  });
+
   it("clears stale workspace-scoped sidebar rows during startup purge after restart", async () => {
     stateMgr.writeState(
       makeRecord({


### PR DESCRIPTION
## Summary
- add a local seat-registry parser/assertion against `~/.golems/config.yaml`
- persist spawned-agent seat identity fields (`seat_id`, `seat_lane`, `seat_role`, assertion status/error)
- surface launcher/repo seat mismatches as blocking `seat_identity_mismatch` health in the sidebar
- preserve the existing `orchestrator` checkout ↔ `orc` launcher/registry alias

## Test plan
- [x] RED: targeted seat identity tests failed before implementation
- [x] `bun run typecheck && bun run test`
- [x] push hook reran `run_tests.sh` successfully

## Notes
- Local `coderabbit review --agent` was attempted before commit but hit free OSS rate limit (`waitTime: 41 minutes`), so this PR relies on local verification and PR-level review.
- Per lane instruction: do not merge; lead merges after review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn-time behavior and health classification for fleet layout; mismatches are visible but do not abort spawn, so wrong-lane agents can still boot until operators act.
> 
> **Overview**
> Adds **seat identity assertion** at managed spawn time: a new `seat-identity` module loads `seatRegistry` from `~/.golems/config.yaml` (or an injected registry) and matches spawn **repo**, **CLI launcher**, and optional **lane** to a registered seat, including **orchestrator ↔ orc** repo aliasing.
> 
> **`spawnAgent`** runs this after launcher preflight, persists `seat_id`, `seat_lane`, `seat_role`, and assertion status/error on the initial agent record, and returns spawn **warnings** when status is `mismatch` (spawn still proceeds). Sidebar status strings now include `seat=` and `lane=` when present.
> 
> **Health/sidebar:** `evaluateAgentHealth` treats `seat_identity_status === "mismatch"` as a **blocking** `seat_identity_mismatch` issue (unhealthy in sidebar sync). Missing or empty registry yields `unknown` without that blocking issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a549358a9cb5907aafe991f8943c6001d13954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert spawned agent seat identity against a seat registry and surface mismatches as blocking health issues
> - Adds a new [seat-identity.ts](https://github.com/EtanHey/cmuxlayer/pull/238/files#diff-b6c64d3457c6a287dafbab4a484e243e0f3964aa9930249306339512fa433b86) module that loads a `SeatRegistry` from `~/.golems/config.yaml` and asserts whether a spawning agent's repo, launcher, and lane match a registered seat.
> - `AgentEngine.spawnAgent` now calls `assertSeatIdentity` after preflight and writes `seat_id`, `seat_lane`, `seat_role`, `seat_identity_status`, and `seat_identity_error` into the initial `AgentRecord`; a warning is appended to spawn results when the status is `mismatch`.
> - `evaluateAgentHealth` adds a blocking `seat_identity_mismatch` health issue when `seat_identity_status === 'mismatch'`, which propagates to sidebar sync status.
> - `AgentEngine.buildSidebarStatusValue` now includes `seat=<id>` and `lane=<lane>` segments when present, filtering out empty parts.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 91a5493. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->