### PR TITLE
fix(health): downgrade column flags for resync-repaired seats

### DIFF
--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -120,10 +120,11 @@ function issueSeverity(
     screenActive: boolean;
     inboxMonitorWithinBootGrace: boolean;
     autoDiscovered: boolean;
+    lacksManagedPlacement: boolean;
   },
 ): AgentHealthIssueSeverity {
   if (
-    context.autoDiscovered &&
+    context.lacksManagedPlacement &&
     (code === "orchestrator_not_leftmost" ||
       code === "worker_in_leftmost_column")
   ) {
@@ -147,6 +148,7 @@ function deriveIssueSeverities(
     screenActive: boolean;
     inboxMonitorWithinBootGrace: boolean;
     autoDiscovered: boolean;
+    lacksManagedPlacement: boolean;
   },
 ): Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>> {
   const severities: Partial<
@@ -185,6 +187,11 @@ function isAutoDiscovered(agent: AgentRecord): boolean {
     agent.agent_id.startsWith("auto-") ||
     agent.task_summary === "(auto-discovered)"
   );
+}
+
+/** Seats cmuxlayer did not place via managed spawn_agent (won't move panes per #170). */
+function lacksManagedPlacement(agent: AgentRecord): boolean {
+  return isAutoDiscovered(agent) || agent.task_summary === "(resync-repaired)";
 }
 
 function looksLeadLike(text: string | null | undefined): boolean {
@@ -320,7 +327,10 @@ export function evaluateAgentHealth(
     );
   }
 
-  if (input.monitor_alive === false && input.inbox_channel_dir_deleted === true) {
+  if (
+    input.monitor_alive === false &&
+    input.inbox_channel_dir_deleted === true
+  ) {
     addIssue(
       issueCodes,
       issues,
@@ -508,6 +518,7 @@ export function evaluateAgentHealth(
   const issueSeverities = deriveIssueSeverities(issueCodes, {
     screenActive,
     autoDiscovered,
+    lacksManagedPlacement: lacksManagedPlacement(agent),
     inboxMonitorWithinBootGrace: isWithinInboxMonitorBootGrace(
       agent,
       deps.now?.() ?? Date.now(),

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -275,10 +275,13 @@ describe("agent lifecycle health", () => {
   });
 
   it("marks registry workspace mismatch against the live surface as unhealthy", () => {
-    const health = evaluateAgentHealth(makeRecord({ workspace_id: "workspace:5" }), {
-      monitor_alive: true,
-      surface_workspace_id: "workspace:1",
-    });
+    const health = evaluateAgentHealth(
+      makeRecord({ workspace_id: "workspace:5" }),
+      {
+        monitor_alive: true,
+        surface_workspace_id: "workspace:1",
+      },
+    );
 
     expect(health.status).toBe("unhealthy");
     expect(health.issue_codes).toContain("registry_surface_workspace_mismatch");
@@ -351,6 +354,92 @@ describe("agent lifecycle health", () => {
       issue_codes: [],
       issues: [],
     });
+  });
+
+  it("downgrades resync-repaired column placement flags to info", () => {
+    const repairedLead = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "driverBuddy",
+        cli: "claude",
+        role: "orchestrator",
+        repo: "driverBuddy",
+        launcher_name: "driverBuddyClaude",
+        seat_id: "driverBuddy",
+        task_summary: "(resync-repaired)",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "driverBuddy",
+        topology: { column: 1, column_count: 2 },
+      },
+    );
+    const repairedWorker = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "pr3-quadratic-fix",
+        role: "worker",
+        launcher_name: "cmuxlayerCodex",
+        task_summary: "(resync-repaired)",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "pr3-quadratic-fix",
+        topology: { column: 0, column_count: 2 },
+      },
+    );
+
+    expect(repairedLead.status).toBe("healthy");
+    expect(repairedLead.issue_codes).toContain("orchestrator_not_leftmost");
+    expect(repairedLead.issue_severities).toMatchObject({
+      orchestrator_not_leftmost: "info",
+    });
+    expect(repairedLead.issue_codes).not.toContain("auto_discovered_agent");
+
+    expect(repairedWorker.status).toBe("healthy");
+    expect(repairedWorker.issue_codes).toContain("worker_in_leftmost_column");
+    expect(repairedWorker.issue_severities).toMatchObject({
+      worker_in_leftmost_column: "info",
+    });
+    expect(repairedWorker.issue_codes).not.toContain("auto_discovered_agent");
+  });
+
+  it("keeps managed spawn_agent column placement flags blocking", () => {
+    const managedLead = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "cmuxlayerLead",
+        cli: "claude",
+        role: "orchestrator",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerClaude",
+        seat_id: "cmuxlayerLead",
+        task_summary: "Coordinate the column-flag follow-up",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "cmuxlayerClaude",
+        topology: { column: 1, column_count: 2 },
+      },
+    );
+    const managedWorker = evaluateAgentHealth(
+      makeRecord({
+        agent_id: "cmuxlayerCodex-pending-1-abcd",
+        role: "worker",
+        task_summary: "Implement the column-flag fix",
+      }),
+      {
+        monitor_alive: true,
+        surface_title: "cmuxlayerCodex",
+        topology: { column: 0, column_count: 2 },
+      },
+    );
+
+    expect(managedLead.status).toBe("unhealthy");
+    expect(managedLead.issue_severities?.orchestrator_not_leftmost).toBe(
+      "blocking",
+    );
+    expect(managedWorker.status).toBe("unhealthy");
+    expect(managedWorker.issue_severities?.worker_in_leftmost_column).toBe(
+      "blocking",
+    );
   });
 
   it("downgrades auto-discovered column placement flags to info", () => {


### PR DESCRIPTION
## Summary
- Extends #268 B2 column-topology downgrade from auto-discovered agents to resync-repaired seats (`task_summary: "(resync-repaired)"`), matching seats cmuxlayer never placed via managed `spawn_agent`.
- Managed spawn_agent-placed orchestrators/workers in wrong columns still surface blocking `orchestrator_not_leftmost` / `worker_in_leftmost_column` flags.

## Test plan
- [x] `tests/agent-health.test.ts` — repaired seats in wrong column → `info`, not `unhealthy`
- [x] `tests/agent-health.test.ts` — managed spawn seats in wrong column → still `blocking`
- [x] Full suite (1509 tests), typecheck, build green


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Downgrade column placement issue severity for resync-repaired agents
> - Introduces a `lacksManagedPlacement` helper in [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/270/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3) that returns `true` for auto-discovered agents or those with `task_summary` equal to `'(resync-repaired)'`.
> - Replaces the `autoDiscovered`-only condition in `issueSeverity` with `lacksManagedPlacement`, so `orchestrator_not_leftmost` and `worker_in_leftmost_column` issues are downgraded to `info` severity for resync-repaired agents in addition to auto-discovered ones.
> - Behavioral Change: resync-repaired agents with column placement issues no longer contribute a `blocking` severity, which may change the computed overall health status for those agents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e07351b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted agent health severity handling for leftmost-column placement issues so repaired agents are treated differently from fully managed agents.
  * Agents marked as resync-repaired now receive a less severe status for certain placement warnings, while managed spawn agents remain flagged as unhealthy in those cases.
  * No behavior change for inbox health checks; related formatting changes only.

* **Tests**
  * Expanded coverage for column placement and inbox health scenarios to reflect the updated severity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->