### PR TITLE
fix: make multiline paste atomic on socket transport

### DIFF
--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -31,6 +31,8 @@ export { CmuxSocketError } from "./cmux-socket-error.js";
 // ── Configuration ──────────────────────────────────────────────────────
 
 const REQUEST_TIMEOUT_MS = 10_000;
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
 const RETRY_SAFE_V2_METHODS = new Set([
   "system.ping",
@@ -494,11 +496,20 @@ export class CmuxSocketClient {
     text: string,
     opts?: { workspace?: string },
   ): Promise<void> {
-    if (!this.cliFallback) {
-      throw new CmuxSocketError(
-        "paste-text is only available through the CLI fallback",
-        "method_not_found",
-      );
+    const workspace = await this.resolveWorkspace(surface, opts?.workspace);
+    const params: Record<string, unknown> = {
+      surface_id: surface,
+      text: `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`,
+      workspace_id: workspace,
+    };
+
+    try {
+      await this.call("surface.send_text", params);
+      return;
+    } catch (error) {
+      if (!this.isMethodNotFound(error) || !this.cliFallback) {
+        throw error;
+      }
     }
     await this.cliFallbackPinned()!.pasteText(surface, text, opts);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -267,6 +267,7 @@ const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 export const SEND_INPUT_CHUNK_THRESHOLD = 500;
+const BOOT_PROMPT_PATH_WARNING_CHARS = 500;
 export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
 export const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
@@ -3356,6 +3357,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     retry_count: number;
     submit_verified: boolean | null;
     prompt_text: string | null;
+    prompt_warning: string | null;
   }> => {
     const bootPromptPath = getBootPromptPath(opts.boot_prompt_path);
     assertBootPromptMode(opts.prompt, bootPromptPath);
@@ -3365,6 +3367,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         retry_count: 0,
         submit_verified: null,
         prompt_text: null,
+        prompt_warning: null,
       };
     }
 
@@ -3379,6 +3382,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const rawPrompt = bootPromptPath
       ? await readFile(bootPromptPath, "utf8")
       : opts.prompt!;
+    const promptWarning =
+      bootPromptPath && rawPrompt.length > BOOT_PROMPT_PATH_WARNING_CHARS
+        ? `boot_prompt_path is ${rawPrompt.length} characters; prefer a one-line file pointer for boot prompts over ${BOOT_PROMPT_PATH_WARNING_CHARS} characters`
+        : null;
     const sanitizedText = sanitizeTerminalInput(rawPrompt);
     const chunks =
       sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
@@ -3408,7 +3415,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }),
         { toolName: "boot_prompt", workspace: opts.workspace },
       );
-      return { ...delivery, prompt_text: rawPrompt };
+      return {
+        ...delivery,
+        prompt_text: rawPrompt,
+        prompt_warning: promptWarning,
+      };
     } catch (error) {
       if (error instanceof SurfaceGoneError) {
         throw error;
@@ -3431,6 +3442,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             retry_count: error.retry_count,
             submit_verified: true,
             prompt_text: rawPrompt,
+            prompt_warning: promptWarning,
           };
         }
       }
@@ -4949,6 +4961,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           boot_prompt_bytes: bootPromptDelivery?.bytes,
           boot_prompt_submit_verified: bootPromptDelivery?.submit_verified ?? null,
