### PR TITLE
fix: bound real event log balloon

### DIFF
--- a/scripts/event-log-bounded-rss-check.mjs
+++ b/scripts/event-log-bounded-rss-check.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import { createWriteStream, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i], process.argv[i + 1]);
+}
+
+const sizeMb = Number(args.get("--size-mb") ?? 256);
+const maxRssDeltaMb = Number(args.get("--max-rss-delta-mb") ?? 128);
+if (!Number.isFinite(sizeMb) || sizeMb <= 0) {
+  throw new Error("--size-mb must be a positive number");
+}
+if (!Number.isFinite(maxRssDeltaMb) || maxRssDeltaMb <= 0) {
+  throw new Error("--max-rss-delta-mb must be a positive number");
+}
+
+const { EventLog } = await import("../dist/event-log.js");
+const dir = mkdtempSync(join(tmpdir(), "cmux-event-log-rss-"));
+const filePath = join(dir, "events.jsonl");
+
+try {
+  await writeFixture(filePath, Math.floor(sizeMb * 1024 * 1024));
+  global.gc?.();
+  const before = process.memoryUsage().rss;
+  const closes = new EventLog(dir).readCloseEvents();
+  global.gc?.();
+  const after = process.memoryUsage().rss;
+  const delta = after - before;
+  const maxDelta = maxRssDeltaMb * 1024 * 1024;
+
+  console.log(
+    JSON.stringify(
+      {
+        file: filePath,
+        file_bytes: statSync(filePath).size,
+        close_events: closes.length,
+        rss_before: before,
+        rss_after: after,
+        rss_delta: delta,
+        max_rss_delta: maxDelta,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!closes.some((entry) => entry.target === "surface:recent")) {
+    throw new Error("recent close event was not returned from the bounded tail");
+  }
+  if (delta > maxDelta) {
+    throw new Error(`RSS delta ${delta} exceeded limit ${maxDelta}`);
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+async function writeFixture(path, targetBytes) {
+  const stream = createWriteStream(path, { encoding: "utf8" });
+  const filler = {
+    ts: "2026-07-06T12:00:00Z",
+    agent_id: "agent-filler",
+    event: "transition",
+    from_state: "ready",
+    to_state: "working",
+    surface_id: "surface:filler",
+    source: "fixture",
+    error: null,
+    payload: "x".repeat(4096),
+  };
+  let written = 0;
+  while (written < targetBytes) {
+    const line = JSON.stringify({
+      ...filler,
+      agent_id: `agent-${written}`,
+    }) + "\n";
+    written += Buffer.byteLength(line);
+    if (!stream.write(line)) await waitForStreamEvent(stream, "drain");
+  }
+
+  const recentClose =
+    JSON.stringify({
+      ts: "2026-07-06T12:05:00Z",
+      event_type: "close",
+      event: "close_surface",
+      target: "surface:recent",
+      caller: "bounded-rss-fixture",
+      force: false,
+      reason: null,
+      refused: false,
+    }) + "\n";
+  if (!stream.write(recentClose)) await waitForStreamEvent(stream, "drain");
+  stream.end();
+  await waitForStreamEvent(stream, "finish");
+}
+
+async function waitForStreamEvent(stream, event) {
+  await new Promise((resolve, reject) => {
+    const cleanup = () => {
+      stream.off(event, onEvent);
+      stream.off("error", onError);
+    };
+    const onEvent = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    stream.once(event, onEvent);
+    stream.once("error", onError);
+  });
+}

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -698,11 +698,7 @@ export function createDefaultCloseForensicsRunner(config: {
       readMcpCloses: () =>
         config.stateMgr
           .getEventLog()
-          .readEntries()
-          .filter(
-            (entry): entry is CloseTelemetryEvent =>
-              (entry as { event_type?: string }).event_type === "close",
-          ),
+          .readCloseEvents(),
       surfaceRefByCmuxId: () => buildSurfaceRefMap(config.stateMgr),
       appendForensics: (event) =>
         config.stateMgr.getEventLog().appendCloseForensics(event),

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -4,7 +4,17 @@
  * Path: {baseDir}/events.jsonl
  */
 
-import { appendFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 import type {
   CloseForensicsEvent,
@@ -15,11 +25,39 @@ import type {
   StateTransition,
 } from "./agent-types.js";
 
+export const DEFAULT_EVENT_LOG_MAX_READ_BYTES = 1024 * 1024;
+export const DEFAULT_EVENT_LOG_MAX_FILE_BYTES = 64 * 1024 * 1024;
+export const DEFAULT_EVENT_LOG_ROTATED_SEGMENTS = 2;
+
+export interface EventLogOptions {
+  maxReadBytes?: number;
+  maxFileBytes?: number;
+  rotatedSegments?: number;
+}
+
 export class EventLog {
   private filePath: string;
+  private maxReadBytes: number;
+  private maxFileBytes: number;
+  private rotatedSegments: number;
 
-  constructor(baseDir: string) {
+  constructor(baseDir: string, options: EventLogOptions = {}) {
     this.filePath = join(baseDir, "events.jsonl");
+    this.maxReadBytes = positiveInt(
+      options.maxReadBytes,
+      envInt("CMUX_EVENT_LOG_MAX_READ_BYTES"),
+      DEFAULT_EVENT_LOG_MAX_READ_BYTES,
+    );
+    this.maxFileBytes = positiveInt(
+      options.maxFileBytes,
+      envInt("CMUX_EVENT_LOG_MAX_FILE_BYTES"),
+      DEFAULT_EVENT_LOG_MAX_FILE_BYTES,
+    );
+    this.rotatedSegments = positiveInt(
+      options.rotatedSegments,
+      envInt("CMUX_EVENT_LOG_ROTATED_SEGMENTS"),
+      DEFAULT_EVENT_LOG_ROTATED_SEGMENTS,
+    );
     mkdirSync(baseDir, { recursive: true });
   }
 
@@ -60,20 +98,117 @@ export class EventLog {
   }
 
   readEntries(): EventLogEntry[] {
-    if (!existsSync(this.filePath)) return [];
-    const content = readFileSync(this.filePath, "utf-8").trim();
-    if (!content) return [];
-    return content
-      .split("\n")
-      .map((line) => JSON.parse(line) as EventLogEntry);
+    return this.readBoundedEntries();
   }
 
   readForAgent(agentId: string): StateTransition[] {
     return this.readAll().filter((entry) => entry.agent_id === agentId);
   }
 
+  readCloseEvents(): CloseTelemetryEvent[] {
+    return this.readBoundedEntries().filter(
+      (entry): entry is CloseTelemetryEvent =>
+        (entry as { event_type?: string }).event_type === "close",
+    );
+  }
+
   private appendEntry(entry: EventLogEntry): void {
     const line = JSON.stringify(entry) + "\n";
+    this.rotateIfNeeded(Buffer.byteLength(line));
     appendFileSync(this.filePath, line, "utf-8");
   }
+
+  private readBoundedEntries(): EventLogEntry[] {
+    const content = this.readBoundedTailText();
+    if (!content.trim()) return [];
+    return content
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as EventLogEntry);
+  }
+
+  private readBoundedTailText(): string {
+    let remainingBytes = this.maxReadBytes;
+    const chunks: string[] = [];
+    for (const path of this.segmentPathsNewestFirst()) {
+      if (remainingBytes <= 0) break;
+      if (!existsSync(path)) continue;
+      const chunk = readFileTail(path, remainingBytes);
+      if (!chunk) continue;
+      chunks.unshift(chunk.text);
+      remainingBytes -= chunk.bytesRead;
+    }
+    return chunks.join("");
+  }
+
+  private segmentPathsNewestFirst(): string[] {
+    const paths = [this.filePath];
+    for (let segment = 1; segment <= this.rotatedSegments; segment++) {
+      paths.push(`${this.filePath}.${segment}`);
+    }
+    return paths;
+  }
+
+  private rotateIfNeeded(incomingBytes: number): void {
+    if (!existsSync(this.filePath)) return;
+    const currentSize = statSync(this.filePath).size;
+    if (currentSize === 0 || currentSize + incomingBytes <= this.maxFileBytes) {
+      return;
+    }
+
+    const oldest = `${this.filePath}.${this.rotatedSegments}`;
+    rmSync(oldest, { force: true });
+    for (let segment = this.rotatedSegments - 1; segment >= 1; segment--) {
+      const from = `${this.filePath}.${segment}`;
+      const to = `${this.filePath}.${segment + 1}`;
+      if (existsSync(from)) renameSync(from, to);
+    }
+    renameSync(this.filePath, `${this.filePath}.1`);
+  }
+}
+
+function envInt(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function positiveInt(
+  explicit: number | undefined,
+  environment: number | undefined,
+  fallback: number,
+): number {
+  for (const value of [explicit, environment]) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.floor(value);
+    }
+  }
+  return fallback;
+}
+
+function readFileTail(
+  path: string,
+  maxBytes: number,
+): { text: string; bytesRead: number } | null {
+  const size = statSync(path).size;
+  if (size <= 0) return null;
+  const bytesToRead = Math.min(maxBytes, size);
+  const start = Math.max(0, size - bytesToRead);
+  const buffer = Buffer.allocUnsafe(bytesToRead);
+  const fd = openSync(path, "r");
+  let bytesRead = 0;
+  try {
+    bytesRead = readSync(fd, buffer, 0, bytesToRead, start);
+  } finally {
+    closeSync(fd);
+  }
+  if (bytesRead <= 0) return null;
+
+  let text = buffer.subarray(0, bytesRead).toString("utf8");
+  if (start > 0) {
+    const firstNewline = text.indexOf("\n");
+    text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+  }
+  return { text, bytesRead };
 }

--- a/src/heap-guard.ts
+++ b/src/heap-guard.ts
@@ -1,0 +1,92 @@
+export const DEFAULT_HEAP_GUARD_THRESHOLD_BYTES = 1.5 * 1024 * 1024 * 1024;
+export const DEFAULT_HEAP_GUARD_INTERVAL_MS = 15_000;
+export const DEFAULT_NODE_MAX_OLD_SPACE_MB = 1536;
+export const HEAP_GUARD_EXIT_CODE = 70;
+
+export interface HeapGuardOptions {
+  thresholdBytes?: number;
+  intervalMs?: number;
+  memoryUsage?: () => Pick<NodeJS.MemoryUsage, "heapUsed" | "rss">;
+  log?: (message: string) => void;
+  exit?: (code: number) => void;
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (timer: unknown) => void;
+}
+
+export function installHeapGuard(options: HeapGuardOptions = {}): unknown {
+  const thresholdBytes = positiveNumber(
+    options.thresholdBytes,
+    envNumber("CMUXLAYER_HEAP_GUARD_BYTES"),
+    DEFAULT_HEAP_GUARD_THRESHOLD_BYTES,
+  );
+  const intervalMs = positiveNumber(
+    options.intervalMs,
+    envNumber("CMUXLAYER_HEAP_GUARD_INTERVAL_MS"),
+    DEFAULT_HEAP_GUARD_INTERVAL_MS,
+  );
+  const memoryUsage = options.memoryUsage ?? (() => process.memoryUsage());
+  const log = options.log ?? ((message: string) => console.error(message));
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const setIntervalFn = options.setIntervalFn ?? setInterval;
+  const clearIntervalFn =
+    options.clearIntervalFn ??
+    ((value: unknown) => clearInterval(value as ReturnType<typeof setInterval>));
+
+  let timer: unknown;
+  const check = () => {
+    const usage = memoryUsage();
+    const used = Math.max(usage.heapUsed, usage.rss);
+    if (used < thresholdBytes) return;
+
+    log(
+      [
+        "[cmuxlayer] FATAL heap guard:",
+        `rss=${usage.rss}`,
+        `heapUsed=${usage.heapUsed}`,
+        `threshold=${thresholdBytes}`,
+        "exiting before the MCP child can balloon into a host OOM",
+      ].join(" "),
+    );
+    if (timer) clearIntervalFn(timer);
+    exit(HEAP_GUARD_EXIT_CODE);
+  };
+
+  timer = setIntervalFn(check, intervalMs);
+  if (typeof (timer as { unref?: unknown })?.unref === "function") {
+    (timer as { unref: () => void }).unref();
+  }
+  return timer;
+}
+
+export function ensureNodeMaxOldSpaceEnv(): void {
+  const nodeOptions = process.env.NODE_OPTIONS ?? "";
+  if (/(^|\s)--max-old-space-size(=|\s)/.test(nodeOptions)) return;
+  const maxOldSpaceMb = positiveNumber(
+    undefined,
+    envNumber("CMUXLAYER_NODE_MAX_OLD_SPACE_MB"),
+    DEFAULT_NODE_MAX_OLD_SPACE_MB,
+  );
+  process.env.NODE_OPTIONS = `${nodeOptions} --max-old-space-size=${Math.floor(
+    maxOldSpaceMb,
+  )}`.trim();
+}
+
+function envNumber(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function positiveNumber(
+  explicit: number | undefined,
+  environment: number | undefined,
+  fallback: number,
+): number {
+  for (const value of [explicit, environment]) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return fallback;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ import {
   httpNotifyMonitorDeadman,
 } from "./monitor-registry.js";
 import { bindStdioLifecycle } from "./stdio-lifecycle.js";
+import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
+
+ensureNodeMaxOldSpaceEnv();
+installHeapGuard();
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   appendFileSync,
   mkdtempSync,
@@ -565,6 +565,43 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
         (e) => (e as { event_type?: string }).event_type === "close_forensics",
       ) as CloseForensicsEvent[];
     expect(forensics[0].cmux_surface_id).toBe("AFTER-ROTATE");
+  });
+
+  it("reads MCP closes through the bounded close-event reader, not readEntries", () => {
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })) + "\n",
+      "utf-8",
+    );
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.getEventLog().appendClose(
+      mcpClose({
+        target: "S1",
+        caller: "mcp-test-caller",
+        ts: "2026-07-06T21:34:14.000Z",
+      }),
+    );
+    const unboundedRead = vi
+      .spyOn(stateMgr.getEventLog(), "readEntries")
+      .mockImplementation(() => {
+        throw new Error("readEntries is the unbounded path");
+      });
+
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+    });
+
+    expect(runner().emitted).toBe(1);
+    const forensics = readFileSync(join(stateDir, "events.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { event_type?: string })
+      .filter((e) => e.event_type === "close_forensics") as CloseForensicsEvent[];
+    expect(forensics).toHaveLength(1);
+    expect(forensics[0].attribution).toBe("mcp:close_surface caller=mcp-test-caller");
+    expect(unboundedRead).not.toHaveBeenCalled();
   });
 
   it("caps a single cmux events read window", () => {

--- a/tests/event-log.test.ts
+++ b/tests/event-log.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventLog } from "../src/event-log.js";
@@ -161,5 +168,78 @@ describe("EventLog", () => {
     });
     // Close entries carry no agent_id, so they are not mistaken for transitions.
     expect(log.readAll()).toHaveLength(0);
+  });
+
+  it("reads only a bounded tail window while preserving recent entries", () => {
+    const log = new EventLog(TEST_DIR, { maxReadBytes: 512 });
+    const filePath = join(TEST_DIR, "events.jsonl");
+    const oldClose: CloseTelemetryEvent = {
+      ts: "2026-07-06T12:00:00Z",
+      event_type: "close",
+      event: "close_surface",
+      target: "surface:old",
+      caller: "old-caller",
+      force: false,
+      reason: null,
+      refused: false,
+    };
+    const recentClose: CloseTelemetryEvent = {
+      ...oldClose,
+      ts: "2026-07-06T12:05:00Z",
+      target: "surface:recent",
+      caller: "recent-caller",
+    };
+
+    writeFileSync(
+      filePath,
+      [
+        JSON.stringify(oldClose),
+        ...Array.from({ length: 40 }, (_, index) =>
+          JSON.stringify(
+            makeTransition({
+              agent_id: `agent-filler-${index}`,
+              surface_id: `surface:${index}`,
+            }),
+          ),
+        ),
+        JSON.stringify(recentClose),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    expect(statSync(filePath).size).toBeGreaterThan(512);
+
+    const read = log.readCloseEvents();
+    expect(read.map((entry) => entry.target)).toEqual(["surface:recent"]);
+    expect(
+      log.readAll().some((entry) => entry.agent_id === "agent-filler-0"),
+    ).toBe(false);
+  });
+
+  it("rotates before the active event log can grow beyond its cap", () => {
+    const log = new EventLog(TEST_DIR, {
+      maxFileBytes: 900,
+      maxReadBytes: 2048,
+    });
+    const filePath = join(TEST_DIR, "events.jsonl");
+    const rotatedPath = join(TEST_DIR, "events.jsonl.1");
+
+    for (let i = 0; i < 30; i++) {
+      log.append(
+        makeTransition({
+          agent_id: `agent-${i}`,
+          surface_id: `surface:${i}`,
+        }),
+      );
+    }
+    log.append(
+      makeTransition({
+        agent_id: "agent-recent",
+        surface_id: "surface:recent",
+      }),
+    );
+
+    expect(existsSync(rotatedPath)).toBe(true);
+    expect(statSync(filePath).size).toBeLessThanOrEqual(900);
+    expect(log.readForAgent("agent-recent")).toHaveLength(1);
   });
 });

--- a/tests/heap-guard.test.ts
+++ b/tests/heap-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { installHeapGuard } from "../src/heap-guard.js";
+
+describe("heap guard", () => {
+  it("logs loudly and exits non-zero when rss crosses the threshold", () => {
+    let tick: (() => void) | null = null;
+    const log = vi.fn();
+    const exit = vi.fn();
+    const clearIntervalFn = vi.fn();
+
+    installHeapGuard({
+      thresholdBytes: 1_500,
+      intervalMs: 10,
+      memoryUsage: () => ({ heapUsed: 1_100, rss: 1_600 }),
+      log,
+      exit,
+      setIntervalFn: (fn) => {
+        tick = fn;
+        return "timer";
+      },
+      clearIntervalFn,
+    });
+
+    tick?.();
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("[cmuxlayer] FATAL heap guard"),
+    );
+    expect(exit).toHaveBeenCalledWith(expect.any(Number));
+    expect(exit.mock.calls[0][0]).not.toBe(0);
+    expect(clearIntervalFn).toHaveBeenCalledWith("timer");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the real balloon target: `~/.local/state/cmux-agents/events.jsonl`, written by `src/event-log.ts`.
- Root cause: `EventLog.readEntries()` slurped the whole JSONL file with `readFileSync(...).split("\n").map(JSON.parse)`, and `createDefaultCloseForensicsRunner` used that path via close-forensics for every sweep. On a 6.6GB file this can balloon an MCP child to multi-GB RSS.
- Bounds every EventLog reader (`readEntries`, `readAll`, `readForAgent`, and new `readCloseEvents`) to a named tail window, and switches close-forensics MCP close lookup to the bounded close-event reader.
- Adds write-side rotation before `events.jsonl` exceeds the named 64MB cap, keeping rotated segments for recent-reader continuity.
- Adds an in-process heap guard with env-overridable RSS/heap threshold and a loud non-zero exit path.
- Adds `NODE_OPTIONS=--max-old-space-size=1536` env setup for child processes started after boot. Note: the launcher `~/.golems/bin/cmuxlayer-mcp` should also carry `--max-old-space-size` because setting `NODE_OPTIONS` inside `src/index.ts` cannot retroactively constrain the already-running Node process.
- Adds `scripts/event-log-bounded-rss-check.mjs` so lead can generate a large fixture and assert bounded RSS against built `dist/event-log.js`.

## Test plan
- [x] RED verified before implementation: targeted tests failed for missing bounded close reader, missing rotation, default close-forensics still using unbounded path, and missing heap guard.
- [x] `bun run typecheck` — exit 0.
- [x] `bunx vitest run tests/event-log.test.ts tests/close-forensics.test.ts tests/heap-guard.test.ts` — 3 files, 35 tests passed.
- [x] `bun run test` — 80 files, 1472 tests passed.
- [x] pre-push hook — `run_tests.sh finished with exit status 0`; 80 files, 1472 tests passed.
- [x] `node --expose-gc scripts/event-log-bounded-rss-check.mjs --size-mb 16 --max-rss-delta-mb 64` — generated 16,779,301-byte fixture, returned 1 close event, RSS delta 950,272 bytes under 67,108,864-byte limit.

## Release gate
Do not merge or release from this PR yet. The lead still needs to run the live heap check against a multi-GB fixture / real balloon-class file before merge/release.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core telemetry I/O and process exit behavior; bounded reads may omit older events outside the tail window, which could affect any code expecting full history from read APIs.
> 
> **Overview**
> Fixes unbounded memory use when **`events.jsonl`** grows very large: readers no longer load the whole file, writes rotate at a cap, and the MCP process gets a safety net at boot.
> 
> **`EventLog`** now reads only a configurable tail (default 1MB, env/options) across the active file and rotated segments, adds **`readCloseEvents()`**, and rotates **`events.jsonl`** before it exceeds 64MB (keeping numbered segments). **Close forensics** MCP close lookup uses **`readCloseEvents()`** instead of filtering a full **`readEntries()`** load.
> 
> **`heap-guard`** is wired from **`index.ts`**: periodic RSS/heap threshold check with a loud fatal exit, plus **`ensureNodeMaxOldSpaceEnv()`** to append **`--max-old-space-size`** when not already set. A new **`scripts/event-log-bounded-rss-check.m Generating large fixtures and asserting bounded RSS on **`readCloseEvents()`**.
> 
> Tests cover bounded tail/rotation, forensics using the bounded close path, and heap-guard exit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae19caa9fc7582af0f11d020a3b57a7e973baad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound EventLog reads and add log rotation and heap guard to prevent unbounded RSS growth
> - Replaces unbounded full-file reads in [`EventLog`](https://github.com/EtanHey/cmuxlayer/pull/261/files#diff-f71f2b1c91cb65f4fd1d7f3cc9909e02b16fb843bc782cc439c31e0b8a6f3fd2) with a bounded tail read (`readBoundedEntries`), controlled by `DEFAULT_EVENT_LOG_MAX_READ_BYTES` and overridable via env vars.
> - Adds log rotation to `appendEntry`: when an append would exceed the configured max file size, the oldest segment is deleted and existing segments are shifted, keeping a configurable number of rotated segments.
> - Adds `readCloseEvents()` to `EventLog` and updates [`close-forensics.ts`](https://github.com/EtanHey/cmuxlayer/pull/261/files#diff-f2c6509ec1163d316086dcaae2b98686183a54a84527fc006f3a12a7f06cda8a) to use it instead of filtering all entries via `readEntries()`.
> - Adds [`heap-guard.ts`](https://github.com/EtanHey/cmuxlayer/pull/261/files#diff-c23a4c36f62642e87924b85f95d6e79a5c3fe7a86d5d5199beca2b1e78fffd78) with `installHeapGuard()` (periodic RSS/heap check that exits the process if a threshold is exceeded) and `ensureNodeMaxOldSpaceEnv()` (sets `--max-old-space-size` in `NODE_OPTIONS` if absent), both invoked at server startup in [`index.ts`](https://github.com/EtanHey/cmuxlayer/pull/261/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
> - Risk: `readEntries()` now returns only bounded tail entries rather than all entries, which is a behavioral change for any callers expecting the full log history.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1ae19ca. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic memory protection at startup to help prevent runaway heap usage.
  * Event logs now keep a bounded, rotating history so they stay smaller over time.
  * Added a reportable check for log-related memory growth and recent close-event presence.

* **Bug Fixes**
  * Close-event processing now reads only the relevant close records, improving reliability and efficiency.
  * Log reads now use recent data first, reducing memory pressure when working with large logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->