### PR TITLE
fix: resolve spawn agent launchers from registry

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3,7 +3,6 @@
  * These 7 functions are the engine that MCP tools (and later the 2-tool facade) drive.
  */
 
-import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
@@ -85,6 +84,11 @@ import {
   type AgentHealth,
   type AgentHealthInput,
 } from "./agent-health.js";
+import {
+  launcherNameCandidates,
+  resolveLauncherNameFromRegistry,
+  type LauncherSuffix,
+} from "./launcher-registry.js";
 import { buildAgentHealthInput } from "./agent-health-input.js";
 import {
   assertSeatIdentity,
@@ -218,8 +222,8 @@ function sessionCollisionSuffix(sessionId: string): string {
 
 /**
  * Result of the spawn preflight. `launcherName` carries the launcher function
- * name resolved by the candidate probe (see resolveLauncherName) so spawnAgent
- * launches the form that actually registered, even when hyphens were stripped.
+ * name resolved from the launcher registry so spawnAgent launches the form
+ * that actually registered, even when the prefix differs from the repo name.
  */
 export interface SpawnPreflightResult {
   launcherName?: string;
@@ -549,9 +553,9 @@ export function buildLaunchCommand(
   cli: CliType,
   repo: string,
   model?: string,
-  // Resolved launcher function name (from resolveLauncherName). When provided
+  // Resolved launcher function name from launchers.zsh. When provided
   // for a launcher CLI it overrides the naive `${repo}${Suffix}` guess so
-  // hyphen-stripped registrations launch correctly. Honored for the launcher
+  // registry-prefix registrations launch correctly. Honored for the launcher
   // CLIs (claude/codex/cursor/gemini); ignored for kiro (raw cd+exec).
   launcherName?: string,
   opts?: { cwd?: string; envPrefix?: string; allowModelOverride?: boolean },
@@ -600,152 +604,23 @@ export function extractSessionId(text: string): string | null {
   return uniqueMatches.length === 1 ? uniqueMatches[0] : null;
 }
 
-export type LauncherSuffix = "Claude" | "Codex" | "Cursor" | "Gemini";
-
-const REPO_LAUNCHER_ALIASES: Record<string, string[]> = {
-  // The orchestrator checkout lives at ~/Gits/orchestrator, but the
-  // repoGolem registry key is `orc`, so the launchers are orcClaude/Codex/Cursor.
-  orchestrator: ["orc"],
-};
-
-/**
- * Ordered, de-duplicated launcher-name candidates for a repo + suffix.
- *
- * The repoGolem registry emits launcher function names INCONSISTENTLY per repo
- * (see ~/.config/ralphtools/golem-dispatch.zsh `_golem_register_wrappers`):
- *   - the primary wrapper uses the lowercased, hyphen-stripped registry key
- *     (`${(L)name}` -> `agenthtmlhostCursor`), and
- *   - the P10 "hyphen-aware verbatim alias" is emitted ONLY for some repos
- *     (`agent-html-hostCursor` exists for `maakaf-home`/`skill-creator` but
- *     NOT for `agent-html-host`).
- *
- * AIDEV-NOTE: R-039(cmuxlayer-code: launcher-name resolution) is distinct from weave-registry R-038 (wait_for(done) transcript ground-truth) and weave-registry R-039 (delta-wave coverage).
- *
- * cmuxlayer cannot know which form a given repo registered, so we generate
- * both and probe in order. Candidate #1 preserves today's behavior (verbatim
- * dir name); candidate #2 matches the registry's primary wrapper.
- */
-export function launcherNameCandidates(
-  repo: string,
-  suffix: LauncherSuffix,
-): string[] {
-  const safeRepo = sanitizeRepoName(repo);
-  const prefixes = [
-    safeRepo,
-    safeRepo.replace(/-/g, "").toLowerCase(),
-    ...(REPO_LAUNCHER_ALIASES[safeRepo] ?? []),
-  ];
-  return [...new Set(prefixes)].map((prefix) => `${prefix}${suffix}`);
-}
-
-/** Returns true when a launcher function/command resolves in the login shell. */
-export type LauncherProbe = (launcher: string) => Promise<boolean>;
-
-const shellLauncherProbe: LauncherProbe = async (launcher) => {
-  const shell = process.env.SHELL || "/bin/zsh";
-  const probe = `type ${launcher} >/dev/null 2>&1 || command -v ${launcher} >/dev/null 2>&1`;
-  try {
-    await runDetachedShellProbe(shell, probe);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-function runDetachedShellProbe(shell: string, probe: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(shell, ["-ilc", probe], {
-      detached: true,
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    let timedOut = false;
-    let settled = false;
-    let postTermTimer: ReturnType<typeof setTimeout> | null = null;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      postTermTimer = setTimeout(() => {
-        child.kill("SIGKILL");
-        finishReject(
-          new Error("launcher probe failed to terminate after SIGTERM"),
-        );
-      }, 1_000);
-    }, 5_000);
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      if (postTermTimer) clearTimeout(postTermTimer);
-    };
-    const finishResolve = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve();
-    };
-    const finishReject = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-
-    child.once("error", (error) => {
-      finishReject(error);
-    });
-    child.once("exit", (code, signal) => {
-      if (timedOut) {
-        finishReject(new Error("launcher probe timed out"));
-        return;
-      }
-      if (code === 0) {
-        finishResolve();
-        return;
-      }
-      finishReject(
-        new Error(
-          `launcher probe exited with ${code ?? `signal ${signal ?? "unknown"}`}`,
-        ),
-      );
-    });
-  });
-}
-
-/**
- * Resolve the actual launcher function name by probing candidate forms in
- * order. Returns the first candidate that resolves in the login shell; throws a
- * clear registration error (listing every form tried) when none resolve. The
- * probe is injectable for deterministic tests.
- */
-export async function resolveLauncherName(
-  repo: string,
-  suffix: LauncherSuffix,
-  probe: LauncherProbe = shellLauncherProbe,
-): Promise<string> {
-  const candidates = launcherNameCandidates(repo, suffix);
-  for (const candidate of candidates) {
-    if (await probe(candidate)) {
-      return candidate;
-    }
-  }
-  throw new Error(
-    `Launcher not found for repo "${repo}". Tried: ${candidates.join(", ")}. ` +
-      `The repoGolem registry may strip hyphens (e.g. "agent-html-host" -> ` +
-      `"agenthtmlhostCursor"). Register the launcher in golem-powers or use ` +
-      `cli="kiro" which uses a direct cd+exec path.`,
-  );
-}
-
 /**
  * Validate that a launcher is registered and return its resolved name. Probes
- * candidate forms so multi-hyphen repos that registered a stripped name resolve
- * instead of failing on the naive verbatim guess.
+ * the launcher registry instead of executing shell profile code.
  */
 export async function assertLauncherAvailable(
   repo: string,
   suffix: LauncherSuffix,
 ): Promise<string> {
-  return resolveLauncherName(repo, suffix);
+  const cli =
+    suffix === "Claude"
+      ? "claude"
+      : suffix === "Codex"
+        ? "codex"
+        : suffix === "Cursor"
+          ? "cursor"
+          : "gemini";
+  return resolveLauncherNameFromRegistry(repo, cli);
 }
 
 export class AgentEngine {

--- a/src/launcher-registry.ts
+++ b/src/launcher-registry.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type { CliType } from "./agent-types.js";
+import { sanitizeRepoName } from "./agent-command.js";
+
+export const DEFAULT_LAUNCHER_REGISTRY_PATH = join(
+  homedir(),
+  ".config/ralphtools/launchers.zsh",
+);
+
+export interface LauncherRegistryEntry {
+  prefix: string;
+  path: string;
+  repoBasename: string;
+}
+
+export interface LauncherRegistryOptions {
+  sourcePath?: string;
+  entries?: LauncherRegistryEntry[];
+  readRegistry?: (path: string) => string;
+}
+
+export type LauncherSuffix = "Claude" | "Codex" | "Cursor" | "Gemini";
+
+const CLI_SUFFIX: Partial<Record<CliType, LauncherSuffix>> = {
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+  gemini: "Gemini",
+};
+
+const LAUNCHER_SUFFIXES: LauncherSuffix[] = [
+  "Claude",
+  "Codex",
+  "Cursor",
+  "Gemini",
+];
+
+function registryPath(options?: LauncherRegistryOptions): string {
+  return (
+    options?.sourcePath ??
+    process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH ??
+    DEFAULT_LAUNCHER_REGISTRY_PATH
+  );
+}
+
+function normalizeLauncherKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[-_\s]/g, "");
+}
+
+function shellWords(line: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of line) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#") break;
+    if (/\s/.test(char)) {
+      if (current) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaped) current += "\\";
+  if (current) words.push(current);
+  return words;
+}
+
+export function parseLauncherRegistry(
+  input: string,
+  _sourcePath: string,
+): LauncherRegistryEntry[] {
+  const entries: LauncherRegistryEntry[] = [];
+  for (const line of input.split(/\r?\n/)) {
+    const words = shellWords(line.trim());
+    if (words[0] !== "repoGolem" || words.length < 3) continue;
+    const [, prefix, path] = words;
+    if (!prefix || !path) continue;
+    entries.push({
+      prefix,
+      path,
+      repoBasename: basename(path),
+    });
+  }
+  return entries;
+}
+
+function loadLauncherRegistry(
+  options?: LauncherRegistryOptions,
+): { entries: LauncherRegistryEntry[]; sourcePath: string } {
+  const sourcePath = registryPath(options);
+  if (options?.entries) return { entries: options.entries, sourcePath };
+  const reader = options?.readRegistry ?? ((path: string) => readFileSync(path, "utf8"));
+  let input: string;
+  try {
+    input = reader(sourcePath);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Launcher registry unavailable at ${sourcePath}: ${reason}. ` +
+        "Register repoGolem launchers before using spawn_agent.",
+    );
+  }
+  return {
+    entries: parseLauncherRegistry(input, sourcePath),
+    sourcePath,
+  };
+}
+
+export function resolveLauncherPrefix(
+  input: string,
+  entries: readonly LauncherRegistryEntry[],
+): string | null {
+  const normalized = normalizeLauncherKey(input);
+  for (const entry of entries) {
+    if (
+      normalizeLauncherKey(entry.prefix) === normalized ||
+      normalizeLauncherKey(entry.repoBasename) === normalized ||
+      normalizeLauncherKey(entry.path) === normalized
+    ) {
+      return entry.prefix;
+    }
+  }
+  return null;
+}
+
+function launcherName(prefix: string, suffix: LauncherSuffix): string {
+  return `${prefix}${suffix}`;
+}
+
+function registeredLauncherSummary(
+  entries: readonly LauncherRegistryEntry[],
+): string {
+  if (entries.length === 0) return "(none parsed)";
+  return entries
+    .map((entry) => {
+      const names = LAUNCHER_SUFFIXES.map((suffix) =>
+        launcherName(entry.prefix, suffix),
+      ).join(", ");
+      return `${entry.prefix} (${entry.repoBasename} at ${entry.path}): ${names}`;
+    })
+    .join("; ");
+}
+
+export function launcherNameCandidates(
+  repo: string,
+  suffix: LauncherSuffix,
+  entries?: readonly LauncherRegistryEntry[],
+): string[] {
+  const safeRepo = sanitizeRepoName(repo);
+  const prefixes = [safeRepo, safeRepo.replace(/-/g, "").toLowerCase()];
+  const registeredPrefix = entries
+    ? resolveLauncherPrefix(repo, entries)
+    : null;
+  if (registeredPrefix) prefixes.push(registeredPrefix);
+  return [...new Set(prefixes)].map((prefix) => launcherName(prefix, suffix));
+}
+
+export function resolveLauncherNameFromRegistry(
+  repo: string,
+  cli: CliType,
+  options?: LauncherRegistryOptions,
+): string {
+  const suffix = CLI_SUFFIX[cli];
+  if (!suffix) return sanitizeRepoName(repo);
+
+  const { entries, sourcePath } = loadLauncherRegistry(options);
+  const registeredPrefix = resolveLauncherPrefix(repo, entries);
+  if (registeredPrefix) return launcherName(registeredPrefix, suffix);
+
+  const candidates = launcherNameCandidates(repo, suffix);
+  throw new Error(
+    `Launcher registry miss for repo "${repo}" cli="${cli}". ` +
+      `Resolved candidates: ${candidates.join(", ")}. ` +
+      `Registry source: ${sourcePath}. ` +
+      `Registered launchers: ${registeredLauncherSummary(entries)}.`,
+  );
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -22,10 +22,9 @@ import {
   buildLaunchCommand,
   buildResumeCommand,
   extractSessionId,
-  launcherNameCandidates,
-  resolveLauncherName,
   resolveSweepTiming,
 } from "../src/agent-engine.js";
+import { launcherNameCandidates } from "../src/launcher-registry.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
@@ -5357,6 +5356,37 @@ To continue this session, run codex resume ${sessionId}`,
         }
       },
     );
