### PR TITLE
feat: add broadcast agent tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -324,6 +324,24 @@ const SendToArgsSchema = z.object({
   allow_long_inline: z.boolean().optional().default(false),
 });
 
+const BroadcastRoleSchema = z.enum(["leads", "workers", "all"]);
+const BroadcastArgsSchema = z.object({
+  text: z.string(),
+  role: BroadcastRoleSchema.optional().default("leads"),
+  exclude: z.array(z.string()).optional().default([]),
+  workspace: z.string().optional(),
+  press_enter: z.boolean().optional().default(true),
+});
+type BroadcastRole = z.infer<typeof BroadcastRoleSchema>;
+type BroadcastReceipt = {
+  agent_id: string;
+  seat: string;
+  delivered: boolean;
+  submit_verified: boolean | null;
+  error?: string;
+  skipped?: string;
+};
+
 type DeliveryStatus = "delivering" | "delivered" | "failed";
 
 export interface DeliveryRecord {
@@ -1038,6 +1056,27 @@ function assertInlineInputAllowed(opts: {
   throw new Error(
     `${argName} is ${opts.value.length} characters, above CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}. Pane keystrokes are capped to one-line pointers: write the payload to a file and send "Read and follow <path>" instead.${promptPathGuidance} To deliberately send raw inline text, pass allow_long_inline:true. CMUXLAYER_MAX_INLINE_CHARS may be set to a positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}.`,
   );
+}
+
+function assertBroadcastInlineInputAllowed(text: string): void {
+  if (text.length <= SEND_INPUT_MAX_INLINE_CHARS) {
+    return;
+  }
+
+  throw new Error(
+    `broadcast.text is ${text.length} characters, above CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}. ` +
+      `Broadcasts are capped to one-line pointers: write the payload to a file and broadcast "Read and follow <path>" instead. ` +
+      `CMUXLAYER_MAX_INLINE_CHARS may be set to a positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}.`,
+  );
+}
+
+function broadcastRoleMatches(
+  requestedRole: BroadcastRole,
+  agentRole: AgentRole | undefined,
+): boolean {
+  if (requestedRole === "all") return true;
+  if (requestedRole === "workers") return agentRole === "worker";
+  return agentRole === "orchestrator" || agentRole === "ic";
 }
 
 function assertBootPromptMode(
@@ -7155,6 +7194,174 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return err(fallbackError);
             }
           }
+          return err(e);
+        }
+      },
+    );
+
+    const resolveBroadcastCallerRefs = async (): Promise<Set<string>> => {
+      const refs = new Set<string>();
+      const add = (value: string | undefined): void => {
+        const trimmed = value?.trim();
+        if (trimmed) refs.add(trimmed);
+      };
+      add(process.env.CMUX_AGENT_ID);
+      add(process.env.CMUX_TAB_ID);
+      add(process.env.CMUX_SURFACE_ID);
+
+      for (const surface of [process.env.CMUX_SURFACE_ID, process.env.CMUX_TAB_ID]) {
+        if (!surface?.trim()) continue;
+        try {
+          const identified = await client.identify(surface.trim());
+          add(identified.caller?.surface_ref);
+          add(identified.focused?.surface_ref);
+        } catch {
+          // Caller identity is best-effort. Explicit env refs above still apply.
+        }
+      }
+      return refs;
+    };
+
+    const broadcastSkipReason = (agent: AgentRecord): string | null => {
+      if (TERMINAL_AGENT_STATES.has(agent.state)) {
+        return `dead:${agent.state}`;
+      }
+      if (!INTERACTIVE_AGENT_STATES.has(agent.state)) {
+        return `not_interactive:${agent.state}`;
+      }
+      return null;
+    };
+
+    const agentSeatLabel = (agent: AgentRecord): string =>
+      agent.seat_id?.trim() ||
+      agent.task_summary?.trim() ||
+      agent.surface_id ||
+      agent.agent_id;
+
+    server.tool(
+      "broadcast",
+      `Fan out a short pointer-style message to registered agents by role using the same guarded delivery path as send_to. Defaults to role=leads (orchestrator + ic). Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters; for larger payloads write a file and broadcast "Read and follow <path>". Returns per-agent receipts so one failed target never hides the rest.`,
+      {
+        text: BroadcastArgsSchema.shape.text.describe(
+          `Message to broadcast. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters; write larger payloads to a file and broadcast "Read and follow <path>".`,
+        ),
+        role: BroadcastArgsSchema.shape.role.describe(
+          "Target role set: leads means orchestrator + ic; workers means worker; all means every registered agent.",
+        ),
+        exclude: BroadcastArgsSchema.shape.exclude.describe(
+          "Agent IDs to skip in addition to the caller's own agent.",
+        ),
+        workspace: BroadcastArgsSchema.shape.workspace.describe(
+          "Optional workspace ref/id to scope targets. Omit to broadcast across all workspaces.",
+        ),
+        press_enter: BroadcastArgsSchema.shape.press_enter.describe(
+          "Press enter after sending the text to each target.",
+        ),
+      },
+      ANNOTATIONS.mutating,
+      async (rawArgs) => {
+        try {
+          const parsedArgs = BroadcastArgsSchema.safeParse(rawArgs);
+          if (!parsedArgs.success) {
+            return err(
+              new Error(formatToolValidationError("broadcast", parsedArgs.error)),
+            );
+          }
+          const args = parsedArgs.data;
+          assertBroadcastInlineInputAllowed(args.text);
+
+          const scopedWorkspace = await canonicalWorkspaceRef(args.workspace);
+          const excludedAgentIds = new Set(args.exclude);
+          const callerRefs = await resolveBroadcastCallerRefs();
+          const workspaceMatches = (agent: AgentRecord): boolean =>
+            !scopedWorkspace ||
+            agent.workspace_id === scopedWorkspace ||
+            agent.workspace_id === args.workspace;
+          const isCaller = (agent: AgentRecord): boolean =>
+            callerRefs.has(agent.agent_id) || callerRefs.has(agent.surface_id);
+
+          const collectTargets = async (): Promise<AgentRecord[]> => {
+            try {
+              return await registry.listMerged(discovery);
+            } catch (e) {
+              if (isSurfaceEnumerationError(e)) {
+                return registry.list();
+              }
+              throw e;
+            }
+          };
+
+          const targets = (await collectTargets()).filter(
+            (agent) =>
+              broadcastRoleMatches(args.role, agent.role) &&
+              workspaceMatches(agent) &&
+              !excludedAgentIds.has(agent.agent_id) &&
+              !isCaller(agent),
+          );
+
+          const receipts: BroadcastReceipt[] = [];
+          for (const agent of targets) {
+            const skipped = broadcastSkipReason(agent);
+            if (skipped) {
+              receipts.push({
+                agent_id: agent.agent_id,
+                seat: agentSeatLabel(agent),
+                delivered: false,
+                submit_verified: null,
+                skipped,
+              });
+              continue;
+            }
+
+            try {
+              const delivery = await deliverAgentInput({
+                agent_id: agent.agent_id,
+                text: args.text,
+                press_enter: args.press_enter,
+                source_event: "send_to",
+              });
+              receipts.push({
+                agent_id: agent.agent_id,
+                seat: agentSeatLabel(agent),
+                delivered: true,
+                submit_verified: delivery.submit_verified,
+              });
+            } catch (e) {
+              receipts.push({
+                agent_id: agent.agent_id,
+                seat: agentSeatLabel(agent),
+                delivered: false,
+                submit_verified:
+                  e instanceof SubmitVerificationError
+                    ? false
+                    : e instanceof DeliverySafetyGateError
+                      ? e.submit_verified
+                      : null,
+                error: e instanceof Error ? e.message : String(e),
+              });
+            }
+          }
+
+          const deliveredCount = receipts.filter(
+            (receipt) => receipt.delivered,
+          ).length;
+          const skippedCount = receipts.filter(
+            (receipt) => receipt.skipped,
+          ).length;
+          const failedCount = receipts.length - deliveredCount - skippedCount;
+          const data = {
+            role: args.role,
+            target_count: receipts.length,
+            delivered_count: deliveredCount,
+            failed_count: failedCount,
+            skipped_count: skippedCount,
+            receipts: receipts as unknown as Record<string, unknown>[],
+          };
+          return okFormatted(
+            `broadcast ${args.role}: ${deliveredCount} delivered, ${failedCount} failed, ${skippedCount} skipped`,
+            data,
+          );
+        } catch (e) {
           return err(e);
         }
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -99,6 +99,8 @@ import {
   chooseSurfaceClosePolicy,
   deriveColumnIndex,
   inferAgentRole,
+  inferRecordRoleOrNull,
+  isAgentRoleInferenceError,
   launcherNameForCli,
 } from "./layout-policy.js";
 import type {
@@ -1072,11 +1074,27 @@ function assertBroadcastInlineInputAllowed(text: string): void {
 
 function broadcastRoleMatches(
   requestedRole: BroadcastRole,
-  agentRole: AgentRole | undefined,
+  agentRole: AgentRole | null,
 ): boolean {
   if (requestedRole === "all") return true;
   if (requestedRole === "workers") return agentRole === "worker";
   return agentRole === "orchestrator" || agentRole === "ic";
+}
+
+function inferBroadcastRecordRole(agent: AgentRecord): AgentRole | null {
+  try {
+    return inferAgentRole({
+      role: agent.role,
+      cli: agent.cli,
+      launcherName: agent.launcher_name ?? launcherNameForCli(agent.repo, agent.cli),
+      title: agent.task_summary,
+    });
+  } catch (error) {
+    if (isAgentRoleInferenceError(error)) {
+      return inferRecordRoleOrNull(agent);
+    }
+    throw error;
+  }
 }
 
 function assertBootPromptMode(
@@ -7285,7 +7303,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return await registry.listMerged(discovery);
             } catch (e) {
               if (isSurfaceEnumerationError(e)) {
-                return registry.list();
+                throw new Error(
+                  `Refusing broadcast because live surface enumeration failed: ${
+                    e instanceof Error ? e.message : String(e)
+                  }`,
+                );
               }
               throw e;
             }
@@ -7293,7 +7315,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
           const targets = (await collectTargets()).filter(
             (agent) =>
-              broadcastRoleMatches(args.role, agent.role) &&
+              broadcastRoleMatches(args.role, inferBroadcastRecordRole(agent)) &&
               workspaceMatches(agent) &&
               !excludedAgentIds.has(agent.agent_id) &&
               !isCaller(agent),

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -64,6 +64,7 @@ describe("B1: ToolAnnotations on all tools", () => {
     "spawn_in_workspace",
     "resync_agents",
     "send_to",
+    "broadcast",
     "supersede_agent_goal",
     "send_to_agent",
     "wait_for",
@@ -90,9 +91,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 41 tools have annotations", () => {
+  it("all 42 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(41);
+    expect(toolNames.length).toBe(42);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import {
   createServer,
   createServerContext,
@@ -310,7 +310,11 @@ type BroadcastMockClient = {
 
 function makeBroadcastClient(
   records: AgentRecord[],
-  opts: { failSurface?: string; callerSurface?: string } = {},
+  opts: {
+    failSurface?: string;
+    callerSurface?: string;
+    malformedEnumeration?: boolean;
+  } = {},
 ): BroadcastMockClient {
   const submittedSurfaces = new Set<string>();
   const sendCalls: Array<{ surface: string; text: string; workspace?: string }> =
@@ -342,15 +346,19 @@ function makeBroadcastClient(
   };
 
   const client = {
-    listWorkspaces: vi.fn().mockResolvedValue({
-      workspaces: workspaces.map((ref, index) => ({
-        ref,
-        title: ref,
-        index,
-        selected: index === 0,
-        pinned: false,
-      })),
-    }),
+    listWorkspaces: vi.fn().mockImplementation(async () =>
+      opts.malformedEnumeration
+        ? { workspaces: null }
+        : {
+            workspaces: workspaces.map((ref, index) => ({
+              ref,
+              title: ref,
+              index,
+              selected: index === 0,
+              pinned: false,
+            })),
+          },
+    ),
     listPanes: vi.fn().mockImplementation(async ({ workspace }) => {
       const workspaceRecords = recordsForWorkspace(workspace);
       return {
@@ -434,7 +442,11 @@ function makeBroadcastClient(
 
 async function createBroadcastServer(
   records: AgentRecord[],
-  opts: { failSurface?: string; callerSurface?: string } = {},
+  opts: {
+    failSurface?: string;
+    callerSurface?: string;
+    malformedEnumeration?: boolean;
+  } = {},
 ) {
   const { client, sendCalls, sendKeyCalls } = makeBroadcastClient(records, opts);
   const server = createTrackedServer({
@@ -453,12 +465,8 @@ async function createBroadcastServer(
   return { server, client, sendCalls, sendKeyCalls };
 }
 
-function readOutboxMtimeMs(): number | null {
-  try {
-    return statSync(join(homedir(), ".golems-zikaron", "outbox.md")).mtimeMs;
-  } catch {
-    return null;
-  }
+function readOutboxMtimeMs(path: string): number {
+  return statSync(path).mtimeMs;
 }
 
 type TestToolResult = {
@@ -2347,6 +2355,48 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("broadcast infers unset record roles before selecting lead targets", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "implicit-orchestrator",
+        surface_id: "surface:implicit-orc",
+        state: "ready",
+        role: undefined,
+        cli: "claude",
+        repo: "orchestrator",
+        task_summary: "implicit Claude lead",
+      }),
+      makeServerAgentRecord({
+        agent_id: "implicit-worker",
+        surface_id: "surface:implicit-worker",
+        state: "ready",
+        role: undefined,
+        cli: "codex",
+        repo: "brainlayer",
+        task_summary: "implicit Codex worker",
+      }),
+    ];
+    const { server, sendCalls } = await createBroadcastServer(records);
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "Role inference target test", role: "leads", press_enter: false },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      role: "leads",
+      target_count: 1,
+      delivered_count: 1,
+    });
+    expect(sendCalls.map((call) => call.surface)).toEqual([
+      "surface:implicit-orc",
+    ]);
+  });
+
   it("broadcast returns per-lead receipts when one delivery fails without aborting others", async () => {
     const records = [
       makeServerAgentRecord({
@@ -2417,7 +2467,9 @@ describe("agent lifecycle tool handlers", () => {
   });
 
   it("broadcast refuses over-cap text with file-pointer guidance before delivery", async () => {
-    const outboxMtimeBefore = readOutboxMtimeMs();
+    const outboxPath = join(TEST_DIR, "mock-outbox.md");
+    writeFileSync(outboxPath, "not touched by broadcast\n", "utf8");
+    const outboxMtimeBefore = readOutboxMtimeMs(outboxPath);
     const records = [
       makeServerAgentRecord({
         agent_id: "ic-target",
@@ -2442,7 +2494,36 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.error).not.toContain("allow_long_inline");
     expect(sendCalls).toHaveLength(0);
     expect(sendKeyCalls).toHaveLength(0);
-    expect(readOutboxMtimeMs()).toBe(outboxMtimeBefore);
+    expect(readOutboxMtimeMs(outboxPath)).toBe(outboxMtimeBefore);
+  });
+
+  it("broadcast fails closed when live surface enumeration is malformed", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "ic-stale",
+        surface_id: "surface:stale",
+        state: "ready",
+        role: "ic",
+        task_summary: "possibly stale lead",
+      }),
+    ];
+    const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(
+      records,
+      { malformedEnumeration: true },
+    );
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "Must not deliver on stale enumeration", role: "leads" },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Malformed cmux surface enumeration");
+    expect(sendCalls).toHaveLength(0);
+    expect(sendKeyCalls).toHaveLength(0);
   });
 
   it("broadcast records dead and non-interactive lead targets as skipped", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10,15 +10,17 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  statSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import {
   createServer,
   createServerContext,
   reconcileAgentLiveState,
+  SEND_INPUT_MAX_INLINE_CHARS,
   type CmuxServerContext,
   type CreateServerOptions,
 } from "../src/server.js";
@@ -40,6 +42,7 @@ const AGENT_TOOLS = [
   "wait_for_all",
   "get_agent_state",
   "list_agents",
+  "broadcast",
   "stop_agent",
   "send_to_agent",
   "read_agent_output",
@@ -299,6 +302,165 @@ function makeServerAgentRecord(
   };
 }
 
+type BroadcastMockClient = {
+  client: Record<string, any>;
+  sendCalls: Array<{ surface: string; text: string; workspace?: string }>;
+  sendKeyCalls: Array<{ surface: string; key: string; workspace?: string }>;
+};
+
+function makeBroadcastClient(
+  records: AgentRecord[],
+  opts: { failSurface?: string; callerSurface?: string } = {},
+): BroadcastMockClient {
+  const submittedSurfaces = new Set<string>();
+  const sendCalls: Array<{ surface: string; text: string; workspace?: string }> =
+    [];
+  const sendKeyCalls: Array<{
+    surface: string;
+    key: string;
+    workspace?: string;
+  }> = [];
+  const workspaces = [
+    ...new Set(records.map((record) => record.workspace_id ?? "workspace:1")),
+  ];
+  const recordsForWorkspace = (workspace?: string) =>
+    records.filter((record) => (record.workspace_id ?? "workspace:1") === workspace);
+  const screenFor = (surface: string): string => {
+    const record = records.find((candidate) => candidate.surface_id === surface);
+    if (submittedSurfaces.has(surface)) {
+      return record?.cli === "claude"
+        ? "Claude Code\nWorking\n"
+        : "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+    }
+    if (record?.cli === "claude") {
+      return "Claude Code\nWhat can I help you with?\n>";
+    }
+    if (record?.cli === "cursor") {
+      return "cursor>\n";
+    }
+    return "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ";
+  };
+
+  const client = {
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: workspaces.map((ref, index) => ({
+        ref,
+        title: ref,
+        index,
+        selected: index === 0,
+        pinned: false,
+      })),
+    }),
+    listPanes: vi.fn().mockImplementation(async ({ workspace }) => {
+      const workspaceRecords = recordsForWorkspace(workspace);
+      return {
+        workspace_ref: workspace,
+        window_ref: `window:${workspace}`,
+        panes: [
+          {
+            ref: `pane:${workspace}`,
+            index: 0,
+            focused: true,
+            surface_count: workspaceRecords.length,
+            surface_refs: workspaceRecords.map((record) => record.surface_id),
+            selected_surface_ref: workspaceRecords[0]?.surface_id,
+          },
+        ],
+      };
+    }),
+    listPaneSurfaces: vi.fn().mockImplementation(async ({ workspace, pane }) => {
+      const workspaceRecords = recordsForWorkspace(workspace);
+      return {
+        workspace_ref: workspace,
+        window_ref: `window:${workspace}`,
+        pane_ref: pane ?? `pane:${workspace}`,
+        surfaces: workspaceRecords.map((record, index) => ({
+          ref: record.surface_id,
+          title: record.task_summary,
+          type: "terminal",
+          index,
+          selected: index === 0,
+          workspace_ref: workspace,
+          pane_ref: pane ?? `pane:${workspace}`,
+        })),
+      };
+    }),
+    readScreen: vi.fn().mockImplementation(async (surface) => ({
+      surface,
+      text: screenFor(surface),
+      lines: 20,
+      scrollback_used: false,
+    })),
+    send: vi.fn().mockImplementation(async (surface, text, sendOpts) => {
+      sendCalls.push({ surface, text, workspace: sendOpts?.workspace });
+      if (opts.failSurface === surface) {
+        throw new Error(`send failed for ${surface}`);
+      }
+    }),
+    sendKey: vi.fn().mockImplementation(async (surface, key, keyOpts) => {
+      sendKeyCalls.push({ surface, key, workspace: keyOpts?.workspace });
+      if (key === "return") {
+        submittedSurfaces.add(surface);
+      }
+    }),
+    log: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn().mockResolvedValue(undefined),
+    newSplit: vi.fn(),
+    newSurface: vi.fn(),
+    selectWorkspace: vi.fn(),
+    closeSurface: vi.fn(),
+    notify: vi.fn(),
+    listStatus: vi.fn().mockResolvedValue([]),
+    identify: vi.fn().mockImplementation(async () => ({
+      caller: {
+        surface_ref: opts.callerSurface ?? process.env.CMUX_TAB_ID,
+        workspace_ref: records.find(
+          (record) =>
+            record.surface_id === (opts.callerSurface ?? process.env.CMUX_TAB_ID),
+        )?.workspace_id,
+      },
+      focused: {
+        surface_ref: opts.callerSurface ?? process.env.CMUX_TAB_ID,
+      },
+    })),
+    browser: vi.fn().mockResolvedValue({}),
+  };
+
+  return { client, sendCalls, sendKeyCalls };
+}
+
+async function createBroadcastServer(
+  records: AgentRecord[],
+  opts: { failSurface?: string; callerSurface?: string } = {},
+) {
+  const { client, sendCalls, sendKeyCalls } = makeBroadcastClient(records, opts);
+  const server = createTrackedServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+    sessionIdentityResolver: () => null,
+  });
+  await serverContexts[serverContexts.length - 1]?.lifecycleStartPromise;
+  const engine = testLifecycleEngine(server);
+  const registry = engine.getRegistry();
+  for (const record of records) {
+    engine.stateMgr.writeState(record);
+    registry.set(record.agent_id, record);
+  }
+  return { server, client, sendCalls, sendKeyCalls };
+}
+
+function readOutboxMtimeMs(): number | null {
+  try {
+    return statSync(join(homedir(), ".golems-zikaron", "outbox.md")).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
 type TestToolResult = {
   structuredContent?: Record<string, unknown>;
   content: Array<{ text: string }>;
@@ -352,7 +514,7 @@ function readCloseEvents(stateDir: string): Array<Record<string, unknown>> {
 }
 
 describe("agent lifecycle tool registration", () => {
-  it("registers all 14 phase-5 lifecycle tools when lifecycle is enabled", () => {
+  it("registers all 15 phase-5 lifecycle tools when lifecycle is enabled", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
@@ -380,11 +542,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 41", () => {
+  it("total tool count is 42", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(41);
+    expect(Object.keys(registeredTools)).toHaveLength(42);
   });
 });
 
@@ -2067,6 +2229,342 @@ describe("agent lifecycle tool handlers", () => {
         "non_resumable",
       ]),
     });
+  });
+
+  it("broadcast defaults to leads and excludes the caller, workers, and explicit excludes", async () => {
+    const previousTabId = process.env.CMUX_TAB_ID;
+    const previousAgentId = process.env.CMUX_AGENT_ID;
+    process.env.CMUX_TAB_ID = "surface:caller";
+    delete process.env.CMUX_AGENT_ID;
+
+    try {
+      const records = [
+        makeServerAgentRecord({
+          agent_id: "orc-caller",
+          surface_id: "surface:caller",
+          state: "ready",
+          role: "orchestrator",
+          task_summary: "caller lead",
+        }),
+        makeServerAgentRecord({
+          agent_id: "ic-target",
+          surface_id: "surface:ic",
+          state: "ready",
+          role: "ic",
+          task_summary: "ic lane",
+        }),
+        makeServerAgentRecord({
+          agent_id: "orc-target",
+          surface_id: "surface:orc",
+          state: "idle",
+          role: "orchestrator",
+          task_summary: "orchestrator lane",
+        }),
+        makeServerAgentRecord({
+          agent_id: "ic-excluded",
+          surface_id: "surface:excluded",
+          state: "ready",
+          role: "ic",
+          task_summary: "excluded lane",
+        }),
+        makeServerAgentRecord({
+          agent_id: "worker-target",
+          surface_id: "surface:worker",
+          state: "ready",
+          role: "worker",
+          task_summary: "worker lane",
+        }),
+      ];
+      const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(
+        records,
+        { callerSurface: "surface:caller" },
+      );
+      const broadcast = (server as any)._registeredTools["broadcast"];
+
+      const result = await broadcast.handler(
+        {
+          text: "Read and follow /tmp/lead-update.md",
+          exclude: ["ic-excluded"],
+        },
+        {} as any,
+      );
+      const parsed = parseToolResult(result);
+      const receipts = parsed.receipts as Array<Record<string, unknown>>;
+
+      expect(result.isError).toBeFalsy();
+      expect(parsed).toMatchObject({
+        ok: true,
+        role: "leads",
+        target_count: 2,
+        delivered_count: 2,
+        failed_count: 0,
+        skipped_count: 0,
+      });
+      expect(sendCalls.map((call) => call.surface)).toEqual([
+        "surface:ic",
+        "surface:orc",
+      ]);
+      expect(sendKeyCalls.map((call) => call.surface)).toEqual([
+        "surface:ic",
+        "surface:orc",
+      ]);
+      expect(receipts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agent_id: "ic-target",
+            seat: "ic lane",
+            delivered: true,
+            submit_verified: true,
+          }),
+          expect.objectContaining({
+            agent_id: "orc-target",
+            seat: "orchestrator lane",
+            delivered: true,
+            submit_verified: true,
+          }),
+        ]),
+      );
+      expect(receipts.map((receipt) => receipt.agent_id)).not.toContain(
+        "orc-caller",
+      );
+      expect(receipts.map((receipt) => receipt.agent_id)).not.toContain(
+        "worker-target",
+      );
+      expect(receipts.map((receipt) => receipt.agent_id)).not.toContain(
+        "ic-excluded",
+      );
+    } finally {
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+      if (previousAgentId === undefined) {
+        delete process.env.CMUX_AGENT_ID;
+      } else {
+        process.env.CMUX_AGENT_ID = previousAgentId;
+      }
+    }
+  });
+
+  it("broadcast returns per-lead receipts when one delivery fails without aborting others", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "ic-ok-1",
+        surface_id: "surface:ok-1",
+        state: "ready",
+        role: "ic",
+        task_summary: "first ok lead",
+      }),
+      makeServerAgentRecord({
+        agent_id: "ic-fail",
+        surface_id: "surface:fail",
+        state: "ready",
+        role: "ic",
+        task_summary: "failing lead",
+      }),
+      makeServerAgentRecord({
+        agent_id: "orc-ok-2",
+        surface_id: "surface:ok-2",
+        state: "ready",
+        role: "orchestrator",
+        task_summary: "second ok lead",
+      }),
+    ];
+    const { server, sendCalls } = await createBroadcastServer(records, {
+      failSurface: "surface:fail",
+    });
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "Short receipt test", role: "leads" },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+    const receipts = parsed.receipts as Array<Record<string, unknown>>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      target_count: 3,
+      delivered_count: 2,
+      failed_count: 1,
+      skipped_count: 0,
+    });
+    expect(sendCalls.map((call) => call.surface)).toEqual(
+      expect.arrayContaining(["surface:ok-1", "surface:fail", "surface:ok-2"]),
+    );
+    expect(receipts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: "ic-ok-1",
+          delivered: true,
+          submit_verified: true,
+        }),
+        expect.objectContaining({
+          agent_id: "ic-fail",
+          delivered: false,
+          submit_verified: null,
+          error: expect.stringContaining("send failed for surface:fail"),
+        }),
+        expect.objectContaining({
+          agent_id: "orc-ok-2",
+          delivered: true,
+          submit_verified: true,
+        }),
+      ]),
+    );
+  });
+
+  it("broadcast refuses over-cap text with file-pointer guidance before delivery", async () => {
+    const outboxMtimeBefore = readOutboxMtimeMs();
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "ic-target",
+        surface_id: "surface:ic",
+        state: "ready",
+        role: "ic",
+      }),
+    ];
+    const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(records);
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "x".repeat(SEND_INPUT_MAX_INLINE_CHARS + 1) },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("broadcast.text");
+    expect(parsed.error).toContain("Read and follow <path>");
+    expect(parsed.error).not.toContain("allow_long_inline");
+    expect(sendCalls).toHaveLength(0);
+    expect(sendKeyCalls).toHaveLength(0);
+    expect(readOutboxMtimeMs()).toBe(outboxMtimeBefore);
+  });
+
+  it("broadcast records dead and non-interactive lead targets as skipped", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "ic-ready",
+        surface_id: "surface:ready",
+        state: "ready",
+        role: "ic",
+      }),
+      makeServerAgentRecord({
+        agent_id: "ic-working",
+        surface_id: "surface:working",
+        state: "working",
+        role: "ic",
+      }),
+      makeServerAgentRecord({
+        agent_id: "orc-error",
+        surface_id: "surface:error",
+        state: "error",
+        role: "orchestrator",
+        error: "pane died",
+      }),
+    ];
+    const { server, sendCalls } = await createBroadcastServer(records);
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "Skip accounting", role: "leads", press_enter: false },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+    const receipts = parsed.receipts as Array<Record<string, unknown>>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      target_count: 3,
+      delivered_count: 1,
+      failed_count: 0,
+      skipped_count: 2,
+    });
+    expect(sendCalls.map((call) => call.surface)).toEqual(["surface:ready"]);
+    expect(receipts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: "ic-ready",
+          delivered: true,
+          submit_verified: null,
+        }),
+        expect.objectContaining({
+          agent_id: "ic-working",
+          delivered: false,
+          submit_verified: null,
+          skipped: "not_interactive:working",
+        }),
+        expect.objectContaining({
+          agent_id: "orc-error",
+          delivered: false,
+          submit_verified: null,
+          skipped: "dead:error",
+        }),
+      ]),
+    );
+  });
+
+  it("broadcast role=workers and role=all select the requested target sets", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "orc-target",
+        surface_id: "surface:orc",
+        state: "ready",
+        role: "orchestrator",
+      }),
+      makeServerAgentRecord({
+        agent_id: "ic-target",
+        surface_id: "surface:ic",
+        state: "ready",
+        role: "ic",
+      }),
+      makeServerAgentRecord({
+        agent_id: "worker-target",
+        surface_id: "surface:worker",
+        state: "ready",
+        role: "worker",
+      }),
+    ];
+    const { server, sendCalls } = await createBroadcastServer(records);
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    let result = await broadcast.handler(
+      { text: "Workers only", role: "workers", press_enter: false },
+      {} as any,
+    );
+    let parsed = parseToolResult(result);
+    expect(parsed).toMatchObject({
+      ok: true,
+      role: "workers",
+      target_count: 1,
+      delivered_count: 1,
+    });
+    expect(sendCalls.map((call) => call.surface)).toEqual(["surface:worker"]);
+
+    sendCalls.splice(0);
+
+    result = await broadcast.handler(
+      { text: "Everyone", role: "all", press_enter: false },
+      {} as any,
+    );
+    parsed = parseToolResult(result);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      role: "all",
+      target_count: 3,
+      delivered_count: 3,
+    });
+    expect(sendCalls.map((call) => call.surface)).toEqual([
+      "surface:orc",
+      "surface:ic",
+      "surface:worker",
+    ]);
   });
 
   it("list_agents state filter uses the reconciled screen-active state", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -273,7 +273,7 @@ function finalizeAgentAlias(server: any, pendingId: string, finalId: string) {
 }
 
 describe("V2 tool registration", () => {
-  it("registers interact and kill tools", () => {
+  it("registers interact, kill, and broadcast tools", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
@@ -282,16 +282,17 @@ describe("V2 tool registration", () => {
     const tools = Object.keys((server as any)._registeredTools);
     expect(tools).toContain("interact");
     expect(tools).toContain("kill");
+    expect(tools).toContain("broadcast");
   });
 
-  it("total tool count is 41", () => {
+  it("total tool count is 42", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(41);
+    expect(count).toBe(42);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a new `broadcast` MCP lifecycle tool that fans short messages to `leads` by default, with `workers` and `all` role sets.
- Enforce the existing inline pointer-discipline cap for broadcasts without exposing `allow_long_inline`.
- Reuse registry enumeration and the existing `send_to` delivery path, returning per-target delivery, failure, and skipped receipts.

## Test plan
- `bun run typecheck`
- `bunx vitest run tests/server-agent-tools.test.ts tests/v2-interact-kill.test.ts tests/security-hardening.test.ts`
- `bun run test`
- Pre-push hook: `scripts/run_tests.sh` completed with exit status 0

## Notes
- Pre-commit CodeRabbit CLI review was attempted with a 3-minute cap; it timed out in `reviewing` without emitting findings.
- This PR intentionally does not merge itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutating tool that can deliver keystrokes to many agent surfaces at once; mitigations include the send_to delivery gates, inline cap, caller skip, and fail-closed enumeration, but mis-targeted broadcasts could still disrupt multiple sessions.
> 
> **Overview**
> Adds a new **`broadcast`** MCP tool that sends a short inline message to many registered agents through the same guarded **`deliverAgentInput`** path as **`send_to`**, with per-target receipts instead of failing the whole operation on one bad target.
> 
> Targeting defaults to **`role=leads`** (orchestrator + IC), with **`workers`** and **`all`**, optional workspace scoping, and an **`exclude`** list. The caller is omitted via env refs and best-effort **`identify`**. Role filtering uses **`inferAgentRole`** with a fallback to **`inferRecordRoleOrNull`** when inference errors. Dead or non-interactive agents are recorded as **skipped**; over-length **`text`** is rejected up front by **`assertBroadcastInlineInputAllowed`** (no **`allow_long_inline`**). If merged registry enumeration is broken, the tool **refuses to broadcast** rather than delivering on a stale view.
> 
> Tool counts and security annotation coverage move from 41 to **42** tools, with broad integration tests for defaults, partial failures, caps, enumeration fail-closed, and role sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c49d2c33e1e3b59091dbf6896f63fa7b1454995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `broadcast` tool to send messages to multiple agents by role
> - Adds a new `broadcast` MCP tool in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/251/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that delivers a text message to registered agents filtered by role (`leads`, `workers`, or `all`), with workspace scoping, caller/explicit exclusions, and interactive-state gating.
> - Role inference uses `inferBroadcastRecordRole` with a fallback to `inferRecordRoleOrNull` for agents with unset roles.
> - Text payloads exceeding `SEND_INPUT_MAX_INLINE_CHARS` are rejected immediately with guidance to write to a file and broadcast a pointer.
> - Delivery continues across all targets even when individual sends fail; each target gets a per-agent receipt with delivered/skipped/failed status.
> - Risk: enumeration errors from `registry.listMerged` cause the tool to fail closed, delivering to no agents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c49d2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new broadcast action that sends a short message to multiple agents based on role, workspace, and exclusions.
  * Returns per-agent delivery receipts, including success, skipped, and failure outcomes.
* **Bug Fixes**
  * Enforces inline message length limits with clearer guidance when content is too long.
  * Avoids sending to the caller or agents that are unavailable or non-interactive.
* **Tests**
  * Updated tool-registration coverage and added broadcast-specific integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->