### PR TITLE
test: characterize phantom-no chunk delivery

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -53,6 +53,27 @@ const REAL_CLAUDE_READY_BASELINE_SCREEN =
 const REAL_CLAUDE_DIRTY_COMPOSER_SCREEN =
   REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN.replace("\n❯ \n", "\n❯ still typing\n");
 
+function makePhantomNoBootPrompt(): string {
+  const lines = [
+    "# Worker Boot Brief",
+    "You are a Codex worker receiving a long boot prompt.",
+    "Do NOT answer with a bare no.",
+    "Do NOT submit a separate confirmation turn.",
+  ];
+
+  for (let index = 0; index < 48; index += 1) {
+    const clause =
+      index % 4 === 0
+        ? "Do NOT split this directive into a separate no turn."
+        : "Keep the entire boot brief in one composer message.";
+    const filler = `section-${String(index).padStart(2, "0")} ${clause} `;
+    lines.push(filler + "context ".repeat(14));
+  }
+
+  lines.push("Final instruction: Do NOT emit no as its own message.");
+  return `${lines.join("\n")}\n`;
+}
+
 async function advanceTimers(ms: number): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -2992,6 +3013,96 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(submittedMessages).toEqual([longText]);
+  });
+
+  it("send_input keeps multi-kb Do NOT prompts on paste path without type-mode newline submits", async () => {
+    const typedChunks: string[] = [];
+    const pastedChunks: string[] = [];
+    const mockClient = {
+      send: vi.fn().mockImplementation(
+        (_surface: string, text: string) => {
+          typedChunks.push(text);
+          return Promise.resolve();
+        },
+      ),
+      pasteText: vi.fn().mockImplementation(
+        (_surface: string, text: string) => {
+          pastedChunks.push(text);
+          return Promise.resolve();
+        },
+      ),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const prompt = makePhantomNoBootPrompt();
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text: prompt,
+        chunk_size: 160,
+        press_enter: false,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const submittedTypeFragments = typedChunks
+      .map((chunk) => chunk.trim().toLowerCase())
+      .filter((chunk) => chunk === "no" || chunk === "not");
+
+    expect(parsed.ok).toBe(true);
+    expect(pastedChunks.length).toBeGreaterThan(1);
+    expect(pastedChunks.join("")).toBe(prompt);
+    expect(typedChunks).toEqual([]);
+    expect(submittedTypeFragments).toEqual([]);
+  });
+
+  it.skip("RED: chunked prompt delivery should not create multiple paste blocks", async () => {
+    // TODO(phantom-no): Current behavior performs one pasteText call per
+    // chunk. Claude can render those as separate [Pasted text #N] blocks,
+    // which matches the observed phantom-"no" failure class. Coalescing the
+    // chunks into one paste operation would change chunk retry/progress
+    // semantics, so keep this repro skipped until that delivery redesign is
+    // reviewed deliberately.
+    const pastedChunks: string[] = [];
+    const mockClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+      pasteText: vi.fn().mockImplementation(
+        (_surface: string, text: string) => {
+          pastedChunks.push(text);
+          return Promise.resolve();
+        },
+      ),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const prompt = makePhantomNoBootPrompt();
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text: prompt,
+        chunk_size: 160,
+        press_enter: true,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(pastedChunks).toEqual([prompt]);
   });
 
   it("send_input fails instead of falling back to send when paste delivery is unsupported", async () => {


### PR DESCRIPTION
## Summary
- Adds a realistic multi-KB `Do NOT` boot prompt fixture in `tests/server.test.ts`.
- Adds an active characterization test proving the current `send_input` path reconstructs the prompt and does not use TYPE mode for multi-chunk delivery.
- Adds a skipped RED repro documenting the unsafe shape: current chunked delivery performs one `pasteText` operation per chunk, which can render as multiple receiver paste blocks.

## Root-cause finding
The tested hypotheses about `chunkTerminalInput` emitting a literal `no` fragment via TYPE mode did not reproduce. For multi-chunk input, `shouldPasteInputChunk(chunk, totalChunks)` forces paste mode because `totalChunks > 1`, so newline-bearing chunks are not typed and cannot submit partial lines through raw TYPE-mode enter behavior.

The reproducible risk is structural: `deliverInputChunks` loops over chunks and calls `pasteText` once per chunk. The RED repro failed before being marked `.skip` because the realistic prompt produced 97 paste operations instead of one. That matches the observed Claude-side symptom of multiple `[Pasted text #N]` blocks, where a receiver can treat part of the prompt as a separate turn.

I did not apply a production fix because coalescing chunks into one paste operation would change existing chunk retry/progress semantics and is not clearly low-risk for this PR.

## Verification
- `graphify query "cmuxlayer phantom no chunkTerminalInput shouldPasteInputChunk deliverInputChunks src/server.ts"` failed because `graphify-out/graph.json` is missing in this worktree.
- RED check before skip: `bunx vitest run tests/server.test.ts -t "Do NOT prompts|chunked prompt delivery"` failed as expected on `expected [ ...(97) ] to deeply equal [ Array(1) ]`.
- Focused green after skip: `bunx vitest run tests/server.test.ts -t "Do NOT prompts|chunked prompt delivery"` passed: 1 test passed, 131 skipped.
- `bun run typecheck` passed.
- `bun run test` passed on rerun: 75 test files passed, 1378 tests passed, 1 skipped.
- Pre-commit CodeRabbit: `timeout 180 coderabbit review --agent` completed with `findings:0`.
- Pre-push hook reran tests and finished with exit status 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or delivery logic modifications.
> 
> **Overview**
> Adds test coverage around **multi-KB boot prompts** that repeat “Do NOT …” directives, aimed at the **phantom “no”** failure mode when `send_input` delivers long text in chunks.
> 
> Introduces **`makePhantomNoBootPrompt()`** as a realistic fixture and a **passing characterization test** that asserts chunked delivery uses **`pasteText` only** (full prompt reassembled, **no** `send`/TYPE path and no stray `no`/`not` fragments).
> 
> Adds a **skipped RED test** documenting current behavior: **`deliverInputChunks` calls `pasteText` once per chunk** (~97 pastes for the fixture), which can show up as multiple receiver paste blocks—not a single coalesced paste. No production change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b524d1a2d29a5e890021398f98931977ee5b4c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Characterize phantom-no chunk delivery in `send_input` tool handler tests
> - Adds `makePhantomNoBootPrompt` helper in [tests/server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/245/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d) that generates a multi-kilobyte prompt with repeated 'Do NOT' directives, used by new tests.
> - Adds a passing test verifying that `send_input` routes large inputs to `pasteText` in multiple chunks (not via `send`) when `press_enter: false` and `allow_long_inline: true`.
> - Adds a skipped (`it.skip`) test documenting the current undesired behavior where chunked delivery produces one `pasteText` call per chunk instead of a single call with the full prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b524d1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->