### PR TITLE
fix: bound forensics memory and stdio lifecycle

### DIFF
--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -21,7 +21,16 @@
  * the sweep wiring stays a thin, best-effort adapter.
  */
 
-import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -59,6 +68,10 @@ export interface CloseForensicsInput {
   deltaMs: number;
   /** Cursor: only emit forensics for events with seq strictly greater than this. */
   lastSeq: number;
+  /** Last close boot_id from a prior offset-tail sweep, for continuity. */
+  previousCloseBootId?: string | null;
+  /** Last window key/unkey event from a prior offset-tail sweep. */
+  previousWindowKeyEvent?: CloseForensicsWindowKeyCursor | null;
   /** Injected clock producing the forensics record's `ts`. */
   now: () => string;
 }
@@ -67,6 +80,22 @@ export interface CloseForensicsResult {
   events: CloseForensicsEvent[];
   /** Advanced cursor = max seq observed across ALL input events (>= lastSeq). */
   nextSeq: number;
+  /** Last close boot_id observed across this input batch and prior cursor state. */
+  lastCloseBootId: string | null;
+  /** Last window key/unkey event observed across this batch and prior cursor. */
+  lastWindowKeyEvent: CloseForensicsWindowKeyCursor | null;
+}
+
+export interface CloseForensicsWindowKeyCursor {
+  name: "window.keyed" | "window.unkeyed";
+  occurredAt: string;
+}
+
+export interface CloseForensicsCursorState {
+  lastSeq: number;
+  lastOffset: number;
+  lastCloseBootId: string | null;
+  lastWindowKeyEvent: CloseForensicsWindowKeyCursor | null;
 }
 
 const SURFACE_CLOSED = "surface.closed";
