### PR TITLE
feat: expose monitor registry MCP tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 36 MCP tools across three categories (keep in sync with server.ts and the
+ * 41 MCP tools across four categories (keep in sync with server.ts and the
  * "total tool count" assertion in tests/server-agent-tools.test.ts):
  *   Core (18): list_surfaces, control_health, select_workspace,
  *              create_workspace, new_split, new_surface, move_surface,
@@ -11,6 +11,9 @@
  *              read_screen, rename_tab, notify, set_status, set_progress,
  *              close_surface, browser_surface
  *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
+ *   Monitor registry (5): register_monitor, signal_monitor,
+ *                         deregister_monitor, list_monitors,
+ *                         query_monitor_registry
  *   Agent lifecycle (16): spawn_agent, new_worktree_split, spawn_in_workspace,
  *                         resync_agents,
  *                         send_to (canonical), send_to_agent (deprecated alias),

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,16 @@ import {
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
-import type { MonitorDeadmanNotify } from "./monitor-registry.js";
+import {
+  deregisterMonitor,
+  queryMonitorRegistryForGates,
+  readMonitorRegistry,
+  registerMonitor,
+  signalMonitor,
+  type MonitorDeadmanNotify,
+  type MonitorRegistryOptions,
+  type RegisterMonitorInput,
+} from "./monitor-registry.js";
 import { AgentDiscovery, type DiscoveredAgent } from "./agent-discovery.js";
 import {
   resumeCommandForAgent,
@@ -185,6 +194,56 @@ const ANNOTATIONS = {
     openWorldHint: false,
   } as const,
 };
+
+const MonitorMechanismSchema = z.enum(["event", "offset-poll"]);
+const MonitorDedupeSchema = z.enum(["offset", "seen-set", "header-keyed"]);
+const MonitorRegistryGateSchema = z.enum(["gate-9", "gate-10"]);
+
+const RegisterMonitorArgsSchema = {
+  monitor_id: z.string().describe("Stable unique monitor id"),
+  owner_seat: z.string().describe("Seat/agent responsible for the monitor"),
+  watch_targets: z
+    .array(z.string())
+    .min(1)
+    .describe("Files, channels, or resources this monitor watches"),
+  mechanism: MonitorMechanismSchema.describe("Monitor mechanism"),
+  watermark_key: z
+    .string()
+    .optional()
+    .describe("Required for offset-poll monitors"),
+  dedupe: MonitorDedupeSchema.optional().describe("Dedupe strategy"),
+  pattern: z.string().optional().describe("Optional delivery/watch pattern"),
+  deadman_timeout_s: z
+    .number()
+    .positive()
+    .describe("Required deadman timeout in seconds"),
+  addressee: z.string().optional().describe("Owner to notify on deadman fire"),
+} as const;
+
+const MonitorIdArgsSchema = {
+  monitor_id: z.string().describe("Monitor id"),
+} as const;
+
+const QueryMonitorRegistryArgsSchema = {
+  gate: MonitorRegistryGateSchema.optional().describe(
+    "Optional gate query mode",
+  ),
+  owner_seat: z.string().optional().describe("Filter by owner seat"),
+  monitor_id: z.string().optional().describe("Filter or claimed monitor id"),
+  monitor_ids: z
+    .array(z.string())
+    .optional()
+    .describe("Filter or claimed monitor ids"),
+  claimed_monitor_ids: z
+    .array(z.string())
+    .optional()
+    .describe("Additional monitor ids claimed by a gate caller"),
+  include_dead: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Include intentionally deregistered dead monitors"),
+} as const;
 
 // Re-export for test access
 export { sanitizeTerminalInput } from "./sanitize.js";
@@ -1957,6 +2016,192 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  const monitorRegistryOptions = (): MonitorRegistryOptions => ({
+    ...(opts?.monitorRegistryPath ? { registryPath: opts.monitorRegistryPath } : {}),
+    ...(opts?.monitorRegistryNow ? { now: opts.monitorRegistryNow } : {}),
+  });
+  const monitorRegistryError = (
+    reason: string,
+    monitorId?: string | null,
+    message = reason,
+  ): ToolReturn =>
+    err(new Error(message), {
+      reason,
+      monitor_id: monitorId ?? "<missing-monitor-id>",
+    });
+  const validateRegisterMonitorArgs = (
+    args: Record<string, unknown>,
+  ): RegisterMonitorInput | ToolReturn => {
+    const monitorId = nonEmptyString(args.monitor_id);
+    if (!monitorId) {
+      return monitorRegistryError("missing-monitor-id", null);
+    }
+    const ownerSeat = nonEmptyString(args.owner_seat);
+    if (!ownerSeat || /^(?:unknown|none|null|n\/a)$/i.test(ownerSeat)) {
+      return monitorRegistryError(
+        "missing-or-unknown-owner-seat",
+        monitorId,
+      );
+    }
+    const watchTargets = Array.isArray(args.watch_targets)
+      ? args.watch_targets.map(nonEmptyString)
+      : null;
+    if (
+      !watchTargets ||
+      watchTargets.length === 0 ||
+      watchTargets.some((target) => target === null)
+    ) {
+      return monitorRegistryError("invalid-watch-targets", monitorId);
+    }
+    if (args.mechanism !== "event" && args.mechanism !== "offset-poll") {
+      return monitorRegistryError("invalid-mechanism", monitorId);
+    }
+    const watermarkKey = nonEmptyString(args.watermark_key);
+    if (args.mechanism === "offset-poll" && !watermarkKey) {
+      return monitorRegistryError(
+        "offset-poll-missing-watermark-key",
+        monitorId,
+      );
+    }
+    const dedupe =
+      args.dedupe === "offset" ||
+      args.dedupe === "seen-set" ||
+      args.dedupe === "header-keyed"
+        ? args.dedupe
+        : undefined;
+    if (args.dedupe !== undefined && !dedupe) {
+      return monitorRegistryError("invalid-dedupe", monitorId);
+    }
+    if (
+      typeof args.deadman_timeout_s !== "number" ||
+      !Number.isFinite(args.deadman_timeout_s) ||
+      args.deadman_timeout_s <= 0
+    ) {
+      return monitorRegistryError("invalid-deadman-timeout", monitorId);
+    }
+    const addressee = nonEmptyString(args.addressee);
+    if (args.addressee !== undefined && !addressee) {
+      return monitorRegistryError("invalid-addressee", monitorId);
+    }
+
+    return {
+      monitor_id: monitorId,
+      owner_seat: ownerSeat,
+      watch_targets: watchTargets as string[],
+      mechanism: args.mechanism,
+      ...(nonEmptyString(args.pattern)
+        ? { pattern: nonEmptyString(args.pattern)! }
+        : {}),
+      ...(watermarkKey ? { watermark_key: watermarkKey } : {}),
+      ...(dedupe ? { dedupe } : {}),
+      ...(addressee ? { addressee } : {}),
+      deadman_timeout_s: args.deadman_timeout_s,
+    };
+  };
+  const isToolReturn = (
+    value: RegisterMonitorInput | ToolReturn,
+  ): value is ToolReturn => "content" in value;
+  const collectMonitorIds = (args: {
+    monitor_id?: string;
+    monitor_ids?: string[];
+    claimed_monitor_ids?: string[];
+  }): string[] => {
+    const ids = [
+      ...(nonEmptyString(args.monitor_id) ? [nonEmptyString(args.monitor_id)!] : []),
+      ...(Array.isArray(args.monitor_ids) ? args.monitor_ids : []),
+      ...(Array.isArray(args.claimed_monitor_ids)
+        ? args.claimed_monitor_ids
+        : []),
+    ]
+      .map(nonEmptyString)
+      .filter((id): id is string => id !== null);
+    return [...new Set(ids)];
+  };
+  const filterMonitorRegistryRecords = <
+    T extends { monitor_id: string; owner_seat?: string; state?: string },
+  >(
+    records: T[],
+    args: {
+      owner_seat?: string;
+      include_dead?: boolean;
+      monitor_id?: string;
+      monitor_ids?: string[];
+      claimed_monitor_ids?: string[];
+    },
+    includeDeadByDefault: boolean,
+  ): T[] => {
+    const ownerSeat = nonEmptyString(args.owner_seat);
+    const ids = collectMonitorIds(args);
+    const idSet = new Set(ids);
+    const includeDead = args.include_dead ?? includeDeadByDefault;
+    return records.filter((record) => {
+      if (!includeDead && record.state === "dead") return false;
+      if (ownerSeat && record.owner_seat !== ownerSeat) return false;
+      if (idSet.size > 0 && !idSet.has(record.monitor_id)) return false;
+      return true;
+    });
+  };
+  const queryMonitorRegistryTool = (
+    args: {
+      gate?: "gate-9" | "gate-10";
+      owner_seat?: string;
+      monitor_id?: string;
+      monitor_ids?: string[];
+      claimed_monitor_ids?: string[];
+      include_dead?: boolean;
+    },
+    toolName: "list_monitors" | "query_monitor_registry",
+  ): ToolReturn => {
+    const gate = args.gate;
+    if (!gate) {
+      const registry = readMonitorRegistry(monitorRegistryOptions());
+      const monitors = filterMonitorRegistryRecords(
+        registry.monitors,
+        args,
+        false,
+      );
+      return ok({
+        tool: toolName,
+        version: registry.version,
+        monitors,
+      });
+    }
+
+    const claimedMonitorIds = collectMonitorIds(args);
+    const query = queryMonitorRegistryForGates({
+      ...monitorRegistryOptions(),
+      ...(claimedMonitorIds.length > 0 ? { claimedMonitorIds } : {}),
+    });
+    const requestedIds = new Set(claimedMonitorIds);
+    const monitors = filterMonitorRegistryRecords(
+      query.monitors,
+      args,
+      true,
+    );
+    const monitorById = new Map(
+      query.monitors.map((monitor) => [monitor.monitor_id, monitor]),
+    );
+    const violations = query.violations.filter((violation) => {
+      if (violation.gate !== gate) return false;
+      if (requestedIds.size > 0 && !requestedIds.has(violation.monitor_id)) {
+        return false;
+      }
+      const ownerSeat = nonEmptyString(args.owner_seat);
+      if (!ownerSeat) return true;
+      const monitor = monitorById.get(violation.monitor_id);
+      return !monitor || monitor.owner_seat === ownerSeat;
+    });
+    return ok({
+      tool: toolName,
+      gate,
+      verdict: violations.length > 0 ? "fire" : "pass",
+      queried_at: query.queried_at,
+      latency_ms: query.latency_ms,
+      monitors,
+      violations,
+    });
+  };
+
   const server = new McpServer(
     {
       name: "cmuxlayer",
@@ -3685,6 +3930,129 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return okFormatted(formatControlHealth(health), {
           health,
         });
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "register_monitor",
+    "Register or re-arm a shared monitor-registry deadman record. Offset-poll monitors require a watermark_key; fired monitor ids cannot be reused.",
+    RegisterMonitorArgsSchema,
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        const inputOrError = validateRegisterMonitorArgs(args);
+        if (isToolReturn(inputOrError)) {
+          return inputOrError;
+        }
+        const existing = readMonitorRegistry(monitorRegistryOptions()).monitors.find(
+          (record) => record.monitor_id === inputOrError.monitor_id,
+        );
+        if (existing?.state === "deadman-fired") {
+          return monitorRegistryError(
+            "cannot-rearm-fired-monitor-id",
+            inputOrError.monitor_id,
+            "cannot re-arm a fired monitor_id; use a new id",
+          );
+        }
+        const record = await registerMonitor(
+          inputOrError,
+          monitorRegistryOptions(),
+        );
+        return ok({ record });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        if (/cannot re-arm a fired monitor_id/i.test(message)) {
+          return monitorRegistryError(
+            "cannot-rearm-fired-monitor-id",
+            nonEmptyString(args.monitor_id),
+            message,
+          );
+        }
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "signal_monitor",
+    "Signal a registered monitor's liveness heartbeat by updating last_signal_at.",
+    MonitorIdArgsSchema,
+    ANNOTATIONS.idempotentMutating,
+    async (args) => {
+      try {
+        const monitorId = nonEmptyString(args.monitor_id);
+        if (!monitorId) {
+          return monitorRegistryError("missing-monitor-id", null);
+        }
+        const record = await signalMonitor(monitorId, monitorRegistryOptions());
+        if (!record) {
+          return monitorRegistryError(
+            "monitor-id-absent-or-not-alive",
+            monitorId,
+            `Monitor not found or not alive: ${monitorId}`,
+          );
+        }
+        return ok({ record });
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "deregister_monitor",
+    "Mark a monitor as intentionally stopped so later signals do not revive it.",
+    MonitorIdArgsSchema,
+    ANNOTATIONS.idempotentMutating,
+    async (args) => {
+      try {
+        const monitorId = nonEmptyString(args.monitor_id);
+        if (!monitorId) {
+          return monitorRegistryError("missing-monitor-id", null);
+        }
+        const record = await deregisterMonitor(
+          monitorId,
+          monitorRegistryOptions(),
+        );
+        if (!record) {
+          return monitorRegistryError(
+            "monitor-id-absent",
+            monitorId,
+            `Monitor not found: ${monitorId}`,
+          );
+        }
+        return ok({ record });
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "list_monitors",
+    "List monitor-registry records, optionally filtering by gate, owner_seat, or monitor id.",
+    QueryMonitorRegistryArgsSchema,
+    ANNOTATIONS.readOnly,
+    async (args) => {
+      try {
+        return queryMonitorRegistryTool(args, "list_monitors");
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.tool(
+    "query_monitor_registry",
+    "Query the monitor registry for gate-9/gate-10 pass/fire verdicts and monitor metadata.",
+    QueryMonitorRegistryArgsSchema,
+    ANNOTATIONS.readOnly,
+    async (args) => {
+      try {
+        return queryMonitorRegistryTool(args, "query_monitor_registry");
       } catch (e) {
         return err(e);
       }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -352,7 +352,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.start();
 
     await expect(rawToolsList(path, 100)).resolves.toMatchObject({
-      toolCount: 20,
+      toolCount: 25,
     });
 
     await daemon.shutdown();

--- a/tests/monitor-registry-mcp.test.ts
+++ b/tests/monitor-registry-mcp.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import { registerMonitor } from "../src/monitor-registry.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmuxlayer-monitor-registry-mcp-test");
+
+function registryPath(): string {
+  return join(TEST_DIR, "monitor-registry.json");
+}
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<any> {
+  const tool = server._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return parseResult(await tool.handler(args, {} as any));
+}
+
+function makeNoopExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [],
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  });
+}
+
+describe("monitor registry MCP tools", () => {
+  let now = 1_000;
+  let notify: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    now = 1_000;
+    notify = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  function createMonitorServer() {
+    return createServer({
+      exec: makeNoopExec(),
+      skipAgentLifecycle: true,
+      monitorRegistryPath: registryPath(),
+      monitorRegistryNow: () => now,
+      monitorRegistryNotify: notify,
+    });
+  }
+
+  it("registers the monitor registry tool surface", () => {
+    const tools = Object.keys((createMonitorServer() as any)._registeredTools);
+
+    expect(tools).toContain("register_monitor");
+    expect(tools).toContain("signal_monitor");
+    expect(tools).toContain("deregister_monitor");
+    expect(tools).toContain("list_monitors");
+    expect(tools).toContain("query_monitor_registry");
+  });
+
+  it("round-trips register_monitor through list_monitors and query_monitor_registry", async () => {
+    const server = createMonitorServer();
+
+    const registered = await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-collab-watch",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      pattern: "@seat-a|BLOCKED",
+      deadman_timeout_s: 60,
+    });
+    const listed = await callTool(server, "list_monitors", {});
+    const queried = await callTool(server, "query_monitor_registry", {
+      gate: "gate-9",
+      owner_seat: "seat-a",
+      monitor_id: "seat-a-collab-watch",
+    });
+
+    expect(registered).toMatchObject({
+      ok: true,
+      record: {
+        monitor_id: "seat-a-collab-watch",
+        owner_seat: "seat-a",
+        watch_targets: ["orchestrator/collab/example.md"],
+        mechanism: "event",
+        addressee: "seat-a",
+        deadman_timeout_s: 60,
+        state: "alive",
+      },
+    });
+    expect(listed).toMatchObject({
+      ok: true,
+      monitors: [
+        expect.objectContaining({ monitor_id: "seat-a-collab-watch" }),
+      ],
+    });
+    expect(queried).toMatchObject({
+      ok: true,
+      gate: "gate-9",
+      monitors: [
+        expect.objectContaining({
+          monitor_id: "seat-a-collab-watch",
+          liveness: "alive",
+        }),
+      ],
+      violations: [],
+    });
+  });
+
+  it("signal_monitor updates last_signal_at without moving an alive monitor out of alive", async () => {
+    const server = createMonitorServer();
+    await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-flowing",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+    });
+
+    now = 31_000;
+    const signaled = await callTool(server, "signal_monitor", {
+      monitor_id: "seat-a-flowing",
+    });
+    const queried = await callTool(server, "query_monitor_registry", {
+      gate: "gate-9",
+      monitor_id: "seat-a-flowing",
+    });
+
+    expect(signaled).toMatchObject({
+      ok: true,
+      record: {
+        monitor_id: "seat-a-flowing",
+        last_signal_at: new Date(31_000).toISOString(),
+        state: "alive",
+      },
+    });
+    expect(queried.violations).toEqual([]);
+    expect(queried.monitors[0]).toMatchObject({
+      monitor_id: "seat-a-flowing",
+      liveness: "alive",
+    });
+  });
+
+  it("deregister_monitor marks an intentional stop dead and removes it from live listings by default", async () => {
+    const server = createMonitorServer();
+    await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-stop",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+    });
+
+    const stopped = await callTool(server, "deregister_monitor", {
+      monitor_id: "seat-a-stop",
+    });
+    const listed = await callTool(server, "list_monitors", {});
+    const all = await callTool(server, "list_monitors", {
+      include_dead: true,
+    });
+
+    expect(stopped).toMatchObject({
+      ok: true,
+      record: {
+        monitor_id: "seat-a-stop",
+        state: "dead",
+      },
+    });
+    expect(listed.monitors).toEqual([]);
+    expect(all.monitors).toEqual([
+      expect.objectContaining({
+        monitor_id: "seat-a-stop",
+        state: "dead",
+      }),
+    ]);
+  });
+
+  it("reports gate-9 monitor-id-absent for a claimed monitor missing from the registry", async () => {
+    const server = createMonitorServer();
+
+    const queried = await callTool(server, "query_monitor_registry", {
+      gate: "gate-9",
+      monitor_id: "absent-monitor",
+    });
+
+    expect(queried).toMatchObject({
+      ok: true,
+      gate: "gate-9",
+      violations: [
+        {
+          gate: "gate-9",
+          monitor_id: "absent-monitor",
+          reason: "monitor-id-absent",
+        },
+      ],
+    });
+  });
+
+  it("rejects gate-10 invalid registrations up front with contract reasons", async () => {
+    const server = createMonitorServer();
+
+    const noWatermark = await callTool(server, "register_monitor", {
+      monitor_id: "offset-no-watermark",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "offset-poll",
+      deadman_timeout_s: 60,
+    });
+    const noDeadman = await callTool(server, "register_monitor", {
+      monitor_id: "tail-no-deadman",
+      owner_seat: "seat-a",
+      watch_targets: ["tail -n0 -F orchestrator/collab/example.md"],
+      mechanism: "event",
+    });
+
+    expect(noWatermark).toMatchObject({
+      ok: false,
+      monitor_id: "offset-no-watermark",
+      reason: "offset-poll-missing-watermark-key",
+    });
+    expect(noDeadman).toMatchObject({
+      ok: false,
+      monitor_id: "tail-no-deadman",
+      reason: "invalid-deadman-timeout",
+    });
+  });
+
+  it("rejects re-arming a fired monitor_id through register_monitor", async () => {
+    const server = createMonitorServer();
+    await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-fired",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+    });
+    now = 62_000;
+    await registerMonitor(
+      {
+        monitor_id: "other-live",
+        owner_seat: "seat-b",
+        watch_targets: ["orchestrator/collab/other.md"],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => now },
+    );
+    await (await import("../src/monitor-registry.js")).sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => now,
+      notify,
+    });
+
+    const rearm = await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-fired",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+    });
+
+    expect(rearm).toMatchObject({
+      ok: false,
+      monitor_id: "seat-a-fired",
+      reason: "cannot-rearm-fired-monitor-id",
+    });
+  });
+
+  it("agent-engine sweep invokes the wired monitor deadman notify callback end to end", async () => {
+    const server = createServer({
+      exec: makeNoopExec(),
+      stateDir: join(TEST_DIR, "state"),
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      monitorRegistryPath: registryPath(),
+      monitorRegistryNow: () => now,
+      monitorRegistryNotify: notify,
+    });
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    await callTool(server, "register_monitor", {
+      monitor_id: "engine-sweep-deadman",
+      owner_seat: "seat-a",
+      watch_targets: ["orchestrator/collab/example.md"],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+    });
+
+    now = 62_000;
+    await engine.runSweep();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitor_id: "engine-sweep-deadman",
+        owner_seat: "seat-a",
+        fired_by_agent_id: "agent-engine",
+      }),
+    );
+    const queried = await callTool(server, "query_monitor_registry", {
+      gate: "gate-9",
+      monitor_id: "engine-sweep-deadman",
+    });
+    expect(queried.monitors[0]).toMatchObject({
+      monitor_id: "engine-sweep-deadman",
+      state: "deadman-fired",
+      liveness: "deadman-fired",
+    });
+  });
+});

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -39,6 +39,8 @@ describe("B1: ToolAnnotations on all tools", () => {
     "my_agents",
     "read_agent_output",
     "inbox_check",
+    "list_monitors",
+    "query_monitor_registry",
   ];
 
   const DESTRUCTIVE_TOOLS = ["kill", "close_surface", "stop_agent"];
@@ -68,6 +70,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     "wait_for_all",
     "interact",
     "dispatch_to_agent",
+    "register_monitor",
+    "signal_monitor",
+    "deregister_monitor",
   ];
 
   let tools: Record<string, { annotations?: Record<string, unknown> }>;
@@ -85,9 +90,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 36 tools have annotations", () => {
+  it("all 41 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(36);
+    expect(toolNames.length).toBe(41);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -380,11 +380,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 36", () => {
+  it("total tool count is 41", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(36);
+    expect(Object.keys(registeredTools)).toHaveLength(41);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -49,6 +49,11 @@ const EXPECTED_TOOLS = [
   "browser_surface",
   "dispatch_to_agent",
   "inbox_check",
+  "register_monitor",
+  "signal_monitor",
+  "deregister_monitor",
+  "list_monitors",
+  "query_monitor_registry",
 ] as const;
 
 const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
@@ -247,7 +252,7 @@ describe("input delivery batching helpers", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 20 core tools", () => {
+  it("registers all 25 core tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -284,14 +284,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("kill");
   });
 
-  it("total tool count is 36", () => {
+  it("total tool count is 41", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(36);
+    expect(count).toBe(41);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add MCP tools over the existing monitor-registry core: `register_monitor`, `signal_monitor`, `deregister_monitor`, `list_monitors`, and `query_monitor_registry`.
- Keep the core registry implementation intact; validation and response shaping live in `src/server.ts`.
- Add acceptance fixtures for register/list round trips, signal heartbeat updates, deregistration, gate-9 absent/deadman behavior, gate-10 invalid shapes, re-arm rejection, and agent-engine sweep to injected notify.
- Update tool-count and ToolAnnotations expectations for the five new tools.

## Deadman notify path
- Existing live entrypoints already wire `defaultMonitorRegistryPath()` plus `httpNotifyMonitorDeadman` into the agent-engine sweep.
- New fixture verifies `AgentEngine.runSweep()` calls the wired `monitorRegistryNotify` callback when a registered monitor lapses and flips to `deadman-fired`.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (76 files, 1401 tests)
- [x] Real MCP client smoke via `Client` + `InMemoryTransport`: listed 25 skip-lifecycle tools, called `register_monitor`, then called `query_monitor_registry` successfully.
- [x] Confirmed `~/.golems-zikaron/outbox.md` mtime unchanged before/after full test run: `1783337759`.
- [x] `git diff --check`

## Review note
- Local `coderabbit review --agent` was attempted before commit and timed out after 180 seconds while still returning heartbeat-only `reviewing` status; no findings were returned before timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutating tools write shared monitor-registry state and gate queries affect orchestration decisions; core registry logic is reused rather than rewritten.
> 
> **Overview**
> Adds **five MCP tools** on top of the existing monitor-registry core so agents can register deadman monitors, send heartbeats, deregister, list records, and run **gate-9 / gate-10** queries with pass/fire verdicts.
> 
> **`register_monitor`** validates registration args in `server.ts` (owner seat, watch targets, mechanism, offset-poll watermark, deadman timeout, etc.) and blocks re-arming **`deadman-fired`** monitor ids. **`signal_monitor`** and **`deregister_monitor`** update liveness and intentional stop state. **`list_monitors`** and **`query_monitor_registry`** share filtering helpers and optional gate mode via `queryMonitorRegistryForGates`.
> 
> Tool surface grows from **36 → 41** (25 when agent lifecycle is skipped); tests cover round trips, gate violations, contract rejections, and agent-engine sweep → **`monitorRegistryNotify`**. Read-only vs mutating **ToolAnnotations** are updated for the new tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cb3e4797fc501aa167b1750d545b0b8b707932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose monitor registry as five MCP tools in server
> - Adds `register_monitor`, `signal_monitor`, `deregister_monitor`, `list_monitors`, and `query_monitor_registry` tools to [server.ts](https://github.com/EtanHey/cmuxlayer/pull/250/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), bringing the total tool count from 36 to 41.
> - Input validation enforces allowed enum values for mechanism (`event`|`offset-poll`), dedupe strategy, and gate mode (`gate-9`|`gate-10`), returning structured errors with `reason` and `monitor_id` fields.
> - `query_monitor_registry` supports gate-9/gate-10 semantics, returning `pass`/`fire` verdicts with filtered violations and timing metadata.
> - Re-arming a monitor in `deadman-fired` state is explicitly rejected with reason `cannot-rearm-fired-monitor-id`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e4cb3e4. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->