### PR TITLE
Fix daemon caller workspace context

### DIFF
--- a/src/caller-context.ts
+++ b/src/caller-context.ts
@@ -1,0 +1,121 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+export const CALLER_CONTEXT_META_KEY = "cmuxlayer/callerContext";
+
+export interface CallerContext {
+  workspaceId?: string;
+  tabId?: string;
+  surfaceId?: string;
+}
+
+const callerContextStore = new AsyncLocalStorage<CallerContext>();
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function hasCallerContext(
+  context: CallerContext | undefined,
+): context is CallerContext {
+  return Boolean(context?.workspaceId || context?.tabId || context?.surfaceId);
+}
+
+export function callerContextFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): CallerContext | undefined {
+  const context: CallerContext = {
+    workspaceId: nonEmptyString(env.CMUX_WORKSPACE_ID),
+    tabId: nonEmptyString(env.CMUX_TAB_ID),
+    surfaceId: nonEmptyString(env.CMUX_SURFACE_ID),
+  };
+  return hasCallerContext(context) ? context : undefined;
+}
+
+export function currentCallerContext(): CallerContext | undefined {
+  return callerContextStore.getStore();
+}
+
+export function runWithCallerContext<T>(
+  context: CallerContext | undefined,
+  callback: () => T,
+): T {
+  if (!hasCallerContext(context)) {
+    return callback();
+  }
+  return callerContextStore.run(context, callback);
+}
+
+function callerContextFromUnknown(value: unknown): CallerContext | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const context: CallerContext = {
+    workspaceId:
+      nonEmptyString(record.workspaceId) ??
+      nonEmptyString(record.CMUX_WORKSPACE_ID),
+    tabId: nonEmptyString(record.tabId) ?? nonEmptyString(record.CMUX_TAB_ID),
+    surfaceId:
+      nonEmptyString(record.surfaceId) ??
+      nonEmptyString(record.CMUX_SURFACE_ID),
+  };
+  return hasCallerContext(context) ? context : undefined;
+}
+
+export function callerContextFromMessage(
+  message: JSONRPCMessage,
+): CallerContext | undefined {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("method" in message) ||
+    message.method !== "tools/call" ||
+    !("params" in message) ||
+    typeof message.params !== "object" ||
+    message.params === null
+  ) {
+    return undefined;
+  }
+  const params = message.params as { _meta?: Record<string, unknown> };
+  const meta = params._meta;
+  if (!meta) {
+    return undefined;
+  }
+  return callerContextFromUnknown(meta[CALLER_CONTEXT_META_KEY]);
+}
+
+export function attachCallerContextToMessage<T extends JSONRPCMessage>(
+  message: T,
+  context: CallerContext | undefined,
+): T {
+  if (
+    !hasCallerContext(context) ||
+    typeof message !== "object" ||
+    message === null ||
+    !("method" in message) ||
+    message.method !== "tools/call"
+  ) {
+    return message;
+  }
+
+  const record = message as Record<string, unknown>;
+  const params =
+    typeof record.params === "object" && record.params !== null
+      ? { ...(record.params as Record<string, unknown>) }
+      : {};
+  const existingMeta =
+    typeof params._meta === "object" && params._meta !== null
+      ? (params._meta as Record<string, unknown>)
+      : {};
+  record.params = {
+    ...params,
+    _meta: {
+      ...existingMeta,
+      [CALLER_CONTEXT_META_KEY]: context,
+    },
+  };
+  return message;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -31,6 +31,10 @@ import type {
 import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
 import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
 import { JsonRpcLineBuffer } from "./json-rpc-line-buffer.js";
+import {
+  callerContextFromMessage,
+  runWithCallerContext,
+} from "./caller-context.js";
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const LISTEN_FD_START = 3;
@@ -155,7 +159,9 @@ export class SocketJsonRpcTransport implements Transport {
         if (isJsonRpcRequest(message)) {
           this.onRequestObserved?.(message);
         }
-        this.onmessage?.(message);
+        runWithCallerContext(callerContextFromMessage(message), () => {
+          this.onmessage?.(message);
+        });
       } catch (error) {
         this.onerror?.(
           error instanceof Error ? error : new Error(String(error)),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,6 +13,10 @@ import {
   extractJsonRpcFrameMetadata,
   JsonRpcLineBuffer,
 } from "./json-rpc-line-buffer.js";
+import {
+  attachCallerContextToMessage,
+  callerContextFromEnv,
+} from "./caller-context.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
@@ -311,9 +315,13 @@ export class CmuxLayerProxy {
     }
 
     this.expiredRequestKeys.delete(key);
+    const messageForDaemon = attachCallerContextToMessage(
+      cloneMessage(message),
+      callerContextFromEnv(),
+    );
     const pending: PendingRequest = {
       id: message.id,
-      message: cloneMessage(message),
+      message: messageForDaemon,
       sequence: this.nextSequence++,
       requestKey: key,
       sent: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,6 +117,7 @@ import type {
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
+import { currentCallerContext } from "./caller-context.js";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
   matchReadyPattern,
@@ -3557,14 +3558,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const callerWorkspaceStrict = async (): Promise<string | undefined> => {
     try {
       const { workspaces } = await client.listWorkspaces();
-      const envCandidates = [
-        process.env.CMUX_WORKSPACE_ID,
-        process.env.CMUX_TAB_ID,
+      const callerContext = currentCallerContext();
+      const requestCandidates = [
+        callerContext?.workspaceId,
+        callerContext?.tabId,
       ].filter(
         (value): value is string =>
           typeof value === "string" && value.trim().length > 0,
       );
-      for (const candidate of envCandidates) {
+      const envCandidates =
+        requestCandidates.length > 0
+          ? []
+          : [process.env.CMUX_WORKSPACE_ID, process.env.CMUX_TAB_ID].filter(
+              (value): value is string =>
+                typeof value === "string" && value.trim().length > 0,
+            );
+      const candidates = [...requestCandidates, ...envCandidates];
+      for (const candidate of candidates) {
         const match = workspaces.find((workspace) =>
           envWorkspaceMatches(workspace, candidate),
         );

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -168,6 +168,67 @@ function createLifecycleExec(): ExecFn {
   });
 }
 
+function createPlacementClient(
+  workspaces: Array<Record<string, unknown>>,
+  calls: string[] = [],
+) {
+  let surfaceIndex = 0;
+  return {
+    createWorkspace: vi.fn(),
+    selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
+      calls.push(`select:${workspace}`);
+    }),
+    listWorkspaces: vi.fn().mockResolvedValue({ workspaces }),
+    listPanes: vi
+      .fn()
+      .mockImplementation(async ({ workspace }: { workspace?: string } = {}) => ({
+        workspace_ref: workspace ?? "workspace:focused",
+        window_ref: "window:1",
+        panes: [],
+      })),
+    listPaneSurfaces: vi
+      .fn()
+      .mockImplementation(async ({ workspace }: { workspace?: string } = {}) => ({
+        workspace_ref: workspace ?? "workspace:focused",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [],
+      })),
+    newSplit: vi
+      .fn()
+      .mockImplementation(
+        async (_direction: string, opts: { workspace?: string }) => {
+          surfaceIndex += 1;
+          calls.push(`spawn:${opts.workspace}`);
+          return {
+            workspace: opts.workspace,
+            surface: `surface:caller-${surfaceIndex}`,
+            pane: `pane:caller-${surfaceIndex}`,
+            title: "",
+            type: "terminal",
+          };
+        },
+      ),
+    newSurface: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: "surface:caller",
+      text: "codex> ",
+      lines: 20,
+      scrollback_used: false,
+    }),
+    log: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn().mockResolvedValue(undefined),
+    listSurfaces: vi.fn().mockResolvedValue([]),
+    identify: vi.fn().mockResolvedValue({}),
+    browser: vi.fn().mockResolvedValue({}),
+  };
+}
+
 async function connectClient(path: string): Promise<Client> {
   const socket = net.createConnection(path);
   const transport = new SocketJsonRpcTransport(socket);
@@ -201,6 +262,71 @@ function deferred<T>() {
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function rawToolCall(
+  path: string,
+  params: Record<string, unknown>,
+  timeoutMs = 1_000,
+): Promise<Record<string, any>> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(path);
+    let buffer = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settle(new Error("timed out waiting for raw tools/call response"));
+    }, timeoutMs);
+    const send = (message: Record<string, unknown>) => {
+      socket.write(`${JSON.stringify(message)}\n`);
+    };
+    const settle = (error?: Error, response?: Record<string, any>) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      socket.destroy();
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(response ?? {});
+    };
+
+    socket.on("connect", () => {
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "raw-spawn-test", version: "0.1.0" },
+        },
+      });
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line.trim()) {
+          continue;
+        }
+        const message = JSON.parse(line);
+        if (message.id === 1) {
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params });
+          continue;
+        }
+        if (message.id === 2) {
+          settle(undefined, message);
+        }
+      }
+    });
+    socket.on("error", (error) => settle(error));
+  });
 }
 
 async function listen(server: net.Server, path: string): Promise<void> {
@@ -510,6 +636,185 @@ describe("CmuxLayerDaemon", () => {
     await clientA.close();
     await clientB.close();
     await daemon.shutdown();
+  });
+
+  it("uses per-request caller workspace metadata when daemon env has no workspace", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    delete process.env.CMUX_WORKSPACE_ID;
+    delete process.env.CMUX_TAB_ID;
+    const path = socketPath("caller-workspace");
+    const calls: string[] = [];
+    const context = createServerContext({
+      client: createPlacementClient(
+        [
+          {
+            id: "caller-workspace-uuid",
+            ref: "workspace:1",
+            title: "Caller Workspace",
+            selected: false,
+          },
+          {
+            id: "selected-workspace-uuid",
+            ref: "workspace:5",
+            title: "Focused Workspace",
+            selected: true,
+          },
+        ],
+        calls,
+      ) as any,
+      stateDir: stateDir("caller-workspace-state"),
+      disableSpawnPreflight: true,
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      context,
+      disableSpawnPreflight: true,
+    });
+
+    try {
+      await daemon.start();
+
+      const response = await rawToolCall(path, {
+        name: "spawn_agent",
+        arguments: {
+          repo: "brainlayer",
+          model: "gpt-5.5",
+          cli: "codex",
+          force_new: true,
+        },
+        _meta: {
+          "cmuxlayer/callerContext": {
+            workspaceId: "caller-workspace-uuid",
+            tabId: "caller-tab-id",
+            surfaceId: "surface:caller",
+          },
+        },
+      });
+
+      expect(response.result?.structuredContent).toMatchObject({
+        ok: true,
+        workspace_id: "workspace:1",
+      });
+      expect(calls).toContain("spawn:workspace:1");
+      expect(calls).not.toContain("spawn:workspace:5");
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+      await daemon.shutdown().catch(() => {});
+    }
+  });
+
+  it("keeps concurrent caller workspace metadata isolated per request", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    delete process.env.CMUX_WORKSPACE_ID;
+    delete process.env.CMUX_TAB_ID;
+    const path = socketPath("caller-workspace-concurrent");
+    const calls: string[] = [];
+    const context = createServerContext({
+      client: createPlacementClient(
+        [
+          {
+            id: "workspace-x-uuid",
+            ref: "workspace:10",
+            title: "Caller X",
+            selected: false,
+          },
+          {
+            id: "workspace-y-uuid",
+            ref: "workspace:11",
+            title: "Caller Y",
+            selected: false,
+          },
+          {
+            id: "focused-workspace-uuid",
+            ref: "workspace:5",
+            title: "Focused Workspace",
+            selected: true,
+          },
+        ],
+        calls,
+      ) as any,
+      stateDir: stateDir("caller-workspace-concurrent-state"),
+      disableSpawnPreflight: true,
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      context,
+      disableSpawnPreflight: true,
+    });
+
+    try {
+      await daemon.start();
+
+      const [xResponse, yResponse] = await Promise.all([
+        rawToolCall(path, {
+          name: "spawn_agent",
+          arguments: {
+            repo: "brainlayer",
+            model: "gpt-5.5",
+            cli: "codex",
+            force_new: true,
+          },
+          _meta: {
+            "cmuxlayer/callerContext": {
+              workspaceId: "workspace-x-uuid",
+              surfaceId: "surface:x",
+            },
+          },
+        }),
+        rawToolCall(path, {
+          name: "spawn_agent",
+          arguments: {
+            repo: "voicelayer",
+            model: "gpt-5.5",
+            cli: "codex",
+            force_new: true,
+          },
+          _meta: {
+            "cmuxlayer/callerContext": {
+              workspaceId: "workspace-y-uuid",
+              surfaceId: "surface:y",
+            },
+          },
+        }),
+      ]);
+
+      expect(xResponse.result?.structuredContent).toMatchObject({
+        ok: true,
+        workspace_id: "workspace:10",
+      });
+      expect(yResponse.result?.structuredContent).toMatchObject({
+        ok: true,
+        workspace_id: "workspace:11",
+      });
+      expect(calls).toContain("spawn:workspace:10");
+      expect(calls).toContain("spawn:workspace:11");
+      expect(calls).not.toContain("spawn:workspace:5");
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+      await daemon.shutdown().catch(() => {});
+    }
   });
 
   it("serves the same list_agents and read_screen state as a direct in-process server", async () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -150,6 +150,20 @@ function isResponseFor(id: number) {
     ("result" in message || "error" in message);
 }
 
+function callerContextMeta(message: JSONRPCMessage): unknown {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("params" in message) ||
+    typeof message.params !== "object" ||
+    message.params === null
+  ) {
+    return undefined;
+  }
+  const params = message.params as { _meta?: Record<string, unknown> };
+  return params._meta?.["cmuxlayer/callerContext"];
+}
+
 class FakeDaemon {
   readonly connections: Array<{
     socket: net.Socket;
@@ -392,6 +406,62 @@ describe("CmuxLayerProxy", () => {
       0,
       (message) => "method" in message && message.method === "tools/list",
     );
+  });
+
+  it("attaches caller cmux env to each forwarded tool call", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    const previousTabId = process.env.CMUX_TAB_ID;
+    const previousSurfaceId = process.env.CMUX_SURFACE_ID;
+    process.env.CMUX_WORKSPACE_ID = "workspace-x-uuid";
+    process.env.CMUX_TAB_ID = "tab-x";
+    process.env.CMUX_SURFACE_ID = "surface-x";
+
+    try {
+      const path = socketPath("caller-context");
+      const daemon = new FakeDaemon(path);
+      daemons.push(daemon);
+      await daemon.start();
+      const { input, collector } = createProxy(path);
+
+      writeFrame(input, request(1, "initialize", { capabilities: {} }));
+      await collector.waitForMessage(isResponseFor(1));
+      writeFrame(input, notification("notifications/initialized"));
+      writeFrame(
+        input,
+        request(2, "tools/call", {
+          name: "spawn_agent",
+          arguments: { repo: "brainlayer", cli: "codex" },
+        }),
+      );
+
+      await collector.waitForMessage(isResponseFor(2));
+      const forwarded = await daemon.waitForMessage(
+        0,
+        (message) => "method" in message && message.method === "tools/call",
+      );
+      expect(callerContextMeta(forwarded)).toEqual({
+        workspaceId: "workspace-x-uuid",
+        tabId: "tab-x",
+        surfaceId: "surface-x",
+      });
+    } finally {
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+      if (previousTabId === undefined) {
+        delete process.env.CMUX_TAB_ID;
+      } else {
+        process.env.CMUX_TAB_ID = previousTabId;
+      }
+      if (previousSurfaceId === undefined) {
+        delete process.env.CMUX_SURFACE_ID;
+      } else {
+        process.env.CMUX_SURFACE_ID = previousSurfaceId;
+      }
+    }
   });
 
   it("relays large daemon responses without parsing and reserializing the frame", async () => {


### PR DESCRIPTION
## Summary
- propagate per-agent caller env through the proxy on every `tools/call` via private MCP `_meta`
- run daemon request handling inside per-request caller context and resolve caller workspace before daemon env/focused fallback
- add raw daemon/socket regression coverage for blank daemon env and concurrent X/Y callers

## Verification
- `bun test tests/proxy.test.ts tests/daemon.test.ts`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `git diff --check`
- runtime receipt: built `dist/proxy.js` forwarded `cmuxlayer/callerContext` from child env over an isolated socket
- runtime receipt: built `dist/daemon.js` placed metadata-carried spawn in caller `workspace:1`, not focused `workspace:5`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace resolution for spawn and related tools; wrong metadata could misplace agents, but behavior is scoped to caller context with env/focused fallbacks and regression tests.
> 
> **Overview**
> Fixes agent spawn/placement targeting the wrong workspace when the shared daemon has no (or a different) `CMUX_*` env than the calling agent.
> 
> Adds **`caller-context`** with `AsyncLocalStorage`, env/message helpers, and MCP `_meta` key `cmuxlayer/callerContext` (`workspaceId`, `tabId`, `surfaceId`). The **proxy** stamps each forwarded `tools/call` with context from the agent’s env. The **daemon** runs inbound message handling inside that context and **`callerWorkspaceStrict`** prefers request metadata over daemon env before falling back to the focused workspace.
> 
> Tests cover proxy forwarding, single-request metadata with blank daemon env, and concurrent callers with isolated workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e619b345d89ecf720cef3d47817824ef91f1b816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests now carry caller workspace, tab, and surface context through the system, improving routing and isolation for concurrent actions.
  * Workspace selection can now follow per-request context when available, instead of relying only on global environment settings.

* **Bug Fixes**
  * Fixed cases where requests could be routed to the wrong workspace during overlapping or parallel calls.
  * Improved consistency so incoming and forwarded requests preserve caller context end to end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon caller workspace context using per-request `AsyncLocalStorage` propagation
> - Adds a new [caller-context.ts](https://github.com/EtanHey/cmuxlayer/pull/269/files#diff-5f4c85e0994fcf272853d647620639451653586cc9eb65ffd77c97922a179dca) module that extracts `workspaceId`/`tabId`/`surfaceId` from `tools/call` message metadata and propagates them via `AsyncLocalStorage`.
> - In [daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/269/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539), wraps each `onmessage` callback in `runWithCallerContext` so request handlers can call `currentCallerContext()` to get per-request workspace context.
> - In [server.ts](https://github.com/EtanHey/cmuxlayer/pull/269/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), workspace resolution now prefers per-request caller context over `CMUX_WORKSPACE_ID`/`CMUX_TAB_ID` environment variables.
> - In [proxy.ts](https://github.com/EtanHey/cmuxlayer/pull/269/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2), forwarded `tools/call` messages are stamped with `params._meta['cmuxlayer/callerContext']` populated from `CMUX_*` env vars so the daemon can recover the originating workspace.
> - Behavioral Change: concurrent requests to the daemon now carry isolated workspace contexts rather than sharing the process-level environment variables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e619b34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->