### PR TITLE
fix: root-cause errno-32 transport failures

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -23,6 +23,7 @@ import type {
   CmuxNewSurfaceResult,
   CmuxReadScreenResult,
   CmuxSendOptions,
+  CmuxStatusUpdate,
   CmuxWorkspace,
 } from "./types.js";
 import {
@@ -453,6 +454,7 @@ interface AgentEngineClient {
       surface?: string;
     },
   ): Promise<void>;
+  setStatuses?(updates: CmuxStatusUpdate[]): Promise<boolean | void>;
   readScreen(
     surface: string,
     opts?: { workspace?: string; lines?: number; scrollback?: boolean },
@@ -2520,6 +2522,11 @@ export class AgentEngine {
     const total = agents.length;
     const done = agents.filter((a) => a.state === "done").length;
     const surfaceTopology = await collectSurfaceTopology(this.client);
+    const statusUpdates: CmuxStatusUpdate[] = [];
+    const pendingStatusSnapshots: Array<{
+      agentId: string;
+      snapshot: SidebarStatusSnapshot;
+    }> = [];
 
     for (const originalAgent of agents) {
       const sweepCtx: SweepAgentContext = {};
@@ -2683,20 +2690,27 @@ export class AgentEngine {
           }
         }
         const sidebar = STATE_SIDEBAR[state];
-        await this.client.setStatus(agentId, statusValue, {
+        statusUpdates.push({
+          key: agentId,
+          value: statusValue,
           icon: sidebar.icon,
           color: sidebar.color,
           surface: surface_id,
           workspace: agent.workspace_id ?? undefined,
         });
       }
-      this.sidebarSnapshot.set(agentId, {
+      const nextSnapshot = {
         ...statusSnapshot,
         healthSignature:
           shouldNotifyHealth && !healthNotificationDelivered
             ? (prev?.healthSignature ?? "pending_health_notification")
             : statusSnapshot.healthSignature,
-      });
+      };
+      if (statusChanged) {
+        pendingStatusSnapshots.push({ agentId, snapshot: nextSnapshot });
+      } else {
+        this.sidebarSnapshot.set(agentId, nextSnapshot);
+      }
 
       // Quality tracking: check context usage for non-terminal agents
       // AIDEV-NOTE: Uses parseScreen for model-aware context_pct (handles Claude, Codex, Gemini).
@@ -2738,6 +2752,26 @@ export class AgentEngine {
         } catch {
           // readScreen failures are non-fatal — next sweep will retry
         }
+      }
+    }
+
+    let statusBatchApplied = true;
+    if (statusUpdates.length === 1) {
+      const [update] = statusUpdates;
+      await this.client.setStatus(update.key, update.value, update);
+    } else if (statusUpdates.length > 1) {
+      if (this.client.setStatuses) {
+        statusBatchApplied =
+          (await this.client.setStatuses(statusUpdates)) !== false;
+      } else {
+        for (const update of statusUpdates) {
+          await this.client.setStatus(update.key, update.value, update);
+        }
+      }
+    }
+    if (statusBatchApplied) {
+      for (const pending of pendingStatusSnapshots) {
+        this.sidebarSnapshot.set(pending.agentId, pending.snapshot);
       }
     }
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -167,6 +167,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       log: async () => {},
       listWorkspaces: () => this.client.listWorkspaces(),
       setStatus: async () => {},
+      setStatuses: async () => {},
       clearStatus: async () => {},
       readScreen: (surface, readOpts) => this.client.readScreen(surface, readOpts),
       send: (surface, text, sendOpts) =>

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -6,7 +6,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
-import { isAbsolute } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import type {
   CmuxPane,
@@ -19,9 +19,11 @@ import type {
   CmuxReadScreenResult,
   CmuxSendOptions,
   CmuxStatusEntry,
+  CmuxStatusUpdate,
   CmuxTerminalMetadata,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
+import { CmuxSocketError } from "./cmux-socket-error.js";
 
 const execFileAsync = promisify(execFile);
 const STANDARD_BUNDLED_CMUX =
@@ -111,6 +113,9 @@ export class CmuxClient {
     const explicitBin = cleanAbsoluteOrCommand(this.bin);
     if (explicitBin) return explicitBin;
 
+    const shim = this.resolvePathShim(env?.PATH ?? process.env.PATH);
+    if (shim) return shim;
+
     const envBundled = cleanAbsolutePath(env?.CMUX_BUNDLED_CLI_PATH);
     if (envBundled) return envBundled;
 
@@ -124,6 +129,15 @@ export class CmuxClient {
     }
 
     return "cmux";
+  }
+
+  private resolvePathShim(pathValue: string | undefined): string | null {
+    for (const directory of pathValue?.split(delimiter) ?? []) {
+      if (!directory) continue;
+      const candidate = join(directory, "cmux");
+      if (this.existsSync(candidate)) return candidate;
+    }
+    return null;
   }
 
   private parse<T>(raw: string, command: string): T {
@@ -188,7 +202,17 @@ export class CmuxClient {
       details.push(`exit ${String(code)}`);
 
     const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
-    return new Error(`cmux ${args[0]} failed: ${error.message}${suffix}`);
+    const message = `cmux ${args[0]} failed: ${error.message}${suffix}`;
+    if (/\b(?:EPIPE|ECONNRESET|broken pipe|errno\s*32)\b/i.test(message)) {
+      const stdout =
+        "stdout" in error && typeof error.stdout === "string"
+          ? error.stdout.trim()
+          : "";
+      return new CmuxSocketError(message, "connection_error", {
+        transportPhase: stdout ? "response" : "write",
+      });
+    }
+    return new Error(message);
   }
 
   private assertSupportedSendOptions(opts?: CmuxSendOptions): void {
@@ -573,6 +597,14 @@ export class CmuxClient {
         : undefined);
     if (workspace) args.push("--workspace", workspace);
     await this.run(args);
+  }
+
+  async setStatuses(updates: CmuxStatusUpdate[]): Promise<boolean> {
+    if (updates.length === 0) return true;
+    console.error(
+      `[cmuxlayer] skipped ${updates.length} sidebar status pushes while socket batching is unavailable`,
+    );
+    return false;
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -140,7 +140,10 @@ export class CmuxPersistentSocket {
 
       this.socket.on("error", (err: Error) => {
         this.connected = false;
-        const socketError = this.toConnectionError(err);
+        const socketError = this.toConnectionError(
+          err,
+          settled ? "response" : "connect",
+        );
         this.rejectAllPending(socketError);
         if (!settled) {
           settled = true;
@@ -157,6 +160,7 @@ export class CmuxPersistentSocket {
           new CmuxSocketError(
             "Socket closed unexpectedly",
             "connection_closed",
+            { transportPhase: "response" },
           ),
         );
       });
@@ -297,10 +301,14 @@ export class CmuxPersistentSocket {
     });
   }
 
-  private toConnectionError(error: Error): CmuxSocketError {
+  private toConnectionError(
+    error: Error,
+    transportPhase: "connect" | "write" | "response" = "response",
+  ): CmuxSocketError {
     return new CmuxSocketError(
       `Socket error: ${error.message}`,
       "connection_error",
+      { transportPhase },
     );
   }
 
@@ -310,7 +318,11 @@ export class CmuxPersistentSocket {
   ): void {
     const socket = this.socket;
     if (!socket) {
-      onWriteError(new CmuxSocketError("Socket disconnected", "connection_closed"));
+      onWriteError(
+        new CmuxSocketError("Socket disconnected", "connection_closed", {
+          transportPhase: "write",
+        }),
+      );
       return;
     }
 
@@ -322,11 +334,15 @@ export class CmuxPersistentSocket {
       if (settled) return;
       settled = true;
       cleanup();
-      onWriteError(this.toConnectionError(error));
+      onWriteError(this.toConnectionError(error, "write"));
     };
     const onError = (error: Error) => fail(error);
 
-    socket.once("error", onError);
+    // Run the write-scoped listener before the connection-wide listener. Node
+    // invokes EventEmitter listeners in registration order; without prepend,
+    // an asynchronous EPIPE is conservatively mislabeled as post-response and
+    // a safe pre-response mutation retry is suppressed.
+    socket.prependOnceListener("error", onError);
     try {
       socket.write(payload, () => {
         if (settled) return;

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -19,6 +19,7 @@ import type {
   CmuxReadScreenResult,
   CmuxSendOptions,
   CmuxStatusEntry,
+  CmuxStatusUpdate,
   CmuxTerminalMetadata,
 } from "./types.js";
 import { CmuxClient } from "./cmux-client.js";
@@ -34,12 +35,6 @@ const REQUEST_TIMEOUT_MS = 10_000;
 const V1_SAFE_VALUE_RE = /^(?!-)[A-Za-z0-9_./:@%+=#,-]+$/;
 const RETRY_SAFE_V2_METHODS = new Set([
   "system.ping",
-  "system.identify",
-  "workspace.list",
-  "surface.list",
-  "pane.list",
-  "surface.read_text",
-  "status.list",
 ]);
 
 interface V1RawArg {
@@ -599,6 +594,13 @@ export class CmuxSocketClient {
     const tabId = await this.resolveSidebarTabId(opts);
     if (tabId) args.push(this.rawV1Arg(`--tab=${tabId}`));
     await this.sendV1Args("set_status", args);
+  }
+
+  async setStatuses(updates: CmuxStatusUpdate[]): Promise<boolean> {
+    for (const update of updates) {
+      await this.setStatus(update.key, update.value, update);
+    }
+    return true;
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {

--- a/src/cmux-socket-error.ts
+++ b/src/cmux-socket-error.ts
@@ -1,9 +1,15 @@
 export class CmuxSocketError extends Error {
+  readonly transport_phase?: "connect" | "write" | "response";
+  retry_count?: number;
+  transport_state?: string;
+
   constructor(
     message: string,
     public readonly code?: string,
+    opts?: { transportPhase?: "connect" | "write" | "response" },
   ) {
     super(message);
     this.name = "CmuxSocketError";
+    this.transport_phase = opts?.transportPhase;
   }
 }

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -16,11 +16,15 @@ import {
   resolveSocketPath,
   type SocketProbeResult,
 } from "./cmux-socket-probe.js";
+import { recordTransportRetry } from "./transport-retry-context.js";
 
 export const DEFAULT_PING_RETRY_ATTEMPTS = 3;
 export const DEFAULT_PING_RETRY_BACKOFF_MS = [100, 250, 500] as const;
 export const DEFAULT_TRANSPORT_REPROBE_MS = 5_000;
 export const DEFAULT_TRANSPORT_REPROBE_CAP_MS = 30_000;
+export const DEFAULT_INTERACTIVE_RETRY_ATTEMPTS = 3;
+export const DEFAULT_INTERACTIVE_RETRY_BASE_MS = 100;
+export const DEFAULT_INTERACTIVE_RETRY_CAP_MS = 400;
 
 export interface TransportHealthSignal {
   mode: "socket" | "cli";
@@ -52,6 +56,9 @@ export interface CmuxSelfHealingClientOptions {
   probeUsable?: typeof probeUsableSocket;
   probeSocketHealth?: typeof probeSocketHealth;
   resolvePath?: typeof resolveSocketPath;
+  retryAttempts?: number;
+  retryBaseMs?: number;
+  retryCapMs?: number;
 }
 
 const FORWARDED_ASYNC_METHODS = [
@@ -72,6 +79,7 @@ const FORWARDED_ASYNC_METHODS = [
   "renameTab",
   "notify",
   "setStatus",
+  "setStatuses",
   "clearStatus",
   "setProgress",
   "clearProgress",
@@ -88,6 +96,7 @@ type ForwardedAsyncMethod = (typeof FORWARDED_ASYNC_METHODS)[number];
 interface FailedPayload {
   method: ForwardedAsyncMethod;
   args: unknown[];
+  error: unknown;
 }
 
 interface QueuedFailedPayload {
@@ -95,6 +104,16 @@ interface QueuedFailedPayload {
   resolve: (value: unknown) => void;
   reject: (error: unknown) => void;
 }
+
+const READ_ONLY_METHODS = new Set<ForwardedAsyncMethod>([
+  "listWorkspaces",
+  "listPaneSurfaces",
+  "listPanes",
+  "listTerminalMetadata",
+  "readScreen",
+  "listStatus",
+  "identify",
+]);
 
 export function decorrelatedJitterDelayMs(opts: {
   baseMs: number;
@@ -153,6 +172,7 @@ export class CmuxSelfHealingClient {
   private failedPayloadQueue: QueuedFailedPayload[] = [];
   private flushingFailedPayloadQueue: Promise<void> | null = null;
   private transportDenial: TransportDenialSignal | null = null;
+  private completedRetryCount = 0;
 
   constructor(private readonly opts: CmuxSelfHealingClientOptions) {
     this.socketClient = opts.socket ?? null;
@@ -193,6 +213,12 @@ export class CmuxSelfHealingClient {
       current_socket_path: this.opts.socketPath,
       ...denial,
     };
+  }
+
+  consumeRetryCount(): number {
+    const count = this.completedRetryCount;
+    this.completedRetryCount = 0;
+    return count;
   }
 
   setEnv(env: NodeJS.ProcessEnv | undefined): void {
@@ -258,6 +284,7 @@ export class CmuxSelfHealingClient {
     method: ForwardedAsyncMethod,
     args: unknown[],
   ): Promise<unknown> {
+    this.completedRetryCount = 0;
     const delegate = this.delegate;
     const startedOnSocket =
       this.socketClient !== null && delegate === this.socketClient;
@@ -344,14 +371,18 @@ export class CmuxSelfHealingClient {
     args: unknown[],
     startedOnSocket: boolean,
   ): Promise<unknown> | null {
-    if (!startedOnSocket || !this.isRecoverableSocketError(error)) {
+    if (
+      startedOnSocket &&
+      this.socketClient &&
+      this.isRecoverableSocketError(error)
+    ) {
+      this.downgradeToCli();
+    }
+    if (!this.canRetryPayload(error, method)) {
       return null;
     }
 
-    const replay = this.enqueueFailedPayload({ method, args });
-    if (this.socketClient) {
-      this.downgradeToCli();
-    }
+    const replay = this.enqueueFailedPayload({ method, args, error });
     void this.flushFailedPayloadQueue();
     return replay;
   }
@@ -371,10 +402,7 @@ export class CmuxSelfHealingClient {
       while (this.failedPayloadQueue.length > 0) {
         const entry = this.failedPayloadQueue[0]!;
         try {
-          const result = await this.callDelegate(
-            entry.payload.method,
-            entry.payload.args,
-          );
+          const result = await this.retryPayload(entry.payload);
           entry.resolve(result);
         } catch (error) {
           entry.reject(error);
@@ -387,6 +415,69 @@ export class CmuxSelfHealingClient {
     });
 
     return this.flushingFailedPayloadQueue;
+  }
+
+  private canRetryPayload(
+    error: unknown,
+    method: ForwardedAsyncMethod,
+  ): boolean {
+    if (!this.isRecoverableSocketError(error)) return false;
+    if (READ_ONLY_METHODS.has(method)) return true;
+    const phase =
+      error instanceof CmuxSocketError ? error.transport_phase : undefined;
+    const message = error instanceof Error ? error.message : String(error);
+    return (
+      phase === "connect" ||
+      phase === "write" ||
+      (phase === undefined && /\bwrite\b/i.test(message))
+    );
+  }
+
+  private async retryPayload(payload: FailedPayload): Promise<unknown> {
+    const attempts = Math.max(
+      1,
+      this.opts.retryAttempts ?? DEFAULT_INTERACTIVE_RETRY_ATTEMPTS,
+    );
+    const baseMs = this.opts.retryBaseMs ?? DEFAULT_INTERACTIVE_RETRY_BASE_MS;
+    const capMs = this.opts.retryCapMs ?? DEFAULT_INTERACTIVE_RETRY_CAP_MS;
+    const sleep = this.opts.sleep ?? defaultSleep;
+    let previousMs = baseMs;
+    let lastError = payload.error;
+
+    for (let retryCount = 1; retryCount < attempts; retryCount++) {
+      const delayMs = decorrelatedJitterDelayMs({
+        baseMs,
+        previousMs,
+        capMs,
+        random: this.opts.random,
+      });
+      previousMs = delayMs;
+      await sleep(delayMs);
+      this.completedRetryCount = retryCount;
+      recordTransportRetry();
+      try {
+        return await this.callDelegate(payload.method, payload.args);
+      } catch (error) {
+        lastError = error;
+        if (!this.canRetryPayload(error, payload.method)) break;
+      }
+    }
+
+    throw this.annotateRetryError(lastError, this.completedRetryCount);
+  }
+
+  private annotateRetryError(error: unknown, retryCount: number): unknown {
+    if (error && typeof error === "object") {
+      Object.assign(error, {
+        retry_count: retryCount,
+        transport_state:
+          error instanceof CmuxSocketError &&
+          error.transport_phase === "response"
+            ? "response_failed"
+            : "write_failed",
+      });
+    }
+    return error;
   }
 
   private downgradeToCli(): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,10 @@ import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { createStaleBuildWarner, readVersion } from "./version.js";
 import { StateManager } from "./state-manager.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
+import {
+  currentTransportRetryCount,
+  withTransportRetryTracking,
+} from "./transport-retry-context.js";
 import { AgentRegistry } from "./agent-registry.js";
 import {
   AgentEngine,
@@ -562,7 +566,11 @@ function surfaceGonePayload(
 }
 
 function ok(data: Record<string, unknown>): ToolReturn {
-  const payload = { ok: true, ...data };
+  const payload = {
+    ok: true,
+    retry_count: currentTransportRetryCount(),
+    ...data,
+  };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
@@ -574,7 +582,11 @@ function okFormatted(
   formattedText: string,
   data: Record<string, unknown>,
 ): ToolReturn {
-  const payload = { ok: true, ...data };
+  const payload = {
+    ok: true,
+    retry_count: currentTransportRetryCount(),
+    ...data,
+  };
   return {
     content: [{ type: "text", text: formattedText }],
     structuredContent: payload,
@@ -593,7 +605,32 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
           control: error.control,
         }
       : {};
-  const payload = { ok: false, error: message, ...modeExtra, ...extra };
+  const retryMeta =
+    error && typeof error === "object"
+      ? {
+          retry_count:
+            "retry_count" in error &&
+            typeof (error as { retry_count?: unknown }).retry_count === "number"
+              ? (error as { retry_count: number }).retry_count
+              : currentTransportRetryCount(),
+          ...(error &&
+          "transport_state" in error &&
+          typeof (error as { transport_state?: unknown }).transport_state ===
+            "string"
+            ? {
+                transport_state: (error as { transport_state: string })
+                  .transport_state,
+              }
+            : {}),
+        }
+      : { retry_count: currentTransportRetryCount() };
+  const payload = {
+    ok: false,
+    error: message,
+    ...retryMeta,
+    ...modeExtra,
+    ...extra,
+  };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
@@ -2335,6 +2372,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }
       : undefined,
   );
+  const rawTool = server.tool.bind(server) as (...args: unknown[]) => unknown;
+  (
+    server as unknown as { tool: (...args: unknown[]) => unknown }
+  ).tool = (...args: unknown[]): unknown => {
+    const handlerIndex = args.length - 1;
+    const handler = args[handlerIndex];
+    if (typeof handler === "function") {
+      args[handlerIndex] = (...handlerArgs: unknown[]) =>
+        withTransportRetryTracking(() => handler(...handlerArgs));
+    }
+    return rawTool(...args);
+  };
   if (ownsContext) {
     const close = server.close.bind(server);
     server.close = async (): Promise<void> => {
@@ -6126,6 +6175,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           listWorkspaces: () => client.listWorkspaces(),
           setStatus: (key, value, statusOpts) =>
             client.setStatus(key, value, statusOpts),
+          setStatuses: async (updates) => {
+            if (typeof client.setStatuses === "function") {
+              return client.setStatuses(updates);
+            }
+            for (const update of updates) {
+              await client.setStatus(update.key, update.value, update);
+            }
+            return true;
+          },
           clearStatus: (key, clearOpts) => client.clearStatus(key, clearOpts),
           readScreen: (surface, readOpts) =>
             client.readScreen(surface, readOpts),

--- a/src/transport-retry-context.ts
+++ b/src/transport-retry-context.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface TransportRetryContext {
+  retryCount: number;
+}
+
+const retryStorage = new AsyncLocalStorage<TransportRetryContext>();
+
+export function withTransportRetryTracking<T>(fn: () => T): T {
+  return retryStorage.run({ retryCount: 0 }, fn);
+}
+
+export function recordTransportRetry(): void {
+  const context = retryStorage.getStore();
+  if (context) context.retryCount += 1;
+}
+
+export function currentTransportRetryCount(): number {
+  return retryStorage.getStore()?.retryCount ?? 0;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,11 @@ export interface CmuxStatusEntry {
   color?: string;
 }
 
+export interface CmuxStatusUpdate extends CmuxStatusEntry {
+  workspace?: string;
+  surface?: string;
+}
+
 export interface ToolResult {
   ok: boolean;
   surface?: string;

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -537,6 +537,30 @@ describe("CmuxClient CLI-fallback socket env (instance pin)", () => {
 });
 
 describe("CmuxClient CLI binary resolution", () => {
+  it("prefers the reload-aware PATH shim while preserving the pinned socket env", async () => {
+    const exec = mockExec({ workspaces: [] });
+    const client = new CmuxClient({
+      exec,
+      env: {
+        CMUX_SOCKET_PATH: "/tmp/pinned.sock",
+        CMUX_BUNDLED_CLI_PATH:
+          "/Applications/cmux.app/Contents/Resources/bin/cmux",
+        PATH: "/opt/cmux-shims:/usr/bin",
+      },
+      existsSync: (candidate) =>
+        candidate === "/opt/cmux-shims/cmux" ||
+        candidate === STANDARD_BUNDLED_CMUX,
+    });
+
+    await client.listWorkspaces();
+
+    expect(exec).toHaveBeenCalledWith(
+      "/opt/cmux-shims/cmux",
+      ["--json", "list-workspaces"],
+      expect.objectContaining({ CMUX_SOCKET_PATH: "/tmp/pinned.sock" }),
+    );
+  });
+
   it("uses explicit opts.bin before any bundled cmux env", async () => {
     const exec = mockExec({ workspaces: [] });
     const client = new CmuxClient({

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
+import { CmuxSocketError } from "../src/cmux-socket-error.js";
 
 const TEST_ROOT = join("/tmp", "cmux-persistent-socket-test");
 const servers: net.Server[] = [];
@@ -234,9 +235,12 @@ describe("CmuxPersistentSocket V1 demux", () => {
     class FakeSocket extends EventEmitter {
       destroyed = false;
 
-      once(event: string, listener: (...args: unknown[]) => void): this {
-        if (event === "error") events.push("once:error");
-        return super.once(event, listener);
+      prependOnceListener(
+        event: string,
+        listener: (...args: unknown[]) => void,
+      ): this {
+        if (event === "error") events.push("prependOnce:error");
+        return super.prependOnceListener(event, listener);
       }
 
       write(payload: string, callback?: () => void): boolean {
@@ -258,7 +262,7 @@ describe("CmuxPersistentSocket V1 demux", () => {
     const result = socket.call("system.ping");
     await Promise.resolve();
     expect(capturedPayload).toContain("system.ping");
-    expect(events.slice(0, 2)).toEqual(["once:error", "write"]);
+    expect(events.slice(0, 2)).toEqual(["prependOnce:error", "write"]);
     const request = JSON.parse(capturedPayload.trim()) as { id: string };
     (
       socket as unknown as {
@@ -306,6 +310,45 @@ describe("CmuxPersistentSocket V1 demux", () => {
     expect(
       (socket as unknown as { pending: Map<string, unknown> }).pending.size,
     ).toBe(0);
+    socket.disconnect();
+  });
+
+  it("classifies an asynchronously emitted write EPIPE before the global socket listener", async () => {
+    class EmittingSocket extends EventEmitter {
+      destroyed = false;
+
+      write(): boolean {
+        const error = new Error("write EPIPE");
+        (error as NodeJS.ErrnoException).code = "EPIPE";
+        queueMicrotask(() => this.emit("error", error));
+        return true;
+      }
+
+      destroy(): void {
+        this.destroyed = true;
+      }
+    }
+
+    const socket = new CmuxPersistentSocket({ timeoutMs: 500 });
+    const transport = new EmittingSocket();
+    transport.on("error", (error: Error) => {
+      const internals = socket as unknown as {
+        rejectAllPending: (error: CmuxSocketError) => void;
+      };
+      internals.rejectAllPending(
+        new CmuxSocketError(`Socket error: ${error.message}`, "connection_error", {
+          transportPhase: "response",
+        }),
+      );
+    });
+    (socket as unknown as { connected: boolean }).connected = true;
+    (socket as unknown as { socket: EmittingSocket }).socket =
+      transport;
+
+    await expect(socket.call("surface.send_text")).rejects.toMatchObject({
+      code: "connection_error",
+      transport_phase: "write",
+    });
     socket.disconnect();
   });
 });

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -602,6 +602,22 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     // No throw = success
   });
 
+  it("sends a 12-entry status batch through one persistent connection", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.setStatuses(
+      Array.from({ length: 12 }, (_, index) => ({
+        key: `agent-${index}`,
+        value: "working",
+      })),
+    );
+
+    expect(connectionCount).toBe(1);
+    expect(
+      mockEvents.filter((event) => event.type === "v1"),
+    ).toHaveLength(12);
+  });
+
   it("authenticates before V1 commands when password is configured", async () => {
     const client = new CmuxSocketClient({
       socketPath: MOCK_SOCKET_PATH,
@@ -1412,7 +1428,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
     }
   });
 
-  it("flushes a failed mutating socket call through CLI fallback", async () => {
+  it("does not replay a mutation when the socket closes after receiving it", async () => {
     const stateDir = mkdtempSync(join(tmpdir(), "cmux-state-"));
     const firstSocketPath = join(stateDir, "first.sock");
     fs.writeFileSync(
@@ -1445,21 +1461,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("createCmuxClient factory", () => {
         client.send("surface:1", "do-not-duplicate", {
           workspace: "workspace:1",
         }),
-      ).resolves.toBeUndefined();
+      ).rejects.toMatchObject({ transport_phase: "response" });
       expect(first.seenMethods).toContain("surface.send_text");
-      expect(exec).toHaveBeenCalledWith(
-        "cmux",
-        [
-          "--json",
-          "send",
-          "--surface",
-          "surface:1",
-          "--workspace",
-          "workspace:1",
-          "do-not-duplicate",
-        ],
-        expect.objectContaining({ CMUX_SOCKET_PATH: firstSocketPath }),
-      );
+      expect(exec).not.toHaveBeenCalled();
       expect(getTransportHealth(client)).toMatchObject({
         mode: "cli",
         degraded: true,

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -143,6 +143,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   const servers: Array<{ server: net.Server; path: string }> = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     for (const { server, path } of servers.splice(0)) {
       await stopPingServer(server, path);
     }
@@ -430,6 +431,93 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("retries an interactive CLI call after errno 32 with injected backoff", async () => {
+    vi.useFakeTimers();
+    const transportFailure = Object.assign(
+      new Error("Failed to write to socket (Broken pipe, errno 32)"),
+      { code: 1, stderr: "Failed to write to socket (Broken pipe, errno 32)" },
+    );
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(transportFailure)
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath: "/tmp/retry.sock",
+      reprobeIntervalMs: 60_000,
+      retryBaseMs: 100,
+      retryCapMs: 400,
+      retryAttempts: 3,
+      random: () => 0,
+    });
+
+    const result = client.listWorkspaces();
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(result).resolves.toEqual({ workspaces: [] });
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(client.consumeRetryCount()).toBe(1);
+    client.stop();
+  });
+
+  it("surfaces exhausted transport state and retry count", async () => {
+    vi.useFakeTimers();
+    const transportFailure = Object.assign(
+      new Error("write ECONNRESET"),
+      { code: 1, stderr: "write ECONNRESET" },
+    );
+    const exec = vi.fn().mockRejectedValue(transportFailure);
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath: "/tmp/retry-exhausted.sock",
+      reprobeIntervalMs: 60_000,
+      retryBaseMs: 100,
+      retryCapMs: 400,
+      retryAttempts: 3,
+      random: () => 0,
+    });
+
+    const result = client.listWorkspaces();
+    const rejection = expect(result).rejects.toMatchObject({
+      retry_count: 2,
+      transport_state: "write_failed",
+    });
+    await vi.advanceTimersByTimeAsync(200);
+
+    await rejection;
+    expect(exec).toHaveBeenCalledTimes(3);
+    client.stop();
+  });
+
+  it("does not replay a mutation after a post-response transport failure", async () => {
+    const socketPath = join(tmpdir(), `cmux-response-${process.pid}.sock`);
+    const exec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const cli = new CmuxClient({
+      exec,
+      bin: "cmux",
+    });
+    const responseFailure = Object.assign(
+      new CmuxSocketError("connection reset after response", "connection_error"),
+      { transport_phase: "response" },
+    );
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      closeSurface: vi.fn().mockRejectedValue(responseFailure),
+    } as unknown as CmuxSocketClient;
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      reprobeIntervalMs: 60_000,
+    });
+
+    await expect(
+      client.closeSurface("surface:1", { workspace: "workspace:1" }),
+    ).rejects.toBe(responseFailure);
+    expect(exec).not.toHaveBeenCalled();
+    client.stop();
+  });
+
   it("flushes queued failed payloads sequentially", async () => {
     const socketPath = join(tmpdir(), `cmux-queue-seq-${process.pid}.sock`);
     let activeFlushes = 0;
@@ -450,7 +538,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       send: vi
         .fn()
         .mockRejectedValue(
-          new CmuxSocketError("Socket error: ECONNRESET", "connection_error"),
+          new CmuxSocketError("Socket error: ECONNRESET", "connection_error", {
+            transportPhase: "write",
+          }),
         ),
       ping: vi
         .fn()

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -279,7 +279,7 @@ function startEngineServer(
 }
 
 describe("Phase 10 painpoint e2e replay", () => {
-  it("sidebar-scale sweeps many agents with bounded, diffed status emissions", async () => {
+  it("sidebar-scale sweeps skip degraded-CLI status bursts", async () => {
     const dir = tempDir("sidebar-scale");
     const stateMgr = new StateManager(dir);
     const agentCount = 25;
@@ -309,17 +309,7 @@ describe("Phase 10 painpoint e2e replay", () => {
 
       await engine.runSweep();
 
-      expect(statusCalls).toHaveLength(agentCount);
-      expect(statusCalls.map((call) => call.key).sort()).toEqual(
-        [...agentIds].sort(),
-      );
-      expect(
-        statusCalls.every(
-          (call) =>
-            call.value.includes("role=worker") &&
-            call.value.includes("state=ready"),
-        ),
-      ).toBe(true);
+      expect(statusCalls).toEqual([]);
 
       statusCalls.length = 0;
       await engine.runSweep();

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -130,6 +130,7 @@ describe("proxy version-bump auto-reconnect", () => {
   const proxies: CmuxLayerProxy[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     for (const proxy of proxies.splice(0)) {
       await proxy.stop();
     }
@@ -207,6 +208,39 @@ describe("proxy version-bump auto-reconnect", () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("installed version bump detected"),
     );
+  });
+
+  it("reconnects an idle proxy after a version bump with zero agent requests", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("idle-bump");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    let stale = false;
+    const detectStaleBuild = vi.fn(() =>
+      stale
+        ? { stale: true, running: "0.3.31", installed: "0.3.32" }
+        : { stale: false, running: "0.3.31", installed: "0.3.31" },
+    );
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input: new PassThrough(),
+      output: new PassThrough(),
+      staleRecheckIntervalMs: 60_000,
+      detectStaleBuild,
+      spawnDaemonForVersionBump,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+    });
+    proxies.push(proxy);
+    vi.useFakeTimers();
+    proxy.start();
+    stale = true;
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
+    expect(detectStaleBuild).toHaveBeenCalled();
   });
 
   it("trips the reconnect-storm guard after repeated version-bump attempts", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2479,6 +2479,7 @@ describe("tool handler integration", () => {
     expect(Object.keys(data).sort()).toEqual([
       "ok",
       "pane",
+      "retry_count",
       "surface",
       "workspace",
     ]);

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -21,6 +21,7 @@ const TEST_DIR = join(tmpdir(), "cmux-agents-test-sidebar");
 type MockClient = CmuxClient & {
   notify: ReturnType<typeof vi.fn>;
   notifyLifecycleEvent: ReturnType<typeof vi.fn>;
+  setStatuses: ReturnType<typeof vi.fn>;
 };
 
 function makeMockClient(overrides?: Partial<CmuxClient>): MockClient {
@@ -42,6 +43,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): MockClient {
     }),
     renameTab: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
+    setStatuses: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),
     listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     listPanes: vi.fn().mockResolvedValue({ panes: [] }),
@@ -176,6 +178,34 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("batches a 12-agent sweep into one status session and keeps skipped rows dirty", async () => {
+    for (let index = 0; index < 12; index++) {
+      const agentId = `batch-${index}`;
+      const surfaceId = `surface:${index}`;
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          surface_id: surfaceId,
+          workspace_id: "workspace:cmuxlayer",
+          cli_session_id: `session-${index}`,
+        }),
+      );
+      liveSurfaces.push(makeSurface(surfaceId));
+      writeHeartbeat(agentId, inboxOpts);
+    }
+    await engine.getRegistry().reconstitute();
+    mockClient.setStatuses.mockResolvedValue(false);
+
+    await engine.runSweep();
+
+    expect(mockClient.setStatuses).toHaveBeenCalledTimes(1);
+    expect(mockClient.setStatuses.mock.calls[0]?.[0]).toHaveLength(12);
+    expect(mockClient.setStatus).not.toHaveBeenCalled();
+
+    await engine.runSweep();
+    expect(mockClient.setStatuses).toHaveBeenCalledTimes(2);
+  });
+
   it("discriminates health by state instead of marking every missing-session row unhealthy", async () => {
     stateMgr.writeState(
       makeRecord({
@@ -204,15 +234,21 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "booting-agent",
-      "brainlayer | role=worker | state=booting | health=healthy | blocked=- | last_prompt=Boot worker | worktree=- | branch=- | report=n/a | pr=n/a",
-      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
-    );
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "working-agent",
-      "brainlayer | role=worker | state=working | health=healthy(missing_cli_session_id:info,non_resumable:info) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
-      expect.objectContaining({ workspace: "workspace:cmuxlayer" }),
+    expect(mockClient.setStatuses).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "booting-agent",
+          value:
+            "brainlayer | role=worker | state=booting | health=healthy | blocked=- | last_prompt=Boot worker | worktree=- | branch=- | report=n/a | pr=n/a",
+          workspace: "workspace:cmuxlayer",
+        }),
+        expect.objectContaining({
+          key: "working-agent",
+          value:
+            "brainlayer | role=worker | state=working | health=healthy(missing_cli_session_id:info,non_resumable:info) | blocked=- | last_prompt=Run worker | worktree=- | branch=- | report=n/a | pr=n/a",
+          workspace: "workspace:cmuxlayer",
+        }),
+      ]),
     );
   });
 
@@ -326,15 +362,11 @@ describe("Sidebar Sync", () => {
 
     await expect(engine.runSweep()).resolves.toBeUndefined();
 
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "a1",
-      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
-      expect.objectContaining({ surface: "surface:1" }),
-    );
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "a2",
-      "brainlayer | role=worker | state=working | health=healthy | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
-      expect.objectContaining({ surface: "surface:2" }),
+    expect(mockClient.setStatuses).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "a1", surface: "surface:1" }),
+        expect.objectContaining({ key: "a2", surface: "surface:2" }),
+      ]),
     );
   });
 
@@ -1189,15 +1221,19 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(mockClient.setProgress).not.toHaveBeenCalled();
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "a1",
-      expect.stringContaining("state=working"),
-      expect.objectContaining({ workspace: "workspace:alpha" }),
-    );
-    expect(mockClient.setStatus).toHaveBeenCalledWith(
-      "a2",
-      expect.stringContaining("state=done"),
-      expect.objectContaining({ workspace: "workspace:beta" }),
+    expect(mockClient.setStatuses).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "a1",
+          value: expect.stringContaining("state=working"),
+          workspace: "workspace:alpha",
+        }),
+        expect.objectContaining({
+          key: "a2",
+          value: expect.stringContaining("state=done"),
+          workspace: "workspace:beta",
+        }),
+      ]),
     );
   });
 

--- a/tests/transport-retry-tool.test.ts
+++ b/tests/transport-retry-tool.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CmuxClient } from "../src/cmux-client.js";
+import { wrapCliWithSelfHeal } from "../src/cmux-transport-self-heal.js";
+import { createServer } from "../src/server.js";
+
+describe("interactive tool transport retry metadata", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("returns retry_count=1 after an errno-32 write retry succeeds", async () => {
+    vi.useFakeTimers();
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Broken pipe, errno 32"), {
+          code: 1,
+          stderr: "Failed to write to socket (Broken pipe, errno 32)",
+        }),
+      )
+      .mockResolvedValue({ stdout: "{}", stderr: "" });
+    const retryClient = wrapCliWithSelfHeal(
+      new CmuxClient({ exec, bin: "cmux" }),
+      {
+        socketPath: "/tmp/retry-tool.sock",
+        reprobeIntervalMs: 60_000,
+        retryBaseMs: 100,
+        retryCapMs: 400,
+        retryAttempts: 3,
+        random: () => 0,
+      },
+    );
+    const server = createServer({
+      client: retryClient as unknown as CmuxClient,
+      skipAgentLifecycle: true,
+    });
+    const client = new Client({ name: "retry-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+
+    const call = client.callTool({
+      name: "set_status",
+      arguments: { key: "build", value: "retrying" },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await call;
+
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      retry_count: 1,
+    });
+    expect(exec).toHaveBeenCalledTimes(2);
+    retryClient.stop();
+    await client.close();
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- retry recoverable interactive cmux transport failures with bounded decorrelated-jitter backoff and expose retry_count / loud transport state
- retry mutations only for connect/write-phase failures; never replay post-response mutations
- batch sweep sidebar status pushes over one persistent socket session and suppress degraded-CLI subprocess bursts while keeping skipped rows dirty
- prefer the reload-aware PATH shim when available while preserving pinned CMUX_SOCKET_PATH; fall back to the absolute bundled CLI for restricted daemon PATHs
- prove the existing unref version-bump watcher reconnects an idle proxy with zero agent requests using fake timers

## Root cause evidence
The fallback already forwarded CMUX_SOCKET_PATH, but CmuxClient.resolveBin unconditionally preferred /Applications/cmux.app/Contents/Resources/bin/cmux whenever present. The PATH shim is reload-aware: it consults /tmp/cmux-last-cli-path before falling back to the bundled binary. Bypassing that shim can select a different CLI build than the running reload-selected cmux instance. The resolver now uses an absolute PATH shim when present and retains the bundled absolute fallback for launchd environments where the shim is absent.

## Test plan
- [x] failing-first injected errno-32 retry tests
- [x] write-vs-response mutation safety tests, including asynchronously emitted EPIPE ordering
- [x] 12-agent one-connection status batch test
- [x] pinned CMUX_SOCKET_PATH + reload-aware shim resolution test
- [x] fake-timer idle proxy version-bump test with zero agent requests
- [x] bun run test — 86 files, 1539 tests passed
- [x] bun run typecheck
- [x] bun run build

## Review status
- Local CodeRabbit review was bounded to 180s and timed out without findings.
- Local Claude headless review did not return a verdict in its bounded window. Required cross-engine review is routed to cmuxlayerLead on this ready-for-review PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transport retry and mutation-replay rules plus sweep sidebar consistency; mistakes could duplicate terminal input or leave stale UI, though behavior is heavily covered by new tests.
> 
> **Overview**
> Hardens **cmux transport** against broken-pipe / errno-32 style failures: CLI errors are classified as `CmuxSocketError` with a **transport phase** (connect / write / response), the persistent socket registers **write-scoped error listeners before** connection-wide ones so async EPIPE is not mislabeled, and the self-healing client **retries** recoverable calls with decorrelated-jitter backoff while **only replaying mutations** for connect/write failures—not after a post-response close (avoiding duplicate sends).
> 
> **Sidebar sweeps** now collect changed agent statuses and call optional **`setStatuses`** in one session (socket client loops on one connection; CLI **`setStatuses` returns false** and skips subprocess bursts). Sidebar snapshots update only when the batch succeeds so skipped rows stay dirty for the next sweep.
> 
> **CLI resolution** prefers an absolute **`cmux` on PATH** (reload-aware shim) before the bundled app binary, still honoring pinned `CMUX_SOCKET_PATH`. MCP **`ok`/`err` payloads** include **`retry_count`** (and **`transport_state`** on failures) via async-local tracking on tool handlers.
> 
> Tests cover retry success/exhaustion, mutation no-replay on response failure, EPIPE ordering, 12-agent status batching, shim resolution, and idle proxy version-bump reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6703b769e9174c013ea0005b003802657b0ab5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix errno-32 transport failures by adding transport phase tagging, retry logic, and batched status updates
> - Tags socket errors with transport phase (`connect`, `write`, `response`) in [`CmuxSocketError`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-e8fc65020065b8e8ae4d98f1bc697f75a9dcb7ad7605f4dd2604bdf55cb0bde3) and [`CmuxPersistentSocket`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-4241cd7c196a7c577e98f44bd5ac5ad678fbfa738d9a631f6422e7ff2135cd03) so callers can classify failures accurately.
> - Adds bounded retry logic with decorrelated jitter backoff in [`CmuxSelfHealingClient`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-fbf073b8b6f02d58f4addfd2d8fcaed58d9e495a3ec139005951626f13e03267); retries are gated by phase and method mutability — post-response failures on mutating methods are never retried.
> - Batches sidebar status pushes in [`AgentEngine.syncSidebar`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) via a new `setStatuses` API; snapshot entries for changed rows are only committed after a successful batch apply.
> - Exposes `retry_count` and `transport_state` on all tool responses in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) using `AsyncLocalStorage`-backed tracking from the new [`transport-retry-context`](https://github.com/EtanHey/cmuxlayer/pull/273/files#diff-61cdb76fdfd41cf504251e4676b820026e20879db615c3c71810d7917c45feb3) module.
> - Behavioral Change: `RETRY_SAFE_V2_METHODS` is trimmed to only `system.ping`; previously retried methods that are mutating will no longer be automatically retried after a response-phase failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6703b76. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar status updates are now sent in batches, improving responsiveness during large refreshes.
  * Transport failures now include clearer phase and retry details.
  * Temporary connection failures can be retried automatically with configurable limits and backoff.
  * Tool responses now report retry counts when applicable.
  * The client can locate the active command-line executable through the system PATH.

* **Bug Fixes**
  * Prevented potentially unsafe replay of completed mutations after response-side failures.
  * Improved handling of broken-pipe and connection-reset errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->