### PR TITLE
fix: prevent duplicate submit retries

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -275,7 +275,7 @@ const SEND_INPUT_RETRY_ATTEMPTS = 3;
 const SEND_INPUT_RETRY_DELAY_MS = 25;
 const SEND_INPUT_ENTER_DELAY_MS = 50;
 const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
-const DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 2000;
+const DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 5000;
 function parsePositiveIntegerMs(
   value: string | undefined,
   fallback: number,
@@ -301,6 +301,8 @@ export const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
   DEFAULT_SEND_INPUT_MAX_INLINE_CHARS,
 );
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
+const SEND_INPUT_SAFE_RETRY_OBSERVE_MS = 2500;
+const SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS = 300;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const BOOT_PROMPT_UPDATE_MAX_MS = 120_000;
@@ -1247,7 +1249,7 @@ function screenHasAnyAgentIdentity(
 ): boolean {
   return (
     hasParsedAgentIdentity(parsed) ||
-    /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?|(?:^|\n)\s*(?:codex>|cursor>|kiro>)\s*$/im.test(
+    /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?|(?:^|\n)\s*(?:codex>|cursor>|kiro>)(?:\s|$)/im.test(
       screenText,
     )
   );
@@ -2720,6 +2722,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_agent?: string | null;
     verify_submit: boolean;
     require_working_status?: boolean;
+    allow_recovery_enter_retry?: boolean;
     timeout_ms?: number;
   }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
     if (!opts.verify_submit) {
@@ -2735,6 +2738,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let sawClearedComposerEvidence = false;
     let sawAllowedClearedComposerEvidence = false;
     let lastHasPendingInput = false;
+    let lastRetryEligiblePendingInput = false;
+    let retryEligiblePendingSince: number | null = null;
+    let retriedAt: number | null = null;
     const screenIncludesSubmittedText = (screenText: string): boolean => {
       const trimmed = opts.text.trim();
       if (!trimmed) {
@@ -2775,43 +2781,43 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !screenIncludesSubmittedText(snapshot.text);
         if (allowClearedComposerSubmitEvidence) {
           sawAllowedClearedComposerEvidence = true;
-        }
-        if (!opts.require_working_status && allowClearedComposerSubmitEvidence) {
           return { submit_verified: true, retry_count: retryCount };
         }
-      }
-
-      if (opts.require_working_status) {
-        if (!retried) {
-          await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
-          await sendKeyWithRetry(opts.surface, "return", opts.workspace);
-          retryCount += 1;
-          appendDeliveryEvent({
-            event_type: "press_enter",
-            source_agent: opts.source_agent ?? null,
-            target_surface: opts.surface,
-            bytes: opts.bytes,
-            press_enter: true,
-            submit_verified: null,
-            retry_count: retryCount,
-          });
-          retried = true;
-          continue;
-        }
-
-        await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
-        continue;
       }
 
       const shouldRetryEnter =
         hasPendingInput ||
         (opts.source_event === "spawn_agent" &&
           screenIncludesSubmittedText(snapshot.text));
+      const retryEligiblePendingInput =
+        opts.allow_recovery_enter_retry !== false &&
+        shouldRetryEnter &&
+        ((screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+          snapshot.parsed.status === "idle") ||
+          (opts.source_event === "spawn_agent" &&
+            !hasParsedAgentIdentity(snapshot.parsed)));
+      lastRetryEligiblePendingInput = retryEligiblePendingInput;
+      if (retryEligiblePendingInput) {
+        retryEligiblePendingSince ??= Date.now();
+      } else {
+        retryEligiblePendingSince = null;
+      }
+      const retryObserveMs =
+        opts.source_event === "spawn_agent" &&
+        !hasParsedAgentIdentity(snapshot.parsed)
+          ? 0
+          : Math.min(timeoutMs, SEND_INPUT_SAFE_RETRY_OBSERVE_MS);
 
-      // Pending input is ambiguous: the first Return may have been missed. A
-      // launch command echoed in shell history keeps its legacy advisory retry.
-      // A recognized cleared agent composer is handled above as submit evidence.
-      if (!retried && shouldRetryEnter) {
+      // Pending input is ambiguous: the first Return may have been missed, or
+      // it may have landed while a slow agent has not repainted the composer
+      // yet. Observe before retrying, and only retry an idle agent composer that
+      // still definitively holds the original text.
+      if (
+        !retried &&
+        retryEligiblePendingInput &&
+        retryEligiblePendingSince !== null &&
+        Date.now() - retryEligiblePendingSince >= retryObserveMs
+      ) {
         await delay(SEND_INPUT_RECOVERY_ENTER_DELAY_MS);
         await sendKeyWithRetry(opts.surface, "return", opts.workspace);
         retryCount += 1;
@@ -2825,17 +2831,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           retry_count: retryCount,
         });
         retried = true;
+        retriedAt = Date.now();
         continue;
+      }
+
+      if (
+        retriedAt !== null &&
+        retryEligiblePendingInput &&
+        Date.now() - retriedAt >= SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS
+      ) {
+        return { submit_verified: false, retry_count: retryCount };
       }
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
     return {
-      submit_verified: opts.require_working_status
-        ? false
-        : sawClearedComposerEvidence && sawAllowedClearedComposerEvidence
+      submit_verified:
+        sawClearedComposerEvidence && sawAllowedClearedComposerEvidence
           ? true
-          : lastHasPendingInput
+          : opts.require_working_status
+            ? false
+          : lastRetryEligiblePendingInput
             ? false
             : null,
       retry_count: retryCount,
@@ -2854,6 +2870,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_event?: DeliveryEventType;
     source_agent?: string | null;
     verify_submit?: boolean;
+    allow_recovery_enter_retry?: boolean;
     submit_verify_timeout_ms?: number;
   }): Promise<{
     bytes: number;
@@ -2912,6 +2929,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         source_event: opts.source_event ?? "send_command",
         source_agent: opts.source_agent,
         verify_submit: opts.verify_submit ?? false,
+        allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
         timeout_ms: opts.submit_verify_timeout_ms,
         require_working_status: opts.source_event === "boot_prompt",
       });
