### PR TITLE
fix: prevent retry-enter duplicate submits

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2792,10 +2792,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const retryEligiblePendingInput =
         opts.allow_recovery_enter_retry !== false &&
         shouldRetryEnter &&
-        ((screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
-          snapshot.parsed.status === "idle") ||
-          (opts.source_event === "spawn_agent" &&
-            !hasParsedAgentIdentity(snapshot.parsed)));
+        !screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed) &&
+        opts.source_event === "spawn_agent" &&
+        !hasParsedAgentIdentity(snapshot.parsed);
       lastRetryEligiblePendingInput = retryEligiblePendingInput;
       if (retryEligiblePendingInput) {
         retryEligiblePendingSince ??= Date.now();
@@ -2850,6 +2849,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         sawClearedComposerEvidence && sawAllowedClearedComposerEvidence
           ? true
           : opts.require_working_status
+            ? false
+          : lastHasPendingInput
             ? false
           : lastRetryEligiblePendingInput
             ? false
@@ -6343,11 +6344,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_agent: args.agent_id,
             // Verify every relay to an interactive agent — not just long ones.
             // A short relay (the common agent-to-agent case) to a frozen
-            // terminal must be caught, never reported as ok. allow_busy sends to
-            // a non-interactive (working) agent stay unverified to avoid
-            // false-failing a legitimate interjection.
+            // terminal must be caught, never reported as ok. allow_busy sends
+            // are deliberate queue/interjection writes and stay unverified to
+            // avoid false-failing accepted queued input.
             verify_submit:
-              args.press_enter && INTERACTIVE_AGENT_STATES.has(route.state),
+              args.press_enter &&
+              !args.allow_busy &&
+              INTERACTIVE_AGENT_STATES.has(route.state),
             allow_recovery_enter_retry: !args.allow_busy,
           });
         },

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -276,6 +276,7 @@ class FakeSlowClearingAgentClient extends FakeClaudeSurfaceClient {
   readonly sendKeyCalls: string[] = [];
   clearAfterReads = 22;
   duplicateSubmits = 0;
+  cli: "claude" | "cursor" = "claude";
   private pendingText = "";
   private submittedText: string | null = null;
   private readsSinceSubmit = 0;
@@ -333,6 +334,15 @@ class FakeSlowClearingAgentClient extends FakeClaudeSurfaceClient {
 
   private renderScreen(): string {
     const tail = this.pendingText.slice(-160);
+    if (this.cli === "cursor") {
+      if (!tail && this.submittedText !== null) {
+        return "Cursor Agent\nGenerating 1.2k tokens\n";
+      }
+      return `Cursor Agent\ncursor> ${tail}\nAuto\n`;
+    }
+    if (!tail && this.submittedText !== null) {
+      return "Claude Code\n✻ Working\n";
+    }
     return `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
   }
 }
@@ -420,7 +430,7 @@ describe("enter reliability", () => {
     expect(parsed.error).toMatch(/press_enter|allow_busy|boolean/i);
   });
 
-  it("retries Enter for send_to when the first submit leaves Claude idle", async () => {
+  it("does not retry Enter for send_to when the agent composer remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     server = createReliabilityServer(client);
     registerAgent(server);
@@ -434,23 +444,26 @@ describe("enter reliability", () => {
     const parsed = parseResult(result);
     const events = readEventLog();
 
-    expect(parsed.ok).toBe(true);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
     expect(client.sendCalls.join("")).toHaveLength(2000);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      2,
+      1,
     );
     expect(
       events.some(
         (event) =>
           event.event_type === "send_to" &&
-          event.submit_verified === true &&
-          event.retry_count === 1,
+          event.submit_verified === false &&
+          event.retry_count === 0,
       ),
     ).toBe(true);
     expect(
       events.some((event) => event.event_type === "press_enter"),
     ).toBe(true);
-  });
+  }, 10_000);
 
   it("verifies a cleared idle composer without waiting for working status", async () => {
     const client = new FakeClaudeSurfaceClient();
@@ -476,10 +489,17 @@ describe("enter reliability", () => {
     expect(events[0]?.retry_count).toBe(0);
   });
 
-  it("does not press Enter twice when a submitted agent composer clears slowly", async () => {
+  it.each([
+    ["Cursor queued composer", "cursor"],
+    ["generic slow-clearing agent composer", "claude"],
+  ] as const)(
+    "does not press Enter twice when a submitted %s still shows accepted input",
+    async (_name, cli) => {
     const client = new FakeSlowClearingAgentClient();
+    client.cli = cli;
+    client.clearAfterReads = 35;
     server = createReliabilityServer(client);
-    registerAgent(server);
+    registerAgent(server, { cli });
 
     const result = await callTool(server, "send_to", {
       agent_id: "agent-1",
@@ -495,9 +515,10 @@ describe("enter reliability", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
     expect(parsed.retry_count).toBe(0);
-  });
+    },
+  );
 
-  it("reports a failed send_to submit when text remains in the composer after retry", async () => {
+  it("leaves send_to submit verification unknown when agent text remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -514,21 +535,21 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
-    expect(parsed.retry_count).toBe(1);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(2);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
     expect(
       events.some(
         (event) =>
           event.event_type === "send_to" &&
           event.submit_verified === false &&
-          event.retry_count === 1,
+          event.retry_count === 0,
       ),
     ).toBe(true);
-  });
+  }, 10_000);
 
-  it("verifies a mid-session idle send_to after retry clears the full composer", async () => {
+  it("verifies a mid-session idle send_to when the first Return clears the full composer", async () => {
     const client = new FakeClaudeSurfaceClient();
-    client.requiredReturns = 2;
+    client.requiredReturns = 1;
     client.completionMode = "idle";
     server = createReliabilityServer(client);
     registerAgent(server, { state: "idle" });
@@ -543,20 +564,19 @@ describe("enter reliability", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
-    expect(parsed.retry_count).toBeGreaterThanOrEqual(1);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(2);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
     expect(
       events.some(
         (event) =>
           event.event_type === "send_to" &&
           event.submit_verified === true &&
-          typeof event.retry_count === "number" &&
-          event.retry_count >= 1,
+          event.retry_count === 0,
       ),
     ).toBe(true);
   });
 
-  it("retries Enter for send_command on a Claude surface", async () => {
+  it("does not retry Enter for send_command when the agent composer remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     server = createReliabilityServer(client);
     registerAgent(server);
@@ -569,21 +589,24 @@ describe("enter reliability", () => {
     const parsed = parseResult(result);
     const events = readEventLog();
 
-    expect(parsed.ok).toBe(true);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      2,
+      1,
     );
     expect(
       events.some(
         (event) =>
           event.event_type === "send_command" &&
-          event.submit_verified === true &&
-          event.retry_count === 1,
+          event.submit_verified === false &&
+          event.retry_count === 0,
       ),
     ).toBe(true);
-  });
+  }, 10_000);
 
-  it("reports a failed short send_command submit after retry leaves Claude idle", async () => {
+  it("leaves short send_command verification unknown when agent text remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -599,21 +622,21 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
-    expect(parsed.retry_count).toBe(1);
+    expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      2,
+      1,
     );
     expect(
       events.some(
         (event) =>
           event.event_type === "send_command" &&
           event.submit_verified === false &&
-          event.retry_count === 1,
+          event.retry_count === 0,
       ),
     ).toBe(true);
-  });
+  }, 10_000);
 
-  it("reports a failed short send_input submit after retry leaves Claude idle", async () => {
+  it("leaves short send_input verification unknown when agent text remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -630,19 +653,19 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
-    expect(parsed.retry_count).toBe(1);
+    expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      2,
+      1,
     );
     expect(
       events.some(
         (event) =>
           event.event_type === "send_input" &&
           event.submit_verified === false &&
-          event.retry_count === 1,
+          event.retry_count === 0,
       ),
     ).toBe(true);
-  });
+  }, 10_000);
 
   it("does not false-fail send_input to a busy cached agent surface", async () => {
     const client = new FakeClaudeSurfaceClient();
@@ -722,6 +745,7 @@ describe("enter reliability", () => {
 
   it("uses the verified send path for interact(action=send)", async () => {
     const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
     server = createReliabilityServer(client);
     registerAgent(server);
 
@@ -734,21 +758,24 @@ describe("enter reliability", () => {
     const events = readEventLog();
 
     expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      2,
+      1,
     );
     expect(
       events.some(
         (event) =>
           event.event_type === "interact" &&
           event.submit_verified === true &&
-          event.retry_count === 1,
+          event.retry_count === 0,
       ),
     ).toBe(true);
   });
 
   it("verifies each back-to-back send_to instead of assuming the previous submit pattern holds", async () => {
     const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
     server = createReliabilityServer(client);
     registerAgent(server);
 
@@ -769,13 +796,13 @@ describe("enter reliability", () => {
       (event) => event.event_type === "send_to",
     );
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      4,
+      2,
     );
     expect(events).toHaveLength(2);
     expect(
       events.every(
         (event) =>
-          event.submit_verified === true && event.retry_count === 1,
+          event.submit_verified === true && event.retry_count === 0,
       ),
     ).toBe(true);
   }, 10_000);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2063,7 +2063,7 @@ describe("agent lifecycle tool handlers", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(launcherReturnCount).toBeGreaterThanOrEqual(2);
+    expect(launcherReturnCount).toBe(1);
     expect(promptDelivered).toBe(true);
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3804,6 +3804,258 @@ describe("tool handler integration", () => {
     });
   });
 
+  it("send_input does not retry Return for a Cursor queued composer that still shows the prompt", async () => {
+    vi.useFakeTimers();
+    const stateDir = join(tmpdir(), "cmuxlayer-cursor-queued-submit-verify");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "agent-cursor-queued-submit",
+      surface_id: "surface:cursor-queued",
+      workspace_id: null,
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "auto",
+      cli: "cursor",
+      cli_session_id: null,
+      task_summary: "cursor queued submit verification",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-07T00:00:00.000Z",
+      updated_at: "2026-07-07T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+    const text = "Read and follow docs.local/briefs/dup-cursor-retry-enter.md";
+    let textSent = false;
+    let returnPresses = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args: string[]) => {
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("send")) {
+        textSent = true;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:cursor-queued",
+            text:
+              textSent && returnPresses > 0
+                ? `Cursor Agent\ncursor> ${text}\nAuto\n`
+                : "Cursor Agent\ncursor> \nAuto\n",
+            lines: 4,
+          }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const resultPromise = tool.handler(
+      {
+        surface: "surface:cursor-queued",
+        text,
+        press_enter: true,
+      },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await resultPromise;
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(returnPresses).toBe(1);
+  }, 10_000);
+
+  it("send_input verifies a fast-cleared Codex composer without a retry", async () => {
+    vi.useFakeTimers();
+    const stateDir = join(tmpdir(), "cmuxlayer-codex-cleared-submit-verify");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "agent-codex-cleared-submit",
+      surface_id: "surface:codex-cleared",
+      workspace_id: null,
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "gpt-5",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "codex cleared submit verification",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-07T00:00:00.000Z",
+      updated_at: "2026-07-07T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+    let textSent = false;
+    let returnPresses = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args: string[]) => {
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("send")) {
+        textSent = true;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:codex-cleared",
+            text:
+              textSent && returnPresses > 0
+                ? "OpenAI Codex\ncodex> \ngpt-5 · idle\n"
+                : "OpenAI Codex\ncodex> ping codex\ngpt-5 · idle\n",
+            lines: 4,
+          }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const resultPromise = tool.handler(
+      {
+        surface: "surface:codex-cleared",
+        text: "ping codex",
+        press_enter: true,
+      },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await resultPromise;
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(returnPresses).toBe(1);
+  });
+
+  it("send_input does not retry Return for a non-Cursor idle composer that may have queued input", async () => {
+    vi.useFakeTimers();
+    const stateDir = join(tmpdir(), "cmuxlayer-codex-dropped-submit-retry");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "agent-codex-dropped-submit",
+      surface_id: "surface:codex-dropped",
+      workspace_id: null,
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "gpt-5",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "codex dropped submit retry",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-07T00:00:00.000Z",
+      updated_at: "2026-07-07T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+    let textSent = false;
+    let returnPresses = 0;
+    mockExec = vi.fn().mockImplementation((_cmd, args: string[]) => {
+      if (args.includes("send-key") && args.includes("return")) {
+        returnPresses += 1;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("send")) {
+        textSent = true;
+        return Promise.resolve({ stdout: "{}", stderr: "" });
+      }
+      if (args.includes("read-screen")) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            surface_ref: "surface:codex-dropped",
+            text:
+              textSent && returnPresses >= 2
+                ? "OpenAI Codex\ncodex> \ngpt-5 · idle\n"
+                : "OpenAI Codex\ncodex> retry me\ngpt-5 · idle\n",
+            lines: 4,
+          }),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ stdout: "{}", stderr: "" });
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+    });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const resultPromise = tool.handler(
+      {
+        surface: "surface:codex-dropped",
+        text: "retry me",
+        press_enter: true,
+      },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await resultPromise;
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(returnPresses).toBe(1);
+  }, 10_000);
+
   it("send_input background mode blocks the same surface but allows other surfaces", async () => {
     vi.useFakeTimers();
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
@@ -7190,7 +7442,7 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:2",
             text:
-              promptSent && returnPresses >= 2
+              promptSent && returnPresses >= 1
                 ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
                 : promptSent
                   ? `codex> ${prompt}`
@@ -7294,7 +7546,7 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBe(1);
   }, 10_000);
 
-  it("new_split fails loudly when a short boot prompt stays pending after submit retry", async () => {
+  it("new_split fails loudly when a short boot prompt stays pending without retrying Return", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-short-dropped-return.md");
     const prompt = "short boot prompt";
@@ -7358,7 +7610,7 @@ describe("tool handler integration", () => {
     expect(parsed.error).toContain("Boot prompt delivery failed");
     expect(parsed.error).toContain("Enter submit could not be verified");
     expect(parsed.boot_prompt_delivered).not.toBe(true);
-    expect(returnPresses).toBe(2);
+    expect(returnPresses).toBe(1);
   }, 10_000);
 
   it("new_split reports a short boot prompt delivered after submit verification succeeds", async () => {
@@ -7420,7 +7672,7 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBe(1);
   }, 10_000);
 
-  it("new_split keeps verifying long boot prompts and retries a missed submit", async () => {
+  it("new_split keeps verifying long boot prompts without retrying Return", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-long-retry.md");
     const prompt = "long boot prompt ".repeat(40);
@@ -7461,9 +7713,9 @@ describe("tool handler integration", () => {
             text:
               !promptSent
                 ? "codex> "
-                : returnPresses === 1
-                  ? `codex> ${typedText.slice(-100)}`
-                  : "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)",
+                : returnPresses >= 1
+                  ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                  : `codex> ${typedText.slice(-100)}`,
             lines: 30,
             scrollback_used: false,
           }),
@@ -7490,7 +7742,7 @@ describe("tool handler integration", () => {
     expect(parsed.boot_prompt_delivered).toBe(true);
     expect(sendCalls).toHaveLength(1);
     expect(sendCalls.join("")).toBe(prompt);
-    expect(returnPresses).toBe(2);
+    expect(returnPresses).toBe(1);
   }, 10_000);
 
   it("new_split renames the new surface when a title is provided", async () => {

--- a/tests/verified-relay.test.ts
+++ b/tests/verified-relay.test.ts
@@ -199,9 +199,8 @@ describe("verified relay", () => {
     // A relay that cannot confirm the input landed must NOT report success.
     expect(result.isError).toBe(true);
     expect(parsed.ok).not.toBe(true);
-    // It should have at least retried Enter before giving up.
     expect(
       client.sendKeyCalls.filter((key) => key === "return").length,
-    ).toBeGreaterThanOrEqual(2);
-  });
+    ).toBe(1);
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary
- Prevent submit verification from pressing Return a second time when an agent composer still shows the submitted text.
- Treat still-visible agent composer input as ambiguous accepted/queued input, not positive dropped-Enter evidence.
- Keep `allow_busy` sends unverified so deliberate queue/interjection writes do not false-fail or retry.

## Repro / Root Cause
- Live 3-way repro showed one `send_to` could emit two `press_enter` events (`retry:0` + `retry:1`) and duplicate a message.
- Cursor hit this most because its composer can keep showing accepted queued input while slow to verify, but the bug is broader: any slow-to-clear or queuing composer can be re-submitted by the speculative retry-Enter path.
- The unsafe predicate was pending visible text after Return; pending text is not positive evidence that Return was dropped.

## Fix
- Recovery Enter is no longer eligible when any agent identity is visible on the screen.
- If pending agent composer text remains through the verify timeout, report `submit_verified:false` with `retry_count:0` instead of pressing Return again.
- Positive verification still comes from working/thinking status or cleared-composer evidence.

## Test plan
- [x] RED first: parameterized `send_to` regression failed for a generic slow-clearing agent under the previous Cursor-only guard.
- [x] `bun run typecheck`
- [x] `bun run test` (80 files, 1478 tests)

## Review notes
- Pre-commit `coderabbit review --agent` was attempted before the first commit and hit OSS rate limit (`waitTime: 7 minutes`).
- This PR must not be merged here; lead live-verifies real Cursor one-copy delivery before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal input delivery and success/failure signaling for all interactive agent sends; wrong behavior could drop messages or still duplicate submits, but scope is narrowly focused on retry eligibility and verification outcomes.
> 
> **Overview**
> Stops submit verification from pressing **Return** a second time when the agent composer still shows the submitted text, which could duplicate messages (especially on slow-clearing or queued composers like Cursor).
> 
> Recovery **Enter** retry is now limited to **`spawn_agent`** boot flows where no agent identity is visible yet. For normal **`send_to` / `send_input` / `send_command`** paths, lingering composer text is treated as ambiguous accepted/queued input: verification ends with **`submit_verified: false`** and **`retry_count: 0`** instead of another **Return**. Timeouts also mark pending composer text as failed verification rather than unknown.
> 
> **`allow_busy`** relays skip submit verification entirely so deliberate queue/interjection writes are not false-failed or retried.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3f4974135dad39af78a74836c7e77f616f66de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent duplicate Enter submissions when composer state is ambiguously pending
> - `submit_verified` now returns `false` when `lastHasPendingInput` is true, stopping retry attempts when the composer hasn't clearly cleared.
> - `verify_submit` is suppressed for `allow_busy` routes, preventing Enter retries on non-interactive agent states.
> - `retryEligiblePendingInput` tightens eligibility to require no agent identity on screen, `spawn_agent` source, and no parsed identity — removing the prior idle-state allowance.
> - Tests across enter-reliability, server, and verified-relay suites are updated to assert `retry_count=0` and a single Return keypress for ambiguous or frozen states.
> - Behavioral Change: agents previously receiving multiple Enter presses on slow-clearing or frozen composers will now receive only one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f3f497.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->