+          boot_prompt_warning: bootPromptDelivery?.prompt_warning ?? null,
         };
         return okFormatted(
           formatDelivery("send_command", {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -1048,25 +1048,51 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
     expect(result.surface).toBe("surface:cli-tab");
   });
 
-  it("pasteText uses CLI fallback", async () => {
+  it("pasteText sends bracketed paste over the socket without CLI fallback", async () => {
     const client = new CmuxSocketClient({
       socketPath: MOCK_SOCKET_PATH,
-      cliFallback: createMockCli(),
+      timeoutMs: 1000,
     });
 
     await client.pasteText("surface:1", "line one\nline two", {
       workspace: "workspace:1",
     });
 
-    expect(cliCalls).toHaveLength(1);
-    expect(cliCalls[0]).toEqual({
-      method: "pasteText",
-      args: [
-        "surface:1",
-        "line one\nline two",
-        { workspace: "workspace:1" },
-      ],
+    expect(lastV2Request).toEqual({
+      method: "surface.send_text",
+      params: {
+        surface_id: "surface:1",
+        text: "\x1b[200~line one\nline two\x1b[201~",
+        workspace_id: "workspace:1",
+      },
     });
+  });
+
+  it("pasteText uses CLI fallback when surface.send_text is unavailable", async () => {
+    const saved = MOCK_RESPONSES["surface.send_text"];
+    delete MOCK_RESPONSES["surface.send_text"];
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: createMockCli(),
+      });
+
+      await client.pasteText("surface:1", "line one\nline two", {
+        workspace: "workspace:1",
+      });
+
+      expect(cliCalls).toHaveLength(1);
+      expect(cliCalls[0]).toEqual({
+        method: "pasteText",
+        args: [
+          "surface:1",
+          "line one\nline two",
+          { workspace: "workspace:1" },
+        ],
+      });
+    } finally {
+      MOCK_RESPONSES["surface.send_text"] = saved;
+    }
   });
 
   it("moveSurface uses CLI fallback", async () => {
@@ -1155,34 +1181,33 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
       return { stdout: "{}", stderr: "" };
     });
     const sharedCli = new CmuxClient({ exec });
+    const saved = MOCK_RESPONSES["surface.send_text"];
+    delete MOCK_RESPONSES["surface.send_text"];
 
-    const nightly = "/tmp/cmux-nightly.sock";
-    const prod = "/tmp/cmux-prod.sock";
+    try {
+      const firstClient = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: sharedCli,
+      });
+      const secondClient = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: sharedCli,
+      });
+      await secondClient.pasteText("surface:p", "second text", {
+        workspace: "workspace:1",
+      });
 
-    // Nightly client constructed first (syncs fallback env -> nightly)...
-    const nightlyClient = new CmuxSocketClient({
-      socketPath: nightly,
-      cliFallback: sharedCli,
-    });
-    // ...then a prod client constructed and used, which last-synced the SHARED
-    // fallback env -> prod. Without a per-delegation re-sync, the nightly paste
-    // below would inherit prod.
-    const prodClient = new CmuxSocketClient({
-      socketPath: prod,
-      cliFallback: sharedCli,
-    });
-    await prodClient.pasteText("surface:p", "prod text", {
-      workspace: "workspace:1",
-    });
+      execEnvs.length = 0;
+      await firstClient.pasteText("surface:n", "first text", {
+        workspace: "workspace:1",
+      });
 
-    execEnvs.length = 0;
-    await nightlyClient.pasteText("surface:n", "nightly text", {
-      workspace: "workspace:1",
-    });
-
-    expect(execEnvs.length).toBeGreaterThan(0);
-    for (const env of execEnvs) {
-      expect(env?.CMUX_SOCKET_PATH).toBe(nightly);
+      expect(execEnvs.length).toBeGreaterThan(0);
+      for (const env of execEnvs) {
+        expect(env?.CMUX_SOCKET_PATH).toBe(MOCK_SOCKET_PATH);
+      }
+    } finally {
+      MOCK_RESPONSES["surface.send_text"] = saved;
     }
   });
 });

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -201,8 +201,10 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const after = sendCalls(exec);
     expect(after.length).toBeGreaterThan(before);
     const nudgeCall = after.at(-1)!;
+    const nudgeText = String(nudgeCall.at(-1) ?? "");
     expect(nudgeCall.join(" ")).toContain("surface:new");
     expect(nudgeCall.join(" ")).toContain("inbox");
+    expect(nudgeText).not.toMatch(/[\n\r]/);
     // And the message itself is durably in the inbox file.
     expect(
       readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2052,6 +2052,42 @@ describe("tool handler integration", () => {
     );
   });
 
