### PR TITLE
fix: coalesce chunked paste delivery

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -195,6 +195,7 @@ const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 export const SEND_INPUT_CHUNK_THRESHOLD = 500;
 export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
+const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
@@ -800,6 +801,103 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
   }
 
   return chunks;
+}
+
+interface InputDeliveryBatch {
+  text: string;
+  firstChunkNumber: number;
+  deliveredChunkCounts: number[];
+}
+
+function splitTextByUtf8ByteLimit(text: string, maxBytes: number): string[] {
+  if (text.length === 0) {
+    return [text];
+  }
+
+  const parts: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+
+  for (const char of text) {
+    const charBytes = Buffer.byteLength(char, "utf-8");
+    if (current && currentBytes + charBytes > maxBytes) {
+      parts.push(current);
+      current = char;
+      currentBytes = charBytes;
+      continue;
+    }
+
+    current += char;
+    currentBytes += charBytes;
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function buildInputDeliveryBatches(
+  chunks: string[],
+  maxPasteBytes = SEND_INPUT_PASTE_BATCH_MAX_BYTES,
+): InputDeliveryBatch[] {
+  const batches: InputDeliveryBatch[] = [];
+  let pendingText = "";
+  let pendingBytes = 0;
+  let pendingFirstChunkNumber = 1;
+  let pendingDeliveredChunkCounts: number[] = [];
+
+  const flushPending = () => {
+    if (pendingDeliveredChunkCounts.length === 0) {
+      return;
+    }
+
+    batches.push({
+      text: pendingText,
+      firstChunkNumber: pendingFirstChunkNumber,
+      deliveredChunkCounts: pendingDeliveredChunkCounts,
+    });
+    pendingText = "";
+    pendingBytes = 0;
+    pendingDeliveredChunkCounts = [];
+  };
+
+  for (const [index, chunk] of chunks.entries()) {
+    const chunkNumber = index + 1;
+    const chunkBytes = Buffer.byteLength(chunk, "utf-8");
+
+    if (chunkBytes > maxPasteBytes) {
+      flushPending();
+      const parts = splitTextByUtf8ByteLimit(chunk, maxPasteBytes);
+      for (const [partIndex, part] of parts.entries()) {
+        batches.push({
+          text: part,
+          firstChunkNumber: chunkNumber,
+          deliveredChunkCounts:
+            partIndex === parts.length - 1 ? [chunkNumber] : [],
+        });
+      }
+      continue;
+    }
+
+    if (
+      pendingDeliveredChunkCounts.length > 0 &&
+      pendingBytes + chunkBytes > maxPasteBytes
+    ) {
+      flushPending();
+    }
+
+    if (pendingDeliveredChunkCounts.length === 0) {
+      pendingFirstChunkNumber = chunkNumber;
+    }
+    pendingText += chunk;
+    pendingBytes += chunkBytes;
+    pendingDeliveredChunkCounts.push(chunkNumber);
+  }
+
+  flushPending();
+  return batches;
 }
 
 function shouldPasteInputChunk(text: string, totalChunks: number): boolean {
@@ -2402,18 +2500,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     retry_count: number;
     submit_verified: boolean | null;
   }> => {
-    for (const [index, chunk] of opts.chunks.entries()) {
+    const deliveryBatches = buildInputDeliveryBatches(opts.chunks);
+    for (const [index, batch] of deliveryBatches.entries()) {
       await sendChunkWithRetry(
         opts.surface,
-        chunk,
+        batch.text,
         {
           workspace: opts.workspace,
         },
-        index + 1,
+        batch.firstChunkNumber,
         opts.chunks.length,
       );
-      opts.onChunkDelivered?.(index + 1);
-      if (index < opts.chunks.length - 1) {
+      for (const sentChunks of batch.deliveredChunkCounts) {
+        opts.onChunkDelivered?.(sentChunks);
+      }
+      if (index < deliveryBatches.length - 1) {
         await delay(opts.chunk_delay_ms);
       }
     }

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -217,7 +217,7 @@ describe("pane input pointer discipline", () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 
-  it("send_input allow_long_inline preserves chunked delivery", async () => {
+  it("send_input allow_long_inline uses bounded paste delivery", async () => {
     process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
     const { createServer } = await loadServerModule();
     const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
@@ -239,8 +239,15 @@ describe("pane input pointer discipline", () => {
     const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
       args.includes("set-buffer"),
     );
+    const pasteBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("paste-buffer"),
+    );
     expect(parsed.ok).toBe(true);
-    expect(setBufferCalls.length).toBeGreaterThan(1);
+    expect(setBufferCalls).toHaveLength(1);
+    expect(pasteBufferCalls).toHaveLength(1);
+    expect(setBufferCalls[0][1][setBufferCalls[0][1].length - 1]).toBe(
+      "x".repeat(2_000),
+    );
   });
 
   it("CMUXLAYER_MAX_INLINE_CHARS changes the cap and invalid values fall back to the default", async () => {
@@ -630,8 +637,15 @@ describe("pane input pointer discipline", () => {
     const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
       args.includes("set-buffer"),
     );
+    const pasteBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("paste-buffer"),
+    );
     expect(parsed.ok).toBe(true);
-    expect(setBufferCalls.length).toBeGreaterThan(1);
+    expect(setBufferCalls).toHaveLength(1);
+    expect(pasteBufferCalls).toHaveLength(1);
+    expect(setBufferCalls[0][1][setBufferCalls[0][1].length - 1]).toBe(
+      "x".repeat(2_000),
+    );
     context.dispose();
   });
 
@@ -712,10 +726,17 @@ describe("pane input pointer discipline", () => {
 
     parsed = parseToolResult(result);
     expect(parsed.ok).toBe(true);
-    expect(
-      mockExec.mock.calls.filter(([, args]) => args.includes("set-buffer"))
-        .length,
-    ).toBeGreaterThan(1);
+    const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("set-buffer"),
+    );
+    const pasteBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("paste-buffer"),
+    );
+    expect(setBufferCalls).toHaveLength(1);
+    expect(pasteBufferCalls).toHaveLength(1);
+    expect(setBufferCalls[0][1][setBufferCalls[0][1].length - 1]).toBe(
+      "x".repeat(2_000),
+    );
     context.dispose();
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1134,9 +1134,8 @@ describe("agent lifecycle tool handlers", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
-    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.length).toBeGreaterThan(0);
     expect(chunks.every((chunk) => chunk.trim().length > 0)).toBe(true);
-    expect(chunks.every((chunk) => chunk.length <= 501)).toBe(true);
     expect(chunks.join("")).toBe(prompt);
     expect(chunks.join("")).toContain("\n\n");
   });
@@ -3301,8 +3300,8 @@ codex>
 
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
-    expect(setBufferCalls).toHaveLength(2);
-    expect(pasteBufferCalls).toHaveLength(2);
+    expect(setBufferCalls).toHaveLength(1);
+    expect(pasteBufferCalls).toHaveLength(1);
     expect(sendKeyCalls).toHaveLength(1);
     expect(deliveredText).toBe(sanitizedText);
     expect(deliveredText).not.toContain("\x1b");

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1896,7 +1896,7 @@ describe("tool handler integration", () => {
     expect(result.content[0].text).not.toContain("col ");
   });
 
-  it("send_input handler calls cmux send", async () => {
+  it("send_input handler calls cmux send for small single-chunk input", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
@@ -1912,6 +1912,9 @@ describe("tool handler integration", () => {
       "cmux",
       expect.arrayContaining(["send"]),
     );
+    expect(
+      mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer")),
+    ).toHaveLength(0);
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
@@ -2899,7 +2902,7 @@ describe("tool handler integration", () => {
     );
   });
 
-  it("send_input chunks long text transparently before sending", async () => {
+  it("send_input coalesces long chunked text into one bounded paste operation", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
@@ -2924,25 +2927,55 @@ describe("tool handler integration", () => {
     const pasteBufferCalls = mockExec.mock.calls.filter(([, args]) =>
       args.includes("paste-buffer"),
     );
-    expect(setBufferCalls).toHaveLength(5);
-    expect(pasteBufferCalls).toHaveLength(5);
+    expect(setBufferCalls).toHaveLength(1);
+    expect(pasteBufferCalls).toHaveLength(1);
     expect(
       mockExec.mock.calls.filter(([, args]) => args.includes("send")),
     ).toHaveLength(0);
-    for (const [index, call] of setBufferCalls.entries()) {
-      expect(call[0]).toBe("cmux");
-      expect(call[1]).toEqual(expect.arrayContaining(["set-buffer"]));
-      const chunk = call[1][call[1].length - 1];
-      expect(typeof chunk).toBe("string");
-      expect((chunk as string).length).toBeLessThanOrEqual(121);
-      if (index < setBufferCalls.length - 1) {
-        expect((chunk as string).endsWith("\n")).toBe(true);
-      }
-    }
+    expect(setBufferCalls[0][0]).toBe("cmux");
+    expect(setBufferCalls[0][1]).toEqual(expect.arrayContaining(["set-buffer"]));
+    expect(setBufferCalls[0][1][setBufferCalls[0][1].length - 1]).toBe(
+      longText,
+    );
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
+  });
+
+  it("send_input keeps coalesced paste operations under the paste batch cap", async () => {
+    mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+    const longText = ["a".repeat(15_000), "b".repeat(15_000), "c".repeat(5_000)]
+      .join("\n");
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text: longText,
+        chunk_size: 500,
+        allow_long_inline: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const pastedTexts = mockExec.mock.calls
+      .filter(([, args]) => args.includes("set-buffer"))
+      .map(([, args]) => String(args[args.length - 1]));
+
+    expect(parsed.ok).toBe(true);
+    expect(pastedTexts.length).toBeGreaterThan(1);
+    expect(pastedTexts.join("")).toBe(longText);
+    expect(
+      pastedTexts.every(
+        (text) => Buffer.byteLength(text, "utf-8") <= 16_000,
+      ),
+    ).toBe(true);
   });
 
   it("send_input submits chunked multiline text as one receiver message", async () => {
@@ -3057,19 +3090,12 @@ describe("tool handler integration", () => {
       .filter((chunk) => chunk === "no" || chunk === "not");
 
     expect(parsed.ok).toBe(true);
-    expect(pastedChunks.length).toBeGreaterThan(1);
-    expect(pastedChunks.join("")).toBe(prompt);
+    expect(pastedChunks).toEqual([prompt]);
     expect(typedChunks).toEqual([]);
     expect(submittedTypeFragments).toEqual([]);
   });
 
-  it.skip("RED: chunked prompt delivery should not create multiple paste blocks", async () => {
-    // TODO(phantom-no): Current behavior performs one pasteText call per
-    // chunk. Claude can render those as separate [Pasted text #N] blocks,
-    // which matches the observed phantom-"no" failure class. Coalescing the
-    // chunks into one paste operation would change chunk retry/progress
-    // semantics, so keep this repro skipped until that delivery redesign is
-    // reviewed deliberately.
+  it("send_input chunked prompt delivery does not create multiple paste blocks", async () => {
     const pastedChunks: string[] = [];
     const mockClient = {
       send: vi.fn().mockResolvedValue(undefined),
@@ -3351,8 +3377,8 @@ describe("tool handler integration", () => {
     for (let i = 0; i < 50; i++) {
       await advanceTimers(5);
       if (
-        mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer"))
-          .length === 5
+          mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer"))
+            .length === 1
       ) {
         break;
       }
@@ -3360,7 +3386,7 @@ describe("tool handler integration", () => {
 
     expect(
       mockExec.mock.calls.filter(([, args]) => args.includes("paste-buffer")),
-    ).toHaveLength(5);
+    ).toHaveLength(1);
 
     await Promise.resolve();
 
@@ -3673,6 +3699,52 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(sendAttempts).toBe(2);
+  });
+
+  it("send_input retries a transient coalesced paste failure before succeeding", async () => {
+    let pasteAttempts = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("paste-buffer")) {
+        pasteAttempts += 1;
+        if (pasteAttempts === 1) {
+          return Promise.reject(
+            new Error("socket closed before receiving response"),
+          );
+        }
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const tool = registeredTools["send_input"];
+    const longText = [
+      "abcdef".repeat(20),
+      "ghijkl".repeat(20),
+      "mnopqr".repeat(20),
+      "stuvwx".repeat(20),
+      "yz1234".repeat(20),
+    ].join("\n");
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: longText, chunk_size: 120 },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    const setBufferCalls = mockExec.mock.calls.filter(([, args]) =>
+      args.includes("set-buffer"),
+    );
+    expect(parsed.ok).toBe(true);
+    expect(pasteAttempts).toBe(2);
+    expect(setBufferCalls).toHaveLength(2);
+    expect(setBufferCalls[0][1][setBufferCalls[0][1].length - 1]).toBe(
+      longText,
+    );
+    expect(setBufferCalls[1][1][setBufferCalls[1][1].length - 1]).toBe(
+      longText,
+    );
   });
 
   it("send_input reports the failed chunk when retries are exhausted", async () => {
@@ -6795,7 +6867,8 @@ describe("tool handler integration", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
-    expect(sendCalls.length).toBeGreaterThan(1);
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls.join("")).toBe(prompt);
     expect(returnPresses).toBe(2);
   });
 


### PR DESCRIPTION
## Summary
- Root cause: `deliverInputChunks` called `sendChunkWithRetry` once per logical chunk, and `pasteText` maps each call to one `set-buffer` plus `paste-buffer`, so the #245 prompt produced ~97 receiver paste blocks.
- Fix: coalesce logical chunks into bounded paste batches capped at 16,000 UTF-8 bytes, while keeping the original chunk list for delivery metadata/progress.
- Retry is preserved at the paste-batch operation level; `onChunkDelivered` still advances through the original logical chunk counts after a successful batch. Small single-chunk input still uses the existing `send` path.

## Paste Limit Evidence
- `getconf ARG_MAX`: `1048576`.
- `cmux set-buffer` succeeded at 8 KiB, 16 KiB, 32 KiB, and 64 KiB payloads.
- One 64 KiB `cmux paste-buffer` into a temporary terminal returned `OK` and visibly landed. A redirected-file byte-count probe was inconclusive, so this PR uses a conservative 16 KiB paste-batch cap instead of the larger observed value.

## Test Plan
- [x] Targeted RED run before fix: affected expectations failed with 5 paste ops / 97 paste ops / 6 retry attempts.
- [x] `bun run typecheck`
- [x] `bun run test` — 75 files, 1386 tests passed.
- [x] Confirmed `~/.golems-zikaron/outbox.md` mtime unchanged: `1783337759 Jul 6 14:35:59 2026`.
- [x] Pre-push hook reran tests successfully.

## Review Note
- `coderabbit review --agent` was attempted before commit and returned a free OSS rate-limit error with a 23 minute wait time, so no local CodeRabbit pre-commit review was available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal input delivery for all long/multiline `send_input` and agent paths; wrong batching or progress callbacks could affect delivery UX or phantom paste artifacts, though behavior is heavily test-covered.
> 
> **Overview**
> **Coalesced paste delivery** replaces one `set-buffer`/`paste-buffer` cycle per logical chunk with **bounded paste batches** (default **16,000 UTF-8 bytes**). Logical chunking still drives metadata and progress; after each successful batch, `onChunkDelivered` advances through the original chunk numbers.
> 
> New helpers **`splitTextByUtf8ByteLimit`** and **`buildInputDeliveryBatches`** merge adjacent chunks when they fit under the cap and split oversized chunks/payloads across multiple paste ops. **`deliverInputChunks`** now loops batches through **`sendChunkWithRetry`** (retries stay at the paste-operation level). Small single-chunk input that does not need paste is unchanged.
> 
> Tests were updated to expect **one** paste for typical long coalesced text, **multiple** pastes only when total size exceeds 16KB (each part ≤ cap), **batch-level retry** on transient paste failure, and the former skipped “no multiple paste blocks” case is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb25405660d17d4318e72a977d688f60f26522c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce chunked paste delivery into bounded batches for `send_input`
> - Introduces `buildInputDeliveryBatches` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/248/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to coalesce sequential input chunks into paste batches, each capped at 16,000 UTF-8 bytes (`SEND_INPUT_PASTE_BATCH_MAX_BYTES`).
> - Adds `splitTextByUtf8ByteLimit` to split individual oversized chunks along character boundaries when a single chunk exceeds the cap.
> - The delivery loop now calls `onChunkDelivered` for all chunks completed by each batch and passes the batch's first chunk number to `sendChunkWithRetry`; inter-batch delay replaces the previous per-chunk delay.
> - Behavioral Change: short single-chunk input no longer triggers a paste-buffer call; previously multi-chunk long input now results in one or more coalesced pastes rather than one paste per chunk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb25405.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery of long text inputs by sending them in bounded batches, reducing issues with oversized pastes.
  * Ensured long inline prompts and chunked text are handled more reliably, including retry behavior.
  * Updated agent-related text delivery to avoid empty chunks and preserve sanitized content.

* **Tests**
  * Refined coverage to match the new bounded paste behavior and verify fewer paste operations.
  * Added checks for coalesced delivery, retry handling, and correct handling of long prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->