+
+    it("uses the launcher registry and fails loudly before any bare split fallback", async () => {
+      const registryPath = join(TEST_DIR, "launchers.zsh");
+      writeFileSync(
+        registryPath,
+        'repoGolem mm "/Users/etanheyman/Gits/matchmat"\n',
+      );
+      vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      const defaultEngine = new AgentEngine(stateMgr, registry, mockClient);
+      try {
+        await expect(
+          defaultEngine.spawnAgent({
+            repo: "missinglauncher",
+            model: "test",
+            cli: "claude",
+            prompt: "",
+            cwd: "/tmp/cmux-worktree",
+          }),
+        ).rejects.toThrow(
+          /Launcher registry miss.*missinglauncherClaude.*launchers\.zsh.*\/Users\/etanheyman\/Gits\/matchmat.*mmClaude/s,
+        );
+        expect(mockClient.newSplit).not.toHaveBeenCalled();
+        expect(mockClient.send).not.toHaveBeenCalled();
+        expect(stateMgr.listStates()).toHaveLength(0);
+      } finally {
+        defaultEngine.dispose();
+        vi.unstubAllEnvs();
+      }
+    });
   });
 
   describe("waitForAll", () => {
@@ -6308,97 +6338,46 @@ describe("buildLaunchCommand", () => {
 });
 
 describe("assertLauncherAvailable", () => {
+  const registryPath = join(TEST_DIR, "assert-launchers.zsh");
+
   beforeEach(() => {
-    spawnMock.mockReset();
-    vi.stubEnv("SHELL", "/bin/zsh");
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(
+      registryPath,
+      [
+        'repoGolem brainlayer "/Users/etanheyman/Gits/brainlayer"',
+        'repoGolem agenthtmlhost "/Users/etanheyman/Gits/agent-html-host"',
+        'repoGolem orc "/Users/etanheyman/Gits/orchestrator"',
+      ].join("\n"),
+    );
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("resolves to the verbatim launcher name when the probe returns 0", async () => {
-    spawnMock.mockImplementation(() => mockSpawnExit(0));
-
+  it("resolves to the registered launcher name from launchers.zsh", async () => {
     await expect(assertLauncherAvailable("brainlayer", "Cursor")).resolves.toBe(
       "brainlayerCursor",
     );
-
-    expect(spawnMock).toHaveBeenCalledWith(
-      "/bin/zsh",
-      [
-        "-ilc",
-        "type brainlayerCursor >/dev/null 2>&1 || command -v brainlayerCursor >/dev/null 2>&1",
-      ],
-      {
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-      },
-    );
   });
 
-  it("falls back to the hyphen-stripped launcher when verbatim is unregistered", async () => {
-    // agent-html-host registered only as agenthtmlhostCursor (hyphens stripped).
-    spawnMock.mockImplementation((_cmd, args) => {
-      const probe = String(args?.[1] ?? "");
-      if (probe.includes("agenthtmlhostCursor")) {
-        return mockSpawnExit(0);
-      }
-      return mockSpawnExit(1);
-    });
-
+  it("resolves the registry prefix when it differs from the repo basename", async () => {
     await expect(
       assertLauncherAvailable("agent-html-host", "Cursor"),
     ).resolves.toBe("agenthtmlhostCursor");
+    await expect(
+      assertLauncherAvailable("orchestrator", "Cursor"),
+    ).resolves.toBe("orcCursor");
   });
 
-  it("throws listing every candidate when none resolve", async () => {
-    spawnMock.mockImplementation(() => mockSpawnExit(1));
-
+  it("throws with candidates, source, and registered launchers when missing", async () => {
     await expect(
       assertLauncherAvailable("skill-creator", "Cursor"),
-    ).rejects.toThrow(/skill-creatorCursor.*skillcreatorCursor.*cli="kiro"/s);
-  });
-
-  it("waits for the launcher probe process to exit after SIGTERM timeout", async () => {
-    vi.useFakeTimers();
-    let exitCallback: ((code: number | null, signal: NodeJS.Signals | null) => void)
-      | null = null;
-    const child = {
-      kill: vi.fn(),
-      once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
-        if (event === "exit") {
-          exitCallback = callback as typeof exitCallback;
-        }
-        return child;
-      }),
-    };
-    spawnMock.mockImplementation(() => child);
-
-    try {
-      const probe = assertLauncherAvailable("brainlayer", "Cursor");
-      let settled = false;
-      probe.then(
-        () => {
-          settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
-
-      await vi.advanceTimersByTimeAsync(5_000);
-      await Promise.resolve();
-
-      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(settled).toBe(false);
-
-      exitCallback?.(null, "SIGTERM");
-      await expect(probe).rejects.toThrow(/Launcher not found/);
-    } finally {
-      vi.useRealTimers();
-    }
+    ).rejects.toThrow(
+      /Launcher registry miss.*skill-creatorCursor.*skillcreatorCursor.*assert-launchers\.zsh.*brainlayerCursor/s,
+    );
   });
 });
 
@@ -6410,7 +6389,15 @@ describe("launcherNameCandidates", () => {
   });
 
   it("includes the repoGolem orc alias for orchestrator", () => {
-    expect(launcherNameCandidates("orchestrator", "Cursor")).toEqual([
+    expect(
+      launcherNameCandidates("orchestrator", "Cursor", [
+        {
+          prefix: "orc",
+          path: "/Users/etanheyman/Gits/orchestrator",
+          repoBasename: "orchestrator",
+        },
+      ]),
+    ).toEqual([
       "orchestratorCursor",
       "orcCursor",
     ]);
@@ -6428,41 +6415,6 @@ describe("launcherNameCandidates", () => {
       "maakaf-homeClaude",
       "maakafhomeClaude",
     ]);
-  });
-});
-
-describe("resolveLauncherName", () => {
-  it("returns the verbatim launcher when it resolves first", async () => {
-    const probe = vi.fn(async (name: string) => name === "maakaf-homeCursor");
-    await expect(
-      resolveLauncherName("maakaf-home", "Cursor", probe),
-    ).resolves.toBe("maakaf-homeCursor");
-    expect(probe).toHaveBeenCalledWith("maakaf-homeCursor");
-  });
-
-  it("probes the stripped form only after the verbatim form misses", async () => {
-    const probe = vi.fn(async (name: string) => name === "agenthtmlhostCursor");
-    await expect(
-      resolveLauncherName("agent-html-host", "Cursor", probe),
-    ).resolves.toBe("agenthtmlhostCursor");
-    expect(probe).toHaveBeenNthCalledWith(1, "agent-html-hostCursor");
-    expect(probe).toHaveBeenNthCalledWith(2, "agenthtmlhostCursor");
-  });
-
-  it("falls back to the orc launcher alias for the orchestrator repo", async () => {
-    const probe = vi.fn(async (name: string) => name === "orcCursor");
-    await expect(
-      resolveLauncherName("orchestrator", "Cursor", probe),
-    ).resolves.toBe("orcCursor");
-    expect(probe).toHaveBeenNthCalledWith(1, "orchestratorCursor");
-    expect(probe).toHaveBeenNthCalledWith(2, "orcCursor");
-  });
-
-  it("throws when no candidate resolves", async () => {
-    const probe = vi.fn(async () => false);
-    await expect(
-      resolveLauncherName("agent-html-host", "Cursor", probe),
-    ).rejects.toThrow(/agent-html-hostCursor.*agenthtmlhostCursor/s);
   });
 });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5339,6 +5339,13 @@ To continue this session, run codex resume ${sessionId}`,
     ] as const)(
       "rejects missing %s repoGolem launchers before creating a surface",
       async (cli, suffix) => {
+        const registryPath = join(TEST_DIR, `missing-${cli}-launchers.zsh`);
+        writeFileSync(
+          registryPath,
+          'repoGolem mm "/Users/etanheyman/Gits/matchmat"\n',
+        );
+        vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+
         const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
         const defaultEngine = new AgentEngine(stateMgr, registry, mockClient);
         try {
@@ -5353,6 +5360,7 @@ To continue this session, run codex resume ${sessionId}`,
           expect(mockClient.newSplit).not.toHaveBeenCalled();
         } finally {
           defaultEngine.dispose();
+          vi.unstubAllEnvs();
         }
       },
     );

--- a/tests/launcher-registry.test.ts
+++ b/tests/launcher-registry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseLauncherRegistry,
+  resolveLauncherNameFromRegistry,
+  resolveLauncherPrefix,
+} from "../src/launcher-registry.js";
+
+const REGISTRY = `
+# comments and blanks are ignored
+repoGolem mm "/Users/etanheyman/Gits/matchmat"
+repoGolem cmuxlayer "/Users/etanheyman/Gits/cmuxlayer"
+repoGolem hyphen "/Users/etanheyman/Gits/hyphen-repo"
+`;
+
+describe("launcher registry", () => {
+  it("parses repoGolem prefix/path entries including prefix != basename", () => {
+    expect(parseLauncherRegistry(REGISTRY, "/tmp/launchers.zsh")).toEqual([
+      {
+        prefix: "mm",
+        path: "/Users/etanheyman/Gits/matchmat",
+        repoBasename: "matchmat",
+      },
+      {
+        prefix: "cmuxlayer",
+        path: "/Users/etanheyman/Gits/cmuxlayer",
+        repoBasename: "cmuxlayer",
+      },
+      {
+        prefix: "hyphen",
+        path: "/Users/etanheyman/Gits/hyphen-repo",
+        repoBasename: "hyphen-repo",
+      },
+    ]);
+  });
+
+  it("resolves a repo basename and direct prefix to the registered prefix", () => {
+    const entries = parseLauncherRegistry(REGISTRY, "/tmp/launchers.zsh");
+
+    expect(resolveLauncherPrefix("matchmat", entries)).toBe("mm");
+    expect(resolveLauncherPrefix("mm", entries)).toBe("mm");
+    expect(resolveLauncherPrefix("hyphen_repo", entries)).toBe("hyphen");
+  });
+
+  it("returns registered launcher names for repo names and prefixes", () => {
+    const entries = parseLauncherRegistry(REGISTRY, "/tmp/launchers.zsh");
+
+    expect(
+      resolveLauncherNameFromRegistry("matchmat", "claude", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toBe("mmClaude");
+    expect(
+      resolveLauncherNameFromRegistry("mm", "claude", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toBe("mmClaude");
+  });
+
+  it("throws a self-answering miss error with source and registered launchers", () => {
+    const entries = parseLauncherRegistry(REGISTRY, "/tmp/launchers.zsh");
+
+    expect(() =>
+      resolveLauncherNameFromRegistry("unknown", "claude", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toThrow(
+      /Launcher registry miss.*unknownClaude.*\/tmp\/launchers\.zsh.*matchmat.*mmClaude.*mmCodex/s,
+    );
+  });
+
+  it("reports a missing registry file as a clear registry error", () => {
+    expect(() =>
+      resolveLauncherNameFromRegistry("matchmat", "claude", {
+        readRegistry: () => {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        },
+        sourcePath: "/missing/launchers.zsh",
+      }),
+    ).toThrow(/Launcher registry unavailable.*\/missing\/launchers\.zsh/s);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace spawn launcher preflight shell probing with a parser/resolver for `~/.config/ralphtools/launchers.zsh` `repoGolem <prefix> <path>` entries.
- Resolve launcher names by registered prefix for both repo basename and direct prefix inputs, so `matchmat` and `mm` resolve to `mmClaude`/`mmCodex`/etc.
- Make launcher misses fail before surface creation with a self-answering error that includes resolved candidates, registry source, and registered launcher names/paths.
- Preserve the no-bare-fallback boundary: default `spawn_agent` preflight now fails before `newSplit`/send/state creation when the registry cannot resolve the launcher.

## Episode
`spawn_agent(repo:"matchmat", cli:"claude")` previously derived `matchmatClaude`, missed the actual `mmClaude` registry function, and could degrade into a bare split. This PR makes the registry lookup authoritative for cmuxlayer launch names so that a failed lookup is loud and pre-spawn.

## Tests
- [x] `bun run typecheck`
- [x] `bun run test` (78 files, 1443 tests)
- [x] Push hook reran tests and exited 0
- [x] Pre-commit CodeRabbit attempted with `timeout 180s coderabbit review --agent`; timed out while still reviewing, no findings returned.

## Item D findings
Observed but not implemented here: launcher authority is split across `~/.config/ralphtools/launchers.zsh` as the actual working registry, `golems.registry.json` with no launcher prefix data, and fleet-canon rule 6 claiming `launcherPrefix` overrides are authoritative. This should be reconciled in the golems repo by crowning one source of truth and sweeping the `.pre-p10-bak` hand-edit siblings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn preflight for all launcher CLIs; behavior now depends on registry file presence and parsing instead of live shell resolution, though tests cover misses and prefix aliases.
> 
> **Overview**
> **Spawn preflight** no longer probes the login shell with `type`/`command -v`; it reads and parses `~/.config/ralphtools/launchers.zsh` (`repoGolem <prefix> <path>` lines) via new **`launcher-registry.ts`**.
> 
> **`assertLauncherAvailable`** maps CLI suffix to **`resolveLauncherNameFromRegistry`**, which matches repo basename, prefix, or path (normalized) and returns names like **`mmClaude`**. Overrides: **`CMUXLAYER_LAUNCHER_REGISTRY_PATH`** or injectable options for tests.
> 
> On a miss, spawn fails **before** `newSplit`/send with an error listing candidates, registry path, and registered launchers—avoiding wrong names (e.g. `matchmatClaude` vs `mmClaude`) and bare-split fallback. **`launcherNameCandidates`** and related types move out of **`agent-engine.ts`**; the hardcoded **`orchestrator` → `orc`** alias is replaced by registry prefix resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05bf83258aa83fa769a72dd65ab4b1c4a2fefe13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace shell-probe launcher resolution with registry-based resolution in `assertLauncherAvailable`
> - Removes shell-spawning launcher probes (`shellLauncherProbe`, `runDetachedShellProbe`, `resolveLauncherName`) from [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/255/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) in favour of a new [launcher-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/255/files#diff-8dbe1f62bf5830e9bf985cfd067c4d85a8af7dc9df4a4fabc375f8d16cb28d1a) module.
> - The new registry module parses `~/.config/ralphtools/launchers.zsh` (overridable via `CMUXLAYER_LAUNCHER_REGISTRY_PATH`) into structured entries and resolves launcher names by matching repo name, basename, or prefix.
> - `assertLauncherAvailable` now calls `resolveLauncherNameFromRegistry` and throws detailed errors including candidates, registry source, and all registered launchers on a miss.
> - Behavioral Change: launcher resolution no longer executes shell profile code; the registered prefix is used even when it differs from the repo basename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05bf832.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->