@@ -87,8 +116,16 @@ function toMillis(iso: string): number {
 export function ingestCloseForensics(
   input: CloseForensicsInput,
 ): CloseForensicsResult {
-  const { cmuxEvents, mcpCloses, surfaceRefByCmuxId, deltaMs, lastSeq, now } =
-    input;
+  const {
+    cmuxEvents,
+    mcpCloses,
+    surfaceRefByCmuxId,
+    deltaMs,
+    lastSeq,
+    previousCloseBootId,
+    previousWindowKeyEvent,
+    now,
+  } = input;
 
   let nextSeq = lastSeq;
   for (const ev of cmuxEvents) {
@@ -96,8 +133,23 @@ export function ingestCloseForensics(
   }
 
   // Window key-focus events power the rc/screen-share attach/detach signal.
-  const windowKeyEvents = cmuxEvents.filter(
+  const currentWindowKeyEvents = cmuxEvents.filter(
     (ev) => ev?.name === WINDOW_KEYED || ev?.name === WINDOW_UNKEYED,
+  );
+  const windowKeyEvents: Array<Pick<CmuxEvent, "name" | "occurred_at">> = [
+    ...(previousWindowKeyEvent
+      ? [
+          {
+            name: previousWindowKeyEvent.name,
+            occurred_at: previousWindowKeyEvent.occurredAt,
+          },
+        ]
+      : []),
+    ...currentWindowKeyEvents,
+  ];
+  const lastWindowKeyEvent = latestWindowKeyCursor(
+    currentWindowKeyEvents,
+    previousWindowKeyEvent ?? null,
   );
 
   // Closes sorted by seq give a stable "previous close" for boot_id continuity.
@@ -107,8 +159,8 @@ export function ingestCloseForensics(
     .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
 
   const results: CloseForensicsEvent[] = [];
-  let prevBootId: string | null = null;
-  let sawPrevClose = false;
+  let prevBootId: string | null = previousCloseBootId ?? null;
+  let sawPrevClose = prevBootId !== null;
 
   for (const close of closes) {
     const bootIdChanged =
@@ -160,7 +212,27 @@ export function ingestCloseForensics(
     });
   }
 
-  return { events: results, nextSeq };
+  return {
+    events: results,
+    nextSeq,
+    lastCloseBootId: prevBootId,
+    lastWindowKeyEvent,
+  };
+}
+
+function latestWindowKeyCursor(
+  currentWindowKeyEvents: CmuxEvent[],
+  previousWindowKeyEvent: CloseForensicsWindowKeyCursor | null,
+): CloseForensicsWindowKeyCursor | null {
+  let latest: CmuxEvent | null = null;
+  for (const ev of currentWindowKeyEvents) {
+    if (!latest || (ev.seq ?? 0) > (latest.seq ?? 0)) latest = ev;
+  }
+  if (!latest) return previousWindowKeyEvent;
+  return {
+    name: latest.name === WINDOW_KEYED ? WINDOW_KEYED : WINDOW_UNKEYED,
+    occurredAt: latest.occurred_at,
+  };
 }
 
 function attributeClose(args: {
@@ -198,7 +270,7 @@ function attributeClose(args: {
 }
 
 function deriveWindowKeyContext(
-  windowKeyEvents: CmuxEvent[],
+  windowKeyEvents: Array<Pick<CmuxEvent, "name" | "occurred_at">>,
   closeMs: number,
   deltaMs: number,
 ): {
@@ -212,8 +284,12 @@ function deriveWindowKeyContext(
   // Candidates within Δt of the close. Prefer the most recent one AT OR BEFORE
   // the close (the focus state the window was in when it died); otherwise the
   // nearest one after.
-  let beforeBest: { ev: CmuxEvent; t: number } | null = null;
-  let afterBest: { ev: CmuxEvent; dist: number } | null = null;
+  let beforeBest: { ev: Pick<CmuxEvent, "name" | "occurred_at">; t: number } | null =
+    null;
+  let afterBest: {
+    ev: Pick<CmuxEvent, "name" | "occurred_at">;
+    dist: number;
+  } | null = null;
   for (const ev of windowKeyEvents) {
     const t = toMillis(ev.occurred_at);
     if (Number.isNaN(t)) continue;
@@ -286,11 +362,21 @@ export interface CloseForensicsCursorStore {
   /** Last ingested cmux seq (0 when none / unreadable). */
   read(): number;
   write(seq: number): void;
+  readState?(): CloseForensicsCursorState;
+  writeState?(state: CloseForensicsCursorState): void;
+}
+
+export interface CmuxEventsTextRead {
+  text: string;
+  nextOffset: number;
+  truncated: boolean;
 }
 
 export interface CloseForensicsDeps {
   /** Reads the raw cmux events file; returns null when absent/unreadable. */
-  readCmuxEventsText: () => string | null;
+  readCmuxEventsText: (
+    cursor?: CloseForensicsCursorState,
+  ) => string | CmuxEventsTextRead | null;
   /** cmuxlayer's own MCP close-log records. */
   readMcpCloses: () => CloseTelemetryEvent[];
   /** cmux-UUID → surface-ref map (may be empty). */
@@ -312,23 +398,66 @@ export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
   emitted: number;
 } {
   try {
-    const text = safe(() => deps.readCmuxEventsText(), null);
-    if (!text) return { emitted: 0 };
+    const cursorState =
+      safe(() => deps.cursor.readState?.(), undefined) ?? undefined;
+    const lastSeq =
+      cursorState?.lastSeq ?? (safe(() => deps.cursor.read(), 0) ?? 0);
+    const readResult = safe(() => deps.readCmuxEventsText(cursorState), null);
+    const resetForTruncation =
+      typeof readResult === "object" && readResult !== null
+        ? readResult.truncated
+        : false;
+    const effectiveCursorState: CloseForensicsCursorState | undefined =
+      resetForTruncation
+        ? {
+            lastSeq: 0,
+            lastOffset: 0,
+            lastCloseBootId: null,
+            lastWindowKeyEvent: null,
+          }
+        : cursorState;
+    const effectiveLastSeq = resetForTruncation ? 0 : lastSeq;
+    const text =
+      typeof readResult === "string" || readResult === null
+        ? readResult
+        : readResult.text;
+    if (!text) {
+      if (typeof readResult === "object" && readResult !== null) {
+        const nextOffset = readResult.nextOffset;
+        if (nextOffset !== (cursorState?.lastOffset ?? nextOffset)) {
+          try {
+            deps.cursor.writeState?.({
+              lastSeq: effectiveLastSeq,
+              lastOffset: nextOffset,
+              lastCloseBootId: effectiveCursorState?.lastCloseBootId ?? null,
+              lastWindowKeyEvent:
+                effectiveCursorState?.lastWindowKeyEvent ?? null,
+            });
+          } catch {
+            // Best-effort: an offset write failure only retries the same chunk.
+          }
+        }
+      }
+      return { emitted: 0 };
+    }
     const cmuxEvents =
       safe(() => parseCmuxEvents(text), [] as CmuxEvent[]) ?? [];
-    const lastSeq = safe(() => deps.cursor.read(), 0) ?? 0;
     const mcpCloses =
       safe(() => deps.readMcpCloses(), [] as CloseTelemetryEvent[]) ?? [];
     const surfaceRefByCmuxId =
       safe(() => deps.surfaceRefByCmuxId(), new Map<string, string>()) ??
       new Map<string, string>();
 
-    const { events, nextSeq } = ingestCloseForensics({
+    const { events, nextSeq, lastCloseBootId, lastWindowKeyEvent } =
+      ingestCloseForensics({
       cmuxEvents,
       mcpCloses,
       surfaceRefByCmuxId,
       deltaMs: deps.deltaMs,
-      lastSeq,
+      lastSeq: effectiveLastSeq,
+      previousCloseBootId: effectiveCursorState?.lastCloseBootId ?? null,
+      previousWindowKeyEvent:
+        effectiveCursorState?.lastWindowKeyEvent ?? null,
       now: deps.now,
     });
 
@@ -339,9 +468,29 @@ export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
         // Best-effort: one bad append must not lose the rest of the batch.
       }
     }
-    if (nextSeq > lastSeq) {
+    const nextOffset =
+      typeof readResult === "object" && readResult !== null
+        ? readResult.nextOffset
+        : (cursorState?.lastOffset ?? 0);
+    const nextState: CloseForensicsCursorState = {
+      lastSeq: nextSeq,
+      lastOffset: nextOffset,
+      lastCloseBootId,
+      lastWindowKeyEvent,
+    };
+    const stateChanged =
+      resetForTruncation ||
+      nextSeq > effectiveLastSeq ||
+      nextOffset !== (cursorState?.lastOffset ?? nextOffset) ||
+      lastCloseBootId !== (effectiveCursorState?.lastCloseBootId ?? null) ||
+      lastWindowKeyEvent?.name !==
+        effectiveCursorState?.lastWindowKeyEvent?.name ||
+      lastWindowKeyEvent?.occurredAt !==
+        effectiveCursorState?.lastWindowKeyEvent?.occurredAt;
+    if (stateChanged) {
       try {
-        deps.cursor.write(nextSeq);
+        if (deps.cursor.writeState) deps.cursor.writeState(nextState);
+        else deps.cursor.write(nextSeq);
       } catch {
         // A cursor-write failure re-processes next sweep; append de-dup is owned
         // by cursor advances, so we log at-most-once per successful advance.
@@ -369,6 +518,55 @@ export function defaultCmuxEventsPath(): string {
 }
 
 const DEFAULT_DELTA_MS = 30_000;
+const DEFAULT_MAX_CMUX_EVENTS_READ_BYTES = 256 * 1024;
+
+export function readAppendedCmuxEventsText(args: {
+  path: string;
+  offset: number;
+  maxBytes?: number;
+}): CmuxEventsTextRead {
+  const maxBytes = Math.max(
+    1,
+    args.maxBytes ?? DEFAULT_MAX_CMUX_EVENTS_READ_BYTES,
+  );
+  const size = statSync(args.path).size;
+  const start = args.offset > size ? 0 : Math.max(0, args.offset);
+  const truncated = args.offset > size;
+  if (start >= size) {
+    return { text: "", nextOffset: start, truncated };
+  }
+
+  const bytesToRead = Math.min(maxBytes, size - start);
+  const buffer = Buffer.allocUnsafe(bytesToRead);
+  const fd = openSync(args.path, "r");
+  let bytesRead = 0;
+  try {
+    bytesRead = readSync(fd, buffer, 0, bytesToRead, start);
+  } finally {
+    closeSync(fd);
+  }
+
+  if (bytesRead <= 0) {
+    return { text: "", nextOffset: start, truncated };
+  }
+
+  const reachedEof = start + bytesRead >= size;
+  const chunk = buffer.subarray(0, bytesRead).toString("utf8");
+  const lastNewline = chunk.lastIndexOf("\n");
+  if (lastNewline < 0) {
+    return { text: "", nextOffset: start, truncated };
+  }
+  if (reachedEof && lastNewline === chunk.length - 1) {
+    return { text: chunk, nextOffset: start + bytesRead, truncated };
+  }
+
+  const text = chunk.slice(0, lastNewline + 1);
+  return {
+    text,
+    nextOffset: start + Buffer.byteLength(text),
+    truncated,
+  };
+}
 
 /**
  * cmux's surface-session-index keys by cmuxlayer ref ("surface:N"), not by cmux
@@ -405,28 +603,98 @@ export function createDefaultCloseForensicsRunner(config: {
   );
 
   const cursor: CloseForensicsCursorStore = {
-    read: () => {
-      if (!existsSync(cursorPath)) return 0;
+    readState: () => {
+      if (!existsSync(cursorPath)) {
+        return {
+          lastSeq: 0,
+          lastOffset: 0,
+          lastCloseBootId: null,
+          lastWindowKeyEvent: null,
+        };
+      }
       try {
         const parsed = JSON.parse(readFileSync(cursorPath, "utf-8")) as {
           last_seq?: number;
+          last_offset?: number;
+          last_close_boot_id?: string | null;
+          last_window_key_event?: {
+            name?: string;
+            occurred_at?: string;
+          } | null;
         };
-        return typeof parsed.last_seq === "number" ? parsed.last_seq : 0;
+        const parsedWindowKeyName = parsed.last_window_key_event?.name;
+        const lastWindowKeyEvent: CloseForensicsWindowKeyCursor | null =
+          (parsedWindowKeyName === WINDOW_KEYED ||
+            parsedWindowKeyName === WINDOW_UNKEYED) &&
+          typeof parsed.last_window_key_event?.occurred_at === "string"
+            ? {
+                name: parsedWindowKeyName,
+                occurredAt: parsed.last_window_key_event.occurred_at,
+              }
+            : null;
+        return {
+          lastSeq: typeof parsed.last_seq === "number" ? parsed.last_seq : 0,
+          lastOffset:
+            typeof parsed.last_offset === "number" ? parsed.last_offset : 0,
+          lastCloseBootId:
+            typeof parsed.last_close_boot_id === "string"
+              ? parsed.last_close_boot_id
+              : null,
+          lastWindowKeyEvent,
+        };
       } catch {
-        return 0;
+        return {
+          lastSeq: 0,
+          lastOffset: 0,
+          lastCloseBootId: null,
+          lastWindowKeyEvent: null,
+        };
       }
+    },
+    read: () => cursor.readState?.().lastSeq ?? 0,
+    writeState: (state: CloseForensicsCursorState) => {
+      const tmp = `${cursorPath}.tmp`;
+      writeFileSync(
+        tmp,
+        JSON.stringify({
+          last_seq: state.lastSeq,
+          last_offset: state.lastOffset,
+          last_close_boot_id: state.lastCloseBootId,
+          last_window_key_event: state.lastWindowKeyEvent
+            ? {
+                name: state.lastWindowKeyEvent.name,
+                occurred_at: state.lastWindowKeyEvent.occurredAt,
+              }
+            : null,
+        }),
+        "utf-8",
+      );
+      renameSync(tmp, cursorPath);
     },
     write: (seq: number) => {
       const tmp = `${cursorPath}.tmp`;
-      writeFileSync(tmp, JSON.stringify({ last_seq: seq }), "utf-8");
+      writeFileSync(
+        tmp,
+        JSON.stringify({
+          last_seq: seq,
+          last_offset: 0,
+          last_window_key_event: null,
+        }),
+        "utf-8",
+      );
       renameSync(tmp, cursorPath);
     },
   };
 
   return () =>
     runCloseForensicsSweep({
-      readCmuxEventsText: () =>
-        existsSync(eventsPath) ? readFileSync(eventsPath, "utf-8") : null,
+      readCmuxEventsText: (cursorState) =>
+        existsSync(eventsPath)
+          ? readAppendedCmuxEventsText({
+              path: eventsPath,
+              offset: cursorState?.lastOffset ?? 0,
+            })
+          : null,
       readMcpCloses: () =>
         config.stateMgr
           .getEventLog()

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -5,7 +5,14 @@
 // the SAME map — keep both in lockstep. Terminal scraping survives ONLY for live-TUI
 // liveness (wedge/menu/permission/idle) the JSONL can't show, and for Cursor context%
 // (its JSONL carries neither tokens nor window).
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -401,13 +408,44 @@ export function readHarnessSessionFromFile(
   harness: Harness,
   path: string,
 ): HarnessSessionState | null {
-  let content: string;
+  const content = readHarnessSessionTextWindow(path);
+  if (content === null) return null;
+  return parseHarnessSession(harness, content);
+}
+
+const DEFAULT_HARNESS_SESSION_TAIL_BYTES = 512 * 1024;
+const DEFAULT_HARNESS_SESSION_IDENTITY_BYTES = 256 * 1024;
+
+export function readHarnessSessionTextWindow(
+  path: string,
+  opts: { maxBytes?: number } = {},
+): string | null {
   try {
-    content = readFileSync(path, "utf8");
+    const maxBytes = Math.max(
+      1,
+      opts.maxBytes ?? DEFAULT_HARNESS_SESSION_TAIL_BYTES,
+    );
+    const size = statSync(path).size;
+    if (size <= maxBytes) return readFileSync(path, "utf8");
+
+    const start = size - maxBytes;
+    const buffer = Buffer.allocUnsafe(maxBytes);
+    const fd = openSync(path, "r");
+    let bytesRead = 0;
+    try {
+      bytesRead = readSync(fd, buffer, 0, maxBytes, start);
+    } finally {
+      closeSync(fd);
+    }
+    if (bytesRead <= 0) return "";
+
+    let text = buffer.subarray(0, bytesRead).toString("utf8");
+    const firstNewline = text.indexOf("\n");
+    if (firstNewline >= 0) text = text.slice(firstNewline + 1);
+    return text;
   } catch {
     return null;
   }
-  return parseHarnessSession(harness, content);
 }
 
 export interface HarnessSessionWithMeta {
@@ -458,8 +496,31 @@ function sessionIdFromJsonlName(path: string): string | null {
 }
 
 function readTextFile(path: string): string | null {
+  return readHarnessSessionIdentityWindow(path);
+}
+
+function readHarnessSessionIdentityWindow(path: string): string | null {
   try {
-    return readFileSync(path, "utf8");
+    const size = statSync(path).size;
+    const maxBytes = DEFAULT_HARNESS_SESSION_IDENTITY_BYTES;
+    if (size <= maxBytes * 2) return readFileSync(path, "utf8");
+
+    const headBuffer = Buffer.allocUnsafe(maxBytes);
+    const tailBuffer = Buffer.allocUnsafe(maxBytes);
+    const fd = openSync(path, "r");
+    let headBytes = 0;
+    let tailBytes = 0;
+    try {
+      headBytes = readSync(fd, headBuffer, 0, maxBytes, 0);
+      tailBytes = readSync(fd, tailBuffer, 0, maxBytes, size - maxBytes);
+    } finally {
+      closeSync(fd);
+    }
+
+    let tail = tailBuffer.subarray(0, tailBytes).toString("utf8");
+    const firstTailNewline = tail.indexOf("\n");
+    if (firstTailNewline >= 0) tail = tail.slice(firstTailNewline + 1);
+    return `${headBuffer.subarray(0, headBytes).toString("utf8")}\n${tail}`;
   } catch {
     return null;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   defaultMonitorRegistryPath,
   httpNotifyMonitorDeadman,
 } from "./monitor-registry.js";
+import { bindStdioLifecycle } from "./stdio-lifecycle.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 
@@ -85,6 +86,29 @@ async function main() {
     enableCloseForensics: true,
   });
   const transport = new StdioServerTransport();
+  let shutdownStarted = false;
+  bindStdioLifecycle({
+    stdin: process.stdin,
+    transport: transport as any,
+    shutdown: (reason) => {
+      if (shutdownStarted) return;
+      shutdownStarted = true;
+      const forceExit = setTimeout(() => {
+        console.error(`[cmuxlayer] forced stdio shutdown after ${reason}`);
+        process.exit(0);
+      }, 1_000);
+      forceExit.unref();
+      void server
+        .close()
+        .catch((error) => {
+          console.error("[cmuxlayer] stdio shutdown failed", error);
+        })
+        .finally(() => {
+          clearTimeout(forceExit);
+          process.exit(0);
+        });
+    },
+  });
   await server.connect(transport);
 }
 

--- a/src/stdio-lifecycle.ts
+++ b/src/stdio-lifecycle.ts
@@ -1,0 +1,33 @@
+import type { EventEmitter } from "node:events";
+
+export type StdioShutdownReason =
+  | "stdin:end"
+  | "stdin:close"
+  | "stdin:error"
+  | "transport:close";
+
+export interface StdioLifecycleOptions {
+  stdin: EventEmitter;
+  transport: Partial<EventEmitter> & { onclose?: () => void };
+  shutdown: (reason: StdioShutdownReason) => void;
+}
+
+export function bindStdioLifecycle(opts: StdioLifecycleOptions): void {
+  let shuttingDown = false;
+  const shutdown = (reason: StdioShutdownReason) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    opts.shutdown(reason);
+  };
+
+  opts.stdin.once("end", () => shutdown("stdin:end"));
+  opts.stdin.once("close", () => shutdown("stdin:close"));
+  opts.stdin.once("error", () => shutdown("stdin:error"));
+
+  const previousOnClose = opts.transport.onclose;
+  opts.transport.onclose = () => {
+    previousOnClose?.();
+    shutdown("transport:close");
+  };
+  opts.transport.once?.("close", () => shutdown("transport:close"));
+}

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
+  appendFileSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
   statSync,
@@ -11,6 +13,7 @@ import { join } from "node:path";
 import {
   ingestCloseForensics,
   parseCmuxEvents,
+  readAppendedCmuxEventsText,
   runCloseForensicsSweep,
   createDefaultCloseForensicsRunner,
   type CmuxEvent,
@@ -392,7 +395,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       [
         JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })),
         JSON.stringify(surfaceClosed({ seq: 2, surface_id: "S2" })),
-      ].join("\n"),
+      ].join("\n") + "\n",
       "utf-8",
     );
     const stateMgr = new StateManager(stateDir);
@@ -423,6 +426,194 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
         (e) => (e as { event_type?: string }).event_type === "close_forensics",
       );
     expect(forensicsAfter).toHaveLength(2);
+  });
+
+  it("reads only bytes appended after the persisted offset and advances that offset", () => {
+    const oldLine = JSON.stringify(surfaceClosed({ seq: 1, surface_id: "OLD" })) + "\n";
+    const oldBytes = Buffer.byteLength(oldLine);
+    writeFileSync(eventsPath, oldLine, "utf-8");
+
+    const stateMgr = new StateManager(stateDir);
+    writeFileSync(
+      join(stateDir, "close-forensics-cursor.json"),
+      JSON.stringify({ last_seq: 1, last_offset: oldBytes, last_close_boot_id: "BOOT-OLD" }),
+      "utf-8",
+    );
+
+    appendFileSync(
+      eventsPath,
+      JSON.stringify(
+        surfaceClosed({
+          seq: 2,
+          surface_id: "NEW",
+          boot_id: "BOOT-NEW",
+        }),
+      ) + "\n",
+      "utf-8",
+    );
+
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+    });
+
+    const result = runner();
+    expect(result.emitted).toBe(1);
+
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      ) as CloseForensicsEvent[];
+    expect(forensics).toHaveLength(1);
+    expect(forensics[0].cmux_surface_id).toBe("NEW");
+    expect(forensics[0].client_context.boot_id_changed_since_prev).toBe(true);
+
+    const cursor = JSON.parse(
+      readFileSync(join(stateDir, "close-forensics-cursor.json"), "utf-8"),
+    ) as { last_seq: number; last_offset: number; last_close_boot_id: string };
+    expect(cursor.last_seq).toBe(2);
+    expect(cursor.last_offset).toBe(statSync(eventsPath).size);
+    expect(cursor.last_close_boot_id).toBe("BOOT-NEW");
+  });
+
+  it("persists window key lookback across offset-tail sweeps", () => {
+    const stateMgr = new StateManager(stateDir);
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(
+        windowKey("window.keyed", "2026-07-06T21:34:01.256Z", 1),
+      ) + "\n",
+      "utf-8",
+    );
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+    });
+
+    expect(runner().emitted).toBe(0);
+    appendFileSync(
+      eventsPath,
+      JSON.stringify(
+        surfaceClosed({
+          seq: 2,
+          occurred_at: "2026-07-06T21:34:13.820Z",
+          surface_id: "AFTER-KEY",
+        }),
+      ) + "\n",
+      "utf-8",
+    );
+
+    expect(runner().emitted).toBe(1);
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      ) as CloseForensicsEvent[];
+    expect(forensics).toHaveLength(1);
+    expect(forensics[0].cmux_surface_id).toBe("AFTER-KEY");
+    expect(forensics[0].client_context.window_key_cycle_near_close).toBe(true);
+    expect(forensics[0].client_context.last_window_key_event).toBe("keyed");
+  });
+
+  it("resets the byte offset when the cmux events file is truncated or rotated", () => {
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 7, surface_id: "ROTATED" })) + "\n",
+      "utf-8",
+    );
+
+    const read = readAppendedCmuxEventsText({
+      path: eventsPath,
+      offset: 9_999,
+      maxBytes: 4096,
+    });
+
+    expect(read.text).toContain("ROTATED");
+    expect(read.nextOffset).toBe(statSync(eventsPath).size);
+    expect(read.truncated).toBe(true);
+  });
+
+  it("treats truncation as a fresh sequence stream instead of reusing the old seq cursor", () => {
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "AFTER-ROTATE" })) + "\n",
+      "utf-8",
+    );
+    const stateMgr = new StateManager(stateDir);
+    writeFileSync(
+      join(stateDir, "close-forensics-cursor.json"),
+      JSON.stringify({ last_seq: 99, last_offset: 9_999, last_close_boot_id: "OLD" }),
+      "utf-8",
+    );
+
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+    });
+
+    expect(runner().emitted).toBe(1);
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      ) as CloseForensicsEvent[];
+    expect(forensics[0].cmux_surface_id).toBe("AFTER-ROTATE");
+  });
+
+  it("caps a single cmux events read window", () => {
+    writeFileSync(
+      eventsPath,
+      [
+        JSON.stringify(surfaceClosed({ seq: 1, surface_id: "A" })),
+        JSON.stringify(surfaceClosed({ seq: 2, surface_id: "B" })),
+        JSON.stringify(surfaceClosed({ seq: 3, surface_id: "C" })),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const read = readAppendedCmuxEventsText({
+      path: eventsPath,
+      offset: 0,
+      maxBytes: 80,
+    });
+
+    expect(Buffer.byteLength(read.text)).toBeLessThanOrEqual(80);
+    expect(read.nextOffset).toBeLessThan(statSync(eventsPath).size);
+  });
+
+  it("does not advance past an over-cap chunk with no complete JSONL line", () => {
+    writeFileSync(eventsPath, "x".repeat(200), "utf-8");
+
+    const read = readAppendedCmuxEventsText({
+      path: eventsPath,
+      offset: 0,
+      maxBytes: 80,
+    });
+
+    expect(read.text).toBe("");
+    expect(read.nextOffset).toBe(0);
+  });
+
+  it("does not advance past an unterminated EOF JSONL record", () => {
+    const complete = JSON.stringify(surfaceClosed({ seq: 1, surface_id: "DONE" })) + "\n";
+    const partial = JSON.stringify(surfaceClosed({ seq: 2, surface_id: "PARTIAL" }));
+    writeFileSync(eventsPath, complete + partial, "utf-8");
+
+    const read = readAppendedCmuxEventsText({
+      path: eventsPath,
+      offset: 0,
+      maxBytes: 4096,
+    });
+
+    expect(read.text).toBe(complete);
+    expect(read.nextOffset).toBe(Buffer.byteLength(complete));
   });
 });
 

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -21,6 +21,7 @@ import {
   loadHarnessSessionWithMeta,
   applyHarnessState,
   harnessJsonlEnabled,
+  readHarnessSessionTextWindow,
 } from "../src/harness-session.js";
 
 const FIX = join(__dirname, "fixtures", "harness");
@@ -265,6 +266,37 @@ describe("resolveSessionPath (cwd + sessionId → JSONL path)", () => {
   });
 });
 
+describe("readHarnessSessionTextWindow", () => {
+  it("reads only the tail window of a large harness transcript", () => {
+    const dir = mkdtempSync(join(tmpdir(), "harness-window-"));
+    const path = join(dir, "session.jsonl");
+    try {
+      const oldLine = JSON.stringify({
+        type: "assistant",
+        message: { model: "claude-opus-4-8", usage: { input_tokens: 1 } },
+      });
+      const latestLine = JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-8",
+          usage: { input_tokens: 123, output_tokens: 4 },
+          content: [{ type: "text", text: "latest tail text" }],
+        },
+      });
+      writeFileSync(path, `${oldLine}\n`.repeat(2000) + `${latestLine}\n`, "utf8");
+
+      const text = readHarnessSessionTextWindow(path, { maxBytes: 2048 });
+
+      expect(text).not.toBeNull();
+      expect(Buffer.byteLength(text ?? "")).toBeLessThanOrEqual(2048);
+      expect(text).toContain("latest tail text");
+      expect(text).not.toBe(readFileSync(path, "utf8"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("readHarnessSessionFromFile", () => {
   it("reads + parses a Codex fixture file end to end", () => {
     const s = readHarnessSessionFromFile("codex", join(FIX, "codex.jsonl"));
@@ -440,6 +472,38 @@ describe("findLatestHarnessSessionIdentity (cwd → real session id)", () => {
       session_id: "019e942c-0dda-76f2-bbca-0ef6e484d1c9",
     });
     expect(identity?.path).toContain("not-the-real-id.jsonl");
+  });
+
+  it("Codex: finds session_meta near the head of a large transcript", () => {
+    const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-large-head-"));
+    const cwd = "/Users/e/Gits/cmuxlayer";
+    const root = join(localHome, ".codex", "sessions", "2026", "07", "07");
+    mkdirSync(root, { recursive: true });
+    const file = join(root, "rollout-2026-07-07T00-00-00-large-head.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "large-head", cwd },
+        }),
+        `${JSON.stringify({ type: "assistant", message: "noise" })}\n`.repeat(
+          9000,
+        ),
+      ].join("\n"),
+      "utf8",
+    );
+
+    try {
+      const identity = findLatestHarnessSessionIdentity("codex", cwd, {
+        home: localHome,
+      });
+
+      expect(identity?.session_id).toBe("large-head");
+      expect(identity?.path).toBe(file);
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
   });
 
   it("Codex: skips malformed lines and session_meta entries missing ids", () => {

--- a/tests/stdio-lifecycle.test.ts
+++ b/tests/stdio-lifecycle.test.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { bindStdioLifecycle } from "../src/stdio-lifecycle.js";
+
+describe("bindStdioLifecycle", () => {
+  it("runs shutdown when stdin ends or closes", () => {
+    const stdin = new EventEmitter();
+    const transport = new EventEmitter();
+    const shutdown = vi.fn();
+
+    bindStdioLifecycle({ stdin, transport, shutdown });
+
+    stdin.emit("end");
+    stdin.emit("close");
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledWith("stdin:end");
+  });
+
+  it("runs shutdown when stdin errors", () => {
+    const stdin = new EventEmitter();
+    const transport = new EventEmitter();
+    const shutdown = vi.fn();
+
+    bindStdioLifecycle({ stdin, transport, shutdown });
+
+    stdin.emit("error", new Error("pipe failed"));
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledWith("stdin:error");
+  });
+
+  it("runs shutdown when the stdio transport closes", () => {
+    const stdin = new EventEmitter();
+    const transport = new EventEmitter();
+    const shutdown = vi.fn();
+
+    bindStdioLifecycle({ stdin, transport, shutdown });
+
+    transport.emit("close");
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledWith("transport:close");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the P0 memory balloon root cause: close-forensics no longer slurps the unbounded `~/.cmuxterm/events.jsonl` on every sweep; it persists a byte offset alongside the existing seq cursor and reads only a bounded append window.
- Preserves close-forensics output semantics by carrying previous close `boot_id` in the cursor, resetting seq/offset safely on truncation/rotation, and avoiding silent skips for over-cap incomplete JSONL chunks.
- Audits harness transcript reads by parsing from a capped tail window instead of reading large session JSONL files wholesale.
- Adds stdio lifecycle shutdown binding so stale MCP server children exit when stdin ends/closes/errors or the stdio transport closes.

## Test plan
- [x] RED: focused regression tests failed for missing offset-tail, harness tail, and stdio lifecycle APIs.
- [x] `bunx vitest run tests/close-forensics.test.ts tests/harness-session.test.ts tests/stdio-lifecycle.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test` (79 files, 1463 tests)
- [x] `git diff --check`
- [x] Push hook `scripts/run_tests.sh` completed with exit status 0.

## Review notes
- Local `coderabbit review --agent` first run timed out at 180s after emitting three major findings; all three were fixed with added regression coverage.
- Second local `coderabbit review --agent` run timed out at 180s with no new findings emitted.

Do not merge yet: independent review and live memory check gate the merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches periodic sweep I/O and MCP process lifecycle; bounded reads and truncation reset are well-tested but wrong cursor behavior could miss or duplicate forensics events until corrected.
> 
> **Overview**
> Fixes a **P0 memory balloon** by stopping full-file reads of unbounded logs on every sweep. **Close forensics** now tails `~/.cmuxterm/events.jsonl` from a persisted **byte offset** (256KB cap per read, complete JSONL lines only), stores **`last_offset`**, **`last_close_boot_id`**, and **window key lookback** in the cursor, and **resets seq/offset** when the file is truncated or rotated so attribution and `boot_id` continuity stay correct across incremental passes.
> 
> **Harness session** parsing no longer loads entire large transcripts: session state uses a **512KB tail window**; identity/resume scans use a **head+tail window** so early `session_meta` still resolves on huge Codex rollouts.
> 
> Adds **`bindStdioLifecycle`** and wires it in the MCP entrypoint so the process **closes the server once** when stdin ends/closes/errors or the stdio transport closes, with a **1s forced exit** fallback to avoid zombie children.
> 
> Cursor JSON on disk gains new optional fields; older cursors default missing offset/boot fields safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb951456bf0cc392c8b8a24c07612778fca43fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound forensics memory usage and fix stdio lifecycle shutdown in MCP server
> - [close-forensics.ts](https://github.com/EtanHey/cmuxlayer/pull/259/files#diff-f2c6509ec1163d316086dcaae2b98686183a54a84527fc006f3a12a7f06cda8a) now reads only appended bytes from the cmux events file using offset-based, line-aligned, 256 KiB-capped reads via the new `readAppendedCmuxEventsText` util, preventing unbounded memory use on large files.
> - File truncation/rotation is detected and resets the seq/offset cursor; `boot_id` continuity and last window key/unkey event are persisted across sweeps via richer cursor state (`readState`/`writeState`).
> - [harness-session.ts](https://github.com/EtanHey/cmuxlayer/pull/259/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) replaces full-file reads with bounded tail and head+tail window reads for session parsing and identity discovery.
> - [stdio-lifecycle.ts](https://github.com/EtanHey/cmuxlayer/pull/259/files#diff-50d3ca95194420dfc6ce1fa4899d70fc00abf1ded76fa348d6c8cbd870289fcc) introduces `bindStdioLifecycle`, wiring stdin end/close/error and transport close events to a single-shot shutdown callback with a 1-second forced-exit watchdog.
> - Behavioral Change: the default close forensics runner now persists file byte offsets alongside sequence numbers; existing cursor files written by the old runner (seq only) are handled via legacy fallback but will be upgraded on next write.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fb9514.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background processing to continue from the last seen position, making repeated runs faster and more reliable.
  * Added safer handling for large log/transcript files by reading only the most recent portion when needed.

* **Bug Fixes**
  * Fixed issues caused by truncated or rotated files so processing can recover cleanly instead of using stale cursor data.
  * Added more reliable shutdown handling for streaming sessions to prevent hangs and ensure clean exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->