### PR TITLE
feat: structured close-event observability + restart version-verify

### DIFF
--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -177,10 +177,45 @@ export interface ControlHealthTelemetryEvent {
   snapshot: unknown;
 }
 
+/** Which close/kill path emitted the event. */
+export type CloseEventPath =
+  | "close_surface"
+  | "stop_agent"
+  | "kill"
+  | "internal";
+
+/**
+ * Durable, attributed record of a surface close or agent kill/stop. Answers
+ * "who tore this down, forcibly or not, and was the attempt refused?" from the
+ * SAME events.jsonl the other telemetry entries land in, so a pane-death
+ * investigation reads one log instead of reconstructing intent from transcripts.
+ */
+export interface CloseTelemetryEvent {
+  ts: string;
+  event_type: "close";
+  /** Which handler/teardown path initiated the close. */
+  event: CloseEventPath;
+  /** Surface ref and/or agent_id being closed/killed. */
+  target: string;
+  /**
+   * Best available identity of the caller: an env-derived id
+   * (`CMUX_TAB_ID=...`), the `mcp:<toolName>` fallback for a tool-driven call
+   * with no resolvable id, or `internal:<reason>` for a teardown path.
+   */
+  caller: string;
+  /** The force flag on the originating call (kill/stop/close force). */
+  force: boolean;
+  /** Short reason / opts summary if available. */
+  reason: string | null;
+  /** True when a protected live-agent close was refused (attempt still logged). */
+  refused: boolean;
+}
+
 export type EventLogEntry =
   | StateTransition
   | DeliveryTelemetryEvent
