### PR TITLE
fix: dock lead-spawned workers right

### DIFF
--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -468,14 +468,16 @@ export function chooseAgentSpawnPlacement(
     layouts.some(isLeadMajorityPane) ||
     context.parentRole === "orchestrator" ||
     context.parentRole === "ic";
-  // A worktree worker has no classified destination surface yet. If the only
-  // visible column is lead-owned, seed the right worker column without anchoring
-  // the split to a lead pane.
+  const hasLeadCaller =
+    context.parentRole === "orchestrator" || context.parentRole === "ic";
+  // A worker from a lead-owned single-column workspace has no classified
+  // destination surface yet. Seed the right worker column without anchoring the
+  // split to the lead pane.
   if (
     role === "worker" &&
-    context.worktree &&
     columnCount < 2 &&
-    hasLeadColumn
+    hasLeadColumn &&
+    (context.worktree || hasLeadCaller)
   ) {
     return { kind: "split", direction: "right" };
   }

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1510,6 +1510,40 @@ describe("worktree worker placement — always right, never left", () => {
     assertNeverLeft(placement);
   });
 
+  it.each([
+    { worktree: true, label: "worktree" },
+    { worktree: false, label: "non-worktree" },
+  ])(
+    "col-0 lead caller seeds a right worker column for a $label worker without anchoring to the lead pane",
+    ({ worktree }) => {
+      const panes = [
+        makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      ];
+      const paneSurfaces = [
+        makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      ];
+
+      const placement = chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        {
+          orchestrator: new Set(["surface:orchestrator"]),
+          ic: new Set(),
+          worker: new Set(),
+        },
+        {
+          role: "worker",
+          parentRole: "orchestrator",
+          parentSurfaceId: "surface:orchestrator",
+          worktree,
+        },
+      );
+
+      expect(placement).toEqual({ kind: "split", direction: "right" });
+      assertNeverLeft(placement);
+    },
+  );
+
   it("(b) lead column + existing right worker pane: DOCKS as a tab, not a new pane", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),


### PR DESCRIPTION
## Summary
- Reproduces the col-0 lead caller regression where a non-worktree `role:worker` anchored a right split to the lead pane.
- Removes the `context.worktree`-only gate for lead-caller worker seeding while preserving the existing parentless fallback.
- Guarantees lead-owned single-column worker spawns seed the right worker column without anchoring to column 0; existing two-column worker docking still uses the rightmost non-lead worker pane.

## Root Cause
`chooseAgentSpawnPlacement` only used the unanchored right-column seed path when `role === "worker"`, `context.worktree` was true, `columnCount < 2`, and a lead column was detected. Non-worktree workers spawned by a col-0 lead skipped that path and fell through to the parent-role fallback, returning `{ kind: "split", direction: "right", pane: "pane:lead" }`.

## Test Plan
- RED: `bunx vitest run tests/layout-policy.test.ts` failed for the non-worktree col-0 lead caller case with an anchored `pane:lead` placement.
- GREEN: `bunx vitest run tests/layout-policy.test.ts` -> 55 passed.
- GREEN: `bun run typecheck` -> exit 0.
- GREEN: `bun run test` -> 80 files, 1474 tests passed.
- GREEN on push hook: regression scripts + `bun run test` -> 80 files, 1474 tests passed.
- CodeRabbit pre-commit: `coderabbit review --agent` -> findings: 0.

Co-Authored-By: OpenAI Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout-policy change with targeted tests; behavior only affects worker spawn placement when column count is 1 and a lead caller is present.
> 
> **Overview**
> Fixes a regression in **`chooseAgentSpawnPlacement`** where workers spawned by a col-0 **orchestrator** or **IC** in a one-column workspace could return a right split **anchored to the lead pane** (`pane: lead`) instead of seeding a new worker column.
> 
> The unanchored early path (`{ kind: "split", direction: "right" }` with no `pane`) no longer requires **`context.worktree`**. It also runs when the caller is a lead parent (`hasLeadCaller`), while keeping the existing worktree and parentless fallbacks. Comments are updated to describe lead-owned single-column workspaces rather than worktree-only behavior.
> 
> Tests add a parameterized case for **worktree and non-worktree** lead callers in col-0, both expecting an unanchored right split and never anchoring to the lead pane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8e0e470d9000e4b1b6c7d5a781090d0a07829d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dock placement for lead-spawned workers in single-column layouts
> In `chooseAgentSpawnPlacement`, a worker in a single lead-owned column now splits right (seeding the worker column) when the caller is an orchestrator or IC role, not only when spawned from a worktree. Previously, non-worktree workers spawned by a lead caller were not placed correctly. The fix introduces a `hasLeadCaller` predicate in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/262/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) and expands the split-right condition to `worktree || hasLeadCaller`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0d8e0e4. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->