### PR TITLE
fix: add monitor registry deadman core

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -85,21 +85,24 @@ import {
   type AgentHealth,
   type AgentHealthInput,
 } from "./agent-health.js";
-import {
-  AGENT_HEALTH_MONITOR_MAX_AGE_MS,
-  buildAgentHealthInput,
-} from "./agent-health-input.js";
+import { buildAgentHealthInput } from "./agent-health-input.js";
 import {
   assertSeatIdentity,
   loadSeatRegistryFromConfig,
   type SeatRegistry,
 } from "./seat-identity.js";
 import {
+  latestMonitorForOwnerSeats,
+  sweepMonitorRegistry,
+  transferMonitorRegistryOwner,
+  type MonitorDeadmanNotify,
+} from "./monitor-registry.js";
+import {
   collectSurfaceTopology,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
 } from "./surface-topology.js";
-import { readLastAgentHeartbeat, type InboxOpts } from "./inbox.js";
+import type { InboxOpts } from "./inbox.js";
 
 type ProcessLiveness = "alive" | "gone" | "unknown";
 
@@ -238,6 +241,14 @@ export interface AgentEngineOptions {
    * production entrypoints inject `() => drainOutbox()`.
    */
   outboxDrain?: () => Promise<unknown>;
+  /**
+   * Optional monitor-registry deadman sweep. Omitted by default so tests and
+   * library construction never read/write the real home-directory registry.
+   * Production entrypoints pass the canonical path and injected notify hook.
+   */
+  monitorRegistryPath?: string;
+  monitorRegistryNow?: () => number;
+  monitorRegistryNotify?: MonitorDeadmanNotify;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
@@ -282,11 +293,6 @@ interface SidebarStatusSnapshot {
   surfaceId: string | null;
   workspaceId: string | null;
   healthSignature: string;
-}
-
-interface LeadMonitorDeathTimer {
-  timer: ReturnType<typeof setTimeout>;
-  dueAtMs: number;
 }
 
 export interface SweepTimingOptions {
@@ -755,14 +761,16 @@ export class AgentEngine {
   private notifiedEvents = new Set<string>();
   /** agentId values whose current lead monitor-death alert was delivered. */
   private deliveredLeadMonitorDeathAlerts = new Set<string>();
-  /** agentId → wake-on-timeout timer for lead monitor-death detection. */
-  private leadMonitorDeathTimers = new Map<string, LeadMonitorDeathTimer>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
   /** Best-effort outbox drainer invoked each sweep (injectable for tests). */
   private outboxDrain: () => Promise<unknown>;
   /** Guards against overlapping outbox drains if a sweep runs long. */
   private outboxDrainInFlight = false;
+  private monitorRegistryPath?: string;
+  private monitorRegistryNow?: () => number;
+  private monitorRegistryNotify: MonitorDeadmanNotify;
+  private monitorRegistrySweepInFlight = false;
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
@@ -788,6 +796,9 @@ export class AgentEngine {
     // the real outbox or network. Production entrypoints inject the real
     // drainOutbox (see server.ts createServer / app-server-runtime).
     this.outboxDrain = opts?.outboxDrain ?? (async () => {});
+    this.monitorRegistryPath = opts?.monitorRegistryPath;
+    this.monitorRegistryNow = opts?.monitorRegistryNow;
+    this.monitorRegistryNotify = opts?.monitorRegistryNotify ?? (async () => {});
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.postSpawnLivenessMs =
       opts?.postSpawnLivenessMs ??
@@ -1876,7 +1887,12 @@ export class AgentEngine {
     if (this.deliveredLeadMonitorDeathAlerts.delete(previousAgentId)) {
       this.deliveredLeadMonitorDeathAlerts.add(nextAgentId);
     }
-    this.transferLeadMonitorDeathTimer(previousAgentId, nextAgentId);
+    if (this.monitorRegistryPath) {
+      void transferMonitorRegistryOwner(previousAgentId, nextAgentId, {
+        registryPath: this.monitorRegistryPath,
+        now: this.monitorRegistryNow,
+      }).catch(() => {});
+    }
   }
 
   private finalizeCapturedSession(
@@ -2428,60 +2444,17 @@ export class AgentEngine {
       }
     }
     this.deliveredLeadMonitorDeathAlerts.delete(agentId);
-    this.clearLeadMonitorDeathTimer(agentId);
-  }
-
-  private clearLeadMonitorDeathTimer(agentId: string): void {
-    const entry = this.leadMonitorDeathTimers.get(agentId);
-    if (!entry) return;
-    clearTimeout(entry.timer);
-    this.leadMonitorDeathTimers.delete(agentId);
-  }
-
-  private armLeadMonitorDeathTimer(
-    agentId: string,
-    delayMs: number,
-    dueAtMs: number,
-  ): void {
-    const timer = setTimeout(() => {
-      this.leadMonitorDeathTimers.delete(agentId);
-      void this.fireLeadMonitorDeathDeadman(agentId);
-    }, delayMs);
-    this.leadMonitorDeathTimers.set(agentId, { timer, dueAtMs });
-  }
-
-  private transferLeadMonitorDeathTimer(
-    previousAgentId: string,
-    nextAgentId: string,
-  ): void {
-    const entry = this.leadMonitorDeathTimers.get(previousAgentId);
-    if (!entry) return;
-
-    clearTimeout(entry.timer);
-    this.leadMonitorDeathTimers.delete(previousAgentId);
-    if (this.leadMonitorDeathTimers.has(nextAgentId)) {
-      return;
-    }
-
-    const now = (this.inboxOpts?.now ?? Date.now)();
-    this.armLeadMonitorDeathTimer(
-      nextAgentId,
-      Math.max(0, entry.dueAtMs - now),
-      entry.dueAtMs,
-    );
   }
 
   private isLeadWatchBlind(
     agent: AgentRecord,
-    healthInput: AgentHealthInput,
+    _healthInput: AgentHealthInput,
   ): boolean {
     if (inferRecordRoleOrNull(agent) !== "orchestrator") {
       return false;
     }
 
-    if (healthInput.monitor_alive === false) {
-      return readLastAgentHeartbeat(agent.agent_id, this.inboxOpts) !== null;
-    }
+    if (this.latestLeadMonitor(agent)?.state === "deadman-fired") return true;
 
     if (
       agent.pid !== null &&
@@ -2499,23 +2472,35 @@ export class AgentEngine {
     );
   }
 
+  private leadOwnerSeats(agent: AgentRecord): string[] {
+    return [agent.seat_id, agent.agent_id].filter(
+      (ownerSeat): ownerSeat is string =>
+        typeof ownerSeat === "string" && ownerSeat.trim().length > 0,
+    );
+  }
+
+  private latestLeadMonitor(agent: AgentRecord) {
+    if (!this.monitorRegistryPath) return null;
+    return latestMonitorForOwnerSeats(this.leadOwnerSeats(agent), {
+      registryPath: this.monitorRegistryPath,
+      now: this.monitorRegistryNow,
+    });
+  }
+
   private async maybeNotifyLeadMonitorDeath(
     agent: AgentRecord,
     healthInput: AgentHealthInput,
   ): Promise<void> {
     if (inferRecordRoleOrNull(agent) !== "orchestrator") {
-      this.clearLeadMonitorDeathTimer(agent.agent_id);
       this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
       return;
     }
 
     if (!this.isLeadWatchBlind(agent, healthInput)) {
-      this.scheduleLeadMonitorDeathDeadman(agent);
       this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
       return;
     }
 
-    this.clearLeadMonitorDeathTimer(agent.agent_id);
     if (this.deliveredLeadMonitorDeathAlerts.has(agent.agent_id)) {
       return;
     }
@@ -2537,36 +2522,6 @@ export class AgentEngine {
     } catch {
       // Notification delivery is best-effort; do not break sweeps. Retry next sweep.
     }
-  }
-
-  private scheduleLeadMonitorDeathDeadman(agent: AgentRecord): void {
-    this.clearLeadMonitorDeathTimer(agent.agent_id);
-
-    const heartbeat = readLastAgentHeartbeat(agent.agent_id, this.inboxOpts);
-    if (!heartbeat) {
-      return;
-    }
-
-    const now = (this.inboxOpts?.now ?? Date.now)();
-    const ageMs = Math.max(0, now - heartbeat.ts_ms);
-    const delayMs = Math.max(
-      0,
-      AGENT_HEALTH_MONITOR_MAX_AGE_MS - ageMs + 1,
-    );
-    this.armLeadMonitorDeathTimer(agent.agent_id, delayMs, now + delayMs);
-  }
-
-  private async fireLeadMonitorDeathDeadman(agentId: string): Promise<void> {
-    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
-    if (!agent) {
-      this.clearLeadMonitorDeathTimer(agentId);
-      return;
-    }
-
-    const healthInput = await buildAgentHealthInput(agent, {
-      inboxOpts: this.inboxOpts,
-    });
-    await this.maybeNotifyLeadMonitorDeath(agent, healthInput);
   }
 
   private async logLifecycleEvent(
@@ -2915,8 +2870,27 @@ export class AgentEngine {
     }
 
     await this.registry.purgeTerminal();
+    await this.sweepMonitorRegistryBestEffort();
     await this.syncSidebar();
     await this.drainOutboxBestEffort();
+  }
+
+  private async sweepMonitorRegistryBestEffort(): Promise<void> {
+    if (!this.monitorRegistryPath) return;
+    if (this.monitorRegistrySweepInFlight) return;
+    this.monitorRegistrySweepInFlight = true;
+    try {
+      await sweepMonitorRegistry({
+        registryPath: this.monitorRegistryPath,
+        now: this.monitorRegistryNow,
+        notify: this.monitorRegistryNotify,
+      });
+    } catch {
+      // The registry deadman is best-effort inside the sweep; never break
+      // lifecycle reconciliation because the shared file is temporarily busy.
+    } finally {
+      this.monitorRegistrySweepInFlight = false;
+    }
   }
 
   /**
@@ -3030,10 +3004,6 @@ export class AgentEngine {
       clearTimeout(timer);
     }
     this.postSpawnLivenessTimers.clear();
-    for (const entry of this.leadMonitorDeathTimers.values()) {
-      clearTimeout(entry.timer);
-    }
-    this.leadMonitorDeathTimers.clear();
     this.sweepTiming = null;
     this.lastSweepSignature = null;
     this.unchangedSweepCount = 0;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -5,6 +5,10 @@ import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
+import {
+  defaultMonitorRegistryPath,
+  httpNotifyMonitorDeadman,
+} from "./monitor-registry.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { StateManager } from "./state-manager.js";
 import { parseScreen } from "./screen-parser.js";
@@ -192,6 +196,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         await this.sendCommand(surface, command, workspace);
       },
       outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
+      monitorRegistryPath: defaultMonitorRegistryPath(),
+      monitorRegistryNotify: httpNotifyMonitorDeadman,
     });
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -19,6 +19,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createCmuxClient } from "./cmux-client-factory.js";
 import { createServer, createServerContext } from "./server.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
+import {
+  defaultMonitorRegistryPath,
+  httpNotifyMonitorDeadman,
+} from "./monitor-registry.js";
 import type { ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import type { CmuxClient } from "./cmux-client.js";
@@ -400,6 +404,8 @@ export class CmuxLayerDaemon {
     const mcpServer = createServer({
       context,
       outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
+      monitorRegistryPath: defaultMonitorRegistryPath(),
+      monitorRegistryNotify: httpNotifyMonitorDeadman,
     });
     const pendingRequestIds = new Set<RequestId>();
     this.activeTransports.add(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ import { createCmuxClient } from "./cmux-client-factory.js";
 import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";
 import { readVersion } from "./version.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
+import {
+  defaultMonitorRegistryPath,
+  httpNotifyMonitorDeadman,
+} from "./monitor-registry.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 
@@ -73,6 +77,8 @@ async function main() {
   const server = createServer({
     client,
     outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
+    monitorRegistryPath: defaultMonitorRegistryPath(),
+    monitorRegistryNotify: httpNotifyMonitorDeadman,
   });
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/monitor-registry.ts
+++ b/src/monitor-registry.ts
@@ -1,0 +1,465 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { httpDeliver } from "./outbox-drainer.js";
+
+export type MonitorMechanism = "event" | "offset-poll";
+export type MonitorState = "alive" | "deadman-fired" | "dead";
+
+export interface MonitorRegistryRecord {
+  monitor_id: string;
+  owner_seat: string;
+  watch_targets: string[];
+  mechanism: MonitorMechanism;
+  pattern?: string;
+  deadman_timeout_s: number;
+  armed_at: string;
+  last_signal_at: string;
+  state: MonitorState;
+}
+
+export interface MonitorRegistryFile {
+  version: 1;
+  monitors: MonitorRegistryRecord[];
+}
+
+export interface RegisterMonitorInput {
+  monitor_id: string;
+  owner_seat: string;
+  watch_targets: string[];
+  mechanism: MonitorMechanism;
+  pattern?: string;
+  deadman_timeout_s: number;
+}
+
+export interface MonitorRegistryOptions {
+  registryPath?: string;
+  now?: () => number;
+}
+
+export interface MonitorDeadmanEvent {
+  monitor_id: string;
+  owner_seat: string;
+  watch_targets: string[];
+  mechanism: MonitorMechanism;
+  deadman_timeout_s: number;
+  armed_at: string;
+  last_signal_at: string;
+  fired_at: string;
+  fired_by_agent_id: string;
+  elapsed_s: number;
+}
+
+export interface InvalidMonitorRegistryRecord {
+  monitor_id: string;
+  reason: string;
+}
+
+export interface MonitorRegistrySweepResult {
+  fired: MonitorDeadmanEvent[];
+  invalid: InvalidMonitorRegistryRecord[];
+  alive: string[];
+}
+
+export type MonitorDeadmanNotify = (
+  event: MonitorDeadmanEvent,
+) => Promise<unknown> | unknown;
+
+export interface MonitorRegistrySweepOptions extends MonitorRegistryOptions {
+  notify?: MonitorDeadmanNotify;
+  sweeperAgentId?: string;
+}
+
+type RawMonitorRecord = Record<string, unknown>;
+
+const STATE_VERSION = 1;
+const DEFAULT_NOTIFY_URL = "http://127.0.0.1:3847/notify";
+const DEFAULT_NOTIFY_SOURCE = "cmuxlayer-monitor-registry";
+const DEFAULT_SWEEPER_ID = "agent-engine";
+
+export function defaultMonitorRegistryPath(): string {
+  return join(homedir(), ".golems-zikaron", "monitor-registry.json");
+}
+
+function nowIso(now?: () => number): string {
+  return new Date((now ?? Date.now)()).toISOString();
+}
+
+function registryPathFor(opts?: MonitorRegistryOptions): string {
+  return opts?.registryPath ?? defaultMonitorRegistryPath();
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRawRegistry(path: string): {
+  version: 1;
+  monitors: RawMonitorRecord[];
+} {
+  if (!existsSync(path)) return { version: STATE_VERSION, monitors: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (Array.isArray(parsed)) {
+      return {
+        version: STATE_VERSION,
+        monitors: parsed.filter(isObject),
+      };
+    }
+    if (isObject(parsed) && Array.isArray(parsed.monitors)) {
+      return {
+        version: STATE_VERSION,
+        monitors: parsed.monitors.filter(isObject),
+      };
+    }
+  } catch {
+    return { version: STATE_VERSION, monitors: [] };
+  }
+  return { version: STATE_VERSION, monitors: [] };
+}
+
+function writeRawRegistry(path: string, monitors: readonly unknown[]): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(
+    tmpPath,
+    `${JSON.stringify({ version: STATE_VERSION, monitors }, null, 2)}\n`,
+    "utf8",
+  );
+  renameSync(tmpPath, path);
+}
+
+function withRegistryWriteLock<T>(path: string, fn: () => T): T {
+  const lockDir = `${path}.lock`;
+  mkdirSync(dirname(path), { recursive: true });
+  mkdirSync(lockDir);
+  try {
+    return fn();
+  } finally {
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+function cleanString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isUnknownOwnerSeat(value: string | null): boolean {
+  if (!value) return true;
+  return /^(?:unknown|none|null|n\/a)$/i.test(value);
+}
+
+function isMechanism(value: unknown): value is MonitorMechanism {
+  return value === "event" || value === "offset-poll";
+}
+
+function isState(value: unknown): value is MonitorState {
+  return value === "alive" || value === "deadman-fired" || value === "dead";
+}
+
+function parseTimeMs(value: unknown): number | null {
+  const text = cleanString(value);
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function validWatchTargets(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const targets = value.map(cleanString);
+  if (targets.some((target) => target === null)) return null;
+  return targets as string[];
+}
+
+function toValidRecord(record: RawMonitorRecord): MonitorRegistryRecord | null {
+  const monitorId = cleanString(record.monitor_id);
+  const ownerSeat = cleanString(record.owner_seat);
+  const watchTargets = validWatchTargets(record.watch_targets);
+  const timeout = record.deadman_timeout_s;
+  const armedAt = cleanString(record.armed_at);
+  const lastSignalAt = cleanString(record.last_signal_at);
+  if (
+    !monitorId ||
+    !ownerSeat ||
+    isUnknownOwnerSeat(ownerSeat) ||
+    !watchTargets ||
+    !isMechanism(record.mechanism) ||
+    typeof timeout !== "number" ||
+    !Number.isFinite(timeout) ||
+    timeout <= 0 ||
+    !armedAt ||
+    !lastSignalAt ||
+    !isState(record.state)
+  ) {
+    return null;
+  }
+  return {
+    monitor_id: monitorId,
+    owner_seat: ownerSeat,
+    watch_targets: watchTargets,
+    mechanism: record.mechanism,
+    ...(typeof record.pattern === "string" ? { pattern: record.pattern } : {}),
+    deadman_timeout_s: timeout,
+    armed_at: armedAt,
+    last_signal_at: lastSignalAt,
+    state: record.state,
+  };
+}
+
+function invalidReason(record: RawMonitorRecord): string | null {
+  if (!cleanString(record.monitor_id)) return "missing-monitor-id";
+  if (isUnknownOwnerSeat(cleanString(record.owner_seat))) {
+    return "missing-or-unknown-owner-seat";
+  }
+  if (!validWatchTargets(record.watch_targets)) return "invalid-watch-targets";
+  if (!isMechanism(record.mechanism)) return "invalid-mechanism";
+  if (
+    typeof record.deadman_timeout_s !== "number" ||
+    !Number.isFinite(record.deadman_timeout_s) ||
+    record.deadman_timeout_s <= 0
+  ) {
+    return "invalid-deadman-timeout";
+  }
+  if (parseTimeMs(record.armed_at) === null) return "invalid-armed-at";
+  if (parseTimeMs(record.last_signal_at) === null) {
+    return "invalid-last-signal-at";
+  }
+  if (!isState(record.state)) return "invalid-state";
+  return null;
+}
+
+function monitorIdForInvalid(record: RawMonitorRecord): string {
+  return cleanString(record.monitor_id) ?? "<missing-monitor-id>";
+}
+
+function assertRegisterInput(input: RegisterMonitorInput): void {
+  if (!cleanString(input.monitor_id)) throw new Error("monitor_id is required");
+  if (isUnknownOwnerSeat(cleanString(input.owner_seat))) {
+    throw new Error("owner_seat is required");
+  }
+  if (!validWatchTargets(input.watch_targets)) {
+    throw new Error("watch_targets must be strings");
+  }
+  if (!isMechanism(input.mechanism)) throw new Error("mechanism is invalid");
+  if (
+    !Number.isFinite(input.deadman_timeout_s) ||
+    input.deadman_timeout_s <= 0
+  ) {
+    throw new Error("deadman_timeout_s must be positive");
+  }
+}
+
+export function readMonitorRegistry(
+  opts: MonitorRegistryOptions = {},
+): MonitorRegistryFile {
+  const raw = readRawRegistry(registryPathFor(opts));
+  return {
+    version: STATE_VERSION,
+    monitors: raw.monitors
+      .map(toValidRecord)
+      .filter((record): record is MonitorRegistryRecord => record !== null),
+  };
+}
+
+export async function registerMonitor(
+  input: RegisterMonitorInput,
+  opts: MonitorRegistryOptions = {},
+): Promise<MonitorRegistryRecord> {
+  assertRegisterInput(input);
+  const path = registryPathFor(opts);
+  const stamp = nowIso(opts.now);
+  let saved: MonitorRegistryRecord | null = null;
+
+  withRegistryWriteLock(path, () => {
+    const registry = readRawRegistry(path);
+    const existing = registry.monitors.find(
+      (record) => cleanString(record.monitor_id) === input.monitor_id,
+    );
+    if (existing?.state === "deadman-fired") {
+      throw new Error("cannot re-arm a fired monitor_id; use a new id");
+    }
+    const next: MonitorRegistryRecord = {
+      monitor_id: input.monitor_id,
+      owner_seat: input.owner_seat,
+      watch_targets: [...input.watch_targets],
+      mechanism: input.mechanism,
+      ...(input.pattern ? { pattern: input.pattern } : {}),
+      deadman_timeout_s: input.deadman_timeout_s,
+      armed_at: stamp,
+      last_signal_at: stamp,
+      state: "alive",
+    };
+    const monitors: unknown[] = registry.monitors.filter(
+      (record) => cleanString(record.monitor_id) !== input.monitor_id,
+    );
+    monitors.push(next);
+    writeRawRegistry(path, monitors);
+    saved = next;
+  });
+
+  return saved!;
+}
+
+export async function deregisterMonitor(
+  monitorId: string,
+  opts: MonitorRegistryOptions = {},
+): Promise<MonitorRegistryRecord | null> {
+  const path = registryPathFor(opts);
+  let updated: MonitorRegistryRecord | null = null;
+  withRegistryWriteLock(path, () => {
+    const registry = readRawRegistry(path);
+    const monitors = registry.monitors.map((record) => {
+      if (cleanString(record.monitor_id) !== monitorId) return record;
+      const valid = toValidRecord(record);
+      if (!valid) return record;
+      updated = { ...valid, state: "dead" };
+      return updated;
+    });
+    writeRawRegistry(path, monitors);
+  });
+  return updated;
+}
+
+export async function signalMonitor(
+  monitorId: string,
+  opts: MonitorRegistryOptions = {},
+): Promise<MonitorRegistryRecord | null> {
+  const path = registryPathFor(opts);
+  let updated: MonitorRegistryRecord | null = null;
+  withRegistryWriteLock(path, () => {
+    const registry = readRawRegistry(path);
+    const monitors = registry.monitors.map((record) => {
+      if (cleanString(record.monitor_id) !== monitorId) return record;
+      const valid = toValidRecord(record);
+      if (!valid || valid.state !== "alive") return record;
+      updated = { ...valid, last_signal_at: nowIso(opts.now) };
+      return updated;
+    });
+    writeRawRegistry(path, monitors);
+  });
+  return updated;
+}
+
+export async function transferMonitorRegistryOwner(
+  previousOwnerSeat: string,
+  nextOwnerSeat: string,
+  opts: MonitorRegistryOptions = {},
+): Promise<number> {
+  if (previousOwnerSeat === nextOwnerSeat) return 0;
+  const path = registryPathFor(opts);
+  let changed = 0;
+  withRegistryWriteLock(path, () => {
+    const registry = readRawRegistry(path);
+    const monitors = registry.monitors.map((record) => {
+      if (cleanString(record.owner_seat) !== previousOwnerSeat) return record;
+      changed += 1;
+      return { ...record, owner_seat: nextOwnerSeat };
+    });
+    if (changed > 0) writeRawRegistry(path, monitors);
+  });
+  return changed;
+}
+
+export function latestMonitorForOwnerSeats(
+  ownerSeats: readonly string[],
+  opts: MonitorRegistryOptions = {},
+): MonitorRegistryRecord | null {
+  const owners = new Set(
+    ownerSeats
+      .map((ownerSeat) => ownerSeat.trim())
+      .filter((ownerSeat) => !isUnknownOwnerSeat(ownerSeat)),
+  );
+  if (owners.size === 0) return null;
+  const matches = readMonitorRegistry(opts).monitors.filter((record) =>
+    owners.has(record.owner_seat),
+  );
+  matches.sort((a, b) => {
+    const armedDiff = Date.parse(b.armed_at) - Date.parse(a.armed_at);
+    if (armedDiff !== 0) return armedDiff;
+    return Date.parse(b.last_signal_at) - Date.parse(a.last_signal_at);
+  });
+  return matches[0] ?? null;
+}
+
+const noopNotify: MonitorDeadmanNotify = async () => {};
+
+export async function sweepMonitorRegistry(
+  opts: MonitorRegistrySweepOptions = {},
+): Promise<MonitorRegistrySweepResult> {
+  const path = registryPathFor(opts);
+  const nowMs = (opts.now ?? Date.now)();
+  const fired: MonitorDeadmanEvent[] = [];
+  const invalid: InvalidMonitorRegistryRecord[] = [];
+  const alive: string[] = [];
+
+  withRegistryWriteLock(path, () => {
+    const registry = readRawRegistry(path);
+    const monitors = registry.monitors.map((record) => {
+      const reason = invalidReason(record);
+      if (reason !== null) {
+        invalid.push({ monitor_id: monitorIdForInvalid(record), reason });
+        return record;
+      }
+      const valid = toValidRecord(record)!;
+      if (valid.state !== "alive") return record;
+      const lastSignalAtMs = parseTimeMs(valid.last_signal_at)!;
+      const elapsedMs = nowMs - lastSignalAtMs;
+      if (elapsedMs <= valid.deadman_timeout_s * 1000) {
+        alive.push(valid.monitor_id);
+        return record;
+      }
+      const firedAt = new Date(nowMs).toISOString();
+      fired.push({
+        monitor_id: valid.monitor_id,
+        owner_seat: valid.owner_seat,
+        watch_targets: valid.watch_targets,
+        mechanism: valid.mechanism,
+        deadman_timeout_s: valid.deadman_timeout_s,
+        armed_at: valid.armed_at,
+        last_signal_at: valid.last_signal_at,
+        fired_at: firedAt,
+        fired_by_agent_id: opts.sweeperAgentId ?? DEFAULT_SWEEPER_ID,
+        elapsed_s: elapsedMs / 1000,
+      });
+      return { ...valid, state: "deadman-fired" };
+    });
+    if (fired.length > 0) writeRawRegistry(path, monitors);
+  });
+
+  const notify = opts.notify ?? noopNotify;
+  for (const event of fired) {
+    try {
+      await notify(event);
+    } catch {
+      // State is canonical; notification delivery is best-effort and injected.
+    }
+  }
+
+  return { fired, invalid, alive };
+}
+
+export async function httpNotifyMonitorDeadman(
+  event: MonitorDeadmanEvent,
+  notifyUrl = DEFAULT_NOTIFY_URL,
+): Promise<boolean> {
+  return httpDeliver(
+    {
+      title: "Monitor deadman fired",
+      body: `Monitor ${event.monitor_id} for ${event.owner_seat} missed signals for ${Math.round(
+        event.elapsed_s,
+      )}s; watch_targets=${event.watch_targets.join(", ")}`,
+      source: DEFAULT_NOTIFY_SOURCE,
+      priority: "high",
+    },
+    notifyUrl,
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import {
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
+import type { MonitorDeadmanNotify } from "./monitor-registry.js";
 import { AgentDiscovery, type DiscoveredAgent } from "./agent-discovery.js";
 import {
   resumeCommandForAgent,
@@ -1481,6 +1482,13 @@ export interface CreateServerOptions {
    * to actually flush `~/.golems-zikaron/outbox.md` to the notify path.
    */
   outboxDrain?: () => Promise<unknown>;
+  /**
+   * Canonical monitor-registry file scanned by the agent-engine deadman sweep.
+   * Omitted by default so tests do not touch ~/.golems-zikaron.
+   */
+  monitorRegistryPath?: string;
+  monitorRegistryNow?: () => number;
+  monitorRegistryNotify?: MonitorDeadmanNotify;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -5290,6 +5298,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await sendLauncherCommandToSurface({ surface, workspace, command });
           },
           outboxDrain: opts?.outboxDrain,
+          monitorRegistryPath: opts?.monitorRegistryPath,
+          monitorRegistryNow: opts?.monitorRegistryNow,
+          monitorRegistryNotify: opts?.monitorRegistryNotify,
         },
       );
     context.lifecycleSweepEngine = engine;

--- a/tests/monitor-registry.test.ts
+++ b/tests/monitor-registry.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  deregisterMonitor,
+  readMonitorRegistry,
+  registerMonitor,
+  signalMonitor,
+  sweepMonitorRegistry,
+} from "../src/monitor-registry.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-monitor-registry-test");
+
+function registryPath(): string {
+  return join(TEST_DIR, "monitor-registry.json");
+}
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function rawRegistry(): unknown {
+  return JSON.parse(readFileSync(registryPath(), "utf8"));
+}
+
+describe("monitor registry deadman core", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("keeps an armed monitor alive when signals are flowing and does not notify", async () => {
+    await registerMonitor(
+      {
+        monitor_id: "scd-flowing",
+        owner_seat: "skillcreatorLead",
+        watch_targets: ["orchestrator/collab/example.md"],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    await signalMonitor("scd-flowing", {
+      registryPath: registryPath(),
+      now: () => 31_000,
+    });
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const result = await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 60_000,
+      notify,
+      sweeperAgentId: "second-agent",
+    });
+
+    expect(result.fired).toEqual([]);
+    expect(result.invalid).toEqual([]);
+    expect(notify).not.toHaveBeenCalled();
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      monitor_id: "scd-flowing",
+      last_signal_at: iso(31_000),
+      state: "alive",
+    });
+  });
+
+  it("lets a second agent sweep fire a lapsed monitor exactly once and emit the injected wake", async () => {
+    await registerMonitor(
+      {
+        monitor_id: "scd-lapsed",
+        owner_seat: "skillcreatorLead",
+        watch_targets: ["orchestrator/collab/example.md"],
+        mechanism: "offset-poll",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const notify = vi.fn().mockResolvedValue(undefined);
+
+    const first = await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 61_001,
+      notify,
+      sweeperAgentId: "second-agent",
+    });
+    const second = await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      notify,
+      sweeperAgentId: "third-agent",
+    });
+
+    expect(first.fired).toEqual([
+      expect.objectContaining({
+        monitor_id: "scd-lapsed",
+        owner_seat: "skillcreatorLead",
+        fired_by_agent_id: "second-agent",
+      }),
+    ]);
+    expect(second.fired).toEqual([]);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitor_id: "scd-lapsed",
+        owner_seat: "skillcreatorLead",
+        fired_by_agent_id: "second-agent",
+      }),
+    );
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]?.state).toBe(
+      "deadman-fired",
+    );
+  });
+
+  it("fail-closes ownerless or unknown-owner records as invalid instead of firing them", async () => {
+    writeFileSync(
+      registryPath(),
+      `${JSON.stringify(
+        {
+          version: 1,
+          monitors: [
+            {
+              monitor_id: "missing-owner",
+              watch_targets: ["orchestrator/collab/example.md"],
+              mechanism: "event",
+              deadman_timeout_s: 1,
+              armed_at: iso(1_000),
+              last_signal_at: iso(1_000),
+              state: "alive",
+            },
+            {
+              monitor_id: "unknown-owner",
+              owner_seat: "UNKNOWN",
+              watch_targets: ["orchestrator/collab/example.md"],
+              mechanism: "event",
+              deadman_timeout_s: 1,
+              armed_at: iso(1_000),
+              last_signal_at: iso(1_000),
+              state: "alive",
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    const notify = vi.fn().mockResolvedValue(undefined);
+
+    const result = await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 10_000,
+      notify,
+      sweeperAgentId: "second-agent",
+    });
+
+    expect(result.fired).toEqual([]);
+    expect(result.invalid.map((entry) => entry.monitor_id)).toEqual([
+      "missing-owner",
+      "unknown-owner",
+    ]);
+    expect(notify).not.toHaveBeenCalled();
+    expect(rawRegistry()).toMatchObject({
+      monitors: [
+        { monitor_id: "missing-owner", state: "alive" },
+        { monitor_id: "unknown-owner", state: "alive" },
+      ],
+    });
+  });
+
+  it("deregisters intentional stops without letting later signals revive the monitor", async () => {
+    await registerMonitor(
+      {
+        monitor_id: "scd-stop",
+        owner_seat: "skillcreatorLead",
+        watch_targets: ["orchestrator/collab/example.md"],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    await deregisterMonitor("scd-stop", {
+      registryPath: registryPath(),
+      now: () => 2_000,
+    });
+    await signalMonitor("scd-stop", {
+      registryPath: registryPath(),
+      now: () => 3_000,
+    });
+
+    const monitor = readMonitorRegistry({ registryPath: registryPath() }).monitors[0];
+    expect(monitor).toMatchObject({
+      monitor_id: "scd-stop",
+      last_signal_at: iso(1_000),
+      state: "dead",
+    });
+  });
+});

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -11,6 +11,7 @@ import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { ack, dispatch, writeHeartbeat } from "../src/inbox.js";
 import { AGENT_HEALTH_MONITOR_MAX_AGE_MS } from "../src/agent-health-input.js";
+import { readMonitorRegistry, registerMonitor } from "../src/monitor-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
 import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
@@ -69,6 +70,25 @@ function makeWorkspace(ref: string) {
     selected: false,
     pinned: false,
   };
+}
+
+async function armLeadMonitor(input: {
+  registryPath: string;
+  monitorId: string;
+  ownerSeat: string;
+  now: () => number;
+  timeoutS?: number;
+}): Promise<void> {
+  await registerMonitor(
+    {
+      monitor_id: input.monitorId,
+      owner_seat: input.ownerSeat,
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: input.timeoutS ?? 60,
+    },
+    { registryPath: input.registryPath, now: input.now },
+  );
 }
 
 function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
@@ -601,9 +621,10 @@ describe("Sidebar Sync", () => {
     ]);
   });
 
-  it("fires one proactive alert when a lead monitor heartbeat goes stale", async () => {
-    const inboxDir = join(TEST_DIR, "lead-stale-monitor-inbox");
-    const agentId = "cmuxlayer-lead-stale-monitor";
+  it("fires one proactive alert when the registry deadman fires for a lead", async () => {
+    const inboxDir = join(TEST_DIR, "lead-registry-deadman-inbox");
+    const registryPath = join(TEST_DIR, "lead-deadman-registry.json");
+    const agentId = "cmuxlayer-lead-registry-deadman";
     let now = 1_000_000;
     stateMgr.writeState(
       makeRecord({
@@ -625,8 +646,15 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
-    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-deadman-1",
+      ownerSeat: agentId,
+      now: () => now,
+    });
     now += 61_000;
     await engine.getRegistry().reconstitute();
 
@@ -636,8 +664,8 @@ describe("Sidebar Sync", () => {
     expect(mockClient.notify).toHaveBeenCalledTimes(1);
     expect(mockClient.notify).toHaveBeenCalledWith({
       title: "Lead monitor/session ended",
-      subtitle: "cmuxlayer lead cmuxlayer-lead-stale-monitor",
-      body: "Lead seat cmuxlayer-lead-stale-monitor in workspace workspace:cmuxlayer is watch-blind: monitor/session ended - lead is watch-blind. Last-known state: working.",
+      subtitle: "cmuxlayer lead cmuxlayer-lead-registry-deadman",
+      body: "Lead seat cmuxlayer-lead-registry-deadman in workspace workspace:cmuxlayer is watch-blind: monitor/session ended - lead is watch-blind. Last-known state: working.",
       workspace: "workspace:cmuxlayer",
       surface: "surface:lead-stale",
     });
@@ -648,9 +676,10 @@ describe("Sidebar Sync", () => {
     );
   });
 
-  it("does not alert when a lead monitor was never armed", async () => {
-    const inboxDir = join(TEST_DIR, "lead-never-armed-monitor-inbox");
-    const agentId = "cmuxlayer-lead-never-armed-monitor";
+  it("does not alert from stale inbox heartbeat when no registry deadman fired", async () => {
+    const inboxDir = join(TEST_DIR, "lead-stale-inbox-only");
+    const registryPath = join(TEST_DIR, "lead-stale-inbox-only-registry.json");
+    const agentId = "cmuxlayer-lead-stale-inbox-only";
     let now = 1_500_000;
     stateMgr.writeState(
       makeRecord({
@@ -672,7 +701,11 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    now += 61_000;
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -687,9 +720,10 @@ describe("Sidebar Sync", () => {
     );
   });
 
-  it("does not fire the proactive monitor-death alert for a worker", async () => {
-    const inboxDir = join(TEST_DIR, "worker-stale-monitor-inbox");
-    const agentId = "cmuxlayer-worker-stale-monitor";
+  it("does not fire the lead monitor-death alert for a worker registry deadman", async () => {
+    const inboxDir = join(TEST_DIR, "worker-registry-deadman-inbox");
+    const registryPath = join(TEST_DIR, "worker-registry-deadman.json");
+    const agentId = "cmuxlayer-worker-registry-deadman";
     let now = 2_000_000;
     stateMgr.writeState(
       makeRecord({
@@ -709,8 +743,15 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
-    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "worker-deadman-1",
+      ownerSeat: agentId,
+      now: () => now,
+    });
     now += 61_000;
     await engine.getRegistry().reconstitute();
 
@@ -726,8 +767,9 @@ describe("Sidebar Sync", () => {
     );
   });
 
-  it("re-arms the lead monitor-death alert after heartbeat recovery", async () => {
+  it("re-arms the lead monitor-death alert after a newer alive registry monitor appears", async () => {
     const inboxDir = join(TEST_DIR, "lead-monitor-rearm-inbox");
+    const registryPath = join(TEST_DIR, "lead-monitor-rearm-registry.json");
     const agentId = "cmuxlayer-lead-monitor-rearm";
     let now = 3_000_000;
     stateMgr.writeState(
@@ -750,15 +792,27 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
-    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-rearm-1",
+      ownerSeat: agentId,
+      now: () => now,
+    });
     now += 61_000;
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
 
     now += 1_000;
-    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-rearm-2",
+      ownerSeat: agentId,
+      now: () => now,
+    });
     await engine.runSweep();
 
     now += 61_000;
@@ -767,9 +821,10 @@ describe("Sidebar Sync", () => {
     expect(mockClient.notify).toHaveBeenCalledTimes(2);
   });
 
-  it("deadman timeout fires a lead monitor-death alert without a follow-up sweep", async () => {
+  it("registry deadman timeout waits for a cross-agent sweep instead of an owner-local timer", async () => {
     vi.useFakeTimers();
-    const inboxDir = join(TEST_DIR, "lead-monitor-deadman-inbox");
+    const inboxDir = join(TEST_DIR, "lead-monitor-cross-agent-inbox");
+    const registryPath = join(TEST_DIR, "lead-monitor-cross-agent-sweep.json");
     const agentId = "cmuxlayer-lead-monitor-deadman";
     let now = 4_000_000;
     stateMgr.writeState(
@@ -792,8 +847,15 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
-    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-cross-agent-1",
+      ownerSeat: agentId,
+      now: () => now,
+    });
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -817,6 +879,10 @@ describe("Sidebar Sync", () => {
       await Promise.resolve();
     }
 
+    expect(mockClient.notify).not.toHaveBeenCalled();
+
+    await engine.runSweep();
+
     expect(mockClient.notify).toHaveBeenCalledTimes(1);
     expect(mockClient.notify).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -828,7 +894,8 @@ describe("Sidebar Sync", () => {
   });
 
   it("lead monitor-death delivery memory follows session-capture rename", async () => {
-    const inboxDir = join(TEST_DIR, "lead-monitor-rename-deadman-inbox");
+    const inboxDir = join(TEST_DIR, "lead-monitor-rename-inbox");
+    const registryPath = join(TEST_DIR, "lead-monitor-rename-registry.json");
     const pendingAgentId = "claude-cmuxlayer-pending-lead";
     const sessionId = "12345678-1234-1234-1234-123456789abc";
     const finalAgentId = generateAgentId("claude", "cmuxlayer", sessionId);
@@ -855,8 +922,15 @@ describe("Sidebar Sync", () => {
       spawnPreflight: async () => {},
       inboxOpts: { baseDir: inboxDir, now: () => now },
       sessionIdentityResolver: () => capturedSessionId,
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
     });
-    writeHeartbeat(pendingAgentId, { baseDir: inboxDir, now: () => now });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-rename-1",
+      ownerSeat: pendingAgentId,
+      now: () => now,
+    });
     now += AGENT_HEALTH_MONITOR_MAX_AGE_MS + 1;
     await engine.getRegistry().reconstitute();
 
@@ -876,6 +950,10 @@ describe("Sidebar Sync", () => {
     expect(stateMgr.readState(pendingAgentId)).toBeNull();
     expect(stateMgr.readState(finalAgentId)).not.toBeNull();
     expect(mockClient.notify).toHaveBeenCalledTimes(1);
+    expect(readMonitorRegistry({ registryPath }).monitors[0]).toMatchObject({
+      monitor_id: "lead-rename-1",
+      owner_seat: finalAgentId,
+    });
   });
 
   it("does not emit done notifications until a worker has verified terminal evidence", async () => {


### PR DESCRIPTION
## Summary
- Add the canonical `~/.golems-zikaron/monitor-registry.json` deadman core with register, signal, deregister, invalid-record fail-closed handling, and injected notify delivery.
- Wire the agent-engine sweep to flip lapsed monitor records to `deadman-fired` before sidebar sync, with production entrypoints injecting the HTTP notify path and tests keeping it no-op/injected.
- Migrate the #237 lead monitor-death alert away from inbox heartbeat liveness and onto registry `deadman-fired` events while preserving dedup, re-arm on newer monitor id, worker gating, and session-capture id transfer.

## Do Not Merge
Lead owns merge after review. This PR is capture-only per lane brief.

## Test Plan
- RED: `./node_modules/.bin/vitest run tests/monitor-registry.test.ts tests/sidebar-sync.test.ts` initially failed because `../src/monitor-registry.js` did not exist.
- GREEN focused: `./node_modules/.bin/vitest run tests/monitor-registry.test.ts tests/sidebar-sync.test.ts` -> 2 files passed, 31 tests passed.
- Full: `bun run typecheck && bun run test` -> 74 files passed, 1358 tests passed.
- Push hook tail: `run_tests.sh finished with exit status 0` after race fixture checks and full Vitest suite.

## Review Notes
- Pre-commit `coderabbit review --agent` was run with a 180s timeout. It connected and reached `reviewing`, then timed out with exit 142 before returning findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator lead alerting semantics and adds cross-process shared state plus HTTP notifications; behavior is covered by focused tests and failures are best-effort inside sweeps.
> 
> **Overview**
> Introduces a **shared monitor deadman** backed by `~/.golems-zikaron/monitor-registry.json`, with register/signal/deregister, owner transfer on session rename, sweep-driven timeout firing (exactly once per monitor), invalid-record fail-closed handling, and injectable HTTP notify.
> 
> **AgentEngine** drops per-lead inbox-heartbeat timers and instead runs a best-effort registry sweep each lifecycle sweep (before sidebar sync). Lead “watch-blind” proactive alerts now key off registry `deadman-fired` (plus existing PID/session error paths), with dedup, re-arm when a newer monitor is registered, worker gating, and owner transfer on id rename unchanged in intent.
> 
> Production entrypoints (`index`, `daemon`, `app-server-runtime`, `createServer`) inject the default registry path and `httpNotifyMonitorDeadman`; tests/libraries stay no-op unless options are passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27698bb4f95cbf1331614b75b12c40d27213b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add monitor registry deadman core for lead monitor death detection
> - Introduces [monitor-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/241/files#diff-31e50deaff71fd7c2f67d754a4e883322f6e1888d19e5b0708d1813cd7c115c0) with functions to register, signal, deregister, transfer, and sweep monitors using an atomic file-based registry, replacing per-agent in-memory `setTimeout` timers.
> - `AgentEngine` gains optional `monitorRegistryPath`, `monitorRegistryNow`, and `monitorRegistryNotify` fields; each sweep calls `sweepMonitorRegistry` to fire deadman notifications for stale monitors.
> - `isLeadWatchBlind` now checks the registry for a `deadman-fired` state instead of reading inbox heartbeat staleness or consulting local timers.
> - App server, daemon, and CLI entry points all wire in `defaultMonitorRegistryPath()` and `httpNotifyMonitorDeadman` by default.
> - Behavioral Change: deadman alert timing is now driven by sweep cadence and registry state rather than per-agent `setTimeout`; tests and libraries that omit `monitorRegistryPath` are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d27698b. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitor-registry based deadman alerts for agents, with support for configurable registry storage and notification delivery.
  * Agent and server startup now automatically wire in monitor-registry settings.

* **Bug Fixes**
  * Improved lead-monitor alerting so notifications fire once per agent when monitoring goes stale.
  * Ownership updates now carry over correctly when an agent is renamed.

* **Tests**
  * Added coverage for monitor registration, signaling, sweep behavior, deregistration, and alert delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->