### PR TITLE
feat: attribute app-level tab_close events + client/attach context (close forensics)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -261,6 +261,14 @@ export interface AgentEngineOptions {
   monitorRegistryPath?: string;
   monitorRegistryNow?: () => number;
   monitorRegistryNotify?: MonitorDeadmanNotify;
+  /**
+   * Best-effort close-forensics ingest, run at the tail of each sweep. It reads
+   * cmux's OWN event stream (`~/.cmuxterm/events.jsonl`) and attributes
+   * app-level `tab_close` deaths that never went through an MCP tool. Defaults
+   * to DISABLED (`null`) so bare construction never reads the real cmux file;
+   * production entrypoints inject the runner. Pass an explicit runner in tests.
+   */
+  closeForensicsRunner?: (() => { emitted: number }) | null;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
@@ -783,6 +791,9 @@ export class AgentEngine {
   private monitorRegistryNow?: () => number;
   private monitorRegistryNotify: MonitorDeadmanNotify;
   private monitorRegistrySweepInFlight = false;
+  /** Best-effort close-forensics ingest; null when disabled. */
+  private closeForensicsRunner: (() => { emitted: number }) | null;
+  private closeForensicsSweepInFlight = false;
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
@@ -811,6 +822,12 @@ export class AgentEngine {
     this.monitorRegistryPath = opts?.monitorRegistryPath;
     this.monitorRegistryNow = opts?.monitorRegistryNow;
     this.monitorRegistryNotify = opts?.monitorRegistryNotify ?? (async () => {});
+    // Default DISABLED: bare construction (tests, libraries) must never read the
+    // real `~/.cmuxterm/events.jsonl`. Production entrypoints inject the real
+    // runner (see app-server-runtime / server.ts createServer). `null` keeps it
+    // off; an explicit runner (tests) drives it deterministically.
+    this.closeForensicsRunner =
+      opts?.closeForensicsRunner !== undefined ? opts.closeForensicsRunner : null;
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.postSpawnLivenessMs =
       opts?.postSpawnLivenessMs ??
@@ -2885,8 +2902,28 @@ export class AgentEngine {
 
     await this.registry.purgeTerminal();
     await this.sweepMonitorRegistryBestEffort();
+    this.runCloseForensicsBestEffort();
     await this.syncSidebar();
     await this.drainOutboxBestEffort();
+  }
+
+  /**
+   * Ingest cmux's own app-level close events at the tail of a sweep and attribute
+   * them (see close-forensics.ts). Fully best-effort: the runner is self-guarding
+   * and never throws, and an in-flight guard prevents overlap if a sweep runs
+   * long. Forensics must never break lifecycle reconciliation.
+   */
+  private runCloseForensicsBestEffort(): void {
+    if (!this.closeForensicsRunner) return;
+    if (this.closeForensicsSweepInFlight) return;
+    this.closeForensicsSweepInFlight = true;
+    try {
+      this.closeForensicsRunner();
+    } catch {
+      // Never break the sweep on a forensics failure; it retries next sweep.
+    } finally {
+      this.closeForensicsSweepInFlight = false;
+    }
   }
 
   private async sweepMonitorRegistryBestEffort(): Promise<void> {

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -211,11 +211,68 @@ export interface CloseTelemetryEvent {
   refused: boolean;
 }
 
+/**
+ * Client/attach context around an app-level close, derived by correlating the
+ * cmux `surface.closed` event with nearby `window.keyed`/`window.unkeyed` events
+ * and boot_id changes. This is the rc/screen-share-reconnect signal: the
+ * operator drives this Mac over remote-control + Screens5 screen-sharing, so an
+ * attach/detach or reconnect cycles window key-focus (and can restart cmux,
+ * changing boot_id) right around the moment tabs die.
+ */
+export interface CloseForensicsClientContext {
+  /** A window.keyed/unkeyed event occurred within delta-t of the close. */
+  window_key_cycle_near_close: boolean;
+  /** The nearest window key-focus event within delta-t: "keyed"/"unkeyed"/none. */
+  last_window_key_event: "keyed" | "unkeyed" | null;
+  /** The close's boot_id differs from the previous close's boot_id (cmux restart). */
+  boot_id_changed_since_prev: boolean;
+}
+
+/**
+ * Forensics record that ATTRIBUTES a cmux app-level `surface.closed`
+ * (origin `tab_close`/`workspace_teardown`) -- events cmux emits to its OWN
+ * stream (`~/.cmuxterm/events.jsonl`) with NO actor. cmuxlayer's
+ * `CloseTelemetryEvent` only sees MCP-tool-driven closes, so app-level tab
+ * deaths were invisible/unattributed; this pairs each app-level close with the
+ * MCP close (if any) for the mapped surface within delta-t, and captures the
+ * client/attach context that reveals rc/screen-share churn as the culprit.
+ */
+export interface CloseForensicsEvent {
+  /** When forensics ingested this record (injected clock). */
+  ts: string;
+  event_type: "close_forensics";
+  /** cmux internal surface UUID from the surface.closed event. */
+  cmux_surface_id: string | null;
+  /** cmux internal pane UUID. */
+  cmux_pane_id: string | null;
+  /** cmux window id (UUID or numeric), often null for a bare tab_close. */
+  window_id: string | number | null;
+  /** cmux app boot session UUID; a change signals a cmux restart/reconnect. */
+  boot_id: string | null;
+  /** cmux workspace UUID. */
+  workspace_id: string | null;
+  /** payload.origin: "tab_close" | "workspace_teardown" | other. */
+  origin: string;
+  /** The cmux event's own occurred_at (ISO) -- when the surface actually closed. */
+  occurred_at: string;
+  /**
+   * Attribution verdict:
+   *  - `mcp:<tool> caller=<x>` when a cmuxlayer MCP close for the mapped surface
+   *    landed within delta-t of this app-level close (cmuxlayer DID tear it down).
+   *  - `app-level:no-mcp-close` when no MCP close matches -- the smoking gun that
+   *    something OUTSIDE cmuxlayer (the app, or an rc/attach cycle) killed it.
+   */
+  attribution: string;
+  /** rc/screen-share-reconnect signal (see CloseForensicsClientContext). */
+  client_context: CloseForensicsClientContext;
+}
+
 export type EventLogEntry =
   | StateTransition
   | DeliveryTelemetryEvent
   | ControlHealthTelemetryEvent
-  | CloseTelemetryEvent;
+  | CloseTelemetryEvent
+  | CloseForensicsEvent;
 
 export interface WaitResult {
   matched: boolean;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
+import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
 import {
   defaultMonitorRegistryPath,
@@ -198,6 +199,9 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
       monitorRegistryPath: defaultMonitorRegistryPath(),
       monitorRegistryNotify: httpNotifyMonitorDeadman,
+      closeForensicsRunner: createDefaultCloseForensicsRunner({
+        stateMgr: this.stateMgr,
+      }),
     });
   }
 

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -1,0 +1,445 @@
+/**
+ * Close forensics — attribute cmux app-level `surface.closed` events.
+ *
+ * cmuxlayer's {@link CloseTelemetryEvent} only records closes that flow through
+ * an MCP tool (close_surface / stop_agent / kill), so it CANNOT see cmux's own
+ * app-level `tab_close` — the deaths that have been killing the driver + leads
+ * with no actor recorded. cmux DOES emit those to its own event stream
+ * (`~/.cmuxterm/events.jsonl`, `protocol:"cmux-events"`), but the record carries
+ * no caller.
+ *
+ * This module reads that stream, and for each app-level close:
+ *  1. tries to ATTRIBUTE it to a cmuxlayer MCP close for the same surface within
+ *     Δt (`mcp:<tool> caller=…`); if none exists it is a genuine app-level death
+ *     (`app-level:no-mcp-close`), and
+ *  2. captures CLIENT/ATTACH CONTEXT — nearby `window.keyed`/`window.unkeyed`
+ *     focus cycles and cmux `boot_id` changes — the rc/Screens5-reconnect signal.
+ *
+ * The ingest is a PURE function ({@link ingestCloseForensics}); ALL I/O (reading
+ * the cmux file, the cursor, the MCP close log) is injected via
+ * {@link CloseForensicsDeps} so tests never touch `~/.cmuxterm` or real state and
+ * the sweep wiring stays a thin, best-effort adapter.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  CloseForensicsEvent,
+  CloseTelemetryEvent,
+} from "./agent-types.js";
+import type { StateManager } from "./state-manager.js";
+
+/** Minimal shape of a parsed line from `~/.cmuxterm/events.jsonl`. */
+export interface CmuxEvent {
+  name: string;
+  seq: number;
+  occurred_at: string;
+  surface_id: string | null;
+  pane_id: string | null;
+  window_id: string | number | null;
+  boot_id: string | null;
+  workspace_id: string | null;
+  payload: { origin?: string; [key: string]: unknown } | null;
+}
+
+export interface CloseForensicsInput {
+  /** Parsed cmux events (any subset of the stream; unordered is fine). */
+  cmuxEvents: CmuxEvent[];
+  /** cmuxlayer's own MCP close-log records (event_type "close"). */
+  mcpCloses: CloseTelemetryEvent[];
+  /**
+   * Map from a cmux internal surface UUID → cmuxlayer surface ref ("surface:N").
+   * Used to join a cmux `surface.closed` UUID against an MCP close whose `target`
+   * is a `surface:N` ref. May be empty (live wiring cannot always resolve it —
+   * see {@link buildSurfaceRefMap}); attribution then falls to app-level.
+   */
+  surfaceRefByCmuxId: Map<string, string>;
+  /** Correlation window in ms for MCP-close / window-key matching. */
+  deltaMs: number;
+  /** Cursor: only emit forensics for events with seq strictly greater than this. */
+  lastSeq: number;
+  /** Injected clock producing the forensics record's `ts`. */
+  now: () => string;
+}
+
+export interface CloseForensicsResult {
+  events: CloseForensicsEvent[];
+  /** Advanced cursor = max seq observed across ALL input events (>= lastSeq). */
+  nextSeq: number;
+}
+
+const SURFACE_CLOSED = "surface.closed";
+const WINDOW_KEYED = "window.keyed";
+const WINDOW_UNKEYED = "window.unkeyed";
+
+function toMillis(iso: string): number {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? NaN : t;
+}
+
+/**
+ * Pure ingest: (cmux events, MCP closes, surface map, Δt, cursor, clock) →
+ * attributed {@link CloseForensicsEvent}[]. Never throws on malformed input —
+ * events with an unparseable timestamp still emit, degrading only the fields
+ * that need time math.
+ */
+export function ingestCloseForensics(
+  input: CloseForensicsInput,
+): CloseForensicsResult {
+  const { cmuxEvents, mcpCloses, surfaceRefByCmuxId, deltaMs, lastSeq, now } =
+    input;
+
+  let nextSeq = lastSeq;
+  for (const ev of cmuxEvents) {
+    if (typeof ev?.seq === "number" && ev.seq > nextSeq) nextSeq = ev.seq;
+  }
+
+  // Window key-focus events power the rc/screen-share attach/detach signal.
+  const windowKeyEvents = cmuxEvents.filter(
+    (ev) => ev?.name === WINDOW_KEYED || ev?.name === WINDOW_UNKEYED,
+  );
+
+  // Closes sorted by seq give a stable "previous close" for boot_id continuity.
+  const closes = cmuxEvents
+    .filter((ev) => ev?.name === SURFACE_CLOSED)
+    .slice()
+    .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
+
+  const results: CloseForensicsEvent[] = [];
+  let prevBootId: string | null = null;
+  let sawPrevClose = false;
+
+  for (const close of closes) {
+    const bootIdChanged =
+      sawPrevClose && prevBootId !== null && close.boot_id !== prevBootId;
+    // Advance the boot-continuity cursor across EVERY close (even ones below the
+    // seq cursor) so a re-run's first new close still compares to the right prev.
+    prevBootId = close.boot_id ?? null;
+    sawPrevClose = true;
+
+    // Cursor: only NEW closes are emitted; older ones only seed prevBootId.
+    if (typeof close.seq === "number" && close.seq <= lastSeq) continue;
+
+    const origin =
+      typeof close.payload?.origin === "string"
+        ? close.payload.origin
+        : "unknown";
+    const cmuxSurfaceId =
+      close.surface_id ??
+      (typeof close.payload?.surface_id === "string"
+        ? close.payload.surface_id
+        : null);
+    const closeMs = toMillis(close.occurred_at);
+
+    results.push({
+      ts: now(),
+      event_type: "close_forensics",
+      cmux_surface_id: cmuxSurfaceId,
+      cmux_pane_id:
+        close.pane_id ??
+        (typeof close.payload?.pane_id === "string"
+          ? close.payload.pane_id
+          : null),
+      window_id: close.window_id ?? null,
+      boot_id: close.boot_id ?? null,
+      workspace_id: close.workspace_id ?? null,
+      origin,
+      occurred_at: close.occurred_at,
+      attribution: attributeClose({
+        cmuxSurfaceId,
+        closeMs,
+        mcpCloses,
+        surfaceRefByCmuxId,
+        deltaMs,
+      }),
+      client_context: {
+        ...deriveWindowKeyContext(windowKeyEvents, closeMs, deltaMs),
+        boot_id_changed_since_prev: bootIdChanged,
+      },
+    });
+  }
+
+  return { events: results, nextSeq };
+}
+
+function attributeClose(args: {
+  cmuxSurfaceId: string | null;
+  closeMs: number;
+  mcpCloses: CloseTelemetryEvent[];
+  surfaceRefByCmuxId: Map<string, string>;
+  deltaMs: number;
+}): string {
+  const { cmuxSurfaceId, closeMs, mcpCloses, surfaceRefByCmuxId, deltaMs } =
+    args;
+  if (Number.isNaN(closeMs)) return "app-level:no-mcp-close";
+
+  const ref = cmuxSurfaceId
+    ? (surfaceRefByCmuxId.get(cmuxSurfaceId) ?? null)
+    : null;
+
+  let best: { rec: CloseTelemetryEvent; dist: number } | null = null;
+  for (const rec of mcpCloses) {
+    // A close matches this surface if its target is the mapped ref, or the raw
+    // cmux UUID directly (some callers target a UUID rather than a surface:N ref).
+    const targetsThisSurface =
+      (ref !== null && rec.target === ref) ||
+      (cmuxSurfaceId !== null && rec.target === cmuxSurfaceId);
+    if (!targetsThisSurface) continue;
+    const recMs = toMillis(rec.ts);
+    if (Number.isNaN(recMs)) continue;
+    const dist = Math.abs(recMs - closeMs);
+    if (dist > deltaMs) continue;
+    if (best === null || dist < best.dist) best = { rec, dist };
+  }
+
+  if (best) return `mcp:${best.rec.event} caller=${best.rec.caller}`;
+  return "app-level:no-mcp-close";
+}
+
+function deriveWindowKeyContext(
+  windowKeyEvents: CmuxEvent[],
+  closeMs: number,
+  deltaMs: number,
+): {
+  window_key_cycle_near_close: boolean;
+  last_window_key_event: "keyed" | "unkeyed" | null;
+} {
+  if (Number.isNaN(closeMs)) {
+    return { window_key_cycle_near_close: false, last_window_key_event: null };
+  }
+
+  // Candidates within Δt of the close. Prefer the most recent one AT OR BEFORE
+  // the close (the focus state the window was in when it died); otherwise the
+  // nearest one after.
+  let beforeBest: { ev: CmuxEvent; t: number } | null = null;
+  let afterBest: { ev: CmuxEvent; dist: number } | null = null;
+  for (const ev of windowKeyEvents) {
+    const t = toMillis(ev.occurred_at);
+    if (Number.isNaN(t)) continue;
+    if (Math.abs(t - closeMs) > deltaMs) continue;
+    if (t <= closeMs) {
+      if (beforeBest === null || t > beforeBest.t) beforeBest = { ev, t };
+    } else {
+      const dist = t - closeMs;
+      if (afterBest === null || dist < afterBest.dist) afterBest = { ev, dist };
+    }
+  }
+
+  const chosen = beforeBest?.ev ?? afterBest?.ev ?? null;
+  if (!chosen) {
+    return { window_key_cycle_near_close: false, last_window_key_event: null };
+  }
+  return {
+    window_key_cycle_near_close: true,
+    last_window_key_event: chosen.name === WINDOW_KEYED ? "keyed" : "unkeyed",
+  };
+}
+
+/**
+ * Tolerant line parser for `~/.cmuxterm/events.jsonl`: skips blank/malformed
+ * lines and lines missing the required shape, never throws. Returns whatever it
+ * could parse so a single corrupt line can't blind the whole ingest.
+ */
+export function parseCmuxEvents(text: string): CmuxEvent[] {
+  const out: CmuxEvent[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!obj || typeof obj !== "object") continue;
+    const rec = obj as Record<string, unknown>;
+    if (typeof rec.name !== "string") continue;
+    if (typeof rec.seq !== "number") continue;
+    out.push({
+      name: rec.name,
+      seq: rec.seq,
+      occurred_at: typeof rec.occurred_at === "string" ? rec.occurred_at : "",
+      surface_id: typeof rec.surface_id === "string" ? rec.surface_id : null,
+      pane_id: typeof rec.pane_id === "string" ? rec.pane_id : null,
+      window_id:
+        typeof rec.window_id === "string" || typeof rec.window_id === "number"
+          ? (rec.window_id as string | number)
+          : null,
+      boot_id: typeof rec.boot_id === "string" ? rec.boot_id : null,
+      workspace_id:
+        typeof rec.workspace_id === "string" ? rec.workspace_id : null,
+      payload:
+        rec.payload && typeof rec.payload === "object"
+          ? (rec.payload as { origin?: string; [k: string]: unknown })
+          : null,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Sweep-driven runner (thin, best-effort I/O adapter over the pure ingest).
+// ---------------------------------------------------------------------------
+
+export interface CloseForensicsCursorStore {
+  /** Last ingested cmux seq (0 when none / unreadable). */
+  read(): number;
+  write(seq: number): void;
+}
+
+export interface CloseForensicsDeps {
+  /** Reads the raw cmux events file; returns null when absent/unreadable. */
+  readCmuxEventsText: () => string | null;
+  /** cmuxlayer's own MCP close-log records. */
+  readMcpCloses: () => CloseTelemetryEvent[];
+  /** cmux-UUID → surface-ref map (may be empty). */
+  surfaceRefByCmuxId: () => Map<string, string>;
+  /** Append one attributed forensics record to the event log. */
+  appendForensics: (event: CloseForensicsEvent) => void;
+  cursor: CloseForensicsCursorStore;
+  now: () => string;
+  deltaMs: number;
+}
+
+/**
+ * Run one forensics ingest pass. Fully best-effort: ANY failure (missing file,
+ * malformed lines, cursor I/O error, append error) is swallowed — this is
+ * forensics, never a critical path, and it must never throw into the sweep.
+ * Returns the count emitted for observability/tests.
+ */
+export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
+  emitted: number;
+} {
+  try {
+    const text = safe(() => deps.readCmuxEventsText(), null);
+    if (!text) return { emitted: 0 };
+    const cmuxEvents =
+      safe(() => parseCmuxEvents(text), [] as CmuxEvent[]) ?? [];
+    const lastSeq = safe(() => deps.cursor.read(), 0) ?? 0;
+    const mcpCloses =
+      safe(() => deps.readMcpCloses(), [] as CloseTelemetryEvent[]) ?? [];
+    const surfaceRefByCmuxId =
+      safe(() => deps.surfaceRefByCmuxId(), new Map<string, string>()) ??
+      new Map<string, string>();
+
+    const { events, nextSeq } = ingestCloseForensics({
+      cmuxEvents,
+      mcpCloses,
+      surfaceRefByCmuxId,
+      deltaMs: deps.deltaMs,
+      lastSeq,
+      now: deps.now,
+    });
+
+    for (const event of events) {
+      try {
+        deps.appendForensics(event);
+      } catch {
+        // Best-effort: one bad append must not lose the rest of the batch.
+      }
+    }
+    if (nextSeq > lastSeq) {
+      try {
+        deps.cursor.write(nextSeq);
+      } catch {
+        // A cursor-write failure re-processes next sweep; append de-dup is owned
+        // by cursor advances, so we log at-most-once per successful advance.
+      }
+    }
+    return { emitted: events.length };
+  } catch {
+    return { emitted: 0 };
+  }
+}
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+/** Default path to cmux's own event stream (override with CMUX_EVENTS_PATH). */
+export function defaultCmuxEventsPath(): string {
+  return (
+    process.env.CMUX_EVENTS_PATH ?? join(homedir(), ".cmuxterm", "events.jsonl")
+  );
+}
+
+const DEFAULT_DELTA_MS = 30_000;
+
+/**
+ * cmux's surface-session-index keys by cmuxlayer ref ("surface:N"), not by cmux
+ * internal surface UUID, so there is no UUID↔ref link to harvest yet. An empty
+ * map keeps attribution honest (`app-level:no-mcp-close`) until such a bridge
+ * exists — which for the current mystery is the CORRECT finding (these tab
+ * deaths do NOT go through cmuxlayer). The ingest is map-driven, so the day cmux
+ * exposes a UUID↔ref bridge, attribution lights up with no ingest change. Kept
+ * as a named seam so that wiring point is obvious.
+ */
+export function buildSurfaceRefMap(
+  _stateMgr: StateManager,
+): Map<string, string> {
+  return new Map<string, string>();
+}
+
+/**
+ * Build the default sweep-driven runner bound to real fs + a StateManager. The
+ * returned function is what the engine calls each sweep; it is a thin wrapper
+ * over {@link runCloseForensicsSweep} with production I/O.
+ */
+export function createDefaultCloseForensicsRunner(config: {
+  stateMgr: StateManager;
+  eventsPath?: string;
+  deltaMs?: number;
+  now?: () => string;
+}): () => { emitted: number } {
+  const eventsPath = config.eventsPath ?? defaultCmuxEventsPath();
+  const deltaMs = config.deltaMs ?? DEFAULT_DELTA_MS;
+  const now = config.now ?? (() => new Date().toISOString());
+  const cursorPath = join(
+    config.stateMgr.getBaseDir(),
+    "close-forensics-cursor.json",
+  );
+
+  const cursor: CloseForensicsCursorStore = {
+    read: () => {
+      if (!existsSync(cursorPath)) return 0;
+      try {
+        const parsed = JSON.parse(readFileSync(cursorPath, "utf-8")) as {
+          last_seq?: number;
+        };
+        return typeof parsed.last_seq === "number" ? parsed.last_seq : 0;
+      } catch {
+        return 0;
+      }
+    },
+    write: (seq: number) => {
+      const tmp = `${cursorPath}.tmp`;
+      writeFileSync(tmp, JSON.stringify({ last_seq: seq }), "utf-8");
+      renameSync(tmp, cursorPath);
+    },
+  };
+
+  return () =>
+    runCloseForensicsSweep({
+      readCmuxEventsText: () =>
+        existsSync(eventsPath) ? readFileSync(eventsPath, "utf-8") : null,
+      readMcpCloses: () =>
+        config.stateMgr
+          .getEventLog()
+          .readEntries()
+          .filter(
+            (entry): entry is CloseTelemetryEvent =>
+              (entry as { event_type?: string }).event_type === "close",
+          ),
+      surfaceRefByCmuxId: () => buildSurfaceRefMap(config.stateMgr),
+      appendForensics: (event) =>
+        config.stateMgr.getEventLog().appendCloseForensics(event),
+      cursor,
+      now,
+      deltaMs,
+    });
+}

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -7,6 +7,7 @@
 import { appendFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type {
+  CloseForensicsEvent,
   CloseTelemetryEvent,
   ControlHealthTelemetryEvent,
   DeliveryTelemetryEvent,
@@ -39,6 +40,16 @@ export class EventLog {
    * same events.jsonl as every other telemetry entry so forensics read one log.
    */
   appendClose(event: CloseTelemetryEvent): void {
+    this.appendEntry(event);
+  }
+
+  /**
+   * Record an ATTRIBUTED app-level close (cmux `tab_close`/`workspace_teardown`
+   * that carries no actor) into the same events.jsonl. Mirrors {@link appendClose}
+   * so a pane-death investigation still reads one log -- now including the deaths
+   * that never went through an MCP tool. See {@link CloseForensicsEvent}.
+   */
+  appendCloseForensics(event: CloseForensicsEvent): void {
     this.appendEntry(event);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ async function main() {
     outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,
+    enableCloseForensics: true,
   });
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { readVersion } from "./version.js";
 import { StateManager } from "./state-manager.js";
+import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
   AgentEngine,
@@ -1729,6 +1730,13 @@ export interface CreateServerOptions {
   monitorRegistryPath?: string;
   monitorRegistryNow?: () => number;
   monitorRegistryNotify?: MonitorDeadmanNotify;
+  /**
+   * Enable close forensics: ingest cmux's OWN app-level `tab_close` events from
+   * `~/.cmuxterm/events.jsonl` and attribute them each sweep. Omitted/false by
+   * default so tests never read the real cmux events file; the real MCP
+   * entrypoint (index.ts) passes `true`.
+   */
+  enableCloseForensics?: boolean;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -5978,6 +5986,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           monitorRegistryPath: opts?.monitorRegistryPath,
           monitorRegistryNow: opts?.monitorRegistryNow,
           monitorRegistryNotify: opts?.monitorRegistryNotify,
+          closeForensicsRunner: opts?.enableCloseForensics
+            ? createDefaultCloseForensicsRunner({ stateMgr })
+            : null,
         },
       );
     context.lifecycleSweepEngine = engine;

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -185,6 +185,10 @@ export class StateManager {
     mkdirSync(baseDir, { recursive: true });
   }
 
+  getBaseDir(): string {
+    return this.baseDir;
+  }
+
   getEventLog(): EventLog {
     return this.eventLog;
   }

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  statSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import {
+  ingestCloseForensics,
+  parseCmuxEvents,
+  runCloseForensicsSweep,
+  createDefaultCloseForensicsRunner,
+  type CmuxEvent,
+  type CloseForensicsCursorStore,
+} from "../src/close-forensics.js";
+import type {
+  CloseForensicsEvent,
+  CloseTelemetryEvent,
+} from "../src/agent-types.js";
+import { StateManager } from "../src/state-manager.js";
+
+const FIXED_TS = "2026-07-07T00:00:00.000Z";
+const now = () => FIXED_TS;
+
+function surfaceClosed(over: Partial<CmuxEvent> = {}): CmuxEvent {
+  return {
+    name: "surface.closed",
+    seq: 100,
+    occurred_at: "2026-07-06T21:34:13.820Z",
+    surface_id: "92AF15C5-EB43-4427-9820-5CE77AFC31AB",
+    pane_id: "C4E5F762-99BC-4B29-A065-697FD59744DF",
+    window_id: null,
+    boot_id: "4E2A818D-54A0-48D3-954D-317057EC001C",
+    workspace_id: "A4D082D6-EF72-4791-9DD8-AC083CCBAEC2",
+    payload: {
+      origin: "tab_close",
+      surface_id: "92AF15C5-EB43-4427-9820-5CE77AFC31AB",
+    },
+    ...over,
+  };
+}
+
+function windowKey(
+  name: "window.keyed" | "window.unkeyed",
+  occurred_at: string,
+  seq: number,
+): CmuxEvent {
+  return {
+    name,
+    seq,
+    occurred_at,
+    surface_id: null,
+    pane_id: null,
+    window_id: "E0AE2C38-6EC1-46C8-9414-0095EDCC659D",
+    boot_id: "4E2A818D-54A0-48D3-954D-317057EC001C",
+    workspace_id: "A4D082D6-EF72-4791-9DD8-AC083CCBAEC2",
+    payload: { origin: "appkit_key" },
+  };
+}
+
+function mcpClose(
+  over: Partial<CloseTelemetryEvent> = {},
+): CloseTelemetryEvent {
+  return {
+    ts: "2026-07-06T21:34:13.000Z",
+    event_type: "close",
+    event: "close_surface",
+    target: "surface:42",
+    caller: "CMUX_TAB_ID=abc",
+    force: false,
+    reason: null,
+    refused: false,
+    ...over,
+  };
+}
+
+describe("ingestCloseForensics — attribution", () => {
+  it("attributes to the MCP close when one matches the mapped surface within Δt", () => {
+    const map = new Map([
+      ["92AF15C5-EB43-4427-9820-5CE77AFC31AB", "surface:42"],
+    ]);
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [surfaceClosed()],
+      mcpCloses: [mcpClose({ ts: "2026-07-06T21:34:14.000Z" })], // ~0.2s after close
+      surfaceRefByCmuxId: map,
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].attribution).toBe(
+      "mcp:close_surface caller=CMUX_TAB_ID=abc",
+    );
+    expect(events[0].origin).toBe("tab_close");
+    expect(events[0].cmux_surface_id).toBe(
+      "92AF15C5-EB43-4427-9820-5CE77AFC31AB",
+    );
+    expect(events[0].ts).toBe(FIXED_TS);
+  });
+
+  it("does NOT attribute an MCP close that is outside Δt", () => {
+    const map = new Map([
+      ["92AF15C5-EB43-4427-9820-5CE77AFC31AB", "surface:42"],
+    ]);
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [surfaceClosed()],
+      // 10 minutes after the close — well outside a 30s Δt.
+      mcpCloses: [mcpClose({ ts: "2026-07-06T21:44:13.000Z" })],
+      surfaceRefByCmuxId: map,
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[0].attribution).toBe("app-level:no-mcp-close");
+  });
+
+  it("reports app-level when NO MCP close matches (the smoking gun)", () => {
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [surfaceClosed()],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[0].attribution).toBe("app-level:no-mcp-close");
+  });
+
+  it("matches an MCP close whose target is the raw cmux UUID (no ref map)", () => {
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [surfaceClosed()],
+      mcpCloses: [
+        mcpClose({
+          target: "92AF15C5-EB43-4427-9820-5CE77AFC31AB",
+          event: "kill",
+          caller: "mcp:stop_agent",
+        }),
+      ],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[0].attribution).toBe("mcp:kill caller=mcp:stop_agent");
+  });
+});
+
+describe("ingestCloseForensics — client_context (rc/screen-share signal)", () => {
+  it("flags a window key cycle within Δt and records the nearest key event", () => {
+    const close = surfaceClosed({
+      occurred_at: "2026-07-06T21:34:13.820Z",
+      seq: 200,
+    });
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [
+        windowKey("window.unkeyed", "2026-07-06T21:33:56.240Z", 198), // ~17s before
+        windowKey("window.keyed", "2026-07-06T21:34:01.256Z", 199), // ~12s before (nearer)
+        close,
+      ],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[0].client_context.window_key_cycle_near_close).toBe(true);
+    // Nearest at-or-before the close is the "keyed" event.
+    expect(events[0].client_context.last_window_key_event).toBe("keyed");
+  });
+
+  it("does not flag a key cycle when window events are outside Δt", () => {
+    const close = surfaceClosed({
+      occurred_at: "2026-07-06T21:34:13.820Z",
+      seq: 200,
+    });
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [
+        windowKey("window.unkeyed", "2026-07-06T21:20:00.000Z", 198), // >14min before
+        close,
+      ],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[0].client_context.window_key_cycle_near_close).toBe(false);
+    expect(events[0].client_context.last_window_key_event).toBeNull();
+  });
+
+  it("flags boot_id_changed_since_prev when consecutive closes have different boot_ids", () => {
+    const first = surfaceClosed({ seq: 10, boot_id: "BOOT-AAA" });
+    const second = surfaceClosed({ seq: 20, boot_id: "BOOT-BBB" });
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [first, second],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events).toHaveLength(2);
+    expect(events[0].client_context.boot_id_changed_since_prev).toBe(false); // no prior close
+    expect(events[1].client_context.boot_id_changed_since_prev).toBe(true); // boot changed
+  });
+
+  it("does not flag boot change when consecutive closes share a boot_id", () => {
+    const first = surfaceClosed({ seq: 10, boot_id: "BOOT-AAA" });
+    const second = surfaceClosed({ seq: 20, boot_id: "BOOT-AAA" });
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [first, second],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 0,
+      now,
+    });
+    expect(events[1].client_context.boot_id_changed_since_prev).toBe(false);
+  });
+});
+
+describe("ingestCloseForensics — cursor", () => {
+  it("only emits closes with seq > lastSeq and advances the cursor", () => {
+    const events = [
+      surfaceClosed({ seq: 5 }),
+      surfaceClosed({ seq: 10 }),
+      surfaceClosed({ seq: 15 }),
+    ];
+    const first = ingestCloseForensics({
+      cmuxEvents: events,
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 8,
+      now,
+    });
+    // Only seq 10 and 15 are newer than 8.
+    expect(first.events).toHaveLength(2);
+    expect(first.nextSeq).toBe(15);
+
+    // Re-run with the advanced cursor → nothing new.
+    const second = ingestCloseForensics({
+      cmuxEvents: events,
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: first.nextSeq,
+      now,
+    });
+    expect(second.events).toHaveLength(0);
+    expect(second.nextSeq).toBe(15);
+  });
+
+  it("seeds boot continuity from below-cursor closes so the first new close compares correctly", () => {
+    const older = surfaceClosed({ seq: 5, boot_id: "BOOT-AAA" });
+    const newer = surfaceClosed({ seq: 10, boot_id: "BOOT-BBB" });
+    const { events } = ingestCloseForensics({
+      cmuxEvents: [older, newer],
+      mcpCloses: [],
+      surfaceRefByCmuxId: new Map(),
+      deltaMs: 30_000,
+      lastSeq: 5, // older is below cursor, only newer emits
+      now,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].boot_id).toBe("BOOT-BBB");
+    // Compares against the below-cursor older close's boot_id → changed.
+    expect(events[0].client_context.boot_id_changed_since_prev).toBe(true);
+  });
+});
+
+describe("parseCmuxEvents / ingest — malformed & missing tolerance", () => {
+  it("skips malformed lines and still parses the good ones", () => {
+    const text = [
+      '{"name":"surface.closed","seq":1,"occurred_at":"2026-07-06T21:00:00.000Z","surface_id":"S1","pane_id":null,"window_id":null,"boot_id":"B","workspace_id":"W","payload":{"origin":"tab_close"}}',
+      "not json at all {",
+      "",
+      '{"missing":"name and seq"}',
+      '{"name":"surface.closed","seq":2,"occurred_at":"2026-07-06T21:01:00.000Z","surface_id":"S2","pane_id":null,"window_id":null,"boot_id":"B","workspace_id":"W","payload":{"origin":"workspace_teardown"}}',
+    ].join("\n");
+    const parsed = parseCmuxEvents(text);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.map((e) => e.name)).toEqual([
+      "surface.closed",
+      "surface.closed",
+    ]);
+    expect(parsed[1].payload?.origin).toBe("workspace_teardown");
+  });
+
+  it("runCloseForensicsSweep never throws when the events file is missing", () => {
+    const emitted: CloseForensicsEvent[] = [];
+    const cursor: CloseForensicsCursorStore = {
+      read: () => 0,
+      write: () => {},
+    };
+    const result = runCloseForensicsSweep({
+      readCmuxEventsText: () => null, // missing file
+      readMcpCloses: () => [],
+      surfaceRefByCmuxId: () => new Map(),
+      appendForensics: (e) => emitted.push(e),
+      cursor,
+      now,
+      deltaMs: 30_000,
+    });
+    expect(result.emitted).toBe(0);
+    expect(emitted).toHaveLength(0);
+  });
+
+  it("runCloseForensicsSweep never throws when a dependency throws", () => {
+    const result = runCloseForensicsSweep({
+      readCmuxEventsText: () => {
+        throw new Error("disk exploded");
+      },
+      readMcpCloses: () => {
+        throw new Error("nope");
+      },
+      surfaceRefByCmuxId: () => new Map(),
+      appendForensics: () => {
+        throw new Error("append fail");
+      },
+      cursor: {
+        read: () => {
+          throw new Error("cursor read fail");
+        },
+        write: () => {
+          throw new Error("cursor write fail");
+        },
+      },
+      now,
+      deltaMs: 30_000,
+    });
+    expect(result.emitted).toBe(0);
+  });
+});
+
+describe("runCloseForensicsSweep — persisted cursor end-to-end", () => {
+  it("appends new forensics, advances the cursor, and does not double-emit on re-run", () => {
+    const appended: CloseForensicsEvent[] = [];
+    let cursorSeq = 0;
+    const cursor: CloseForensicsCursorStore = {
+      read: () => cursorSeq,
+      write: (seq) => {
+        cursorSeq = seq;
+      },
+    };
+    const text = [
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })),
+      JSON.stringify(surfaceClosed({ seq: 2, surface_id: "S2" })),
+    ].join("\n");
+    const deps = {
+      readCmuxEventsText: () => text,
+      readMcpCloses: () => [] as CloseTelemetryEvent[],
+      surfaceRefByCmuxId: () => new Map<string, string>(),
+      appendForensics: (e: CloseForensicsEvent) => appended.push(e),
+      cursor,
+      now,
+      deltaMs: 30_000,
+    };
+    const first = runCloseForensicsSweep(deps);
+    expect(first.emitted).toBe(2);
+    expect(appended).toHaveLength(2);
+    expect(cursorSeq).toBe(2);
+
+    const second = runCloseForensicsSweep(deps);
+    expect(second.emitted).toBe(0);
+    expect(appended).toHaveLength(2); // unchanged — no double emit
+  });
+});
+
+describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () => {
+  let stateDir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "cf-state-"));
+    eventsPath = join(
+      mkdtempSync(join(tmpdir(), "cf-events-")),
+      "events.jsonl",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("ingests from a real events file, writes to the event log, and persists the cursor", () => {
+    writeFileSync(
+      eventsPath,
+      [
+        JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })),
+        JSON.stringify(surfaceClosed({ seq: 2, surface_id: "S2" })),
+      ].join("\n"),
+      "utf-8",
+    );
+    const stateMgr = new StateManager(stateDir);
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+    });
+
+    const first = runner();
+    expect(first.emitted).toBe(2);
+
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      );
+    expect(forensics).toHaveLength(2);
+
+    // Re-run: cursor persisted → no double emit.
+    const second = runner();
+    expect(second.emitted).toBe(0);
+    const forensicsAfter = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      );
+    expect(forensicsAfter).toHaveLength(2);
+  });
+});
+
+describe("close forensics — does not disturb the operator outbox", () => {
+  it("leaves ~/.golems-zikaron/outbox.md mtime unchanged across a full run", () => {
+    // Guard: forensics must never write to the operator outbox. We assert the
+    // real outbox's mtime is untouched (creating an empty temp one only if
+    // absent so the assertion is meaningful without mutating real content).
+    const outboxDir = join(homedir(), ".golems-zikaron");
+    const outboxPath = join(outboxDir, "outbox.md");
+    let createdForTest = false;
+    let before: number;
+    try {
+      before = statSync(outboxPath).mtimeMs;
+    } catch {
+      mkdirSync(outboxDir, { recursive: true });
+      writeFileSync(outboxPath, "", "utf-8");
+      createdForTest = true;
+      before = statSync(outboxPath).mtimeMs;
+    }
+
+    const stateDir = mkdtempSync(join(tmpdir(), "cf-outbox-"));
+    const eventsPath = join(
+      mkdtempSync(join(tmpdir(), "cf-outbox-ev-")),
+      "events.jsonl",
+    );
+    try {
+      writeFileSync(
+        eventsPath,
+        JSON.stringify(surfaceClosed({ seq: 1 })) + "\n",
+        "utf-8",
+      );
+      const stateMgr = new StateManager(stateDir);
+      const runner = createDefaultCloseForensicsRunner({
+        stateMgr,
+        eventsPath,
+        now,
+      });
+      runner();
+
+      const after = statSync(outboxPath).mtimeMs;
+      expect(after).toBe(before);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+      if (createdForTest) rmSync(outboxPath, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The mystery

Agent panes keep dying via cmux's **app-level `tab_close`** with **no actor recorded**, repeatedly killing the driver + leads. cmuxlayer's existing close-logging (`CloseTelemetryEvent`, #6) only records **MCP-tool-driven** closes (`close_surface`/`stop_agent`/`kill`) with a caller — it never sees cmux's own app-level `surface.closed` events, so those deaths are invisible and unattributed.

The operator drives this Mac via remote-control + Screens5 screen-sharing, so an rc/attach or screen-share reconnect is a prime suspect for cycling tabs — but nothing captured that context.

## What this adds

A best-effort forensics ingest that reads cmux's **own** event stream (`~/.cmuxterm/events.jsonl`, `protocol:"cmux-events"`) and, for each app-level `surface.closed`:

1. **Attributes** it — finds a cmuxlayer MCP close for the mapped surface within Δt →
   `mcp:<tool> caller=<x>`; otherwise `app-level:no-mcp-close` (the smoking gun: a death that did **not** go through cmuxlayer).
2. **Captures client/attach context** — correlates the close with nearby `window.keyed`/`window.unkeyed` focus cycles and cmux `boot_id` changes. This is the rc/screen-share-reconnect signal.

### New `CloseForensicsEvent` (event_type `"close_forensics"`)

`ts`, `cmux_surface_id`, `cmux_pane_id`, `window_id`, `boot_id`, `workspace_id`, `origin` (`tab_close`/`workspace_teardown`/…), `occurred_at`, **`attribution`**, and **`client_context`**:
- `window_key_cycle_near_close: boolean`
- `last_window_key_event: "keyed" | "unkeyed" | null`
- `boot_id_changed_since_prev: boolean`

Added to the `EventLogEntry` union; `EventLog.appendCloseForensics` mirrors `appendClose` so a pane-death investigation still reads **one** log.

## Mechanism / wiring

- **Pure, testable ingest** (`src/close-forensics.ts`): `ingestCloseForensics(cmuxEvents, mcpCloses, surfaceRefByCmuxId, Δt, cursor, clock) → CloseForensicsEvent[]`. All I/O (reading the cmux file, the cursor, the MCP close log) is injected, so tests never touch real `~/.cmuxterm` or state.
- **Sweep-driven** via a new best-effort call in `AgentEngine.runSweep` (next to the monitor-registry sweep). It **never throws into the sweep** (swallow + continue — forensics, not a critical path) and is guarded against overlap.
- **Persisted cursor** (`close-forensics-cursor.json`, last-read `seq`) so each sweep only ingests **NEW** `surface.closed` events and never double-emits.
- **Off by default** for bare construction (tests/libraries never read the real cmux file); enabled at the real MCP entrypoint (`index.ts` → `enableCloseForensics: true`) and in `app-server-runtime`.

### Known limitation (documented in code)

The `surface-session-index` currently keys by cmuxlayer ref (`surface:N`), not cmux surface UUID, so there is no UUID↔ref bridge to harvest yet — live attribution therefore resolves to `app-level:no-mcp-close`, which for this mystery is the **correct** finding (these tab deaths do not go through cmuxlayer). The ingest is map-driven, so the day cmux exposes that bridge, MCP attribution lights up with **zero** ingest changes.

## Tests

16 fully-mocked cases in `tests/close-forensics.test.ts`: attribution match / no-match / raw-UUID-target / outside-Δt; `client_context` window-cycle + boot-change; cursor only-new + no-double-emit + boot-continuity seeding; malformed-line / missing-file tolerance (never throws); real-fs wiring in temp dirs; and a guard that the operator outbox (`~/.golems-zikaron/outbox.md`) mtime is untouched.

`bun run typecheck` clean. `bun run test` green: **1424 passed (77 files), 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only path on the sweep tail; failures are swallowed and lifecycle reconciliation is unchanged. Minor local file I/O on cmux events and cursor state.
> 
> **Overview**
> Adds **close forensics** so cmux app-level `surface.closed` events (`tab_close` / `workspace_teardown`) from `~/.cmuxterm/events.jsonl` are ingested and written into the same cmuxlayer `events.jsonl` as MCP close telemetry—closing the gap where pane deaths had no actor.
> 
> Each sweep runs a **best-effort, non-throwing** ingest (injectable runner, off by default for tests). New **`CloseForensicsEvent`** records include **attribution** (MCP close within Δt vs `app-level:no-mcp-close`) and **client_context** (nearby `window.keyed`/`window.unkeyed`, `boot_id` change vs prior close). A **persisted seq cursor** avoids double-emits. Production enables this via `enableCloseForensics` / `createDefaultCloseForensicsRunner` in MCP and app-server runtime.
> 
> **`EventLog.appendCloseForensics`** and **`StateManager.getBaseDir`** support persistence. **`buildSurfaceRefMap`** is currently empty, so live runs often report app-level-only attribution until a UUID↔`surface:N` bridge exists. Covered by **`tests/close-forensics.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298a016642e63c25491a27a0663bb308f8d816f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add close forensics pipeline to attribute app-level cmux tab close events
> - Introduces [close-forensics.ts](https://github.com/EtanHey/cmuxlayer/pull/253/files#diff-f2c6509ec1163d316086dcaae2b98686183a54a84527fc006f3a12a7f06cda8a) with a full ingest pipeline that reads `cmux` `surface.closed` events from `events.jsonl`, correlates them with MCP close records within a configurable time window, and writes attributed `close_forensics` entries to the agent event log each sweep.
> - Adds client/attach context to each forensics record: `window_key_cycle_near_close`, `last_window_key_event`, and `boot_id_changed_since_prev`.
> - Wires the runner into `AgentEngine` via a new `closeForensicsRunner` option; the default CLI server enables it via `enableCloseForensics: true` in `createServer`.
> - Parsing is tolerant of malformed jsonl lines and the sweep runner swallows errors to avoid disrupting the main agent sweep.
> - `EventLog` gains an `appendCloseForensics` method to persist `close_forensics` entries, and `StateManager` gains a `getBaseDir()` accessor used for the fs-backed cursor.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 298a016. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->