### PR TITLE
Fix cmux CLI ENOENT fallback and socket recovery

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -8,13 +8,16 @@ import { CmuxSocketClient } from "./cmux-socket-client.js";
 import {
   candidateSocketPathsForOpts,
   probeUsableSocket,
+  probeSocketHealth,
   resolveSocketPath,
+  type SocketProbeResult,
   type SocketProbeOptions,
 } from "./cmux-socket-probe.js";
 import {
   DEFAULT_PING_RETRY_ATTEMPTS,
   DEFAULT_PING_RETRY_BACKOFF_MS,
   wrapCliWithSelfHeal,
+  wrapSocketWithSelfHeal,
 } from "./cmux-transport-self-heal.js";
 
 export interface CreateCmuxClientOptions extends SocketProbeOptions {
@@ -32,26 +35,33 @@ export interface CreateCmuxClientOptions extends SocketProbeOptions {
   sleep?: (ms: number) => Promise<void>;
   /** CLI→socket live re-probe interval when degraded (default 5s) */
   reprobeIntervalMs?: number;
+  /** Max delay for decorrelated-jitter transport re-probe scheduling */
+  reprobeCapMs?: number;
+  /** Injectable random source for deterministic jitter tests */
+  random?: () => number;
 }
 
 async function probeUsableSocketWithRetry(
   socketPath: string,
   opts?: CreateCmuxClientOptions,
-): Promise<boolean> {
+): Promise<SocketProbeResult> {
   const attempts = opts?.pingRetryAttempts ?? DEFAULT_PING_RETRY_ATTEMPTS;
   const backoff = opts?.pingRetryBackoffMs ?? DEFAULT_PING_RETRY_BACKOFF_MS;
   const sleep = opts?.sleep ?? defaultSleep;
+  let lastResult: SocketProbeResult = { usable: false, socketPath };
 
   for (let attempt = 0; attempt < attempts; attempt++) {
-    if (await probeUsableSocket(socketPath, opts)) {
-      return true;
+    const result = await probeSocketHealth(socketPath, opts);
+    if (result.usable || result.denied_reason === "access-control") {
+      return result;
     }
+    lastResult = result;
     if (attempt < attempts - 1) {
       const delayMs = backoff[attempt] ?? backoff[backoff.length - 1] ?? 100;
       await sleep(delayMs);
     }
   }
-  return false;
+  return lastResult;
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -81,9 +91,13 @@ export async function createCmuxClient(
   const pinned = instancePin(opts) !== undefined;
 
   const usable: string[] = [];
+  const denied: SocketProbeResult[] = [];
   for (const socketPath of candidates) {
-    if (await probeUsableSocketWithRetry(socketPath, opts)) {
+    const probeResult = await probeUsableSocketWithRetry(socketPath, opts);
+    if (probeResult.usable) {
       usable.push(socketPath);
+    } else if (probeResult.denied_reason === "access-control") {
+      denied.push(probeResult);
     }
   }
 
@@ -106,17 +120,41 @@ export async function createCmuxClient(
             `you are using.`,
         );
       }
-      return client;
+      return wrapSocketWithSelfHeal(client, cliFallback, {
+        socketPath,
+        factoryOpts: opts,
+        reprobeIntervalMs: opts?.reprobeIntervalMs,
+        reprobeCapMs: opts?.reprobeCapMs,
+        random: opts?.random,
+        logger,
+        sleep: opts?.sleep,
+      }) as unknown as CmuxSocketClient;
     } catch {
       // Socket reachable but not usable — try next candidate before CLI.
     }
   }
 
+  const accessDenied = denied[0] ?? null;
+  if (accessDenied) {
+    const error = accessDenied.error ?? "Access denied";
+    logger.error(
+      `[cmuxlayer] transport denied: access-control (${accessDenied.socketPath}): ${error}`,
+    );
+  }
   logger.error("[cmuxlayer] transport selected: cli (degraded)");
   return wrapCliWithSelfHeal(cliFallback, {
     socketPath: candidates[0] ?? null,
     factoryOpts: opts,
     reprobeIntervalMs: opts?.reprobeIntervalMs,
+    reprobeCapMs: opts?.reprobeCapMs,
+    random: opts?.random,
+    initialDenial: accessDenied
+      ? {
+          denied_reason: "access-control",
+          socketPath: accessDenied.socketPath,
+          error: accessDenied.error ?? "Access denied",
+        }
+      : undefined,
     logger,
     sleep: opts?.sleep,
   }) as unknown as CmuxClient;

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -5,6 +5,8 @@
 
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { isAbsolute } from "node:path";
 import { promisify } from "node:util";
 import type {
   CmuxPane,
@@ -22,6 +24,19 @@ import type {
 import { normalizeKeyName } from "./key-names.js";
 
 const execFileAsync = promisify(execFile);
+const STANDARD_BUNDLED_CMUX =
+  "/Applications/cmux.app/Contents/Resources/bin/cmux";
+
+function cleanAbsolutePath(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !isAbsolute(trimmed)) return null;
+  return trimmed;
+}
+
+function cleanAbsoluteOrCommand(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
 
 export interface ExecFn {
   (
@@ -29,6 +44,13 @@ export interface ExecFn {
     args: string[],
     env?: NodeJS.ProcessEnv,
   ): Promise<{ stdout: string; stderr: string }>;
+}
+
+interface CmuxClientOptions {
+  exec?: ExecFn;
+  bin?: string;
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (path: string) => boolean;
 }
 
 interface CmuxIdentifyResult {
@@ -46,13 +68,15 @@ interface CmuxIdentifyResult {
 
 export class CmuxClient {
   private exec?: ExecFn;
-  private bin: string;
+  private bin?: string;
   private env?: NodeJS.ProcessEnv;
+  private existsSync: (path: string) => boolean;
 
-  constructor(opts?: { exec?: ExecFn; bin?: string; env?: NodeJS.ProcessEnv }) {
+  constructor(opts?: CmuxClientOptions) {
     this.exec = opts?.exec;
-    this.bin = opts?.bin ?? "cmux";
+    this.bin = opts?.bin;
     this.env = opts?.env;
+    this.existsSync = opts?.existsSync ?? fs.existsSync;
   }
 
   setEnv(env: NodeJS.ProcessEnv | undefined): void {
@@ -67,19 +91,39 @@ export class CmuxClient {
       // The env is forwarded on BOTH the injected-exec path and the real
       // execFile path; dropping it on either is collab O2 #8.
       const env = this.env;
+      const bin = this.resolveBin(env);
       const { stdout } = this.exec
         ? await this.exec(
-            this.bin,
+            bin,
             ["--json", ...args],
             ...(env ? ([env] as const) : ([] as const)),
           )
-        : await execFileAsync(this.bin, ["--json", ...args], {
+        : await execFileAsync(bin, ["--json", ...args], {
             ...(env ? { env } : {}),
           });
       return stdout;
     } catch (error) {
       throw this.normalizeCliError(args, error);
     }
+  }
+
+  private resolveBin(env?: NodeJS.ProcessEnv): string {
+    const explicitBin = cleanAbsoluteOrCommand(this.bin);
+    if (explicitBin) return explicitBin;
+
+    const envBundled = cleanAbsolutePath(env?.CMUX_BUNDLED_CLI_PATH);
+    if (envBundled) return envBundled;
+
+    const processBundled = cleanAbsolutePath(
+      process.env.CMUX_BUNDLED_CLI_PATH,
+    );
+    if (processBundled) return processBundled;
+
+    if (this.existsSync(STANDARD_BUNDLED_CMUX)) {
+      return STANDARD_BUNDLED_CMUX;
+    }
+
+    return "cmux";
   }
 
   private parse<T>(raw: string, command: string): T {

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -92,13 +92,22 @@ export class CmuxPersistentSocket {
   /** Advance backoff to the next exponential step. */
   incrementBackoff(): void {
     this.backoffAttempt++;
-    const exponential = Math.min(
-      this.backoffBaseMs * Math.pow(2, this.backoffAttempt - 1),
+    if (!this.backoffJitter) {
+      this._currentBackoffMs = Math.min(
+        this.backoffBaseMs * Math.pow(2, this.backoffAttempt - 1),
+        this.backoffMaxMs,
+      );
+      return;
+    }
+
+    const previous = this._currentBackoffMs || this.backoffBaseMs;
+    const upper = Math.max(this.backoffBaseMs, previous * 3);
+    this._currentBackoffMs = Math.min(
       this.backoffMaxMs,
+      Math.round(
+        this.backoffBaseMs + Math.random() * (upper - this.backoffBaseMs),
+      ),
     );
-    this._currentBackoffMs = this.backoffJitter
-      ? Math.round(exponential * (0.5 + Math.random() * 0.5))
-      : exponential;
   }
 
   /** Reset backoff after a successful connection. */
@@ -122,6 +131,7 @@ export class CmuxPersistentSocket {
         this.resetBackoff();
         resolve();
       });
+      this.raiseSocketListenerLimit(this.socket);
 
       this.socket.on("data", (chunk: Buffer) => {
         this.buffer += chunk.toString("utf-8");
@@ -130,21 +140,12 @@ export class CmuxPersistentSocket {
 
       this.socket.on("error", (err: Error) => {
         this.connected = false;
-        this.rejectAllPending(
-          new CmuxSocketError(
-            `Socket error: ${err.message}`,
-            "connection_error",
-          ),
-        );
+        const socketError = this.toConnectionError(err);
+        this.rejectAllPending(socketError);
         if (!settled) {
           settled = true;
           this.connectPromise = null;
-          reject(
-            new CmuxSocketError(
-              `Socket error: ${err.message}`,
-              "connection_error",
-            ),
-          );
+          reject(socketError);
         }
       });
 
@@ -162,6 +163,13 @@ export class CmuxPersistentSocket {
     });
 
     return this.connectPromise;
+  }
+
+  private raiseSocketListenerLimit(socket: net.Socket): void {
+    const current = socket.getMaxListeners();
+    if (current > 0 && current < this.maxInFlight + 8) {
+      socket.setMaxListeners(this.maxInFlight + 8);
+    }
   }
 
   private async ensureConnected(): Promise<void> {
@@ -278,7 +286,56 @@ export class CmuxPersistentSocket {
   private writeNextV1(): void {
     if (!this.socket || this.pendingV1.length === 0) return;
     const entry = this.pendingV1[0];
-    this.socket.write(entry.payload);
+    this.writePayload(entry.payload, (error) => {
+      const index = this.pendingV1.indexOf(entry);
+      if (index === -1) return;
+      const wasHead = index === 0;
+      this.pendingV1.splice(index, 1);
+      clearTimeout(entry.timer);
+      entry.reject(error);
+      if (wasHead) this.writeNextV1();
+    });
+  }
+
+  private toConnectionError(error: Error): CmuxSocketError {
+    return new CmuxSocketError(
+      `Socket error: ${error.message}`,
+      "connection_error",
+    );
+  }
+
+  private writePayload(
+    payload: string,
+    onWriteError: (error: CmuxSocketError) => void,
+  ): void {
+    const socket = this.socket;
+    if (!socket) {
+      onWriteError(new CmuxSocketError("Socket disconnected", "connection_closed"));
+      return;
+    }
+
+    let settled = false;
+    const cleanup = () => {
+      socket.off("error", onError);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      onWriteError(this.toConnectionError(error));
+    };
+    const onError = (error: Error) => fail(error);
+
+    socket.once("error", onError);
+    try {
+      socket.write(payload, () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+      });
+    } catch (error) {
+      fail(error instanceof Error ? error : new Error(String(error)));
+    }
   }
 
   private assertInFlightCapacity(): void {
@@ -327,7 +384,13 @@ export class CmuxPersistentSocket {
         timer,
       });
 
-      this.socket!.write(payload);
+      this.writePayload(payload, (error) => {
+        const entry = this.pending.get(id);
+        if (!entry) return;
+        clearTimeout(entry.timer);
+        this.pending.delete(id);
+        entry.reject(error);
+      });
     });
   }
 

--- a/src/cmux-socket-probe.ts
+++ b/src/cmux-socket-probe.ts
@@ -13,6 +13,13 @@ export interface SocketProbeOptions {
   password?: string;
 }
 
+export interface SocketProbeResult {
+  usable: boolean;
+  socketPath: string;
+  denied_reason?: "access-control";
+  error?: string;
+}
+
 /**
  * Bound on the probe `system.ping`. A wedged cmux can ACCEPT the socket connect
  * but never answer (the Surface.deinit deadlock), and probing every candidate
@@ -20,6 +27,17 @@ export interface SocketProbeOptions {
  * hung instance. The probe only needs a liveness yes/no, so cap it short.
  */
 const PROBE_PING_TIMEOUT_MS = 2000;
+const ACCESS_CONTROL_DENIED_RE =
+  /Access denied\s*[—-]\s*only processes started inside cmux can connect/i;
+
+export function isCmuxAccessControlDenied(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return ACCESS_CONTROL_DENIED_RE.test(message);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /**
  * Probe whether a Unix socket is listening.
@@ -63,8 +81,15 @@ export async function probeUsableSocket(
   socketPath: string,
   opts?: Pick<SocketProbeOptions, "timeoutMs" | "password">,
 ): Promise<boolean> {
+  return (await probeSocketHealth(socketPath, opts)).usable;
+}
+
+export async function probeSocketHealth(
+  socketPath: string,
+  opts?: Pick<SocketProbeOptions, "timeoutMs" | "password">,
+): Promise<SocketProbeResult> {
   if (!(await probeSocket(socketPath, opts?.timeoutMs))) {
-    return false;
+    return { usable: false, socketPath };
   }
 
   const transport = new CmuxPersistentSocket({
@@ -80,9 +105,18 @@ export async function probeUsableSocket(
       await transport.call("auth.login", { password: opts.password });
     }
     const result = await transport.call<{ pong: boolean }>("system.ping");
-    return result.pong === true;
-  } catch {
-    return false;
+    return { usable: result.pong === true, socketPath };
+  } catch (error) {
+    const message = errorMessage(error);
+    if (isCmuxAccessControlDenied(error)) {
+      return {
+        usable: false,
+        socketPath,
+        denied_reason: "access-control",
+        error: message,
+      };
+    }
+    return { usable: false, socketPath, error: message };
   } finally {
     transport.disconnect();
   }

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -1,41 +1,58 @@
 /**
- * CLI→socket transport self-healing for createCmuxClient.
- * When startup socket probes fail, the daemon runs degraded on CLI but
- * periodically re-probes and upgrades without a process restart.
+ * Bidirectional transport self-healing for createCmuxClient.
+ * When startup socket probes fail, the daemon runs degraded on CLI and
+ * periodically re-probes. When an active socket breaks, failed payloads are
+ * replayed through the CLI fallback and the same re-probe path upgrades later.
  */
 
 import { CmuxClient } from "./cmux-client.js";
 import { CmuxSocketClient } from "./cmux-socket-client.js";
+import { CmuxSocketError } from "./cmux-socket-error.js";
 import type { CreateCmuxClientOptions } from "./cmux-client-factory.js";
 import {
   candidateSocketPathsForOpts,
+  probeSocketHealth,
   probeUsableSocket,
   resolveSocketPath,
+  type SocketProbeResult,
 } from "./cmux-socket-probe.js";
 
 export const DEFAULT_PING_RETRY_ATTEMPTS = 3;
 export const DEFAULT_PING_RETRY_BACKOFF_MS = [100, 250, 500] as const;
 export const DEFAULT_TRANSPORT_REPROBE_MS = 5_000;
+export const DEFAULT_TRANSPORT_REPROBE_CAP_MS = 30_000;
 
 export interface TransportHealthSignal {
   mode: "socket" | "cli";
   degraded: boolean;
   current_socket_path?: string | null;
+  denied_reason?: "access-control";
+  last_error?: string;
+}
+
+export interface TransportDenialSignal {
+  denied_reason: "access-control";
+  socketPath: string;
+  error: string;
 }
 
 export interface CmuxSelfHealingClientOptions {
   cli: CmuxClient;
+  /** Initial socket transport. Omit when starting degraded on CLI. */
+  socket?: CmuxSocketClient;
   /** Primary socket path to re-probe for upgrade; may be null when unpinned and all dead. */
   socketPath: string | null;
   factoryOpts?: CreateCmuxClientOptions;
   reprobeIntervalMs?: number;
+  reprobeCapMs?: number;
+  random?: () => number;
+  initialDenial?: TransportDenialSignal;
   logger?: Pick<Console, "error">;
   sleep?: (ms: number) => Promise<void>;
   probeUsable?: typeof probeUsableSocket;
+  probeSocketHealth?: typeof probeSocketHealth;
   resolvePath?: typeof resolveSocketPath;
 }
-
-type CmuxLayerClient = CmuxClient | CmuxSocketClient;
 
 const FORWARDED_ASYNC_METHODS = [
   "listWorkspaces",
@@ -64,6 +81,35 @@ const FORWARDED_ASYNC_METHODS = [
   "identify",
   "browser",
 ] as const;
+
+type CmuxLayerClient = CmuxClient | CmuxSocketClient;
+type ForwardedAsyncMethod = (typeof FORWARDED_ASYNC_METHODS)[number];
+
+interface FailedPayload {
+  method: ForwardedAsyncMethod;
+  args: unknown[];
+}
+
+interface QueuedFailedPayload {
+  payload: FailedPayload;
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+export function decorrelatedJitterDelayMs(opts: {
+  baseMs: number;
+  previousMs: number;
+  capMs: number;
+  random?: () => number;
+}): number {
+  const base = Math.max(0, Math.floor(opts.baseMs));
+  const cap = Math.max(base, Math.floor(opts.capMs));
+  const previous = Math.max(base, Math.floor(opts.previousMs));
+  const random = opts.random ?? Math.random;
+  const upper = Math.max(base, previous * 3);
+  const next = base + random() * (upper - base);
+  return Math.min(cap, Math.max(base, Math.round(next)));
+}
 
 export function getTransportHealth(
   client: unknown,
@@ -101,26 +147,30 @@ export class CmuxSelfHealingClient {
   private socketClient: CmuxSocketClient | null = null;
   private inFlight = 0;
   private reprobeTimer: NodeJS.Timeout | null = null;
+  private previousReprobeDelayMs = 0;
   private upgrading = false;
   private stopped = false;
+  private failedPayloadQueue: QueuedFailedPayload[] = [];
+  private flushingFailedPayloadQueue: Promise<void> | null = null;
+  private transportDenial: TransportDenialSignal | null = null;
 
   constructor(private readonly opts: CmuxSelfHealingClientOptions) {
-    this.delegate = opts.cli;
+    this.socketClient = opts.socket ?? null;
+    this.delegate = opts.socket ?? opts.cli;
+    this.transportDenial = opts.initialDenial ?? null;
+    if (this.socketClient) {
+      this.pinCliToSocket(this.socketClient);
+    }
     for (const method of FORWARDED_ASYNC_METHODS) {
       (this as Record<string, unknown>)[method] = (...args: unknown[]) =>
-        this.trackInFlight(() =>
-          (
-            this.delegate as unknown as Record<
-              string,
-              (...inner: unknown[]) => Promise<unknown>
-            >
-          )[method](...args),
-        );
+        this.invokeForwarded(method, args);
     }
-    opts.logger?.error(
-      "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
-    );
-    this.startReprobe();
+    if (!this.socketClient) {
+      opts.logger?.error(
+        "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
+      );
+      this.startReprobe();
+    }
   }
 
   getTransportHealth(): TransportHealthSignal {
@@ -131,10 +181,17 @@ export class CmuxSelfHealingClient {
         current_socket_path: this.socketClient.currentSocketPath(),
       };
     }
+    const denial = this.transportDenial
+      ? {
+          denied_reason: this.transportDenial.denied_reason,
+          last_error: this.transportDenial.error,
+        }
+      : {};
     return {
       mode: "cli",
       degraded: true,
       current_socket_path: this.opts.socketPath,
+      ...denial,
     };
   }
 
@@ -177,7 +234,7 @@ export class CmuxSelfHealingClient {
   stop(): void {
     this.stopped = true;
     if (this.reprobeTimer) {
-      clearInterval(this.reprobeTimer);
+      clearTimeout(this.reprobeTimer);
       this.reprobeTimer = null;
     }
     this.disconnect();
@@ -187,18 +244,180 @@ export class CmuxSelfHealingClient {
     this.inFlight += 1;
     try {
       return await fn();
+    } catch (error) {
+      if (this.shouldDowngrade(error)) {
+        this.downgradeToCli();
+      }
+      throw error;
     } finally {
       this.inFlight -= 1;
     }
   }
 
+  private async invokeForwarded(
+    method: ForwardedAsyncMethod,
+    args: unknown[],
+  ): Promise<unknown> {
+    const delegate = this.delegate;
+    const startedOnSocket =
+      this.socketClient !== null && delegate === this.socketClient;
+    this.inFlight += 1;
+    try {
+      return await this.callDelegate(method, args, delegate);
+    } catch (error) {
+      const replay = this.recoverFailedPayload(
+        error,
+        method,
+        args,
+        startedOnSocket,
+      );
+      if (replay) {
+        return replay;
+      }
+      throw error;
+    } finally {
+      this.inFlight -= 1;
+    }
+  }
+
+  private callDelegate(
+    method: ForwardedAsyncMethod,
+    args: unknown[],
+    delegate: CmuxLayerClient = this.delegate,
+  ): Promise<unknown> {
+    return (
+      delegate as unknown as Record<
+        ForwardedAsyncMethod,
+        (...inner: unknown[]) => Promise<unknown>
+      >
+    )[method](...args);
+  }
+
   private startReprobe(): void {
-    const interval =
-      this.opts.reprobeIntervalMs ?? DEFAULT_TRANSPORT_REPROBE_MS;
-    this.reprobeTimer = setInterval(() => {
+    if (this.reprobeTimer || this.stopped || this.socketClient) {
+      return;
+    }
+    const delayMs = this.nextReprobeDelayMs();
+    this.reprobeTimer = setTimeout(() => {
+      this.reprobeTimer = null;
       void this.tryUpgrade();
-    }, interval);
+    }, delayMs);
     this.reprobeTimer.unref?.();
+  }
+
+  private nextReprobeDelayMs(): number {
+    const baseMs = this.opts.reprobeIntervalMs ?? DEFAULT_TRANSPORT_REPROBE_MS;
+    const previousMs = this.previousReprobeDelayMs || baseMs;
+    const delayMs = decorrelatedJitterDelayMs({
+      baseMs,
+      previousMs,
+      capMs: this.opts.reprobeCapMs ?? DEFAULT_TRANSPORT_REPROBE_CAP_MS,
+      random: this.opts.random,
+    });
+    this.previousReprobeDelayMs = delayMs;
+    return delayMs;
+  }
+
+  private shouldDowngrade(error: unknown): boolean {
+    if (!this.socketClient) {
+      return false;
+    }
+
+    return this.isRecoverableSocketError(error);
+  }
+
+  private isRecoverableSocketError(error: unknown): boolean {
+    const isTransportError =
+      error instanceof CmuxSocketError &&
+      (error.code === "connection_error" ||
+        error.code === "connection_closed");
+    const message = error instanceof Error ? error.message : String(error);
+    const hasBrokenPipeSignal = /\b(?:EPIPE|ECONNRESET|broken pipe)\b/i.test(
+      message,
+    );
+    return isTransportError || hasBrokenPipeSignal;
+  }
+
+  private recoverFailedPayload(
+    error: unknown,
+    method: ForwardedAsyncMethod,
+    args: unknown[],
+    startedOnSocket: boolean,
+  ): Promise<unknown> | null {
+    if (!startedOnSocket || !this.isRecoverableSocketError(error)) {
+      return null;
+    }
+
+    const replay = this.enqueueFailedPayload({ method, args });
+    if (this.socketClient) {
+      this.downgradeToCli();
+    }
+    void this.flushFailedPayloadQueue();
+    return replay;
+  }
+
+  private enqueueFailedPayload(payload: FailedPayload): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      this.failedPayloadQueue.push({ payload, resolve, reject });
+    });
+  }
+
+  private flushFailedPayloadQueue(): Promise<void> {
+    if (this.flushingFailedPayloadQueue) {
+      return this.flushingFailedPayloadQueue;
+    }
+
+    this.flushingFailedPayloadQueue = (async () => {
+      while (this.failedPayloadQueue.length > 0) {
+        const entry = this.failedPayloadQueue[0]!;
+        try {
+          const result = await this.callDelegate(
+            entry.payload.method,
+            entry.payload.args,
+          );
+          entry.resolve(result);
+        } catch (error) {
+          entry.reject(error);
+        } finally {
+          this.failedPayloadQueue.shift();
+        }
+      }
+    })().finally(() => {
+      this.flushingFailedPayloadQueue = null;
+    });
+
+    return this.flushingFailedPayloadQueue;
+  }
+
+  private downgradeToCli(): void {
+    if (!this.socketClient) {
+      return;
+    }
+
+    try {
+      this.socketClient.disconnect();
+    } catch {
+      // The socket is already unusable; the CLI fallback is the recovery path.
+    }
+    this.socketClient = null;
+    this.delegate = this.opts.cli;
+    this.transportDenial = null;
+    this.opts.logger?.error(
+      "[cmuxlayer] transport downgraded: socket -> cli (periodic socket re-probe active)",
+    );
+    this.startReprobe();
+  }
+
+  private pinCliToSocket(socket: CmuxSocketClient): void {
+    try {
+      this.opts.cli.setEnv({
+        ...process.env,
+        CMUX_SOCKET_PATH: socket.currentSocketPath(),
+      });
+    } catch {
+      // Keep the socket transport active; CLI pinning will be retried after any
+      // downgrade/upgrade that has a resolved socket path.
+    }
   }
 
   private async tryUpgrade(): Promise<void> {
@@ -206,12 +425,12 @@ export class CmuxSelfHealingClient {
       return;
     }
     if (this.inFlight > 0) {
+      this.startReprobe();
       return;
     }
 
-    const sleep = this.opts.sleep ?? defaultSleep;
-    const probe = this.opts.probeUsable ?? probeUsableSocket;
     const factoryOpts = this.opts.factoryOpts;
+    const sleep = this.opts.sleep ?? defaultSleep;
     const resolvePath = this.opts.resolvePath ?? resolveSocketPath;
 
     let socketPath = this.opts.socketPath;
@@ -219,9 +438,17 @@ export class CmuxSelfHealingClient {
       socketPath = await resolvePath(factoryOpts);
     }
     if (!socketPath) {
+      this.startReprobe();
       return;
     }
-    if (!(await probe(socketPath, factoryOpts))) {
+    const probeResult = await this.checkSocketHealth(socketPath, factoryOpts);
+    if (probeResult.denied_reason === "access-control") {
+      this.recordAccessControlDenial(probeResult);
+      this.startReprobe();
+      return;
+    }
+    if (!probeResult.usable) {
+      this.startReprobe();
       return;
     }
 
@@ -240,20 +467,53 @@ export class CmuxSelfHealingClient {
         socketPathResolver: () => resolvePath(factoryOpts),
       });
       await client.ping();
+      this.pinCliToSocket(client);
       this.socketClient = client;
       this.delegate = client;
+      this.transportDenial = null;
       this.clearReprobe();
+      this.previousReprobeDelayMs = 0;
       this.opts.logger?.error("[cmuxlayer] transport upgraded: cli -> socket");
     } catch {
       // Stay on CLI until the next re-probe tick.
     } finally {
       this.upgrading = false;
+      if (!this.socketClient && !this.stopped) {
+        this.startReprobe();
+      }
     }
+  }
+
+  private async checkSocketHealth(
+    socketPath: string,
+    factoryOpts?: CreateCmuxClientOptions,
+  ): Promise<SocketProbeResult> {
+    if (this.opts.probeSocketHealth) {
+      return this.opts.probeSocketHealth(socketPath, factoryOpts);
+    }
+    if (this.opts.probeUsable) {
+      return {
+        usable: await this.opts.probeUsable(socketPath, factoryOpts),
+        socketPath,
+      };
+    }
+    return probeSocketHealth(socketPath, factoryOpts);
+  }
+
+  private recordAccessControlDenial(result: SocketProbeResult): void {
+    this.transportDenial = {
+      denied_reason: "access-control",
+      socketPath: result.socketPath,
+      error: result.error ?? "Access denied",
+    };
+    this.opts.logger?.error(
+      `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}`,
+    );
   }
 
   private clearReprobe(): void {
     if (this.reprobeTimer) {
-      clearInterval(this.reprobeTimer);
+      clearTimeout(this.reprobeTimer);
       this.reprobeTimer = null;
     }
   }
@@ -268,6 +528,14 @@ export function wrapCliWithSelfHeal(
   opts: Omit<CmuxSelfHealingClientOptions, "cli">,
 ): CmuxSelfHealingClient {
   return new CmuxSelfHealingClient({ cli, ...opts });
+}
+
+export function wrapSocketWithSelfHeal(
+  socket: CmuxSocketClient,
+  cli: CmuxClient,
+  opts: Omit<CmuxSelfHealingClientOptions, "cli" | "socket">,
+): CmuxSelfHealingClient {
+  return new CmuxSelfHealingClient({ cli, socket, ...opts });
 }
 
 export function primaryCandidateSocketPath(

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -80,6 +80,8 @@ export interface ControlHealth {
     current_socket_path?: string;
     transport_mode?: "socket" | "cli";
     transport_degraded?: boolean;
+    transport_denied?: "access-control";
+    transport_error?: string;
   };
   cmux_instances: {
     production: CmuxInstanceHealth;
@@ -314,6 +316,12 @@ function describeClient(client: unknown): ControlHealth["selected_transport"] {
       ? {
           transport_mode: transportHealth.mode,
           transport_degraded: transportHealth.degraded,
+          ...(transportHealth.denied_reason
+            ? { transport_denied: transportHealth.denied_reason }
+            : {}),
+          ...(transportHealth.last_error
+            ? { transport_error: transportHealth.last_error }
+            : {}),
         }
       : {}),
   };
@@ -373,6 +381,13 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
   }
 
   if (
+    health.selected_transport.transport_denied === "access-control" &&
+    health.selected_transport.transport_error
+  ) {
+    warnings.push(
+      `cmuxlayer control transport denied: access-control; ${health.selected_transport.transport_error}`,
+    );
+  } else if (
     health.selected_transport.transport_degraded === true &&
     !warnings.some((warning) => warning.includes("transport degraded"))
   ) {
@@ -536,6 +551,12 @@ export function formatControlHealth(health: ControlHealth): string {
         ? ` (${health.selected_transport.current_socket_path})`
         : ""
     }`,
+    ...(health.selected_transport.transport_denied
+      ? [
+          `transport_denied: ${health.selected_transport.transport_denied}`,
+          `transport_error: ${health.selected_transport.transport_error ?? "unknown"}`,
+        ]
+      : []),
     `env CMUX_SOCKET_PATH: ${health.current_process.env.CMUX_SOCKET_PATH ?? "unset"}`,
     `env CMUX_BUNDLED_CLI_PATH: ${health.current_process.env.CMUX_BUNDLED_CLI_PATH ?? "unset"}`,
     "cmux resolution:",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1852,7 +1852,11 @@ export function createServerContext(
   opts?: Omit<CreateServerOptions, "context">,
 ): CmuxServerContext {
   const client =
-    opts?.client ?? new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+    opts?.client ??
+    new CmuxClient({
+      exec: opts?.exec,
+      bin: opts?.bin ?? (opts?.exec ? "cmux" : undefined),
+    });
   const autoVitestStateDir =
     !opts?.stateDir && process.env.VITEST === "true"
       ? mkdtempSync(join(tmpdir(), "cmuxlayer-vitest-state-"))

--- a/src/test-fallback.ts
+++ b/src/test-fallback.ts
@@ -6,7 +6,7 @@
  */
 
 import { createCmuxClient } from "./cmux-client-factory.js";
-import { CmuxSocketClient } from "./cmux-socket-client.js";
+import { getTransportHealth } from "./cmux-transport-self-heal.js";
 
 function assert(label: string, condition: boolean): void {
   if (condition) {
@@ -20,24 +20,26 @@ function assert(label: string, condition: boolean): void {
 async function test() {
   console.log("=== Manual Test: Graceful Fallback ===\n");
 
-  // Test 1: Socket available → CmuxSocketClient
+  // Test 1: Socket available → socket transport
   const socketClient = await createCmuxClient();
+  const socketHealth = getTransportHealth(socketClient);
   assert(
-    "Socket available → CmuxSocketClient",
-    socketClient instanceof CmuxSocketClient,
+    "Socket available → socket transport",
+    socketHealth?.mode === "socket" && socketHealth.degraded === false,
   );
 
-  // Test 2: Socket unavailable → CmuxClient fallback
+  // Test 2: Socket unavailable → CLI fallback
   const fallbackClient = await createCmuxClient({
     socketPath: "/tmp/nonexistent.sock",
   });
+  const fallbackHealth = getTransportHealth(fallbackClient);
   assert(
     "Fallback to CLI when socket missing",
-    !(fallbackClient instanceof CmuxSocketClient),
+    fallbackHealth?.mode === "cli" && fallbackHealth.degraded === true,
   );
 
   // Test 3-5: Socket client works for real operations
-  if (socketClient instanceof CmuxSocketClient) {
+  if (socketHealth?.mode === "socket") {
     const ws = await socketClient.listWorkspaces();
     assert(
       `Socket listWorkspaces (${ws.workspaces.length} workspaces)`,

--- a/tests/cmux-client-factory.test.ts
+++ b/tests/cmux-client-factory.test.ts
@@ -11,9 +11,9 @@ import * as net from "node:net";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CmuxSocketClient } from "../src/cmux-socket-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
 import { stateSocketPath } from "../src/cmux-socket-path.js";
+import { getTransportHealth } from "../src/cmux-transport-self-heal.js";
 
 const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
 
@@ -107,7 +107,10 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
       });
 
       // Authoritative pin: a down pin falls back to CLI, NOT the other live one.
-      expect(client).not.toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "cli",
+        degraded: true,
+      });
       expect(logger.error).not.toHaveBeenCalledWith(
         expect.stringContaining(otherInstance),
       );
@@ -127,7 +130,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
         logger,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: mine,
+      });
       // Pinned: no ambiguity warning even though it bound to a socket.
       expect(logger.error).not.toHaveBeenCalledWith(
         expect.stringContaining("live cmux sockets found"),
@@ -157,7 +164,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
         logger,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: first,
+      });
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("live cmux sockets found"),
       );
@@ -185,7 +196,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
         logger,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: only,
+      });
       expect(logger.error).not.toHaveBeenCalledWith(
         expect.stringContaining("live cmux sockets found"),
       );

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { CmuxClient, type ExecFn } from "../src/cmux-client.js";
+
+const STANDARD_BUNDLED_CMUX =
+  "/Applications/cmux.app/Contents/Resources/bin/cmux";
+const savedBundledCliPath = process.env.CMUX_BUNDLED_CLI_PATH;
+
+beforeEach(() => {
+  delete process.env.CMUX_BUNDLED_CLI_PATH;
+});
+
+afterEach(() => {
+  if (savedBundledCliPath === undefined) {
+    delete process.env.CMUX_BUNDLED_CLI_PATH;
+  } else {
+    process.env.CMUX_BUNDLED_CLI_PATH = savedBundledCliPath;
+  }
+});
 
 function mockExec(response: object | string): ExecFn {
   const stdout =
@@ -9,7 +25,7 @@ function mockExec(response: object | string): ExecFn {
 
 function mockClient(response: object | string) {
   const exec = mockExec(response);
-  const client = new CmuxClient({ exec });
+  const client = new CmuxClient({ exec, existsSync: () => false });
   return { client, exec };
 }
 
@@ -178,7 +194,7 @@ describe("CmuxClient.newSplit", () => {
         stderr: "",
       })
       .mockResolvedValueOnce({ stdout: JSON.stringify(split), stderr: "" });
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await client.newSplit("left", {
       workspace: "workspace:1",
@@ -229,7 +245,7 @@ describe("CmuxClient.newSplit", () => {
         stderr: "",
       })
       .mockResolvedValueOnce({ stdout: JSON.stringify(split), stderr: "" });
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await client.newSplit("left", {
       workspace: "workspace:1",
@@ -489,7 +505,7 @@ describe("CmuxClient.pasteText", () => {
 describe("CmuxClient CLI-fallback socket env (instance pin)", () => {
   it("forwards CMUX_SOCKET_PATH to an injected exec when env is set", async () => {
     const exec = mockExec({});
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
     client.setEnv({ ...process.env, CMUX_SOCKET_PATH: "/tmp/nightly.sock" });
 
     await client.pasteText("surface:1", "hello", { workspace: "workspace:1" });
@@ -506,7 +522,7 @@ describe("CmuxClient CLI-fallback socket env (instance pin)", () => {
 
   it("does not pass an env argument to an injected exec when env is unset", async () => {
     const exec = mockExec({});
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await client.selectWorkspace("workspace:1");
 
@@ -516,6 +532,95 @@ describe("CmuxClient CLI-fallback socket env (instance pin)", () => {
       "select-workspace",
       "--workspace",
       "workspace:1",
+    ]);
+  });
+});
+
+describe("CmuxClient CLI binary resolution", () => {
+  it("uses explicit opts.bin before any bundled cmux env", async () => {
+    const exec = mockExec({ workspaces: [] });
+    const client = new CmuxClient({
+      exec,
+      bin: "/tmp/custom-cmux",
+      env: {
+        ...process.env,
+        CMUX_BUNDLED_CLI_PATH: "/Applications/cmux.app/Contents/Resources/bin/cmux",
+      },
+    });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith(
+      "/tmp/custom-cmux",
+      ["--json", "list-workspaces"],
+      expect.objectContaining({
+        CMUX_BUNDLED_CLI_PATH:
+          "/Applications/cmux.app/Contents/Resources/bin/cmux",
+      }),
+    );
+  });
+
+  it("execs the absolute bundled cmux path from the per-run env", async () => {
+    const exec = mockExec({ workspaces: [] });
+    const bundledPath = "/Applications/cmux.app/Contents/Resources/bin/cmux";
+    const client = new CmuxClient({ exec, existsSync: () => false });
+    client.setEnv({
+      ...process.env,
+      CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+      CMUX_BUNDLED_CLI_PATH: bundledPath,
+    });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith(
+      bundledPath,
+      ["--json", "list-workspaces"],
+      expect.objectContaining({
+        CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+        CMUX_BUNDLED_CLI_PATH: bundledPath,
+      }),
+    );
+    expect(bundledPath.startsWith("/")).toBe(true);
+  });
+
+  it("execs the absolute bundled cmux path from process.env when no per-run env is set", async () => {
+    const exec = mockExec({ workspaces: [] });
+    process.env.CMUX_BUNDLED_CLI_PATH =
+      "/Applications/cmux.app/Contents/Resources/bin/cmux";
+    const client = new CmuxClient({ exec, existsSync: () => false });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith(process.env.CMUX_BUNDLED_CLI_PATH, [
+      "--json",
+      "list-workspaces",
+    ]);
+  });
+
+  it("probes the standard bundled cmux location before falling back to PATH", async () => {
+    const exec = mockExec({ workspaces: [] });
+    const client = new CmuxClient({
+      exec,
+      existsSync: (candidate) => candidate === STANDARD_BUNDLED_CMUX,
+    });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith(STANDARD_BUNDLED_CMUX, [
+      "--json",
+      "list-workspaces",
+    ]);
+  });
+
+  it("uses bare cmux only as the last resort", async () => {
+    const exec = mockExec({ workspaces: [] });
+    const client = new CmuxClient({ exec, existsSync: () => false });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "list-workspaces",
     ]);
   });
 });
@@ -683,7 +788,7 @@ describe("CmuxClient.listStatus", () => {
       ].join("\n"),
       stderr: "",
     });
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     const result = await client.listStatus({ workspace: "workspace:1" });
 
@@ -778,7 +883,7 @@ describe("CmuxClient CLI error handling", () => {
         stderr: "surface not found",
       }),
     );
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await expect(client.readScreen("surface:999")).rejects.toThrow();
   });
@@ -790,7 +895,7 @@ describe("CmuxClient CLI error handling", () => {
         stderr: "surface not found",
       }),
     );
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await expect(client.readScreen("surface:999")).rejects.toThrow(
       /surface not found/,
@@ -802,7 +907,7 @@ describe("CmuxClient CLI error handling", () => {
       stdout: "not json",
       stderr: "",
     });
-    const client = new CmuxClient({ exec });
+    const client = new CmuxClient({ exec, existsSync: () => false });
 
     await expect(client.listWorkspaces()).rejects.toThrow(
       /invalid JSON.*list-workspaces/i,

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -1,4 +1,5 @@
 import net from "node:net";
+import { EventEmitter } from "node:events";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -163,8 +164,17 @@ describe("CmuxPersistentSocket V1 demux", () => {
       const first = socket.call("list_workspaces");
       const second = socket.call("list_panes");
 
-      await expect(first).rejects.toMatchObject({ code: "protocol_error" });
-      await expect(second).rejects.toMatchObject({ code: "protocol_error" });
+      const results = await Promise.allSettled([first, second]);
+      expect(results).toEqual([
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({ code: "protocol_error" }),
+        }),
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({ code: "protocol_error" }),
+        }),
+      ]);
       expect(received).toHaveLength(2);
     } finally {
       socket.disconnect();
@@ -198,8 +208,17 @@ describe("CmuxPersistentSocket V1 demux", () => {
     try {
       const first = socket.call("list_workspaces");
       const second = socket.call("list_panes");
-      await expect(first).rejects.toMatchObject({ code: "protocol_error" });
-      await expect(second).rejects.toMatchObject({ code: "protocol_error" });
+      const results = await Promise.allSettled([first, second]);
+      expect(results).toEqual([
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({ code: "protocol_error" }),
+        }),
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({ code: "protocol_error" }),
+        }),
+      ]);
 
       await expect(socket.sendLine("set_status after malformed")).resolves.toBe(
         "OK",
@@ -207,5 +226,86 @@ describe("CmuxPersistentSocket V1 demux", () => {
     } finally {
       socket.disconnect();
     }
+  });
+
+  it("attaches a socket error listener before writing each V2 payload", async () => {
+    const events: string[] = [];
+    let capturedPayload = "";
+    class FakeSocket extends EventEmitter {
+      destroyed = false;
+
+      once(event: string, listener: (...args: unknown[]) => void): this {
+        if (event === "error") events.push("once:error");
+        return super.once(event, listener);
+      }
+
+      write(payload: string, callback?: () => void): boolean {
+        events.push("write");
+        capturedPayload = payload;
+        callback?.();
+        return true;
+      }
+
+      destroy(): void {
+        this.destroyed = true;
+      }
+    }
+
+    const socket = new CmuxPersistentSocket({ timeoutMs: 500 });
+    (socket as unknown as { connected: boolean }).connected = true;
+    (socket as unknown as { socket: FakeSocket }).socket = new FakeSocket();
+
+    const result = socket.call("system.ping");
+    await Promise.resolve();
+    expect(capturedPayload).toContain("system.ping");
+    expect(events.slice(0, 2)).toEqual(["once:error", "write"]);
+    const request = JSON.parse(capturedPayload.trim()) as { id: string };
+    (
+      socket as unknown as {
+        buffer: string;
+        processBuffer: () => void;
+      }
+    ).buffer = `${JSON.stringify({
+      id: request.id,
+      ok: true,
+      result: { pong: true },
+    })}\n`;
+    (
+      socket as unknown as {
+        processBuffer: () => void;
+      }
+    ).processBuffer();
+    await expect(result).resolves.toEqual({ pong: true });
+    socket.disconnect();
+  });
+
+  it("rejects and clears pending V2 state when a write throws EPIPE", async () => {
+    class ThrowingSocket extends EventEmitter {
+      destroyed = false;
+
+      write(): boolean {
+        const error = new Error("write EPIPE");
+        (error as NodeJS.ErrnoException).code = "EPIPE";
+        throw error;
+      }
+
+      destroy(): void {
+        this.destroyed = true;
+      }
+    }
+
+    const socket = new CmuxPersistentSocket({ timeoutMs: 500 });
+    (socket as unknown as { connected: boolean }).connected = true;
+    (socket as unknown as { socket: ThrowingSocket }).socket =
+      new ThrowingSocket();
+
+    await expect(socket.call("system.ping")).rejects.toMatchObject({
+      name: "CmuxSocketError",
+      code: "connection_error",
+    });
+    expect(
+      (socket as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(0);
+    socket.disconnect();
   });
 });

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
 import { CmuxClient, type ExecFn } from "../src/cmux-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
+import { getTransportHealth } from "../src/cmux-transport-self-heal.js";
 
 // ── Mock V2 Socket Server ──────────────────────────────────────────────
 
@@ -1230,17 +1231,23 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
 });
 
 describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
-  it("returns CmuxSocketClient when socket is available", async () => {
+  it("returns a socket-mode client when socket is available", async () => {
     const client = await createCmuxClient({ socketPath: MOCK_SOCKET_PATH });
-    expect(client).toBeInstanceOf(CmuxSocketClient);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "socket",
+      degraded: false,
+      current_socket_path: MOCK_SOCKET_PATH,
+    });
   });
 
-  it("falls back to CmuxClient when socket is unavailable", async () => {
+  it("falls back to CLI mode when socket is unavailable", async () => {
     const client = await createCmuxClient({
       socketPath: "/tmp/cmux-does-not-exist.sock",
     });
-    // Should not be a CmuxSocketClient
-    expect(client).not.toBeInstanceOf(CmuxSocketClient);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+    });
   });
 
   it("uses last-socket-path before legacy defaults when no env socket is set", async () => {
@@ -1262,7 +1269,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
         logger,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: liveSocketPath,
+      });
       expect(logger.error).toHaveBeenCalledWith(
         "[cmuxlayer] transport selected: socket",
       );
@@ -1305,7 +1316,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
         bin: fakeCmux,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: liveSocketPath,
+      });
       const result = await (client as CmuxSocketClient).newSurface({
         pane: "pane:1",
         workspace: "workspace:1",
@@ -1334,7 +1349,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
         socketStateDir: stateDir,
       });
 
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: liveSocketPath,
+      });
     } finally {
       if (savedEnv === undefined) {
         delete process.env.CMUX_SOCKET_PATH;
@@ -1364,7 +1383,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
       const client = await createCmuxClient({
         socketStateDir: stateDir,
       });
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: firstSocketPath,
+      });
       expect(await client.ping()).toBe(true);
 
       await stopSocketServer(firstServer, firstSocketPath);
@@ -1389,10 +1412,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
     }
   });
 
-  it("does not replay mutating calls after re-probing a failed socket", async () => {
+  it("flushes a failed mutating socket call through CLI fallback", async () => {
     const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
     const firstSocketPath = join(stateDir, "first.sock");
-    const secondSocketPath = join(stateDir, "second.sock");
     fs.writeFileSync(
       join(stateDir, "last-socket-path"),
       `${firstSocketPath}\n`,
@@ -1404,29 +1426,45 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
     );
     const savedEnv = process.env.CMUX_SOCKET_PATH;
     delete process.env.CMUX_SOCKET_PATH;
+    const exec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
 
-    let secondServer: net.Server | null = null;
     try {
       const client = await createCmuxClient({
         socketStateDir: stateDir,
+        exec,
+        bin: "cmux",
+        reprobeIntervalMs: 60_000,
       });
-      expect(client).toBeInstanceOf(CmuxSocketClient);
-
-      fs.writeFileSync(
-        join(stateDir, "last-socket-path"),
-        `${secondSocketPath}\n`,
-        "utf-8",
-      );
-      secondServer = await startSocketServer(secondSocketPath);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: firstSocketPath,
+      });
 
       await expect(
         client.send("surface:1", "do-not-duplicate", {
           workspace: "workspace:1",
         }),
-      ).rejects.toThrow(/Socket closed unexpectedly|Socket error/i);
+      ).resolves.toBeUndefined();
       expect(first.seenMethods).toContain("surface.send_text");
-
-      await expect(client.ping()).resolves.toBe(true);
+      expect(exec).toHaveBeenCalledWith(
+        "cmux",
+        [
+          "--json",
+          "send",
+          "--surface",
+          "surface:1",
+          "--workspace",
+          "workspace:1",
+          "do-not-duplicate",
+        ],
+        expect.objectContaining({ CMUX_SOCKET_PATH: firstSocketPath }),
+      );
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "cli",
+        degraded: true,
+        current_socket_path: firstSocketPath,
+      });
     } finally {
       if (savedEnv === undefined) {
         delete process.env.CMUX_SOCKET_PATH;
@@ -1434,9 +1472,6 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
         process.env.CMUX_SOCKET_PATH = savedEnv;
       }
       await stopSocketServer(first.server, firstSocketPath);
-      if (secondServer) {
-        await stopSocketServer(secondServer, secondSocketPath);
-      }
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
@@ -1487,7 +1522,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
       const client = await createCmuxClient({
         socketStateDir: stateDir,
       });
-      expect(client).toBeInstanceOf(CmuxSocketClient);
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: firstSocketPath,
+      });
       expect(await client.ping()).toBe(true);
 
       await stopSocketServer(firstServer, firstSocketPath);

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -8,15 +8,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CmuxClient } from "../src/cmux-client.js";
+import { CmuxSocketError } from "../src/cmux-socket-error.js";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
 import {
   CmuxSelfHealingClient,
+  decorrelatedJitterDelayMs,
   getTransportHealth,
   wrapCliWithSelfHeal,
+  wrapSocketWithSelfHeal,
 } from "../src/cmux-transport-self-heal.js";
 
 const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
+const ACCESS_CONTROL_DENIED_TEXT =
+  "Access denied — only processes started inside cmux can connect";
 
 function startPingServer(
   socketPath: string,
@@ -74,6 +79,66 @@ function stopPingServer(server: net.Server, socketPath: string): Promise<void> {
   });
 }
 
+function startAccessDeniedPingServer(
+  socketPath: string,
+): Promise<{ server: net.Server }> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+          const req = JSON.parse(line);
+          conn.write(
+            JSON.stringify({
+              id: req.id,
+              ok: false,
+              error: {
+                code: "access_denied",
+                message: ACCESS_CONTROL_DENIED_TEXT,
+              },
+            }) + "\n",
+          );
+        }
+      });
+    });
+    (server as unknown as { _conns: Set<net.Socket> })._conns = connections;
+    server.listen(socketPath, () => resolve({ server }));
+  });
+}
+
+async function waitForExpectation(
+  assertion: () => void | Promise<void>,
+  opts: { timeout: number; interval: number },
+): Promise<void> {
+  const deadline = Date.now() + opts.timeout;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      await assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, opts.interval));
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   const servers: Array<{ server: net.Server; path: string }> = [];
 
@@ -105,7 +170,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       sleep,
     });
 
-    expect(client).toBeInstanceOf(CmuxSocketClient);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "socket",
+      degraded: false,
+      current_socket_path: socketPath,
+    });
     expect(sleep).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(
       "[cmuxlayer] transport selected: socket",
@@ -130,7 +199,6 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       reprobeIntervalMs: 20,
     });
 
-    expect(client).not.toBeInstanceOf(CmuxSocketClient);
     expect(getTransportHealth(client)).toMatchObject({
       mode: "cli",
       degraded: true,
@@ -139,7 +207,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     const { server } = await startPingServer(socketPath);
     track(server, socketPath);
 
-    await vi.waitFor(
+    await waitForExpectation(
       async () => {
         expect(await client.ping()).toBe(true);
       },
@@ -177,7 +245,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
         stderr: "",
       };
     });
-    const cli = new CmuxClient({ exec });
+    const cli = new CmuxClient({ exec, bin: "cmux" });
     const probe = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
 
     const client = wrapCliWithSelfHeal(cli, {
@@ -197,7 +265,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     releaseCli();
     await listPromise;
 
-    await vi.waitFor(
+    await waitForExpectation(
       async () => {
         expect(getTransportHealth(client)?.mode).toBe("socket");
       },
@@ -220,5 +288,288 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       current_socket_path: "/tmp/example.sock",
     });
     client.stop();
+  });
+
+  it("logs and exposes cmux access-control denial instead of generic CLI fallback", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-access-denied-"));
+    const socketPath = join(stateDir, "denied.sock");
+    const { server } = await startAccessDeniedPingServer(socketPath);
+    track(server, socketPath);
+    const logger = { error: vi.fn() };
+    const exec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+
+    const client = await createCmuxClient({
+      socketPath,
+      exec,
+      bin: "cmux",
+      logger,
+      reprobeIntervalMs: 60_000,
+    });
+
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: socketPath,
+      denied_reason: "access-control",
+      last_error: expect.stringContaining(ACCESS_CONTROL_DENIED_TEXT),
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("transport denied: access-control"),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(ACCESS_CONTROL_DENIED_TEXT),
+    );
+    await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+    if ("stop" in client && typeof client.stop === "function") {
+      client.stop();
+    }
+  });
+
+  it("downgrades from socket to CLI after an EPIPE transport error", async () => {
+    const socketPath = join(tmpdir(), `cmux-epipe-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const exec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    const cli = new CmuxClient({ exec, bin: "cmux" });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      ping: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: write EPIPE", "connection_error"),
+        ),
+    } as unknown as CmuxSocketClient;
+
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 60_000,
+      factoryOpts: { socketPath },
+    });
+
+    await expect(client.ping()).rejects.toThrow(/EPIPE/);
+    expect(getTransportHealth(client)).toEqual({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: socketPath,
+    });
+
+    await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      ["--json", "list-workspaces"],
+      expect.objectContaining({ CMUX_SOCKET_PATH: socketPath }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport downgraded: socket -> cli (periodic socket re-probe active)",
+    );
+    client.stop();
+  });
+
+  it("queues and flushes a failed socket payload through CLI after EPIPE", async () => {
+    const socketPath = join(tmpdir(), `cmux-queue-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const exec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ ok: true }),
+      stderr: "",
+    });
+    const cli = new CmuxClient({ exec, bin: "cmux" });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      send: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: write EPIPE", "connection_error"),
+        ),
+      ping: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: write EPIPE", "connection_error"),
+        ),
+    } as unknown as CmuxSocketClient;
+
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 60_000,
+      factoryOpts: { socketPath },
+    });
+
+    await expect(
+      client.send("surface:1", "lost payload", { workspace: "workspace:1" }),
+    ).resolves.toBeUndefined();
+
+    expect(socket.send).toHaveBeenCalledWith("surface:1", "lost payload", {
+      workspace: "workspace:1",
+    });
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      [
+        "--json",
+        "send",
+        "--surface",
+        "surface:1",
+        "--workspace",
+        "workspace:1",
+        "lost payload",
+      ],
+      expect.objectContaining({ CMUX_SOCKET_PATH: socketPath }),
+    );
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: socketPath,
+    });
+    client.stop();
+  });
+
+  it("flushes queued failed payloads sequentially", async () => {
+    const socketPath = join(tmpdir(), `cmux-queue-seq-${process.pid}.sock`);
+    let activeFlushes = 0;
+    let maxActiveFlushes = 0;
+    const flushOrder: string[] = [];
+    const exec = vi.fn().mockImplementation(async (_cmd, args) => {
+      activeFlushes++;
+      maxActiveFlushes = Math.max(maxActiveFlushes, activeFlushes);
+      flushOrder.push(String(args.at(-1)));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeFlushes--;
+      return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+    });
+    const cli = new CmuxClient({ exec, bin: "cmux" });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      send: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: ECONNRESET", "connection_error"),
+        ),
+      ping: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: ECONNRESET", "connection_error"),
+        ),
+    } as unknown as CmuxSocketClient;
+
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      reprobeIntervalMs: 60_000,
+      factoryOpts: { socketPath },
+    });
+
+    await expect(
+      Promise.all([
+        client.send("surface:1", "first", { workspace: "workspace:1" }),
+        client.send("surface:1", "second", { workspace: "workspace:1" }),
+      ]),
+    ).resolves.toEqual([undefined, undefined]);
+
+    expect(flushOrder).toEqual(["first", "second"]);
+    expect(maxActiveFlushes).toBe(1);
+    client.stop();
+  });
+
+  it("computes decorrelated jitter delays for re-probe scheduling", () => {
+    expect(
+      decorrelatedJitterDelayMs({
+        baseMs: 100,
+        previousMs: 100,
+        capMs: 1_000,
+        random: () => 0.5,
+      }),
+    ).toBe(200);
+    expect(
+      decorrelatedJitterDelayMs({
+        baseMs: 100,
+        previousMs: 200,
+        capMs: 1_000,
+        random: () => 0.5,
+      }),
+    ).toBe(350);
+    expect(
+      decorrelatedJitterDelayMs({
+        baseMs: 100,
+        previousMs: 1_000,
+        capMs: 1_000,
+        random: () => 1,
+      }),
+    ).toBe(1_000);
+  });
+
+  it("resumes socket re-probe after downgrading from a broken socket", async () => {
+    const socketPath = join(tmpdir(), `cmux-recover-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const exec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    const cli = new CmuxClient({ exec, bin: "cmux" });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      ping: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: Broken pipe", "connection_error"),
+        ),
+    } as unknown as CmuxSocketClient;
+
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 20,
+      factoryOpts: { socketPath },
+    });
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "socket",
+      degraded: false,
+      current_socket_path: socketPath,
+    });
+
+    await expect(client.ping()).rejects.toThrow(/Broken pipe/i);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: socketPath,
+    });
+    await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      ["--json", "list-workspaces"],
+      expect.objectContaining({ CMUX_SOCKET_PATH: socketPath }),
+    );
+
+    const recovered = await startPingServer(socketPath);
+    track(recovered.server, socketPath);
+
+    await waitForExpectation(
+      async () => {
+        expect(await client.ping()).toBe(true);
+      },
+      { timeout: 2_000, interval: 25 },
+    );
+
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "socket",
+      degraded: false,
+      current_socket_path: socketPath,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport downgraded: socket -> cli (periodic socket re-probe active)",
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] transport upgraded: cli -> socket",
+    );
+    if ("stop" in client && typeof client.stop === "function") {
+      client.stop();
+    }
   });
 });

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -13,6 +13,23 @@ import { AgentRegistry } from "../src/agent-registry.js";
 import { StateManager } from "../src/state-manager.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-control-health-test");
