### PR TITLE
feat: make cmuxlayer entry daemon-first

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pre-pr": "bun run typecheck && bun run pre-pr:harness",
     "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/live-agent-harness-replay.test.ts tests/pre-pr-scripts.test.ts",
     "pre-pr:live": "bun run live:harness",
+    "bench:daemon": "node scripts/bench-daemon.mjs",
     "test:watch": "vitest",
     "live:harness": "node scripts/run-live-agent-harness.mjs"
   },

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import net from "node:net";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distIndex = join(repoRoot, "dist", "index.js");
+const distDaemon = join(repoRoot, "dist", "daemon.js");
+const DEFAULT_CLIENTS = 8;
+const DEFAULT_ROUNDS = 12;
+const LATENCY_REGRESSION_RATIO = 1.25;
+const LATENCY_REGRESSION_SLACK_MS = 5;
+
+function parsePositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+const clientCount = Math.max(
+  DEFAULT_CLIENTS,
+  parsePositiveInt(process.env.CMUXLAYER_BENCH_N, DEFAULT_CLIENTS),
+);
+const rounds = parsePositiveInt(
+  process.env.CMUXLAYER_BENCH_ROUNDS,
+  DEFAULT_ROUNDS,
+);
+
+function nowMs() {
+  return Number(process.hrtime.bigint()) / 1_000_000;
+}
+
+function percentile(samples, pct) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((pct / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+}
+
+function round(value, digits = 2) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function compact(value) {
+  return JSON.stringify(value);
+}
+
+async function execCapture(command, args) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} exited ${code}: ${stderr.trim()}`,
+          ),
+        );
+        return;
+      }
+      resolvePromise(stdout);
+    });
+  });
+}
+
+async function processStats(pid) {
+  try {
+    const stdout = await execCapture("ps", ["-o", "rss=,pcpu=", "-p", String(pid)]);
+    const [rssKbRaw, cpuPctRaw] = stdout.trim().split(/\s+/);
+    return {
+      rssKb: Number(rssKbRaw) || 0,
+      cpuPct: Number(cpuPctRaw) || 0,
+    };
+  } catch {
+    return { rssKb: 0, cpuPct: 0 };
+  }
+}
+
+async function totalRssMb(pids) {
+  const stats = await Promise.all(pids.map((pid) => processStats(pid)));
+  return round(
+    stats.reduce((sum, stat) => sum + stat.rssKb, 0) / 1024,
+    2,
+  );
+}
+
+function waitForSocket(path, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolvePromise, reject) => {
+    const tryOnce = () => {
+      const socket = net.createConnection(path);
+      let settled = false;
+      const settle = (ok) => {
+        if (settled) return;
+        settled = true;
+        socket.removeAllListeners();
+        socket.on("error", () => {});
+        socket.destroy();
+        if (ok) {
+          resolvePromise();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(new Error(`timed out waiting for daemon socket ${path}`));
+          return;
+        }
+        setTimeout(tryOnce, 50);
+      };
+      socket.setTimeout(200, () => settle(false));
+      socket.once("connect", () => settle(true));
+      socket.once("error", () => settle(false));
+    };
+    tryOnce();
+  });
+}
+
+class McpProcess {
+  constructor(label, command, args, env) {
+    this.label = label;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.stderr = "";
+    this.readBuffer = new ReadBuffer();
+    this.child = spawn(command, args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child.stdout.on("data", (chunk) => {
+      this.readBuffer.append(chunk);
+      while (true) {
+        const message = this.readBuffer.readMessage();
+        if (message === null) break;
+        this.handleMessage(message);
+      }
+    });
+    this.child.stderr.on("data", (chunk) => {
+      this.stderr += chunk.toString("utf8");
+    });
+    this.child.on("exit", (code, signal) => {
+      const error = new Error(
+        `${this.label} exited code=${code} signal=${signal} stderr=${this.stderr.trim()}`,
+      );
+      for (const pending of this.pending.values()) {
+        pending.reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  get pid() {
+    return this.child.pid;
+  }
+
+  handleMessage(message) {
+    if (!message || typeof message !== "object" || !("id" in message)) {
+      return;
+    }
+    const pending = this.pending.get(message.id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pending.delete(message.id);
+    if ("error" in message) {
+      pending.reject(
+        new Error(`${this.label} JSON-RPC error: ${compact(message.error)}`),
+      );
+      return;
+    }
+    pending.resolve(message);
+  }
+
+  send(message) {
+    this.child.stdin.write(serializeMessage(message));
+  }
+
+  request(method, params = {}, timeoutMs = 10_000) {
+    const id = this.nextId++;
+    const message = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolvePromise, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${this.label} timed out waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolvePromise, reject, timeout });
+      this.send(message);
+    });
+  }
+
+  notify(method, params = {}) {
+    this.send({ jsonrpc: "2.0", method, params });
+  }
+
+  async initialize() {
+    await this.request("initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "cmuxlayer-bench", version: "0.1.0" },
+    });
+    this.notify("notifications/initialized");
+  }
+
+  async callTool(name, args = {}) {
+    const response = await this.request("tools/call", {
+      name,
+      arguments: args,
+    });
+    return response.result;
+  }
+
+  close() {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error(`${this.label} closed`));
+    }
+    this.pending.clear();
+    this.child.kill("SIGTERM");
+    setTimeout(() => {
+      if (this.child.exitCode === null) {
+        this.child.kill("SIGKILL");
+      }
+    }, 1_000).unref();
+  }
+}
+
+async function writeFakeCmux(binDir) {
+  const fakePath = join(binDir, "cmux");
+  await writeFile(
+    fakePath,
+    `#!/usr/bin/env node
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--json" ? rawArgs.slice(1) : rawArgs;
+const command = args[0] || "";
+const surfaceCount = Number(process.env.CMUXLAYER_BENCH_SURFACES || "8");
+const cwd = process.env.PWD || process.cwd();
+const surfaces = Array.from({ length: surfaceCount }, (_, index) => ({
+  ref: "surface:bench-" + index,
+  title: "bench-agent-" + index,
+  type: "terminal",
+  index,
+  selected: index === 0,
+  current_directory: cwd
+}));
+function write(value) {
+  process.stdout.write(JSON.stringify(value));
+}
+if (command === "list-workspaces") {
+  write({ workspaces: [{ ref: "workspace:bench", title: "Bench", index: 0, selected: true, pinned: false, current_directory: cwd }] });
+} else if (command === "list-panes") {
+  write({ workspace_ref: "workspace:bench", window_ref: "window:bench", panes: [{ ref: "pane:bench", index: 0, focused: true, surface_count: surfaces.length, surface_refs: surfaces.map((surface) => surface.ref), selected_surface_ref: surfaces[0].ref, current_directory: cwd }] });
+} else if (command === "list-pane-surfaces") {
+  write({ workspace_ref: "workspace:bench", window_ref: "window:bench", pane_ref: "pane:bench", surfaces });
+} else if (command === "debug-terminals") {
+  write({ terminals: surfaces.map((surface) => ({ surface_ref: surface.ref, current_directory: cwd })) });
+} else if (command === "read-screen") {
+  const surface = args[args.indexOf("--surface") + 1] || surfaces[0].ref;
+  write({ surface_ref: surface, text: "codex> benchmark ready on " + surface + "\\nTASK_DONE", lines: 2, scrollback_used: false });
+} else if (command === "identify") {
+  write({ caller: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref }, focused: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref } });
+} else if (command === "list-status") {
+  write([]);
+} else {
+  write({ ok: true });
+}
+`,
+  );
+  await chmod(fakePath, 0o755);
+  return fakePath;
+}
+
+async function startClients(label, count, env) {
+  const clients = [];
+  for (let index = 0; index < count; index += 1) {
+    const client = new McpProcess(`${label}-${index}`, process.execPath, [
+      distIndex,
+    ], env);
+    clients.push(client);
+  }
+  await Promise.all(clients.map((client) => client.initialize()));
+  return clients;
+}
+
+async function measureLatency(clients) {
+  const listSamples = [];
+  const readSamples = [];
+  let listResult = null;
+  let readResult = null;
+
+  for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
+    await Promise.all(
+      clients.map(async (client) => {
+        let startedAt = nowMs();
+        const list = await client.callTool("list_surfaces", {
+          verbose: false,
+          include_screen_preview: false,
+        });
+        listSamples.push(nowMs() - startedAt);
+        listResult ??= list;
+
+        startedAt = nowMs();
+        const read = await client.callTool("read_screen", {
+          surface: "surface:bench-0",
+          workspace: "workspace:bench",
+          lines: 5,
+        });
+        readSamples.push(nowMs() - startedAt);
+        readResult ??= read;
+      }),
+    );
+  }
+
+  return {
+    list_surfaces: {
+      p50_ms: round(percentile(listSamples, 50)),
+      p99_ms: round(percentile(listSamples, 99)),
+    },
+    read_screen: {
+      p50_ms: round(percentile(readSamples, 50)),
+      p99_ms: round(percentile(readSamples, 99)),
+    },
+    firstResults: { listResult, readResult },
+  };
+}
+
+function latencyGate(baseline, daemon, tool, percentileName) {
+  const base = baseline[tool][percentileName];
+  const candidate = daemon[tool][percentileName];
+  return (
+    candidate <= base * LATENCY_REGRESSION_RATIO + LATENCY_REGRESSION_SLACK_MS
+  );
+}
+
+async function main() {
+  if (!existsSync(distIndex) || !existsSync(distDaemon)) {
+    throw new Error("dist/index.js and dist/daemon.js are required; run bun run build first");
+  }
+
+  const tempRoot = await mkdtemp(join(tmpdir(), "cmuxlayer-daemon-bench-"));
+  const binDir = join(tempRoot, "bin");
+  await mkdir(binDir, { recursive: true });
+  await writeFakeCmux(binDir);
+  const daemonSocket = join(tempRoot, "cmuxlayer-stated.sock");
+  const missingCmuxSocket = join(tempRoot, "missing-cmux.sock");
+  const baseEnv = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    CMUX_SOCKET_PATH: missingCmuxSocket,
+    CMUXLAYER_BENCH_SURFACES: String(clientCount),
+    CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS: "0",
+    CMUXLAYER_SWEEP_INTERVAL_MS: "60000",
+    CMUXLAYER_SWEEP_IDLE_INTERVAL_MS: "60000",
+    CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "1536",
+  };
+
+  let baselineClients = [];
+  let daemonClients = [];
+  let daemon = null;
+  try {
+    baselineClients = await startClients("baseline", clientCount, {
+      ...baseEnv,
+      CMUXLAYER_FORCE_INPROCESS: "1",
+      CMUXLAYER_DAEMON_SOCKET: join(tempRoot, "baseline-unused.sock"),
+    });
+    const baselineLatency = await measureLatency(baselineClients);
+    const baselineRssMb = await totalRssMb(
+      baselineClients.map((client) => client.pid).filter(Boolean),
+    );
+
+    daemon = spawn(process.execPath, [distDaemon], {
+      cwd: repoRoot,
+      env: {
+        ...baseEnv,
+        CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let daemonStderr = "";
+    daemon.stderr.on("data", (chunk) => {
+      daemonStderr += chunk.toString("utf8");
+    });
+    daemon.on("exit", (code, signal) => {
+      if (code !== null && code !== 0) {
+        console.error(
+          `[bench] daemon exited code=${code} signal=${signal}: ${daemonStderr.trim()}`,
+        );
+      }
+    });
+    await waitForSocket(daemonSocket);
+
+    daemonClients = await startClients("daemon", clientCount, {
+      ...baseEnv,
+      CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+    });
+    const daemonLatency = await measureLatency(daemonClients);
+    const daemonRssMb = await totalRssMb(
+      [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
+    );
+    const daemonStats = await processStats(daemon.pid);
+    const truthfulState =
+      compact(baselineLatency.firstResults.listResult?.structuredContent) ===
+        compact(daemonLatency.firstResults.listResult?.structuredContent) &&
+      compact(baselineLatency.firstResults.readResult?.structuredContent) ===
+        compact(daemonLatency.firstResults.readResult?.structuredContent);
+
+    const gates = {
+      rss_improved: daemonRssMb < baselineRssMb,
+      truthful_state: truthfulState,
+      list_surfaces_p50_no_regression: latencyGate(
+        baselineLatency,
+        daemonLatency,
+        "list_surfaces",
+        "p50_ms",
+      ),
+      list_surfaces_p99_no_regression: latencyGate(
+        baselineLatency,
+        daemonLatency,
+        "list_surfaces",
+        "p99_ms",
+      ),
+      read_screen_p50_no_regression: latencyGate(
+        baselineLatency,
+        daemonLatency,
+        "read_screen",
+        "p50_ms",
+      ),
+      read_screen_p99_no_regression: latencyGate(
+        baselineLatency,
+        daemonLatency,
+        "read_screen",
+        "p99_ms",
+      ),
+    };
+    const green = Object.values(gates).every(Boolean);
+    const result = {
+      verdict: green ? "GREEN" : "RED",
+      clients: clientCount,
+      rounds,
+      rss: {
+        baseline_inprocess_total_mb: baselineRssMb,
+        daemon_total_mb: daemonRssMb,
+        reduction_mb: round(baselineRssMb - daemonRssMb),
+        reduction_pct: round(
+          ((baselineRssMb - daemonRssMb) / baselineRssMb) * 100,
+        ),
+      },
+      latency: {
+        baseline_inprocess: {
+          list_surfaces: baselineLatency.list_surfaces,
+          read_screen: baselineLatency.read_screen,
+        },
+        daemon_path: {
+          list_surfaces: daemonLatency.list_surfaces,
+          read_screen: daemonLatency.read_screen,
+        },
+      },
+      daemon_cpu_pct: round(daemonStats.cpuPct, 2),
+      gates,
+    };
+
+    console.log(`cmuxlayer daemon benchmark: ${result.verdict}`);
+    console.log(
+      `N=${result.clients} rounds=${result.rounds} RSS baseline=${result.rss.baseline_inprocess_total_mb}MB daemon=${result.rss.daemon_total_mb}MB reduction=${result.rss.reduction_mb}MB (${result.rss.reduction_pct}%)`,
+    );
+    console.log(
+      `list_surfaces p50/p99 baseline=${result.latency.baseline_inprocess.list_surfaces.p50_ms}/${result.latency.baseline_inprocess.list_surfaces.p99_ms}ms daemon=${result.latency.daemon_path.list_surfaces.p50_ms}/${result.latency.daemon_path.list_surfaces.p99_ms}ms`,
+    );
+    console.log(
+      `read_screen p50/p99 baseline=${result.latency.baseline_inprocess.read_screen.p50_ms}/${result.latency.baseline_inprocess.read_screen.p99_ms}ms daemon=${result.latency.daemon_path.read_screen.p50_ms}/${result.latency.daemon_path.read_screen.p99_ms}ms`,
+    );
+    console.log(`daemon CPU=${result.daemon_cpu_pct}%`);
+    console.log(JSON.stringify(result, null, 2));
+
+    if (!green) {
+      process.exitCode = 1;
+    }
+  } finally {
+    for (const client of [...baselineClients, ...daemonClients]) {
+      client.close();
+    }
+    daemon?.kill("SIGTERM");
+    setTimeout(() => {
+      if (daemon && daemon.exitCode === null) {
+        daemon.kill("SIGKILL");
+      }
+    }, 1_000).unref();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exit(1);
+});

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -7,10 +7,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import net from "node:net";
-import {
-  ReadBuffer,
-  serializeMessage,
-} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const distIndex = join(repoRoot, "dist", "index.js");
@@ -19,6 +16,7 @@ const DEFAULT_CLIENTS = 8;
 const DEFAULT_ROUNDS = 12;
 const LATENCY_REGRESSION_RATIO = 1.25;
 const LATENCY_REGRESSION_SLACK_MS = 5;
+let JsonRpcLineBuffer;
 
 function parsePositiveInt(raw, fallback) {
   const value = Number(raw);
@@ -139,7 +137,7 @@ class McpProcess {
     this.nextId = 1;
     this.pending = new Map();
     this.stderr = "";
-    this.readBuffer = new ReadBuffer();
+    this.readBuffer = new JsonRpcLineBuffer();
     this.child = spawn(command, args, {
       cwd: repoRoot,
       env,
@@ -354,6 +352,7 @@ async function main() {
   if (!existsSync(distIndex) || !existsSync(distDaemon)) {
     throw new Error("dist/index.js and dist/daemon.js are required; run bun run build first");
   }
+  ({ JsonRpcLineBuffer } = await import("../dist/json-rpc-line-buffer.js"));
 
   const tempRoot = await mkdtemp(join(tmpdir(), "cmuxlayer-daemon-bench-"));
   const binDir = join(tempRoot, "bin");

--- a/src/daemon-socket-path.ts
+++ b/src/daemon-socket-path.ts
@@ -1,0 +1,20 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DAEMON_SOCKET_FILENAME = "cmuxlayer-stated.sock";
+
+export function defaultDaemonSocketPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_DAEMON_SOCKET?.trim();
+  if (override) {
+    return override;
+  }
+  return join(
+    homedir(),
+    ".local",
+    "state",
+    "cmux",
+    DAEMON_SOCKET_FILENAME,
+  );
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,10 +4,7 @@ import net from "node:net";
 import { mkdir, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
-import {
-  ReadBuffer,
-  serializeMessage,
-} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
   Transport,
   TransportSendOptions,
@@ -33,6 +30,7 @@ import type {
 } from "./server.js";
 import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
 import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
+import { JsonRpcLineBuffer } from "./json-rpc-line-buffer.js";
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const LISTEN_FD_START = 3;
@@ -46,7 +44,7 @@ export class SocketJsonRpcTransport implements Transport {
   onRequestObserved?: (message: JSONRPCMessage) => void;
   onSend?: (message: JSONRPCMessage) => void;
 
-  private readBuffer = new ReadBuffer();
+  private readBuffer = new JsonRpcLineBuffer();
   private started = false;
   private closed = false;
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import net from "node:net";
-import { unlink } from "node:fs/promises";
+import { mkdir, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   ReadBuffer,
@@ -30,8 +31,9 @@ import type {
   CmuxServerContext,
   CreateServerOptions,
 } from "./server.js";
+import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
+import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
 
-const DEFAULT_SOCKET_PATH = "/tmp/cmuxlayer.sock";
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const LISTEN_FD_START = 3;
 
@@ -302,9 +304,7 @@ export class CmuxLayerDaemon {
   constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
     this.context = opts.context ?? null;
     this.socketPath =
-      opts.socketPath ??
-      process.env.CMUXLAYER_DAEMON_SOCKET ??
-      DEFAULT_SOCKET_PATH;
+      opts.socketPath ?? defaultDaemonSocketPath(process.env);
     this.listenFd = opts.listenFd ?? parseListenFd(process.env);
     this.drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
   }
@@ -315,6 +315,7 @@ export class CmuxLayerDaemon {
     }
 
     if (this.listenFd === undefined) {
+      await mkdir(dirname(this.socketPath), { recursive: true });
       await unlinkStaleSocket(this.socketPath);
     }
 
@@ -555,6 +556,8 @@ export class CmuxLayerDaemon {
 export async function runDaemon(
   opts: CmuxLayerDaemonOptions = {},
 ): Promise<CmuxLayerDaemon> {
+  ensureNodeMaxOldSpaceEnv();
+  installHeapGuard();
   const daemon = new CmuxLayerDaemon(opts);
   const shutdown = (signal: NodeJS.Signals) => {
     daemon

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -30,6 +30,8 @@ export interface StartInProcessOptions {
   fallbackWarnings?: string[];
 }
 
+export type ExitFn = (code: number) => void;
+
 export type EntryRuntime =
   | { mode: "daemon-proxy"; proxy: CmuxLayerProxy }
   | { mode: "in-process"; server: McpServer; fallbackWarnings: string[] };
@@ -47,6 +49,7 @@ export interface DaemonFirstEntryOptions {
   daemonScriptPath?: string;
   autostartTimeoutMs?: number;
   autostartPollMs?: number;
+  exit?: ExitFn;
 }
 
 function isEnabled(value: string | undefined): boolean {
@@ -55,6 +58,30 @@ function isEnabled(value: string | undefined): boolean {
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function terminateSpawnedDaemon(
+  spawnedDaemon: unknown,
+  logger: Pick<Console, "error">,
+): void {
+  const kill =
+    spawnedDaemon &&
+    typeof spawnedDaemon === "object" &&
+    "kill" in spawnedDaemon &&
+    typeof spawnedDaemon.kill === "function"
+      ? spawnedDaemon.kill
+      : null;
+  if (!kill) {
+    return;
+  }
+  try {
+    kill.call(spawnedDaemon, "SIGTERM");
+  } catch (error) {
+    logger.error(
+      "[cmuxlayer] failed to terminate timed-out daemon autostart",
+      error,
+    );
+  }
 }
 
 function defaultDaemonScriptPath(): string {
@@ -196,6 +223,42 @@ export async function startInProcessRuntime(
   return server;
 }
 
+export function bindProxyStdioLifecycle(opts: {
+  input: Readable;
+  proxy: Pick<CmuxLayerProxy, "stop">;
+  logger: Pick<Console, "error">;
+  exit: ExitFn;
+}): void {
+  let shutdownStarted = false;
+  const shutdown = (reason: string) => {
+    if (shutdownStarted) {
+      return;
+    }
+    shutdownStarted = true;
+    const forceExit = setTimeout(() => {
+      opts.logger.error(
+        `[cmuxlayer-proxy] forced stdio shutdown after ${reason}`,
+      );
+      opts.exit(0);
+    }, 1_000);
+    forceExit.unref?.();
+    void opts.proxy.stop().then(
+      () => {
+        clearTimeout(forceExit);
+        opts.exit(0);
+      },
+      (error) => {
+        clearTimeout(forceExit);
+        opts.logger.error("[cmuxlayer-proxy] stdio shutdown failed", error);
+        opts.exit(1);
+      },
+    );
+  };
+
+  opts.input.once("end", () => shutdown("stdin end"));
+  opts.input.once("close", () => shutdown("stdin close"));
+}
+
 export async function runDaemonFirstEntry(
   opts: DaemonFirstEntryOptions = {},
 ): Promise<EntryRuntime> {
@@ -207,19 +270,25 @@ export async function runDaemonFirstEntry(
   const spawnDaemon = opts.spawnDaemon ?? spawnDaemonProcess;
   const startInProcess = opts.startInProcess ?? startInProcessRuntime;
   const sleep = opts.sleep ?? defaultSleep;
+  const exit = opts.exit ?? ((code) => process.exit(code));
   const autostartTimeoutMs =
     opts.autostartTimeoutMs ?? DEFAULT_AUTOSTART_TIMEOUT_MS;
   const autostartPollMs = opts.autostartPollMs ?? DEFAULT_AUTOSTART_POLL_MS;
 
-  const startProxy = async (): Promise<EntryRuntime> => ({
-    mode: "daemon-proxy",
-    proxy: await runProxy({
+  const startProxy = async (): Promise<EntryRuntime> => {
+    const input = opts.input ?? process.stdin;
+    const proxy = await runProxy({
       socketPath,
-      input: opts.input,
+      input,
       output: opts.output,
       logger,
-    }),
-  });
+    });
+    bindProxyStdioLifecycle({ input, proxy, logger, exit });
+    return {
+      mode: "daemon-proxy",
+      proxy,
+    };
+  };
 
   const fallback = async (warning: string): Promise<EntryRuntime> => {
     logger.error(`[cmuxlayer] WARNING: ${warning}`);
@@ -240,8 +309,9 @@ export async function runDaemonFirstEntry(
     return startProxy();
   }
 
+  let spawnedDaemon: unknown;
   try {
-    await spawnDaemon({
+    spawnedDaemon = await spawnDaemon({
       socketPath,
       env,
       daemonScriptPath: opts.daemonScriptPath,
@@ -265,6 +335,11 @@ export async function runDaemonFirstEntry(
     return startProxy();
   }
 
+  if (await probeDaemon(socketPath)) {
+    return startProxy();
+  }
+
+  terminateSpawnedDaemon(spawnedDaemon, logger);
   return fallback(
     `daemon unavailable; using heavy in-process runtime after daemon autostart timeout at ${socketPath}`,
   );

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,0 +1,271 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Readable, Writable } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CreateServerOptions } from "./server.js";
+import {
+  CmuxLayerProxy,
+  runProxy as runProxyRuntime,
+  type CmuxLayerProxyOptions,
+} from "./proxy.js";
+import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
+
+const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
+const DEFAULT_AUTOSTART_POLL_MS = 50;
+
+export { resolveDefaultDaemonSocketPath as defaultDaemonSocketPath };
+
+export interface SpawnDaemonOptions {
+  socketPath: string;
+  env: NodeJS.ProcessEnv;
+  daemonScriptPath?: string;
+  logger: Pick<Console, "error">;
+}
+
+export interface StartInProcessOptions {
+  fallbackWarnings?: string[];
+}
+
+export type EntryRuntime =
+  | { mode: "daemon-proxy"; proxy: CmuxLayerProxy }
+  | { mode: "in-process"; server: McpServer; fallbackWarnings: string[] };
+
+export interface DaemonFirstEntryOptions {
+  env?: NodeJS.ProcessEnv;
+  input?: Readable;
+  output?: Writable;
+  logger?: Pick<Console, "error">;
+  probeDaemon?: (socketPath: string) => Promise<boolean>;
+  spawnDaemon?: (opts: SpawnDaemonOptions) => Promise<unknown> | unknown;
+  runProxy?: (opts: CmuxLayerProxyOptions) => Promise<CmuxLayerProxy>;
+  startInProcess?: (opts: StartInProcessOptions) => Promise<McpServer>;
+  sleep?: (ms: number) => Promise<void>;
+  daemonScriptPath?: string;
+  autostartTimeoutMs?: number;
+  autostartPollMs?: number;
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function defaultDaemonScriptPath(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "daemon.js");
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function probeDaemonSocket(socketPath: string): Promise<boolean> {
+  return new Promise((resolveProbe) => {
+    const socket = net.createConnection(socketPath);
+    let settled = false;
+    const settle = (connected: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.removeAllListeners();
+      socket.on("error", () => {});
+      socket.destroy();
+      resolveProbe(connected);
+    };
+    socket.setTimeout(250, () => settle(false));
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
+  });
+}
+
+export async function spawnDaemonProcess(
+  opts: SpawnDaemonOptions,
+): Promise<ChildProcess> {
+  await mkdir(dirname(opts.socketPath), { recursive: true });
+  const daemonScriptPath = opts.daemonScriptPath ?? defaultDaemonScriptPath();
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...opts.env,
+    CMUXLAYER_DAEMON_SOCKET: opts.socketPath,
+  };
+  const nodeOptions = env.NODE_OPTIONS ?? "";
+  if (!/(^|\s)--max-old-space-size(=|\s)/.test(nodeOptions)) {
+    env.NODE_OPTIONS = `${nodeOptions} --max-old-space-size=${
+      env.CMUXLAYER_NODE_MAX_OLD_SPACE_MB ?? "1536"
+    }`.trim();
+  }
+  const child = spawn(process.execPath, [daemonScriptPath], {
+    detached: true,
+    env,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  child.unref();
+  return child;
+}
+
+async function waitForDaemon(
+  socketPath: string,
+  opts: Required<
+    Pick<
+      DaemonFirstEntryOptions,
+      "probeDaemon" | "sleep" | "autostartTimeoutMs" | "autostartPollMs"
+    >
+  >,
+): Promise<boolean> {
+  const deadline = Date.now() + opts.autostartTimeoutMs;
+  do {
+    if (await opts.probeDaemon(socketPath)) {
+      return true;
+    }
+    if (opts.autostartTimeoutMs === 0) {
+      return false;
+    }
+    await opts.sleep(opts.autostartPollMs);
+  } while (Date.now() < deadline);
+
+  return opts.probeDaemon(socketPath);
+}
+
+export async function startInProcessRuntime(
+  opts: StartInProcessOptions = {},
+): Promise<McpServer> {
+  const [
+    { StdioServerTransport },
+    { bindStdioLifecycle },
+    { createCmuxClient },
+    { createServer },
+    { drainOutbox, httpDeliver },
+    { defaultMonitorRegistryPath, httpNotifyMonitorDeadman },
+    { ensureNodeMaxOldSpaceEnv, installHeapGuard },
+  ] = await Promise.all([
+    import("@modelcontextprotocol/sdk/server/stdio.js"),
+    import("./stdio-lifecycle.js"),
+    import("./cmux-client-factory.js"),
+    import("./server.js"),
+    import("./outbox-drainer.js"),
+    import("./monitor-registry.js"),
+    import("./heap-guard.js"),
+  ]);
+
+  ensureNodeMaxOldSpaceEnv();
+  installHeapGuard();
+  const client = await createCmuxClient();
+  const serverOpts: CreateServerOptions = {
+    client,
+    outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
+    monitorRegistryPath: defaultMonitorRegistryPath(),
+    monitorRegistryNotify: httpNotifyMonitorDeadman,
+    enableCloseForensics: true,
+    ...(opts.fallbackWarnings
+      ? { controlHealthWarnings: opts.fallbackWarnings }
+      : {}),
+  };
+  const server = createServer(serverOpts);
+  const transport = new StdioServerTransport();
+  let shutdownStarted = false;
+  bindStdioLifecycle({
+    stdin: process.stdin,
+    transport: transport as any,
+    shutdown: (reason) => {
+      if (shutdownStarted) return;
+      shutdownStarted = true;
+      const forceExit = setTimeout(() => {
+        console.error(`[cmuxlayer] forced stdio shutdown after ${reason}`);
+        process.exit(0);
+      }, 1_000);
+      forceExit.unref();
+      void server
+        .close()
+        .catch((error) => {
+          console.error("[cmuxlayer] stdio shutdown failed", error);
+        })
+        .finally(() => {
+          clearTimeout(forceExit);
+          process.exit(0);
+        });
+    },
+  });
+  await server.connect(transport);
+  return server;
+}
+
+export async function runDaemonFirstEntry(
+  opts: DaemonFirstEntryOptions = {},
+): Promise<EntryRuntime> {
+  const env = opts.env ?? process.env;
+  const logger = opts.logger ?? console;
+  const socketPath = resolveDefaultDaemonSocketPath(env);
+  const probeDaemon = opts.probeDaemon ?? probeDaemonSocket;
+  const runProxy = opts.runProxy ?? runProxyRuntime;
+  const spawnDaemon = opts.spawnDaemon ?? spawnDaemonProcess;
+  const startInProcess = opts.startInProcess ?? startInProcessRuntime;
+  const sleep = opts.sleep ?? defaultSleep;
+  const autostartTimeoutMs =
+    opts.autostartTimeoutMs ?? DEFAULT_AUTOSTART_TIMEOUT_MS;
+  const autostartPollMs = opts.autostartPollMs ?? DEFAULT_AUTOSTART_POLL_MS;
+
+  const startProxy = async (): Promise<EntryRuntime> => ({
+    mode: "daemon-proxy",
+    proxy: await runProxy({
+      socketPath,
+      input: opts.input,
+      output: opts.output,
+      logger,
+    }),
+  });
+
+  const fallback = async (warning: string): Promise<EntryRuntime> => {
+    logger.error(`[cmuxlayer] WARNING: ${warning}`);
+    return {
+      mode: "in-process",
+      server: await startInProcess({ fallbackWarnings: [warning] }),
+      fallbackWarnings: [warning],
+    };
+  };
+
+  if (isEnabled(env.CMUXLAYER_FORCE_INPROCESS)) {
+    return fallback(
+      "CMUXLAYER_FORCE_INPROCESS=1; using heavy in-process runtime instead of daemon proxy",
+    );
+  }
+
+  if (await probeDaemon(socketPath)) {
+    return startProxy();
+  }
+
+  try {
+    await spawnDaemon({
+      socketPath,
+      env,
+      daemonScriptPath: opts.daemonScriptPath,
+      logger,
+    });
+  } catch (error) {
+    return fallback(
+      `daemon unavailable; using heavy in-process runtime after daemon autostart failed at ${socketPath}: ${errorText(
+        error,
+      )}`,
+    );
+  }
+
+  const available = await waitForDaemon(socketPath, {
+    probeDaemon,
+    sleep,
+    autostartTimeoutMs,
+    autostartPollMs,
+  });
+  if (available) {
+    return startProxy();
+  }
+
+  return fallback(
+    `daemon unavailable; using heavy in-process runtime after daemon autostart timeout at ${socketPath}`,
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,21 +22,9 @@
  *                         wait_for_all, stop_agent, kill, interact
  */
 
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createServer } from "./server.js";
-import { createCmuxClient } from "./cmux-client-factory.js";
 import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";
 import { readVersion } from "./version.js";
-import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
-import {
-  defaultMonitorRegistryPath,
-  httpNotifyMonitorDeadman,
-} from "./monitor-registry.js";
-import { bindStdioLifecycle } from "./stdio-lifecycle.js";
-import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
-
-ensureNodeMaxOldSpaceEnv();
-installHeapGuard();
+import { runDaemonFirstEntry } from "./entry.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 
@@ -54,6 +42,12 @@ Usage:
 Environment:
   CMUX_SOCKET_PATH     Pin the MCP to a specific cmux instance's Unix socket
                        (authoritative — never falls through to another instance).
+  CMUXLAYER_DAEMON_SOCKET
+                       Override the cmuxlayer daemon Unix socket. Defaults to
+                       ~/.local/state/cmux/cmuxlayer-stated.sock.
+  CMUXLAYER_FORCE_INPROCESS=1
+                       Escape hatch: run the legacy in-process MCP runtime and
+                       log/surface a warning in control_health.
 `;
 
 async function main() {
@@ -79,41 +73,7 @@ async function main() {
     return;
   }
 
-  const client = await createCmuxClient();
-  // Wire the real outbox drainer into the live MCP server so this agent's
-  // periodic sweep flushes ~/.golems-zikaron/outbox.md to the notify path.
-  const server = createServer({
-    client,
-    outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
-    monitorRegistryPath: defaultMonitorRegistryPath(),
-    monitorRegistryNotify: httpNotifyMonitorDeadman,
-    enableCloseForensics: true,
-  });
-  const transport = new StdioServerTransport();
-  let shutdownStarted = false;
-  bindStdioLifecycle({
-    stdin: process.stdin,
-    transport: transport as any,
-    shutdown: (reason) => {
-      if (shutdownStarted) return;
-      shutdownStarted = true;
-      const forceExit = setTimeout(() => {
-        console.error(`[cmuxlayer] forced stdio shutdown after ${reason}`);
-        process.exit(0);
-      }, 1_000);
-      forceExit.unref();
-      void server
-        .close()
-        .catch((error) => {
-          console.error("[cmuxlayer] stdio shutdown failed", error);
-        })
-        .finally(() => {
-          clearTimeout(forceExit);
-          process.exit(0);
-        });
-    },
-  });
-  await server.connect(transport);
+  await runDaemonFirstEntry();
 }
 
 main().catch((error) => {

--- a/src/json-rpc-line-buffer.ts
+++ b/src/json-rpc-line-buffer.ts
@@ -1,0 +1,360 @@
+import {
+  JSONRPCMessageSchema,
+  type JSONRPCMessage,
+  type RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const LF = 0x0a;
+const CR = 0x0d;
+const DOUBLE_QUOTE = 0x22;
+const BACKSLASH = 0x5c;
+
+export interface JsonRpcFrameMetadata {
+  id?: RequestId;
+  hasId: boolean;
+  method?: string;
+  hasResult: boolean;
+  hasError: boolean;
+  isRequest: boolean;
+  isResponse: boolean;
+}
+
+export class JsonRpcLineBuffer {
+  private chunks: Buffer[] = [];
+  private headOffset = 0;
+  private bufferedBytes = 0;
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0) {
+      return;
+    }
+    this.chunks.push(chunk);
+    this.bufferedBytes += chunk.length;
+  }
+
+  readFrame(): Buffer | null {
+    const frameLength = this.nextFrameLength();
+    if (frameLength === null) {
+      return null;
+    }
+    return this.take(frameLength);
+  }
+
+  readMessage(): JSONRPCMessage | null {
+    const frame = this.readFrame();
+    if (frame === null) {
+      return null;
+    }
+    return deserializeJsonRpcFrame(frame);
+  }
+
+  clear(): void {
+    this.chunks = [];
+    this.headOffset = 0;
+    this.bufferedBytes = 0;
+  }
+
+  private nextFrameLength(): number | null {
+    let scanned = 0;
+    for (let index = 0; index < this.chunks.length; index += 1) {
+      const chunk = this.chunks[index];
+      const start = index === 0 ? this.headOffset : 0;
+      const newline = chunk.indexOf(LF, start);
+      if (newline >= 0) {
+        return scanned + newline - start + 1;
+      }
+      scanned += chunk.length - start;
+    }
+    return null;
+  }
+
+  private take(byteLength: number): Buffer {
+    const first = this.chunks[0];
+    const firstAvailable = first.length - this.headOffset;
+    if (byteLength <= firstAvailable) {
+      const frame = first.subarray(
+        this.headOffset,
+        this.headOffset + byteLength,
+      );
+      this.consume(byteLength);
+      return frame;
+    }
+
+    const frame = Buffer.allocUnsafe(byteLength);
+    let copied = 0;
+    while (copied < byteLength) {
+      const chunk = this.chunks[0];
+      const available = chunk.length - this.headOffset;
+      const nextCopy = Math.min(byteLength - copied, available);
+      chunk.copy(
+        frame,
+        copied,
+        this.headOffset,
+        this.headOffset + nextCopy,
+      );
+      this.consume(nextCopy);
+      copied += nextCopy;
+    }
+    return frame;
+  }
+
+  private consume(byteLength: number): void {
+    let remaining = byteLength;
+    this.bufferedBytes -= byteLength;
+    while (remaining > 0 && this.chunks.length > 0) {
+      const chunk = this.chunks[0];
+      const available = chunk.length - this.headOffset;
+      if (remaining < available) {
+        this.headOffset += remaining;
+        return;
+      }
+      remaining -= available;
+      this.chunks.shift();
+      this.headOffset = 0;
+    }
+    if (this.chunks.length === 0) {
+      this.headOffset = 0;
+    }
+  }
+}
+
+export function deserializeJsonRpcFrame(frame: Buffer): JSONRPCMessage {
+  return JSONRPCMessageSchema.parse(JSON.parse(frameToJsonText(frame)));
+}
+
+export function extractJsonRpcFrameMetadata(
+  frame: Buffer,
+): JsonRpcFrameMetadata | null {
+  const end = jsonEnd(frame);
+  let index = skipWhitespace(frame, 0, end);
+  if (frame[index] !== 0x7b) {
+    return null;
+  }
+  index += 1;
+
+  let id: RequestId | undefined;
+  let hasId = false;
+  let method: string | undefined;
+  let hasResult = false;
+  let hasError = false;
+
+  while (index < end) {
+    index = skipWhitespace(frame, index, end);
+    if (frame[index] === 0x7d) {
+      break;
+    }
+    if (frame[index] === 0x2c) {
+      index += 1;
+      continue;
+    }
+
+    const key = readJsonString(frame, index, end);
+    if (!key) {
+      return null;
+    }
+    index = skipWhitespace(frame, key.end, end);
+    if (frame[index] !== 0x3a) {
+      return null;
+    }
+    index = skipWhitespace(frame, index + 1, end);
+
+    if (key.value === "id") {
+      const idValue = readJsonRpcId(frame, index, end);
+      if (idValue) {
+        id = idValue.value;
+        hasId = true;
+        index = idValue.end;
+      } else {
+        const skipped = skipJsonValue(frame, index, end);
+        if (skipped === null) {
+          return null;
+        }
+        index = skipped;
+      }
+      continue;
+    }
+
+    if (key.value === "method") {
+      const methodValue = readJsonString(frame, index, end);
+      if (methodValue) {
+        method = methodValue.value;
+        index = methodValue.end;
+      } else {
+        const skipped = skipJsonValue(frame, index, end);
+        if (skipped === null) {
+          return null;
+        }
+        index = skipped;
+      }
+      continue;
+    }
+
+    if (key.value === "result") {
+      hasResult = true;
+    } else if (key.value === "error") {
+      hasError = true;
+    }
+    const skipped = skipJsonValue(frame, index, end);
+    if (skipped === null) {
+      return null;
+    }
+    index = skipped;
+  }
+
+  return {
+    id,
+    hasId,
+    method,
+    hasResult,
+    hasError,
+    isRequest: hasId && typeof method === "string",
+    isResponse: hasId && (hasResult || hasError),
+  };
+}
+
+function frameToJsonText(frame: Buffer): string {
+  return frame.toString("utf8", 0, jsonEnd(frame));
+}
+
+function jsonEnd(frame: Buffer): number {
+  let end = frame.length;
+  if (end > 0 && frame[end - 1] === LF) {
+    end -= 1;
+  }
+  if (end > 0 && frame[end - 1] === CR) {
+    end -= 1;
+  }
+  return end;
+}
+
+function skipWhitespace(frame: Buffer, index: number, end: number): number {
+  while (index < end) {
+    const byte = frame[index];
+    if (byte !== 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d) {
+      break;
+    }
+    index += 1;
+  }
+  return index;
+}
+
+function readJsonString(
+  frame: Buffer,
+  index: number,
+  end: number,
+): { value: string; end: number } | null {
+  if (frame[index] !== DOUBLE_QUOTE) {
+    return null;
+  }
+  let escaped = false;
+  let sawEscape = false;
+  const valueStart = index + 1;
+  for (let cursor = valueStart; cursor < end; cursor += 1) {
+    const byte = frame[cursor];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (byte === BACKSLASH) {
+      escaped = true;
+      sawEscape = true;
+      continue;
+    }
+    if (byte === DOUBLE_QUOTE) {
+      const raw = frame.toString("utf8", index, cursor + 1);
+      return {
+        value: sawEscape ? (JSON.parse(raw) as string) : raw.slice(1, -1),
+        end: cursor + 1,
+      };
+    }
+  }
+  return null;
+}
+
+function readJsonRpcId(
+  frame: Buffer,
+  index: number,
+  end: number,
+): { value: RequestId; end: number } | null {
+  if (frame[index] === DOUBLE_QUOTE) {
+    const value = readJsonString(frame, index, end);
+    return value ? { value: value.value, end: value.end } : null;
+  }
+
+  const start = index;
+  while (index < end) {
+    const byte = frame[index];
+    if (
+      (byte >= 0x30 && byte <= 0x39) ||
+      byte === 0x2d ||
+      byte === 0x2b ||
+      byte === 0x2e ||
+      byte === 0x45 ||
+      byte === 0x65
+    ) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  if (index === start) {
+    return null;
+  }
+  const value = Number(frame.toString("utf8", start, index));
+  return Number.isFinite(value) ? { value, end: index } : null;
+}
+
+function skipJsonValue(
+  frame: Buffer,
+  index: number,
+  end: number,
+): number | null {
+  index = skipWhitespace(frame, index, end);
+  const first = frame[index];
+  if (first === DOUBLE_QUOTE) {
+    return readJsonString(frame, index, end)?.end ?? null;
+  }
+
+  if (first === 0x7b || first === 0x5b) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let cursor = index; cursor < end; cursor += 1) {
+      const byte = frame[cursor];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (byte === BACKSLASH) {
+          escaped = true;
+        } else if (byte === DOUBLE_QUOTE) {
+          inString = false;
+        }
+        continue;
+      }
+      if (byte === DOUBLE_QUOTE) {
+        inString = true;
+        continue;
+      }
+      if (byte === 0x7b || byte === 0x5b) {
+        depth += 1;
+        continue;
+      }
+      if (byte === 0x7d || byte === 0x5d) {
+        depth -= 1;
+        if (depth === 0) {
+          return cursor + 1;
+        }
+      }
+    }
+    return null;
+  }
+
+  while (index < end) {
+    const byte = frame[index];
+    if (byte === 0x2c || byte === 0x7d || byte === 0x5d) {
+      break;
+    }
+    index += 1;
+  }
+  return index;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,15 +3,16 @@
 import net from "node:net";
 import { pathToFileURL } from "node:url";
 import type { Readable, Writable } from "node:stream";
