### PR TITLE
fix: seed worktree workers in right column

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -138,6 +138,18 @@ export interface SpawnAgentResult {
   mcp_env?: string;
 }
 
+function isWorktreeLaunch(
+  params: Pick<SpawnAgentParams, "cwd" | "worktree_branch">,
+): boolean {
+  if (params.worktree_branch) return true;
+  const cwd = params.cwd;
+  if (!cwd) return false;
+  return (
+    /(?:^|[/\\])[^/\\]+\.wt(?:[/\\]|$)/.test(cwd) ||
+    /(?:^|[/\\])\.worktrees(?:[/\\]|$)/.test(cwd)
+  );
+}
+
 export type HarvestabilityDoneSource = "transcript" | "screen" | "none";
 
 export interface HarvestabilityEvidenceChannel {
@@ -1486,6 +1498,7 @@ export class AgentEngine {
       role?: AgentRole;
       parentAgent?: AgentRecord | null;
       repo?: string;
+      worktree?: boolean;
     },
   ): Promise<CreatedAgentSurface> {
     // Pin a child worker to the parent orchestrator's ACTUAL workspace before
@@ -1584,6 +1597,7 @@ export class AgentEngine {
           parentRole,
           parentSurfaceId: parentAgent?.surface_id ?? null,
           childWorkerSurfaceIds,
+          worktree: context?.worktree,
         },
       );
       const surface =
@@ -3134,6 +3148,7 @@ export class AgentEngine {
       role,
       parentAgent,
       repo: spawnParams.repo,
+      worktree: isWorktreeLaunch(spawnParams),
     });
 
     // 2. Write initial state (creating → booting)

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -39,6 +39,7 @@ export interface AgentPlacementContext {
   parentRole?: AgentRole | null;
   parentSurfaceId?: string | null;
   childWorkerSurfaceIds?: ReadonlySet<string>;
+  worktree?: boolean;
 }
 
 function emptyRoleSurfaceIds(): RoleSurfaceIds {
@@ -461,6 +462,22 @@ export function chooseAgentSpawnPlacement(
     return orchestratorPane
       ? { kind: "surface", pane: orchestratorPane.pane.ref }
       : { kind: "split", direction: "left" };
+  }
+
+  const hasLeadColumn =
+    layouts.some(isLeadMajorityPane) ||
+    context.parentRole === "orchestrator" ||
+    context.parentRole === "ic";
+  // A worktree worker has no classified destination surface yet. If the only
+  // visible column is lead-owned, seed the right worker column without anchoring
+  // the split to a lead pane.
+  if (
+    role === "worker" &&
+    context.worktree &&
+    columnCount < 2 &&
+    hasLeadColumn
+  ) {
+    return { kind: "split", direction: "right" };
   }
 
   const workerPanes = layouts.filter(isDedicatedWorkerPane);

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -834,12 +834,72 @@ describe("AgentEngine", () => {
         "workspace:parent",
       );
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
-        pane: "pane:parent",
         workspace: "workspace:parent",
         type: "terminal",
       });
       // The parent pin short-circuits repo-name resolution entirely.
       expect(mockClient.listWorkspaces).not.toHaveBeenCalled();