+const ACCESS_CONTROL_DENIED_TEXT =
+  "Access denied — only processes started inside cmux can connect";
+
+async function advanceTimers(ms: number): Promise<void> {
+  const advanceAsync = (
+    vi as unknown as {
+      advanceTimersByTimeAsync?: (value: number) => Promise<void>;
+    }
+  ).advanceTimersByTimeAsync;
+  if (advanceAsync) {
+    await advanceAsync.call(vi, ms);
+  } else {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
 
 function createHealthNotificationEngine() {
   const stateDir = join(TEST_ROOT, `engine-${Date.now()}-${Math.random()}`);
@@ -311,6 +328,44 @@ describe("control health", () => {
     }
   });
 
+  it("surfaces cmux access-control transport denial in selected transport and warnings", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-denied");
+    const tmp = join(TEST_ROOT, "tmp-denied");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    const socketPath = join(tmp, "cmux-denied.sock");
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "/bin", CMUX_SOCKET_PATH: socketPath },
+      client: {
+        constructor: { name: "CmuxSelfHealingClient" },
+        getTransportHealth: () => ({
+          mode: "cli",
+          degraded: true,
+          current_socket_path: socketPath,
+          denied_reason: "access-control",
+          last_error: ACCESS_CONTROL_DENIED_TEXT,
+        }),
+      },
+      execFile: async () => ({ stdout: "" }),
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+
+    expect(health.selected_transport).toMatchObject({
+      transport_mode: "cli",
+      transport_degraded: true,
+      current_socket_path: socketPath,
+      transport_denied: "access-control",
+      transport_error: ACCESS_CONTROL_DENIED_TEXT,
+    });
+    expect(health.warnings).toContain(
+      `cmuxlayer control transport denied: access-control; ${ACCESS_CONTROL_DENIED_TEXT}`,
+    );
+    expect(formatControlHealth(health)).toContain(ACCESS_CONTROL_DENIED_TEXT);
+  });
+
   it("periodically appends control health snapshots without tool invocation", async () => {
     vi.useFakeTimers();
     rmSync(TEST_ROOT, { recursive: true, force: true });
@@ -367,7 +422,7 @@ describe("control health", () => {
     });
 
     createServer({ context });
-    await vi.advanceTimersByTimeAsync(10_000);
+    await advanceTimers(10_000);
 
     context.dispose();
     const lines = readFileSync(join(TEST_ROOT, "events.jsonl"), "utf8")

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -97,11 +97,44 @@ function makePhantomNoBootPrompt(): string {
 }
 
 async function advanceTimers(ms: number): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  vi.advanceTimersByTime(ms);
-  await Promise.resolve();
-  await Promise.resolve();
+  const advanceAsync = (
+    vi as unknown as {
+      advanceTimersByTimeAsync?: (value: number) => Promise<void>;
+    }
+  ).advanceTimersByTimeAsync;
+  if (advanceAsync) {
+    await advanceAsync.call(vi, ms);
+    return;
+  }
+  const flush = async () => {
+    for (let i = 0; i < 6; i += 1) {
+      await Promise.resolve();
+    }
+  };
+  vi.advanceTimersByTime(0);
+  await flush();
+  let remaining = ms;
+  while (remaining > 0) {
+    const step = Math.min(remaining, 50);
+    vi.advanceTimersByTime(step);
+    await flush();
+    remaining -= step;
+  }
+  vi.advanceTimersByTime(0);
+  await flush();
+}
+
+function setFakeSystemTime(now: Date): void {
+  const setSystemTime = (
+    vi as unknown as {
+      setSystemTime?: (value: Date) => void;
+    }
+  ).setSystemTime;
+  if (setSystemTime) {
+    setSystemTime.call(vi, now);
+  } else {
+    vi.useFakeTimers({ now });
+  }
 }
 
 describe("createServer", () => {
@@ -401,7 +434,7 @@ describe("Claude channels", () => {
 
   it("includes health issue summary in health channel notifications", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-05T12:00:00.000Z"));
+    setFakeSystemTime(new Date("2026-07-05T12:00:00.000Z"));
     rmSync(CHANNEL_TEST_DIR, { recursive: true, force: true });
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     const inboxDir = join(CHANNEL_TEST_DIR, "inbox");
@@ -3872,7 +3905,7 @@ describe("tool handler integration", () => {
     expect(parsed.status).toBe("delivering");
     expect(parsed.submit_verified).toBeNull();
 
-    await vi.advanceTimersByTimeAsync(3_000);
+    await advanceTimers(3_000);
 
     const readAfterDelivery = await readTool.handler(
       { surface: "surface:agent-bg", parsed_only: true },
@@ -3962,7 +3995,7 @@ describe("tool handler integration", () => {
       },
       {} as any,
     );
-    await vi.advanceTimersByTimeAsync(6_000);
+    await advanceTimers(6_000);
     const result = await resultPromise;
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -4046,7 +4079,7 @@ describe("tool handler integration", () => {
       },
       {} as any,
     );
-    await vi.advanceTimersByTimeAsync(250);
+    await advanceTimers(250);
     const result = await resultPromise;
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -4129,7 +4162,7 @@ describe("tool handler integration", () => {
       },
       {} as any,
     );
-    await vi.advanceTimersByTimeAsync(6_000);
+    await advanceTimers(6_000);
     const result = await resultPromise;
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);


### PR DESCRIPTION
## Summary
- Resolve CLI fallback binary lookup per run: explicit `bin`, bundled CLI env, standard app bundle path, then `cmux` on PATH.
- Wrap socket-mode clients in the self-healing transport so EPIPE/ECONNRESET/broken-pipe failures downgrade to CLI, queue the failed payload, flush it through CLI, and continue jittered socket re-probes.
- Attach socket error listeners before writes and clear pending request state on write failure to prevent unhandled broken-pipe process exits.
- Distinguish cmux access-control socket denial (`Access denied — only processes started inside cmux can connect`) in transport logs and `control_health` instead of collapsing it into generic CLI fallback.
- Stabilize Bun/Vitest test harnesses where host bundled-cmux paths and missing async timer helpers made tests environment-sensitive.

## Verification
- `bun run typecheck`
- `bun run build`
- `bun run test` (85 files, 1530 tests)
- pre-push hook reran `run_tests.sh`: 85 files, 1530 tests
- `git diff --check`

## Notes
- Local CodeRabbit CLI reached the review phase but did not complete within a 180s cap; no review result was available pre-PR.
- Live installed cmuxlayer daemon smoke: `control_health` returned successfully; `list_surfaces` repeatedly returned `Socket closed unexpectedly` from the currently installed old daemon, matching the bug this PR fixes rather than the worktree build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MCP→cmux transport (factory, self-heal, persistent socket) and CLI resolution; failed mutating calls are replayed via CLI after socket errors, which could duplicate side effects if a call partially succeeded before the pipe broke.
> 
> **Overview**
> Hardens cmuxlayer **control transport** so CLI fallback works reliably, broken sockets recover without losing work, and access denials are visible in logs and health.
> 
> **CLI binary resolution** now picks the executable in order: explicit `bin`, `CMUX_BUNDLED_CLI_PATH` (per-run env then process), the standard `/Applications/cmux.app/.../cmux` bundle if present, then bare `cmux` on PATH—reducing ENOENT when PATH lacks cmux.
> 
> **Bidirectional self-healing** wraps both socket and CLI clients: transport errors (EPIPE, ECONNRESET, broken pipe, connection closed) **downgrade** to CLI, **queue and replay** the failed call through CLI (pinned via `CMUX_SOCKET_PATH`), and keep **decorrelated-jitter** socket re-probes until upgrade. Startup probing uses **`probeSocketHealth`** and stops retrying on **access-control** denial instead of treating it like a dead socket.
> 
> **Persistent socket writes** attach error listeners before `write`, reject in-flight requests on write failure, and bump listener limits—aimed at avoiding unhandled broken-pipe process exits.
> 
> **`control_health`** exposes `transport_denied` / `transport_error` and dedicated warnings when cmux rejects external socket connections.
> 
> Tests and timer helpers were adjusted for bundled-cmux paths and Bun/Vitest async timer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bb33bd88357c7f3f54176ffe6f5bfa4012aa2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cmux CLI ENOENT fallback and socket recovery with self-healing transport
> - Adds `wrapSocketWithSelfHeal` and extends `CmuxSelfHealingClient` to support bidirectional transitions: downgrades from socket to CLI on EPIPE/ECONNRESET, replays failed payloads via CLI, and upgrades back when the socket recovers.
> - Introduces `probeSocketHealth` in [`src/cmux-socket-probe.ts`](https://github.com/EtanHey/cmuxlayer/pull/272/files#diff-fd278404ca36fd0f03810f607b3ab7acd88b6e5aaccbec4625dae9ecb32191e3) to distinguish access-control denials from other socket failures, surfacing denial details in health reports and warnings.
> - `CmuxClient` now resolves the CLI binary via a priority chain: explicit `bin` → `CMUX_BUNDLED_CLI_PATH` env → standard macOS bundled path → bare `cmux` on PATH.
> - `CmuxPersistentSocket` fixes write-time errors: attaches an error listener before each write and rejects pending requests with a normalized `CmuxSocketError` on failure instead of hanging.
> - Behavioral Change: the factory (`createCmuxClient`) now always returns a self-healing transport wrapper, so socket and CLI clients both support automatic downgrade/upgrade without process restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 92bb33b. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery between socket and CLI transports when connectivity changes.
  * Failed socket requests are retried through the CLI fallback while preserving order.
  * Added configurable bundled CLI discovery and command-path overrides.
  * Transport health now reports access-control denials and relevant error details.

* **Bug Fixes**
  * Improved handling of connection and write failures, preventing stalled requests.
  * Enhanced socket probing to distinguish unavailable sockets from access restrictions.

* **Tests**
  * Expanded coverage for transport recovery, fallback behavior, CLI resolution, and health reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->