### PR TITLE
fix: cap send_input paste chunks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -195,7 +195,7 @@ const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 export const SEND_INPUT_CHUNK_THRESHOLD = 500;
 export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
-const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
+export const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
@@ -803,13 +803,27 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
   return chunks;
 }
 
-interface InputDeliveryBatch {
+function limitInputChunksByUtf8ByteSize(
+  chunks: string[],
+  maxBytes = SEND_INPUT_PASTE_BATCH_MAX_BYTES,
+): string[] {
+  return chunks.flatMap((chunk) =>
+    Buffer.byteLength(chunk, "utf-8") > maxBytes
+      ? splitTextByUtf8ByteLimit(chunk, maxBytes)
+      : [chunk],
+  );
+}
+
+export interface InputDeliveryBatch {
   text: string;
   firstChunkNumber: number;
   deliveredChunkCounts: number[];
 }
 
-function splitTextByUtf8ByteLimit(text: string, maxBytes: number): string[] {
+export function splitTextByUtf8ByteLimit(
+  text: string,
+  maxBytes: number,
+): string[] {
   if (text.length === 0) {
     return [text];
   }
@@ -838,7 +852,7 @@ function splitTextByUtf8ByteLimit(text: string, maxBytes: number): string[] {
   return parts;
 }
 
-function buildInputDeliveryBatches(
+export function buildInputDeliveryBatches(
   chunks: string[],
   maxPasteBytes = SEND_INPUT_PASTE_BATCH_MAX_BYTES,
 ): InputDeliveryBatch[] {
@@ -902,6 +916,17 @@ function buildInputDeliveryBatches(
 
 function shouldPasteInputChunk(text: string, totalChunks: number): boolean {
   return totalChunks > 1 || /[\n\r\t]|\\[nrt]/.test(text);
+}
+
+function shouldPasteInputDelivery(
+  chunks: string[],
+  deliveryBatchCount: number,
+): boolean {
+  return (
+    chunks.length > 1 ||
+    deliveryBatchCount > 1 ||
+    chunks.some((chunk) => shouldPasteInputChunk(chunk, 1))
+  );
 }
 
 function isMethodNotFoundError(error: unknown): boolean {
@@ -2129,13 +2154,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     opts: { workspace?: string },
     chunkNumber: number,
     totalChunks: number,
+    shouldPaste: boolean,
   ) => {
     let attempt = 0;
     let lastError: unknown;
 
     while (attempt < SEND_INPUT_RETRY_ATTEMPTS) {
       try {
-        const shouldPaste = shouldPasteInputChunk(chunk, totalChunks);
         if (shouldPaste) {
           if (typeof client.pasteText !== "function") {
             throw pasteRequiredError("client does not support pasteText");
@@ -2501,6 +2526,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verified: boolean | null;
   }> => {
     const deliveryBatches = buildInputDeliveryBatches(opts.chunks);
+    const shouldPaste = shouldPasteInputDelivery(
+      opts.chunks,
+      deliveryBatches.length,
+    );
     for (const [index, batch] of deliveryBatches.entries()) {
       await sendChunkWithRetry(
         opts.surface,
@@ -2510,6 +2539,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
         batch.firstChunkNumber,
         opts.chunks.length,
+        shouldPaste,
       );
       for (const sentChunks of batch.deliveredChunkCounts) {
         opts.onChunkDelivered?.(sentChunks);
@@ -4229,9 +4259,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           allowLongInline: args.allow_long_inline,
         });
         const sanitizedText = sanitizeTerminalInput(args.text);
+        const effectiveChunkSize = Math.min(
+          args.chunk_size,
+          SEND_INPUT_PASTE_BATCH_MAX_BYTES,
+        );
         const chunks =
           sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
-            ? chunkTerminalInput(sanitizedText, args.chunk_size)
+            ? limitInputChunksByUtf8ByteSize(
+                chunkTerminalInput(sanitizedText, effectiveChunkSize),
+              )
             : [sanitizedText];
         const targetRecord = resolveLatestSurfaceAgentRecord(
           stateMgr,
@@ -4255,7 +4291,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             status: "delivering",
             total_chunks: chunks.length,
             sent_chunks: 0,
-            chunk_size: args.chunk_size,
+            chunk_size: effectiveChunkSize,
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             chunks,
             press_enter: args.press_enter,
@@ -4292,7 +4328,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface: args.surface,
             workspace: args.workspace,
             chunks,
-            chunk_size: args.chunk_size,
+            chunk_size: effectiveChunkSize,
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: args.press_enter,
             rename_to_task: args.rename_to_task,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1136,6 +1136,11 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.boot_prompt_delivered).toBe(true);
     expect(chunks.length).toBeGreaterThan(0);
     expect(chunks.every((chunk) => chunk.trim().length > 0)).toBe(true);
+    expect(
+      chunks.every(
+        (chunk) => Buffer.byteLength(chunk, "utf-8") <= 16_000,
+      ),
+    ).toBe(true);
     expect(chunks.join("")).toBe(prompt);
     expect(chunks.join("")).toContain("\n\n");
   });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -10,6 +10,23 @@ import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { dispatch, writeHeartbeat } from "../src/inbox.js";
 
+type InputDeliveryTestModule = typeof import("../src/server.js") & {
+  SEND_INPUT_PASTE_BATCH_MAX_BYTES: number;
+  splitTextByUtf8ByteLimit: (text: string, maxBytes: number) => string[];
+  buildInputDeliveryBatches: (
+    chunks: string[],
+    maxPasteBytes?: number,
+  ) => Array<{
+    text: string;
+    firstChunkNumber: number;
+    deliveredChunkCounts: number[];
+  }>;
+};
+
+async function loadInputDeliveryTestModule(): Promise<InputDeliveryTestModule> {
+  return (await import("../src/server.js")) as InputDeliveryTestModule;
+}
+
 // Core low-level and metadata tools.
 const EXPECTED_TOOLS = [
   "list_surfaces",
@@ -158,6 +175,74 @@ describe("submit evidence parser", () => {
         "still typing",
       ),
     ).toBe(true);
+  });
+});
+
+describe("input delivery batching helpers", () => {
+  it("splitTextByUtf8ByteLimit keeps multi-byte characters within byte limits", async () => {
+    const { splitTextByUtf8ByteLimit } = await loadInputDeliveryTestModule();
+
+    const parts = splitTextByUtf8ByteLimit("ab😊cd", 6);
+
+    expect(parts).toEqual(["ab😊", "cd"]);
+    expect(
+      parts.every((part) => Buffer.byteLength(part, "utf-8") <= 6),
+    ).toBe(true);
+  });
+
+  it("splitTextByUtf8ByteLimit keeps exact-boundary text in one part", async () => {
+    const { splitTextByUtf8ByteLimit } = await loadInputDeliveryTestModule();
+
+    expect(splitTextByUtf8ByteLimit("ab😊", 6)).toEqual(["ab😊"]);
+  });
+
+  it("splitTextByUtf8ByteLimit splits oversized text into three parts", async () => {
+    const { splitTextByUtf8ByteLimit } = await loadInputDeliveryTestModule();
+
+    expect(splitTextByUtf8ByteLimit("abcdefghijkl", 4)).toEqual([
+      "abcd",
+      "efgh",
+      "ijkl",
+    ]);
+  });
+
+  it("buildInputDeliveryBatches preserves chunk metadata across coalesced batches", async () => {
+    const { buildInputDeliveryBatches } = await loadInputDeliveryTestModule();
+
+    expect(buildInputDeliveryBatches(["aa", "bb", "cc"], 4)).toEqual([
+      {
+        text: "aabb",
+        firstChunkNumber: 1,
+        deliveredChunkCounts: [1, 2],
+      },
+      {
+        text: "cc",
+        firstChunkNumber: 3,
+        deliveredChunkCounts: [3],
+      },
+    ]);
+  });
+
+  it("buildInputDeliveryBatches records oversized split metadata", async () => {
+    const { buildInputDeliveryBatches } = await loadInputDeliveryTestModule();
+
+    expect(buildInputDeliveryBatches(["abcdefghijkl"], 4)).toEqual([
+      {
+        text: "abcd",
+        firstChunkNumber: 1,
+        deliveredChunkCounts: [],
+      },
+      {
+        text: "efgh",
+        firstChunkNumber: 1,
+        deliveredChunkCounts: [],
+      },
+      {
+        text: "ijkl",
+        firstChunkNumber: 1,
+        deliveredChunkCounts: [1],
+      },
+    ]);
   });
 });
 
@@ -2976,6 +3061,103 @@ describe("tool handler integration", () => {
         (text) => Buffer.byteLength(text, "utf-8") <= 16_000,
       ),
     ).toBe(true);
+  });
+
+  it("send_input caps oversized requested chunk_size in background delivery records", async () => {
+    vi.useFakeTimers();
+    mockExec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:1",
+            text: "$ ",
+            lines: 1,
+          }),
+          stderr: "",
+        });
+      }
+      if (args.includes("list-workspaces")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({ workspaces: [] }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const registeredTools = (server as any)._registeredTools;
+    const sendTool = registeredTools["send_input"];
+    const readTool = registeredTools["read_screen"];
+
+    const result = await sendTool.handler(
+      {
+        surface: "surface:1",
+        text: "x".repeat(35_000),
+        chunk_size: 50_000,
+        allow_long_inline: true,
+        background: true,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+
+    const readWhileDelivering = await readTool.handler(
+      { surface: "surface:1", parsed_only: true },
+      {} as any,
+    );
+    const readWhileDeliveringParsed =
+      readWhileDelivering.structuredContent ??
+      JSON.parse(readWhileDelivering.content[0].text);
+    expect(readWhileDeliveringParsed.delivery).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      status: "delivering",
+      chunk_size: 16_000,
+      total_chunks: 3,
+    });
+  });
+
+  it("send_input forces paste for every split batch of one multiline logical chunk", async () => {
+    const typedChunks: string[] = [];
+    const pastedChunks: string[] = [];
+    const mockClient = {
+      send: vi.fn().mockImplementation((_surface: string, text: string) => {
+        typedChunks.push(text);
+        return Promise.resolve();
+      }),
+      pasteText: vi.fn().mockImplementation(
+        (_surface: string, text: string) => {
+          pastedChunks.push(text);
+          return Promise.resolve();
+        },
+      ),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const text = `${"a".repeat(16_000)}\n${"b".repeat(10)}`;
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        text,
+        chunk_size: 50_000,
+        allow_long_inline: true,
+        press_enter: false,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(typedChunks).toEqual([]);
+    expect(pastedChunks.length).toBeGreaterThan(1);
+    expect(pastedChunks.join("")).toBe(text);
   });
 
   it("send_input submits chunked multiline text as one receiver message", async () => {


### PR DESCRIPTION
## Summary
- cap effective send_input chunk_size at SEND_INPUT_PASTE_BATCH_MAX_BYTES (16,000) and byte-split any post-chunk multi-byte overflow before delivery batching
- choose paste vs type from the whole delivery batch plan, so every coalesced or multi-batch multiline delivery stays on pasteText
- add direct helper coverage for UTF-8 splitting, exact boundaries, oversized split metadata, capped background delivery records, and split-batch paste routing

## Verification
- bun run typecheck
- bunx vitest run tests/server.test.ts tests/server-agent-tools.test.ts
- bun run test
- push hook: run_tests.sh finished with exit status 0
- coderabbit review --agent: 0 findings

Do not merge yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal input delivery and paste/type routing for large or multiline payloads; incorrect batching could corrupt agent input, but behavior is heavily unit-tested.
> 
> **Overview**
> **send_input** now treats **16,000 UTF-8 bytes** as the hard ceiling for chunking and paste batches, even when callers request a larger `chunk_size`. After character-based chunking, **`limitInputChunksByUtf8ByteSize`** re-splits any chunk that still exceeds that limit (including multi-byte characters).
> 
> Paste vs keystroke delivery is decided once from the **full delivery plan** (`shouldPasteInputDelivery`), not per physical batch. That keeps coalesced or byte-split multiline payloads on **`pasteText`** for every batch instead of mixing paste and type.
> 
> Several batching helpers and **`SEND_INPUT_PASTE_BATCH_MAX_BYTES`** are **exported** for unit tests. Background delivery metadata records the **capped** `chunk_size`. Tests cover UTF-8 splitting, batch metadata, capped background records, and forced paste across split batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0935f3823406f446d08f5c21f74a82c184bcf97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap `send_input` paste chunks at 16,000 UTF-8 bytes per chunk
> - Adds `limitInputChunksByUtf8ByteSize` to split any logical chunk exceeding `SEND_INPUT_PASTE_BATCH_MAX_BYTES` (16,000 bytes) before delivery, respecting multi-byte character boundaries.
> - Computes the paste-vs-type decision once per delivery via a new `shouldPasteInputDelivery` helper, ensuring all batches in a multi-chunk delivery use the same mode.
> - Caps `args.chunk_size` at 16,000 in the `send_input` tool handler so both foreground and background delivery records respect the byte limit.
> - Behavioral Change: chunk_size reported in delivery records is now capped at 16,000 regardless of the requested value; paste mode is now consistent across all batches in a delivery rather than decided per-chunk.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b0935f3. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->