+    });
+
+    it("seeds a worktree worker to the right without anchoring to the left lead pane", async () => {
+      const parent = makeRecord({
+        agent_id: "parent-claude",
+        surface_id: "surface:parent",
+        workspace_id: "workspace:parent",
+        state: "ready",
+        role: "orchestrator",
+        cli: "claude",
+        repo: "brainlayer",
+        parent_agent_id: null,
+      });
+      engine.getRegistry().set(parent.agent_id, parent);
+      liveSurfaces = [makeSurface("surface:parent")];
+
+      (mockClient.listWorkspaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspaces: [],
+      });
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "workspace:parent",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:parent",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:parent"],
+          },
+        ],
+      });
+      (mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "workspace:parent",
+        window_ref: "window:1",
+        pane_ref: "pane:parent",
+        surfaces: [makeSurface("surface:parent")],
+      });
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace: "workspace:parent",
+        surface: "surface:worker",
+        pane: "pane:worker",
+        title: "",
+        type: "terminal",
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        model: "gpt-5.4",
+        cli: "codex",
+        prompt: "Fix the watcher",
+        parent_agent_id: "parent-claude",
+        cwd: "/Users/etanheyman/Gits/brainlayer.wt/watcher-fix",
+        worktree_branch: "fix/watcher",
+      });
+
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        workspace: "workspace:parent",
+        type: "terminal",
+      });
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
 
     it("docks the first worker into the rightmost sparse non-lead pane when user panes already exist", async () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1271,6 +1271,62 @@ describe("layout policy", () => {
     });
   });
 
+  it("seeds a worktree worker column without anchoring to the left lead pane", () => {
+    const panes = [makePane("pane:lead", 0, ["surface:orchestrator"])];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        worktree: true,
+      },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+    });
+  });
+
+  it("does not dock an nth worktree worker into a left-column worker pane", () => {
+    const leftColumn = { x: 0, y: 0, width: 500, height: 900 };
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:left-worker", 1, ["surface:worker-1"], leftColumn),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:left-worker", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
+      },
+      { role: "worker", worktree: true },
+    );
+
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+    });
+  });
+
   it("does not dock a sparse parentless worker into the leftmost pane", () => {
     const panes = [makePane("pane:left", 0, ["surface:unclassified-lead"])];
     const paneSurfaces = [


### PR DESCRIPTION
## Summary
- Root-cause fix: mark worktree launches in `AgentEngine` and pass that context into `chooseAgentSpawnPlacement`.
- When a worktree worker is spawned while only a lead-owned column exists, seed the worker column with an unanchored `split right` instead of anchoring the split to the left lead pane.
- Added regression coverage for first worktree worker placement and an Nth-worker case where prior workers are already stuck in the left column.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test -- tests/layout-policy.test.ts tests/agent-engine.test.ts`
- [x] `bun run test` (75 files, 1380 tests)
- [x] push hook `run_tests.sh` completed with exit status 0
- [x] `~/.golems-zikaron/outbox.md` mtime remained `1783337759`

## Review notes
- Local `coderabbit review --agent` was attempted before commit and returned a free OSS rate limit (`waitTime: 43 minutes`), so no local CodeRabbit verdict is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic pane placement for worktree worker spawns; behavior is scoped to worktree detection and covered by layout/engine tests, but incorrect heuristics could still misplace terminals in edge layouts.
> 
> **Overview**
> Worktree worker spawns were sometimes **splitting off the left lead pane** instead of opening a dedicated worker column to the right when only an orchestrator/IC column existed.
> 
> **AgentEngine** now detects worktree launches (`worktree_branch` or cwd under `*.wt` / `.worktrees`) and passes a **`worktree`** flag into surface creation and placement.
> 
> **Layout policy** uses that flag: for a worker in a single-column layout with a lead-owned column, it returns an **unanchored `split right`** (no `pane` on the split) so cmux seeds the worker column without docking to the parent orchestrator pane.
> 
> Regression tests cover first worktree worker placement and an nth-worker case where prior workers were already in the left column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45b7b01ec28f45c7d9f8bf50db6075948706243b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree worker spawns to seed a right split column instead of anchoring to the left lead pane
> - Adds an `isWorktreeLaunch` helper in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/247/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) that detects worktree spawns via `worktree_branch` or `.wt`/`.worktrees` patterns in `cwd`.
> - Adds a `worktree` flag to `AgentPlacementContext` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/247/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) and updates `chooseAgentSpawnPlacement` to return an unanchored right split when a worker is launched in a single-column worktree layout.
> - Behavioral Change: worktree workers no longer dock into the left lead pane; they now open in a new right-split column.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 45b7b01. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->