### PR TITLE
fix: make agent health info tiers representative

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -105,6 +105,7 @@ import {
   collectSurfaceTopology,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
+  type SurfaceTopologySnapshot,
 } from "./surface-topology.js";
 import type { InboxOpts } from "./inbox.js";
 
@@ -2500,6 +2501,16 @@ export class AgentEngine {
     return health.status === "unhealthy";
   }
 
+  private isKnownClosedSurface(
+    agent: AgentRecord,
+    surfaceTopology: SurfaceTopologySnapshot | null,
+  ): boolean {
+    if (!surfaceTopology || surfaceTopology.workspaceBySurface.size === 0) {
+      return false;
+    }
+    return !surfaceTopology.workspaceBySurface.has(agent.surface_id);
+  }
+
   /**
    * Sync sidebar: diff agents against snapshot, push only changes.
    * Logs lifecycle events (spawned, done, error) once each.
@@ -2520,6 +2531,21 @@ export class AgentEngine {
       const taskDoneResult = await this.maybeMarkTaskDone(readyAgent, sweepCtx);
       const agent = taskDoneResult.agent;
       const { agent_id: agentId, state, surface_id } = agent;
+      if (this.isKnownClosedSurface(agent, surfaceTopology)) {
+        const prev = this.sidebarSnapshot.get(agentId);
+        if (prev) {
+          try {
+            await this.client.clearStatus(agentId, {
+              workspace: prev.workspaceId ?? undefined,
+            });
+          } catch {
+            // Best-effort cleanup; closed panes must not emit fresh health signals.
+          }
+        }
+        this.sidebarSnapshot.delete(agentId);
+        this.clearAgentLifecycleMemory(agentId);
+        continue;
+      }
       const harvestability = this.assessHarvestability(agent);
       const healthScreenContexts = new Map<string, SweepAgentContext>();
       const healthScreenContextFor = (

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -32,6 +32,8 @@ export type AgentHealthIssueCode =
   | "orchestrator_not_leftmost"
   | "worker_in_leftmost_column";
 
+export const AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS = 30_000;
+
 export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   AgentHealthIssueCode,
   AgentHealthIssueSeverity
@@ -51,10 +53,10 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   inbox_channel_dir_deleted: "blocking",
   stale_inbox_dispatches: "blocking",
   missing_managed_lead_agent_id: "degraded",
-  missing_cli_session_id: "degraded",
-  non_resumable: "degraded",
-  inbox_monitor_not_alive: "degraded",
-  auto_discovered_agent: "degraded",
+  missing_cli_session_id: "info",
+  non_resumable: "info",
+  inbox_monitor_not_alive: "info",
+  auto_discovered_agent: "info",
   ambiguous_repo_cwd_label: "info",
   registry_screen_disagreement: "degraded",
 };
@@ -88,6 +90,10 @@ export interface AgentHealth {
   recommended_actions?: string[];
 }
 
+export interface AgentHealthDeps {
+  now?: () => number;
+}
+
 function addIssue(
   codes: AgentHealthIssueCode[],
   issues: string[],
@@ -110,17 +116,23 @@ function addRecommendedAction(actions: string[], action: string): void {
 
 function issueSeverity(
   code: AgentHealthIssueCode,
-  context: { screenActive: boolean },
+  context: { screenActive: boolean; inboxMonitorWithinBootGrace: boolean },
 ): AgentHealthIssueSeverity {
   if (code === "registry_screen_disagreement" && context.screenActive) {
     return "info";
+  }
+  if (
+    code === "inbox_monitor_not_alive" &&
+    !context.inboxMonitorWithinBootGrace
+  ) {
+    return "degraded";
   }
   return DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code];
 }
 
 function deriveIssueSeverities(
   codes: AgentHealthIssueCode[],
-  context: { screenActive: boolean },
+  context: { screenActive: boolean; inboxMonitorWithinBootGrace: boolean },
 ): Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>> {
   const severities: Partial<
     Record<AgentHealthIssueCode, AgentHealthIssueSeverity>
@@ -135,10 +147,13 @@ function deriveStatus(
   codes: AgentHealthIssueCode[],
   severities: Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>>,
 ): AgentHealthStatus {
-  if (codes.length === 0) return "healthy";
-  return codes.some((code) => severities[code] === "blocking")
-    ? "unhealthy"
-    : "degraded";
+  if (codes.some((code) => severities[code] === "blocking")) {
+    return "unhealthy";
+  }
+  if (codes.some((code) => severities[code] === "degraded")) {
+    return "degraded";
+  }
+  return "healthy";
 }
 
 function isLongRunning(agent: AgentRecord): boolean {
@@ -210,9 +225,27 @@ function inferTopologyRole(
   );
 }
 
+function parseAgentTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function isWithinInboxMonitorBootGrace(
+  agent: AgentRecord,
+  now: number,
+): boolean {
+  const firstSeenAt =
+    parseAgentTimestamp(agent.created_at) ??
+    parseAgentTimestamp(agent.updated_at);
+  if (firstSeenAt === null) return false;
+  return now - firstSeenAt <= AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS;
+}
+
 export function evaluateAgentHealth(
   agent: AgentRecord,
   input: AgentHealthInput = {},
+  deps: AgentHealthDeps = {},
 ): AgentHealth {
   const issueCodes: AgentHealthIssueCode[] = [];
   const issues: string[] = [];
@@ -456,7 +489,13 @@ export function evaluateAgentHealth(
     }
   }
 
-  const issueSeverities = deriveIssueSeverities(issueCodes, { screenActive });
+  const issueSeverities = deriveIssueSeverities(issueCodes, {
+    screenActive,
+    inboxMonitorWithinBootGrace: isWithinInboxMonitorBootGrace(
+      agent,
+      deps.now?.() ?? Date.now(),
+    ),
+  });
   const status = deriveStatus(issueCodes, issueSeverities);
 
   return {

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { evaluateAgentHealth } from "../src/agent-health.js";
+import {
+  AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS,
+  evaluateAgentHealth,
+} from "../src/agent-health.js";
 import type { AgentRecord } from "../src/agent-types.js";
 
 function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
@@ -40,45 +43,90 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
 }
 
 describe("agent lifecycle health", () => {
-  it("degrades a working-screen agent without a CLI session or monitor without marking it unhealthy", () => {
+  it("keeps a fresh agent healthy when it only has info-tier launch-time issues", () => {
+    const createdAt = "2026-06-26T20:00:00.000Z";
     const health = evaluateAgentHealth(
       makeRecord({
+        agent_id: "auto-cmuxlayerCodex-pending-1-abcd",
         state: "working",
         cli_session_id: null,
         cli_session_path: null,
+        task_summary: "(auto-discovered)",
+        created_at: createdAt,
       }),
       { monitor_alive: false, screen_status: "working" },
+      { now: () => Date.parse(createdAt) + 1_000 },
     );
 
-    expect(health.status).toBe("degraded");
+    expect(health.status).toBe("healthy");
     expect(health.issue_codes).toEqual([
+      "auto_discovered_agent",
       "missing_cli_session_id",
       "non_resumable",
       "inbox_monitor_not_alive",
     ]);
     expect(health.issue_severities).toMatchObject({
-      missing_cli_session_id: "degraded",
-      non_resumable: "degraded",
-      inbox_monitor_not_alive: "degraded",
+      auto_discovered_agent: "info",
+      missing_cli_session_id: "info",
+      non_resumable: "info",
+      inbox_monitor_not_alive: "info",
     });
   });
 
-  it("marks auto-discovered agents as degraded even if they look ready", () => {
+  it("escalates an absent inbox monitor after the boot grace window", () => {
+    const createdAt = "2026-06-26T20:00:00.000Z";
+    const withinGrace = evaluateAgentHealth(
+      makeRecord({
+        state: "working",
+        cli_session_id: null,
+        created_at: createdAt,
+      }),
+      { monitor_alive: false, screen_status: "working" },
+      {
+        now: () =>
+          Date.parse(createdAt) + AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS - 1,
+      },
+    );
+    const pastGrace = evaluateAgentHealth(
+      makeRecord({
+        state: "working",
+        cli_session_id: null,
+        created_at: createdAt,
+      }),
+      { monitor_alive: false, screen_status: "working" },
+      {
+        now: () =>
+          Date.parse(createdAt) + AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS + 1,
+      },
+    );
+
+    expect(withinGrace.issue_severities?.inbox_monitor_not_alive).toBe("info");
+    expect(withinGrace.status).toBe("healthy");
+    expect(pastGrace.issue_severities?.inbox_monitor_not_alive).toBe(
+      "degraded",
+    );
+    expect(pastGrace.status).toBe("degraded");
+  });
+
+  it("marks auto-discovered agents as info if they look ready", () => {
+    const createdAt = "2026-06-26T20:00:00.000Z";
     const health = evaluateAgentHealth(
       makeRecord({
         agent_id: "auto-codex-surface-306",
         task_summary: "(auto-discovered)",
         cli_session_id: null,
+        created_at: createdAt,
       }),
       { monitor_alive: false },
+      { now: () => Date.parse(createdAt) + 1_000 },
     );
 
-    expect(health.status).toBe("degraded");
+    expect(health.status).toBe("healthy");
     expect(health.issue_codes).toContain("auto_discovered_agent");
     expect(health.issue_codes).toContain("missing_cli_session_id");
     expect(health.issue_severities).toMatchObject({
-      auto_discovered_agent: "degraded",
-      missing_cli_session_id: "degraded",
+      auto_discovered_agent: "info",
+      missing_cli_session_id: "info",
     });
   });
 
@@ -164,7 +212,7 @@ describe("agent lifecycle health", () => {
       },
     );
 
-    expect(health.status).toBe("degraded");
+    expect(health.status).toBe("healthy");
     expect(health.reconciled_state).toBe("working");
     expect(health.issue_codes).toContain("registry_screen_disagreement");
     expect(health.issue_severities?.registry_screen_disagreement).toBe("info");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -601,7 +601,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
     expect(parsed.health).toMatchObject({
-      status: "degraded",
+      status: "healthy",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
@@ -1156,7 +1156,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("ic");
-    expect(parsed.health.status).toBe("degraded");
+    expect(parsed.health.status).toBe("healthy");
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -2357,7 +2357,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agents[0].resume_command).toBeUndefined();
     expect(parsed.agents[0].surface_id).toBeUndefined();
     expect(parsed.agents[0].health).toMatchObject({
-      status: "degraded",
+      status: "healthy",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
@@ -2799,7 +2799,7 @@ describe("agent lifecycle tool handlers", () => {
       repo: "brainlayer",
       state: "working",
       health: {
-        status: "degraded",
+        status: "healthy",
         issue_codes: expect.arrayContaining([
           "registry_screen_disagreement",
         ]),
@@ -2873,7 +2873,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.cli).toBe("codex");
     expect(parsed.resume_command).toBeUndefined();
     expect(parsed.health).toMatchObject({
-      status: "degraded",
+      status: "healthy",
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
@@ -3672,7 +3672,7 @@ codex>
       pid: null,
       resumable: false,
       health: {
-        status: "degraded",
+        status: "healthy",
         issue_codes: expect.arrayContaining([
           "auto_discovered_agent",
           "missing_cli_session_id",

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -211,7 +211,7 @@ describe("Sidebar Sync", () => {
     );
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       "working-agent",
-      "brainlayer | role=worker | state=working | health=degraded(missing_cli_session_id:degraded,non_resumable:degraded) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
+      "brainlayer | role=worker | state=working | health=healthy(missing_cli_session_id:info,non_resumable:info) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
       expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
     );
   });
@@ -676,6 +676,75 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("suppresses watch-blind alerts and sidebar status when the lead pane is already closed", async () => {
+    const inboxDir = join(TEST_DIR, "lead-closed-pane-inbox");
+    const registryPath = join(TEST_DIR, "lead-closed-pane-registry.json");
+    const agentId = "cmuxlayer-lead-closed-pane";
+    let now = 1_250_000;
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "working",
+        surface_id: "surface:lead-closed",
+        workspace_id: "workspace:cmuxlayer",
+        cli_session_id: "session-lead-closed",
+        cli: "claude",
+        model: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        task_summary: "Lead remediation lane",
+      }),
+    );
+    liveSurfaces = [makeSurface("surface:other-live")];
+    mockClient.listWorkspaces.mockResolvedValue({
+      workspaces: [makeWorkspace("workspace:cmuxlayer")],
+    });
+    mockClient.listPanes.mockResolvedValue({
+      workspace_ref: "workspace:cmuxlayer",
+      panes: [
+        {
+          ref: "pane:other-live",
+          index: 0,
+          focused: false,
+          surface_count: 1,
+          surface_refs: ["surface:other-live"],
+        },
+      ],
+    });
+    mockClient.listPaneSurfaces.mockResolvedValue({
+      workspace_ref: "workspace:cmuxlayer",
+      window_ref: "window:1",
+      pane_ref: "pane:other-live",
+      surfaces: [makeSurface("surface:other-live")],
+    });
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      inboxOpts: { baseDir: inboxDir, now: () => now },
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
+    });
+    await armLeadMonitor({
+      registryPath,
+      monitorId: "lead-closed-pane-1",
+      ownerSeat: agentId,
+      now: () => now,
+    });
+    now += 61_000;
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(mockClient.notify).not.toHaveBeenCalled();
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).not.toHaveBeenCalledWith(
+      agentId,
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
   it("does not alert from stale inbox heartbeat when no registry deadman fired", async () => {
     const inboxDir = join(TEST_DIR, "lead-stale-inbox-only");
     const registryPath = join(TEST_DIR, "lead-stale-inbox-only-registry.json");
@@ -1032,7 +1101,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.setStatus).toHaveBeenCalledTimes(2);
     expect(mockClient.setStatus).toHaveBeenLastCalledWith(
       "a1",
-      "brainlayer | role=worker | state=working | health=degraded(missing_cli_session_id:degraded,non_resumable:degraded) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+      "brainlayer | role=worker | state=working | health=healthy(missing_cli_session_id:info,non_resumable:info) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
       expect.objectContaining({
         workspace: "workspace:coach",
         surface: "surface:99",


### PR DESCRIPTION
## Summary
- Demotes Etan-confirmed transient/expected health codes to `info`: `missing_cli_session_id`, `non_resumable`, `auto_discovered_agent`, and `inbox_monitor_not_alive` during boot grace.
- Adds `AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS = 30_000` and injected `now()` support so `inbox_monitor_not_alive` is `info` for fresh agents, then escalates to `degraded` after grace.
- Changes rollup to `unhealthy` for any `blocking`, `degraded` for any `degraded`, otherwise `healthy`, so all-info issue sets read healthy.
- Suppresses closed-pane watch-blind/session-ended/sidebar health signals when cmux topology proves the owning surface no longer exists, while preserving live-pane liveness alerts.

## Etan-confirmed tier table
- `missing_cli_session_id`: `info`
- `non_resumable`: `info`
- `auto_discovered_agent`: `info`
- `inbox_monitor_not_alive`: `info` during 30s boot grace, `degraded` after grace if still dead
- `registry_screen_disagreement`: remains `info` when screen is active
- blocking issues such as `agent_wedged`: unchanged, still `unhealthy`

## Test plan
- [x] RED confirmed first: `bunx vitest run tests/agent-health.test.ts tests/sidebar-sync.test.ts` failed on old degraded rollup/boot grace/closed-pane alert behavior.
- [x] `bunx vitest run tests/agent-health.test.ts tests/sidebar-sync.test.ts` passes: 46 tests.
- [x] `bun run typecheck` passes.
- [x] `bun run test` passes: 78 files, 1454 tests.
- [x] Push hook re-ran full suite and passed.

## Notes
- Local `coderabbit review --agent` was run before commit with a 180s timeout; it remained in `reviewing` heartbeat state and timed out without returning findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible health and sidebar behavior during boot and after pane close; blocking severities are unchanged but mis-tuned grace or topology could hide real monitor problems or leave registry rows without alerts.
> 
> **Overview**
> Agent health now treats common **launch-time** signals as **info** instead of **degraded**: `missing_cli_session_id`, `non_resumable`, and `auto_discovered_agent`. Rollup is **blocking → unhealthy**, **degraded → degraded**, otherwise **healthy**, so info-only issue sets no longer show as degraded.
> 
> **Inbox monitor** uses a **30s boot grace** (`AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS`) with injectable `now()`; `inbox_monitor_not_alive` stays **info** for fresh agents and escalates to **degraded** after grace.
> 
> During **sidebar sync**, if cmux **surface topology** shows an agent’s surface is gone, the engine **clears sidebar status**, drops lifecycle/notification memory, and **skips** further health updates and lead watch-blind alerts for that registry row—avoiding stale signals after a pane is closed.
> 
> Tests and MCP spawn/list expectations were updated to expect **healthy** where only info-tier codes remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7148b10eabc13ffc96b8b023793ade7eaf9dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent health tiers so info-level issues no longer mark agents as degraded
> - Several launch-time conditions (`missing_cli_session_id`, `non_resumable`, `inbox_monitor_not_alive`, `auto_discovered_agent`) are reclassified from `degraded` to `info` severity in [`agent-health.ts`](https://github.com/EtanHey/cmuxlayer/pull/258/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3), so agents with only these issues now report `healthy`.
> - Adds a 30-second boot grace period (`AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS`) during which an absent inbox monitor stays at `info`; it escalates to `degraded` only after the grace window expires.
> - `deriveStatus` is fixed to return `healthy` when all present issues are `info`-tier, previously it returned `degraded` for any non-empty issue set.
> - Agents whose pane surface is no longer in the surface topology are now removed from the sidebar in [`agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/258/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5): their status is cleared, lifecycle memory is reset, and no further health updates are emitted.
> - Behavioral Change: any agent previously shown as `degraded` solely due to launch-time or auto-discovered conditions will now appear `healthy`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7f7148b. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->