### PR TITLE
fix: restore CLI paste path for socket client

### DIFF
--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -31,8 +31,6 @@ export { CmuxSocketError } from "./cmux-socket-error.js";
 // ── Configuration ──────────────────────────────────────────────────────
 
 const REQUEST_TIMEOUT_MS = 10_000;
-const BRACKETED_PASTE_START = "\x1b[200~";
-const BRACKETED_PASTE_END = "\x1b[201~";
 const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
 const RETRY_SAFE_V2_METHODS = new Set([
   "system.ping",
@@ -496,22 +494,15 @@ export class CmuxSocketClient {
     text: string,
     opts?: { workspace?: string },
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(surface, opts?.workspace);
-    const params: Record<string, unknown> = {
-      surface_id: surface,
-      text: `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`,
-      workspace_id: workspace,
-    };
-
-    try {
-      await this.call("surface.send_text", params);
-      return;
-    } catch (error) {
-      if (!this.isMethodNotFound(error) || !this.cliFallback) {
-        throw error;
-      }
+    const cliFallback = this.cliFallbackPinned();
+    if (cliFallback) {
+      return cliFallback.pasteText(surface, text, opts);
     }
-    await this.cliFallbackPinned()!.pasteText(surface, text, opts);
+
+    throw new CmuxSocketError(
+      "Atomic multiline paste requires the cmux CLI paste-buffer path; the socket protocol has no paste RPC, so pasteText is unavailable on a socket-only transport.",
+      "method_not_found",
+    );
   }
 
   async sendKey(

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -1048,51 +1048,68 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
     expect(result.surface).toBe("surface:cli-tab");
   });
 
-  it("pasteText sends bracketed paste over the socket without CLI fallback", async () => {
+  it("pasteText fails loudly without a CLI fallback instead of sending raw markers", async () => {
     const client = new CmuxSocketClient({
       socketPath: MOCK_SOCKET_PATH,
       timeoutMs: 1000,
+    });
+
+    await expect(
+      client.pasteText("surface:1", "line one\nline two", {
+        workspace: "workspace:1",
+      }),
+    ).rejects.toMatchObject({
+      name: "CmuxSocketError",
+      code: "method_not_found",
+      message: expect.stringContaining("requires the cmux CLI"),
+    });
+
+    expect(lastV2Request).toBeNull();
+  });
+
+  it("pasteText uses CLI paste-buffer fallback without sending bracketed markers over the socket", async () => {
+    const execCalls: Array<{
+      cmd: string;
+      args: string[];
+      env?: NodeJS.ProcessEnv;
+    }> = [];
+    const cliFallback = new CmuxClient({
+      exec: async (cmd, args, env) => {
+        execCalls.push({ cmd, args, env });
+        return { stdout: "{}", stderr: "" };
+      },
+    });
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback,
     });
 
     await client.pasteText("surface:1", "line one\nline two", {
       workspace: "workspace:1",
     });
 
-    expect(lastV2Request).toEqual({
-      method: "surface.send_text",
-      params: {
-        surface_id: "surface:1",
-        text: "\x1b[200~line one\nline two\x1b[201~",
-        workspace_id: "workspace:1",
-      },
-    });
-  });
-
-  it("pasteText uses CLI fallback when surface.send_text is unavailable", async () => {
-    const saved = MOCK_RESPONSES["surface.send_text"];
-    delete MOCK_RESPONSES["surface.send_text"];
-    try {
-      const client = new CmuxSocketClient({
-        socketPath: MOCK_SOCKET_PATH,
-        cliFallback: createMockCli(),
-      });
-
-      await client.pasteText("surface:1", "line one\nline two", {
-        workspace: "workspace:1",
-      });
-
-      expect(cliCalls).toHaveLength(1);
-      expect(cliCalls[0]).toEqual({
-        method: "pasteText",
-        args: [
-          "surface:1",
-          "line one\nline two",
-          { workspace: "workspace:1" },
-        ],
-      });
-    } finally {
-      MOCK_RESPONSES["surface.send_text"] = saved;
-    }
+    expect(lastV2Request).toBeNull();
+    expect(execCalls).toHaveLength(2);
+    expect(execCalls[0].args).toEqual([
+      "--json",
+      "set-buffer",
+      "--name",
+      expect.stringMatching(/^cmuxlayer-workspace-1-surface-1-/),
+      "--",
+      "line one\nline two",
+    ]);
+    expect(execCalls[1].args).toEqual([
+      "--json",
+      "paste-buffer",
+      "--name",
+      execCalls[0].args[3],
+      "--surface",
+      "surface:1",
+      "--workspace",
+      "workspace:1",
+    ]);
+    expect(execCalls[0].env?.CMUX_SOCKET_PATH).toBe(MOCK_SOCKET_PATH);
+    expect(execCalls[1].env?.CMUX_SOCKET_PATH).toBe(MOCK_SOCKET_PATH);
   });
 
   it("moveSurface uses CLI fallback", async () => {


### PR DESCRIPTION
## Summary
- Fixes the #254 paste regression where `CmuxSocketClient.pasteText` injected `\x1b[200~` / `\x1b[201~` bracketed-paste markers through `surface.send_text`.
- Root cause: the cmux socket protocol has no native paste RPC; sending ESC-framed text over `surface.send_text` is interpreted by the receiving TUI as key bytes, which leaked `[200~` / `[201~` during boot and triggered Claude Code's Esc-Esc Rewind menu when ready.
- Restores CLI-paste-primary behavior by delegating socket-client `pasteText` to the pinned `CmuxClient.pasteText` fallback, which uses native `set-buffer` + `paste-buffer` at the terminal/PTY layer.
- Socket-only transports now fail loudly with `CmuxSocketError` code `method_not_found` explaining that atomic multiline paste requires the cmux CLI.
- Keeps the useful #254 behavior outside this diff: `server.ts` still routes multiline/tab input through `pasteText`, and the existing `boot_prompt_warning` behavior remains intact.

## Test plan
- [x] RED: `bun run test tests/cmux-socket-client.test.ts` failed on the new regression assertions before the production change.
- [x] GREEN: `bun run test tests/cmux-socket-client.test.ts` (56 tests passed).
- [x] `bun run typecheck`.
- [x] `bun run test` (78 files / 1452 tests passed).
- [x] `bun run pre-pr` (4 files / 59 tests passed).
- [x] Push hook reran `scripts/run_tests.sh` successfully.

## Live validation caveat
Mocked tests are necessary but not sufficient for this class of paste bug; #254 passed mocked tests while failing against a real Claude Code composer. This PR proves the byte/path contract is correct: `pasteText` no longer sends bracketed-paste ESC markers through the socket and uses CLI `paste-buffer` when available. It does **not** prove end-to-end paste works in a live composer; release should wait for independent review plus a live-validation gate.

## Review notes
- Pre-commit CodeRabbit CLI gate attempted with `timeout 180 coderabbit review --agent`; it returned an OSS rate-limit error before review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal input behavior for multiline paste on socket transports; wrong path could still break live composers, though the fix aligns with the intended PTY paste contract and adds explicit failure for socket-only setups.
> 
> **Overview**
> Fixes a paste regression where **`CmuxSocketClient.pasteText`** wrapped multiline text in bracketed-paste ESC sequences and sent it via **`surface.send_text`**, which TUIs treated as key input (leaked `[200~` / `[201~`, triggered Esc menus).
> 
> **`pasteText`** no longer touches the socket for paste: with a pinned **`cliFallback`**, it delegates to **`CmuxClient.pasteText`** (`set-buffer` + `paste-buffer` at the PTY layer). Socket-only clients throw **`CmuxSocketError`** with code **`method_not_found`** and a message that atomic multiline paste needs the cmux CLI. Bracketed-paste constants and the try/socket-then-fallback path are removed.
> 
> Tests now assert no V2 **`surface.send_text`** on paste without fallback, and that CLI fallback uses **`set-buffer`** / **`paste-buffer`** with **`CMUX_SOCKET_PATH`** pinned to the client socket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9c3edbefc63d0eb9247c7034f12c12786ff450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CmuxSocketClient.pasteText` to delegate to CLI fallback instead of sending bracketed paste over socket
> - `pasteText` previously sent bracketed-paste escape sequences via the `surface.send_text` socket RPC, which was incorrect for socket-only transport.
> - Now delegates to `cliFallback.pasteText` when a CLI fallback is available, using `set-buffer` and `paste-buffer` exec calls with `CMUX_SOCKET_PATH` propagated.
> - Behavioral Change: without a CLI fallback, `pasteText` throws a `CmuxSocketError` with code `method_not_found` instead of silently sending malformed data.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cc9c3ed. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multiline paste now falls back to the command-line path when available instead of trying to send it over the socket.
  * If no command-line fallback is configured, paste actions now fail with a clearer error message indicating the required CLI is unavailable.
  * Socket-based paste no longer attempts unsupported protocol behavior for multiline text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->