### PR TITLE
feat: daemon transport self-healing and proxy version-bump reconnect

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -1,73 +1,61 @@
 /**
  * Factory: creates the best available cmux client.
- * Tries socket first (1,400x faster), falls back to CLI.
+ * Tries socket first (1,400x faster), falls back to CLI with live upgrade.
  */
 
-import * as net from "node:net";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
-import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
 import { CmuxSocketClient } from "./cmux-socket-client.js";
-import { cmuxSocketPathCandidates } from "./cmux-socket-path.js";
+import {
+  candidateSocketPathsForOpts,
+  probeUsableSocket,
+  resolveSocketPath,
+  type SocketProbeOptions,
+} from "./cmux-socket-probe.js";
+import {
+  DEFAULT_PING_RETRY_ATTEMPTS,
+  DEFAULT_PING_RETRY_BACKOFF_MS,
+  wrapCliWithSelfHeal,
+} from "./cmux-transport-self-heal.js";
 
-export interface CreateCmuxClientOptions {
-  socketPath?: string;
-  /** Override cmux state dir for tests or nonstandard installs */
-  socketStateDir?: string;
+export interface CreateCmuxClientOptions extends SocketProbeOptions {
   /** CLI exec function (for testing) */
   exec?: ExecFn;
   /** CLI binary name */
   bin?: string;
-  /** Socket timeout in ms */
-  timeoutMs?: number;
-  /** Password for socket access mode "password" */
-  password?: string;
   /** Boot transport logger; defaults to console */
   logger?: Pick<Console, "error">;
+  /** Startup ping probe attempts per candidate (default 3) */
+  pingRetryAttempts?: number;
+  /** Backoff ms between startup ping retries */
+  pingRetryBackoffMs?: readonly number[];
+  /** Injectable sleep for tests */
+  sleep?: (ms: number) => Promise<void>;
+  /** CLI→socket live re-probe interval when degraded (default 5s) */
+  reprobeIntervalMs?: number;
 }
 
-/**
- * Bound on the probe `system.ping`. A wedged cmux can ACCEPT the socket connect
- * but never answer (the Surface.deinit deadlock), and probing every candidate
- * would otherwise inherit the 10s request timeout and stall startup ~10s per
- * hung instance. The probe only needs a liveness yes/no, so cap it short.
- */
-const PROBE_PING_TIMEOUT_MS = 2000;
+async function probeUsableSocketWithRetry(
+  socketPath: string,
+  opts?: CreateCmuxClientOptions,
+): Promise<boolean> {
+  const attempts = opts?.pingRetryAttempts ?? DEFAULT_PING_RETRY_ATTEMPTS;
+  const backoff = opts?.pingRetryBackoffMs ?? DEFAULT_PING_RETRY_BACKOFF_MS;
+  const sleep = opts?.sleep ?? defaultSleep;
 
-/**
- * Probe whether a Unix socket is listening.
- * Connects, immediately disconnects. Returns true if connect succeeds.
- */
-function probeSocket(path: string, timeoutMs = 1000): Promise<boolean> {
-  return new Promise((resolve) => {
-    const sock = net.createConnection({ path }, () => {
-      sock.destroy();
-      resolve(true);
-    });
-    const timer = setTimeout(() => {
-      sock.destroy();
-      resolve(false);
-    }, timeoutMs);
-    sock.on("error", () => {
-      clearTimeout(timer);
-      resolve(false);
-    });
-    sock.on("connect", () => clearTimeout(timer));
-  });
-}
-
-async function resolveSocketPath(
-  opts?: Pick<
-    CreateCmuxClientOptions,
-    "socketPath" | "socketStateDir" | "timeoutMs" | "password"
-  >,
-): Promise<string | null> {
-  for (const candidate of candidateSocketPaths(opts)) {
-    if (await probeUsableSocket(candidate, opts)) {
-      return candidate;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (await probeUsableSocket(socketPath, opts)) {
+      return true;
+    }
+    if (attempt < attempts - 1) {
+      const delayMs = backoff[attempt] ?? backoff[backoff.length - 1] ?? 100;
+      await sleep(delayMs);
     }
   }
+  return false;
+}
 
-  return null;
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function instancePin(
@@ -78,55 +66,10 @@ function instancePin(
   return fromEnv.length > 0 ? fromEnv : undefined;
 }
 
-function candidateSocketPaths(
-  opts?: Pick<CreateCmuxClientOptions, "socketPath" | "socketStateDir">,
-): string[] {
-  // An explicit socketPath or CMUX_SOCKET_PATH is AUTHORITATIVE: cmux sets
-  // CMUX_SOCKET_PATH in each agent's env to point at the instance that spawned
-  // it, so when it is present we bind to that one instance only and never fall
-  // through to another cmux's socket (which is how panes ended up in a
-  // different / nightly app). Only when nothing is pinned do we probe the
-  // ordered candidate list.
-  const pinned = instancePin(opts);
-  if (pinned) return [pinned];
-  return cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
-}
-
-async function probeUsableSocket(
-  socketPath: string,
-  opts?: Pick<CreateCmuxClientOptions, "timeoutMs" | "password">,
-): Promise<boolean> {
-  if (!(await probeSocket(socketPath, opts?.timeoutMs))) {
-    return false;
-  }
-
-  const transport = new CmuxPersistentSocket({
-    socketPath,
-    // Cap the probe ping so a hung-but-accepting candidate can't stall the
-    // probe-all loop by the full request timeout. A caller-supplied timeout
-    // (tests) still wins when smaller.
-    timeoutMs: Math.min(
-      opts?.timeoutMs ?? PROBE_PING_TIMEOUT_MS,
-      PROBE_PING_TIMEOUT_MS,
-    ),
-  });
-
-  try {
-    if (opts?.password) {
-      await transport.call("auth.login", { password: opts.password });
-    }
-    const result = await transport.call<{ pong: boolean }>("system.ping");
-    return result.pong === true;
-  } catch {
-    return false;
-  } finally {
-    transport.disconnect();
-  }
-}
-
 /**
  * Create the best available cmux client.
- * Tries socket first (0.2ms per op), falls back to CLI (287ms per op).
+ * Tries socket first (0.2ms per op), falls back to CLI (287ms per op) with
+ * periodic socket re-probe and live upgrade when the app recovers.
  */
 export async function createCmuxClient(
   opts?: CreateCmuxClientOptions,
@@ -134,16 +77,12 @@ export async function createCmuxClient(
   const logger = opts?.logger ?? console;
   const cliFallback = new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
 
-  const candidates = candidateSocketPaths(opts);
+  const candidates = candidateSocketPathsForOpts(opts);
   const pinned = instancePin(opts) !== undefined;
 
-  // Probe every candidate up front. Dead candidates fail instantly (the socket
-  // path does not exist → ENOENT), so this stays cheap, and it lets us detect
-  // when more than one cmux instance is actually LIVE — the real "which app?"
-  // ambiguity — rather than warning on every multi-path candidate list.
   const usable: string[] = [];
   for (const socketPath of candidates) {
-    if (await probeUsableSocket(socketPath, opts)) {
+    if (await probeUsableSocketWithRetry(socketPath, opts)) {
       usable.push(socketPath);
     }
   }
@@ -156,14 +95,10 @@ export async function createCmuxClient(
       cliFallback,
       socketPathResolver: () => resolveSocketPath(opts),
     });
-    // Verify socket actually works (catches auth failures)
     try {
       await client.ping();
       logger.error("[cmuxlayer] transport selected: socket");
       if (!pinned && usable.length > 1) {
-        // Multiple cmux instances are live and nothing pins us to one: surface
-        // which we bound to so a wrong-app/window placement is diagnosable and
-        // the operator can pin it explicitly.
         logger.error(
           `[cmuxlayer] ${usable.length} live cmux sockets found and CMUX_SOCKET_PATH ` +
             `is not set; bound to ${socketPath} by probe order. If new panes open in the ` +
@@ -173,11 +108,22 @@ export async function createCmuxClient(
       }
       return client;
     } catch {
-      // Socket reachable but not usable (auth required, protocol mismatch, etc.)
-      // Try the next usable candidate before falling through to CLI.
+      // Socket reachable but not usable — try next candidate before CLI.
     }
   }
 
-  logger.error("[cmuxlayer] transport selected: cli");
-  return cliFallback;
+  logger.error("[cmuxlayer] transport selected: cli (degraded)");
+  return wrapCliWithSelfHeal(cliFallback, {
+    socketPath: candidates[0] ?? null,
+    factoryOpts: opts,
+    reprobeIntervalMs: opts?.reprobeIntervalMs,
+    logger,
+    sleep: opts?.sleep,
+  }) as unknown as CmuxClient;
 }
+
+export {
+  candidateSocketPathsForOpts,
+  probeUsableSocket,
+  resolveSocketPath,
+} from "./cmux-socket-probe.js";

--- a/src/cmux-socket-probe.ts
+++ b/src/cmux-socket-probe.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared socket probe helpers for createCmuxClient and transport self-healing.
+ */
+
+import * as net from "node:net";
+import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
+import { cmuxSocketPathCandidates } from "./cmux-socket-path.js";
+
+export interface SocketProbeOptions {
+  socketPath?: string;
+  socketStateDir?: string;
+  timeoutMs?: number;
+  password?: string;
+}
+
+/**
+ * Bound on the probe `system.ping`. A wedged cmux can ACCEPT the socket connect
+ * but never answer (the Surface.deinit deadlock), and probing every candidate
+ * would otherwise inherit the 10s request timeout and stall startup ~10s per
+ * hung instance. The probe only needs a liveness yes/no, so cap it short.
+ */
+const PROBE_PING_TIMEOUT_MS = 2000;
+
+/**
+ * Probe whether a Unix socket is listening.
+ * Connects, immediately disconnects. Returns true if connect succeeds.
+ */
+function probeSocket(path: string, timeoutMs = 1000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ path }, () => {
+      sock.destroy();
+      resolve(true);
+    });
+    const timer = setTimeout(() => {
+      sock.destroy();
+      resolve(false);
+    }, timeoutMs);
+    sock.on("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+    sock.on("connect", () => clearTimeout(timer));
+  });
+}
+
+function instancePin(
+  opts?: Pick<SocketProbeOptions, "socketPath">,
+): string | undefined {
+  if (opts?.socketPath) return opts.socketPath;
+  const fromEnv = (process.env.CMUX_SOCKET_PATH ?? "").trim();
+  return fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+export function candidateSocketPathsForOpts(
+  opts?: Pick<SocketProbeOptions, "socketPath" | "socketStateDir">,
+): string[] {
+  const pinned = instancePin(opts);
+  if (pinned) return [pinned];
+  return cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
+}
+
+export async function probeUsableSocket(
+  socketPath: string,
+  opts?: Pick<SocketProbeOptions, "timeoutMs" | "password">,
+): Promise<boolean> {
+  if (!(await probeSocket(socketPath, opts?.timeoutMs))) {
+    return false;
+  }
+
+  const transport = new CmuxPersistentSocket({
+    socketPath,
+    timeoutMs: Math.min(
+      opts?.timeoutMs ?? PROBE_PING_TIMEOUT_MS,
+      PROBE_PING_TIMEOUT_MS,
+    ),
+  });
+
+  try {
+    if (opts?.password) {
+      await transport.call("auth.login", { password: opts.password });
+    }
+    const result = await transport.call<{ pong: boolean }>("system.ping");
+    return result.pong === true;
+  } catch {
+    return false;
+  } finally {
+    transport.disconnect();
+  }
+}
+
+export async function resolveSocketPath(
+  opts?: SocketProbeOptions,
+): Promise<string | null> {
+  for (const candidate of candidateSocketPathsForOpts(opts)) {
+    if (await probeUsableSocket(candidate, opts)) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -1,0 +1,278 @@
+/**
+ * CLI→socket transport self-healing for createCmuxClient.
+ * When startup socket probes fail, the daemon runs degraded on CLI but
+ * periodically re-probes and upgrades without a process restart.
+ */
+
+import { CmuxClient } from "./cmux-client.js";
+import { CmuxSocketClient } from "./cmux-socket-client.js";
+import type { CreateCmuxClientOptions } from "./cmux-client-factory.js";
+import {
+  candidateSocketPathsForOpts,
+  probeUsableSocket,
+  resolveSocketPath,
+} from "./cmux-socket-probe.js";
+
+export const DEFAULT_PING_RETRY_ATTEMPTS = 3;
+export const DEFAULT_PING_RETRY_BACKOFF_MS = [100, 250, 500] as const;
+export const DEFAULT_TRANSPORT_REPROBE_MS = 5_000;
+
+export interface TransportHealthSignal {
+  mode: "socket" | "cli";
+  degraded: boolean;
+  current_socket_path?: string | null;
+}
+
+export interface CmuxSelfHealingClientOptions {
+  cli: CmuxClient;
+  /** Primary socket path to re-probe for upgrade; may be null when unpinned and all dead. */
+  socketPath: string | null;
+  factoryOpts?: CreateCmuxClientOptions;
+  reprobeIntervalMs?: number;
+  logger?: Pick<Console, "error">;
+  sleep?: (ms: number) => Promise<void>;
+  probeUsable?: typeof probeUsableSocket;
+  resolvePath?: typeof resolveSocketPath;
+}
+
+type CmuxLayerClient = CmuxClient | CmuxSocketClient;
+
+const FORWARDED_ASYNC_METHODS = [
+  "listWorkspaces",
+  "listPaneSurfaces",
+  "listPanes",
+  "listTerminalMetadata",
+  "newSplit",
+  "newSurface",
+  "moveSurface",
+  "reorderSurface",
+  "send",
+  "pasteText",
+  "sendKey",
+  "selectWorkspace",
+  "createWorkspace",
+  "readScreen",
+  "renameTab",
+  "notify",
+  "setStatus",
+  "clearStatus",
+  "setProgress",
+  "clearProgress",
+  "log",
+  "closeSurface",
+  "listStatus",
+  "identify",
+  "browser",
+] as const;
+
+export function getTransportHealth(
+  client: unknown,
+): TransportHealthSignal | null {
+  if (
+    client &&
+    typeof client === "object" &&
+    "getTransportHealth" in client &&
+    typeof (client as { getTransportHealth: unknown }).getTransportHealth ===
+      "function"
+  ) {
+    return (
+      client as { getTransportHealth: () => TransportHealthSignal }
+    ).getTransportHealth();
+  }
+  if (client instanceof CmuxSocketClient) {
+    return {
+      mode: "socket",
+      degraded: false,
+      current_socket_path: client.currentSocketPath(),
+    };
+  }
+  if (client instanceof CmuxClient) {
+    return {
+      mode: "cli",
+      degraded: true,
+      current_socket_path: null,
+    };
+  }
+  return null;
+}
+
+export class CmuxSelfHealingClient {
+  private delegate: CmuxLayerClient;
+  private socketClient: CmuxSocketClient | null = null;
+  private inFlight = 0;
+  private reprobeTimer: NodeJS.Timeout | null = null;
+  private upgrading = false;
+  private stopped = false;
+
+  constructor(private readonly opts: CmuxSelfHealingClientOptions) {
+    this.delegate = opts.cli;
+    for (const method of FORWARDED_ASYNC_METHODS) {
+      (this as Record<string, unknown>)[method] = (...args: unknown[]) =>
+        this.trackInFlight(() =>
+          (
+            this.delegate as unknown as Record<
+              string,
+              (...inner: unknown[]) => Promise<unknown>
+            >
+          )[method](...args),
+        );
+    }
+    opts.logger?.error(
+      "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
+    );
+    this.startReprobe();
+  }
+
+  getTransportHealth(): TransportHealthSignal {
+    if (this.socketClient) {
+      return {
+        mode: "socket",
+        degraded: false,
+        current_socket_path: this.socketClient.currentSocketPath(),
+      };
+    }
+    return {
+      mode: "cli",
+      degraded: true,
+      current_socket_path: this.opts.socketPath,
+    };
+  }
+
+  setEnv(env: NodeJS.ProcessEnv | undefined): void {
+    this.opts.cli.setEnv(env);
+  }
+
+  currentSocketPath(): string | null {
+    if (
+      "currentSocketPath" in this.delegate &&
+      typeof this.delegate.currentSocketPath === "function"
+    ) {
+      return this.delegate.currentSocketPath();
+    }
+    return this.opts.socketPath;
+  }
+
+  async ping(): Promise<boolean> {
+    if (
+      !("ping" in this.delegate) ||
+      typeof this.delegate.ping !== "function"
+    ) {
+      return false;
+    }
+    return this.trackInFlight(async () => {
+      const delegate = this.delegate as CmuxSocketClient;
+      return delegate.ping();
+    });
+  }
+
+  disconnect(): void {
+    if (
+      "disconnect" in this.delegate &&
+      typeof this.delegate.disconnect === "function"
+    ) {
+      this.delegate.disconnect();
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reprobeTimer) {
+      clearInterval(this.reprobeTimer);
+      this.reprobeTimer = null;
+    }
+    this.disconnect();
+  }
+
+  private async trackInFlight<T>(fn: () => Promise<T>): Promise<T> {
+    this.inFlight += 1;
+    try {
+      return await fn();
+    } finally {
+      this.inFlight -= 1;
+    }
+  }
+
+  private startReprobe(): void {
+    const interval =
+      this.opts.reprobeIntervalMs ?? DEFAULT_TRANSPORT_REPROBE_MS;
+    this.reprobeTimer = setInterval(() => {
+      void this.tryUpgrade();
+    }, interval);
+    this.reprobeTimer.unref?.();
+  }
+
+  private async tryUpgrade(): Promise<void> {
+    if (this.stopped || this.socketClient || this.upgrading) {
+      return;
+    }
+    if (this.inFlight > 0) {
+      return;
+    }
+
+    const sleep = this.opts.sleep ?? defaultSleep;
+    const probe = this.opts.probeUsable ?? probeUsableSocket;
+    const factoryOpts = this.opts.factoryOpts;
+    const resolvePath = this.opts.resolvePath ?? resolveSocketPath;
+
+    let socketPath = this.opts.socketPath;
+    if (!socketPath) {
+      socketPath = await resolvePath(factoryOpts);
+    }
+    if (!socketPath) {
+      return;
+    }
+    if (!(await probe(socketPath, factoryOpts))) {
+      return;
+    }
+
+    this.upgrading = true;
+    try {
+      while (this.inFlight > 0) {
+        await sleep(10);
+      }
+
+      const cliFallback = this.opts.cli;
+      const client = new CmuxSocketClient({
+        socketPath,
+        timeoutMs: factoryOpts?.timeoutMs,
+        password: factoryOpts?.password,
+        cliFallback,
+        socketPathResolver: () => resolvePath(factoryOpts),
+      });
+      await client.ping();
+      this.socketClient = client;
+      this.delegate = client;
+      this.clearReprobe();
+      this.opts.logger?.error("[cmuxlayer] transport upgraded: cli -> socket");
+    } catch {
+      // Stay on CLI until the next re-probe tick.
+    } finally {
+      this.upgrading = false;
+    }
+  }
+
+  private clearReprobe(): void {
+    if (this.reprobeTimer) {
+      clearInterval(this.reprobeTimer);
+      this.reprobeTimer = null;
+    }
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function wrapCliWithSelfHeal(
+  cli: CmuxClient,
+  opts: Omit<CmuxSelfHealingClientOptions, "cli">,
+): CmuxSelfHealingClient {
+  return new CmuxSelfHealingClient({ cli, ...opts });
+}
+
+export function primaryCandidateSocketPath(
+  factoryOpts?: CreateCmuxClientOptions,
+): string | null {
+  const paths = candidateSocketPathsForOpts(factoryOpts);
+  return paths[0] ?? null;
+}

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { getTransportHealth } from "./cmux-transport-self-heal.js";
 import { constants as fsConstants } from "node:fs";
 import { access, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -77,6 +78,8 @@ export interface ControlHealth {
   selected_transport: {
     client_class: string | null;
     current_socket_path?: string;
+    transport_mode?: "socket" | "cli";
+    transport_degraded?: boolean;
   };
   cmux_instances: {
     production: CmuxInstanceHealth;
@@ -198,10 +201,7 @@ function splitPathEntries(pathValue: string | undefined): string[] {
 
 async function inspectExecutable(
   path: string,
-  deps: Pick<
-    Required<ControlHealthOptions>,
-    "readFile" | "stat" | "access"
-  >,
+  deps: Pick<Required<ControlHealthOptions>, "readFile" | "stat" | "access">,
 ): Promise<ExecutableStatus | null> {
   try {
     await deps.access(path, fsConstants.X_OK);
@@ -234,10 +234,7 @@ async function inspectExecutable(
 async function resolveExecutables(
   command: string,
   pathEntries: string[],
-  deps: Pick<
-    Required<ControlHealthOptions>,
-    "readFile" | "stat" | "access"
-  >,
+  deps: Pick<Required<ControlHealthOptions>, "readFile" | "stat" | "access">,
 ): Promise<ExecutableStatus[]> {
   const seen = new Set<string>();
   const found: ExecutableStatus[] = [];
@@ -300,15 +297,24 @@ function describeClient(client: unknown): ControlHealth["selected_transport"] {
     record && typeof record.currentSocketPath === "function"
       ? (record.currentSocketPath as () => unknown).call(client)
       : undefined;
+  const transportHealth = getTransportHealth(client);
 
   return {
     client_class:
       client && typeof client === "object"
-        ? (client as { constructor?: { name?: string } }).constructor?.name ??
-          null
+        ? ((client as { constructor?: { name?: string } }).constructor?.name ??
+          null)
         : null,
     ...(typeof currentSocketPath === "string"
       ? { current_socket_path: currentSocketPath }
+      : transportHealth?.current_socket_path
+        ? { current_socket_path: transportHealth.current_socket_path }
+        : {}),
+    ...(transportHealth
+      ? {
+          transport_mode: transportHealth.mode,
+          transport_degraded: transportHealth.degraded,
+        }
       : {}),
   };
 }
@@ -366,6 +372,15 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
     );
   }
 
+  if (
+    health.selected_transport.transport_degraded === true &&
+    !warnings.some((warning) => warning.includes("transport degraded"))
+  ) {
+    warnings.push(
+      "cmuxlayer control transport is degraded on CLI fallback; socket re-probe is active.",
+    );
+  }
+
   return warnings;
 }
 
@@ -394,7 +409,11 @@ export async function collectControlHealth(
   const [prodMarkers, nightlyMarkers, cmuxResolution, processList, ps] =
     await Promise.all([
       Promise.all([
-        readMarker("state_last_socket", join(stateDir, "last-socket-path"), deps),
+        readMarker(
+          "state_last_socket",
+          join(stateDir, "last-socket-path"),
+          deps,
+        ),
         readMarker(
           "tmp_last_socket",
           join(tmpDir, "cmux-last-socket-path"),
@@ -414,13 +433,7 @@ export async function collectControlHealth(
         ),
       ]),
       resolveExecutables("cmux", pathEntries, deps),
-      runOptional(deps.execFile, "ps", [
-        "ax",
-        "-o",
-        "pid=",
-        "-o",
-        "command=",
-      ]),
+      runOptional(deps.execFile, "ps", ["ax", "-o", "pid=", "-o", "command="]),
       runOptional(deps.execFile, "ps", [
         "-o",
         "pid=",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,10 +24,7 @@ import {
 import type { ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import type { CmuxClient } from "./cmux-client.js";
-import type {
-  CmuxServerContext,
-  CreateServerOptions,
-} from "./server.js";
+import type { CmuxServerContext, CreateServerOptions } from "./server.js";
 import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
 import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
 import { JsonRpcLineBuffer } from "./json-rpc-line-buffer.js";
@@ -38,6 +35,21 @@ import {
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const LISTEN_FD_START = 3;
+
+/**
+ * TODO(phase3-hot-reload): After Gemini research, implement drain→swap→resume on
+ * daemon version bump: pause accepts, drain in-flight MCP requests, hand off the
+ * listen socket to a successor process (launchd activation prior art), and
+ * resume proxy children without losing registry state.
+ */
+export interface DaemonHotReloadPlan {
+  readonly kind: "drain-swap-resume";
+  targetVersion: string;
+}
+
+export type DaemonHotReloadHandler = (
+  plan: DaemonHotReloadPlan,
+) => Promise<"not_implemented">;
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
 
@@ -95,7 +107,9 @@ export class SocketJsonRpcTransport implements Transport {
         settle(error);
       };
       const onClose = () => {
-        settle(new Error("SocketJsonRpcTransport closed before write completed"));
+        settle(
+          new Error("SocketJsonRpcTransport closed before write completed"),
+        );
       };
       const cleanup = () => {
         this.socket.off("error", onError);
@@ -183,8 +197,10 @@ export class SocketJsonRpcTransport implements Transport {
   }
 }
 
-export interface CmuxLayerDaemonOptions
-  extends Omit<CreateServerOptions, "context" | "client"> {
+export interface CmuxLayerDaemonOptions extends Omit<
+  CreateServerOptions,
+  "context" | "client"
+> {
   socketPath?: string;
   listenFd?: number;
   drainTimeoutMs?: number;
@@ -307,8 +323,7 @@ export class CmuxLayerDaemon {
 
   constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
     this.context = opts.context ?? null;
-    this.socketPath =
-      opts.socketPath ?? defaultDaemonSocketPath(process.env);
+    this.socketPath = opts.socketPath ?? defaultDaemonSocketPath(process.env);
     this.listenFd = opts.listenFd ?? parseListenFd(process.env);
     this.drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
   }
@@ -582,8 +597,7 @@ export async function runDaemon(
 }
 
 const isMain =
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
   runDaemon().catch((error) => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -282,6 +282,7 @@ export async function runDaemonFirstEntry(
       input,
       output: opts.output,
       logger,
+      spawnDaemonForVersionBump: spawnDaemon,
     });
     bindProxyStdioLifecycle({ input, proxy, logger, exit });
     return {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,12 +17,22 @@ import {
   attachCallerContextToMessage,
   callerContextFromEnv,
 } from "./caller-context.js";
+import type { SpawnDaemonOptions } from "./entry.js";
+import {
+  detectStaleBuild,
+  type DetectStaleBuildDeps,
+  type StaleBuildResult,
+  resolveInstalledDaemonScript,
+} from "./version.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.3;
 const DEFAULT_REQUEST_TIMEOUT_MS = 300_000;
 const DEFAULT_MAX_BUFFERED_REQUESTS = 100;
+const DEFAULT_STALE_RECHECK_INTERVAL_MS = 30_000;
+const DEFAULT_VERSION_BUMP_MAX_ATTEMPTS = 5;
+const DEFAULT_VERSION_BUMP_WINDOW_MS = 60_000;
 const PROXY_ERROR_CODE = -32001;
 
 export interface ReconnectDelayOptions {
@@ -30,6 +40,37 @@ export interface ReconnectDelayOptions {
   maxBackoffMs: number;
   jitterRatio: number;
   random: () => number;
+}
+
+export interface VersionBumpReconnectGuardOptions {
+  maxAttempts?: number;
+  windowMs?: number;
+  now?: () => number;
+}
+
+export class VersionBumpReconnectGuard {
+  private readonly maxAttempts: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly attempts: number[] = [];
+
+  constructor(opts: VersionBumpReconnectGuardOptions = {}) {
+    this.maxAttempts = opts.maxAttempts ?? DEFAULT_VERSION_BUMP_MAX_ATTEMPTS;
+    this.windowMs = opts.windowMs ?? DEFAULT_VERSION_BUMP_WINDOW_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  allow(): boolean {
+    const cutoff = this.now() - this.windowMs;
+    while (this.attempts.length > 0 && this.attempts[0] < cutoff) {
+      this.attempts.shift();
+    }
+    if (this.attempts.length >= this.maxAttempts) {
+      return false;
+    }
+    this.attempts.push(this.now());
+    return true;
+  }
 }
 
 export interface CmuxLayerProxyOptions {
@@ -45,6 +86,13 @@ export interface CmuxLayerProxyOptions {
   maxBufferedRequests?: number;
   onReconnectDelay?: (delayMs: number, attempt: number) => void;
   logger?: Pick<Console, "error">;
+  staleRecheckIntervalMs?: number;
+  detectStaleBuild?: (deps?: DetectStaleBuildDeps) => StaleBuildResult | null;
+  installedDaemonScriptPath?: () => string | null;
+  spawnDaemonForVersionBump?: (
+    opts: SpawnDaemonOptions,
+  ) => Promise<unknown> | unknown;
+  versionBumpReconnectGuard?: VersionBumpReconnectGuard;
 }
 
 type JsonRpcRequest = JSONRPCMessage & {
@@ -174,6 +222,15 @@ export class CmuxLayerProxy {
     attempt: number,
   ) => void;
   private readonly logger: Pick<Console, "error">;
+  private readonly staleRecheckIntervalMs: number;
+  private readonly detectStaleBuildFn: (
+    deps?: DetectStaleBuildDeps,
+  ) => StaleBuildResult | null;
+  private readonly installedDaemonScriptPath: () => string | null;
+  private readonly spawnDaemonForVersionBump?: (
+    opts: SpawnDaemonOptions,
+  ) => Promise<unknown> | unknown;
+  private readonly versionBumpReconnectGuard: VersionBumpReconnectGuard;
 
   private readonly agentReadBuffer = new JsonRpcLineBuffer();
   private daemonReadBuffer: JsonRpcLineBuffer | null = null;
@@ -190,6 +247,8 @@ export class CmuxLayerProxy {
   private reconnectAttempt = 0;
   private reconnectTimer: NodeJS.Timeout | null = null;
   private reconnectTimerResolve: (() => void) | null = null;
+  private versionBumpTimer: NodeJS.Timeout | null = null;
+  private versionBumpReconnecting = false;
   private readonly queue: QueuedMessage[] = [];
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly expiredRequestKeys = new Set<string>();
@@ -204,8 +263,7 @@ export class CmuxLayerProxy {
   };
 
   constructor(opts: CmuxLayerProxyOptions = {}) {
-    this.socketPath =
-      opts.socketPath ?? defaultDaemonSocketPath(process.env);
+    this.socketPath = opts.socketPath ?? defaultDaemonSocketPath(process.env);
     this.input = opts.input ?? process.stdin;
     this.output = opts.output ?? process.stdout;
     this.connect = opts.connect ?? ((path) => net.createConnection(path));
@@ -219,6 +277,14 @@ export class CmuxLayerProxy {
       opts.maxBufferedRequests ?? DEFAULT_MAX_BUFFERED_REQUESTS;
     this.onReconnectDelay = opts.onReconnectDelay;
     this.logger = opts.logger ?? console;
+    this.staleRecheckIntervalMs =
+      opts.staleRecheckIntervalMs ?? DEFAULT_STALE_RECHECK_INTERVAL_MS;
+    this.detectStaleBuildFn = opts.detectStaleBuild ?? detectStaleBuild;
+    this.installedDaemonScriptPath =
+      opts.installedDaemonScriptPath ?? resolveInstalledDaemonScript;
+    this.spawnDaemonForVersionBump = opts.spawnDaemonForVersionBump;
+    this.versionBumpReconnectGuard =
+      opts.versionBumpReconnectGuard ?? new VersionBumpReconnectGuard();
   }
 
   start(): void {
@@ -229,6 +295,7 @@ export class CmuxLayerProxy {
     this.input.on("data", this.onAgentData);
     this.input.on("error", this.onAgentError);
     this.ensureConnecting();
+    this.startVersionBumpWatcher();
   }
 
   async stop(): Promise<void> {
@@ -240,6 +307,7 @@ export class CmuxLayerProxy {
     this.input.off("error", this.onAgentError);
     this.agentReadBuffer.clear();
     this.clearReconnectTimer();
+    this.clearVersionBumpTimer();
     this.disconnectDaemon();
     for (const pending of this.pendingRequests.values()) {
       clearTimeout(pending.timeout);
@@ -777,6 +845,66 @@ export class CmuxLayerProxy {
     }
     this.reconnectTimerResolve?.();
     this.reconnectTimerResolve = null;
+  }
+
+  private startVersionBumpWatcher(): void {
+    this.versionBumpTimer = setInterval(() => {
+      void this.checkVersionBumpReconnect();
+    }, this.staleRecheckIntervalMs);
+    this.versionBumpTimer.unref?.();
+  }
+
+  private clearVersionBumpTimer(): void {
+    if (this.versionBumpTimer) {
+      clearInterval(this.versionBumpTimer);
+      this.versionBumpTimer = null;
+    }
+  }
+
+  private async checkVersionBumpReconnect(): Promise<void> {
+    if (!this.running || this.versionBumpReconnecting) {
+      return;
+    }
+    const stale = this.detectStaleBuildFn();
+    if (!stale?.stale) {
+      return;
+    }
+    if (!this.versionBumpReconnectGuard.allow()) {
+      this.logger.error(
+        "[cmuxlayer-proxy] version-bump reconnect storm guard tripped; backing off",
+      );
+      return;
+    }
+
+    this.versionBumpReconnecting = true;
+    try {
+      this.logger.error(
+        `[cmuxlayer-proxy] installed version bump detected (running v${stale.running}, installed v${stale.installed}); reconnecting to daemon`,
+      );
+      const daemonScriptPath = this.installedDaemonScriptPath();
+      if (daemonScriptPath && this.spawnDaemonForVersionBump) {
+        try {
+          await this.spawnDaemonForVersionBump({
+            socketPath: this.socketPath,
+            env: process.env,
+            logger: this.logger,
+            daemonScriptPath,
+          });
+        } catch (error) {
+          this.logger.error(
+            "[cmuxlayer-proxy] failed to spawn installed daemon for version bump",
+            error,
+          );
+        }
+      }
+      this.clearReconnectTimer();
+      this.disconnectDaemon();
+      this.daemonReady = false;
+      this.reconnectAttempt = 0;
+      this.ensureConnecting();
+    } finally {
+      this.versionBumpReconnecting = false;
+    }
   }
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -113,10 +113,20 @@ function resolveBrewPrefix(): string | null {
 }
 
 /** Default installed-package.json path under the brew opt tree. */
-function defaultOptPackageJsonPath(): string | null {
+export function defaultOptPackageJsonPath(): string | null {
   const prefix = resolveBrewPrefix();
   if (!prefix) return null;
   return join(prefix, "opt", "cmuxlayer", "package.json");
+}
+
+/**
+ * Resolve the brew-installed daemon entrypoint for version-bump reconnect.
+ * Returns null when the opt tree cannot be resolved.
+ */
+export function resolveInstalledDaemonScript(): string | null {
+  const optPackageJson = defaultOptPackageJsonPath();
+  if (!optPackageJson) return null;
+  return join(dirname(optPackageJson), "dist", "daemon.js");
 }
 
 /**

--- a/tests/cmux-socket-probe.test.ts
+++ b/tests/cmux-socket-probe.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { candidateSocketPathsForOpts } from "../src/cmux-socket-probe.js";
+
+describe("cmux-socket-probe", () => {
+  it("honors an explicit socketPath pin in candidate order", () => {
+    expect(
+      candidateSocketPathsForOpts({
+        socketPath: "/tmp/pinned.sock",
+        socketStateDir: "/tmp/state",
+      }),
+    ).toEqual(["/tmp/pinned.sock"]);
+  });
+});

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Phase 3 Scope A — transport self-healing (ping retry, CLI→socket upgrade, health).
+ */
+import * as fs from "node:fs";
+import * as net from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CmuxClient } from "../src/cmux-client.js";
+import { CmuxSocketClient } from "../src/cmux-socket-client.js";
+import { createCmuxClient } from "../src/cmux-client-factory.js";
+import {
+  CmuxSelfHealingClient,
+  getTransportHealth,
+  wrapCliWithSelfHeal,
+} from "../src/cmux-transport-self-heal.js";
+
+const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
+
+function startPingServer(
+  socketPath: string,
+  opts: { respondAfterAttempts?: number } = {},
+): Promise<{ server: net.Server; attempts: { count: number } }> {
+  const attempts = { count: 0 };
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+          attempts.count += 1;
+          const respondAfter = opts.respondAfterAttempts ?? 0;
+          if (attempts.count <= respondAfter) {
+            continue;
+          }
+          const req = JSON.parse(line);
+          conn.write(
+            JSON.stringify({ id: req.id, ok: true, result: { pong: true } }) +
+              "\n",
+          );
+        }
+      });
+    });
+    (server as unknown as { _conns: Set<net.Socket> })._conns = connections;
+    server.listen(socketPath, () => resolve({ server, attempts }));
+  });
+}
+
+function stopPingServer(server: net.Server, socketPath: string): Promise<void> {
+  return new Promise((resolve) => {
+    const conns = (server as unknown as { _conns: Set<net.Socket> })._conns;
+    for (const conn of conns ?? []) conn.destroy();
+    server.close(() => {
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        /* ignore */
+      }
+      resolve();
+    });
+  });
+}
+
+describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
+  const servers: Array<{ server: net.Server; path: string }> = [];
+
+  afterEach(async () => {
+    for (const { server, path } of servers.splice(0)) {
+      await stopPingServer(server, path);
+    }
+  });
+
+  function track(server: net.Server, path: string): void {
+    servers.push({ server, path });
+  }
+
+  it("retries startup system.ping before falling back to CLI", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-retry-"));
+    const socketPath = join(stateDir, "flaky.sock");
+    const { server } = await startPingServer(socketPath, {
+      respondAfterAttempts: 2,
+    });
+    track(server, socketPath);
+    const logger = { error: vi.fn() };
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const client = await createCmuxClient({
+      socketPath,
+      logger,
+      pingRetryAttempts: 3,
+      pingRetryBackoffMs: [1, 1],
+      sleep,
+    });
+
+    expect(client).toBeInstanceOf(CmuxSocketClient);
+    expect(sleep).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport selected: socket",
+    );
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("upgrades from CLI to socket when the app recovers", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-upgrade-"));
+    const socketPath = join(stateDir, "late.sock");
+    const logger = { error: vi.fn() };
+    const exec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+
+    const client = await createCmuxClient({
+      socketPath,
+      exec,
+      logger,
+      pingRetryAttempts: 1,
+      reprobeIntervalMs: 20,
+    });
+
+    expect(client).not.toBeInstanceOf(CmuxSocketClient);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+    });
+
+    const { server } = await startPingServer(socketPath);
+    track(server, socketPath);
+
+    await vi.waitFor(
+      async () => {
+        expect(await client.ping()).toBe(true);
+      },
+      { timeout: 2_000, interval: 25 },
+    );
+
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "socket",
+      degraded: false,
+      current_socket_path: socketPath,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport upgraded: cli -> socket",
+    );
+    if ("stop" in client && typeof client.stop === "function") {
+      client.stop();
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("drains in-flight CLI calls before upgrading to socket", async () => {
+    const socketPath = join(tmpdir(), `cmux-drain-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    let releaseCli!: () => void;
+    const cliGate = new Promise<void>((resolve) => {
+      releaseCli = resolve;
+    });
+    const exec = vi.fn().mockImplementation(async () => {
+      await cliGate;
+      return {
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      };
+    });
+    const cli = new CmuxClient({ exec });
+    const probe = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    const client = wrapCliWithSelfHeal(cli, {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 15,
+      probeUsable: probe,
+      factoryOpts: { socketPath },
+    });
+
+    const listPromise = client.listWorkspaces();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(probe).not.toHaveBeenCalledWith(socketPath, expect.anything());
+
+    const { server } = await startPingServer(socketPath);
+    track(server, socketPath);
+    releaseCli();
+    await listPromise;
+
+    await vi.waitFor(
+      async () => {
+        expect(getTransportHealth(client)?.mode).toBe("socket");
+      },
+      { timeout: 2_000, interval: 25 },
+    );
+    client.stop();
+  });
+
+  it("reports degraded CLI transport via getTransportHealth", () => {
+    const cli = new CmuxClient();
+    const client = new CmuxSelfHealingClient({
+      cli,
+      socketPath: "/tmp/example.sock",
+      reprobeIntervalMs: 60_000,
+    });
+
+    expect(getTransportHealth(client)).toEqual({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: "/tmp/example.sock",
+    });
+    client.stop();
+  });
+});

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Phase 3 Scope B — proxy child version-bump auto-reconnect.
+ */
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ReadBuffer,
+  serializeMessage,
+} from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { CmuxLayerProxy, VersionBumpReconnectGuard } from "../src/proxy.js";
+
+const TEST_ROOT = join("/tmp", "cmuxlayer-proxy-version-bump");
+
+function socketPath(name: string): string {
+  return join(TEST_ROOT, `${name}-${process.pid}-${Date.now()}.sock`);
+}
+
+function writeFrame(stream: NodeJS.WritableStream, message: JSONRPCMessage) {
+  stream.write(serializeMessage(message));
+}
+
+function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error("timed out waiting for condition"));
+        return;
+      }
+      setTimeout(tick, 5);
+    };
+    tick();
+  });
+}
+
+function createCollector(stream: NodeJS.ReadableStream) {
+  const messages: JSONRPCMessage[] = [];
+  const events = new EventEmitter();
+  const readBuffer = new ReadBuffer();
+  stream.on("data", (chunk: Buffer) => {
+    readBuffer.append(chunk);
+    while (true) {
+      const message = readBuffer.readMessage();
+      if (message === null) {
+        break;
+      }
+      messages.push(message);
+      events.emit("message", message);
+    }
+  });
+  return { messages };
+}
+
+class FakeDaemon {
+  private server: net.Server | null = null;
+  readonly connections: net.Socket[] = [];
+
+  constructor(private readonly path: string) {}
+
+  async start(): Promise<void> {
+    rmSync(this.path, { force: true });
+    this.server = net.createServer((socket) => {
+      this.connections.push(socket);
+      let buffer = "";
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          if (!line.trim()) continue;
+          const req = JSON.parse(line);
+          if (req.method === "initialize") {
+            socket.write(
+              serializeMessage({
+                jsonrpc: "2.0",
+                id: req.id,
+                result: {
+                  protocolVersion: "2024-11-05",
+                  serverInfo: { name: "cmuxlayer", version: "0.3.31" },
+                  capabilities: {},
+                },
+              }),
+            );
+            return;
+          }
+          if (req.method === "tools/list") {
+            socket.write(
+              serializeMessage({
+                jsonrpc: "2.0",
+                id: req.id,
+                result: { tools: [] },
+              }),
+            );
+          }
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      this.server?.once("error", reject);
+      this.server?.listen(this.path, () => {
+        this.server?.off("error", reject);
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    for (const socket of this.connections.splice(0)) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      this.server?.close(() => resolve());
+    });
+    this.server = null;
+  }
+}
+
+describe("proxy version-bump auto-reconnect", () => {
+  const daemons: FakeDaemon[] = [];
+  const proxies: CmuxLayerProxy[] = [];
+
+  afterEach(async () => {
+    for (const proxy of proxies.splice(0)) {
+      await proxy.stop();
+    }
+    for (const daemon of daemons.splice(0)) {
+      await daemon.stop();
+    }
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("reconnects to the daemon when an installed-version bump is detected", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("bump");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    let stale = false;
+    const detectStaleBuild = vi.fn(() =>
+      stale
+        ? { stale: true, running: "0.3.30", installed: "0.3.31" }
+        : { stale: false, running: "0.3.30", installed: "0.3.30" },
+    );
+
+    const input = new PassThrough();
+    const output = new PassThrough();
+    createCollector(output);
+    const logger = { error: vi.fn() };
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      logger,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      reconnectJitterRatio: 0,
+      requestTimeoutMs: 500,
+      staleRecheckIntervalMs: 20,
+      detectStaleBuild,
+      spawnDaemonForVersionBump,
+      installedDaemonScriptPath: () =>
+        "/opt/homebrew/opt/cmuxlayer/dist/daemon.js",
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() => daemon.connections.length > 0);
+    const firstConnection = daemon.connections[0];
+
+    stale = true;
+    await vi.waitFor(() => spawnDaemonForVersionBump.mock.calls.length > 0, {
+      timeout: 2_000,
+      interval: 25,
+    });
+    await waitFor(
+      () =>
+        daemon.connections.length > 1 ||
+        daemon.connections[0] !== firstConnection,
+      2_000,
+    );
+
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledWith(
+      expect.objectContaining({
+        daemonScriptPath: "/opt/homebrew/opt/cmuxlayer/dist/daemon.js",
+        socketPath: path,
+      }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("installed version bump detected"),
+    );
+  });
+
+  it("trips the reconnect-storm guard after repeated version-bump attempts", () => {
+    const guard = new VersionBumpReconnectGuard({
+      maxAttempts: 2,
+      windowMs: 60_000,
+      now: () => 1_000,
+    });
+
+    expect(guard.allow()).toBe(true);
+    expect(guard.allow()).toBe(true);
+    expect(guard.allow()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Scope A:** `createCmuxClient` retries socket `system.ping` with short backoff before CLI fallback; degraded CLI clients periodically re-probe and live-upgrade to socket transport (draining in-flight CLI calls); `control_health` surfaces `transport_mode` / `transport_degraded` plus an operator warning.
- **Scope B:** thin MCP proxy detects brew installed-version bumps, spawns the installed daemon binary, and reconnects with bounded backoff via `VersionBumpReconnectGuard` (reconnect-storm protection).
- **Scope C stub:** `DaemonHotReloadPlan` / `DaemonHotReloadHandler` interface left in `daemon.ts` for post-research hot-reload.

## Test plan
- [x] `tests/cmux-transport-self-heal.test.ts` — ping retry, CLI→socket upgrade, in-flight drain, health signal
- [x] `tests/proxy-version-bump.test.ts` — version-bump reconnect + storm guard
- [x] Full suite green (1514 tests), typecheck + build green


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daemon transport self-healing and proxy version-bump reconnect
> - Introduces `CmuxSelfHealingClient` in [cmux-transport-self-heal.ts](https://github.com/EtanHey/cmuxlayer/pull/271/files#diff-fbf073b8b6f02d58f4addfd2d8fcaed58d9e495a3ec139005951626f13e03267): when no usable socket is found at startup, the client falls back to CLI mode and periodically re-probes for socket availability, upgrading to socket transport without restarting the process.
> - Extracts socket probing logic into [cmux-socket-probe.ts](https://github.com/EtanHey/cmuxlayer/pull/271/files#diff-fd278404ca36fd0f03810f607b3ab7acd88b6e5aaccbec4625dae9ecb32191e3) with retry support (`probeUsableSocketWithRetry`) and candidate resolution (`resolveSocketPath`, `candidateSocketPathsForOpts`).
> - Adds a version-bump watcher to `CmuxLayerProxy` in [proxy.ts](https://github.com/EtanHey/cmuxlayer/pull/271/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2): on detecting a stale build, the proxy optionally spawns the installed daemon and reconnects; `VersionBumpReconnectGuard` rate-limits reconnect attempts.
> - Health reports in [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/271/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d) now include `transport_mode` and `transport_degraded` fields, and emit a warning when the transport is degraded on CLI fallback.
> - Risk: the self-healing upgrade path drains in-flight operations before switching transport, but concurrent requests during the drain window may observe mixed CLI/socket behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2ee2a10. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->