### PR TITLE
fix: repair auto-discovered sidebar agents

### DIFF
--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -116,8 +116,19 @@ function addRecommendedAction(actions: string[], action: string): void {
 
 function issueSeverity(
   code: AgentHealthIssueCode,
-  context: { screenActive: boolean; inboxMonitorWithinBootGrace: boolean },
+  context: {
+    screenActive: boolean;
+    inboxMonitorWithinBootGrace: boolean;
+    autoDiscovered: boolean;
+  },
 ): AgentHealthIssueSeverity {
+  if (
+    context.autoDiscovered &&
+    (code === "orchestrator_not_leftmost" ||
+      code === "worker_in_leftmost_column")
+  ) {
+    return "info";
+  }
   if (code === "registry_screen_disagreement" && context.screenActive) {
     return "info";
   }
@@ -132,7 +143,11 @@ function issueSeverity(
 
 function deriveIssueSeverities(
   codes: AgentHealthIssueCode[],
-  context: { screenActive: boolean; inboxMonitorWithinBootGrace: boolean },
+  context: {
+    screenActive: boolean;
+    inboxMonitorWithinBootGrace: boolean;
+    autoDiscovered: boolean;
+  },
 ): Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>> {
   const severities: Partial<
     Record<AgentHealthIssueCode, AgentHealthIssueSeverity>
@@ -251,6 +266,7 @@ export function evaluateAgentHealth(
   const issues: string[] = [];
   const recommendedActions: string[] = [];
   const role = inferRecordRoleOrNull(agent);
+  const autoDiscovered = isAutoDiscovered(agent);
 
   if (agent.seat_identity_status === "mismatch") {
     addIssue(
@@ -262,7 +278,7 @@ export function evaluateAgentHealth(
     );
   }
 
-  if (isAutoDiscovered(agent)) {
+  if (autoDiscovered) {
     addIssue(
       issueCodes,
       issues,
@@ -491,6 +507,7 @@ export function evaluateAgentHealth(
 
   const issueSeverities = deriveIssueSeverities(issueCodes, {
     screenActive,
+    autoDiscovered,
     inboxMonitorWithinBootGrace: isWithinInboxMonitorBootGrace(
       agent,
       deps.now?.() ?? Date.now(),

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -86,6 +86,11 @@ function isPendingAgentId(agentId: string): boolean {
   return PENDING_AGENT_ID_RE.test(agentId);
 }
 
+function pendingBaseAgentId(agentId: string): string | null {
+  if (!isPendingAgentId(agentId)) return null;
+  return agentId.replace(PENDING_AGENT_ID_RE, "");
+}
+
 function isAutoAgentId(agentId: string): boolean {
   return agentId.startsWith("auto-");
 }
@@ -254,11 +259,24 @@ function repairCandidateForSurface(
   };
 }
 
-function surfaceScopedAgentId(baseAgentId: string, surfaceId: string): string {
-  const surfaceToken = surfaceId
-    .replace(/[^a-zA-Z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-  return `${baseAgentId}-${surfaceToken || "surface"}`;
+function recordIdentityKeys(record: AgentRecord): string[] {
+  return [
+    record.seat_id ? `seat:${record.seat_id}` : null,
+    record.launcher_name ? `launcher:${record.launcher_name}` : null,
+    pendingBaseAgentId(record.agent_id)
+      ? `launcher:${pendingBaseAgentId(record.agent_id)}`
+      : null,
+  ].filter((key): key is string => Boolean(key));
+}
+
+function primaryRecordIdentityKey(record: AgentRecord): string | null {
+  if (record.seat_id) return `seat:${record.seat_id}`;
+  if (record.launcher_name) return `launcher:${record.launcher_name}`;
+  return null;
+}
+
+function canonicalIdentityName(record: AgentRecord): string | null {
+  return record.seat_id ?? record.launcher_name ?? null;
 }
 
 function patchForRepairCandidate(
@@ -309,6 +327,7 @@ class AgentNotFoundError extends Error {
 export class AgentRegistry {
   private agents = new Map<string, AgentRecord>();
   private aliases = new Map<string, string>();
+  private repairSuppressedSurfaceRefs = new Set<string>();
   private stateMgr: StateManager;
   private surfaceProvider: SurfaceProvider;
 
@@ -549,6 +568,9 @@ export class AgentRegistry {
         discoveredEntry.cli === "unknown" ||
         discoveredEntry.read_error
       ) {
+        continue;
+      }
+      if (this.repairSuppressedSurfaceRefs.has(discoveredEntry.surface_id)) {
         continue;
       }
       if (seenSurfaces.has(discoveredEntry.surface_id)) {
@@ -809,6 +831,7 @@ export class AgentRegistry {
   ): RegistryRepairSummary {
     const repaired: RegistryRepairEntry[] = [];
     const evicted = new Set<string>();
+    this.repairSuppressedSurfaceRefs = new Set();
     const liveSurfaceRefs = new Set(
       discovered
         .filter((entry) => !entry.read_error)
@@ -835,6 +858,10 @@ export class AgentRegistry {
       }
     }
 
+    for (const removed of this.evictDuplicateManagedRegistrations(liveSurfaceRefs)) {
+      evicted.add(removed);
+    }
+
     for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
       evicted.add(removed);
     }
@@ -849,6 +876,15 @@ export class AgentRegistry {
       return [];
     }
 
+    const managedIdentityKeys = new Set(
+      [...this.agents.values()]
+        .filter(
+          (candidate) =>
+            !isPendingAgentId(candidate.agent_id) &&
+            !isAutoAgentId(candidate.agent_id),
+        )
+        .flatMap((candidate) => recordIdentityKeys(candidate)),
+    );
     const evicted: string[] = [];
     for (const [id, agent] of [...this.agents.entries()]) {
       if (!isPendingAgentId(id)) {
@@ -856,6 +892,9 @@ export class AgentRegistry {
       }
 
       const liveBackingSurface = liveSurfaceRefs.has(agent.surface_id);
+      const supersededByManagedSeat = recordIdentityKeys(agent).some((key) =>
+        managedIdentityKeys.has(key),
+      );
       const supersededByRealRecord = [...this.agents.values()].some(
         (candidate) =>
           candidate.agent_id !== id &&
@@ -864,8 +903,54 @@ export class AgentRegistry {
           !isAutoAgentId(candidate.agent_id),
       );
 
-      if (!liveBackingSurface || supersededByRealRecord) {
+      if (!liveBackingSurface || supersededByRealRecord || supersededByManagedSeat) {
         const removedAgentId = this.evict(id);
+        if (removedAgentId) {
+          evicted.push(removedAgentId);
+        }
+      }
+    }
+
+    return evicted;
+  }
+
+  private evictDuplicateManagedRegistrations(
+    liveSurfaceRefs: ReadonlySet<string>,
+  ): string[] {
+    const byIdentity = new Map<string, AgentRecord[]>();
+    for (const record of this.agents.values()) {
+      if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
+        continue;
+      }
+      const key = primaryRecordIdentityKey(record);
+      if (!key) continue;
+      byIdentity.set(key, [...(byIdentity.get(key) ?? []), record]);
+    }
+
+    const evicted: string[] = [];
+    for (const records of byIdentity.values()) {
+      if (records.length <= 1) continue;
+      const sorted = [...records].sort((left, right) => {
+        const leftCanonical =
+          left.agent_id === canonicalIdentityName(left) ? 0 : 1;
+        const rightCanonical =
+          right.agent_id === canonicalIdentityName(right) ? 0 : 1;
+        if (leftCanonical !== rightCanonical) {
+          return leftCanonical - rightCanonical;
+        }
+        const leftLive = liveSurfaceRefs.has(left.surface_id) ? 0 : 1;
+        const rightLive = liveSurfaceRefs.has(right.surface_id) ? 0 : 1;
+        if (leftLive !== rightLive) {
+          return leftLive - rightLive;
+        }
+        return left.agent_id.localeCompare(right.agent_id);
+      });
+      const keep = sorted[0];
+      for (const duplicate of sorted.slice(1)) {
+        if (duplicate.surface_id !== keep.surface_id) {
+          this.repairSuppressedSurfaceRefs.add(duplicate.surface_id);
+        }
+        const removedAgentId = this.evict(duplicate.agent_id);
         if (removedAgentId) {
           evicted.push(removedAgentId);
         }
@@ -915,36 +1000,8 @@ export class AgentRegistry {
         existingSeatRecord.surface_id !== discovered.surface_id &&
         liveSurfaceRefs.has(existingSeatRecord.surface_id)
       ) {
-        const scopedCandidate = {
-          ...candidate,
-          agentId: surfaceScopedAgentId(
-            candidate.agentId,
-            discovered.surface_id,
-          ),
-        };
-        const existingScopedRecord = this.stateMgr.readState(
-          scopedCandidate.agentId,
-        );
-        if (existingScopedRecord) {
-          const updated = this.updateManagedSurfaceRegistration(
-            existingScopedRecord,
-            discovered,
-            scopedCandidate,
-          );
-          return updated
-            ? this.repairEntry(updated, discovered, scopedCandidate, "updated")
-            : this.repairEntry(
-                existingScopedRecord,
-                discovered,
-                scopedCandidate,
-                "updated",
-              );
-        }
-
-        const created = this.createRepairedRecord(discovered, scopedCandidate);
-        this.stateMgr.writeState(created);
-        this.agents.set(created.agent_id, created);
-        return this.repairEntry(created, discovered, scopedCandidate, "created");
+        this.repairSuppressedSurfaceRefs.add(discovered.surface_id);
+        return null;
       }
 
       const updated = this.updateManagedSurfaceRegistration(

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -165,6 +165,37 @@ function inferLauncherFromSurfaceTitle(
   return null;
 }
 
+function suffixForCli(cli: CliType): string {
+  return CLI_SUFFIXES.find((entry) => entry.cli === cli)?.suffix ?? "";
+}
+
+function repairRepoFromTitle(title: string): string {
+  const inferred = inferRepoFromTitle(title);
+  const token = inferred.match(/[A-Za-z0-9][A-Za-z0-9_.-]*/)?.[0] ?? "";
+  return token.replace(/^[A-Z]/, (match) => match.toLowerCase());
+}
+
+function inferRepairLauncher(
+  discovered: DiscoveredAgent,
+  registry?: SeatRegistry | null,
+): { repo: string; cli: CliType; launcherName: string } | null {
+  const titleLauncher = inferLauncherFromSurfaceTitle(
+    discovered.surface_title,
+    registry,
+  );
+  if (titleLauncher) return titleLauncher;
+
+  if (discovered.cli === "unknown") return null;
+  const repo = repairRepoFromTitle(discovered.surface_title);
+  const suffix = suffixForCli(discovered.cli);
+  if (!repo || !suffix) return null;
+  return {
+    repo,
+    cli: discovered.cli,
+    launcherName: `${repo}${suffix}`,
+  };
+}
+
 function roleFromSeatOrLauncher(input: {
   seat: SeatIdentityAssertion;
   launcherName: string;
@@ -200,10 +231,7 @@ function repairCandidateForSurface(
   discovered: DiscoveredAgent,
   registry?: SeatRegistry | null,
 ): RegistryRepairCandidate | null {
-  const launcher = inferLauncherFromSurfaceTitle(
-    discovered.surface_title,
-    registry,
-  );
+  const launcher = inferRepairLauncher(discovered, registry);
   if (!launcher) return null;
 
   const seat = assertSeatIdentity({
@@ -224,6 +252,13 @@ function repairCandidateForSurface(
     role,
     agentId: seat.seat_id ?? launcher.launcherName,
   };
+}
+
+function surfaceScopedAgentId(baseAgentId: string, surfaceId: string): string {
+  const surfaceToken = surfaceId
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `${baseAgentId}-${surfaceToken || "surface"}`;
 }
 
 function patchForRepairCandidate(
@@ -789,7 +824,12 @@ export class AgentRegistry {
       const candidate = repairCandidateForSurface(entry, opts?.seatRegistry);
       if (!candidate) continue;
 
-      const repair = this.repairDiscoveredSurface(entry, candidate, evicted);
+      const repair = this.repairDiscoveredSurface(
+        entry,
+        candidate,
+        evicted,
+        liveSurfaceRefs,
+      );
       if (repair) {
         repaired.push(repair);
       }
@@ -839,6 +879,7 @@ export class AgentRegistry {
     discovered: DiscoveredAgent,
     candidate: RegistryRepairCandidate,
     evicted: Set<string>,
+    liveSurfaceRefs: ReadonlySet<string>,
   ): RegistryRepairEntry | null {
     const recordsForSurface = [...this.agents.values()].filter(
       (agent) => agent.surface_id === discovered.surface_id,
@@ -870,6 +911,42 @@ export class AgentRegistry {
 
     const existingSeatRecord = this.stateMgr.readState(candidate.agentId);
     if (existingSeatRecord) {
+      if (
+        existingSeatRecord.surface_id !== discovered.surface_id &&
+        liveSurfaceRefs.has(existingSeatRecord.surface_id)
+      ) {
+        const scopedCandidate = {
+          ...candidate,
+          agentId: surfaceScopedAgentId(
+            candidate.agentId,
+            discovered.surface_id,
+          ),
+        };
+        const existingScopedRecord = this.stateMgr.readState(
+          scopedCandidate.agentId,
+        );
+        if (existingScopedRecord) {
+          const updated = this.updateManagedSurfaceRegistration(
+            existingScopedRecord,
+            discovered,
+            scopedCandidate,
+          );
+          return updated
+            ? this.repairEntry(updated, discovered, scopedCandidate, "updated")
+            : this.repairEntry(
+                existingScopedRecord,
+                discovered,
+                scopedCandidate,
+                "updated",
+              );
+        }
+
+        const created = this.createRepairedRecord(discovered, scopedCandidate);
+        this.stateMgr.writeState(created);
+        this.agents.set(created.agent_id, created);
+        return this.repairEntry(created, discovered, scopedCandidate, "created");
+      }
+
       const updated = this.updateManagedSurfaceRegistration(
         existingSeatRecord,
         discovered,

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -78,6 +78,12 @@ interface RegistryRepairCandidate {
   agentId: string;
 }
 
+interface LiveRepairCandidate {
+  discovered: DiscoveredAgent;
+  candidate: RegistryRepairCandidate;
+  identityKeys: string[];
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -279,6 +285,26 @@ function canonicalIdentityName(record: AgentRecord): string | null {
   return record.seat_id ?? record.launcher_name ?? null;
 }
 
+function repairCandidateIdentityKeys(
+  candidate: RegistryRepairCandidate,
+): string[] {
+  return [
+    candidate.seat.seat_id ? `seat:${candidate.seat.seat_id}` : null,
+    `launcher:${candidate.launcherName}`,
+  ].filter((key): key is string => Boolean(key));
+}
+
+function identityKeysOverlap(left: readonly string[], right: readonly string[]) {
+  return left.some((key) => right.includes(key));
+}
+
+function isSelfHealEligibleManagedRecord(record: AgentRecord): boolean {
+  if (record.state !== "error") {
+    return record.state !== "done";
+  }
+  return record.error?.startsWith("Surface ") ?? false;
+}
+
 function patchForRepairCandidate(
   record: AgentRecord,
   discovered: DiscoveredAgent,
@@ -327,7 +353,6 @@ class AgentNotFoundError extends Error {
 export class AgentRegistry {
   private agents = new Map<string, AgentRecord>();
   private aliases = new Map<string, string>();
-  private repairSuppressedSurfaceRefs = new Set<string>();
   private stateMgr: StateManager;
   private surfaceProvider: SurfaceProvider;
 
@@ -510,6 +535,10 @@ export class AgentRegistry {
     await this.evictBootingGhosts(discovered);
 
     const bySurface = new Map(discovered.map((entry) => [entry.surface_id, entry]));
+    const repairCandidates = this.liveRepairCandidatesForDiscovery(discovered);
+    this.selfHealManagedRegistrationsFromDiscovery(repairCandidates, bySurface);
+    const suppressedDuplicateSurfaceRefs =
+      this.duplicateDiscoverySurfaceRefs(repairCandidates);
     const merged: MergedAgent[] = [];
     const seenSurfaces = new Set<string>();
 
@@ -570,7 +599,7 @@ export class AgentRegistry {
       ) {
         continue;
       }
-      if (this.repairSuppressedSurfaceRefs.has(discoveredEntry.surface_id)) {
+      if (suppressedDuplicateSurfaceRefs.has(discoveredEntry.surface_id)) {
         continue;
       }
       if (seenSurfaces.has(discoveredEntry.surface_id)) {
@@ -655,6 +684,124 @@ export class AgentRegistry {
     }
 
     return opts?.agentId ? requested ?? this.get(opts.agentId) : null;
+  }
+
+  private liveRepairCandidatesForDiscovery(
+    discovered: DiscoveredAgent[],
+  ): LiveRepairCandidate[] {
+    return discovered.flatMap((entry) => {
+      if (
+        !entry.has_agent ||
+        entry.cli === "unknown" ||
+        entry.read_error
+      ) {
+        return [];
+      }
+      const candidate = repairCandidateForSurface(entry);
+      if (!candidate) return [];
+      return [
+        {
+          discovered: entry,
+          candidate,
+          identityKeys: repairCandidateIdentityKeys(candidate),
+        },
+      ];
+    });
+  }
+
+  private selfHealManagedRegistrationsFromDiscovery(
+    candidates: LiveRepairCandidate[],
+    bySurface: ReadonlyMap<string, DiscoveredAgent>,
+  ): void {
+    if (candidates.length === 0) return;
+
+    const claimedSurfaceRefs = new Set<string>();
+    for (const record of [...this.agents.values()]) {
+      if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
+        continue;
+      }
+      if (!isSelfHealEligibleManagedRecord(record)) {
+        continue;
+      }
+
+      const recordKeys = recordIdentityKeys(record);
+      if (recordKeys.length === 0) continue;
+
+      const currentLiveCandidate = candidates.find(
+        (entry) =>
+          entry.discovered.surface_id === record.surface_id &&
+          identityKeysOverlap(recordKeys, entry.identityKeys),
+      );
+      if (currentLiveCandidate) {
+        claimedSurfaceRefs.add(currentLiveCandidate.discovered.surface_id);
+        continue;
+      }
+
+      const currentSurface = bySurface.get(record.surface_id);
+      if (
+        currentSurface &&
+        (currentSurface.read_error || currentSurface.has_agent)
+      ) {
+        continue;
+      }
+
+      const replacement = candidates.find(
+        (entry) =>
+          !claimedSurfaceRefs.has(entry.discovered.surface_id) &&
+          identityKeysOverlap(recordKeys, entry.identityKeys),
+      );
+      if (!replacement) continue;
+
+      const moved =
+        this.updateManagedSurfaceRegistration(
+          record,
+          replacement.discovered,
+          replacement.candidate,
+        ) ?? record;
+      const synced = this.syncManagedRecordLifecycleFromDiscovery(
+        moved,
+        replacement.discovered,
+      );
+      claimedSurfaceRefs.add(synced.surface_id);
+    }
+  }
+
+  private duplicateDiscoverySurfaceRefs(
+    candidates: LiveRepairCandidate[],
+  ): Set<string> {
+    const liveManagedIdentityKeys = new Set<string>();
+    const liveManagedSurfaceRefs = new Set<string>();
+
+    for (const record of this.agents.values()) {
+      if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
+        continue;
+      }
+      const recordKeys = recordIdentityKeys(record);
+      const matchingLiveCandidate = candidates.find(
+        (entry) =>
+          entry.discovered.surface_id === record.surface_id &&
+          identityKeysOverlap(recordKeys, entry.identityKeys),
+      );
+      if (!matchingLiveCandidate) continue;
+
+      liveManagedSurfaceRefs.add(record.surface_id);
+      for (const key of recordKeys) {
+        liveManagedIdentityKeys.add(key);
+      }
+    }
+
+    const suppressed = new Set<string>();
+    for (const entry of candidates) {
+      if (liveManagedSurfaceRefs.has(entry.discovered.surface_id)) {
+        continue;
+      }
+      if (
+        entry.identityKeys.some((key) => liveManagedIdentityKeys.has(key))
+      ) {
+        suppressed.add(entry.discovered.surface_id);
+      }
+    }
+    return suppressed;
   }
 
   /**
@@ -747,6 +894,31 @@ export class AgentRegistry {
     }
   }
 
+  private syncManagedRecordLifecycleFromDiscovery(
+    record: AgentRecord,
+    discoveredEntry: DiscoveredAgent,
+  ): AgentRecord {
+    const desiredState = discoveredStatusToAgentState(
+      discoveredEntry.parsed_status,
+    );
+    const desiredError =
+      desiredState === "error"
+        ? "Repaired agent surface reported a frozen state"
+        : null;
+    if (record.state === desiredState && record.error === desiredError) {
+      return record;
+    }
+
+    const updated = this.stateMgr.resetState(
+      record.agent_id,
+      desiredState,
+      { error: desiredError },
+      "listMergedSelfHeal",
+    );
+    this.agents.set(record.agent_id, updated);
+    return updated;
+  }
+
   /**
    * Update an agent in the in-memory map. Used by tools that
    * write state through the StateManager and need to sync the registry.
@@ -831,7 +1003,6 @@ export class AgentRegistry {
   ): RegistryRepairSummary {
     const repaired: RegistryRepairEntry[] = [];
     const evicted = new Set<string>();
-    this.repairSuppressedSurfaceRefs = new Set();
     const liveSurfaceRefs = new Set(
       discovered
         .filter((entry) => !entry.read_error)
@@ -947,9 +1118,6 @@ export class AgentRegistry {
       });
       const keep = sorted[0];
       for (const duplicate of sorted.slice(1)) {
-        if (duplicate.surface_id !== keep.surface_id) {
-          this.repairSuppressedSurfaceRefs.add(duplicate.surface_id);
-        }
         const removedAgentId = this.evict(duplicate.agent_id);
         if (removedAgentId) {
           evicted.push(removedAgentId);
@@ -1000,7 +1168,6 @@ export class AgentRegistry {
         existingSeatRecord.surface_id !== discovered.surface_id &&
         liveSurfaceRefs.has(existingSeatRecord.surface_id)
       ) {
-        this.repairSuppressedSurfaceRefs.add(discovered.surface_id);
         return null;
       }
 

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -352,4 +352,46 @@ describe("agent lifecycle health", () => {
       issues: [],
     });
   });
+
+  it("downgrades auto-discovered column placement flags to info", () => {
+    const autoLead = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "auto-claude-surface-32",
+        cli: "claude",
+        role: "orchestrator",
+        repo: "driverBuddy",
+        task_summary: "(auto-discovered)",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "driverBuddy",
+        topology: { column: 1, column_count: 2 },
+      },
+    );
+    const autoWorker = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "auto-codex-surface-112",
+        role: "worker",
+        task_summary: "(auto-discovered)",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "pr3-quadratic-fix",
+        topology: { column: 0, column_count: 2 },
+      },
+    );
+
+    expect(autoLead.status).toBe("healthy");
+    expect(autoLead.issue_codes).toContain("orchestrator_not_leftmost");
+    expect(autoLead.issue_severities).toMatchObject({
+      auto_discovered_agent: "info",
+      orchestrator_not_leftmost: "info",
+    });
+    expect(autoWorker.status).toBe("healthy");
+    expect(autoWorker.issue_codes).toContain("worker_in_leftmost_column");
+    expect(autoWorker.issue_severities).toMatchObject({
+      auto_discovered_agent: "info",
+      worker_in_leftmost_column: "info",
+    });
+  });
 });

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -573,6 +573,76 @@ describe("AgentRegistry", () => {
       expect(stateMgr.readState("cmuxlayerLead-surface-121")).toBeNull();
     });
 
+    it("self-heals a suppressed duplicate surface when the canonical surface closes", async () => {
+      const surfaceA = "surface:35";
+      const surfaceB = "surface:121";
+      const duplicateDiscoveries = [
+        makeDiscovered({
+          surface_id: surfaceA,
+          surface_title: "cmuxlayerClaude",
+        }),
+        makeDiscovered({
+          surface_id: surfaceB,
+          surface_title: "cmuxlayerClaude",
+        }),
+      ];
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-35",
+          surface_id: surfaceA,
+          workspace_id: "workspace:1",
+          repo: "cmuxlayer",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-121",
+          surface_id: surfaceB,
+          workspace_id: "workspace:1",
+          repo: "cmuxlayer",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+
+      let surfaces = [makeSurface(surfaceA), makeSurface(surfaceB)];
+      const registry = new AgentRegistry(stateMgr, async () => surfaces);
+      await registry.reconstitute();
+      registry.repairFromDiscovery(duplicateDiscoveries, {
+        seatRegistry: REPAIR_SEATS,
+      });
+
+      surfaces = [makeSurface(surfaceB)];
+      const merged = await registry.listMerged({
+        scan: vi.fn().mockResolvedValue([
+          makeDiscovered({
+            surface_id: surfaceB,
+            surface_title: "cmuxlayerClaude",
+          }),
+        ]),
+      } as any);
+
+      expect(merged.map((record) => record.agent_id)).toEqual([
+        "cmuxlayerLead",
+      ]);
+      expect(merged[0]).toMatchObject({
+        agent_id: "cmuxlayerLead",
+        surface_id: surfaceB,
+        state: "working",
+        error: null,
+        launcher_name: "cmuxlayerClaude",
+      });
+      expect(stateMgr.readState("cmuxlayerLead")).toMatchObject({
+        agent_id: "cmuxlayerLead",
+        surface_id: surfaceB,
+        state: "working",
+        error: null,
+      });
+      expect(stateMgr.readState("auto-claude-surface-121")).toBeNull();
+    });
+
     it("deduplicates M1 mimir pending ghosts to one row per launcher seat", async () => {
       const discovered = [
         makeDiscovered({

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { StateManager } from "../src/state-manager.js";
 import type { AgentRecord, AgentState } from "../src/agent-types.js";
+import type { DiscoveredAgent } from "../src/agent-discovery.js";
+import type { SeatRegistry } from "../src/seat-identity.js";
 import type { CmuxSurface } from "../src/types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-registry");
@@ -42,6 +44,43 @@ function makeSurface(ref: string): CmuxSurface {
     selected: false,
   };
 }
+
+function makeDiscovered(
+  overrides: Partial<DiscoveredAgent>,
+): DiscoveredAgent {
+  return {
+    surface_id: "surface:live",
+    surface_title: "cmuxlayerClaude",
+    workspace_id: "workspace:1",
+    cli: "claude",
+    parsed_status: "working",
+    model: "Sonnet 4.6",
+    token_count: null,
+    context_pct: null,
+    has_agent: true,
+    read_error: false,
+    ...overrides,
+  };
+}
+
+const REPAIR_SEATS: SeatRegistry = {
+  driverBuddy: {
+    repo: "driverBuddy",
+    launchers: {
+      claude: "driverBuddyClaude",
+    },
+    lane: "driverBuddy",
+    role: "lead",
+  },
+  cmuxlayerLead: {
+    repo: "cmuxlayer",
+    launchers: {
+      claude: "cmuxlayerClaude",
+    },
+    lane: "cmuxlayer",
+    role: "lead",
+  },
+};
 
 describe("AgentRegistry", () => {
   let stateMgr: StateManager;
@@ -412,6 +451,129 @@ describe("AgentRegistry", () => {
       expect(registry.get("managed-codex-null")?.workspace_id).toBe(
         "workspace:known",
       );
+    });
+  });
+
+  describe("repairFromDiscovery", () => {
+    it("repairs no-suffix auto-discovered panes from parsed cli and title repo evidence", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-32",
+          surface_id: "surface:32",
+          workspace_id: "workspace:1",
+          repo: "driverBuddy",
+          cli: "claude",
+          role: "orchestrator",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:32"),
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:32",
+            surface_title: "🤝 driverBuddy",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          surface_id: "surface:32",
+          agent_id: "driverBuddy",
+          repo: "driverBuddy",
+          cli: "claude",
+          launcher_name: "driverBuddyClaude",
+          seat_id: "driverBuddy",
+          action: "created",
+        }),
+      ]);
+      expect(result.evicted).toEqual(["auto-claude-surface-32"]);
+      expect(stateMgr.readState("auto-claude-surface-32")).toBeNull();
+      expect(stateMgr.readState("driverBuddy")).toMatchObject({
+        agent_id: "driverBuddy",
+        surface_id: "surface:32",
+        repo: "driverBuddy",
+        cli: "claude",
+        launcher_name: "driverBuddyClaude",
+        seat_id: "driverBuddy",
+        seat_lane: "driverBuddy",
+        seat_role: "lead",
+        role: "orchestrator",
+      });
+    });
+
+    it("keeps duplicate launcher-title surfaces as distinct repaired registrations", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-35",
+          surface_id: "surface:35",
+          workspace_id: "workspace:1",
+          repo: "cmuxlayer",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-121",
+          surface_id: "surface:121",
+          workspace_id: "workspace:1",
+          repo: "cmuxlayer",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:35"),
+        makeSurface("surface:121"),
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:35",
+            surface_title: "cmuxlayerClaude",
+          }),
+          makeDiscovered({
+            surface_id: "surface:121",
+            surface_title: "cmuxlayerClaude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          surface_id: "surface:35",
+          agent_id: "cmuxlayerLead",
+          action: "created",
+        }),
+        expect.objectContaining({
+          surface_id: "surface:121",
+          agent_id: "cmuxlayerLead-surface-121",
+          action: "created",
+        }),
+      ]);
+      expect(stateMgr.readState("cmuxlayerLead")).toMatchObject({
+        agent_id: "cmuxlayerLead",
+        surface_id: "surface:35",
+        seat_id: "cmuxlayerLead",
+      });
+      expect(stateMgr.readState("cmuxlayerLead-surface-121")).toMatchObject({
+        agent_id: "cmuxlayerLead-surface-121",
+        surface_id: "surface:121",
+        seat_id: "cmuxlayerLead",
+      });
     });
   });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -510,7 +510,7 @@ describe("AgentRegistry", () => {
       });
     });
 
-    it("keeps duplicate launcher-title surfaces as distinct repaired registrations", async () => {
+    it("keeps duplicate launcher-title surfaces on one canonical repaired registration", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "auto-claude-surface-35",
@@ -558,22 +558,165 @@ describe("AgentRegistry", () => {
           agent_id: "cmuxlayerLead",
           action: "created",
         }),
-        expect.objectContaining({
-          surface_id: "surface:121",
-          agent_id: "cmuxlayerLead-surface-121",
-          action: "created",
-        }),
       ]);
+      expect(result.evicted).toEqual(
+        expect.arrayContaining([
+          "auto-claude-surface-35",
+          "auto-claude-surface-121",
+        ]),
+      );
       expect(stateMgr.readState("cmuxlayerLead")).toMatchObject({
         agent_id: "cmuxlayerLead",
         surface_id: "surface:35",
         seat_id: "cmuxlayerLead",
       });
-      expect(stateMgr.readState("cmuxlayerLead-surface-121")).toMatchObject({
-        agent_id: "cmuxlayerLead-surface-121",
-        surface_id: "surface:121",
-        seat_id: "cmuxlayerLead",
+      expect(stateMgr.readState("cmuxlayerLead-surface-121")).toBeNull();
+    });
+
+    it("deduplicates M1 mimir pending ghosts to one row per launcher seat", async () => {
+      const discovered = [
+        makeDiscovered({
+          surface_id: "surface:101",
+          surface_title: "mimir",
+          cli: "claude",
+        }),
+        makeDiscovered({
+          surface_id: "surface:102",
+          surface_title: "mimir",
+          cli: "claude",
+        }),
+        makeDiscovered({
+          surface_id: "surface:103",
+          surface_title: "mimir",
+          cli: "claude",
+        }),
+        makeDiscovered({
+          surface_id: "surface:201",
+          surface_title: "mimir",
+          cli: "codex",
+          model: "gpt-5.5",
+        }),
+        makeDiscovered({
+          surface_id: "surface:202",
+          surface_title: "mimir",
+          cli: "codex",
+          model: "gpt-5.5",
+        }),
+      ];
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-101",
+          surface_id: "surface:101",
+          repo: "mimir",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "auto-claude-surface-102",
+          surface_id: "surface:102",
+          repo: "mimir",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "mimirClaude-pending-1710000000-abcd",
+          surface_id: "surface:103",
+          repo: "mimir",
+          cli: "claude",
+          launcher_name: "mimirClaude",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "mimirCodex-pending-1710000000-cafe",
+          surface_id: "surface:201",
+          repo: "mimir",
+          cli: "codex",
+          launcher_name: "mimirCodex",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "mimirCodex-pending-1710000000-dead",
+          surface_id: "surface:202",
+          repo: "mimir",
+          cli: "codex",
+          launcher_name: "mimirCodex",
+        }),
+      );
+
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => discovered.map((entry) => makeSurface(entry.surface_id)),
+      );
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(discovered);
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          surface_id: "surface:101",
+          agent_id: "mimirClaude",
+          launcher_name: "mimirClaude",
+          action: "created",
+        }),
+        expect.objectContaining({
+          surface_id: "surface:201",
+          agent_id: "mimirCodex",
+          launcher_name: "mimirCodex",
+          action: "created",
+        }),
+      ]);
+      expect(result.evicted).toEqual(
+        expect.arrayContaining([
+          "auto-claude-surface-101",
+          "auto-claude-surface-102",
+          "mimirClaude-pending-1710000000-abcd",
+          "mimirCodex-pending-1710000000-cafe",
+          "mimirCodex-pending-1710000000-dead",
+        ]),
+      );
+
+      const liveRows = registry
+        .list()
+        .map((record) => record.agent_id)
+        .sort();
+      expect(liveRows).toEqual(["mimirClaude", "mimirCodex"]);
+      expect(stateMgr.readState("mimirClaude")).toMatchObject({
+        agent_id: "mimirClaude",
+        surface_id: "surface:101",
+        repo: "mimir",
+        cli: "claude",
+        role: "orchestrator",
       });
+      expect(stateMgr.readState("mimirCodex")).toMatchObject({
+        agent_id: "mimirCodex",
+        surface_id: "surface:201",
+        repo: "mimir",
+        cli: "codex",
+        role: "worker",
+      });
+      expect(
+        stateMgr
+          .listStates()
+          .filter(
+            (record) =>
+              record.agent_id.startsWith("auto-") ||
+              record.agent_id.includes("-pending-"),
+          ),
+      ).toEqual([]);
+
+      const merged = await registry.listMerged({
+        scan: vi.fn().mockResolvedValue(discovered),
+      } as any);
+      expect(merged.map((record) => record.agent_id).sort()).toEqual([
+        "mimirClaude",
+        "mimirCodex",
+      ]);
     });
   });
 

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -408,7 +408,7 @@ function makeAmbiguousLiveAgentExec(): ExecFn {
           surfaces: [
             {
               ref: "surface:777",
-              title: "review lane",
+              title: "Codex",
               type: "terminal",
               index: 0,
               selected: true,
@@ -1473,7 +1473,7 @@ describe("resync_agents tool", () => {
     expect(parsed.count).toBe(0);
   });
 
-  it("resync_agents reports unresolved live-agent surfaces whose title cannot map to a seat", async () => {
+  it("resync_agents reports unresolved live-agent surfaces whose title has no repo label", async () => {
     const stateMgr = new StateManager(TEST_DIR);
     const server = createServer({
       exec: makeAmbiguousLiveAgentExec(),
@@ -1493,14 +1493,14 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.orphaned_health).toEqual([
       expect.objectContaining({
         surface_id: "surface:777",
-        surface_title: "review lane",
+        surface_title: "Codex",
         status: "degraded",
         issue_codes: ["auto_discovered_agent"],
         issue_severities: { auto_discovered_agent: "info" },
       }),
     ]);
     expect(
-      stateMgr.listStates().some((record) => record.agent_id === "review lane"),
+      stateMgr.listStates().some((record) => record.agent_id === "Codex"),
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- Teach registry repair to convert no-suffix auto-discovered panes using parsed CLI plus title-derived repo evidence, including leading-marker titles like `🤝 driverBuddy`.
- Prevent duplicate live launcher-title surfaces from fighting over one canonical seat record by creating surface-scoped repaired registrations when the canonical seat is already live elsewhere.
- Downgrade `orchestrator_not_leftmost` and `worker_in_leftmost_column` to info severity for auto-discovered agents, while preserving blocking topology health for managed agents.

## Test plan
- [x] Red-first focused tests for no-suffix repair, duplicate-title collision, and auto-discovered topology severity.
- [x] `bun test tests/agent-registry.test.ts tests/agent-health.test.ts`
- [x] `bun test tests/resync-tool.test.ts tests/surface-topology.test.ts`
- [x] `bun run test && bun run typecheck && bun run build` — 82 test files / 1502 tests passed, then typecheck and build exited 0.
- [x] Pre-push hook reran tests — 82 test files / 1502 tests passed.
- [x] `coderabbit review --agent` — findings: 0.

## Notes
- Tool names stay unchanged; no pane moves.
- Full daemon convergence/live fleet resync remains outside this PR per the build brief.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent registry merge/repair and eviction paths that determine which agents appear and which surfaces are suppressed; behavior is covered by new tests but mistakes could mis-bind seats or drop rows.
> 
> **Overview**
> Fixes **auto-discovered sidebar agents** that never matched managed seat repair because pane titles lacked launcher suffixes (e.g. `🤝 driverBuddy`). Repair now falls back to **parsed CLI plus a repo token from the title** when the usual title→launcher inference fails.
> 
> **Registry reconciliation** gains seat/launcher **identity keys** and uses them to collapse duplicate managed rows, evict pending ghosts superseded by a real seat, and **skip creating a second registration** when the canonical seat is already bound to a different live surface. **`listMerged`** additionally **self-heals** eligible managed records onto a replacement surface when the old one closes, suppresses extra auto-rows for duplicate launcher titles, and syncs lifecycle state after repair.
> 
> **Agent health** treats **`orchestrator_not_leftmost`** and **`worker_in_leftmost_column`** as **info** (not blocking) for auto-discovered agents so sidebar placement noise stays healthy while managed agents keep strict topology checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7e0ecb7098564fba9f564cae248b36ee55304b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auto-discovered sidebar agent repair with identity-based self-healing and deduplication
> - Downgrades `orchestrator_not_leftmost` and `worker_in_leftmost_column` issue severities to `info` for auto-discovered agents in [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/268/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3), so column-placement issues no longer degrade their health status.
> - Adds identity key matching (by seat ID and launcher name) in [agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/268/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) so managed records can be re-associated to a new live surface when their original surface closes (self-healing).
> - Suppresses duplicate auto records when a discovered surface matches an existing managed identity, and evicts duplicate managed registrations keeping a single canonical record.
> - Extends launcher inference to handle surfaces without explicit suffixes by combining a repo token derived from the surface title with a CLI-specific suffix.
> - Risk: Self-healing rewrites managed record state and lifecycle in place; records in `done` state (except `error` with a `Surface ` prefix) are ineligible and will not be reassigned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e7e0ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-discovered agents now show reduced-severity health feedback for specific column-placement/liveness issues (while remaining healthy).

* **Bug Fixes**
  * Registry repair/self-heal is more robust: improved launcher inference, identity-based deduplication, conflict suppression across live surfaces, and safer lifecycle reset for repaired records.
  * Resync behavior for title-to-repo mapping edge cases is clearer, reducing confusing state mismatches.

* **Tests**
  * Expanded coverage for the new health severity rules and expanded repair/self-heal scenarios, plus updated resync fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->