### PR TITLE
fix: default splits to caller workspace

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3489,8 +3489,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
-  /** Caller pane workspace ref first, then focused workspace as fallback. */
-  const currentCallerWorkspace = async (): Promise<string | undefined> => {
+  const callerWorkspaceStrict = async (): Promise<string | undefined> => {
     try {
       const { workspaces } = await client.listWorkspaces();
       const envCandidates = [
@@ -3506,10 +3505,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
         if (match) return match.ref;
       }
-      return workspaces.find((w) => w.selected)?.ref;
     } catch {
       return undefined;
     }
+    return undefined;
+  };
+
+  /** Caller pane workspace ref first, then focused workspace as fallback. */
+  const currentCallerWorkspace = async (): Promise<string | undefined> => {
+    const callerWorkspace = await callerWorkspaceStrict();
+    return callerWorkspace ?? (await currentFocusedWorkspace());
   };
 
   /** Currently-focused workspace ref, or undefined if it can't be read. */
@@ -3520,6 +3525,41 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     } catch {
       return undefined;
     }
+  };
+
+  const focusedWorkspaceFallbackWarning =
+    "No explicit workspace, caller workspace, or repo workspace could be resolved; falling back to the currently focused workspace.";
+
+  const resolvePlacementWorkspace = async (opts: {
+    explicitWorkspace?: string;
+    callerWorkspace?: string;
+    repo?: string | null;
+    allowFocusedFallback?: boolean;
+  }): Promise<{ workspace?: string; warnings: string[] }> => {
+    const explicitWorkspace = opts.explicitWorkspace
+      ? await canonicalWorkspaceRef(opts.explicitWorkspace)
+      : undefined;
+    if (explicitWorkspace) return { workspace: explicitWorkspace, warnings: [] };
+
+    const callerWorkspace = opts.callerWorkspace ?? (await callerWorkspaceStrict());
+    if (callerWorkspace) return { workspace: callerWorkspace, warnings: [] };
+
+    const repoWorkspace = await resolveWorkspaceForRepo(opts.repo);
+    if (repoWorkspace) return { workspace: repoWorkspace, warnings: [] };
+
+    if (opts.allowFocusedFallback === false) {
+      return { workspace: undefined, warnings: [] };
+    }
+
+    const focusedWorkspace = await currentFocusedWorkspace();
+    if (focusedWorkspace) {
+      return {
+        workspace: focusedWorkspace,
+        warnings: [focusedWorkspaceFallbackWarning],
+      };
+    }
+
+    return { workspace: undefined, warnings: [] };
   };
 
   /**
@@ -4244,11 +4284,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       let result: CmuxNewSplitResult | undefined;
       try {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
-        const targetWorkspace =
-          args.workspace ??
-          (await resolveWorkspaceForRepo(
-            inferRepoFromLauncherTitle(args.title),
-          ));
         const shouldInferRole =
           Boolean(args.role) ||
           (!args.pane &&
@@ -4266,11 +4301,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "pane/surface cannot be combined with role-based new_split; omit the explicit target or omit role",
           );
         }
-        if (args.surface) {
-          await assertSurfaceMutationAllowed("new_split", args.surface);
-        } else if (targetWorkspace) {
-          await assertWorkspaceMutationAllowed("new_split", targetWorkspace);
-        }
         if (bootPromptPath) {
           if ((args.type ?? "terminal") !== "terminal") {
             throw new Error(
@@ -4278,6 +4308,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
           await preflightBootPromptFile(bootPromptPath);
+        }
+        const targetResolution =
+          args.pane || args.surface
+            ? {
+                workspace: args.workspace,
+                warnings: [],
+              }
+            : await resolvePlacementWorkspace({
+                explicitWorkspace: args.workspace,
+                repo: inferRepoFromLauncherTitle(args.title),
+              });
+        const targetWorkspace = targetResolution.workspace;
+        if (args.surface) {
+          await assertSurfaceMutationAllowed("new_split", args.surface);
+        } else if (targetWorkspace) {
+          await assertWorkspaceMutationAllowed("new_split", targetWorkspace);
         }
 
         // Auto-focus only applies to workspace-targeted splits (no explicit
@@ -4407,6 +4453,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const data: Record<string, unknown> = { ...result };
         data.placement = actualPlacement;
         data.direction = actualDirection;
+        if (targetResolution.warnings.length > 0) {
+          data.warnings = targetResolution.warnings;
+        }
         if (inferredRole) {
           data.role = inferredRole;
         }
@@ -6414,10 +6463,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? (engine.getAgentState(args.parent_agent_id)?.workspace_id ??
               undefined)
             : undefined;
-          const explicitWorkspace = await canonicalWorkspaceRef(args.workspace);
-          const spawnWorkspace =
-            explicitWorkspace ??
-            (args.parent_agent_id ? undefined : await currentCallerWorkspace());
+          const targetResolution = await resolvePlacementWorkspace({
+            explicitWorkspace: args.workspace,
+            callerWorkspace: parentWorkspace,
+            repo: args.repo,
+          });
+          const spawnWorkspace = targetResolution.workspace;
           const comparisonWorkspace = spawnWorkspace ?? parentWorkspace;
           await assertWorkspaceMutationAllowed("spawn_agent", comparisonWorkspace);
           const worktree = await prepareSpawnWorktree(
@@ -6490,6 +6541,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             crash_recover: args.crash_recover,
           });
           appendStaleBuildWarning(result);
+          if (targetResolution.warnings.length > 0) {
+            result.warnings = [
+              ...(result.warnings ?? []),
+              ...targetResolution.warnings,
+            ];
+          }
 
           let bootPromptDelivery:
             | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -6698,14 +6755,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           assertBootPromptMode(args.prompt, null);
-          const explicitWorkspace = await canonicalWorkspaceRef(args.workspace);
-          const mutationWorkspace =
-            explicitWorkspace ?? (await currentCallerWorkspace());
+          await refreshManagedMetadataBestEffort(args.parent_agent_id);
+          const parentWorkspace = args.parent_agent_id
+            ? (engine.getAgentState(args.parent_agent_id)?.workspace_id ??
+              undefined)
+            : undefined;
+          const targetResolution = await resolvePlacementWorkspace({
+            explicitWorkspace: args.workspace,
+            callerWorkspace: parentWorkspace,
+            repo: args.repo,
+          });
+          const mutationWorkspace = targetResolution.workspace;
           await assertWorkspaceMutationAllowed(
             "new_worktree_split",
             mutationWorkspace,
           );
-          const priorFocus = await focusTargetBeforeSplit(args.workspace);
+          const priorFocus = await focusTargetBeforeSplit(mutationWorkspace);
           const worktree = await prepareSpawnWorktree(
             args.repo,
             args.worktree ?? true,
@@ -6718,7 +6783,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             cli: args.cli,
             prompt: args.prompt ?? "",
             boot_prompt_pending: hasPrompt,
-            workspace: args.workspace,
+            workspace: mutationWorkspace,
             cwd: worktree.prepared?.path,
             mcp_env: worktree.mcpEnv,
             mcp_profile_label: worktree.mcpProfileLabel,
@@ -6729,6 +6794,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             crash_recover: args.crash_recover,
           });
           appendStaleBuildWarning(result);
+          if (targetResolution.warnings.length > 0) {
+            result.warnings = [
+              ...(result.warnings ?? []),
+              ...targetResolution.warnings,
+            ];
+          }
 
           let bootPromptDelivery:
             | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -6736,7 +6807,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (hasPrompt) {
             const deliveryWorkspace = spawnDeliveryWorkspace(
               result,
-              args.workspace,
+              mutationWorkspace,
             );
             bootPromptDelivery = await deliverBootPrompt({
               surface: result.surface_id,
@@ -6764,7 +6835,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await restoreFocusAfterRender(
             priorFocus,
             result.surface_id,
-            spawnDeliveryWorkspace(result, args.workspace),
+            spawnDeliveryWorkspace(result, mutationWorkspace),
           );
           await refreshManagedMetadataBestEffort(result.agent_id);
           const currentAgent = engine.getAgentState(result.agent_id);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -664,7 +664,7 @@ describe("agent lifecycle tool handlers", () => {
     ).toBe(false);
   });
 
-  it("spawn_agent inherits the selected workspace when workspace is omitted", async () => {
+  it("spawn_agent uses the repo workspace before the selected workspace when caller env is absent", async () => {
     const calls: string[] = [];
     const mockClient = {
       createWorkspace: vi.fn(),
@@ -677,23 +677,23 @@ describe("agent lifecycle tool handlers", () => {
             ref: "workspace:1",
             title: "Collab",
             selected: true,
-            current_directory: "/Users/etanheyman/Gits/orchestrator",
+            current_directory: "/repo/orchestrator",
           },
           {
             ref: "workspace:5",
             title: "SkillCreator",
             selected: false,
-            current_directory: "/Users/etanheyman/Gits/skillcreator",
+            current_directory: "/repo/skillcreator",
           },
         ],
       }),
       listPanes: vi.fn().mockResolvedValue({
-        workspace_ref: "workspace:1",
+        workspace_ref: "workspace:5",
         window_ref: "window:1",
         panes: [],
       }),
       listPaneSurfaces: vi.fn().mockResolvedValue({
-        workspace_ref: "workspace:1",
+        workspace_ref: "workspace:5",
         window_ref: "window:1",
         pane_ref: "pane:1",
         surfaces: [],
@@ -729,7 +729,7 @@ describe("agent lifecycle tool handlers", () => {
           type: "terminal",
           index: 0,
           selected: true,
-          workspace_ref: "workspace:1",
+          workspace_ref: "workspace:5",
         },
       ]),
       identify: vi.fn().mockResolvedValue({}),
@@ -755,9 +755,9 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.workspace_id).toBe("workspace:1");
-    expect(calls).toContain("spawn:workspace:1");
-    expect(calls).not.toContain("spawn:workspace:5");
+    expect(parsed.workspace_id).toBe("workspace:5");
+    expect(calls).toContain("spawn:workspace:5");
+    expect(calls).not.toContain("spawn:workspace:1");
   });
 
   it("spawn_agent prefers the caller pane workspace over the selected workspace when workspace is omitted", async () => {
@@ -780,14 +780,14 @@ describe("agent lifecycle tool handlers", () => {
               ref: "workspace:1",
               title: "Voice Remediation",
               selected: false,
-              current_directory: "/Users/etanheyman/Gits/orchestrator",
+              current_directory: "/repo/orchestrator",
             },
             {
               id: "selected-workspace-uuid",
               ref: "workspace:5",
               title: "Other Active Workspace",
               selected: true,
-              current_directory: "/Users/etanheyman/Gits/voicelayer",
+              current_directory: "/repo/voicelayer",
             },
           ],
         }),
@@ -1476,6 +1476,132 @@ describe("agent lifecycle tool handlers", () => {
         `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
+  });
+
+  it("new_worktree_split defaults to the caller workspace instead of the selected workspace", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    delete process.env.CMUX_TAB_ID;
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      const repoRoot = join(gitsDir, "cmuxlayer");
+      mkdirSync(repoRoot, { recursive: true });
+      const worktreeExec = vi.fn().mockImplementation(async () => {
+        mkdirSync(join(gitsDir, "cmuxlayer.wt", "caller-worker"), {
+          recursive: true,
+        });
+        return { stdout: "", stderr: "" };
+      });
+      const calls: string[] = [];
+      const mockClient = {
+        createWorkspace: vi.fn(),
+        selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+          calls.push(`select:${workspace}`);
+        }),
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:caller",
+              title: "Caller",
+              selected: false,
+              current_directory: "/repo/orchestrator",
+            },
+            {
+              id: "selected-workspace-uuid",
+              ref: "workspace:selected",
+              title: "Selected",
+              selected: true,
+              current_directory: "/repo/voicelayer",
+            },
+          ],
+        }),
+        listPanes: vi.fn().mockImplementation(async ({ workspace }) => ({
+          workspace_ref: workspace,
+          window_ref: "window:1",
+          panes: [],
+        })),
+        listPaneSurfaces: vi.fn().mockImplementation(async ({ workspace }) => ({
+          workspace_ref: workspace,
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [],
+        })),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => {
+          calls.push(`spawn:${opts.workspace}`);
+          return {
+            workspace: opts.workspace,
+            surface: "surface:caller-worktree",
+            pane: "pane:caller-worktree",
+            title: "",
+            type: "terminal",
+          };
+        }),
+        newSurface: vi.fn(),
+        send: vi.fn().mockResolvedValue(undefined),
+        sendKey: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:caller-worktree",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+        log: vi.fn().mockResolvedValue(undefined),
+        setStatus: vi.fn().mockResolvedValue(undefined),
+        clearStatus: vi.fn().mockResolvedValue(undefined),
+        setProgress: vi.fn().mockResolvedValue(undefined),
+        closeSurface: vi.fn().mockResolvedValue(undefined),
+        listSurfaces: vi.fn().mockResolvedValue([
+          {
+            ref: "surface:caller-worktree",
+            title: "cmuxlayerCodex",
+            type: "terminal",
+            index: 0,
+            selected: true,
+            workspace_ref: "workspace:caller",
+          },
+        ]),
+        identify: vi.fn().mockResolvedValue({}),
+        browser: vi.fn().mockResolvedValue({}),
+      };
+      const server = createTrackedServer({
+        client: mockClient as any,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const tool = (server as any)._registeredTools["new_worktree_split"];
+
+      const result = await tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "codex",
+          cli: "codex",
+          worktree: { name: "caller worker" },
+        },
+        {} as any,
+      );
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.workspace_id).toBe("workspace:caller");
+      expect(calls).toContain("spawn:workspace:caller");
+      expect(calls).not.toContain("spawn:workspace:selected");
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
   });
 
   it("new_worktree_split refuses a manual-mode caller workspace before worktree setup", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3990,6 +3990,314 @@ describe("tool handler integration", () => {
     expect(parsed.surface).toBe("surface:2");
   });
 
+  it("new_split defaults to the caller workspace instead of the selected workspace", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    delete process.env.CMUX_TAB_ID;
+    try {
+      const mockClient = {
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:caller",
+              title: "Caller",
+              selected: false,
+            },
+            {
+              id: "focused-workspace-uuid",
+              ref: "workspace:focused",
+              title: "Focused",
+              selected: true,
+            },
+          ],
+        }),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
+          workspace: opts.workspace,
+          surface: "surface:caller",
+          pane: "pane:caller",
+          title: "",
+          type: "terminal",
+        })),
+        renameTab: vi.fn().mockResolvedValue(undefined),
+        selectWorkspace: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:caller",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+      };
+      const server = createServer({
+        client: mockClient as any,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools["new_split"];
+
+      const result = await tool.handler({ direction: "right" }, {} as any);
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(mockClient.newSplit).toHaveBeenCalledWith(
+        "right",
+        expect.objectContaining({ workspace: "workspace:caller" }),
+      );
+      expect(mockClient.newSplit).not.toHaveBeenCalledWith(
+        "right",
+        expect.objectContaining({ workspace: "workspace:focused" }),
+      );
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
+  });
+
+  it("new_split honors an explicit workspace before caller and focused workspaces", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    delete process.env.CMUX_TAB_ID;
+    try {
+      const mockClient = {
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:caller",
+              title: "Caller",
+              selected: false,
+            },
+            {
+              id: "focused-workspace-uuid",
+              ref: "workspace:focused",
+              title: "Focused",
+              selected: true,
+            },
+            {
+              id: "explicit-workspace-uuid",
+              ref: "workspace:explicit",
+              title: "Explicit",
+              selected: false,
+            },
+          ],
+        }),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
+          workspace: opts.workspace,
+          surface: "surface:explicit",
+          pane: "pane:explicit",
+          title: "",
+          type: "terminal",
+        })),
+        renameTab: vi.fn().mockResolvedValue(undefined),
+        selectWorkspace: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:explicit",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+      };
+      const server = createServer({
+        client: mockClient as any,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools["new_split"];
+
+      const result = await tool.handler(
+        { direction: "right", workspace: "workspace:explicit" },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(mockClient.newSplit).toHaveBeenCalledWith(
+        "right",
+        expect.objectContaining({ workspace: "workspace:explicit" }),
+      );
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
+  });
+
+  it("new_split caller workspace wins over repo-title workspace resolution", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    delete process.env.CMUX_TAB_ID;
+    try {
+      const mockClient = {
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:caller",
+              title: "Caller",
+              selected: false,
+              current_directory: "/repo/orchestrator",
+            },
+            {
+              id: "voice-workspace-uuid",
+              ref: "workspace:voice",
+              title: "Voice",
+              selected: true,
+              current_directory: "/repo/voicelayer",
+            },
+          ],
+        }),
+        listPanes: vi.fn().mockImplementation(async ({ workspace }) => ({
+          workspace_ref: workspace,
+          window_ref: "window:1",
+          panes: [],
+        })),
+        listPaneSurfaces: vi.fn().mockResolvedValue({
+          workspace_ref: "workspace:caller",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [],
+        }),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
+          workspace: opts.workspace,
+          surface: "surface:caller",
+          pane: "pane:caller",
+          title: opts.title ?? "",
+          type: "terminal",
+        })),
+        newSurface: vi.fn(),
+        renameTab: vi.fn().mockResolvedValue(undefined),
+        selectWorkspace: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:caller",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+      };
+      const server = createServer({
+        client: mockClient as any,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools["new_split"];
+
+      const result = await tool.handler(
+        { direction: "right", title: "voicelayerCodex" },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(mockClient.listPanes).toHaveBeenCalledWith({
+        workspace: "workspace:caller",
+      });
+      expect(mockClient.newSplit).toHaveBeenCalledWith(
+        "right",
+        expect.objectContaining({ workspace: "workspace:caller" }),
+      );
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
+  });
+
+  it("new_split warns when it falls back to the focused workspace", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    delete process.env.CMUX_WORKSPACE_ID;
+    delete process.env.CMUX_TAB_ID;
+    try {
+      const mockClient = {
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              id: "caller-workspace-uuid",
+              ref: "workspace:caller",
+              title: "Caller",
+              selected: false,
+            },
+            {
+              id: "focused-workspace-uuid",
+              ref: "workspace:focused",
+              title: "Focused",
+              selected: true,
+            },
+          ],
+        }),
+        newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
+          workspace: opts.workspace,
+          surface: "surface:focused",
+          pane: "pane:focused",
+          title: "",
+          type: "terminal",
+        })),
+        renameTab: vi.fn().mockResolvedValue(undefined),
+        selectWorkspace: vi.fn().mockResolvedValue(undefined),
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:focused",
+          text: "Codex\n>",
+          lines: 1,
+          scrollback_used: false,
+        }),
+      };
+      const server = createServer({
+        client: mockClient as any,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools["new_split"];
+
+      const result = await tool.handler({ direction: "right" }, {} as any);
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(mockClient.newSplit).toHaveBeenCalledWith(
+        "right",
+        expect.objectContaining({ workspace: "workspace:focused" }),
+      );
+      expect(parsed.warnings).toEqual([
+        expect.stringContaining("focused workspace"),
+      ]);
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+    }
+  });
+
   it("new_split inherits workspace from a launcher-style title repo", async () => {
     const mockClient = {
       listWorkspaces: vi.fn().mockResolvedValue({
@@ -7060,9 +7368,17 @@ describe("tool handler integration", () => {
   });
 
   it("new_split renames the new surface when a title is provided", async () => {
-    mockExec = vi
-      .fn()
-      .mockResolvedValueOnce({
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [{ ref: "workspace:1", selected: true }],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
         stdout: JSON.stringify({
           workspace: "workspace:1",
           surface: "surface:2",
@@ -7071,8 +7387,10 @@ describe("tool handler integration", () => {
           type: "terminal",
         }),
         stderr: "",
-      })
-      .mockResolvedValueOnce({ stdout: "{}", stderr: "" });
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const registeredTools = (server as any)._registeredTools;
@@ -7080,8 +7398,7 @@ describe("tool handler integration", () => {
 
     await tool.handler({ direction: "right", title: "Build Task" }, {} as any);
 
-    expect(mockExec).toHaveBeenNthCalledWith(
-      2,
+    expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
         "rename-tab",


### PR DESCRIPTION
## Summary
- Fix workspace placement defaults for `new_split`, `spawn_agent`, and `new_worktree_split` so omitted `workspace` resolves to the caller or parent workspace before repo matching.
- Add a strict caller-workspace resolver for `CMUX_WORKSPACE_ID` / `CMUX_TAB_ID` and keep focused workspace as an explicit last-resort fallback only.
- Surface a warning when placement degrades all the way to the focused workspace.

## Bug
A caller that omitted `workspace` could spawn a split or worker into whichever workspace the user currently had focused. That broke co-working placement when the focused workspace differed from the calling agent's workspace.

## Root Cause
`new_split` skipped `currentCallerWorkspace()` entirely and fell straight through to repo-name resolution. Separately, `currentCallerWorkspace()` mixed caller-env lookup with focused-workspace fallback, so callers could not use caller inheritance without also silently accepting focused-workspace fallback.

## Precedence
1. Explicit `workspace` wins.
2. Caller or parent workspace from `CMUX_WORKSPACE_ID` / `CMUX_TAB_ID` wins next.
3. Repo-name workspace resolution is a fallback.
4. Focused workspace is last resort and emits a warning.

Explicit pane/surface anchors still avoid default workspace resolution because the anchor already pins placement.

## Test Plan
- [x] RED: targeted regressions failed before implementation for `new_split` caller default, caller-over-repo precedence, focused fallback warning, and `new_worktree_split` caller default.
- [x] `bunx vitest run tests/server.test.ts tests/server-agent-tools.test.ts -t "new_split defaults to the caller workspace|new_split honors an explicit workspace|new_split caller workspace wins|new_split warns when it falls back|spawn_agent prefers the caller pane workspace|new_worktree_split defaults to the caller workspace"`
- [x] `bun run typecheck`
- [x] `bun run test` - 77 files, 1447 tests passed
- [x] Push hook reran full test suite successfully (`run_tests.sh finished with exit status 0`)

## Review Notes
- `coderabbit review --agent` completed once and reported one minor fixture-sanitization issue; fixed by replacing personal fixture paths with generic `/repo/...` paths.
- A second CodeRabbit run after that fix hit the free OSS rate limit (`waitTime: 32 minutes`), so final local evidence is typecheck plus full suite after the fix.

Do not merge from this worker; lead owns merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default placement for mutating MCP tools (splits/spawns), which can surprise users who relied on focused-workspace behavior, but precedence is explicit and warnings surface the degraded case.
> 
> **Overview**
> Fixes **wrong workspace placement** when `workspace` is omitted: splits and spawns could land in the user’s **focused** tab instead of the calling agent’s workspace.
> 
> **`resolvePlacementWorkspace`** centralizes resolution with order: explicit `workspace` → caller env (`CMUX_WORKSPACE_ID` / `CMUX_TAB_ID`) or **parent agent workspace** → repo-matched workspace → **focused workspace last**, with a **`warnings`** entry when that last resort is used. **`callerWorkspaceStrict`** reads env only; focused fallback is no longer mixed into caller resolution.
> 
> **`new_split`**, **`spawn_agent`**, and **`new_worktree_split`** use this helper (pane/surface anchors still skip default resolution). **`new_worktree_split`** also uses the resolved workspace for focus restore and boot-prompt delivery instead of raw args.
> 
> Tests cover caller-over-focused, caller-over-repo-from-title, explicit workspace, focused fallback warning, and updated **`spawn_agent`** repo-before-selected behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c863aaf905e83950a1cdd713300a2ecb80571d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default workspace resolution for splits and agents to use caller workspace
> - Introduces `callerWorkspaceStrict` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/256/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that resolves a workspace from `CMUX_WORKSPACE_ID`/`CMUX_TAB_ID` env vars without falling back to the selected workspace.
> - Adds `resolvePlacementWorkspace` with a clear precedence: explicit → caller → repo → focused, emitting warnings when falling back to focused.
> - Updates `new_split`, `spawn_agent`, and `new_worktree_split` tool handlers to use `resolvePlacementWorkspace`, so splits and agents default to the caller's workspace rather than the selected workspace.
> - Behavioral Change: callers that previously received the selected workspace implicitly when no env match was present now receive the focused workspace or a warning instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8c863a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->