### PR TITLE
fix: version-gated outbox quarantine migration (v1→v2, #240 regression)

### DIFF
--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -114,24 +114,38 @@ the drainer itself stays **non-destructive** (idempotency is the sidecar, never 
 mutation of `outbox.md`; see the L7 invariant).
 
 As belt-and-suspenders release hygiene, **before shipping a release that touches
-outbox semantics**, mechanically archive + truncate the live outbox on each
-target Mac so a fresh backlog can never be re-drained through the new code path:
+outbox semantics**, archive the live outbox on each target Mac so operator
+history is preserved before the new code path runs.
+
+> ⚠️ **Never discard undelivered entries.** The drainer reads only `outbox.md`
+> and its sidecar — it does **not** read `outbox-archive.md`. So truncating
+> `outbox.md` while it still holds *undelivered* entries silently drops them
+> (they are archived-as-history but never delivered). Truncation is therefore
+> only safe **after** the outbox is confirmed fully drained. If you cannot
+> confirm that, **archive only — do not truncate.**
 
 ```bash
 # Run on EACH target Mac, per user, before the new binary goes live.
 z=~/.golems-zikaron
 if [ -s "$z/outbox.md" ]; then
+  # 1) Always safe: append a copy to the durable archive (history survives).
   { printf '\n<!-- archived %s (pre-deploy) -->\n' "$(date -u +%FT%TZ)"; cat "$z/outbox.md"; } >> "$z/outbox-archive.md"
-  : > "$z/outbox.md"    # truncate in place; keep the file so the drainer no-ops cleanly
+
+  # 2) Truncate ONLY after confirming the outbox is fully drained — i.e. every
+  #    entry has already been delivered (no pending/undelivered messages). If you
+  #    have not confirmed that, SKIP this line and leave outbox.md in place; the
+  #    version-gated quarantine already prevents a re-send, and the drainer stays
+  #    non-destructive. Truncating an undrained outbox would DROP those messages.
+  : > "$z/outbox.md"   # keep the file so the drainer no-ops cleanly
 fi
 ```
 
 This is a **documented manual deploy step**, not something the drainer does — the
 drainer must remain non-destructive. Do **not** wire an unguarded `rm`/truncate
 into `scripts/release.sh`; a release runs on the maintainer's machine and must not
-silently delete another operator's pending messages. If you add a hook, make it a
-**commented reminder** that prints the step for the operator to run per target
-Mac, gated behind an explicit opt-in flag.
+silently delete another operator's pending (undelivered) messages. If you add a
+hook, make it a **commented reminder** that prints the step for the operator to
+run per target Mac, gated behind an explicit opt-in flag.
 
 ## Behavioural invariants (what changed in v0.2.0)
 

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -101,6 +101,38 @@ Manual equivalent, if you prefer:
 The formula also carries a `head` block, so `--HEAD` installs always track
 `main` with **no** sha/tag bump — that is the on-the-go dogfood path.
 
+## Pre-deploy hygiene: archive the outbox before shipping outbox-semantics changes
+
+Any release that could change how `outbox-drainer.ts` derives dedup ids or
+gates delivery (e.g. #240's byte-position → `sha256(body)#occurrence` switch, or
+the v1→v2 quarantine that followed it) can, on the first drain after deploy,
+re-interpret the *existing* backlog in `~/.golems-zikaron/outbox.md`. The
+in-code guard for this is the **version-gated quarantine** in `drainOutbox`: on a
+`STATE_VERSION` bump it adopts the current backlog as drained *without*
+re-delivering (see `src/outbox-drainer.ts`). That guard is the real safety net —
+the drainer itself stays **non-destructive** (idempotency is the sidecar, never a
+mutation of `outbox.md`; see the L7 invariant).
+
+As belt-and-suspenders release hygiene, **before shipping a release that touches
+outbox semantics**, mechanically archive + truncate the live outbox on each
+target Mac so a fresh backlog can never be re-drained through the new code path:
+
+```bash
+# Run on EACH target Mac, per user, before the new binary goes live.
+z=~/.golems-zikaron
+if [ -s "$z/outbox.md" ]; then
+  { printf '\n<!-- archived %s (pre-deploy) -->\n' "$(date -u +%FT%TZ)"; cat "$z/outbox.md"; } >> "$z/outbox-archive.md"
+  : > "$z/outbox.md"    # truncate in place; keep the file so the drainer no-ops cleanly
+fi
+```
+
+This is a **documented manual deploy step**, not something the drainer does — the
+drainer must remain non-destructive. Do **not** wire an unguarded `rm`/truncate
+into `scripts/release.sh`; a release runs on the maintainer's machine and must not
+silently delete another operator's pending messages. If you add a hook, make it a
+**commented reminder** that prints the step for the operator to run per target
+Mac, gated behind an explicit opt-in flag.
+
 ## Behavioural invariants (what changed in v0.2.0)
 
 These are enforced in code + tests; rely on them and don't regress them.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,4 +97,11 @@ cat <<EOF
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
 Next:
   brew update && brew upgrade etanhey/layers/cmuxlayer
+
+# Outbox-semantics releases only (see docs/releases-and-brew.md "Pre-deploy hygiene"):
+#   if this release changes outbox dedup-id derivation or the delivery gate,
+#   archive+truncate ~/.golems-zikaron/outbox.md on EACH target Mac BEFORE the
+#   new binary goes live. This is a manual, per-Mac step — intentionally NOT
+#   auto-run here, since a release must never silently delete another operator's
+#   pending messages. The in-code version-gated quarantine is the real guard.
 EOF

--- a/src/outbox-drainer.ts
+++ b/src/outbox-drainer.ts
@@ -65,6 +65,19 @@ export interface DrainResult {
   failedCount: number;
   /** Total entries parsed from the outbox file. */
   totalEntries: number;
+  /**
+   * True only on a one-time id-scheme/version-bump migration sweep: the legacy
+   * (or missing/corrupt) sidecar was QUARANTINED — every currently-present entry
+   * was adopted as drained WITHOUT delivering, so the whole pre-existing backlog
+   * is not re-sent under the new id scheme (the #240 mass-respam regression).
+   * Absent (undefined) on every normal drain.
+   */
+  migrated?: boolean;
+  /**
+   * Number of entries adopted-as-drained by the quarantine migration. Populated
+   * only when `migrated` is true.
+   */
+  migratedCount?: number;
 }
 
 export interface OutboxDrainerOptions {
@@ -111,7 +124,10 @@ const DEFAULT_NOTIFY_URL = "http://127.0.0.1:3847/notify";
 const DEFAULT_TITLE = "golems outbox";
 const DEFAULT_SOURCE = "cmuxlayer-outbox";
 const DEFAULT_PRIORITY = "default";
-const STATE_VERSION = 1;
+// v1 → v2: #240 changed the dedup id from byte-position → `sha256(body)#occurrence`.
+// A version bump means prior drained-marks may not map to the current id scheme, so
+// `drainOutbox` gates on it to quarantine (not re-deliver) a legacy backlog.
+const STATE_VERSION = 2;
 
 export function defaultOutboxPath(): string {
   return join(homedir(), ".golems-zikaron", "outbox.md");
@@ -154,19 +170,26 @@ export function parseOutboxEntries(raw: string): OutboxEntry[] {
 }
 
 function loadState(statePath: string): DrainState {
+  // A MISSING sidecar is legacy, not current: default to version 0 so the
+  // migration gate quarantines any co-existing backlog instead of re-sending it
+  // ("deleted sidecar re-arms full re-send" class). Never seed with STATE_VERSION.
   if (!existsSync(statePath)) {
-    return { version: STATE_VERSION, drained: [] };
+    return { version: 0, drained: [] };
   }
   try {
     const parsed = JSON.parse(
       readFileSync(statePath, "utf8"),
     ) as Partial<DrainState>;
     const drained = Array.isArray(parsed.drained) ? parsed.drained : [];
-    return { version: STATE_VERSION, drained };
+    // Preserve the ON-DISK version so `drainOutbox` can detect an id-scheme bump.
+    // A missing/NaN version field is treated as legacy (0), NOT current.
+    const version = Number(parsed.version);
+    return { version: Number.isFinite(version) ? version : 0, drained };
   } catch {
-    // Corrupt sidecar: treat as empty rather than crash. Worst case is a re-send,
-    // which is safer than throwing and blocking all future drains.
-    return { version: STATE_VERSION, drained: [] };
+    // Corrupt sidecar: treat as a lost legacy sidecar (version 0, no drained
+    // records) so the migration gate quarantines rather than re-sends the whole
+    // backlog. Safer than throwing and blocking all future drains.
+    return { version: 0, drained: [] };
   }
 }
 
@@ -257,6 +280,36 @@ export async function drainOutbox(
 
   const state = loadState(statePath);
   const drainedIds = new Set(state.drained.map((r) => r.id));
+
+  // One-time migration on an id-scheme/version bump. A version change means
+  // prior drained-marks may not map to the current id scheme, so re-running the
+  // delivery loop against a legacy sidecar would re-deliver the whole backlog
+  // (the #240 mass-respam regression). We QUARANTINE: adopt every entry
+  // currently present as drained WITHOUT delivering, archive them as history,
+  // then stamp the sidecar to STATE_VERSION. Genuine new messages appended
+  // after migration deliver normally. Also covers a missing/corrupt sidecar
+  // (version 0) → never re-arms a full re-send.
+  if (state.version < STATE_VERSION) {
+    const at = now();
+    for (const entry of entries) {
+      if (!drainedIds.has(entry.id)) {
+        drainedIds.add(entry.id);
+        state.drained.push({ id: entry.id, at });
+        // best-effort history; must never gate exactly-once
+        try {
+          appendArchive(archivePath, entry, at);
+        } catch {
+          // Archive is durable operator history, not the dedup source of truth.
+        }
+      }
+    }
+    state.version = STATE_VERSION;
+    saveState(statePath, state);
+    result.migrated = true;
+    result.migratedCount = entries.length;
+    // fall through: the delivery loop below now skips every entry (all in
+    // drainedIds) → deliveredCount stays 0 on the migration sweep.
+  }
 
   for (const entry of entries) {
     if (drainedIds.has(entry.id)) {

--- a/src/outbox-drainer.ts
+++ b/src/outbox-drainer.ts
@@ -199,6 +199,23 @@ function saveState(statePath: string, state: DrainState): void {
 }
 
 /**
+ * Stamp the sidecar to the current STATE_VERSION when the version boundary is
+ * crossed with NO backlog to quarantine (an empty or absent outbox). Without
+ * this, a fresh v2 deploy whose outbox is momentarily empty/absent would
+ * early-return before the migration block, the sidecar would never be stamped,
+ * and the gate would stay armed — so the FIRST real message to arrive later
+ * would be quarantined and dropped. Existing drained records are preserved.
+ * Returns true iff it stamped (i.e. a boundary was actually crossed).
+ */
+function stampVersionBaseline(statePath: string): boolean {
+  const state = loadState(statePath);
+  if (state.version >= STATE_VERSION) return false;
+  state.version = STATE_VERSION;
+  saveState(statePath, state);
+  return true;
+}
+
+/**
  * Append a delivered entry to the durable archive so operator history survives
  * when the live outbox.md is later trimmed/rotated. Best-effort: the caller
  * treats a throw here as non-fatal (the entry is already marked drained).
@@ -269,12 +286,25 @@ export async function drainOutbox(
   };
 
   if (!existsSync(outboxPath)) {
+    // No outbox file, but a version-boundary crossing must still stamp the v2
+    // baseline so the gate disarms — otherwise the first real message to arrive
+    // later would be quarantined. Nothing to quarantine here, just stamp.
+    if (stampVersionBaseline(statePath)) {
+      result.migrated = true;
+      result.migratedCount = 0;
+    }
     return result;
   }
 
   const entries = parseOutboxEntries(readFileSync(outboxPath, "utf8"));
   result.totalEntries = entries.length;
   if (entries.length === 0) {
+    // Empty outbox: same as above — stamp the v2 baseline so a fresh deploy
+    // does not leave the gate armed against the first genuine message.
+    if (stampVersionBaseline(statePath)) {
+      result.migrated = true;
+      result.migratedCount = 0;
+    }
     return result;
   }
 

--- a/tests/outbox-drainer-sweep.test.ts
+++ b/tests/outbox-drainer-sweep.test.ts
@@ -53,6 +53,13 @@ describe("agent-engine sweep wires the outbox drainer", () => {
     const outboxPath = join(root, "outbox.md");
     const statePath = join(root, ".outbox-drained.json");
     writeFileSync(outboxPath, "sweep must deliver this\n");
+    // Seed a CURRENT-version (v2) sidecar so the one-time id-scheme quarantine
+    // does not fire — this test exercises the delivery + dedup wiring, not the
+    // migration path (a missing sidecar would quarantine and deliver nothing).
+    writeFileSync(
+      statePath,
+      `${JSON.stringify({ version: 2, drained: [] }, null, 2)}\n`,
+    );
 
     calls = [];
     // Inject a drain that exercises the REAL drainOutbox against a temp outbox,

--- a/tests/outbox-drainer.test.ts
+++ b/tests/outbox-drainer.test.ts
@@ -449,10 +449,77 @@ describe("id-scheme migration (v1→v2 quarantine)", () => {
     expect(rec.calls).toHaveLength(0);
     expect(result.deliveredCount).toBe(0);
     expect(result.migrated).toBe(true);
+    expect(result.migratedCount).toBe(2);
     const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
       version: number;
     };
     expect(saved.version).toBe(2);
+  });
+
+  it("fresh v2 deploy with an EMPTY outbox stamps the baseline so the first real message DELIVERS (not quarantined)", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    // Fresh deploy: no sidecar, outbox present but empty (no backlog). The old
+    // code early-returned here BEFORE stamping v2, leaving the gate armed.
+    writeFileSync(outboxPath, "");
+    const firstDrain = recorder();
+    const empty = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: firstDrain.deliver,
+    });
+    expect(firstDrain.calls).toHaveLength(0);
+    expect(empty.deliveredCount).toBe(0);
+    // Gate must be disarmed: sidecar stamped to v2 even with nothing to quarantine.
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      version: number;
+    };
+    expect(saved.version).toBe(2);
+
+    // The FIRST real message arrives later — it must DELIVER, not be quarantined.
+    writeFileSync(outboxPath, "first real message\n");
+    const rec = recorder();
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+    expect(result.deliveredCount).toBe(1);
+    expect(result.migrated).toBeUndefined();
+    expect(rec.calls.map((c) => c.body)).toEqual(["first real message"]);
+  });
+
+  it("fresh v2 deploy with an ABSENT outbox stamps the baseline so the first real message DELIVERS", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    // No outbox file at all yet, no sidecar. Boundary must still be stamped.
+    const firstDrain = recorder();
+    await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: firstDrain.deliver,
+    });
+    expect(firstDrain.calls).toHaveLength(0);
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      version: number;
+    };
+    expect(saved.version).toBe(2);
+
+    // First real message → delivers, not quarantined.
+    writeFileSync(outboxPath, "first real message\n");
+    const rec = recorder();
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+    expect(result.deliveredCount).toBe(1);
+    expect(result.migrated).toBeUndefined();
+    expect(rec.calls.map((c) => c.body)).toEqual(["first real message"]);
   });
 
   it("post-migration delivery works: a NEW entry after migration delivers exactly once", async () => {

--- a/tests/outbox-drainer.test.ts
+++ b/tests/outbox-drainer.test.ts
@@ -45,6 +45,25 @@ function harness(root: string, overrides?: Partial<OutboxDrainerOptions>) {
   return { outboxPath, statePath, archivePath, ...overrides };
 }
 
+/**
+ * Seed a sidecar at a chosen version so a test exercises the intended path:
+ *  - version 2 (STATE_VERSION): the one-time migration gate is SKIPPED, so the
+ *    normal delivery/dedup mechanics run (what most tests below check).
+ *  - version 1 / 0: a legacy sidecar that trips the id-scheme quarantine.
+ * A missing sidecar counts as legacy (version 0) and quarantines, so delivery
+ * tests must seed a current-version sidecar first.
+ */
+function writeSidecar(
+  statePath: string,
+  version: number,
+  drained: Array<{ id: string; at: number }> = [],
+): void {
+  writeFileSync(
+    statePath,
+    `${JSON.stringify({ version, drained }, null, 2)}\n`,
+  );
+}
+
 describe("parseOutboxEntries", () => {
   it("splits blank-line-separated blocks into indexed entries and ignores empties", () => {
     const raw = "first message\n\nsecond message\n\n\n\nthird message\n";
@@ -88,6 +107,9 @@ describe("drainOutbox", () => {
   it("FN: a written entry is delivered exactly once", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    // Current-version sidecar: exercise the delivery path, not the one-time
+    // quarantine that a missing/legacy sidecar would trigger.
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "hello operator\n");
     const rec = recorder();
 
@@ -111,6 +133,7 @@ describe("drainOutbox", () => {
   it("FP: draining twice never double-sends (same process)", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "one\n\ntwo\n");
     const rec = recorder();
 
@@ -134,6 +157,7 @@ describe("drainOutbox", () => {
   it("FP: survives restart — a fresh drainer reading persisted state re-sends nothing", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "durable\n");
 
     const first = recorder();
@@ -154,6 +178,7 @@ describe("drainOutbox", () => {
   it("delivers only newly-appended entries on a subsequent drain", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "old entry\n");
     const rec = recorder();
 
@@ -175,6 +200,7 @@ describe("drainOutbox", () => {
   it("does NOT mark an entry drained when delivery fails, and retries next time", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "flaky\n");
 
     const failing = recorder({ fail: true });
@@ -215,6 +241,7 @@ describe("drainOutbox", () => {
   it("persisted state is valid JSON recording the drained ids", async () => {
     const root = tempRoot();
     const { outboxPath, statePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "audit me\n");
     await drainOutbox({ outboxPath, statePath, deliver: recorder().deliver });
 
@@ -222,7 +249,7 @@ describe("drainOutbox", () => {
       version: number;
       drained: Array<{ id: string; at: number }>;
     };
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
     expect(parsed.drained).toHaveLength(1);
     expect(typeof parsed.drained[0].id).toBe("string");
   });
@@ -232,6 +259,7 @@ describe("rotation-safe dedup", () => {
   it("FN rotation-safety: archiving/truncating outbox.md then re-draining re-sends nothing", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     // A multi-entry log; the earlier entries are what a rotation trims away.
     writeFileSync(outboxPath, "alpha\n\nbeta\n\ngamma\n");
     const first = recorder();
@@ -262,6 +290,7 @@ describe("rotation-safe dedup", () => {
   it("a full truncate followed by a re-drain of old content re-sends nothing", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "one\n\ntwo\n");
     await drainOutbox({
       outboxPath,
@@ -288,6 +317,7 @@ describe("rotation-safe dedup", () => {
   it("genuine repeated identical messages each deliver once", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "ping\n\nping\n");
     const rec = recorder();
     const result = await drainOutbox({
@@ -314,6 +344,7 @@ describe("rotation-safe dedup", () => {
   it("a newly-appended identical message after a drain still delivers", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "ping\n");
     await drainOutbox({
       outboxPath,
@@ -337,10 +368,148 @@ describe("rotation-safe dedup", () => {
   });
 });
 
+describe("id-scheme migration (v1→v2 quarantine)", () => {
+  it("THE regression: a legacy sidecar quarantines the whole backlog — ZERO deliveries", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    // Backlog of 3 entries under the CURRENT id scheme...
+    const raw = "backlog one\n\nbacklog two\n\nbacklog three\n";
+    writeFileSync(outboxPath, raw);
+    const expectedIds = parseOutboxEntries(raw).map((e) => e.id);
+    // ...and a LEGACY (v1) sidecar whose old-scheme ids match none of them. On
+    // the old code the backlog would read as undrained and be re-delivered (the
+    // #240 mass-respam). The migration gate must adopt-as-drained instead.
+    writeSidecar(statePath, 1, [
+      { id: "legacy-pos-0", at: 0 },
+      { id: "legacy-pos-1", at: 0 },
+    ]);
+    const rec = recorder();
+
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+
+    // ZERO deliveries — the entire backlog was quarantined, not re-sent.
+    expect(rec.calls).toHaveLength(0);
+    expect(result.deliveredCount).toBe(0);
+    expect(result.migrated).toBe(true);
+    expect(result.migratedCount).toBe(3);
+
+    // Sidecar stamped to v2 with every current entry's new-scheme id present.
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      version: number;
+      drained: Array<{ id: string; at: number }>;
+    };
+    expect(saved.version).toBe(2);
+    const savedIds = new Set(saved.drained.map((r) => r.id));
+    for (const id of expectedIds) expect(savedIds.has(id)).toBe(true);
+  });
+
+  it("a MISSING sidecar quarantines (kills 'deleted sidecar re-arms full re-send')", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    // No sidecar on disk + a live backlog: legacy by default → quarantine.
+    writeFileSync(outboxPath, "stale one\n\nstale two\n");
+    const rec = recorder();
+
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+
+    expect(rec.calls).toHaveLength(0);
+    expect(result.deliveredCount).toBe(0);
+    expect(result.migrated).toBe(true);
+    expect(result.migratedCount).toBe(2);
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      version: number;
+    };
+    expect(saved.version).toBe(2);
+  });
+
+  it("a CORRUPT sidecar quarantines (treated as lost legacy, not re-sent)", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    writeFileSync(statePath, "{ broken json");
+    writeFileSync(outboxPath, "corrupt-guard one\n\ncorrupt-guard two\n");
+    const rec = recorder();
+
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+
+    expect(rec.calls).toHaveLength(0);
+    expect(result.deliveredCount).toBe(0);
+    expect(result.migrated).toBe(true);
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      version: number;
+    };
+    expect(saved.version).toBe(2);
+  });
+
+  it("post-migration delivery works: a NEW entry after migration delivers exactly once", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    // First drain migrates (missing sidecar → quarantine, zero deliveries).
+    writeFileSync(outboxPath, "pre-existing backlog\n");
+    const migrateRec = recorder();
+    const migrateResult = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: migrateRec.deliver,
+    });
+    expect(migrateResult.migrated).toBe(true);
+    expect(migrateRec.calls).toHaveLength(0);
+
+    // Sidecar is now v2; a genuinely new message appended afterwards delivers
+    // normally — migration is one-time, no re-quarantine.
+    writeFileSync(outboxPath, "pre-existing backlog\n\nfresh message\n");
+    const rec = recorder();
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+    expect(result.deliveredCount).toBe(1);
+    expect(result.migrated).toBeUndefined();
+    expect(rec.calls.map((c) => c.body)).toEqual(["fresh message"]);
+  });
+
+  it("a CURRENT-version (v2) sidecar is untouched — migration does NOT fire", async () => {
+    const root = tempRoot();
+    const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
+    writeFileSync(outboxPath, "deliver me normally\n");
+    const rec = recorder();
+
+    const result = await drainOutbox({
+      outboxPath,
+      statePath,
+      archivePath,
+      deliver: rec.deliver,
+    });
+
+    expect(result.deliveredCount).toBe(1);
+    expect(result.migrated).toBeUndefined();
+    expect(rec.calls.map((c) => c.body)).toEqual(["deliver me normally"]);
+  });
+});
+
 describe("archive", () => {
   it("appends delivered entries to the durable archive file", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "archive me\n\narchive me too\n");
     const rec = recorder();
     await drainOutbox({
@@ -359,6 +528,7 @@ describe("archive", () => {
   it("preserves operator history even after the live outbox is trimmed", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "alpha\n\nbeta\n");
     await drainOutbox({
       outboxPath,
@@ -377,6 +547,7 @@ describe("archive", () => {
   it("only archives entries that were actually delivered", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "never sent\n");
     const failing = recorder({ fail: true });
     await drainOutbox({
@@ -400,6 +571,10 @@ describe("default deliver is a no-op (incident guard)", () => {
   it("draining without injecting a transport delivers nothing and never posts", async () => {
     const root = tempRoot();
     const { outboxPath, statePath, archivePath } = harness(root);
+    // Current-version sidecar so the one-time migration gate does NOT fire —
+    // this isolates the DELIVERY path: the default no-op transport must deliver
+    // nothing and never reach the 3847 notify listener.
+    writeSidecar(statePath, 2);
     writeFileSync(outboxPath, "must never reach 127.0.0.1:3847\n");
     // No `deliver` injected: the library default MUST be a no-op so the test
     // suite (and any caller that forgets to wire a transport) never hits the
@@ -407,8 +582,12 @@ describe("default deliver is a no-op (incident guard)", () => {
     const result = await drainOutbox({ outboxPath, statePath, archivePath });
     expect(result.totalEntries).toBe(1);
     expect(result.deliveredCount).toBe(0);
-    // Nothing delivered -> no drained-state and no archive written.
-    expect(existsSync(statePath)).toBe(false);
+    expect(result.migrated).toBeUndefined();
+    // No-op delivery marks nothing drained and writes no archive.
+    const saved = JSON.parse(readFileSync(statePath, "utf8")) as {
+      drained: unknown[];
+    };
+    expect(saved.drained).toHaveLength(0);
     expect(existsSync(archivePath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem (P1, #240 regression)

#240 changed the outbox dedup id from byte-position → `sha256(body)#occurrence`. But `loadState()` returned `{ version: STATE_VERSION, drained }` — **discarding the on-disk sidecar version**, so there was no migration gate. On the first drain after that change, the old sidecar's records matched no new-scheme id, the entire pre-existing backlog read as undrained, and it re-delivered — Etan received stale July-3 messages. User-visible spam regression.

## Fix — `src/outbox-drainer.ts` only

1. **`STATE_VERSION` 1 → 2.**
2. **`loadState` preserves the on-disk version.** Coerced to a number; missing/NaN → `0` (legacy), never seeded with `STATE_VERSION`. A missing **or** corrupt sidecar returns `{ version: 0, drained: [] }` → treated as legacy and quarantined. This also kills the "deleted sidecar re-arms a full re-send" class.
3. **Version-gated quarantine in `drainOutbox`.** When `state.version < STATE_VERSION`, a one-time sweep adopts every currently-present entry as drained **without delivering**, archives them as history (best-effort), stamps the sidecar to v2, and sets `result.migrated` / `result.migratedCount`. The delivery loop then skips everything → `deliveredCount` stays 0 on the migration sweep. Genuine new messages appended afterward deliver normally.
4. **`DrainResult`** gains documented `migrated?` / `migratedCount?`, populated only on a migration sweep.
5. **Non-destructive.** `outbox.md` is never mutated — quarantine is sidecar-only (the L7 idempotency invariant is load-bearing). Default `deliver` stays the `noopDeliver` incident guard; entrypoint wiring untouched.

## Tests — `tests/outbox-drainer.test.ts`

New `describe("id-scheme migration (v1→v2 quarantine)")`:
- **THE regression:** 3-entry backlog + legacy `{version:1, drained:[legacy-pos-0, legacy-pos-1]}` → **0 deliveries**, `migrated===true`, `migratedCount===3`, sidecar rewritten to v2 with all 3 current new-scheme ids.
- Missing sidecar quarantines (0 deliveries, v2).
- Corrupt sidecar (`"{ broken json"`) quarantines (0 deliveries, v2).
- Post-migration: a NEW entry appended after migration delivers exactly once.
- Current-version (v2) sidecar untouched → normal delivery, migration does not fire.

Existing delivery/dedup tests now seed a `{version:2}` sidecar so they exercise the delivery path rather than the new one-time quarantine (a missing sidecar now legitimately quarantines). Same intent, adjusted premise. **All 1366 tests green; `bun run typecheck` clean.** Verified `~/.golems-zikaron/outbox.md` mtime unchanged across the test run (real-state / incident guard holds).

## Part (b) — release hygiene (docs, not drainer code)

`docs/releases-and-brew.md` gains a **"Pre-deploy hygiene"** section documenting a mechanical, per-Mac archive+truncate of `~/.golems-zikaron/outbox.md` before shipping outbox-semantics changes, plus a **commented reminder** in `scripts/release.sh`. Deliberately manual / never auto-run — a release must not silently delete another operator's pending messages, and the drainer itself stays non-destructive. The in-code version-gated quarantine is the real guard.

## Part (c) — audit note

`deliver: httpDeliver` is wired at all 3 entrypoints — **`index.ts:79` / `daemon.ts:406` / `app-server-runtime.ts:198`** — since #240, **by design**; nothing silently flipped. The v0.3.9 deploy (~12:33) activated the already-live transport with **no migration gate**. This PR's version-gated quarantine IS that gate. (Verified by grep this session; all three lines present.)

Do NOT merge/release — lead reviews + ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade behavior changes: existing queued outbox entries are quarantined (not delivered) on first drain after deploy; operators must understand this and follow manual archive steps if they need delivery guarantees.
> 
> **Overview**
> Fixes the **#240 mass-respam regression** by adding a **one-time v1→v2 migration** in `drainOutbox`: sidecar `STATE_VERSION` is now **2**, `loadState` **keeps the on-disk version** (missing/corrupt sidecar → **version 0**, not current), and when `state.version < STATE_VERSION` the drainer **quarantines** every entry already in `outbox.md`—marks them drained **without notifying**, best-effort archives them, stamps v2—so legacy dedup ids cannot trigger a full backlog re-send. **`DrainResult`** exposes optional **`migrated` / `migratedCount`** for that sweep.
> 
> **`stampVersionBaseline`** runs on **empty or missing** outbox so a fresh deploy does not leave the gate armed and **drop the first new message**. Normal delivery/dedup is unchanged once the sidecar is v2; **`outbox.md` is still never mutated**.
> 
> Release docs add **pre-deploy hygiene** (manual per-Mac archive/truncate guidance) and **`release.sh`** prints a **comment-only reminder**—no auto-truncate on the maintainer machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bd0ec367770427ac3732a9a89fa21acdc5a75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix v1→v2 outbox quarantine migration regression in `drainOutbox`
> - Bumps `STATE_VERSION` from 1 to 2 in [outbox-drainer.ts](https://github.com/EtanHey/cmuxlayer/pull/243/files#diff-c99dfc4088f2d0bdd9610c2f62d96ba7848d6882dab69a484652d8000e5fb49d); on first drain after upgrade, all legacy entries are marked drained without delivery and appended to archive (quarantine), then the sidecar is stamped to v2.
> - Fixes `loadState` to treat a missing or corrupt sidecar as version 0 (legacy) rather than current, so the migration gate fires correctly instead of silently skipping quarantine.
> - Adds `stampVersionBaseline` to stamp the sidecar to v2 when the outbox is empty or absent at upgrade time, preventing the first new message from being incorrectly quarantined.
> - `DrainResult` gains optional `migrated` and `migratedCount` fields so callers can observe when a quarantine occurred.
> - Adds operator guidance in [docs/releases-and-brew.md](https://github.com/EtanHey/cmuxlayer/pull/243/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) and a commented reminder in [scripts/release.sh](https://github.com/EtanHey/cmuxlayer/pull/243/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389) to manually archive and truncate the outbox before deploying outbox-semantics changes.
> - Behavioral Change: existing outbox entries present at the moment of upgrade to v2 are silently discarded (quarantined to archive) rather than delivered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08bd0ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-deploy reminder for releases that change outbox behavior, including a manual archive/truncate step to protect existing pending items.
  * Outbox draining now handles legacy backlog more safely by quarantining older entries during a version transition and reporting migration results.

* **Bug Fixes**
  * Prevents older queued items from being reprocessed after an outbox-semantics release.
  * Improves handling of missing or corrupted drain state so existing backlog is preserved safely rather than replayed unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->