### PR TITLE
fix: use neutral worktree branch prefix

### DIFF
--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -13,6 +13,7 @@ import { promisify } from "node:util";
 import { sanitizeRepoName, shellQuote } from "./agent-command.js";
 
 const execFileAsync = promisify(execFile);
+const DEFAULT_WORKTREE_BRANCH_PREFIX = "wt";
 
 export type WorktreeExec = (
   cmd: string,
@@ -76,6 +77,10 @@ function safeName(input: string): string {
 function defaultWorkerName(repo: string): string {
   const shortId = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
   return safeName(`${repo}-worker-${shortId}`);
+}
+
+function defaultWorktreeBranch(name: string): string {
+  return `${DEFAULT_WORKTREE_BRANCH_PREFIX}/${name}`;
 }
 
 function canonicalPath(path: string): string {
@@ -235,7 +240,7 @@ export async function prepareWorktree(
     : join(homeGitsDir, `${repo}.wt`, spec.name);
   if (spec.generatedName && !spec.path) {
     for (let attempts = 0; attempts < 10; attempts++) {
-      const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+      const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
       const pathExists = existsSync(worktreePath);
       const branchTaken = pathExists
         ? false
@@ -246,7 +251,7 @@ export async function prepareWorktree(
       spec.name = defaultWorkerName(repo);
       worktreePath = join(homeGitsDir, `${repo}.wt`, spec.name);
     }
-    const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+    const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
     if (
       existsSync(worktreePath) ||
       (await branchExists(repoRoot, branch, exec))
@@ -268,7 +273,7 @@ export async function prepareWorktree(
     return {
       path: worktreePath,
       name: basename(worktreePath),
-      branch: spec.branch ?? `cmuxlayer/${spec.name}`,
+      branch: spec.branch ?? defaultWorktreeBranch(spec.name),
       base: spec.base,
       created: false,
       reused: true,
@@ -282,7 +287,7 @@ export async function prepareWorktree(
   }
 
   mkdirSync(dirname(worktreePath), { recursive: true });
-  const branch = spec.branch ?? `cmuxlayer/${spec.name}`;
+  const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
   await exec("git", [
     "-C",
     repoRoot,

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -111,7 +111,7 @@ describe("worktree helpers", () => {
       "worktree",
       "add",
       "-b",
-      `cmuxlayer/${nextName}`,
+      `wt/${nextName}`,
       nextPath,
       "HEAD",
     ]);
@@ -123,7 +123,7 @@ describe("worktree helpers", () => {
     const secondId = (0.25).toString(36).slice(2, 8).padEnd(6, "0");
     const collidingName = `cmuxlayer-worker-${firstId}`;
     const nextName = `cmuxlayer-worker-${secondId}`;
-    const collidingBranch = `cmuxlayer/${collidingName}`;
+    const collidingBranch = `wt/${collidingName}`;
     const nextPath = join(TEST_ROOT, "cmuxlayer.wt", nextName);
     mkdirSync(repoRoot, { recursive: true });
     vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
@@ -156,7 +156,7 @@ describe("worktree helpers", () => {
     expect(result).toMatchObject({
       path: nextPath,
       name: nextName,
-      branch: `cmuxlayer/${nextName}`,
+      branch: `wt/${nextName}`,
       created: true,
       reused: false,
     });


### PR DESCRIPTION
## Summary
- Changed generated default worktree branch names from `cmuxlayer/<name>` to repo-neutral `wt/<name>`.
- Centralized the default prefix in `src/worktree.ts` via `defaultWorktreeBranch()` so generated-name collision checks, final uniqueness checks, reuse metadata, and `git worktree add -b` all use the same default.
- Preserved explicit `worktree.branch` override behavior unchanged.

## Prefix-match audit
- Production grep found the old generated-prefix assumptions only in `src/worktree.ts` branch construction sites.
- No `src` cleanup/prune matcher assumes or parses `cmuxlayer/`.
- Remaining `cmuxlayer` grep hits are repo paths/docs/fixtures or unrelated display examples, not generated worktree branch-prefix logic.

## Test plan
- RED: `bun test tests/worktree.test.ts` failed before production changes because branch probing and `git worktree add -b` still used `cmuxlayer/<name>`.
- GREEN: `bun test tests/worktree.test.ts` -> 15 passed, 0 failed.
- `bun run test` -> 80 test files passed, 1483 tests passed.
- `bun run typecheck` -> exited 0.
- Push pre-hook reran tests via `run_tests.sh` -> 80 test files passed, 1483 tests passed.

## Review notes
- Local pre-commit CodeRabbit CLI was attempted with a 180s bound, but returned OSS rate limit: waitTime `24 minutes`. PR-level bot review requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Naming-only change for default branches; explicit branch overrides and worktree behavior otherwise unchanged.
> 
> **Overview**
> Auto-generated git worktree branches now use **`wt/<name>`** instead of **`cmuxlayer/<name>`**, so default naming is not tied to this repo.
> 
> The default is centralized in **`defaultWorktreeBranch()`** in `worktree.ts`, used for collision checks, reuse metadata, and **`git worktree add -b`**. Explicit **`worktree.branch`** overrides are unchanged.
> 
> Worktree tests were updated to expect the new prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3e83375406948b7f36f4b6c46011d68782609a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change default worktree branch prefix from `cmuxlayer/` to `wt/`
> Replaces the hardcoded `cmuxlayer/<name>` default branch format in `prepareWorktree` with a `wt/<name>` prefix via a new `defaultWorktreeBranch` helper in [worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/265/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d). Behavioral Change: any worktree created without an explicit branch will now use `wt/<name>` instead of `cmuxlayer/<name>`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3f3e833. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->