+  it("send_input pastes short multiline text and presses return once", async () => {
+    const mockClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      pasteText: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+    const text = "first line\nsecond line";
+
+    const result = await tool.handler(
+      { surface: "surface:1", text, press_enter: true },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.pasteText).toHaveBeenCalledTimes(1);
+    expect(mockClient.pasteText).toHaveBeenCalledWith(
+      "surface:1",
+      text,
+      expect.any(Object),
+    );
+    expect(mockClient.send).not.toHaveBeenCalled();
+    expect(mockClient.sendKey).toHaveBeenCalledTimes(1);
+    expect(mockClient.sendKey).toHaveBeenCalledWith(
+      "surface:1",
+      "return",
+      expect.any(Object),
+    );
+  });
+
   it("send_command sends text and return to the same surface", async () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
@@ -2093,6 +2129,37 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.surface).toBe("surface:6");
+  });
+
+  it("send_command pastes short multiline commands and presses return once", async () => {
+    const mockClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      pasteText: vi.fn().mockResolvedValue(undefined),
+      sendKey: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_command"];
+    const command = "printf 'one'\nprintf 'two'";
+
+    const result = await tool.handler(
+      { surface: "surface:6", command },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(mockClient.pasteText).toHaveBeenCalledTimes(1);
+    expect(mockClient.pasteText).toHaveBeenCalledWith(
+      "surface:6",
+      command,
+      expect.any(Object),
+    );
+    expect(mockClient.send).not.toHaveBeenCalled();
+    expect(mockClient.sendKey).toHaveBeenCalledTimes(1);
   });
 
   it("send_input background reads 'delivering' (not FAILED) while in flight (F8)", async () => {
@@ -2330,7 +2397,8 @@ describe("tool handler integration", () => {
   it("send_command sends boot_prompt_path contents after launcher readiness", async () => {
     const promptPath = join(CHANNEL_TEST_DIR, "mandate.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
-    writeFileSync(promptPath, "boot prompt", "utf8");
+    const bootPrompt = "boot prompt line one\nboot prompt line two";
+    writeFileSync(promptPath, bootPrompt, "utf8");
     let promptSent = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
@@ -2346,10 +2414,7 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      if (
-        args.includes("send") &&
-        String(args.at(-1) ?? "") === "boot prompt"
-      ) {
+      if (args.includes("paste-buffer")) {
         promptSent = true;
       }
       return { stdout: "{}", stderr: "" };
@@ -2381,8 +2446,69 @@ describe("tool handler integration", () => {
     );
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
+      expect.arrayContaining(["set-buffer", bootPrompt]),
     );
+    expect(mockExec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["paste-buffer", "--surface", "surface:1"]),
+    );
+    const rawBootPromptSends = mockExec.mock.calls.filter(
+      ([, args]) =>
+        Array.isArray(args) &&
+        args.includes("send") &&
+        args.at(-1) === bootPrompt,
+    );
+    const returnPresses = mockExec.mock.calls.filter(
+      ([, args]) =>
+        Array.isArray(args) &&
+        args.includes("send-key") &&
+        args.at(-1) === "return",
+    );
+    expect(rawBootPromptSends).toHaveLength(0);
+    expect(returnPresses).toHaveLength(2);
+  });
+
+  it("send_command warns when boot_prompt_path contents exceed the pointer threshold", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "long-mandate.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, `${"long boot prompt ".repeat(40)}\n`, "utf8");
+    let promptSent = false;
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:1",
+            text: promptSent
+              ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+              : "codex> ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("paste-buffer")) {
+        promptSent = true;
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      {
+        surface: "surface:1",
+        command: "brainlayerCodex -s",
+        boot_prompt_path: promptPath,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_warning).toContain("boot_prompt_path is");
+    expect(parsed.boot_prompt_warning).toContain("one-line file pointer");
   });
 
   it("send_command verifies a cleared stable Claude boot prompt without a working marker", async () => {


### PR DESCRIPTION
## Summary
- Implement native bracketed paste in `CmuxSocketClient.pasteText` via `surface.send_text`, so socket-only transports can deliver multiline text atomically instead of failing or relying on CLI fallback.
- Keep CLI paste as a compatibility fallback when `surface.send_text` is unavailable.
- Add path coverage for short multiline `send_input`, `send_command`, boot-prompt delivery, socket paste, and the one-line `dispatch_to_agent` nudge invariant.
- Surface a non-fatal `boot_prompt_warning` when a `boot_prompt_path` file is over 500 characters, steering callers toward one-line file pointers.

## Repro / Root Cause
- RED reproduction: `CmuxSocketClient.pasteText` without CLI fallback threw `paste-text is only available through the CLI fallback`, leaving socket-only multiline delivery without an atomic paste path.
- Server `sendChunkWithRetry` already fails loud when paste is required, and `shouldPasteInputDelivery` already marks short multiline text as paste-required. The missing durable piece was native socket paste support.

## Paths Audited
- `send_input`: short multiline now asserted to call `pasteText` once and press return once.
- `send_command`: short multiline now asserted to call `pasteText` once and press return once.
- boot prompt delivery: multiline `boot_prompt_path` now asserted to use paste-buffer, not raw send; long prompt warning asserted.
- `send_to`: existing receiver-message regression remains green.
- `dispatch_to_agent`: nudge pointer asserted to contain no newline characters.
- socket client: native bracketed paste asserted over `surface.send_text`; CLI fallback retained for unavailable socket method.

## Test Plan
- [x] RED: `bunx vitest run tests/cmux-socket-client.test.ts -t "pasteText sends bracketed paste over the socket without CLI fallback"` failed before implementation with `paste-text is only available through the CLI fallback`.
- [x] `bun run typecheck`
- [x] `bun run test` (77 files, 1446 tests)
- [x] Push hook reran root tests successfully.

## Review Notes
- Local `coderabbit review --agent` was run with a hard timeout; it timed out while still reviewing and returned no findings.

Co-Authored-By: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multiline input reaches terminals on socket transport and adds advisory boot-prompt warnings; behavior is covered by tests and CLI fallback is preserved for older daemons.
> 
> **Overview**
> **Socket paste** no longer requires CLI-only fallback: `CmuxSocketClient.pasteText` sends multiline text atomically via `surface.send_text` wrapped in bracketed-paste escape sequences (`\x1b[200~` … `\x1b[201~`). CLI `pasteText` remains when the socket method is missing.
> 
> **Boot prompts** from `boot_prompt_path` now surface a non-fatal **`boot_prompt_warning`** (and `prompt_warning` internally) when the file exceeds **500 characters**, nudging callers toward one-line file pointers. The warning is included in `send_command` structured output as `boot_prompt_warning`.
> 
> Tests were extended for native socket paste, CLI fallback, short multiline `send_input` / `send_command` (single `pasteText` + one return), multiline boot delivery via paste-buffer, long-prompt warning, and inbox nudge text without newlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cc350a067999a3f37ac5555e67e20acc8b241f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make multiline paste atomic by sending bracketed paste sequences over the V2 socket
> - `CmuxSocketClient.pasteText` now sends text via the `surface.send_text` V2 socket method, wrapping it in bracketed paste start/end sequences (`ESC[200~` / `ESC[201~`) to make multiline input atomic.
> - CLI fallback is retained only when the socket returns a method-not-found error; all other errors are rethrown to the caller.
> - Boot prompt delivery in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/254/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now uses tmux buffer operations (`set-buffer` + `paste-buffer`) instead of raw text send, and returns a `boot_prompt_warning` when the boot prompt file exceeds 500 characters.
> - Behavioral Change: `pasteText` previously always fell back to CLI; it now attempts the socket first and only falls back on `method-not-found`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 04cc350. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->