### PR TITLE
fix: repair registry seats during resync

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -17,9 +17,21 @@ import {
   isCrashRecoveryEligible,
   shouldRetainCrashRecoveryError,
   type AgentRecord,
+  type AgentRole,
   type AgentState,
+  type CliType,
 } from "./agent-types.js";
 import type { CmuxSurface } from "./types.js";
+import { extractPrefix } from "./naming.js";
+import {
+  inferAgentRole,
+  isAgentRoleInferenceError,
+} from "./layout-policy.js";
+import {
+  assertSeatIdentity,
+  type SeatIdentityAssertion,
+  type SeatRegistry,
+} from "./seat-identity.js";
 
 export type SurfaceProvider = () => Promise<CmuxSurface[]>;
 
@@ -31,6 +43,222 @@ export interface AgentFilter {
 
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const BOOTING_GHOST_TIMEOUT_MS = 30_000;
+const PENDING_AGENT_ID_RE = /-pending-\d+-[a-z0-9]+$/i;
+const CLI_SUFFIXES: Array<{ suffix: string; cli: CliType }> = [
+  { suffix: "Claude", cli: "claude" },
+  { suffix: "Codex", cli: "codex" },
+  { suffix: "Cursor", cli: "cursor" },
+  { suffix: "Gemini", cli: "gemini" },
+  { suffix: "Kiro", cli: "kiro" },
+];
+
+export interface RegistryRepairEntry {
+  surface_id: string;
+  surface_title: string;
+  agent_id: string;
+  repo: string;
+  cli: CliType;
+  role: AgentRole;
+  launcher_name: string;
+  seat_id: string | null;
+  action: "created" | "updated";
+}
+
+export interface RegistryRepairSummary {
+  repaired: RegistryRepairEntry[];
+  evicted: string[];
+}
+
+interface RegistryRepairCandidate {
+  repo: string;
+  cli: CliType;
+  launcherName: string;
+  seat: SeatIdentityAssertion;
+  role: AgentRole;
+  agentId: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isPendingAgentId(agentId: string): boolean {
+  return PENDING_AGENT_ID_RE.test(agentId);
+}
+
+function isAutoAgentId(agentId: string): boolean {
+  return agentId.startsWith("auto-");
+}
+
+function hasLauncherToken(title: string, launcherName: string): boolean {
+  return new RegExp(
+    `(^|[^a-z0-9])${escapeRegExp(launcherName)}($|[^a-z0-9])`,
+    "i",
+  ).test(title);
+}
+
+function inferLauncherFromSeatRegistry(
+  title: string,
+  registry?: SeatRegistry | null,
+): { repo: string; cli: CliType; launcherName: string } | null {
+  for (const [, entry] of Object.entries(registry ?? {})) {
+    for (const cli of ["claude", "codex", "cursor", "gemini", "kiro"] as const) {
+      const launcherName = entry.launchers[cli];
+      if (launcherName && hasLauncherToken(title, launcherName)) {
+        return { repo: entry.repo, cli, launcherName };
+      }
+    }
+  }
+  return null;
+}
+
+function inferOrcDriverLauncher(
+  title: string,
+  registry?: SeatRegistry | null,
+): { repo: string; cli: CliType; launcherName: string } | null {
+  if (!/\borc(?:[-_\s]?driver)?\b/i.test(title)) {
+    return null;
+  }
+
+  const entry =
+    (registry?.orcClaude ?? null) ||
+    Object.values(registry ?? {}).find(
+      (candidate) =>
+        candidate.repo.toLowerCase() === "orc" ||
+        candidate.role?.toLowerCase() === "orc",
+    );
+  return {
+    repo: entry?.repo ?? "orc",
+    cli: "claude",
+    launcherName: entry?.launchers.claude ?? "orcClaude",
+  };
+}
+
+function inferLauncherFromSurfaceTitle(
+  title: string,
+  registry?: SeatRegistry | null,
+): { repo: string; cli: CliType; launcherName: string } | null {
+  const prefix = extractPrefix(title).trim();
+  const registryMatch = inferLauncherFromSeatRegistry(prefix, registry);
+  if (registryMatch) return registryMatch;
+
+  const orcDriver = inferOrcDriverLauncher(prefix, registry);
+  if (orcDriver) return orcDriver;
+
+  const launcherTokens = [...prefix.matchAll(/[A-Za-z][A-Za-z0-9_.-]*/g)]
+    .map((match) => match[0])
+    .reverse();
+  for (const token of launcherTokens) {
+    for (const { suffix, cli } of CLI_SUFFIXES) {
+      if (!new RegExp(`${suffix}$`, "i").test(token)) continue;
+      const repoPart = token.slice(0, -suffix.length).trim();
+      if (!repoPart || repoPart === "." || repoPart === "..") continue;
+      const repo = repoPart.replace(/^[A-Z]/, (match) => match.toLowerCase());
+      return {
+        repo,
+        cli,
+        launcherName: `${repo}${suffix}`,
+      };
+    }
+  }
+
+  return null;
+}
+
+function roleFromSeatOrLauncher(input: {
+  seat: SeatIdentityAssertion;
+  launcherName: string;
+  surfaceTitle: string;
+  cli: CliType;
+}): AgentRole {
+  const seatRole = input.seat.seat_role?.trim().toLowerCase();
+  if (seatRole === "lead" || seatRole === "orc" || seatRole === "orchestrator") {
+    return "orchestrator";
+  }
+  if (seatRole === "ic") {
+    return "ic";
+  }
+  if (seatRole === "worker") {
+    return "worker";
+  }
+
+  try {
+    return inferAgentRole({
+      launcherName: input.launcherName,
+      title: input.surfaceTitle,
+      cli: input.cli,
+    });
+  } catch (error) {
+    if (isAgentRoleInferenceError(error)) {
+      return inferAgentRole({ cli: input.cli });
+    }
+    throw error;
+  }
+}
+
+function repairCandidateForSurface(
+  discovered: DiscoveredAgent,
+  registry?: SeatRegistry | null,
+): RegistryRepairCandidate | null {
+  const launcher = inferLauncherFromSurfaceTitle(
+    discovered.surface_title,
+    registry,
+  );
+  if (!launcher) return null;
+
+  const seat = assertSeatIdentity({
+    repo: launcher.repo,
+    cli: launcher.cli,
+    launcherName: launcher.launcherName,
+    registry,
+  });
+  const role = roleFromSeatOrLauncher({
+    seat,
+    launcherName: launcher.launcherName,
+    surfaceTitle: discovered.surface_title,
+    cli: launcher.cli,
+  });
+  return {
+    ...launcher,
+    seat,
+    role,
+    agentId: seat.seat_id ?? launcher.launcherName,
+  };
+}
+
+function patchForRepairCandidate(
+  record: AgentRecord,
+  discovered: DiscoveredAgent,
+  candidate: RegistryRepairCandidate,
+): Partial<AgentRecord> {
+  const patch: Partial<AgentRecord> = {};
+  const workspaceId = discovered.workspace_id ?? null;
+  const model = discovered.model ?? record.model;
+  const fields: Partial<AgentRecord> = {
+    surface_id: discovered.surface_id,
+    workspace_id: workspaceId,
+    repo: candidate.repo,
+    model,
+    cli: candidate.cli,
+    launcher_name: candidate.launcherName,
+    seat_id: candidate.seat.seat_id,
+    seat_lane: candidate.seat.seat_lane,
+    seat_role: candidate.seat.seat_role,
+    seat_identity_status: candidate.seat.seat_identity_status,
+    seat_identity_error: candidate.seat.seat_identity_error,
+    role: candidate.role,
+  };
+
+  for (const [key, value] of Object.entries(fields) as Array<
+    [keyof AgentRecord, AgentRecord[keyof AgentRecord]]
+  >) {
+    if ((record[key] ?? null) !== (value ?? null)) {
+      (patch as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return patch;
+}
 
 class AgentNotFoundError extends Error {
   readonly code = "AGENT_NOT_FOUND";
@@ -538,6 +766,203 @@ export class AgentRegistry {
     }
 
     return evicted;
+  }
+
+  repairFromDiscovery(
+    discovered: DiscoveredAgent[],
+    opts?: { seatRegistry?: SeatRegistry | null },
+  ): RegistryRepairSummary {
+    const repaired: RegistryRepairEntry[] = [];
+    const evicted = new Set<string>();
+    const liveSurfaceRefs = new Set(
+      discovered
+        .filter((entry) => !entry.read_error)
+        .map((entry) => entry.surface_id),
+    );
+
+    for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
+      evicted.add(removed);
+    }
+
+    for (const entry of discovered) {
+      if (entry.read_error) continue;
+      const candidate = repairCandidateForSurface(entry, opts?.seatRegistry);
+      if (!candidate) continue;
+
+      const repair = this.repairDiscoveredSurface(entry, candidate, evicted);
+      if (repair) {
+        repaired.push(repair);
+      }
+    }
+
+    for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
+      evicted.add(removed);
+    }
+
+    return { repaired, evicted: [...evicted] };
+  }
+
+  private evictPendingGhostRegistrations(
+    liveSurfaceRefs: ReadonlySet<string>,
+  ): string[] {
+    if (liveSurfaceRefs.size === 0) {
+      return [];
+    }
+
+    const evicted: string[] = [];
+    for (const [id, agent] of [...this.agents.entries()]) {
+      if (!isPendingAgentId(id)) {
+        continue;
+      }
+
+      const liveBackingSurface = liveSurfaceRefs.has(agent.surface_id);
+      const supersededByRealRecord = [...this.agents.values()].some(
+        (candidate) =>
+          candidate.agent_id !== id &&
+          candidate.surface_id === agent.surface_id &&
+          !isPendingAgentId(candidate.agent_id) &&
+          !isAutoAgentId(candidate.agent_id),
+      );
+
+      if (!liveBackingSurface || supersededByRealRecord) {
+        const removedAgentId = this.evict(id);
+        if (removedAgentId) {
+          evicted.push(removedAgentId);
+        }
+      }
+    }
+
+    return evicted;
+  }
+
+  private repairDiscoveredSurface(
+    discovered: DiscoveredAgent,
+    candidate: RegistryRepairCandidate,
+    evicted: Set<string>,
+  ): RegistryRepairEntry | null {
+    const recordsForSurface = [...this.agents.values()].filter(
+      (agent) => agent.surface_id === discovered.surface_id,
+    );
+    const managedRecord = recordsForSurface.find(
+      (agent) =>
+        !isAutoAgentId(agent.agent_id) && !isPendingAgentId(agent.agent_id),
+    );
+
+    if (managedRecord) {
+      const updated = this.updateManagedSurfaceRegistration(
+        managedRecord,
+        discovered,
+        candidate,
+      );
+      return updated
+        ? this.repairEntry(updated, discovered, candidate, "updated")
+        : null;
+    }
+
+    for (const record of recordsForSurface) {
+      if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
+        const removedAgentId = this.evict(record.agent_id);
+        if (removedAgentId) {
+          evicted.add(removedAgentId);
+        }
+      }
+    }
+
+    const existingSeatRecord = this.stateMgr.readState(candidate.agentId);
+    if (existingSeatRecord) {
+      const updated = this.updateManagedSurfaceRegistration(
+        existingSeatRecord,
+        discovered,
+        candidate,
+      );
+      return updated
+        ? this.repairEntry(updated, discovered, candidate, "updated")
+        : this.repairEntry(existingSeatRecord, discovered, candidate, "updated");
+    }
+
+    const created = this.createRepairedRecord(discovered, candidate);
+    this.stateMgr.writeState(created);
+    this.agents.set(created.agent_id, created);
+    return this.repairEntry(created, discovered, candidate, "created");
+  }
+
+  private updateManagedSurfaceRegistration(
+    record: AgentRecord,
+    discovered: DiscoveredAgent,
+    candidate: RegistryRepairCandidate,
+  ): AgentRecord | null {
+    const patch = patchForRepairCandidate(record, discovered, candidate);
+    if (Object.keys(patch).length === 0) {
+      return null;
+    }
+
+    const updated = this.stateMgr.updateRecord(record.agent_id, patch);
+    this.agents.delete(record.agent_id);
+    this.agents.set(updated.agent_id, updated);
+    return updated;
+  }
+
+  private createRepairedRecord(
+    discovered: DiscoveredAgent,
+    candidate: RegistryRepairCandidate,
+  ): AgentRecord {
+    const now = new Date().toISOString();
+    const state = discoveredStatusToAgentState(discovered.parsed_status);
+    return {
+      agent_id: candidate.agentId,
+      surface_id: discovered.surface_id,
+      workspace_id: discovered.workspace_id ?? null,
+      state,
+      repo: candidate.repo,
+      model: discovered.model ?? "unknown",
+      cli: candidate.cli,
+      cli_session_id: null,
+      cli_session_path: null,
+      launcher_name: candidate.launcherName,
+      seat_id: candidate.seat.seat_id,
+      seat_lane: candidate.seat.seat_lane,
+      seat_role: candidate.seat.seat_role,
+      seat_identity_status: candidate.seat.seat_identity_status,
+      seat_identity_error: candidate.seat.seat_identity_error,
+      task_summary: "(resync-repaired)",
+      pid: null,
+      version: 1,
+      created_at: now,
+      updated_at: now,
+      error:
+        state === "error"
+          ? "Repaired agent surface reported a frozen state"
+          : null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      role: candidate.role,
+      auto_archive_on_done: false,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: candidate.role === "orchestrator",
+      respawn_attempts: 0,
+      user_killed: false,
+    };
+  }
+
+  private repairEntry(
+    record: AgentRecord,
+    discovered: DiscoveredAgent,
+    candidate: RegistryRepairCandidate,
+    action: "created" | "updated",
+  ): RegistryRepairEntry {
+    return {
+      surface_id: discovered.surface_id,
+      surface_title: discovered.surface_title,
+      agent_id: record.agent_id,
+      repo: candidate.repo,
+      cli: candidate.cli,
+      role: candidate.role,
+      launcher_name: candidate.launcherName,
+      seat_id: candidate.seat.seat_id,
+      action,
+    };
   }
 
   private evictMissingStateAgent(agentId: string): boolean {

--- a/src/format.ts
+++ b/src/format.ts
@@ -281,12 +281,14 @@ export function formatDelivery(
 export function formatResync(diff: {
   added: string[];
   evicted: string[];
+  repaired?: unknown[];
   mismatches: string[];
   orphaned?: string[];
 }): string {
   const added = diff.added.length;
   const evicted = diff.evicted.length;
+  const repaired = diff.repaired?.length ?? 0;
   const mismatches = diff.mismatches.length;
   const orphaned = diff.orphaned?.length ?? 0;
-  return `✔ resync_agents — added: ${added}  evicted: ${evicted}  mismatches: ${mismatches}  orphaned: ${orphaned}`;
+  return `✔ resync_agents — added: ${added}  repaired: ${repaired}  evicted: ${evicted}  mismatches: ${mismatches}  orphaned: ${orphaned}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -144,6 +144,10 @@ import {
   type McpProfile,
   type WorktreeExec,
 } from "./worktree.js";
+import {
+  loadSeatRegistryFromConfig,
+  type SeatRegistry,
+} from "./seat-identity.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -1733,6 +1737,9 @@ export interface CreateServerOptions {
   controlHealthCollector?: () => Promise<ControlHealth>;
   /** Extra warnings surfaced by control_health, e.g. daemon fallback mode. */
   controlHealthWarnings?: string[];
+  /** Override seat registry repair/identity lookup (primarily for tests). */
+  seatRegistry?: SeatRegistry | null;
+  seatRegistryPath?: string;
   /**
    * Override the process-wide stale-build warner (primarily for tests). Returns
    * the loud warning string when this MCP build is stale vs the installed brew
@@ -1977,6 +1984,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     opts?.controlHealthCollector ?? context.controlHealthCollector;
   const controlHealthWarnings =
     opts?.controlHealthWarnings ?? context.controlHealthWarnings;
+  const seatRegistry =
+    opts?.seatRegistry !== undefined
+      ? opts.seatRegistry
+      : loadSeatRegistryFromConfig(opts?.seatRegistryPath);
   const staleBuildWarning = opts?.staleBuildWarner ?? defaultStaleBuildWarner;
   const appendStaleBuildWarning = (result: { warnings?: string[] }): void => {
     const warning = staleBuildWarning();
@@ -6160,6 +6171,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 listSurfacesForRefMap: surfaceProvider,
               })
             : null,
+          seatRegistry,
+          seatRegistryPath: opts?.seatRegistryPath,
         },
       );
     context.lifecycleSweepEngine = engine;
@@ -7620,21 +7633,44 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const beforeIds = new Set(
             registry.list().map((agent) => agent.agent_id),
           );
+          await registry.reconcile();
+          for (const agent of registry.list()) {
+            beforeIds.add(agent.agent_id);
+          }
+          discovery.invalidate();
+          const discoveredBeforeRepair = await discovery.scan(true);
+          const repair = registry.repairFromDiscovery(discoveredBeforeRepair, {
+            seatRegistry,
+          });
           discovery.invalidate();
           await registry.listMerged(discovery, { force: true });
-          await registry.evictSurfaceless();
+          const surfacelessEvicted = await registry.evictSurfaceless();
           engine.evictDeadProcessAgents();
           discovery.invalidate();
           const after = await registry.listMerged(discovery, { force: true });
           const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));
+          const registeredSurfaceIds = new Set(
+            registry.list().map((agent) => agent.surface_id),
+          );
           const orphanedSurfaces = discovered.filter(
-            (surface) => !surface.has_agent && !surface.read_error,
+            (surface) =>
+              !surface.read_error &&
+              !registeredSurfaceIds.has(surface.surface_id) &&
+              !surface.has_agent,
           );
           const orphanedHealth = orphanedSurfaces.map(buildOrphanSurfaceHealth);
+          const evicted = [
+            ...new Set([
+              ...repair.evicted,
+              ...surfacelessEvicted,
+              ...[...beforeIds].filter((id) => !afterIds.has(id)),
+            ]),
+          ];
           const diff = {
             added: [...afterIds].filter((id) => !beforeIds.has(id)),
-            evicted: [...beforeIds].filter((id) => !afterIds.has(id)),
+            evicted,
+            repaired: repair.repaired,
             mismatches: after
               .filter((agent) => agent.parsed_cli_mismatch)
               .map((agent) => agent.agent_id),

--- a/src/server.ts
+++ b/src/server.ts
@@ -3868,6 +3868,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const buildOrphanSurfaceHealth = (surface: DiscoveredAgent) => {
     const issueCodes: AgentHealthIssueCode[] = [];
     const issues: string[] = [];
+    if (surface.has_agent) {
+      issueCodes.push("auto_discovered_agent");
+      issues.push(
+        "live agent surface has no managed registry seat; repair/register the seat or leave it visible as an unresolved orphan",
+      );
+    }
     if (isLeadLikeSurfaceTitle(surface.surface_title)) {
       issueCodes.push("missing_managed_lead_agent_id");
       issues.push(
@@ -7650,14 +7656,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const after = await registry.listMerged(discovery, { force: true });
           const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));
-          const registeredSurfaceIds = new Set(
-            registry.list().map((agent) => agent.surface_id),
+          const managedSurfaceIds = new Set(
+            registry
+              .list()
+              .filter((agent) => !agent.agent_id.startsWith("auto-"))
+              .map((agent) => agent.surface_id),
           );
           const orphanedSurfaces = discovered.filter(
             (surface) =>
               !surface.read_error &&
-              !registeredSurfaceIds.has(surface.surface_id) &&
-              !surface.has_agent,
+              !managedSurfaceIds.has(surface.surface_id),
           );
           const orphanedHealth = orphanedSurfaces.map(buildOrphanSurfaceHealth);
           const evicted = [

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -360,6 +360,84 @@ function makeShellPromptExec(): ExecFn {
   });
 }
 
+function makeAmbiguousLiveAgentExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:777"],
+              selected_surface_ref: "surface:777",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:777",
+              title: "review lane",
+              type: "terminal",
+              index: 0,
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:777",
+          text: "gpt-5.5 · 82% left · ~/Gits/unknown\nWorking (1m 03s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
 function makeOrphanLeadExec(): ExecFn {
   const base = makeShellPromptExec();
   return vi.fn().mockImplementation(async (cmd, args) => {
@@ -1393,6 +1471,37 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.mismatches).toEqual([]);
     expect(parsed.diff.orphaned).toEqual(["surface:999"]);
     expect(parsed.count).toBe(0);
+  });
+
+  it("resync_agents reports unresolved live-agent surfaces whose title cannot map to a seat", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const server = createServer({
+      exec: makeAmbiguousLiveAgentExec(),
+      stateDir: TEST_DIR,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.repaired).toEqual([]);
+    expect(parsed.diff.orphaned).toEqual(["surface:777"]);
+    expect(parsed.diff.orphaned_health).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:777",
+        surface_title: "review lane",
+        status: "degraded",
+        issue_codes: ["auto_discovered_agent"],
+        issue_severities: { auto_discovered_agent: "info" },
+      }),
+    ]);
+    expect(
+      stateMgr.listStates().some((record) => record.agent_id === "review lane"),
+    ).toBe(false);
   });
 
   it("resync_agents reports orphan lead surfaces as health failures", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -6,6 +6,7 @@ import { createServer } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 import type { AgentRecord } from "../src/agent-types.js";
+import type { SeatRegistry } from "../src/seat-identity.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-resync-tool");
 
@@ -371,7 +372,7 @@ function makeOrphanLeadExec(): ExecFn {
           surfaces: [
             {
               ref: "surface:325",
-              title: "M1 LEAD VoiceLayerCodex",
+              title: "M1 LEAD VoiceLayer",
               type: "terminal",
               index: 0,
               selected: true,
@@ -607,6 +608,170 @@ function makeEmptySurfaceExec(): ExecFn {
           window_ref: "window:1",
           pane_ref: "pane:1",
           surfaces: [],
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+}
+
+const REGISTRY_REPAIR_SEATS: SeatRegistry = {
+  orcClaude: {
+    repo: "orc",
+    launchers: {
+      claude: "orcClaude",
+      codex: "orcCodex",
+      cursor: "orcCursor",
+      gemini: "orcGemini",
+      kiro: "orcKiro",
+    },
+    lane: "orc",
+    role: "orc",
+  },
+  cmuxlayerLead: {
+    repo: "cmuxlayer",
+    launchers: {
+      claude: "cmuxlayerClaude",
+      codex: "cmuxlayerCodex",
+      cursor: "cmuxlayerCursor",
+      gemini: "cmuxlayerGemini",
+      kiro: "cmuxlayerKiro",
+    },
+    lane: "cmuxlayer",
+    role: "lead",
+  },
+  cmuxlayerClaude: {
+    repo: "cmuxlayer",
+    launchers: {
+      claude: "cmuxlayerClaude",
+      codex: "cmuxlayerCodex",
+      cursor: "cmuxlayerCursor",
+      gemini: "cmuxlayerGemini",
+      kiro: "cmuxlayerKiro",
+    },
+    lane: "cmuxlayer",
+    role: "worker",
+  },
+  brainClaude: {
+    repo: "brainlayer",
+    launchers: {
+      claude: "brainlayerClaude",
+      codex: "brainlayerCodex",
+      cursor: "brainlayerCursor",
+      gemini: "brainlayerGemini",
+      kiro: "brainlayerKiro",
+    },
+    lane: "brainlayer",
+    role: "lead",
+  },
+};
+
+function makeRegistryRepairExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Active",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:left",
+              index: 0,
+              focused: true,
+              surface_count: 2,
+              surface_refs: ["surface:4", "surface:35"],
+              selected_surface_ref: "surface:35",
+              pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+            },
+            {
+              ref: "pane:right",
+              index: 1,
+              focused: false,
+              surface_count: 1,
+              surface_refs: ["surface:27"],
+              selected_surface_ref: "surface:27",
+              pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      const pane = args.includes("--pane")
+        ? args[args.indexOf("--pane") + 1]
+        : "pane:left";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces:
+            pane === "pane:left"
+              ? [
+                  {
+                    ref: "surface:4",
+                    title: "🎯 orc-driver",
+                    type: "terminal",
+                    index: 0,
+                    selected: false,
+                  },
+                  {
+                    ref: "surface:35",
+                    title: "cmuxlayerClaude",
+                    type: "terminal",
+                    index: 1,
+                    selected: true,
+                  },
+                ]
+              : [
+                  {
+                    ref: "surface:27",
+                    title: "brainlayerClaude",
+                    type: "terminal",
+                    index: 0,
+                    selected: true,
+                  },
+                ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      const surface = args[args.indexOf("--surface") + 1];
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text:
+            surface === "surface:27"
+              ? "✻ Working…\n  Reading files\n🤖 Sonnet 4.6 | 💰 $0.50 | ⏱️ 41s\n"
+              : "Claude Code\n✻ Working…\n  Coordinating agents\n🤖 Opus 4.8 | 💰 $1.25 | ⏱️ 2m\n",
+          lines: 20,
+          scrollback_used: false,
         }),
         stderr: "",
       };
@@ -1248,12 +1413,168 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.orphaned_health).toEqual([
       expect.objectContaining({
         surface_id: "surface:325",
-        surface_title: "M1 LEAD VoiceLayerCodex",
+        surface_title: "M1 LEAD VoiceLayer",
         status: "degraded",
         issue_codes: ["missing_managed_lead_agent_id"],
         issue_severities: { missing_managed_lead_agent_id: "degraded" },
       }),
     ]);
+  });
+
+  it("resync_agents repairs orphaned launcher surfaces into seat registrations and evicts pending ghosts", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "auto-claude-surface-35",
+        surface_id: "surface:35",
+        workspace_id: "workspace:1",
+        repo: "cmuxlayer",
+        cli: "claude",
+        role: "orchestrator",
+        task_summary: "(auto-discovered)",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "brainlayerClaude-pending-1710000000-abcd",
+        surface_id: "surface:27",
+        workspace_id: "workspace:1",
+        repo: "brainlayer",
+        cli: "claude",
+        role: "orchestrator",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "cmuxlayerCodex-pending-1710000000-dead",
+        surface_id: "surface:missing",
+        workspace_id: "workspace:1",
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+      }),
+    );
+
+    const server = createServer({
+      exec: makeRegistryRepairExec(),
+      stateDir: TEST_DIR,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff.repaired).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          surface_id: "surface:4",
+          agent_id: "orcClaude",
+          seat_id: "orcClaude",
+        }),
+        expect.objectContaining({
+          surface_id: "surface:35",
+          agent_id: "cmuxlayerLead",
+          seat_id: "cmuxlayerLead",
+        }),
+        expect.objectContaining({
+          surface_id: "surface:27",
+          agent_id: "brainClaude",
+          seat_id: "brainClaude",
+        }),
+      ]),
+    );
+    expect(parsed.diff.evicted).toEqual(
+      expect.arrayContaining([
+        "auto-claude-surface-35",
+        "brainlayerClaude-pending-1710000000-abcd",
+        "cmuxlayerCodex-pending-1710000000-dead",
+      ]),
+    );
+    expect(parsed.diff.orphaned).toEqual([]);
+    expect(stateMgr.readState("auto-claude-surface-35")).toBeNull();
+    expect(stateMgr.readState("brainlayerClaude-pending-1710000000-abcd")).toBeNull();
+    expect(stateMgr.readState("cmuxlayerCodex-pending-1710000000-dead")).toBeNull();
+    expect(stateMgr.readState("cmuxlayerLead")).toMatchObject({
+      agent_id: "cmuxlayerLead",
+      surface_id: "surface:35",
+      workspace_id: "workspace:1",
+      repo: "cmuxlayer",
+      cli: "claude",
+      role: "orchestrator",
+      launcher_name: "cmuxlayerClaude",
+      seat_id: "cmuxlayerLead",
+      seat_lane: "cmuxlayer",
+      seat_role: "lead",
+    });
+    expect(stateMgr.readState("brainClaude")).toMatchObject({
+      agent_id: "brainClaude",
+      surface_id: "surface:27",
+      role: "orchestrator",
+      launcher_name: "brainlayerClaude",
+      seat_id: "brainClaude",
+    });
+  });
+
+  it("resync_agents repairs stale worker labels on live lead surfaces instead of flagging worker_in_leftmost_column", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "stale-left-worker",
+        surface_id: "surface:35",
+        workspace_id: "workspace:1",
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+        launcher_name: "cmuxlayerCodex",
+        task_summary: "stale left-column label",
+      }),
+    );
+
+    const server = createServer({
+      exec: makeRegistryRepairExec(),
+      stateDir: TEST_DIR,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    const resyncResult = await (server as any)._registeredTools[
+      "resync_agents"
+    ].handler({}, {} as any);
+    const resynced = parseResult(resyncResult);
+    expect(resynced.ok).toBe(true);
+    expect(resynced.diff.repaired).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: "stale-left-worker",
+          surface_id: "surface:35",
+          seat_id: "cmuxlayerLead",
+        }),
+      ]),
+    );
+
+    const repaired = stateMgr.readState("stale-left-worker");
+    expect(repaired).toMatchObject({
+      agent_id: "stale-left-worker",
+      surface_id: "surface:35",
+      repo: "cmuxlayer",
+      cli: "claude",
+      role: "orchestrator",
+      launcher_name: "cmuxlayerClaude",
+      seat_id: "cmuxlayerLead",
+      seat_lane: "cmuxlayer",
+      seat_role: "lead",
+    });
+
+    const stateResult = await (server as any)._registeredTools[
+      "get_agent_state"
+    ].handler({ agent_id: "stale-left-worker" }, {} as any);
+    const parsedState = parseResult(stateResult);
+    expect(parsedState.health.issue_codes).not.toContain(
+      "worker_in_leftmost_column",
+    );
   });
 
   it("resync_agents evicts registry-only phantom agents instead of failing", async () => {


### PR DESCRIPTION
## Summary
- Make `resync_agents` repair registry state before auto-discovery creates duplicate sidebar rows.
- Re-register repairable orphan surfaces from launcher/seat titles into stable seat records, including `orc-driver`, `cmuxlayerClaude`, and `brainlayerClaude` style panes.
- GC stale `*-pending-*` registrations with no live surface or with a real registration on the same surface, and replace stale `auto-*` ghosts when a seat repair succeeds.
- Patch stale managed records in place when the live surface title/seat proves the row is a lead, clearing false `worker_in_leftmost_column` health for genuinely-correct panes.
- Add `diff.repaired` to `resync_agents` output and include repaired count in the formatted summary.

## Resync Evidence
- Fixture resync now returns `diff.repaired` for `surface:4 -> orcClaude`, `surface:35 -> cmuxlayerLead`, and `surface:27 -> brainClaude`.
- Fixture resync evicts `auto-claude-surface-35`, `brainlayerClaude-pending-1710000000-abcd`, and `cmuxlayerCodex-pending-1710000000-dead`.
- Stale left-column worker fixture is relabeled to `role=orchestrator`, `seat_id=cmuxlayerLead`, and `get_agent_state` no longer reports `worker_in_leftmost_column`.

## Test Plan
- [x] `npx vitest run tests/resync-tool.test.ts` — 23 passed
- [x] `npm run typecheck` — exit 0
- [x] `npm run build` — exit 0
- [x] `bun run pre-pr` — 4 files / 59 tests passed
- [x] `npm test` — 80 files / 1485 tests passed
- [x] pre-push hook — 80 files / 1485 tests passed

## Review Notes
- Local `coderabbit review --agent` was attempted before commit and returned a free OSS rate limit (`waitTime: 13 minutes`), so no local CodeRabbit findings were available.
- VISUAL VERIFICATION NOT PERFORMED in this worker turn: acceptance remains lead/Etan running live `resync_agents` and inspecting Etan's rendered sidebar for one correct row per seat. Do not merge until that rendered-screen gate is satisfied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates persisted agent registry state during resync (create/update/evict) based on title inference; mis-inference could reassign seats or roles, though ambiguous surfaces are left unresolved.
> 
> **Overview**
> **`resync_agents`** now runs a **registry repair pass** before merged auto-discovery, using the loaded **seat registry** to map live surface titles (launcher tokens, `orc-driver`, CLI suffixes) into stable seat-backed **`AgentRecord`** rows.
> 
> **`AgentRegistry.repairFromDiscovery`** creates or patches managed records (repo, CLI, launcher, seat fields, role), evicts superseded **`auto-*`** and stale **`*-pending-*`** ghosts, and returns **`diff.repaired`** plus combined evictions. Ambiguous live-agent surfaces stay orphaned with a new **`auto_discovered_agent`** health hint instead of inventing IDs.
> 
> **`formatResync`** includes a repaired count; **`resync-tool`** tests cover repair, pending GC, ambiguous titles, and stale lead relabeling (e.g. clearing false **`worker_in_leftmost_column`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94fa0b45551075eea31fc6efb2a3be61cc99f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repair registry seats during resync by inferring launcher metadata from discovered surfaces
> - Adds `AgentRegistry.repairFromDiscovery` in [src/agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/267/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) to reconcile live discovered surfaces with the agent registry: updates existing managed records, converts auto/pending records to managed seats, and creates new records when none exist.
> - Adds `evictPendingGhostRegistrations` to remove stale pending-agent ID records that lack a live surface or are superseded by a real record.
> - Extends the `resync_agents` tool in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/267/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) to call `repairFromDiscovery` with the loaded `SeatRegistry`, aggregate evictions from multiple sources, and include repaired entries in the diff.
> - Surfaces that already have a live agent are now flagged as `auto_discovered_agent` in orphan health checks.
> - Updates `formatResync` in [src/format.ts](https://github.com/EtanHey/cmuxlayer/pull/267/files#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36b) to include a repaired count in the summary string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b94fa0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->