-  | ControlHealthTelemetryEvent;
+  | ControlHealthTelemetryEvent
+  | CloseTelemetryEvent;
 
 export interface WaitResult {
   matched: boolean;

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -7,6 +7,7 @@
 import { appendFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type {
+  CloseTelemetryEvent,
   ControlHealthTelemetryEvent,
   DeliveryTelemetryEvent,
   EventLogEntry,
@@ -30,6 +31,14 @@ export class EventLog {
   }
 
   appendControlHealth(event: ControlHealthTelemetryEvent): void {
+    this.appendEntry(event);
+  }
+
+  /**
+   * Record a surface close / agent kill-or-stop with its caller. Lands in the
+   * same events.jsonl as every other telemetry entry so forensics read one log.
+   */
+  appendClose(event: CloseTelemetryEvent): void {
     this.appendEntry(event);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@ import type {
   AgentRole,
   AgentState,
   CliType,
+  CloseTelemetryEvent,
   DeliveryEventType,
   DeliveryTelemetryEvent,
 } from "./agent-types.js";
@@ -2108,6 +2109,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const appendDeliveryEvent = (event: Omit<DeliveryTelemetryEvent, "ts">) => {
     eventLog.appendDelivery({
       ts: new Date().toISOString(),
+      ...event,
+    });
+  };
+
+  // Env vars the calling agent's harness sets in this MCP child's environment.
+  // First non-empty one is the best available caller identity for a close/kill.
+  const CLOSE_CALLER_ENV_KEYS = [
+    "CMUX_TAB_ID",
+    "CMUX_WORKSPACE_ID",
+    "CMUX_SOCKET_PATH",
+  ] as const;
+
+  /**
+   * Best available identity of whoever drove a close/kill. Prefers a real
+   * env-derived id (`CMUX_TAB_ID=...`); falls back to `mcp:<toolName>` for a
+   * tool call with no resolvable id. Never fabricates an id.
+   */
+  const resolveCloseCaller = (toolName: string): string => {
+    for (const key of CLOSE_CALLER_ENV_KEYS) {
+      const value = process.env[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return `${key}=${value.trim()}`;
+      }
+    }
+    return `mcp:${toolName}`;
+  };
+
+  const appendCloseEvent = (
+    event: Omit<CloseTelemetryEvent, "ts" | "event_type">,
+  ) => {
+    eventLog.appendClose({
+      ts: new Date().toISOString(),
+      event_type: "close",
       ...event,
     });
   };
@@ -4720,6 +4754,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 };
               } catch {
                 // If consolidation fails, keep the fail-safe refusal path.
+                appendCloseEvent({
+                  event: "close_surface",
+                  target: `${args.surface} (agent ${backingAgent.agent_id})`,
+                  caller: resolveCloseCaller("close_surface"),
+                  force: args.force ?? false,
+                  reason: `refused: agent still live (${backingAgent.state}), registry consolidation failed`,
+                  refused: true,
+                });
                 return err(
                   new Error(
                     `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live) and registry consolidation failed. Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
@@ -4742,6 +4784,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     !TERMINAL_AGENT_STATES.has(record.state),
                 );
               if (remainingLiveAgent) {
+                appendCloseEvent({
+                  event: "close_surface",
+                  target: `${args.surface} (agent ${remainingLiveAgent.agent_id})`,
+                  caller: resolveCloseCaller("close_surface"),
+                  force: args.force ?? false,
+                  reason: `refused: agent still live (${remainingLiveAgent.state}) after stale registry consolidation`,
+                  refused: true,
+                });
                 return err(
                   new Error(
                     `Refused to close ${args.surface}: agent ${remainingLiveAgent.agent_id} is "${remainingLiveAgent.state}" (still live) after stale registry consolidation. Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
@@ -4759,6 +4809,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 );
               }
             } else {
+              appendCloseEvent({
+                event: "close_surface",
+                target: `${args.surface} (agent ${backingAgent.agent_id})`,
+                caller: resolveCloseCaller("close_surface"),
+                force: args.force ?? false,
+                reason: `refused: agent still live (${backingAgent.state})`,
+                refused: true,
+              });
               return err(
                 new Error(
                   `Refused to close ${args.surface}: agent ${backingAgent.agent_id} is "${backingAgent.state}" (still live). Pass force:true to close anyway. Current pane contents follow in screen/structuredContent.`,
@@ -4825,6 +4883,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         await client.closeSurface(args.surface, {
           workspace: args.workspace,
           collapsePane,
+        });
+        appendCloseEvent({
+          event: "close_surface",
+          target: args.surface,
+          caller: resolveCloseCaller("close_surface"),
+          force: args.force ?? false,
+          reason: staleRegistryDoneConsolidated
+            ? `closed after stale-registry done consolidation (agent ${staleRegistryDoneConsolidated.agent_id})`
+            : null,
+          refused: false,
         });
         const data = {
           surface: args.surface,
@@ -5281,7 +5349,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           closeSurface: (surface, closeOpts) =>
             withSurfaceWrite(
               surface,
-              () => client.closeSurface(surface, closeOpts),
+              async () => {
+                const result = await client.closeSurface(surface, closeOpts);
+                appendCloseEvent({
+                  event: "internal",
+                  target: surface,
+                  caller: "internal:agent_engine",
+                  force: false,
+                  reason: "agent_engine teardown",
+                  refused: false,
+                });
+                return result;
+              },
               { toolName: "close_surface", workspace: closeOpts?.workspace },
             ),
           notify: (notifyOpts) => client.notify(notifyOpts),
@@ -6610,6 +6689,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           await engine.stopAgent(args.agent_id, args.force);
           const state = engine.getAgentState(args.agent_id);
+          appendCloseEvent({
+            event: "stop_agent",
+            target: args.agent_id,
+            caller: resolveCloseCaller("stop_agent"),
+            force: args.force ?? false,
+            reason: `state after stop: ${state?.state ?? "done"}`,
+            refused: false,
+          });
           const data = {
             agent_id: args.agent_id,
             state: state?.state ?? "done",
@@ -7162,6 +7249,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               await engine.stopAgent(agentId, args.force);
               killed.push(agentId);
+              appendCloseEvent({
+                event: "kill",
+                target: agentId,
+                caller: resolveCloseCaller("kill"),
+                force: args.force ?? false,
+                reason: current ? `state before kill: ${current.state}` : null,
+                refused: false,
+              });
             } catch (e) {
               errors.push(
                 `${agentId}: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/version.ts
+++ b/src/version.ts
@@ -16,3 +16,33 @@ export function readVersion(): string {
     return "unknown";
   }
 }
+
+export interface BuildVersionCheck {
+  /** True when the running build matches `expected`. */
+  ok: boolean;
+  /** The version this build actually reports (same source as serverInfo). */
+  running: string;
+  /** The version the caller asserted it should be. */
+  expected: string;
+}
+
+/**
+ * Checkable primitive for restart-readiness: instead of a blind "fresh cmux
+ * loads vX.Y.Z" claim, assert `build == expected` against the version this
+ * process actually reports (the same `readVersion()` the MCP serverInfo uses).
+ * Returns a structured verdict; with `throwOnMismatch`, also throws so a
+ * restart flow can hard-fail on a stale binary.
+ */
+export function assertBuildVersion(
+  expected: string,
+  opts?: { throwOnMismatch?: boolean; running?: string },
+): BuildVersionCheck {
+  const running = opts?.running ?? readVersion();
+  const ok = running === expected;
+  if (!ok && opts?.throwOnMismatch) {
+    throw new Error(
+      `Build version mismatch: running ${running}, expected ${expected}`,
+    );
+  }
+  return { ok, running, expected };
+}

--- a/tests/event-log.test.ts
+++ b/tests/event-log.test.ts
@@ -3,7 +3,10 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventLog } from "../src/event-log.js";
-import type { StateTransition } from "../src/agent-types.js";
+import type {
+  CloseTelemetryEvent,
+  StateTransition,
+} from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-eventlog");
 
@@ -123,5 +126,40 @@ describe("EventLog", () => {
     expect(agentA).toHaveLength(2);
     expect(agentA[0].to_state).toBe("booting");
     expect(agentA[1].to_state).toBe("ready");
+  });
+
+  it("appendClose writes a fully-populated close entry to the same JSONL", () => {
+    const log = new EventLog(TEST_DIR);
+    const filePath = join(TEST_DIR, "events.jsonl");
+    const closeEvent: CloseTelemetryEvent = {
+      ts: "2026-07-06T12:00:00Z",
+      event_type: "close",
+      event: "close_surface",
+      target: "surface:worker-9 (agent codex-9)",
+      caller: "CMUX_TAB_ID=tab-42",
+      force: true,
+      reason: "refused: agent still live (working)",
+      refused: true,
+    };
+
+    log.appendClose(closeEvent);
+
+    // Forensics read ONE log: the close event lands in events.jsonl alongside
+    // every other telemetry entry, with all fields intact.
+    const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0])).toEqual(closeEvent);
+
+    const entries = log.readEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      event_type: "close",
+      event: "close_surface",
+      caller: "CMUX_TAB_ID=tab-42",
+      force: true,
+      refused: true,
+    });
+    // Close entries carry no agent_id, so they are not mistaken for transitions.
+    expect(log.readAll()).toHaveLength(0);
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -336,6 +336,21 @@ function parseToolResult(result: TestToolResult): Record<string, unknown> {
   );
 }
 
+/** Read the durable close/kill telemetry the handlers append to events.jsonl. */
+function readCloseEvents(stateDir: string): Array<Record<string, unknown>> {
+  const filePath = join(stateDir, "events.jsonl");
+  try {
+    return readFileSync(filePath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((entry) => entry.event_type === "close");
+  } catch {
+    return [];
+  }
+}
+
 describe("agent lifecycle tool registration", () => {
   it("registers all 14 phase-5 lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
@@ -764,6 +779,74 @@ describe("agent lifecycle tool handlers", () => {
         process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
       }
     }
+  });
+
+  it("stop_agent logs a durable close entry carrying caller, force, and target", async () => {
+    const server = createLifecycleServer(mockExec);
+    const stopTool = (server as any)._registeredTools["stop_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    // Seed a terminal agent so stopAgent short-circuits (no surface teardown),
+    // isolating the handler's own close-event emission.
+    const record = makeServerAgentRecord({
+      agent_id: "codex-golems-stopme",
+      surface_id: "surface:stopme",
+      state: "done",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+
+    await stopTool.handler(
+      { agent_id: record.agent_id, force: false },
+      {} as any,
+    );
+
+    const stopEvents = readCloseEvents(TEST_DIR).filter(
+      (e) => e.event === "stop_agent",
+    );
+    expect(stopEvents).toHaveLength(1);
+    expect(stopEvents[0]).toMatchObject({
+      event_type: "close",
+      event: "stop_agent",
+      target: "codex-golems-stopme",
+      force: false,
+      refused: false,
+    });
+    expect(typeof stopEvents[0].caller).toBe("string");
+    expect((stopEvents[0].caller as string).length).toBeGreaterThan(0);
+    expect(typeof stopEvents[0].ts).toBe("string");
+  });
+
+  it("kill logs a durable close entry per killed agent with caller and force", async () => {
+    const server = createLifecycleServer(mockExec);
+    const killTool = (server as any)._registeredTools["kill"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const record = makeServerAgentRecord({
+      agent_id: "codex-golems-killme",
+      surface_id: "surface:killme",
+      state: "done",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+
+    const result = await killTool.handler(
+      { target: record.agent_id, force: true },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+    expect(parsed.killed).toContain("codex-golems-killme");
+
+    const killEvents = readCloseEvents(TEST_DIR).filter(
+      (e) => e.event === "kill",
+    );
+    expect(killEvents).toHaveLength(1);
+    expect(killEvents[0]).toMatchObject({
+      event_type: "close",
+      event: "kill",
+      target: "codex-golems-killme",
+      force: true,
+      refused: false,
+    });
+    expect(typeof killEvents[0].caller).toBe("string");
   });
 
   it("spawn_agent warns when an existing same-lane idle agent can be reused", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7275,6 +7275,149 @@ describe("tool handler integration", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
+  it("close_surface logs a durable close entry with caller, force, and target", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-eventlog");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    // A terminal agent backs the surface, so the close proceeds normally.
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-done",
+      surface_id: "surface:worker-done",
+      state: "done",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "shipped",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({ caller: {} }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-done", force: true },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(mockClient.closeSurface).toHaveBeenCalled();
+
+    const closeEvents = readFileSync(join(stateDir, "events.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((e) => e.event_type === "close");
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0]).toMatchObject({
+      event_type: "close",
+      event: "close_surface",
+      target: "surface:worker-done",
+      force: true,
+      refused: false,
+    });
+    expect(typeof closeEvents[0].caller).toBe("string");
+    expect(closeEvents[0].caller.length).toBeGreaterThan(0);
+    expect(typeof closeEvents[0].ts).toBe("string");
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface logs the attempt when a live-agent close is refused", async () => {
+    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-refuse-eventlog");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-live",
+      surface_id: "surface:worker-live",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "mid task",
+      pid: null,
+      version: 1,
+      created_at: "2026-04-16T00:00:00Z",
+      updated_at: "2026-04-16T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockClient = {
+      readScreen: vi.fn().mockResolvedValue({
+        surface: "surface:worker-live",
+        text: "running tests... 115 passed",
+        lines: 1,
+        scrollback_used: false,
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-live" },
+      {} as any,
+    );
+
+    // The close is refused, but the ATTEMPT is still recorded so a pane-death
+    // investigation sees who tried to tear down a live agent.
+    expect(result.isError).toBe(true);
+    expect(mockClient.closeSurface).not.toHaveBeenCalled();
+
+    const closeEvents = readFileSync(join(stateDir, "events.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((e) => e.event_type === "close");
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0]).toMatchObject({
+      event_type: "close",
+      event: "close_surface",
+      force: false,
+      refused: true,
+    });
+    expect(closeEvents[0].target).toContain("worker-live");
+    expect(closeEvents[0].reason).toContain("refused");
+    expect(typeof closeEvents[0].caller).toBe("string");
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("close_surface consolidates stale live registry when pane shows TASK_DONE", async () => {
     const stateDir = join(tmpdir(), "cmuxlayer-close-surface-done-consolidate");
     rmSync(stateDir, { recursive: true, force: true });

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { assertBuildVersion, readVersion } from "../src/version.js";
+
+describe("assertBuildVersion", () => {
+  it("returns ok when the running build matches expected", () => {
+    const running = readVersion();
+    const result = assertBuildVersion(running);
+    expect(result).toEqual({ ok: true, running, expected: running });
+  });
+
+  it("reports a mismatch structurally without throwing by default", () => {
+    const running = readVersion();
+    const result = assertBuildVersion("0.0.0-nope", { running });
+    expect(result).toEqual({
+      ok: false,
+      running,
+      expected: "0.0.0-nope",
+    });
+  });
+
+  it("throws on mismatch when throwOnMismatch is set", () => {
+    expect(() =>
+      assertBuildVersion("0.0.0-nope", {
+        running: "1.2.3",
+        throwOnMismatch: true,
+      }),
+    ).toThrow(/Build version mismatch: running 1\.2\.3, expected 0\.0\.0-nope/);
+  });
+
+  it("does not throw on a match even with throwOnMismatch set", () => {
+    const result = assertBuildVersion("1.2.3", {
+      running: "1.2.3",
+      throwOnMismatch: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why
A recent 2-lead pane-death investigation cost ~1h of transcript archaeology because cmuxlayer logs **no durable, attributed record** of who closed/killed a surface or agent. This lane closes that evidence gap and adds a small restart-readiness primitive. Executes sprint items #3 + #6.

## Part A (primary) — attributed close-event logging
Every surface close and agent kill/stop now emits a durable structured event through the **existing** `EventLog`, so forensics read **one** log (`events.jsonl`) instead of reconstructing intent from transcripts.

- **`CloseTelemetryEvent`** (`event_type: "close"`) added in `agent-types.ts` and to the `EventLogEntry` union, in the same style as the delivery/control-health telemetry events. Fields: `event` (`close_surface` | `stop_agent` | `kill` | `internal`), `target`, `caller`, `force`, `reason`, `refused`, `ts`.
- **`EventLog.appendClose()`** parallels `appendDelivery` / `appendControlHealth`, funnelling through the same private `appendEntry` → same JSONL, same clock.
- **Caller attribution** (`resolveCloseCaller`): best available identity of who drove the close — a real env-derived id (`CMUX_TAB_ID=…` / `CMUX_WORKSPACE_ID` / `CMUX_SOCKET_PATH`), else the explicit `mcp:<toolName>` fallback, else `internal:<reason>` for teardown. **Never fabricates an id.**
- **Wired at every chokepoint** in `server.ts`:
  - `close_surface` — success path **and all three** live-agent refusal paths (a refused, protected close still records the attempt + caller + `refused: true`).
  - `stop_agent`.
  - `kill` — one event per killed agent.
  - The `agent_engine` internal teardown path (`event: "internal"`).

## Part B (small) — restart version-verify primitive
- **`assertBuildVersion(expected)`** in `version.ts` compares the running build (`readVersion()`, the same source as the MCP `serverInfo` version) against `expected`, returning `{ ok, running, expected }` and optionally throwing. Lets any future "fresh cmux loads vX.Y.Z" claim assert `build == expected` instead of asserting blind. Checkable primitive only — **not** wired into a restart flow.

## Tests
- `appendClose` writes a fully-populated close entry to the same JSONL (unit).
- Handler-level close entries carrying caller + force + reason + target for `close_surface` (success **and** refused), `stop_agent`, and `kill`.
- `assertBuildVersion` match + mismatch (+ throw-on-mismatch).
- `bun run typecheck` clean; `bun run test` green (**1377 tests, 75 files**). Real-state untouched (outbox mtime unchanged during the run).

## Scope
Strictly `event-log.ts`, `agent-types.ts`, `server.ts`, `version.ts` + their test files. No redesign of unrelated code; no crons/sprints/fleet-skill changes.

**Do not merge/release — lead review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and a small version helper; close/kill behavior is unchanged aside from append-only JSONL writes on existing paths.
> 
> **Overview**
> Adds **durable close/kill telemetry** to the existing `events.jsonl` pipeline so pane-death investigations can see who initiated teardown, whether `force` was used, and whether a protected close was **refused**—without digging through transcripts.
> 
> A new **`CloseTelemetryEvent`** (`event_type: "close"`) and **`EventLog.appendClose()`** mirror delivery/control-health logging. **`resolveCloseCaller`** attributes MCP-driven closes from env (`CMUX_TAB_ID`, etc.) or falls back to `mcp:<toolName>`; internal engine teardown uses `internal:agent_engine`. Emission is wired for **`close_surface`** (success and all live-agent refusal paths), **`stop_agent`**, **`kill`** (per agent), and the agent engine’s internal **`closeSurface`** wrapper.
> 
> Also introduces **`assertBuildVersion(expected)`** in `version.ts`: compares the running package version to an expected string and returns `{ ok, running, expected }`, with optional throw on mismatch—a standalone restart-readiness check, not hooked into server restart yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961a8856ff5501a93fdabf47348e36f47f4c42a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured close-event telemetry and `assertBuildVersion` to the agent server
> - Introduces `CloseTelemetryEvent` in [src/agent-types.ts](https://github.com/EtanHey/cmuxlayer/pull/244/files#diff-efd9180892738f786d25ac95f9c9adf7070aa3bc8d56cf1c7d726435f977c6d9) with a `CloseEventPath` union (`close_surface`, `stop_agent`, `kill`, `internal`) to classify close/kill sources.
> - Adds `EventLog.appendClose` in [src/event-log.ts](https://github.com/EtanHey/cmuxlayer/pull/244/files#diff-f71f2b1c91cb65f4fd1d7f3cc9909e02b16fb843bc782cc439c31e0b8a6f3fd2) to write close events to `events.jsonl` alongside existing telemetry.
> - Instruments `close_surface`, `stop_agent`, `kill`, and internal teardown paths in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/244/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to emit durable close entries, including refused attempts, caller identity, force flag, and pre-close agent state.
> - Adds `assertBuildVersion` in [src/version.ts](https://github.com/EtanHey/cmuxlayer/pull/244/files#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087) to compare a supplied expected version against the running build, returning a `BuildVersionCheck` result and optionally throwing on mismatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 961a885.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->