### PR TITLE
fix: verify cleared agent composers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2274,7 +2274,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const startedAt = Date.now();
     let retried = false;
     let retryCount = 0;
-    let sawClearedInput = false;
+    let sawClearedComposerEvidence = false;
+    let sawAllowedClearedComposerEvidence = false;
+    let lastHasPendingInput = false;
+    const screenIncludesSubmittedText = (screenText: string): boolean => {
+      const trimmed = opts.text.trim();
+      if (!trimmed) {
+        return false;
+      }
+      const tail = trimmed.slice(-Math.min(80, trimmed.length));
+      return normalizeTerminalText(screenText).includes(tail);
+    };
 
     while (Date.now() - startedAt < timeoutMs) {
       const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
@@ -2293,9 +2303,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
-      if (!hasPendingInput) {
-        sawClearedInput = true;
+      lastHasPendingInput = hasPendingInput;
+      const composerInput = extractComposerInputRegion(snapshot.text);
+      const hasClearedAgentComposer =
+        composerInput !== null &&
+        composerInput.trim() === "" &&
+        !hasPendingInput &&
+        screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed);
+      if (hasClearedAgentComposer) {
+        sawClearedComposerEvidence = true;
+        const allowClearedComposerSubmitEvidence =
+          opts.source_event !== "spawn_agent" ||
+          !screenIncludesSubmittedText(snapshot.text);
+        if (allowClearedComposerSubmitEvidence) {
+          sawAllowedClearedComposerEvidence = true;
+        }
+        if (!opts.require_working_status && allowClearedComposerSubmitEvidence) {
+          return { submit_verified: true, retry_count: retryCount };
+        }
       }
+
       if (opts.require_working_status) {
         if (!retried) {
           await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
@@ -2318,11 +2345,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         continue;
       }
 
-      // Pending input and cleared-but-idle composers are both ambiguous: the
-      // first Return may have been missed, or the CLI may have cleared input
-      // without starting the task. Retry Enter once, then keep polling for real
-      // working/thinking evidence. Cleared input alone is not submit proof.
-      if (!retried) {
+      const shouldRetryEnter =
+        hasPendingInput ||
+        (opts.source_event === "spawn_agent" &&
+          screenIncludesSubmittedText(snapshot.text));
+
+      // Pending input is ambiguous: the first Return may have been missed. A
+      // launch command echoed in shell history keeps its legacy advisory retry.
+      // A recognized cleared agent composer is handled above as submit evidence.
+      if (!retried && shouldRetryEnter) {
         await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
         await sendKeyWithRetry(opts.surface, "return", opts.workspace);
         retryCount += 1;
@@ -2342,8 +2373,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
     return {
-      submit_verified:
-        sawClearedInput && !opts.require_working_status ? null : false,
+      submit_verified: opts.require_working_status
+        ? false
+        : sawClearedComposerEvidence && sawAllowedClearedComposerEvidence
+          ? true
+          : lastHasPendingInput
+            ? false
+            : null,
       retry_count: retryCount,
     };
   };

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -387,7 +387,7 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
-  it("keeps cleared short send_to submissions uncertain without a hard error", async () => {
+  it("verifies a cleared idle composer without waiting for working status", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
     client.completionMode = "idle";
@@ -403,12 +403,71 @@ describe("enter reliability", () => {
     const events = readEventLog().filter((event) => event.event_type === "send_to");
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.submit_verified).toBeNull();
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBe(true);
+    expect(events[0]?.retry_count).toBe(0);
+  });
+
+  it("reports a failed send_to submit when text remains in the composer after retry", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "still pending",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
     expect(parsed.retry_count).toBe(1);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(2);
-    expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBeNull();
-    expect(events[0]?.retry_count).toBe(1);
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_to" &&
+          event.submit_verified === false &&
+          event.retry_count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("verifies a mid-session idle send_to after retry clears the full composer", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 2;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "idle" });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "mid-session prompt",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog();
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBeGreaterThanOrEqual(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(2);
+    expect(
+      events.some(
+        (event) =>
+          event.event_type === "send_to" &&
+          event.submit_verified === true &&
+          typeof event.retry_count === "number" &&
+          event.retry_count >= 1,
+      ),
+    ).toBe(true);
   });
 
   it("retries Enter for send_command on a Claude surface", async () => {

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -210,6 +210,11 @@ describe("false-green empty surface protection", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBeNull();
     expect(
+      (mockExec as any).mock.calls.filter(([, args]: [string, string[]]) =>
+        args.includes("send-key") && args.includes("return"),
+      ),
+    ).toHaveLength(1);
+    expect(
       (mockExec as any).mock.calls.some(([, args]: [string, string[]]) =>
         args.includes("read-screen"),
       ),

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -784,8 +784,8 @@ describe("Phase 10 painpoint e2e replay", () => {
       expect(after.delivery).toMatchObject({
         delivery_id: accepted.delivery_id,
         status: "delivered",
-        submit_verified: null,
-        retry_count: 1,
+        submit_verified: true,
+        retry_count: 0,
       });
     } finally {
       await closeServer(server);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3268,7 +3268,7 @@ describe("tool handler integration", () => {
     });
   });
 
-  it("send_input background press_enter surfaces uncertain cleared submits", async () => {
+  it("send_input background press_enter verifies a cleared agent composer", async () => {
     vi.useFakeTimers();
     const stateDir = join(tmpdir(), "cmuxlayer-background-submit-verify");
     rmSync(stateDir, { recursive: true, force: true });
@@ -3349,8 +3349,8 @@ describe("tool handler integration", () => {
     expect(readAfterDeliveryParsed.delivery).toMatchObject({
       delivery_id: parsed.delivery_id,
       status: "delivered",
-      submit_verified: null,
-      retry_count: 1,
+      submit_verified: true,
+      retry_count: 0,
     });
   });
 


### PR DESCRIPTION
## Summary
- Treat a recognized cleared agent composer as positive submit verification for normal send paths, avoiding false `ok:false`/`null` on slow first-token agents.
- Preserve false-positive protection: pending composer text still fails, unknown no-composer screens remain unverified, launcher shell-history submit verification stays advisory, and boot-prompt `require_working_status` remains strict.
- Add regression coverage for cleared idle sends, stuck composer sends, retry-cleared mid-session sends, background delivery evidence, and unknown shell/no-composer retry behavior.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` — 75 files, 1379 tests passed
- [x] `coderabbit review --agent` — findings: 0 after fixing the initial retry-gate finding
- [x] `~/.golems-zikaron/outbox.md` mtime unchanged: `1783337759 Jul 6 14:35:59 2026`

Do not merge from this PR; worker endpoint is PR opened only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delivery success/failure signaling for send_to and related paths; wrong heuristics could mark failed submits as ok or vice versa, though guards for pending input, spawn_agent shell echo, and boot prompts limit exposure.
> 
> **Overview**
> **Submit verification after Enter** now treats an empty **agent composer** (with agent identity on screen and no pending input) as successful submit for normal send paths, instead of leaving `submit_verified` uncertain when the CLI clears input without immediate working/thinking status.
> 
> Enter **retry** is narrowed: recovery Enter runs when input still looks pending, or on `spawn_agent` when submitted text still appears in shell history—not on every ambiguous cleared screen. **`spawn_agent`** keeps stricter rules when launch text remains visible; **`require_working_status`** (e.g. boot prompts) still demands working status and does not accept cleared-composer alone.
> 
> Timeout outcomes are explicit: pending text → **false**; allowed cleared composer → **true**; unknown screens stay **null**. Tests and e2e expectations move from `submit_verified: null` to **true** for cleared idle/background delivery, with new cases for stuck composer (**false**) and retry-cleared mid-session sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5929549209fcb82000b780db32cd0a6d337228b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix submit verification to treat cleared agent composer as confirmed success
> - The submit verification loop in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/246/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now treats a cleared agent composer with a visible agent identity as definitive proof of submission (`submit_verified: true`), rather than waiting for working status.
> - Introduces tracking variables and a `screenIncludesSubmittedText` helper to distinguish a truly cleared composer from one that merely echoes the submitted text.
> - `shouldRetryEnter` now only retries when input is still pending or a `spawn_agent` command is echoed back; a cleared composer is never retried.
> - Test suites updated across [enter-reliability.test.ts](https://github.com/EtanHey/cmuxlayer/pull/246/files#diff-5e89c52026fcdfee326f57b1efc91920f9bc47ec7a580591cebc889ffb9a21fb), [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/246/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d), and [painpoint-e2e.test.ts](https://github.com/EtanHey/cmuxlayer/pull/246/files#diff-bc90ffb33b06a54a1563b0e95a9978eaa86c922be83f2f321774545177a5dc8c) to assert `submit_verified: true` and `retry_count: 0` for cleared-composer cases.
> - Behavioral Change: previously ambiguous cleared-composer states that returned `null` or triggered a retry now return `true` immediately (or `false` if text persists after retry).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5929549.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->