-import {
-  ReadBuffer,
-  serializeMessage,
-} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
   JSONRPCMessage,
   RequestId,
 } from "@modelcontextprotocol/sdk/types.js";
 import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
+import {
+  extractJsonRpcFrameMetadata,
+  JsonRpcLineBuffer,
+} from "./json-rpc-line-buffer.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
@@ -49,10 +50,6 @@ type JsonRpcRequest = JSONRPCMessage & {
 
 type JsonRpcNotification = JSONRPCMessage & {
   method: string;
-};
-
-type JsonRpcResponse = JSONRPCMessage & {
-  id: RequestId;
 };
 
 interface QueuedMessage {
@@ -101,17 +98,6 @@ function isJsonRpcNotification(
   );
 }
 
-function isJsonRpcResponse(
-  message: JSONRPCMessage,
-): message is JsonRpcResponse {
-  return (
-    typeof message === "object" &&
-    message !== null &&
-    "id" in message &&
-    ("result" in message || "error" in message)
-  );
-}
-
 function requestKey(id: RequestId): string {
   return `${typeof id}:${String(id)}`;
 }
@@ -125,10 +111,17 @@ function writeMessage(
     Partial<Pick<Writable, "destroyed" | "writableEnded">>,
   message: JSONRPCMessage,
 ): Promise<void> {
+  return writeFrame(stream, Buffer.from(serializeMessage(message)));
+}
+
+function writeFrame(
+  stream: Pick<Writable, "write" | "once" | "off"> &
+    Partial<Pick<Writable, "destroyed" | "writableEnded">>,
+  frame: Buffer,
+): Promise<void> {
   if (stream.destroyed || stream.writableEnded) {
     return Promise.reject(new Error("stream is closed"));
   }
-  const payload = serializeMessage(message);
   return new Promise((resolve, reject) => {
     let settled = false;
     const onError = (error: Error) => settle(error);
@@ -154,7 +147,7 @@ function writeMessage(
     stream.once("error", onError);
     stream.once("close", onClose);
     try {
-      stream.write(payload, settle);
+      stream.write(frame, settle);
     } catch (error) {
       settle(error instanceof Error ? error : new Error(String(error)));
     }
@@ -178,8 +171,8 @@ export class CmuxLayerProxy {
   ) => void;
   private readonly logger: Pick<Console, "error">;
 
-  private readonly agentReadBuffer = new ReadBuffer();
-  private daemonReadBuffer: ReadBuffer | null = null;
+  private readonly agentReadBuffer = new JsonRpcLineBuffer();
+  private daemonReadBuffer: JsonRpcLineBuffer | null = null;
   private daemonSocket: net.Socket | null = null;
   private running = false;
   private connecting = false;
@@ -421,7 +414,7 @@ export class CmuxLayerProxy {
       return;
     }
     this.daemonSocket = socket;
-    this.daemonReadBuffer = new ReadBuffer();
+    this.daemonReadBuffer = new JsonRpcLineBuffer();
     socket.on("data", this.onDaemonData);
     socket.on("error", this.onDaemonError);
     socket.on("close", this.onDaemonClose);
@@ -445,17 +438,17 @@ export class CmuxLayerProxy {
       return;
     }
     this.daemonReadBuffer.append(chunk);
-    // handleDaemonMessage may disconnect the daemon mid-loop (e.g. on a rejected
+    // handleDaemonFrame may disconnect the daemon mid-loop (e.g. on a rejected
     // initialize replay), which nulls daemonReadBuffer — re-check it each pass so
     // we don't dereference null and spin forever logging TypeErrors.
     while (this.running && this.daemonReadBuffer) {
       const buffer = this.daemonReadBuffer;
       try {
-        const message = buffer.readMessage();
-        if (message === null) {
+        const frame = buffer.readFrame();
+        if (frame === null) {
           break;
         }
-        this.handleDaemonMessage(message);
+        this.handleDaemonFrame(frame);
       } catch (error) {
         this.logger.error(
           "[cmuxlayer-proxy] failed to parse daemon frame",
@@ -475,10 +468,19 @@ export class CmuxLayerProxy {
     this.handleDaemonDrop();
   };
 
-  private handleDaemonMessage(message: JSONRPCMessage): void {
-    if (this.replayingInitialize && this.isInitializeResponse(message)) {
+  private handleDaemonFrame(frame: Buffer): void {
+    const metadata = extractJsonRpcFrameMetadata(frame);
+    if (!metadata) {
+      this.logger.error("[cmuxlayer-proxy] failed to parse daemon frame");
+      return;
+    }
+
+    if (
+      this.replayingInitialize &&
+      this.isInitializeResponseMetadata(metadata)
+    ) {
       this.replayingInitialize = false;
-      if ("error" in message) {
+      if (metadata.hasError) {
         this.failAllPendingRequests(
           "cmuxlayer daemon initialize replay failed while reconnecting",
         );
@@ -494,18 +496,18 @@ export class CmuxLayerProxy {
       return;
     }
 
-    if (isJsonRpcResponse(message)) {
-      const key = requestKey(message.id);
+    if (metadata.isResponse && metadata.hasId && metadata.id !== undefined) {
+      const key = requestKey(metadata.id);
       const pending = this.pendingRequests.get(key);
       if (!pending) {
         if (this.expiredRequestKeys.has(key)) {
           this.logger.error(
             "[cmuxlayer-proxy] late daemon response for expired request id dropped",
-            { id: message.id },
+            { id: metadata.id },
           );
           return;
         }
-        void this.writeAgent(message);
+        void this.writeAgentFrame(frame);
         return;
       }
       clearTimeout(pending.timeout);
@@ -517,18 +519,22 @@ export class CmuxLayerProxy {
       ) {
         this.initializeResultDelivered = true;
       }
-      void this.writeAgent(message);
+      void this.writeAgentFrame(frame);
       return;
     }
 
-    void this.writeAgent(message);
+    void this.writeAgentFrame(frame);
   }
 
-  private isInitializeResponse(message: JSONRPCMessage): boolean {
+  private isInitializeResponseMetadata(
+    metadata: ReturnType<typeof extractJsonRpcFrameMetadata>,
+  ): boolean {
     return (
-      isJsonRpcResponse(message) &&
+      metadata !== null &&
+      metadata.isResponse &&
+      metadata.id !== undefined &&
       this.initializeRequest !== null &&
-      requestKey(message.id) === requestKey(this.initializeRequest.id)
+      requestKey(metadata.id) === requestKey(this.initializeRequest.id)
     );
   }
 
@@ -732,6 +738,14 @@ export class CmuxLayerProxy {
   private async writeAgent(message: JSONRPCMessage): Promise<void> {
     try {
       await writeMessage(this.output, message);
+    } catch (error) {
+      this.logger.error("[cmuxlayer-proxy] failed to write agent frame", error);
+    }
+  }
+
+  private async writeAgentFrame(frame: Buffer): Promise<void> {
+    try {
+      await writeFrame(this.output, frame);
     } catch (error) {
       this.logger.error("[cmuxlayer-proxy] failed to write agent frame", error);
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,8 +11,8 @@ import type {
   JSONRPCMessage,
   RequestId,
 } from "@modelcontextprotocol/sdk/types.js";
+import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
 
-const DEFAULT_SOCKET_PATH = "/tmp/cmuxlayer.sock";
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.3;
@@ -208,9 +208,7 @@ export class CmuxLayerProxy {
 
   constructor(opts: CmuxLayerProxyOptions = {}) {
     this.socketPath =
-      opts.socketPath ??
-      process.env.CMUXLAYER_DAEMON_SOCKET ??
-      DEFAULT_SOCKET_PATH;
+      opts.socketPath ?? defaultDaemonSocketPath(process.env);
     this.input = opts.input ?? process.stdin;
     this.output = opts.output ?? process.stdout;
     this.connect = opts.connect ?? ((path) => net.createConnection(path));

--- a/src/server.ts
+++ b/src/server.ts
@@ -1729,6 +1729,8 @@ export interface CreateServerOptions {
   worktreeHomeDir?: string;
   /** Override control health collection (primarily for tests). */
   controlHealthCollector?: () => Promise<ControlHealth>;
+  /** Extra warnings surfaced by control_health, e.g. daemon fallback mode. */
+  controlHealthWarnings?: string[];
   /**
    * Override the process-wide stale-build warner (primarily for tests). Returns
    * the loud warning string when this MCP build is stale vs the installed brew
@@ -1785,6 +1787,7 @@ export interface CmuxServerContext {
   lifecycleStartPromise: Promise<void> | null;
   lifecycleSweepEngine: AgentEngine | null;
   controlHealthCollector?: () => Promise<ControlHealth>;
+  controlHealthWarnings: string[];
   controlHealthIntervalMs: number;
   controlHealthTimer: ReturnType<typeof setInterval> | null;
   dispose(): void;
@@ -1868,6 +1871,7 @@ export function createServerContext(
     lifecycleStartPromise: null,
     lifecycleSweepEngine: null,
     controlHealthCollector: opts?.controlHealthCollector,
+    controlHealthWarnings: opts?.controlHealthWarnings ?? [],
     controlHealthIntervalMs: resolveControlHealthIntervalMs(
       opts?.controlHealthIntervalMs,
     ),
@@ -1962,6 +1966,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
   const controlHealthCollector =
     opts?.controlHealthCollector ?? context.controlHealthCollector;
+  const controlHealthWarnings =
+    opts?.controlHealthWarnings ?? context.controlHealthWarnings;
   const staleBuildWarning = opts?.staleBuildWarner ?? defaultStaleBuildWarner;
   const appendStaleBuildWarning = (result: { warnings?: string[] }): void => {
     const warning = staleBuildWarning();
@@ -2608,9 +2614,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   const appendControlHealthSnapshot = async (): Promise<ControlHealth> => {
-    const health = controlHealthCollector
+    const rawHealth = controlHealthCollector
       ? await controlHealthCollector()
       : await collectControlHealth({ client });
+    const health =
+      controlHealthWarnings.length > 0
+        ? {
+            ...rawHealth,
+            warnings: [...rawHealth.warnings, ...controlHealthWarnings],
+          }
+        : rawHealth;
     eventLog.appendControlHealth({
       ts: health.generated_at,
       event_type: "control_health",

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,7 @@ import type {
   CmuxNewSplitResult,
   CmuxNewSurfaceResult,
   CmuxPane,
+  CmuxReadScreenResult,
   CmuxSurface,
   CmuxStatusEntry,
   CmuxTerminalMetadata,
@@ -134,6 +135,7 @@ import {
   EMPTY_SURFACE_TOPOLOGY,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
+  type SurfaceTopologySnapshot,
   type SurfaceTopology,
 } from "./surface-topology.js";
 import {
@@ -1764,6 +1766,11 @@ export interface CreateServerOptions {
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
 
+interface ReadScreenSnapshot {
+  result: CmuxReadScreenResult;
+  topology: SurfaceTopologySnapshot | null;
+}
+
 export interface CmuxServerContext {
   client: CmuxLayerClient;
   stateDir: string;
@@ -1777,6 +1784,7 @@ export interface CmuxServerContext {
   latestDeliveryBySurface: Map<string, string>;
   activeDeliveryBySurface: Map<string, string>;
   activeSurfaceWrites: Map<string, string>;
+  readScreenInflight: Map<string, Promise<ReadScreenSnapshot>>;
   enableClaudeChannels: boolean;
   skipAgentLifecycle: boolean;
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
@@ -1859,6 +1867,7 @@ export function createServerContext(
     latestDeliveryBySurface: new Map(),
     activeDeliveryBySurface: new Map(),
     activeSurfaceWrites: new Map(),
+    readScreenInflight: new Map(),
     enableClaudeChannels:
       opts?.enableClaudeChannels ??
       process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1",
@@ -3725,6 +3734,50 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     workspace?: string,
   ) => collectCmuxSurfaceTopology(client, workspace);
 
+  const readScreenSnapshotKey = (opts: {
+    surface: string;
+    workspace?: string;
+    lines?: number;
+    scrollback?: boolean;
+  }): string =>
+    JSON.stringify([
+      opts.surface,
+      opts.workspace ?? null,
+      opts.lines ?? null,
+      opts.scrollback === true,
+    ]);
+
+  const readScreenSnapshot = async (opts: {
+    surface: string;
+    workspace?: string;
+    lines?: number;
+    scrollback?: boolean;
+  }): Promise<ReadScreenSnapshot> => {
+    const key = readScreenSnapshotKey(opts);
+    const existing = context.readScreenInflight.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const snapshot = (async () => {
+      const result = await client.readScreen(opts.surface, {
+        workspace: opts.workspace,
+        lines: opts.lines,
+        scrollback: opts.scrollback,
+      });
+      const topology = await collectSurfaceTopology(opts.workspace);
+      return { result, topology };
+    })();
+    context.readScreenInflight.set(key, snapshot);
+    try {
+      return await snapshot;
+    } finally {
+      if (context.readScreenInflight.get(key) === snapshot) {
+        context.readScreenInflight.delete(key);
+      }
+    }
+  };
+
   // Resolve a surface's 0-based column + the workspace column_count using the
   // SAME reliable post-F5 logic as list_surfaces: derive columns from pane
   // geometry, then attribute the surface to its pane by membership (pane_id),
@@ -5155,12 +5208,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.readOnly,
     async (args) => {
       try {
-        const result = await client.readScreen(args.surface, {
+        const { result, topology } = await readScreenSnapshot({
+          surface: args.surface,
           workspace: args.workspace,
           lines: args.lines,
           scrollback: args.scrollback,
         });
-        const surface = await findSurfaceByRef(result.surface, args.workspace);
+        const title = topology?.titleBySurface.get(result.surface) ?? null;
+        const { column, column_count } =
+          topology?.topologyBySurface.get(result.surface) ??
+          EMPTY_SURFACE_TOPOLOGY;
         const parsed = applyHarnessState(
           enrichParsedScreen(
             parseScreen(result.text),
@@ -5169,17 +5226,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ),
           resolveHarnessStateForSurface(stateMgr, result.surface),
         );
-        // F7: surface column + workspace column_count so sprawl is visible on
-        // every read. Best-effort — omitted (null) if geometry is unavailable.
-        const { column, column_count } = await resolveSurfaceColumn(
-          result.surface,
-          args.workspace,
-        );
 
         if (args.parsed_only) {
           const data = {
             surface: result.surface,
-            title: surface?.title ?? null,
+            title,
             column,
             column_count,
             parsed,
@@ -5187,7 +5238,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           const formatted = formatReadScreen(
             result.surface,
-            surface?.title ?? null,
+            title,
             null,
             parsed,
             false,
@@ -5202,7 +5253,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Full untrimmed terminal content on explicit request.
           const data = {
             surface: result.surface,
-            title: surface?.title ?? null,
+            title,
             column,
             column_count,
             lines: result.lines,
@@ -5213,7 +5264,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           const formatted = formatReadScreen(
             result.surface,
-            surface?.title ?? null,
+            title,
             result.text,
             parsed,
             result.scrollback_used,
@@ -5232,7 +5283,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : cleanScreenText(result.text, 12) || null;
         const data = {
           surface: result.surface,
-          title: surface?.title ?? null,
+          title,
           column,
           column_count,
           parsed,
@@ -5241,7 +5292,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         };
         const formatted = formatReadScreen(
           result.surface,
-          surface?.title ?? null,
+          title,
           screenPreview,
           parsed,
           false,

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -247,6 +247,70 @@ describe("control health", () => {
     );
   });
 
+  it("control_health surfaces daemon fallback warnings", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const health = {
+      generated_at: "2026-07-08T10:00:00.000Z",
+      current_process: {
+        pid: 123,
+        ppid: 1,
+        cwd: TEST_ROOT,
+        stdin_is_tty: false,
+        env: { PATH: "/bin" },
+        path_entries: ["/bin"],
+        cmux_resolution: [],
+      },
+      selected_transport: {
+        client_class: "CmuxClient",
+      },
+      cmux_instances: {
+        production: {
+          axis: "production",
+          app_bundle_path: "/Applications/cmux.app",
+          app_binary_path: "/Applications/cmux.app/Contents/MacOS/cmux",
+          marker_files: [],
+          socket_path: "/tmp/prod.sock",
+          socket_status: null,
+          processes: [],
+        },
+        nightly: {
+          axis: "nightly",
+          app_bundle_path: "/Applications/cmux NIGHTLY.app",
+          app_binary_path: "/Applications/cmux NIGHTLY.app/Contents/MacOS/cmux",
+          marker_files: [],
+          socket_path: "/tmp/nightly.sock",
+          socket_status: null,
+          processes: [],
+        },
+      },
+      warnings: [],
+    } satisfies ControlHealth;
+    const server = createServer({
+      stateDir: TEST_ROOT,
+      skipAgentLifecycle: true,
+      controlHealthCollector: async () => health,
+      controlHealthWarnings: [
+        "cmuxlayer daemon unavailable; using heavy in-process runtime",
+      ],
+    });
+    const tool = (server as any)._registeredTools["control_health"];
+
+    try {
+      const result = await tool.handler({}, {} as any);
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.health.warnings).toContain(
+        "cmuxlayer daemon unavailable; using heavy in-process runtime",
+      );
+      expect(result.content[0].text).toContain("daemon unavailable");
+    } finally {
+      await server.close();
+      rmSync(TEST_ROOT, { recursive: true, force: true });
+    }
+  });
+
   it("periodically appends control health snapshots without tool invocation", async () => {
     vi.useFakeTimers();
     rmSync(TEST_ROOT, { recursive: true, force: true });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,4 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -172,6 +173,19 @@ async function connectClient(path: string): Promise<Client> {
   const transport = new SocketJsonRpcTransport(socket);
   const client = new Client({ name: "daemon-test", version: "0.1.0" });
   await client.connect(transport);
+  return client;
+}
+
+async function connectInMemoryServer(
+  server: ReturnType<typeof createServer>,
+): Promise<Client> {
+  const client = new Client({ name: "direct-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
   return client;
 }
 
@@ -496,6 +510,74 @@ describe("CmuxLayerDaemon", () => {
     await clientA.close();
     await clientB.close();
     await daemon.shutdown();
+  });
+
+  it("serves the same list_agents and read_screen state as a direct in-process server", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("truthful-state");
+    const dir = stateDir("truthful-state");
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: dir,
+      disableSpawnPreflight: true,
+    });
+    const directServer = createServer({ context });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      context,
+      disableSpawnPreflight: true,
+    });
+
+    await daemon.start();
+    const directClient = await connectInMemoryServer(directServer);
+    const daemonClient = await connectClient(path);
+
+    try {
+      const spawned = await directClient.callTool({
+        name: "spawn_agent",
+        arguments: {
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+        },
+      });
+      const agentId = String(spawned.structuredContent?.agent_id);
+      const [directAgents, daemonAgents, directScreen, daemonScreen] =
+        await Promise.all([
+          directClient.callTool({
+            name: "list_agents",
+            arguments: { include_completed: true },
+          }),
+          daemonClient.callTool({
+            name: "list_agents",
+            arguments: { include_completed: true },
+          }),
+          directClient.callTool({
+            name: "read_screen",
+            arguments: { surface: "surface:new", lines: 5 },
+          }),
+          daemonClient.callTool({
+            name: "read_screen",
+            arguments: { surface: "surface:new", lines: 5 },
+          }),
+        ]);
+
+      expect(daemonAgents.structuredContent).toEqual(
+        directAgents.structuredContent,
+      );
+      expect(daemonScreen.structuredContent).toEqual(
+        directScreen.structuredContent,
+      );
+      expect(daemonAgents.structuredContent).toMatchObject({
+        agents: [expect.objectContaining({ agent_id: agentId })],
+      });
+    } finally {
+      await directClient.close();
+      await daemonClient.close();
+      await daemon.shutdown();
+      await directServer.close();
+      context.dispose();
+    }
   });
 
   it("drains an in-flight request before shutdown completes", async () => {

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Writable } from "node:stream";
+import {
+  defaultDaemonSocketPath,
+  runDaemonFirstEntry,
+  type DaemonFirstEntryOptions,
+} from "../src/entry.js";
+import { AgentEngine } from "../src/agent-engine.js";
+
+function createEntryOptions(
+  overrides: Partial<DaemonFirstEntryOptions> = {},
+): DaemonFirstEntryOptions {
+  return {
+    env: {},
+    logger: { error: vi.fn() },
+    output: { write: vi.fn() } as unknown as Writable,
+    probeDaemon: vi.fn().mockResolvedValue(true),
+    runProxy: vi.fn().mockResolvedValue({ stop: vi.fn() }),
+    spawnDaemon: vi.fn(),
+    startInProcess: vi.fn().mockResolvedValue({
+      close: vi.fn(),
+    }),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    autostartTimeoutMs: 0,
+    ...overrides,
+  };
+}
+
+describe("daemon-first MCP entry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the state-dir daemon socket by default and allows an env override", () => {
+    expect(defaultDaemonSocketPath({})).toBe(
+      join(homedir(), ".local", "state", "cmux", "cmuxlayer-stated.sock"),
+    );
+    expect(
+      defaultDaemonSocketPath({
+        CMUXLAYER_DAEMON_SOCKET: "/custom/cmuxlayer.sock",
+      } as NodeJS.ProcessEnv),
+    ).toBe("/custom/cmuxlayer.sock");
+  });
+
+  it("connects to an already-running daemon and starts only the thin proxy", async () => {
+    const startSweep = vi.spyOn(AgentEngine.prototype, "startSweep");
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/running-daemon.sock" },
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("daemon-proxy");
+    expect(opts.probeDaemon).toHaveBeenCalledWith("/tmp/running-daemon.sock");
+    expect(opts.runProxy).toHaveBeenCalledWith(
+      expect.objectContaining({ socketPath: "/tmp/running-daemon.sock" }),
+    );
+    expect(opts.spawnDaemon).not.toHaveBeenCalled();
+    expect(opts.startInProcess).not.toHaveBeenCalled();
+    expect(startSweep).not.toHaveBeenCalled();
+  });
+
+  it("autostarts the daemon when absent, then forwards through the proxy", async () => {
+    const probeDaemon = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/autostarted.sock" },
+      probeDaemon,
+      autostartTimeoutMs: 100,
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("daemon-proxy");
+    expect(opts.spawnDaemon).toHaveBeenCalledWith(
+      expect.objectContaining({ socketPath: "/tmp/autostarted.sock" }),
+    );
+    expect(opts.runProxy).toHaveBeenCalledWith(
+      expect.objectContaining({ socketPath: "/tmp/autostarted.sock" }),
+    );
+    expect(opts.startInProcess).not.toHaveBeenCalled();
+  });
+
+  it("falls back to in-process mode with a loud warning when daemon start fails", async () => {
+    const logger = { error: vi.fn() };
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/down.sock" },
+      logger,
+      probeDaemon: vi.fn().mockResolvedValue(false),
+      spawnDaemon: vi.fn().mockRejectedValue(new Error("spawn denied")),
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("WARNING: daemon unavailable"),
+    );
+    expect(opts.startInProcess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackWarnings: [
+          expect.stringContaining("daemon unavailable; using heavy in-process runtime"),
+        ],
+      }),
+    );
+    expect(opts.runProxy).not.toHaveBeenCalled();
+  });
+
+  it("honors CMUXLAYER_FORCE_INPROCESS as a loud escape hatch", async () => {
+    const logger = { error: vi.fn() };
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_FORCE_INPROCESS: "1" },
+      logger,
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(opts.probeDaemon).not.toHaveBeenCalled();
+    expect(opts.spawnDaemon).not.toHaveBeenCalled();
+    expect(opts.runProxy).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("CMUXLAYER_FORCE_INPROCESS=1"),
+    );
+  });
+});

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { Writable } from "node:stream";
+import { PassThrough, type Writable } from "node:stream";
 import {
   defaultDaemonSocketPath,
   runDaemonFirstEntry,
@@ -108,6 +108,65 @@ describe("daemon-first MCP entry", () => {
       }),
     );
     expect(opts.runProxy).not.toHaveBeenCalled();
+  });
+
+  it("terminates an autostarted daemon before fallback when readiness times out", async () => {
+    const spawned = { kill: vi.fn() };
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/slow.sock" },
+      probeDaemon: vi.fn().mockResolvedValue(false),
+      spawnDaemon: vi.fn().mockResolvedValue(spawned),
+      autostartTimeoutMs: 0,
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(spawned.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(opts.startInProcess).toHaveBeenCalled();
+  });
+
+  it("uses the proxy instead of killing the autostarted daemon if the final timeout re-probe succeeds", async () => {
+    const spawned = { kill: vi.fn() };
+    const probeDaemon = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/raced-online.sock" },
+      probeDaemon,
+      spawnDaemon: vi.fn().mockResolvedValue(spawned),
+      autostartTimeoutMs: 0,
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("daemon-proxy");
+    expect(spawned.kill).not.toHaveBeenCalled();
+    expect(opts.runProxy).toHaveBeenCalledWith(
+      expect.objectContaining({ socketPath: "/tmp/raced-online.sock" }),
+    );
+    expect(opts.startInProcess).not.toHaveBeenCalled();
+  });
+
+  it("stops the proxy and exits when daemon-proxy stdin ends", async () => {
+    const input = new PassThrough();
+    const proxy = { stop: vi.fn().mockResolvedValue(undefined) };
+    const exit = vi.fn();
+    const opts = createEntryOptions({
+      input,
+      runProxy: vi.fn().mockResolvedValue(proxy),
+      exit,
+    });
+
+    await runDaemonFirstEntry(opts);
+    input.emit("end");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(proxy.stop).toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
   });
 
   it("honors CMUXLAYER_FORCE_INPROCESS as a loud escape hatch", async () => {

--- a/tests/json-rpc-line-buffer.test.ts
+++ b/tests/json-rpc-line-buffer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
+import { JsonRpcLineBuffer } from "../src/json-rpc-line-buffer.js";
+
+describe("JsonRpcLineBuffer", () => {
+  it("reads a split large JSON-RPC frame without repeated Buffer.concat copies", () => {
+    const payload = serializeMessage({
+      jsonrpc: "2.0",
+      id: 7,
+      result: { text: "x".repeat(256 * 1024) },
+    });
+    const chunks = [
+      Buffer.from(payload.slice(0, 17)),
+      Buffer.from(payload.slice(17, 8192)),
+      Buffer.from(payload.slice(8192)),
+    ];
+    const concatSpy = vi.spyOn(Buffer, "concat");
+    const buffer = new JsonRpcLineBuffer();
+
+    for (const chunk of chunks) {
+      buffer.append(chunk);
+    }
+
+    expect(buffer.readFrame()?.toString("utf8")).toBe(payload);
+    expect(buffer.readFrame()).toBeNull();
+    expect(concatSpy).not.toHaveBeenCalled();
+
+    concatSpy.mockRestore();
+  });
+});

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -86,6 +86,49 @@ function createCollector(stream: NodeJS.ReadableStream) {
   return { messages, waitForMessage };
 }
 
+function createRawLineCollector(stream: NodeJS.ReadableStream) {
+  const lines: string[] = [];
+  const events = new EventEmitter();
+  let buffer = "";
+  stream.on("data", (chunk: Buffer) => {
+    buffer += chunk.toString("utf8");
+    let newlineIndex: number;
+    while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, newlineIndex + 1);
+      buffer = buffer.slice(newlineIndex + 1);
+      lines.push(line);
+      events.emit("line", line);
+    }
+  });
+
+  const waitForLine = (
+    predicate: (line: string) => boolean,
+    timeoutMs = 1_000,
+  ): Promise<string> => {
+    const existing = lines.find(predicate);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        events.off("line", onLine);
+        reject(new Error("timed out waiting for raw line"));
+      }, timeoutMs);
+      const onLine = (line: string) => {
+        if (!predicate(line)) {
+          return;
+        }
+        clearTimeout(timeout);
+        events.off("line", onLine);
+        resolve(line);
+      };
+      events.on("line", onLine);
+    });
+  };
+
+  return { lines, waitForLine };
+}
+
 function request(
   id: number,
   method: string,
@@ -349,6 +392,81 @@ describe("CmuxLayerProxy", () => {
       0,
       (message) => "method" in message && message.method === "tools/list",
     );
+  });
+
+  it("relays large daemon responses without parsing and reserializing the frame", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("large-raw-relay");
+    const largeText = "read-screen-payload-".repeat(16_384);
+    const rawReadScreenResponse = ` { "result" : { "content" : [ { "type" : "text" , "text" : ${JSON.stringify(
+      largeText,
+    )} } ] , "structuredContent" : { "ok" : true , "text" : ${JSON.stringify(
+      largeText,
+    )} } } , "id" : 2 , "jsonrpc" : "2.0" }\n`;
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      const readBuffer = new ReadBuffer();
+      socket.on("data", (chunk) => {
+        readBuffer.append(chunk);
+        while (true) {
+          const message = readBuffer.readMessage();
+          if (message === null) {
+            break;
+          }
+          if (
+            typeof message === "object" &&
+            message !== null &&
+            "id" in message &&
+            "method" in message &&
+            message.method === "initialize"
+          ) {
+            writeFrame(socket, {
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-03-26",
+                capabilities: {},
+                serverInfo: { name: "fake-daemon", version: "0.1.0" },
+              },
+            });
+          } else if (
+            typeof message === "object" &&
+            message !== null &&
+            "id" in message
+          ) {
+            socket.write(rawReadScreenResponse);
+          }
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(path, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const { input, output, collector } = createProxy(path);
+    const rawOutput = createRawLineCollector(output);
+
+    try {
+      writeFrame(input, request(1, "initialize", { capabilities: {} }));
+      await collector.waitForMessage(isResponseFor(1));
+      writeFrame(input, notification("notifications/initialized"));
+      writeFrame(input, request(2, "tools/call", { name: "read_screen" }));
+
+      await expect(
+        rawOutput.waitForLine((line) => line.includes('"id" : 2')),
+      ).resolves.toBe(rawReadScreenResponse);
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(path, { force: true });
+    }
   });
 
   it("replays initialize on daemon restart and completes buffered in-flight requests", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1950,6 +1950,91 @@ describe("tool handler integration", () => {
     expect(data.column).toBe(1);
     expect(data.column_count).toBe(2);
     expect(result.content[0].text).toContain("col 2/2");
+    expect(mockClient.listPanes).toHaveBeenCalledTimes(1);
+    expect(mockClient.listPaneSurfaces).toHaveBeenCalledTimes(2);
+  });
+
+  it("read_screen coalesces identical in-flight snapshots in one server context", async () => {
+    let resolveRead!: (value: {
+      surface: string;
+      text: string;
+      lines: number;
+      scrollback_used: boolean;
+    }) => void;
+    const readPromise = new Promise<{
+      surface: string;
+      text: string;
+      lines: number;
+      scrollback_used: boolean;
+    }>((resolve) => {
+      resolveRead = resolve;
+    });
+    const mockClient = {
+      readScreen: vi.fn().mockReturnValue(readPromise),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:1",
+            id: "pane-id",
+            surface_refs: ["surface:1"],
+            surface_ids: ["surface-id"],
+            pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+          },
+        ],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            id: "surface-id",
+            pane_id: "pane-id",
+            ref: "surface:1",
+            title: "sharedAgent",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+    } as any;
+    const server = createServer({
+      client: mockClient,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["read_screen"];
+
+    const first = tool.handler(
+      { surface: "surface:1", workspace: "workspace:1", lines: 5 },
+      {} as any,
+    );
+    const second = tool.handler(
+      { surface: "surface:1", workspace: "workspace:1", lines: 5 },
+      {} as any,
+    );
+    await Promise.resolve();
+
+    expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
+
+    resolveRead({
+      surface: "surface:1",
+      text: "shared screen\nTASK_DONE",
+      lines: 5,
+      scrollback_used: false,
+    });
+    const results = await Promise.all([first, second]);
+    for (const result of results) {
+      const data =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(data.title).toBe("sharedAgent");
+      expect(data.column).toBe(0);
+      expect(data.column_count).toBe(1);
+    }
+    expect(mockClient.listPanes).toHaveBeenCalledTimes(1);
+    expect(mockClient.listPaneSurfaces).toHaveBeenCalledTimes(1);
   });
 
   it("read_screen omits column when pane geometry is unavailable but still returns the screen (F7)", async () => {


### PR DESCRIPTION
## Summary
- Makes `cmuxlayer` / `dist/index.js` daemon-first: connect to the cmuxlayer daemon socket, autostart `dist/daemon.js` if absent, then run the thin stdio<->Unix socket proxy.
- Keeps the legacy in-process runtime behind `CMUXLAYER_FORCE_INPROCESS=1` and as fail-loud fallback. Fallback emits stderr and surfaces a warning through `control_health`.
- Moves the daemon/proxy default socket off `/tmp` to `~/.local/state/cmux/cmuxlayer-stated.sock`, with `CMUXLAYER_DAEMON_SOCKET` override.
- Keeps daemon heap protection by applying `NODE_OPTIONS --max-old-space-size` and the heap guard when `dist/daemon.js` runs.
- Adds `scripts/bench-daemon.mjs` / `bun run bench:daemon` for the binding benchmark gate.
- Review fix: daemon-proxy mode now stops on stdin end/close, and autostart timeout performs a last-chance socket re-probe before terminating the spawned daemon and falling back.
- Benchmark fix: daemon/proxy framing now avoids O(n^2) `ReadBuffer` copies on split frames, large daemon responses are raw-forwarded through the proxy, and identical in-flight `read_screen` snapshots are coalesced in the shared daemon context.

## Benchmark gate
Command: `bun run build && bun run bench:daemon`

Result: GREEN at `bfc995e`

- N: 8 MCP entries, 12 rounds
- RSS baseline, 8 in-process entries: 651.33 MB
- RSS daemon path, daemon + 8 thin entries: 618.59 MB
- RSS reduction: 32.74 MB / 5.03%
- `list_surfaces` p50/p99 baseline: 107.09 / 486.88 ms
- `list_surfaces` p50/p99 daemon path: 105.48 / 120.08 ms
- `read_screen` p50/p99 baseline: 81.91 / 143.50 ms
- `read_screen` p50/p99 daemon path: 70.67 / 76.45 ms
- Daemon CPU: 11.00%
- Truthful-state gate: pass (`list_surfaces` + `read_screen` structured content matched direct baseline)
- Gate booleans: all true, including `read_screen_p99_no_regression:true`

Additional post-fix samples:
- Standard gate sample: RSS -5.72%, `read_screen` p99 86.69 ms baseline vs 73.50 ms daemon
- Standard gate sample: RSS -6.37%, `read_screen` p99 101.82 ms baseline vs 79.90 ms daemon
- 20-round stress sample: RSS -1.76%, `read_screen` p99 115.95 ms baseline vs 90.28 ms daemon

## Fail-loud fallback proof
- `tests/entry.test.ts` covers daemon-connected proxy mode, autostart, autostart failure fallback, forced in-process escape hatch, thin proxy mode not starting a local sweep, autostart timeout child termination before fallback, final timeout re-probe choosing proxy instead of kill+fallback, and proxy stdin lifecycle shutdown.
- `tests/control-health.test.ts` verifies fallback warnings are included in `control_health` output.

## Phase 1b note
- The remaining architecture hardening is the cold-start TOCTOU race: bind/lock before slow `getContext()` or move to launchd socket activation so simultaneous cold starts cannot spawn multiple daemons. Phase 1’s bar is covered here by last-chance re-probe plus kill-on-timeout before any heavy fallback, so the race cannot leave dual sweeps alive after timeout fallback.

## Test plan
- RED checks observed before fixes:
  - entry timeout did not kill spawned daemon
  - daemon-proxy stdin end did not stop proxy
  - final timeout re-probe did not choose proxy when socket raced online
  - split large JSON-RPC frames used repeated `Buffer.concat` copies
  - proxy parsed and reserialized large daemon response frames instead of raw-forwarding them
  - `read_screen` did duplicate topology walks per call
  - concurrent identical `read_screen` calls in one daemon context launched duplicate screen reads
- `bunx vitest run tests/json-rpc-line-buffer.test.ts tests/proxy.test.ts tests/daemon.test.ts tests/entry.test.ts` -> 38 tests passed
- `bunx vitest run tests/server.test.ts -t "read_screen reports the surface column"` -> passed
- `bunx vitest run tests/server.test.ts -t "read_screen coalesces"` -> passed
- `bunx vitest run tests/server.test.ts tests/proxy.test.ts tests/json-rpc-line-buffer.test.ts tests/daemon.test.ts tests/entry.test.ts` -> 190 tests passed
- `bun run typecheck` -> passed
- `bun run build && bun run bench:daemon` -> benchmark GREEN, numbers above
- `CMUXLAYER_BENCH_ROUNDS=20 bun run bench:daemon` -> benchmark GREEN, `read_screen_p99_no_regression:true`
- `bun run test` -> 82 files / 1496 tests passed
- `bun run pre-pr` -> 4 files / 59 tests passed
- Pre-push hook reran `run_tests.sh` after latest commit -> 82 files / 1496 tests passed
- Live built-binary daemon smoke: temporary `dist/daemon.js` + `dist/index.js` proxy returned `list_surfaces` `ok:true` with 12 surfaces, then `read_screen` `ok:true` for `surface:4` from the live cmux environment

## Review notes
- Local `coderabbit review --agent` was run with a 180s cap before `bfc995e` and timed out while still reviewing; no local findings were produced before the cap.
- Do not merge yet. Lead must rerun the benchmark gate live before merge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make cmuxlayer CLI daemon-first with in-process fallback
> - The CLI entry point now attempts to connect to (or autostart) a long-running daemon via a Unix socket, proxying stdio to it instead of running an in-process MCP server, with fallback to in-process when forced (`CMUXLAYER_FORCE_INPROCESS`) or when the daemon is unavailable.
> - Adds `runDaemonFirstEntry` in [entry.ts](https://github.com/EtanHey/cmuxlayer/pull/266/files#diff-f85e80d35f2c16b6ccf2dc6bb1214be34f47e879e725e53055b1902a4900dab7) as the orchestrator: probes the socket, optionally spawns a detached daemon process, waits for readiness with a polling loop, and binds stdio to a `CmuxLayerProxy`.
> - Default daemon socket path resolves to `~/.local/state/cmux/cmuxlayer-stated.sock` (overridable via `CMUXLAYER_DAEMON_SOCKET`), shared across daemon, proxy, and entry.
> - Replaces `ReadBuffer` with `JsonRpcLineBuffer` in the proxy and daemon for line-framed JSON-RPC parsing; the proxy now forwards raw daemon frames to the agent without reparsing or reserializing.
> - Adds `controlHealthWarnings` support so in-process fallback can surface a daemon-unavailable warning through the `control_health` tool.
> - Adds a benchmark script (`scripts/bench-daemon.mjs`) that compares p50/p99 latency and memory between in-process and daemon modes across multiple clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfc995e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default process topology, autospawns a detached daemon, and alters cold-start/fallback behavior; incorrect daemon or proxy handling could affect all MCP clients and duplicate heavy runtimes on race.
> 
> **Overview**
> **Default startup** no longer boots the full in-process MCP server from `index.ts`. It delegates to **`runDaemonFirstEntry()`**, which probes **`~/.local/state/cmux/cmuxlayer-stated.sock`** (override via **`CMUXLAYER_DAEMON_SOCKET`**), autostarts a detached **`daemon.js`** when needed, and runs a thin stdio↔Unix-socket **proxy**. **`CMUXLAYER_FORCE_INPROCESS=1`** or daemon failure still uses the legacy in-process runtime with stderr and **`control_health`** warnings via new **`controlHealthWarnings`**.
> 
> **Daemon/proxy I/O** switches from the SDK **`ReadBuffer`** to a shared **`JsonRpcLineBuffer`**; the proxy **forwards raw daemon frames** to the agent (metadata-only parsing for routing) to avoid re-serializing large **`read_screen`** payloads. **Proxy stdio** shuts down on stdin end/close; autostart timeout does a **final socket re-probe** and **SIGTERM**s a slow spawn before fallback.
> 
> **Server**: **`read_screen`** coalesces identical in-flight reads and reuses one topology snapshot per call. **`scripts/bench-daemon.mjs`** (`bun run bench:daemon`) compares in-process vs daemon-path RSS, latency, and response parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc995eb4870072544ee493c7853949e10d9f477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