@@ -6330,6 +6348,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             // false-failing a legitimate interjection.
             verify_submit:
               args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
+            allow_recovery_enter_retry: !args.allow_busy,
           });
         },
         {

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -272,6 +272,71 @@ class FakeShellSurfaceClient {
   }
 }
 
+class FakeSlowClearingAgentClient extends FakeClaudeSurfaceClient {
+  readonly sendKeyCalls: string[] = [];
+  clearAfterReads = 22;
+  duplicateSubmits = 0;
+  private pendingText = "";
+  private submittedText: string | null = null;
+  private readsSinceSubmit = 0;
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    this.sendCalls.push(text);
+    this.pendingText += text;
+  }
+
+  async pasteText(surface: string, text: string) {
+    await this.send(surface, text);
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    this.sendKeyCalls.push(key);
+    if (key !== "return" || !this.pendingText) {
+      return;
+    }
+
+    if (this.submittedText !== null) {
+      this.duplicateSubmits += 1;
+      return;
+    }
+
+    this.submittedText = this.pendingText;
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+
+    if (this.submittedText !== null) {
+      this.readsSinceSubmit += 1;
+      if (this.readsSinceSubmit >= this.clearAfterReads) {
+        this.pendingText = "";
+      }
+    }
+
+    return {
+      surface,
+      text: this.renderScreen(),
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  private renderScreen(): string {
+    const tail = this.pendingText.slice(-160);
+    return `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
+  }
+}
+
 function createReliabilityServer(client: FakeClaudeSurfaceClient) {
   return createServer({
     client: client as any,
@@ -409,6 +474,27 @@ describe("enter reliability", () => {
     expect(events).toHaveLength(1);
     expect(events[0]?.submit_verified).toBe(true);
     expect(events[0]?.retry_count).toBe(0);
+  });
+
+  it("does not press Enter twice when a submitted agent composer clears slowly", async () => {
+    const client = new FakeSlowClearingAgentClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "slow first token",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(client.duplicateSubmits).toBe(0);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
   });
 
   it("reports a failed send_to submit when text remains in the composer after retry", async () => {
@@ -584,6 +670,32 @@ describe("enter reliability", () => {
     expect(events[0]?.submit_verified).toBeNull();
   });
 
+  it("does not retry Enter for allow_busy agent sends with ambiguous pending input", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready" });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "stack this while busy",
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter((event) => event.event_type === "send_to");
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBeNull();
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBeNull();
+    expect(events[0]?.retry_count).toBe(0);
+  }, 10_000);
+
   it("does not verify send_input to an uncached shell from prompt clearing", async () => {
     const client = new FakeShellSurfaceClient();
     server = createReliabilityServer(client as any);
@@ -666,7 +778,7 @@ describe("enter reliability", () => {
           event.submit_verified === true && event.retry_count === 1,
       ),
     ).toBe(true);
-  });
+  }, 10_000);
 
   it("records UTF-8 byte counts in delivery telemetry", async () => {
     const client = new FakeClaudeSurfaceClient();

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -203,7 +203,7 @@ describe("false-green empty surface protection", () => {
       { surface: "surface:2", command: longCommand },
       {} as any,
     );
-    await vi.advanceTimersByTimeAsync(2500);
+    await vi.advanceTimersByTimeAsync(6000);
     const result = await resultPromise;
 
     const parsed = parseToolResult(result);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1945,7 +1945,7 @@ describe("agent lifecycle tool handlers", () => {
         "file prompt body",
       ]),
     );
-  });
+  }, 10_000);
 
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7011,7 +7011,7 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBeGreaterThanOrEqual(2);
   }, 10_000);
 
-  it("new_split retries Return when the boot prompt clears but the agent does not start working", async () => {
+  it("new_split verifies a cleared boot prompt without pressing Return again", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-idle-clear-retry.md");
     const prompt = "short boot prompt";
@@ -7074,7 +7074,7 @@ describe("tool handler integration", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
-    expect(returnPresses).toBe(2);
+    expect(returnPresses).toBe(1);
   }, 10_000);
 
   it("new_split reports pane_died when the new surface disappears during boot prompt submit verification", async () => {
@@ -7224,7 +7224,7 @@ describe("tool handler integration", () => {
     expect(transientFailureThrown).toBe(true);
   }, 10_000);
 
-  it("new_split fails when the boot prompt clears after retry without agent identity", async () => {
+  it("new_split fails when the boot prompt clears without agent identity", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-idle-after-clear.md");
     const prompt = "short boot prompt";
@@ -7291,7 +7291,7 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Timed out");
     expect(parsed.boot_prompt_delivered).not.toBe(true);
-    expect(returnPresses).toBe(2);
+    expect(returnPresses).toBe(1);
   }, 10_000);
 
   it("new_split fails loudly when a short boot prompt stays pending after submit retry", async () => {
@@ -7418,7 +7418,7 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
     expect(returnPresses).toBe(1);
-  });
+  }, 10_000);
 
   it("new_split keeps verifying long boot prompts and retries a missed submit", async () => {
     vi.useRealTimers();
@@ -7491,7 +7491,7 @@ describe("tool handler integration", () => {
     expect(sendCalls).toHaveLength(1);
     expect(sendCalls.join("")).toBe(prompt);
     expect(returnPresses).toBe(2);
-  });
+  }, 10_000);
 
   it("new_split renames the new surface when a title is provided", async () => {
     mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {

--- a/tests/submit-verify-timeout-env.test.ts
+++ b/tests/submit-verify-timeout-env.test.ts
@@ -155,7 +155,7 @@ async function runSubmitFailureWithEnv(value: string): Promise<any> {
     { surface: client.surface, command: "ping" },
     {} as any,
   );
-  await vi.advanceTimersByTimeAsync(2500);
+  await vi.advanceTimersByTimeAsync(6000);
   const result = await resultPromise;
   disposeServer(server);
 
@@ -185,13 +185,13 @@ describe("submit verification timeout env", () => {
     expect(parsed.error).toContain("within 25ms");
   });
 
-  it("falls back to 2000ms for an invalid CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS", async () => {
+  it("falls back to 5000ms for an invalid CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS", async () => {
     vi.useFakeTimers();
     mkdirSync(TEST_DIR, { recursive: true });
 
     const parsed = await runSubmitFailureWithEnv("not-a-number");
 
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("within 2000ms");
-  });
+    expect(parsed.error).toContain("within 5000ms");
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary
- Fix duplicate prompt delivery caused by `verifySubmitAfterEnter` pressing Return again when a slow agent still showed pending composer text after the first successful submit.
- Treat cleared agent composer evidence as definitive submission success, including boot-prompt verification, so the retry path cannot fire after a clear.
- Gate recovery Return behind a safe observation window that starts when retry-eligible pending input is first seen; keep genuine missed-Enter recovery for idle agent composers and launcher shell commands.
- Disable ambiguous recovery Return for `allow_busy` agent sends; these remain single-Return sends with indeterminate submit verification rather than risking duplicate delivery.
- Raise default submit verification timeout from 2000ms to 5000ms while preserving `CMUXLAYER_SUBMIT_VERIFY_TIMEOUT_MS` override.

## Root Cause
The verifier treated visible pending composer text inside the short 2s window as enough evidence to press Return again. On slow first-token agents like Cursor, the first Return had already submitted or queued the prompt, but the composer had not repainted yet. The recovery Return could therefore resubmit the same text, yielding `submit_verified:false, retry_count:1` duplicate deliveries.

## Test Plan
- RED observed first in `tests/enter-reliability.test.ts`: slow-clearing submitted composer failed before the fix because verification pressed Return twice / failed the send.
- `bun run test` -> 79 files passed, 1468 tests passed.
- `bun run typecheck` -> `tsc -p tsconfig.json --noEmit` passed.
- `git diff --check` passed.
- Local CodeRabbit review: first run found one major issue (retry observe window anchored to delivery start); fixed by timing from first retry-eligible pending evidence. Second run hit free OSS rate limit after the fix, so final validation is based on fresh full suite/typecheck evidence.

## Notes
- Do not merge until independent review and live Cursor-pane one-arrival check are complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal input delivery and verification paths used by send_to, boot prompts, and spawn flows; wrong timing could miss genuine missed-Enter cases or still mis-verify edge cases.
> 
> **Overview**
> Tightens **submit verification** after pressing Enter so slow agent UIs no longer trigger a second Return and duplicate delivery.
> 
> **`verifySubmitAfterEnter`** now treats a **cleared agent composer** as immediate success (including boot prompts), instead of forcing an extra Return when `require_working_status` is set. Recovery Enter is **gated**: it waits up to **`SEND_INPUT_SAFE_RETRY_OBSERVE_MS`** after retry-eligible pending input first appears (idle agent composer still holding text, or spawn launcher cases), then optionally retries once with a short **post-retry grace** before reporting failure. **`allow_recovery_enter_retry`** is wired through delivery and is **off for `allow_busy`** agent relays so ambiguous “busy” sends stay single-Enter with null verification.
> 
> Defaults and detection tweaks: submit verify timeout **2s → 5s** (env override unchanged), agent prompt regex accepts **`codex>` / `cursor>` / `kiro>`** with trailing content, and tests cover slow-clearing composers and updated boot-prompt expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaecbaaedb053f0201f4faf4ecafe106a223c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate submit retries in agent composer verification
> - Reworks `verifySubmitAfterEnter` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/260/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to observe pending input before issuing a recovery Enter, preventing double-submits when an agent composer clears slowly.
> - Adds a short grace window (`SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS = 300ms`) after a retry to fail verification if input remains pending, and increases the base verification timeout from 2000ms to 5000ms.
> - Adds `allow_recovery_enter_retry` option to let callers disable the recovery Enter retry path entirely.
> - Relaxes the terminal prompt regex in `screenHasAnyAgentIdentity` to match prompts with trailing whitespace.
> - Behavioral Change: verification now allows at most one recovery Enter retry, and the default timeout is 5000ms instead of 2000ms.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cfaecba. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->