### PR TITLE
fix: warn on stale MCP build (topology recurrence root cause) + explicit worktree-placement regression test

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
-import { detectStaleBuild, readVersion } from "./version.js";
+import { createStaleBuildWarner, readVersion } from "./version.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
@@ -251,23 +251,15 @@ const QueryMonitorRegistryArgsSchema = {
 export { sanitizeTerminalInput } from "./sanitize.js";
 
 /**
- * Memoized stale-build warning, computed once per server process. After a brew
- * release, an already-running per-agent MCP stdio child keeps serving spawns
- * from its OLD dist until the agent `/mcp reconnect`s — silently mis-placing
- * workers with pre-release logic (the #247 recurrence root cause). We surface
- * this loudly so the operator knows the fix is not live. Cached so we never
- * re-read the opt package.json on every spawn.
+ * Process-wide stale-build warner. After a brew release, an already-running
+ * per-agent MCP stdio child keeps serving spawns from its OLD dist until the
+ * agent `/mcp reconnect`s — silently mis-placing workers with pre-release logic
+ * (the #247 recurrence root cause). The warner (see version.ts) caches the
+ * warning FOREVER once stale, but RE-CHECKS (throttled) while not-yet-stale, so
+ * a fresh child that later goes stale via `brew upgrade` is still flagged
+ * rather than silenced by a permanently-cached non-stale verdict.
  */
-let staleBuildWarningCache: string | null | undefined;
-function staleBuildWarning(): string | null {
-  if (staleBuildWarningCache !== undefined) return staleBuildWarningCache;
-  const stale = detectStaleBuild();
-  staleBuildWarningCache =
-    stale && stale.stale
-      ? `cmuxlayer MCP is running a STALE build (running v${stale.running}, installed v${stale.installed}) — placement/other fixes are not live; /mcp reconnect this agent to load the current build.`
-      : null;
-  return staleBuildWarningCache;
-}
+const staleBuildWarning = createStaleBuildWarner();
 
 function appendStaleBuildWarning(result: { warnings?: string[] }): void {
   const warning = staleBuildWarning();

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
-import { readVersion } from "./version.js";
+import { detectStaleBuild, readVersion } from "./version.js";
 import { StateManager } from "./state-manager.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
@@ -249,6 +249,32 @@ const QueryMonitorRegistryArgsSchema = {
 
 // Re-export for test access
 export { sanitizeTerminalInput } from "./sanitize.js";
+
+/**
+ * Memoized stale-build warning, computed once per server process. After a brew
+ * release, an already-running per-agent MCP stdio child keeps serving spawns
+ * from its OLD dist until the agent `/mcp reconnect`s — silently mis-placing
+ * workers with pre-release logic (the #247 recurrence root cause). We surface
+ * this loudly so the operator knows the fix is not live. Cached so we never
+ * re-read the opt package.json on every spawn.
+ */
+let staleBuildWarningCache: string | null | undefined;
+function staleBuildWarning(): string | null {
+  if (staleBuildWarningCache !== undefined) return staleBuildWarningCache;
+  const stale = detectStaleBuild();
+  staleBuildWarningCache =
+    stale && stale.stale
+      ? `cmuxlayer MCP is running a STALE build (running v${stale.running}, installed v${stale.installed}) — placement/other fixes are not live; /mcp reconnect this agent to load the current build.`
+      : null;
+  return staleBuildWarningCache;
+}
+
+function appendStaleBuildWarning(result: { warnings?: string[] }): void {
+  const warning = staleBuildWarning();
+  if (warning) {
+    result.warnings = [...(result.warnings ?? []), warning];
+  }
+}
 
 const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
@@ -3984,8 +4010,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async () => {
       try {
         const health = await appendControlHealthSnapshot();
-        return okFormatted(formatControlHealth(health), {
-          health,
+        const staleWarning = staleBuildWarning();
+        const healthWithStale = staleWarning
+          ? { ...health, warnings: [...health.warnings, staleWarning] }
+          : health;
+        return okFormatted(formatControlHealth(healthWithStale), {
+          health: healthWithStale,
         });
       } catch (e) {
         return err(e);
@@ -6450,6 +6480,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             max_cost_per_agent: args.max_cost_per_agent,
             crash_recover: args.crash_recover,
           });
+          appendStaleBuildWarning(result);
 
           let bootPromptDelivery:
             | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -6688,6 +6719,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             auto_archive_on_done: args.auto_archive_on_done ?? false,
             crash_recover: args.crash_recover,
           });
+          appendStaleBuildWarning(result);
 
           let bootPromptDelivery:
             | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -6847,6 +6879,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role: agent.role,
               auto_archive_on_done: false,
             });
+            appendStaleBuildWarning(result);
             let bootPromptDelivery:
               | Awaited<ReturnType<typeof deliverBootPrompt>>
               | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -259,14 +259,7 @@ export { sanitizeTerminalInput } from "./sanitize.js";
  * a fresh child that later goes stale via `brew upgrade` is still flagged
  * rather than silenced by a permanently-cached non-stale verdict.
  */
-const staleBuildWarning = createStaleBuildWarner();
-
-function appendStaleBuildWarning(result: { warnings?: string[] }): void {
-  const warning = staleBuildWarning();
-  if (warning) {
-    result.warnings = [...(result.warnings ?? []), warning];
-  }
-}
+const defaultStaleBuildWarner = createStaleBuildWarner();
 
 const CLAUDE_CHANNEL_CAPABILITY = "claude/channel";
 const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
@@ -1731,6 +1724,12 @@ export interface CreateServerOptions {
   worktreeHomeDir?: string;
   /** Override control health collection (primarily for tests). */
   controlHealthCollector?: () => Promise<ControlHealth>;
+  /**
+   * Override the process-wide stale-build warner (primarily for tests). Returns
+   * the loud warning string when this MCP build is stale vs the installed brew
+   * build, or null. Defaults to a real, throttled, sticky-once-stale warner.
+   */
+  staleBuildWarner?: () => string | null;
   /** Periodic control health sample interval. Defaults to env or 60000ms; 0 disables. */
   controlHealthIntervalMs?: number;
   /**
@@ -1951,6 +1950,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
   const controlHealthCollector =
     opts?.controlHealthCollector ?? context.controlHealthCollector;
+  const staleBuildWarning = opts?.staleBuildWarner ?? defaultStaleBuildWarner;
+  const appendStaleBuildWarning = (result: { warnings?: string[] }): void => {
+    const warning = staleBuildWarning();
+    if (warning) {
+      result.warnings = [...(result.warnings ?? []), warning];
+    }
+  };
   const inboxOpts = opts?.inboxBaseDir
     ? { baseDir: opts.inboxBaseDir }
     : undefined;
@@ -6959,15 +6965,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             spawnedAgents[spawnedAgents.length - 1]?.surface_id;
           await restoreFocusAfterRender(priorFocus, lastSurface, workspace);
 
+          // spawn_in_workspace builds its response from the per-agent objects,
+          // which drop each result.warnings — so surface the stale-build warning
+          // at the aggregate level (otherwise a stale MCP serving a multi-agent
+          // workspace spawn would return NO warning).
+          const staleWarning = staleBuildWarning();
+          const workspaceWarnings = staleWarning ? [staleWarning] : [];
+
           return okFormatted(
             formatOk("spawn_in_workspace", {
               workspace,
               agents: spawnedAgents.length,
+              ...(staleWarning ? { warning: staleWarning } : {}),
             }),
             {
               workspace,
               title: workspaceResult.title,
               agents: spawnedAgents,
+              ...(workspaceWarnings.length > 0
+                ? { warnings: workspaceWarnings }
+                : {}),
             },
           );
         } catch (e) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -157,3 +157,62 @@ export function detectStaleBuild(
     return null;
   }
 }
+
+export interface StaleBuildWarnerDeps {
+  /** Override the detector (defaults to `detectStaleBuild`). */
+  detect?: (deps?: DetectStaleBuildDeps) => StaleBuildResult | null;
+  /** Injectable clock in ms (defaults to `Date.now`). */
+  now?: () => number;
+  /**
+   * Minimum ms between re-checks while NOT yet stale. Small fs read, so cheap;
+   * throttled only to avoid a per-spawn read. Defaults to 30s.
+   */
+  recheckIntervalMs?: number;
+}
+
+export const DEFAULT_STALE_RECHECK_INTERVAL_MS = 30_000;
+
+/**
+ * Build a memoized stale-build warner for a single process.
+ *
+ * A running process's OWN build never changes, but the INSTALLED build can bump
+ * mid-lifetime (a `brew upgrade` while the per-agent MCP child keeps running),
+ * so staleness only ever goes false -> true and NEVER back. Therefore:
+ *   - once stale, we cache the warning FOREVER (it cannot un-stale), and
+ *   - while NOT yet stale, we RE-CHECK on each call (throttled to
+ *     `recheckIntervalMs`) so a later upgrade is caught — we never cache a
+ *     not-yet-stale verdict permanently.
+ *
+ * Caching a not-yet-stale verdict permanently would defeat the entire feature:
+ * a child that boots fresh (non-stale) would cache `null` and stay silent
+ * through the very upgrade this warner exists to flag.
+ */
+export function createStaleBuildWarner(
+  deps: StaleBuildWarnerDeps = {},
+): () => string | null {
+  const detect = deps.detect ?? detectStaleBuild;
+  const now = deps.now ?? Date.now;
+  const recheckIntervalMs =
+    deps.recheckIntervalMs ?? DEFAULT_STALE_RECHECK_INTERVAL_MS;
+
+  let stickyWarning: string | null = null;
+  let lastCheckedAt: number | null = null;
+
+  return function staleBuildWarning(): string | null {
+    // Once stale, keep warning forever — it can never un-stale.
+    if (stickyWarning !== null) return stickyWarning;
+
+    const t = now();
+    if (lastCheckedAt !== null && t - lastCheckedAt < recheckIntervalMs) {
+      return null; // Throttled; still not-yet-stale.
+    }
+    lastCheckedAt = t;
+
+    const stale = detect();
+    if (stale && stale.stale) {
+      stickyWarning = `cmuxlayer MCP is running a STALE build (running v${stale.running}, installed v${stale.installed}) — placement/other fixes are not live; /mcp reconnect this agent to load the current build.`;
+      return stickyWarning;
+    }
+    return null;
+  };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -91,13 +91,19 @@ function resolveBrewPrefix(): string | null {
     const fromEnv = process.env.HOMEBREW_PREFIX;
     if (fromEnv && fromEnv.trim()) return fromEnv.trim();
     try {
+      // Bounded timeout: this runs on the first stale-check inside the MCP
+      // process, so a hung/slow `brew` must never block spawns — fall through
+      // to the standard install locations instead. execFileSync throws on
+      // timeout (ETIMEDOUT), which the catch swallows.
       const out = execFileSync("brew", ["--prefix"], {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
       }).trim();
       if (out) return out;
     } catch {
-      // brew not installed / not on PATH — fall through to standard locations.
+      // brew missing / not on PATH / slow (timed out) — fall through to the
+      // standard locations. Never throw from prefix resolution.
     }
     if (existsSync("/opt/homebrew")) return "/opt/homebrew";
     if (existsSync("/usr/local")) return "/usr/local";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -45,4 +46,114 @@ export function assertBuildVersion(
     );
   }
   return { ok, running, expected };
+}
+
+/**
+ * Verdict for the "running child is a stale build" problem. After a release
+ * (`brew upgrade`), the brew-pinned binary + main advance, but every already-
+ * running per-agent MCP stdio child keeps executing the OLD `dist/` until the
+ * agent `/mcp reconnect`s. That stale child silently serves spawns with the
+ * pre-release placement/other logic — the exact class of bug #247 fixed in
+ * source yet kept recurring live. `installed` is the version the brew opt path
+ * reports (what a fresh reconnect would load); `running` is what this process
+ * actually reports. `stale` is true when they differ.
+ */
+export interface StaleBuildResult {
+  /** True when the running build differs from the installed (brew opt) build. */
+  stale: boolean;
+  /** Version this process actually reports (same source as serverInfo). */
+  running: string;
+  /** Version the installed brew opt package.json reports. */
+  installed: string;
+}
+
+export interface DetectStaleBuildDeps {
+  /** Override the running version (defaults to `readVersion()`). */
+  running?: string;
+  /** Override the installed package.json path (defaults to the brew opt path). */
+  optPackageJsonPath?: string | null;
+  /** Override the file reader (defaults to `readFileSync(path, "utf-8")`). */
+  readFile?: (path: string) => string;
+  /** Override the dev-mode flag (defaults to `CMUXLAYER_DEV === "1"`). */
+  isDev?: boolean;
+}
+
+let cachedBrewPrefix: string | null | undefined;
+
+/**
+ * Resolve the Homebrew prefix ONCE per process. Prefers `HOMEBREW_PREFIX`, then
+ * a single `brew --prefix` probe, then the standard install locations. Never
+ * throws; returns null when nothing resolves.
+ */
+function resolveBrewPrefix(): string | null {
+  if (cachedBrewPrefix !== undefined) return cachedBrewPrefix;
+  cachedBrewPrefix = (() => {
+    const fromEnv = process.env.HOMEBREW_PREFIX;
+    if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+    try {
+      const out = execFileSync("brew", ["--prefix"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (out) return out;
+    } catch {
+      // brew not installed / not on PATH — fall through to standard locations.
+    }
+    if (existsSync("/opt/homebrew")) return "/opt/homebrew";
+    if (existsSync("/usr/local")) return "/usr/local";
+    return null;
+  })();
+  return cachedBrewPrefix;
+}
+
+/** Default installed-package.json path under the brew opt tree. */
+function defaultOptPackageJsonPath(): string | null {
+  const prefix = resolveBrewPrefix();
+  if (!prefix) return null;
+  return join(prefix, "opt", "cmuxlayer", "package.json");
+}
+
+/**
+ * Detect whether this process is running a STALE build relative to the version
+ * currently installed via brew. Best-effort and side-effect-light: it reads the
+ * opt package.json directly via `fs` (no per-call shell-out; the brew prefix is
+ * resolved once). Returns `null` (skip — cannot judge) when:
+ *   - `CMUXLAYER_DEV=1` (running from live source, not the brew binary),
+ *   - the running version is unknown,
+ *   - the opt path cannot be resolved or the file is unreadable/unparseable.
+ * NEVER throws — staleness detection must never break a spawn.
+ */
+export function detectStaleBuild(
+  deps: DetectStaleBuildDeps = {},
+): StaleBuildResult | null {
+  try {
+    const isDev = deps.isDev ?? process.env.CMUXLAYER_DEV === "1";
+    if (isDev) return null;
+
+    const running = deps.running ?? readVersion();
+    if (!running || running === "unknown") return null;
+
+    const optPath =
+      deps.optPackageJsonPath === undefined
+        ? defaultOptPackageJsonPath()
+        : deps.optPackageJsonPath;
+    if (!optPath) return null;
+
+    const read =
+      deps.readFile ?? ((path: string) => readFileSync(path, "utf-8"));
+    let installed: unknown;
+    try {
+      const pkg = JSON.parse(read(optPath)) as { version?: unknown };
+      installed = pkg.version;
+    } catch {
+      // Missing / unreadable / unparseable opt package.json — cannot judge.
+      return null;
+    }
+    if (typeof installed !== "string" || !installed) return null;
+
+    return { stale: running !== installed, running, installed };
+  } catch {
+    // Absolutely never let staleness detection break a spawn.
+    return null;
+  }
 }

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1580,15 +1580,31 @@ describe("worktree worker placement — always right, never left", () => {
     assertNeverLeft(placement);
   });
 
-  it("(c) nth worker while a prior worker is stuck in the LEFT column: still splits right, never docks left", () => {
+  it("(c) nth worker while a prior worker is stuck in the LEFT column: docks into the RIGHT column, never the left worker", () => {
+    // A real two-column layout: the lead AND a stray prior worker both live in
+    // the LEFT column (same x), while a genuine RIGHT worker column exists.
+    // columnCount is therefore 2 — this REACHES the rightmost-worker dock path
+    // (not the single-column early return that cases (a)/(c-old) hit). The
+    // worktree worker must dock as a tab into the RIGHT worker pane and must
+    // NEVER dock into the left-column worker.
+    const leftLead = { x: 0, y: 0, width: 500, height: 450 };
+    const leftWorker = { x: 0, y: 450, width: 500, height: 450 };
     const panes = [
-      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
-      makePane("pane:left-worker", 1, ["surface:worker-1"], leftColumn),
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftLead),
+      makePane("pane:left-worker", 1, ["surface:worker-left"], leftWorker),
+      makePane("pane:right", 2, ["surface:worker-right"], rightColumn),
     ];
     const paneSurfaces = [
       makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
-      makePaneSurfaces("pane:left-worker", ["surface:worker-1"]),
+      makePaneSurfaces("pane:left-worker", ["surface:worker-left"]),
+      makePaneSurfaces("pane:right", ["surface:worker-right"]),
     ];
+
+    // Sanity: the fixture is genuinely two-column (regression guard against the
+    // earlier bug where identical left rects collapsed to columnCount === 1 and
+    // the test never exercised the dock path).
+    const columns = deriveColumnIndex(panes);
+    expect(new Set(columns.values()).size).toBe(2);
 
     const placement = chooseAgentSpawnPlacement(
       panes,
@@ -1596,14 +1612,13 @@ describe("worktree worker placement — always right, never left", () => {
       {
         orchestrator: new Set(["surface:orchestrator"]),
         ic: new Set(),
-        worker: new Set(["surface:worker-1"]),
+        worker: new Set(["surface:worker-left", "surface:worker-right"]),
       },
       { role: "worker", worktree: true },
     );
 
-    // The only worker pane lives in the LEFT column — the worktree worker must
-    // NOT dock into it; it seeds a fresh right column instead.
-    expect(placement).toEqual({ kind: "split", direction: "right" });
+    // Docks as a tab into the RIGHT worker column — never into the left worker.
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
     expect(placement).not.toEqual({
       kind: "surface",
       pane: "pane:left-worker",

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1465,3 +1465,149 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:rightmost" });
   });
 });
+
+describe("worktree worker placement — always right, never left", () => {
+  const leftColumn = { x: 0, y: 0, width: 500, height: 900 };
+  const rightColumn = { x: 500, y: 0, width: 500, height: 900 };
+
+  function assertNeverLeft(placement: {
+    kind: string;
+    direction?: string;
+    pane?: string;
+  }): void {
+    // No left split, ever.
+    expect(placement).not.toEqual({ kind: "split", direction: "left" });
+    if (placement.kind === "split") {
+      expect(placement.direction).not.toBe("left");
+    }
+  }
+
+  it("(a) single lead column: seeds the right worker column via a right split", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        worktree: true,
+      },
+    );
+
+    expect(placement).toEqual({ kind: "split", direction: "right" });
+    assertNeverLeft(placement);
+  });
+
+  it("(b) lead column + existing right worker pane: DOCKS as a tab, not a new pane", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:right", 1, ["surface:worker-1"], rightColumn),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        worktree: true,
+      },
+    );
+
+    // Docks into the existing rightmost worker pane as a tab — never a new
+    // pane and never a left placement.
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+    expect(placement).not.toEqual({ kind: "split", direction: "right" });
+    assertNeverLeft(placement);
+  });
+
+  it("(b2) picks the rightmost worker column when several worker panes exist", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:right", 1, ["surface:worker-1"], rightColumn),
+      makePane("pane:rightmost", 2, ["surface:worker-2"], {
+        x: 1000,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right", ["surface:worker-1"]),
+      makePaneSurfaces("pane:rightmost", ["surface:worker-2"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1", "surface:worker-2"]),
+      },
+      {
+        role: "worker",
+        parentRole: "orchestrator",
+        parentSurfaceId: "surface:orchestrator",
+        worktree: true,
+      },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:rightmost" });
+    assertNeverLeft(placement);
+  });
+
+  it("(c) nth worker while a prior worker is stuck in the LEFT column: still splits right, never docks left", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:left-worker", 1, ["surface:worker-1"], leftColumn),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:left-worker", ["surface:worker-1"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker-1"]),
+      },
+      { role: "worker", worktree: true },
+    );
+
+    // The only worker pane lives in the LEFT column — the worktree worker must
+    // NOT dock into it; it seeds a fresh right column instead.
+    expect(placement).toEqual({ kind: "split", direction: "right" });
+    expect(placement).not.toEqual({
+      kind: "surface",
+      pane: "pane:left-worker",
+    });
+    assertNeverLeft(placement);
+  });
+});

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -208,6 +208,45 @@ describe("workspace spawn tools", () => {
     ).toEqual(["workspace:grid", "workspace:grid"]);
   });
 
