### PR TITLE
fix: bridge cmux surface UUID refs

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -273,7 +273,7 @@ export interface AgentEngineOptions {
    * to DISABLED (`null`) so bare construction never reads the real cmux file;
    * production entrypoints inject the runner. Pass an explicit runner in tests.
    */
-  closeForensicsRunner?: (() => { emitted: number }) | null;
+  closeForensicsRunner?: (() => { emitted: number } | Promise<{ emitted: number }>) | null;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
@@ -668,7 +668,7 @@ export class AgentEngine {
   private monitorRegistryNotify: MonitorDeadmanNotify;
   private monitorRegistrySweepInFlight = false;
   /** Best-effort close-forensics ingest; null when disabled. */
-  private closeForensicsRunner: (() => { emitted: number }) | null;
+  private closeForensicsRunner: (() => { emitted: number } | Promise<{ emitted: number }>) | null;
   private closeForensicsSweepInFlight = false;
   constructor(
     stateMgr: StateManager,
@@ -2819,12 +2819,21 @@ export class AgentEngine {
     if (this.closeForensicsSweepInFlight) return;
     this.closeForensicsSweepInFlight = true;
     try {
-      this.closeForensicsRunner();
+      const result = this.closeForensicsRunner();
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        void (result as Promise<unknown>)
+          .catch(() => {
+            // Never break the sweep on a forensics failure; it retries next sweep.
+          })
+          .finally(() => {
+            this.closeForensicsSweepInFlight = false;
+          });
+        return;
+      }
     } catch {
       // Never break the sweep on a forensics failure; it retries next sweep.
-    } finally {
-      this.closeForensicsSweepInFlight = false;
     }
+    this.closeForensicsSweepInFlight = false;
   }
 
   private async sweepMonitorRegistryBestEffort(): Promise<void> {

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -16,6 +16,7 @@ import { parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { matchReadyPattern } from "./pattern-registry.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
+import { enrichSurfaceIdsFromPanes } from "./surface-topology.js";
 import type {
   AppServerBridgeRuntime,
   BridgeScreenSnapshot,
@@ -158,25 +159,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         }),
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
-      const paneByRef = new Map(
-        panesByWorkspace.flatMap(({ ref, panes }) =>
-          panes.panes.map((pane) => [`${ref}:${pane.ref}`, pane] as const),
-        ),
-      );
-      return surfaceGroups.flatMap((group) =>
-        group.surfaces.map((surface) => {
-          const pane = paneByRef.get(`${group.workspace_ref}:${group.pane_ref}`);
-          const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
-          const inferredId =
-            surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;
-          return {
-            ...surface,
-            id: surface.id ?? inferredId,
-            workspace_ref: group.workspace_ref,
-            pane_ref: group.pane_ref,
-          };
-        }),
-      );
+      return enrichSurfaceIdsFromPanes(panesByWorkspace, surfaceGroups);
     };
 
     this.registry = new AgentRegistry(this.stateMgr, surfaceProvider);

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -159,13 +159,13 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
       const paneByRef = new Map(
-        panesByWorkspace.flatMap(({ panes }) =>
-          panes.panes.map((pane) => [pane.ref, pane] as const),
+        panesByWorkspace.flatMap(({ ref, panes }) =>
+          panes.panes.map((pane) => [`${ref}:${pane.ref}`, pane] as const),
         ),
       );
       return surfaceGroups.flatMap((group) =>
         group.surfaces.map((surface) => {
-          const pane = paneByRef.get(group.pane_ref);
+          const pane = paneByRef.get(`${group.workspace_ref}:${group.pane_ref}`);
           const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
           const inferredId =
             surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -158,12 +158,24 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         }),
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
+      const paneByRef = new Map(
+        panesByWorkspace.flatMap(({ panes }) =>
+          panes.panes.map((pane) => [pane.ref, pane] as const),
+        ),
+      );
       return surfaceGroups.flatMap((group) =>
-        group.surfaces.map((surface) => ({
-          ...surface,
-          workspace_ref: group.workspace_ref,
-          pane_ref: group.pane_ref,
-        })),
+        group.surfaces.map((surface) => {
+          const pane = paneByRef.get(group.pane_ref);
+          const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
+          const inferredId =
+            surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;
+          return {
+            ...surface,
+            id: surface.id ?? inferredId,
+            workspace_ref: group.workspace_ref,
+            pane_ref: group.pane_ref,
+          };
+        }),
       );
     };
 
@@ -201,6 +213,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       monitorRegistryNotify: httpNotifyMonitorDeadman,
       closeForensicsRunner: createDefaultCloseForensicsRunner({
         stateMgr: this.stateMgr,
+        listSurfacesForRefMap: surfaceProvider,
       }),
     });
   }

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -520,6 +520,8 @@ export function defaultCmuxEventsPath(): string {
 
 const DEFAULT_DELTA_MS = 30_000;
 const DEFAULT_MAX_CMUX_EVENTS_READ_BYTES = 256 * 1024;
+const DEFAULT_SURFACE_REF_MAP_TTL_MS = 30_000;
+const DEFAULT_SURFACE_REF_MAP_TIMEOUT_MS = 1_000;
 
 export function readAppendedCmuxEventsText(args: {
   path: string;
@@ -633,6 +635,38 @@ function writeSurfaceRefMapCache(
   renameSync(tmp, path);
 }
 
+function mergeSurfaceRefMaps(
+  cached: Map<string, string>,
+  live: Map<string, string>,
+): Map<string, string> {
+  const merged = new Map(cached);
+  for (const cmuxId of live.keys()) {
+    merged.delete(cmuxId);
+  }
+  for (const entry of live.entries()) {
+    merged.set(...entry);
+  }
+  return merged;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(fallback), ms);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 /**
  * Build the default sweep-driven runner bound to real fs + a StateManager. The
  * returned function is what the engine calls each sweep; it is a thin wrapper
@@ -644,10 +678,16 @@ export function createDefaultCloseForensicsRunner(config: {
   deltaMs?: number;
   now?: () => string;
   listSurfacesForRefMap?: SurfaceRefMapLister;
+  surfaceRefMapTtlMs?: number;
+  surfaceRefMapTimeoutMs?: number;
 }): () => Promise<{ emitted: number }> {
   const eventsPath = config.eventsPath ?? defaultCmuxEventsPath();
   const deltaMs = config.deltaMs ?? DEFAULT_DELTA_MS;
   const now = config.now ?? (() => new Date().toISOString());
+  const surfaceRefMapTtlMs =
+    config.surfaceRefMapTtlMs ?? DEFAULT_SURFACE_REF_MAP_TTL_MS;
+  const surfaceRefMapTimeoutMs =
+    config.surfaceRefMapTimeoutMs ?? DEFAULT_SURFACE_REF_MAP_TIMEOUT_MS;
   const cursorPath = join(
     config.stateMgr.getBaseDir(),
     "close-forensics-cursor.json",
@@ -741,18 +781,28 @@ export function createDefaultCloseForensicsRunner(config: {
     },
   };
 
+  let lastSurfaceRefMapRefreshMs = 0;
+  let liveSurfaceRefByCmuxId = new Map<string, string>();
+
   return async () => {
     const cachedSurfaceRefByCmuxId = readSurfaceRefMapCache(
       surfaceRefMapCachePath,
     );
-    const liveSurfaceRefByCmuxId = await buildSurfaceRefMap(
-      config.stateMgr,
-      config.listSurfacesForRefMap,
+    const refreshDue =
+      config.listSurfacesForRefMap &&
+      Date.now() - lastSurfaceRefMapRefreshMs >= surfaceRefMapTtlMs;
+    if (refreshDue) {
+      liveSurfaceRefByCmuxId = await withTimeout(
+        buildSurfaceRefMap(config.stateMgr, config.listSurfacesForRefMap),
+        surfaceRefMapTimeoutMs,
+        new Map<string, string>(),
+      );
+      lastSurfaceRefMapRefreshMs = Date.now();
+    }
+    const surfaceRefByCmuxId = mergeSurfaceRefMaps(
+      cachedSurfaceRefByCmuxId,
+      liveSurfaceRefByCmuxId,
     );
-    const surfaceRefByCmuxId = new Map([
-      ...cachedSurfaceRefByCmuxId,
-      ...liveSurfaceRefByCmuxId,
-    ]);
     if (liveSurfaceRefByCmuxId.size > 0) {
       safe(
         () => writeSurfaceRefMapCache(surfaceRefMapCachePath, surfaceRefByCmuxId),

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -38,6 +38,7 @@ import type {
   CloseTelemetryEvent,
 } from "./agent-types.js";
 import type { StateManager } from "./state-manager.js";
+import type { CmuxSurface } from "./types.js";
 
 /** Minimal shape of a parsed line from `~/.cmuxterm/events.jsonl`. */
 export interface CmuxEvent {
@@ -569,18 +570,37 @@ export function readAppendedCmuxEventsText(args: {
 }
 
 /**
- * cmux's surface-session-index keys by cmuxlayer ref ("surface:N"), not by cmux
- * internal surface UUID, so there is no UUID↔ref link to harvest yet. An empty
- * map keeps attribution honest (`app-level:no-mcp-close`) until such a bridge
- * exists — which for the current mystery is the CORRECT finding (these tab
- * deaths do NOT go through cmuxlayer). The ingest is map-driven, so the day cmux
- * exposes a UUID↔ref bridge, attribution lights up with no ingest change. Kept
- * as a named seam so that wiring point is obvious.
+ * Build the cmux-internal UUID → cmuxlayer ref bridge from a bounded live
+ * surface listing. `surface.list` may expose `surface.id`; callers can also
+ * enrich from `pane.list`'s parallel `surface_ids`/`surface_refs` arrays before
+ * passing surfaces here. Missing IDs are skipped so attribution degrades
+ * honestly to `app-level:no-mcp-close`.
  */
-export function buildSurfaceRefMap(
-  _stateMgr: StateManager,
+export type SurfaceRefMapSurface = Pick<CmuxSurface, "id" | "ref">;
+
+export type SurfaceRefMapLister = () => Promise<SurfaceRefMapSurface[]>;
+
+export function buildSurfaceRefMapFromSurfaces(
+  surfaces: SurfaceRefMapSurface[],
 ): Map<string, string> {
-  return new Map<string, string>();
+  const map = new Map<string, string>();
+  for (const surface of surfaces) {
+    if (!surface.id || !surface.ref) continue;
+    map.set(surface.id, surface.ref);
+  }
+  return map;
+}
+
+export async function buildSurfaceRefMap(
+  _stateMgr: StateManager,
+  listSurfaces?: SurfaceRefMapLister,
+): Promise<Map<string, string>> {
+  if (!listSurfaces) return new Map<string, string>();
+  try {
+    return buildSurfaceRefMapFromSurfaces(await listSurfaces());
+  } catch {
+    return new Map<string, string>();
+  }
 }
 
 /**
@@ -593,7 +613,8 @@ export function createDefaultCloseForensicsRunner(config: {
   eventsPath?: string;
   deltaMs?: number;
   now?: () => string;
-}): () => { emitted: number } {
+  listSurfacesForRefMap?: SurfaceRefMapLister;
+}): () => Promise<{ emitted: number }> {
   const eventsPath = config.eventsPath ?? defaultCmuxEventsPath();
   const deltaMs = config.deltaMs ?? DEFAULT_DELTA_MS;
   const now = config.now ?? (() => new Date().toISOString());
@@ -686,8 +707,12 @@ export function createDefaultCloseForensicsRunner(config: {
     },
   };
 
-  return () =>
-    runCloseForensicsSweep({
+  return async () => {
+    const surfaceRefByCmuxId = await buildSurfaceRefMap(
+      config.stateMgr,
+      config.listSurfacesForRefMap,
+    );
+    return runCloseForensicsSweep({
       readCmuxEventsText: (cursorState) =>
         existsSync(eventsPath)
           ? readAppendedCmuxEventsText({
@@ -699,11 +724,12 @@ export function createDefaultCloseForensicsRunner(config: {
         config.stateMgr
           .getEventLog()
           .readCloseEvents(),
-      surfaceRefByCmuxId: () => buildSurfaceRefMap(config.stateMgr),
+      surfaceRefByCmuxId: () => surfaceRefByCmuxId,
       appendForensics: (event) =>
         config.stateMgr.getEventLog().appendCloseForensics(event),
       cursor,
       now,
       deltaMs,
     });
+  };
 }

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -603,6 +603,36 @@ export async function buildSurfaceRefMap(
   }
 }
 
+const SURFACE_REF_MAP_CACHE_LIMIT = 1000;
+
+function readSurfaceRefMapCache(path: string): Map<string, string> {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return new Map<string, string>();
+    }
+    const map = new Map<string, string>();
+    for (const [cmuxId, surfaceRef] of Object.entries(parsed)) {
+      if (typeof cmuxId === "string" && typeof surfaceRef === "string") {
+        map.set(cmuxId, surfaceRef);
+      }
+    }
+    return map;
+  } catch {
+    return new Map<string, string>();
+  }
+}
+
+function writeSurfaceRefMapCache(
+  path: string,
+  map: Map<string, string>,
+): void {
+  const entries = [...map.entries()].slice(-SURFACE_REF_MAP_CACHE_LIMIT);
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(Object.fromEntries(entries)), "utf-8");
+  renameSync(tmp, path);
+}
+
 /**
  * Build the default sweep-driven runner bound to real fs + a StateManager. The
  * returned function is what the engine calls each sweep; it is a thin wrapper
@@ -621,6 +651,10 @@ export function createDefaultCloseForensicsRunner(config: {
   const cursorPath = join(
     config.stateMgr.getBaseDir(),
     "close-forensics-cursor.json",
+  );
+  const surfaceRefMapCachePath = join(
+    config.stateMgr.getBaseDir(),
+    "close-forensics-surface-ref-map.json",
   );
 
   const cursor: CloseForensicsCursorStore = {
@@ -708,10 +742,23 @@ export function createDefaultCloseForensicsRunner(config: {
   };
 
   return async () => {
-    const surfaceRefByCmuxId = await buildSurfaceRefMap(
+    const cachedSurfaceRefByCmuxId = readSurfaceRefMapCache(
+      surfaceRefMapCachePath,
+    );
+    const liveSurfaceRefByCmuxId = await buildSurfaceRefMap(
       config.stateMgr,
       config.listSurfacesForRefMap,
     );
+    const surfaceRefByCmuxId = new Map([
+      ...cachedSurfaceRefByCmuxId,
+      ...liveSurfaceRefByCmuxId,
+    ]);
+    if (liveSurfaceRefByCmuxId.size > 0) {
+      safe(
+        () => writeSurfaceRefMapCache(surfaceRefMapCachePath, surfaceRefByCmuxId),
+        undefined,
+      );
+    }
     return runCloseForensicsSweep({
       readCmuxEventsText: (cursorState) =>
         existsSync(eventsPath)

--- a/src/server.ts
+++ b/src/server.ts
@@ -5967,13 +5967,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
       const paneByRef = new Map(
-        panesByWorkspace.flatMap(({ panes }) =>
-          panes.panes.map((pane) => [pane.ref, pane] as const),
+        panesByWorkspace.flatMap(({ ref, panes }) =>
+          panes.panes.map((pane) => [`${ref}:${pane.ref}`, pane] as const),
         ),
       );
       return surfaceGroups.flatMap((group) =>
         group.surfaces.map((surface) => {
-          const pane = paneByRef.get(group.pane_ref);
+          const pane = paneByRef.get(`${group.workspace_ref}:${group.pane_ref}`);
           const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
           const inferredId =
             surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -132,6 +132,7 @@ import {
 import {
   collectSurfaceTopology as collectCmuxSurfaceTopology,
   EMPTY_SURFACE_TOPOLOGY,
+  enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   type SurfaceTopology,
 } from "./surface-topology.js";
@@ -5966,25 +5967,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }),
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
-      const paneByRef = new Map(
-        panesByWorkspace.flatMap(({ ref, panes }) =>
-          panes.panes.map((pane) => [`${ref}:${pane.ref}`, pane] as const),
-        ),
-      );
-      return surfaceGroups.flatMap((group) =>
-        group.surfaces.map((surface) => {
-          const pane = paneByRef.get(`${group.workspace_ref}:${group.pane_ref}`);
-          const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
-          const inferredId =
-            surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;
-          return {
-            ...surface,
-            id: surface.id ?? inferredId,
-            workspace_ref: group.workspace_ref,
-            pane_ref: group.pane_ref,
-          };
-        }),
-      );
+      return enrichSurfaceIdsFromPanes(panesByWorkspace, surfaceGroups);
     };
     const surfaceProvider = async () => {
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5966,12 +5966,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }),
       );
       const surfaceGroups = surfaceGroupsByWorkspace.flat();
+      const paneByRef = new Map(
+        panesByWorkspace.flatMap(({ panes }) =>
+          panes.panes.map((pane) => [pane.ref, pane] as const),
+        ),
+      );
       return surfaceGroups.flatMap((group) =>
-        group.surfaces.map((surface) => ({
-          ...surface,
-          workspace_ref: group.workspace_ref,
-          pane_ref: group.pane_ref,
-        })),
+        group.surfaces.map((surface) => {
+          const pane = paneByRef.get(group.pane_ref);
+          const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
+          const inferredId =
+            surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;
+          return {
+            ...surface,
+            id: surface.id ?? inferredId,
+            workspace_ref: group.workspace_ref,
+            pane_ref: group.pane_ref,
+          };
+        }),
       );
     };
     const surfaceProvider = async () => {
@@ -6096,7 +6108,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           monitorRegistryNow: opts?.monitorRegistryNow,
           monitorRegistryNotify: opts?.monitorRegistryNotify,
           closeForensicsRunner: opts?.enableCloseForensics
-            ? createDefaultCloseForensicsRunner({ stateMgr })
+            ? createDefaultCloseForensicsRunner({
+                stateMgr,
+                listSurfacesForRefMap: surfaceProvider,
+              })
             : null,
         },
       );

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -3,7 +3,12 @@ import type { AgentTopologyHealthInput } from "./agent-health.js";
 import type { AgentHealthInputOverrides } from "./agent-health-input.js";
 import { deriveColumnIndex } from "./layout-policy.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
-import type { CmuxPane, CmuxPaneSurfaces, CmuxWorkspace } from "./types.js";
+import type {
+  CmuxPane,
+  CmuxPaneSurfaces,
+  CmuxSurface,
+  CmuxWorkspace,
+} from "./types.js";
 
 export type SurfaceTopology = AgentTopologyHealthInput;
 
@@ -30,6 +35,34 @@ export const EMPTY_SURFACE_TOPOLOGY: SurfaceTopology = {
   column: null,
   column_count: null,
 };
+
+export function enrichSurfaceIdsFromPanes(
+  panesByWorkspace: Array<{
+    ref: string;
+    panes: { panes: CmuxPane[] };
+  }>,
+  surfaceGroups: CmuxPaneSurfaces[],
+): CmuxSurface[] {
+  const paneByRef = new Map(
+    panesByWorkspace.flatMap(({ ref, panes }) =>
+      panes.panes.map((pane) => [`${ref}:${pane.ref}`, pane] as const),
+    ),
+  );
+  return surfaceGroups.flatMap((group) =>
+    group.surfaces.map((surface) => {
+      const pane = paneByRef.get(`${group.workspace_ref}:${group.pane_ref}`);
+      const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
+      const inferredId =
+        surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined;
+      return {
+        ...surface,
+        id: surface.id ?? inferredId,
+        workspace_ref: group.workspace_ref,
+        pane_ref: group.pane_ref,
+      };
+    }),
+  );
+}
 
 export async function collectSurfaceTopology(
   client: SurfaceTopologyClient,

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -677,6 +677,58 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     );
   });
 
+  it("falls back to app-level attribution when the surface ref-map lister rejects", async () => {
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })) + "\n",
+      "utf-8",
+    );
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.getEventLog().appendClose(
+      mcpClose({
+        target: "surface:42",
+        caller: "mcp-test-caller",
+        ts: "2026-07-06T21:34:14.000Z",
+      }),
+    );
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+      listSurfacesForRefMap: async () => {
+        throw new Error("surface listing failed");
+      },
+    });
+
+    expect((await runner()).emitted).toBe(1);
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      ) as CloseForensicsEvent[];
+    expect(forensics).toHaveLength(1);
+    expect(forensics[0].attribution).toBe("app-level:no-mcp-close");
+  });
+
+  it("times out a hung surface ref-map lister and still runs the sweep", async () => {
+    writeFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })) + "\n",
+      "utf-8",
+    );
+    const stateMgr = new StateManager(stateDir);
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+      surfaceRefMapTimeoutMs: 1,
+      listSurfacesForRefMap: async () => new Promise(() => {}),
+    });
+
+    expect((await runner()).emitted).toBe(1);
+  });
+
   it("caps a single cmux events read window", () => {
     writeFileSync(
       eventsPath,

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -16,6 +16,7 @@ import {
   readAppendedCmuxEventsText,
   runCloseForensicsSweep,
   createDefaultCloseForensicsRunner,
+  buildSurfaceRefMapFromSurfaces,
   type CmuxEvent,
   type CloseForensicsCursorStore,
 } from "../src/close-forensics.js";
@@ -339,6 +340,38 @@ describe("parseCmuxEvents / ingest — malformed & missing tolerance", () => {
   });
 });
 
+describe("buildSurfaceRefMapFromSurfaces", () => {
+  it("maps cmux internal surface UUIDs to cmuxlayer refs", () => {
+    const map = buildSurfaceRefMapFromSurfaces([
+      {
+        id: "92AF15C5-EB43-4427-9820-5CE77AFC31AB",
+        ref: "surface:42",
+      },
+      {
+        id: "9EC491F0-6A53-4552-BDA0-21F3F8CB47B2",
+        ref: "surface:43",
+      },
+    ]);
+
+    expect(map).toEqual(
+      new Map([
+        ["92AF15C5-EB43-4427-9820-5CE77AFC31AB", "surface:42"],
+        ["9EC491F0-6A53-4552-BDA0-21F3F8CB47B2", "surface:43"],
+      ]),
+    );
+  });
+
+  it("skips entries that lack either a UUID or a surface ref", () => {
+    const map = buildSurfaceRefMapFromSurfaces([
+      { id: "HAS-NO-REF" },
+      { ref: "surface:no-id" },
+      { id: "HAS-BOTH", ref: "surface:ok" },
+    ]);
+
+    expect(map).toEqual(new Map([["HAS-BOTH", "surface:ok"]]));
+  });
+});
+
 describe("runCloseForensicsSweep — persisted cursor end-to-end", () => {
   it("appends new forensics, advances the cursor, and does not double-emit on re-run", () => {
     const appended: CloseForensicsEvent[] = [];
@@ -389,7 +422,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("ingests from a real events file, writes to the event log, and persists the cursor", () => {
+  it("ingests from a real events file, writes to the event log, and persists the cursor", async () => {
     writeFileSync(
       eventsPath,
       [
@@ -405,7 +438,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       now,
     });
 
-    const first = runner();
+    const first = await runner();
     expect(first.emitted).toBe(2);
 
     const forensics = stateMgr
@@ -417,7 +450,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(forensics).toHaveLength(2);
 
     // Re-run: cursor persisted → no double emit.
-    const second = runner();
+    const second = await runner();
     expect(second.emitted).toBe(0);
     const forensicsAfter = stateMgr
       .getEventLog()
@@ -428,7 +461,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(forensicsAfter).toHaveLength(2);
   });
 
-  it("reads only bytes appended after the persisted offset and advances that offset", () => {
+  it("reads only bytes appended after the persisted offset and advances that offset", async () => {
     const oldLine = JSON.stringify(surfaceClosed({ seq: 1, surface_id: "OLD" })) + "\n";
     const oldBytes = Buffer.byteLength(oldLine);
     writeFileSync(eventsPath, oldLine, "utf-8");
@@ -458,7 +491,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       now,
     });
 
-    const result = runner();
+    const result = await runner();
     expect(result.emitted).toBe(1);
 
     const forensics = stateMgr
@@ -479,7 +512,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(cursor.last_close_boot_id).toBe("BOOT-NEW");
   });
 
-  it("persists window key lookback across offset-tail sweeps", () => {
+  it("persists window key lookback across offset-tail sweeps", async () => {
     const stateMgr = new StateManager(stateDir);
     writeFileSync(
       eventsPath,
@@ -494,7 +527,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       now,
     });
 
-    expect(runner().emitted).toBe(0);
+    expect((await runner()).emitted).toBe(0);
     appendFileSync(
       eventsPath,
       JSON.stringify(
@@ -507,7 +540,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       "utf-8",
     );
 
-    expect(runner().emitted).toBe(1);
+    expect((await runner()).emitted).toBe(1);
     const forensics = stateMgr
       .getEventLog()
       .readEntries()
@@ -538,7 +571,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(read.truncated).toBe(true);
   });
 
-  it("treats truncation as a fresh sequence stream instead of reusing the old seq cursor", () => {
+  it("treats truncation as a fresh sequence stream instead of reusing the old seq cursor", async () => {
     writeFileSync(
       eventsPath,
       JSON.stringify(surfaceClosed({ seq: 1, surface_id: "AFTER-ROTATE" })) + "\n",
@@ -557,7 +590,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       now,
     });
 
-    expect(runner().emitted).toBe(1);
+    expect((await runner()).emitted).toBe(1);
     const forensics = stateMgr
       .getEventLog()
       .readEntries()
@@ -567,7 +600,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(forensics[0].cmux_surface_id).toBe("AFTER-ROTATE");
   });
 
-  it("reads MCP closes through the bounded close-event reader, not readEntries", () => {
+  it("reads MCP closes through the bounded close-event reader, not readEntries", async () => {
     writeFileSync(
       eventsPath,
       JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })) + "\n",
@@ -591,9 +624,10 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
       stateMgr,
       eventsPath,
       now,
+      listSurfacesForRefMap: async () => [{ id: "S1", ref: "surface:42" }],
     });
 
-    expect(runner().emitted).toBe(1);
+    expect((await runner()).emitted).toBe(1);
     const forensics = readFileSync(join(stateDir, "events.jsonl"), "utf-8")
       .trim()
       .split("\n")
@@ -655,7 +689,7 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
 });
 
 describe("close forensics — does not disturb the operator outbox", () => {
-  it("leaves ~/.golems-zikaron/outbox.md mtime unchanged across a full run", () => {
+  it("leaves ~/.golems-zikaron/outbox.md mtime unchanged across a full run", async () => {
     // Guard: forensics must never write to the operator outbox. We assert the
     // real outbox's mtime is untouched (creating an empty temp one only if
     // absent so the assertion is meaningful without mutating real content).
@@ -689,7 +723,7 @@ describe("close forensics — does not disturb the operator outbox", () => {
         eventsPath,
         now,
       });
-      runner();
+      await runner();
 
       const after = statSync(outboxPath).mtimeMs;
       expect(after).toBe(before);

--- a/tests/close-forensics.test.ts
+++ b/tests/close-forensics.test.ts
@@ -638,6 +638,45 @@ describe("createDefaultCloseForensicsRunner — real fs wiring (temp dirs)", () 
     expect(unboundedRead).not.toHaveBeenCalled();
   });
 
+  it("uses a cached UUID ref-map after the closed surface leaves the live listing", async () => {
+    writeFileSync(eventsPath, "", "utf-8");
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.getEventLog().appendClose(
+      mcpClose({
+        target: "surface:42",
+        caller: "mcp-test-caller",
+        ts: "2026-07-06T21:34:14.000Z",
+      }),
+    );
+    let liveSurfaces = [{ id: "S1", ref: "surface:42" }];
+    const runner = createDefaultCloseForensicsRunner({
+      stateMgr,
+      eventsPath,
+      now,
+      listSurfacesForRefMap: async () => liveSurfaces,
+    });
+
+    expect((await runner()).emitted).toBe(0);
+    liveSurfaces = [];
+    appendFileSync(
+      eventsPath,
+      JSON.stringify(surfaceClosed({ seq: 1, surface_id: "S1" })) + "\n",
+      "utf-8",
+    );
+
+    expect((await runner()).emitted).toBe(1);
+    const forensics = stateMgr
+      .getEventLog()
+      .readEntries()
+      .filter(
+        (e) => (e as { event_type?: string }).event_type === "close_forensics",
+      ) as CloseForensicsEvent[];
+    expect(forensics).toHaveLength(1);
+    expect(forensics[0].attribution).toBe(
+      "mcp:close_surface caller=mcp-test-caller",
+    );
+  });
+
   it("caps a single cmux events read window", () => {
     writeFileSync(
       eventsPath,


### PR DESCRIPTION
## Summary
- Populates close-forensics `surfaceRefByCmuxId` from the bounded live surface listing instead of leaving the map empty.
- Bridge source: `surface.list` can provide `CmuxSurface.id`; when it only provides refs, the lifecycle surface providers enrich surfaces from `pane.list`'s parallel `surface_ids` / `surface_refs` arrays.
- Wires that provider into both app-server and MCP-server close-forensics runners so each sweep can attribute cmux UUID `surface.closed` events to cmuxlayer `surface:N` MCP close-log entries.
- Keeps missing UUIDs honest: entries without both `id` and `ref` are skipped, so unresolved surfaces still fall back to `app-level:no-mcp-close` rather than fake attribution.
- Makes the best-effort forensics runner async-aware and swallows async rejection paths so sweep failures do not surface as unhandled promises.

## Test plan
- [x] `bun test tests/close-forensics.test.ts` — 26 passed
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 80 files / 1480 tests passed
- [x] `bun run pre-pr` — 4 files / 59 tests passed
- [x] `git push -u origin fix/surface-uuid-ref-bridge` pre-push hook reran `run_tests.sh`; 80 files / 1480 tests passed

## Review notes
- Local `coderabbit review --agent` found one valid major issue in the async runner rejection path; fixed in this PR.
- Follow-up local `coderabbit review --agent` was bounded by `timeout 180` and timed out with no new findings emitted before the timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lifecycle sweep timing and best-effort I/O (surface listing, cache files); failures degrade to prior app-level attribution rather than breaking sweeps.
> 
> **Overview**
> **Close forensics** can now join cmux `surface.closed` events (internal UUIDs) to MCP close-log entries that use `surface:N` refs, instead of always falling back to `app-level:no-mcp-close`.
> 
> Surface listings are enriched via new `enrichSurfaceIdsFromPanes`, aligning `pane.surface_ids` with `surface_refs` when `surface.list` omits `id`. That enriched provider is passed into `createDefaultCloseForensicsRunner` from **app-server** and **MCP server** entrypoints.
> 
> The default runner builds a UUID→ref map from a TTL-bounded live lister (1s timeout), merges it with a persisted cache under state dir, and refreshes the cache when live data is available—so attribution still works after a tab is gone from the live listing.
> 
> `createDefaultCloseForensicsRunner` is **async** now; `AgentEngine` accepts sync or Promise runners and clears the in-flight guard on async completion/rejection so sweeps are not blocked and rejections stay swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d246290af7b56a124e048a8f9e672b8cd8f0675c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge cmux surface UUID refs in close-forensics attribution
> - Adds `enrichSurfaceIdsFromPanes` in [`surface-topology.ts`](https://github.com/EtanHey/cmuxlayer/pull/264/files#diff-a861838bd88c600f492d934ff6bd5df4c2c8e61e24dda1dcd88f71ec123fd667) to infer cmux internal surface IDs from pane membership, replacing manual flatten/map logic in both [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/264/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [`app-server-runtime.ts`](https://github.com/EtanHey/cmuxlayer/pull/264/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3).
> - Adds `buildSurfaceRefMapFromSurfaces` and cache helpers in [`close-forensics.ts`](https://github.com/EtanHey/cmuxlayer/pull/264/files#diff-f2c6509ec1163d316086dcaae2b98686183a54a84527fc006f3a12a7f06cda8a) to build and persist a UUID→ref map (bounded to 1000 entries, merged with a live-refreshed listing, protected by a timeout).
> - `createDefaultCloseForensicsRunner` is now async and accepts a `listSurfacesForRefMap` lister; it periodically refreshes the UUID→ref bridge and supplies it to `runCloseForensicsSweep` for close attribution.
> - `AgentEngine.runCloseForensicsBestEffort` is updated to handle an async runner, maintaining the in-flight guard until the returned Promise resolves.
> - Behavioral Change: `createDefaultCloseForensicsRunner` now returns `Promise<{ emitted: number }>` instead of a synchronous result; callers must await it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d246290.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Close-forensics now supports asynchronous runners.
  * Surface lookups can now infer missing surface IDs more reliably.

* **Bug Fixes**
  * Improved close-event attribution by better matching surfaces during forensics.
  * Reduced failures when surface details are missing or delayed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->