+  it("spawn_in_workspace surfaces the stale-build warning at the aggregate level", async () => {
+    // spawn_in_workspace rebuilds its response from per-agent objects (which
+    // drop result.warnings), so a stale MCP serving a multi-agent workspace
+    // spawn must still surface the warning at the top level. Inject a forced
+    // stale warner to make the check deterministic in CI.
+    const client = makeWorkspaceClient();
+    const STALE =
+      "cmuxlayer MCP is running a STALE build (running v9.9.9, installed v0.0.0) — placement/other fixes are not live; /mcp reconnect this agent to load the current build.";
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: join(TEST_DIR, "inbox-stale"),
+      staleBuildWarner: () => STALE,
+    });
+    const tool = getTool(server, "spawn_in_workspace");
+
+    const result = await tool.handler(
+      {
+        workspace_title: "red-team",
+        agents: [
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+          { repo: "brainlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {} as any,
+    );
+
+    const parsed = parseStructuredResult<{
+      warnings?: string[];
+      agents: Array<{ agent_id: string }>;
+    }>(result);
+    // Present once at the aggregate level (not per-agent duplication).
+    expect(parsed.warnings).toEqual([STALE]);
+    expect(parsed.agents).toHaveLength(2);
+    // Also echoed in the human-readable summary.
+    expect(result.content[0]!.text).toContain("STALE build");
+  });
+
   it("spawn_in_workspace refuses a manual-mode caller workspace before creating", async () => {
     const client = makeWorkspaceClient();
     client.listWorkspaces.mockResolvedValue({

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { assertBuildVersion, readVersion } from "../src/version.js";
+import {
+  assertBuildVersion,
+  detectStaleBuild,
+  readVersion,
+} from "../src/version.js";
 
 describe("assertBuildVersion", () => {
   it("returns ok when the running build matches expected", () => {
@@ -33,5 +37,113 @@ describe("assertBuildVersion", () => {
       throwOnMismatch: true,
     });
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("detectStaleBuild", () => {
+  const optPath = "/fake/opt/cmuxlayer/package.json";
+  const readInstalled = (version: string) => () => JSON.stringify({ version });
+
+  it("reports stale:false when running matches installed", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.17",
+      optPackageJsonPath: optPath,
+      readFile: readInstalled("0.3.17"),
+    });
+    expect(result).toEqual({
+      stale: false,
+      running: "0.3.17",
+      installed: "0.3.17",
+    });
+  });
+
+  it("reports stale:true when running differs from installed", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.16",
+      optPackageJsonPath: optPath,
+      readFile: readInstalled("0.3.18"),
+    });
+    expect(result).toEqual({
+      stale: true,
+      running: "0.3.16",
+      installed: "0.3.18",
+    });
+  });
+
+  it("returns null (skip) when the opt package.json is unreadable", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.17",
+      optPackageJsonPath: optPath,
+      readFile: () => {
+        throw new Error("ENOENT: no such file");
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null (skip) when the opt package.json is unparseable", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.17",
+      optPackageJsonPath: optPath,
+      readFile: () => "not json {{{",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null (skip) when the installed version field is missing", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.17",
+      optPackageJsonPath: optPath,
+      readFile: () => JSON.stringify({ name: "cmuxlayer" }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null (skip) under CMUXLAYER_DEV (running from source)", () => {
+    const result = detectStaleBuild({
+      isDev: true,
+      running: "0.3.16",
+      optPackageJsonPath: optPath,
+      readFile: readInstalled("0.3.18"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null (skip) when the running version is unknown", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "unknown",
+      optPackageJsonPath: optPath,
+      readFile: readInstalled("0.3.18"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null (skip) when the opt path cannot be resolved", () => {
+    const result = detectStaleBuild({
+      isDev: false,
+      running: "0.3.17",
+      optPackageJsonPath: null,
+      readFile: readInstalled("0.3.18"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("never throws even when the reader throws a non-Error", () => {
+    expect(() =>
+      detectStaleBuild({
+        isDev: false,
+        running: "0.3.17",
+        optPackageJsonPath: optPath,
+        readFile: () => {
+          throw "boom";
+        },
+      }),
+    ).not.toThrow();
   });
 });

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assertBuildVersion,
+  createStaleBuildWarner,
   detectStaleBuild,
   readVersion,
 } from "../src/version.js";
@@ -145,5 +146,100 @@ describe("detectStaleBuild", () => {
         },
       }),
     ).not.toThrow();
+  });
+});
+
+describe("createStaleBuildWarner", () => {
+  const stale = (running: string, installed: string) => ({
+    stale: running !== installed,
+    running,
+    installed,
+  });
+
+  it("does NOT permanently cache a not-yet-stale verdict — warns once a later upgrade bumps installed", () => {
+    // This is the exact timeline this feature exists to catch: a fresh child
+    // boots non-stale, a `brew upgrade` bumps the installed build mid-lifetime,
+    // and the very next (post-throttle) spawn must surface the warning.
+    let installed = "0.3.17";
+    let t = 0;
+    const warn = createStaleBuildWarner({
+      detect: () => stale("0.3.17", installed),
+      now: () => t,
+      recheckIntervalMs: 30_000,
+    });
+
+    // Fresh process: running == installed -> no warning.
+    expect(warn()).toBeNull();
+    // Within the throttle window: still no warning, not permanently cached.
+    t = 10_000;
+    expect(warn()).toBeNull();
+
+    // brew upgrade bumps the installed build; advance past the throttle.
+    installed = "0.3.18";
+    t = 40_000;
+    const message = warn();
+    expect(message).toContain("STALE build");
+    expect(message).toContain("running v0.3.17");
+    expect(message).toContain("installed v0.3.18");
+  });
+
+  it("caches the warning FOREVER once stale (it can never un-stale)", () => {
+    let installed = "0.3.18";
+    let t = 0;
+    const warn = createStaleBuildWarner({
+      detect: () => stale("0.3.17", installed),
+      now: () => t,
+      recheckIntervalMs: 30_000,
+    });
+
+    const first = warn();
+    expect(first).toContain("STALE build");
+
+    // Even if the installed build somehow matches again, the warning sticks.
+    installed = "0.3.17";
+    t = 1_000_000;
+    expect(warn()).toBe(first);
+  });
+
+  it("throttles re-checks while not yet stale (no per-spawn fs read)", () => {
+    let calls = 0;
+    let t = 0;
+    const warn = createStaleBuildWarner({
+      detect: () => {
+        calls += 1;
+        return stale("1.0.0", "1.0.0");
+      },
+      now: () => t,
+      recheckIntervalMs: 30_000,
+    });
+
+    expect(warn()).toBeNull();
+    expect(calls).toBe(1);
+
+    // Inside the throttle window: no re-read.
+    t = 5_000;
+    expect(warn()).toBeNull();
+    expect(calls).toBe(1);
+
+    // Past the throttle window: re-checks.
+    t = 35_000;
+    expect(warn()).toBeNull();
+    expect(calls).toBe(2);
+  });
+
+  it("re-checks on every call when the running version cannot be determined (detect returns null)", () => {
+    let calls = 0;
+    const warn = createStaleBuildWarner({
+      detect: () => {
+        calls += 1;
+        return null;
+      },
+      now: () => 0,
+      recheckIntervalMs: 0,
+    });
+
+    expect(warn()).toBeNull();
+    expect(warn()).toBeNull();
+    expect(calls).toBe(2);
   });
 });


### PR DESCRIPTION
## Root cause — why the topology fix kept recurring live

cmuxlayer's worktree-spawn placement fix (#247, shipped in v0.3.17) is **correct** — its `layout-policy` tests pass and the source policy always places worktree workers on the right. Yet it kept recurring **live**.

The reason is the **per-agent MCP stdio child lifecycle**: each agent runs its own cmuxlayer MCP as a stdio child. A `brew upgrade` advances the brew-pinned binary + `main`, but an **already-running child keeps executing its OLD `dist/`** until the agent `/mcp reconnect`s. So a stale child silently serves spawns with the pre-fix placement logic — and there was **no signal** that a spawn was served by a stale MCP. Result: silent mis-placement.

Fix: **detect staleness and warn loudly.**

## The three fixes

### 1. Stale-build detection + loud warning (PRIMARY)
New `detectStaleBuild()` in `src/version.ts`:
- Reads the **RUNNING** version via `readVersion()`.
- Reads the **INSTALLED** version directly (`fs`, no per-call shell-out) from `<brewPrefix>/opt/cmuxlayer/package.json`, where the brew prefix resolves **once** (`HOMEBREW_PREFIX` → `brew --prefix` → `/opt/homebrew` → `/usr/local`).
- Returns `{ stale, running, installed }`; returns `null` (skip) under `CMUXLAYER_DEV=1`, an unreadable/unparseable opt file, or an unknown running version. **Never throws** — staleness detection must never break a spawn.

`src/server.ts` memoizes the verdict **once per process** and appends a loud WARNING to every `spawn_agent` / `new_worktree_split` / broadcast-spawn result's `warnings` array:

> cmuxlayer MCP is running a STALE build (running vX.Y.Z, installed vA.B.C) — placement/other fixes are not live; /mcp reconnect this agent to load the current build.

Also surfaced in `control_health`.

### 2. Explicit worktree-placement regression test
New describe block in `tests/layout-policy.test.ts` asserting a `worktree: true` worker **always** lands right and **never** left:
- **(a)** single lead column → right split
- **(b)** lead column + existing right worker pane → **docks as a tab** (`{kind:"surface"}`), not a new pane
- **(b2)** rightmost of several worker panes
- **(c)** nth worker while a prior worker is stuck in the **left** column → still splits right, never docks left

Every case carries an explicit **never-left** assertion.

### 3. Unit tests for `detectStaleBuild`
Injected opt-path + running version (never touches the real brew path in CI): same version → `stale:false`; different → `stale:true`; missing / unparseable / missing-field opt file → `null`; `CMUXLAYER_DEV` → `null`; unknown running → `null`; unresolved opt path → `null`; never throws.

## Verification
- `bun run typecheck` clean
- `bun run test` → **1421 passed** (76 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spawn and health tool responses and runs a bounded `brew --prefix` probe on first check; detection is designed never to throw or block spawns.
> 
> **Overview**
> Adds **stale-build detection** so long-lived per-agent MCP stdio children surface when they are still running an old `dist/` after `brew upgrade`, instead of silently serving spawns with pre-release logic (the #247 recurrence).
> 
> **`version.ts`** introduces `detectStaleBuild` (running `readVersion()` vs Homebrew opt `package.json`, best-effort, never throws) and `createStaleBuildWarner` (warning sticks once stale; throttled re-checks while not stale so a mid-lifetime upgrade is still caught).
> 
> **`server.ts`** wires the warner into `control_health`, appends warnings on spawn-related tool results (`spawn_agent`, worktree splits, etc.), and adds aggregate-level warnings for `spawn_in_workspace` where per-agent responses drop `warnings`. Tests can inject `staleBuildWarner`.
> 
> **Tests:** unit coverage for detection/warner behavior, a `spawn_in_workspace` stale-warning integration test, and a new **`layout-policy`** describe block locking **worktree worker** placement to the right (right split, dock in rightmost worker pane, never left)—regression guard only; no production layout changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97b43149487968a1e31b35f06240ac03bc3d3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn on stale MCP build in tool responses and add worktree placement regression tests
> - Adds `createStaleBuildWarner` in [version.ts](https://github.com/EtanHey/cmuxlayer/pull/252/files#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087) that detects when the running MCP build is older than the brew-installed version by comparing `package.json` versions; uses memoization and 30s throttling to avoid per-call filesystem reads.
> - Surfaces the stale-build warning in all spawn tool responses (per-agent and aggregate level for `spawn_in_workspace`) and in `control_health` output, both in structured payloads and human-readable summaries.
> - Adds worktree worker placement regression tests in [layout-policy.test.ts](https://github.com/EtanHey/cmuxlayer/pull/252/files#diff-e19c3e332b3c61ccd559c1ee6439bd622460ecc6ccdf1e21371201e49a48dfd4) covering initial right-split, docking into existing right pane, and never-left enforcement.
> - Adds a `staleBuildWarner` override to `CreateServerOptions` for test injection.
> - Behavioral Change: `control_health` and spawn responses now include a `warnings` array field when the build is stale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f97b431.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning when the app detects it’s running a stale build, and surfaced that warning in health checks and agent/workspace-related tool results.

- **Bug Fixes**
  - Improved worktree worker placement so it consistently prefers the right side, avoids left-side docking, and selects the rightmost suitable pane when multiple options exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->