### PR TITLE
fix: gpt-5.6 family context window (1.05M) + window-source precedence

### DIFF
--- a/docs/harness-jsonl-field-map.md
+++ b/docs/harness-jsonl-field-map.md
@@ -48,7 +48,10 @@ One JSON object per line, **wrapped**: `{ type, timestamp, payload }`. Real type
   - `info.total_token_usage = { ... }` — **cumulative across session; NOT context occupancy.**
   - `info.model_context_window` — **the REAL window for this session** (e.g. `258400`). ✅ in-JSONL.
 - **tokens_used (context occupancy):** `info.last_token_usage.total_tokens` of the **last** token_count event.
-- **context_window:** `info.model_context_window` — **ALWAYS prefer this; never a constant/table.**
+- **context_window:** `info.model_context_window`, except when an explicitly versioned verified
+  table rule is larger. Use the larger value because client CLIs can lag model reality and an
+  under-denominator can wrongly retire an orchestrated seat. Unknown models keep JSONL as their
+  only signal.
 - **model:** last `turn_context` event → `payload.model` (e.g. `"gpt-5.5"`). (`session_meta` has `cwd`,`id`,`cli_version`,`model_provider` but NOT the model id.)
 - **last_text:** last `agent_message` → `payload.message`.
 - **last_tool:** last of `{function_call, custom_tool_call, mcp_tool_call_end}` → `payload.name`.
@@ -65,16 +68,18 @@ One JSON object per line: `{ role, message:{ content:[...] } }`. **Claude-style 
 - **last_tool:** last `message.content[]` item `type:"tool_use"` → `.name` on an `assistant` row.
 - **done:** no explicit field; liveness from screen-peek.
 
-## Verified per-model context-window table (Claude denominator + no-JSONL fallback ONLY)
-Source: researcher, citation-backed, BrainLayer `brainbar-8a3da79c-159` (2026-06-04).
-Used for Claude (no window in JSONL) and as a fallback when a harness's JSONL is unavailable.
-**Codex never uses this — it has `model_context_window` in-JSONL.**
+## Verified per-model context-window table
+Source: researcher, citation-backed, BrainLayer `brainbar-8a3da79c-159` (2026-06-04), plus
+gpt-5.6 verified by Etan web-verify + fleet rules doc §10 (2026-07-11).
+Used for Claude (no window in JSONL), as a fallback when harness JSONL is unavailable, and as a
+floor when an explicitly versioned Codex rule is larger than the CLI-reported JSONL window.
 
 | Model (API id / family) | Window | Notes |
 |---|---|---|
 | `claude-opus-4-6/4-7/4-8`, `claude-sonnet-4-6` | 1,000,000 | 1M now standard (not beta) on these gens. |
 | `claude-haiku-4-5`, Sonnet/Opus 4.0–4.5, `opus-4-1` | 200,000 | 200K tier. |
-| gpt-5 / gpt-5.1 / gpt-5.5 / gpt-5-codex | 400,000 | Total window (272K input + 128K output). Codex JSONL overrides per-session. |
+| gpt-5.6 family | 1,050,000 | Verified whole-family window; larger of this and Codex JSONL wins. |
+| gpt-5 / gpt-5.1 / gpt-5.5 / gpt-5-codex | 400,000 | Generic fallback; Codex JSONL overrides per-session. |
 | gpt-4o / gpt-4-turbo | 128,000 | |
 | gemini-2.5 / 3 / 3.1 pro | 1,048,576 | Not 2M. |
 | unknown | `null` | **Never emit a wrong 1M.** Omit context_pct. |

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -32,10 +32,13 @@ export interface HarnessSessionState {
 }
 
 // AIDEV-NOTE: Verified per-model context windows (researcher, BrainLayer brainbar-8a3da79c-159,
-// 2026-06-04). Used ONLY as the Claude denominator (Claude JSONL has no window) and as the
-// no-JSONL fallback. Codex NEVER uses this — it carries model_context_window in-JSONL per session.
-// Ordered longest-key-first via length sort below for deterministic substring matching.
-const MODEL_WINDOW_RULES: Array<[RegExp, number]> = [
+// 2026-06-04; gpt-5.6: Etan web-verify + fleet rules doc §10, 2026-07-11). Used as the
+// Claude denominator (Claude JSONL has no window), the no-JSONL fallback, and a floor only
+// for explicitly versioned Codex rules when a lagging CLI reports a smaller session window.
+// Rules are checked in order, so specific versions must precede generic family matches.
+const MODEL_WINDOW_RULES: Array<
+  [pattern: RegExp, window: number, jsonlFloor?: boolean]
+> = [
   // Claude — current gen ships 1M standard (Opus 4.6/4.7/4.8, Sonnet 4.6)
   [/(opus-4-?[678])|(sonnet-4-?6)/, 1_000_000],
   // Claude — Fable (Mythos tier) ships 1M standard. A live 151% reading proved it was
@@ -43,7 +46,9 @@ const MODEL_WINDOW_RULES: Array<[RegExp, number]> = [
   [/fable/, 1_000_000],
   // Claude — 200K tier (Haiku, and 4.0–4.5 generation incl. opus-4-1)
   [/haiku|(sonnet-4(?!-6))|(opus-4(?!-?[678]))|(opus-4-1)/, 200_000],
-  // OpenAI GPT-5 / Codex family — 400K total window (272K input + 128K output)
+  // OpenAI GPT-5.6 / Codex family — whole family is 1.05M.
+  [/gpt-5[.-]6(?:$|[^0-9])/, 1_050_000, true],
+  // OpenAI generic GPT-5 / Codex family — 400K total window (272K input + 128K output)
   [/gpt-5/, 400_000],
   // OpenAI GPT-4 family
   [/gpt-4/, 128_000],
@@ -54,13 +59,23 @@ const MODEL_WINDOW_RULES: Array<[RegExp, number]> = [
 /**
  * Resolve a model's context window from the verified table.
  * Returns null for unknown models — NEVER a wrong 1M.
- * NOTE: Codex must prefer its in-JSONL model_context_window over this.
+ * NOTE: Codex normally prefers its in-JSONL model_context_window; explicitly versioned
+ * rules may provide a verified larger floor when the client CLI lags model reality.
  */
 export function modelContextWindow(model: string | null): number | null {
   if (!model) return null;
   const lower = model.toLowerCase().trim();
   for (const [re, window] of MODEL_WINDOW_RULES) {
     if (re.test(lower)) return window;
+  }
+  return null;
+}
+
+function modelContextWindowJsonlFloor(model: string | null): number | null {
+  if (!model) return null;
+  const lower = model.toLowerCase().trim();
+  for (const [re, window, jsonlFloor] of MODEL_WINDOW_RULES) {
+    if (jsonlFloor && re.test(lower)) return window;
   }
   return null;
 }
@@ -292,11 +307,18 @@ function parseCodex(events: Record<string, unknown>[]): HarnessSessionState {
       }
     }
   }
+  const verifiedWindowFloor = modelContextWindowJsonlFloor(model);
+  if (verifiedWindowFloor !== null) {
+    // Client CLIs can lag model reality (codex-cli 0.144.1 reports 353400 for gpt-5.6).
+    // Prefer the larger denominator: undersizing wrongly retires orchestrated seats, while
+    // unknown models retain JSONL as their only signal because they have no verified floor.
+    window = window === null ? verifiedWindowFloor : Math.max(window, verifiedWindowFloor);
+  }
   return {
     harness: "codex",
     model,
     tokens_used: tokensUsed,
-    context_window: window, // ALWAYS the in-JSONL value; never the table
+    context_window: window,
     context_pct: pct(tokensUsed, window),
     last_text: lastText,
     last_tool: lastTool,

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -9,10 +9,11 @@ import type {
 import { modelContextWindow } from "./harness-session.js";
 
 // AIDEV-NOTE: DEFAULT context window sizes per model family. Verified numbers (researcher,
-// BrainLayer brainbar-8a3da79c-159, 2026-06-04) — do NOT guess/round. This is the SCREEN-PARSER
-// FALLBACK only: when the harness JSONL is available it carries the real per-session window
-// (esp. Codex's model_context_window) and supersedes this table — see harness-session.ts +
-// docs/harness-jsonl-field-map.md. All Claude models default to 200K; the 1M tier is detected
+// BrainLayer brainbar-8a3da79c-159, 2026-06-04; gpt-5.6: Etan web-verify + fleet rules doc §10,
+// 2026-07-11) — do NOT guess/round. This is the SCREEN-PARSER FALLBACK only: harness JSONL
+// normally carries the real per-session window, but an explicitly versioned verified rule can
+// floor a stale smaller CLI value — see harness-session.ts + docs/harness-jsonl-field-map.md.
+// All Claude models default to 200K; the 1M tier is detected
 // via version-aware rules, "(1M" suffix, or token_count > 200K (Claude-only — it's the Claude
 // Max/standard tier).
 // ORDER MATTERS: resolveModelMax uses substring matching — longer keys must come first.
@@ -22,7 +23,9 @@ export const MODEL_MAX_TOKENS: Record<string, number> = {
   opus: 200_000,
   sonnet: 200_000,
   haiku: 200_000,
-  // OpenAI GPT-5 / Codex family — 400K TOTAL window (272K input + 128K output). NOT 1M.
+  // OpenAI GPT-5.6 / Codex family — whole family is 1.05M.
+  "gpt-5.6": 1_050_000,
+  // OpenAI generic GPT-5 / Codex family — 400K TOTAL window (272K input + 128K output).
   "gpt-5": 400_000,
   // OpenAI GPT-4 family (gpt-4o, gpt-4-turbo)
   "gpt-4": 128_000,

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -27,6 +27,29 @@ import {
 const FIX = join(__dirname, "fixtures", "harness");
 const read = (name: string) => readFileSync(join(FIX, name), "utf8");
 
+function codexContextJsonl(
+  model: string,
+  tokensUsed: number,
+  contextWindow: number,
+): string {
+  return [
+    JSON.stringify({
+      type: "turn_context",
+      payload: { type: "turn_context", model },
+    }),
+    JSON.stringify({
+      type: "token_count",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { total_tokens: tokensUsed },
+          model_context_window: contextWindow,
+        },
+      },
+    }),
+  ].join("\n");
+}
+
 describe("harnessJsonlEnabled (default-ON, opt-out with =0)", () => {
   const prev = process.env.CMUXLAYER_HARNESS_JSONL;
   afterAll(() => {
@@ -70,6 +93,36 @@ describe("parseHarnessSession", () => {
     expect(s.context_pct).toBe(42); // 108569/258400
     expect(s.last_text).toBe("codex latest message");
     expect(s.last_tool).toBe("exec_command");
+  });
+
+  it("Codex: gpt-5.6 family uses the larger verified window over stale JSONL", () => {
+    const s = parseHarnessSession(
+      "codex",
+      codexContextJsonl("gpt-5.6-sol", 105_000, 353_400),
+    );
+
+    expect(s.context_window).toBe(1_050_000);
+    expect(s.context_pct).toBe(10);
+  });
+
+  it("Codex: unknown models keep their JSONL window as the only signal", () => {
+    const s = parseHarnessSession(
+      "codex",
+      codexContextJsonl("future-unknown-model", 70_680, 353_400),
+    );
+
+    expect(s.context_window).toBe(353_400);
+    expect(s.context_pct).toBe(20);
+  });
+
+  it("Codex: a larger JSONL window stays larger than the verified floor", () => {
+    const s = parseHarnessSession(
+      "codex",
+      codexContextJsonl("gpt-5.6-sol", 210_000, 2_100_000),
+    );
+
+    expect(s.context_window).toBe(2_100_000);
+    expect(s.context_pct).toBe(10);
   });
 
   it("Cursor: NO tokens/window in JSONL — text/tool only, context left to the TUI strip", () => {
@@ -221,7 +274,13 @@ describe("modelContextWindow (Claude denominator + no-JSONL fallback)", () => {
     expect(modelContextWindow("claude-opus-4-1")).toBe(200_000);
   });
 
-  it("GPT-5/Codex family = 400K total window (NOT 1M)", () => {
+  it("GPT-5.6 family = 1.05M verified window", () => {
+    expect(modelContextWindow("gpt-5.6")).toBe(1_050_000);
+    expect(modelContextWindow("gpt-5.6-sol")).toBe(1_050_000);
+  });
+
+  it("plain GPT-5/Codex family stays at 400K", () => {
+    expect(modelContextWindow("gpt-5")).toBe(400_000);
     expect(modelContextWindow("gpt-5.5")).toBe(400_000);
     expect(modelContextWindow("gpt-5-codex")).toBe(400_000);
     expect(modelContextWindow("gpt-5.1")).toBe(400_000);

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1094,6 +1094,18 @@ Working (1m 12s • esc to interrupt)
       expect(parsed.context_pct).toBe(40); // 100 - 60 = 40% used
     });
 
+    it("reports 1.05M for the gpt-5.6 family fallback", () => {
+      const parsed = parseScreen(`
+gpt-5.6-sol xhigh · 90% left · ~/Gits/cmuxlayer
+Working (1m 12s • esc to interrupt)
+`);
+
+      expect(MODEL_MAX_TOKENS["gpt-5.6"]).toBe(1_050_000);
+      expect(resolveModelMax("gpt-5.6-sol")).toBe(1_050_000);
+      expect(parsed.context_window).toBe(1_050_000);
+      expect(parsed.context_pct).toBe(10);
+    });
+
     it("returns null context_pct when model is unknown", () => {
       const parsed = parseScreen(`
 etanheyman ~ [master] $


### PR DESCRIPTION
## Summary
- add verified 1,050,000-token rules for the gpt-5.6 Codex family in the harness and screen fallback tables
- floor stale Codex JSONL windows only for explicitly versioned verified rules, using the larger denominator
- preserve generic gpt-5 at 400,000 and unknown-model JSONL authority
- update the canonical harness field map and provenance comments

## Test plan
- [x] TDD regression: gpt-5.6-sol with JSONL window 353400 resolves to 1050000 and 10%
- [x] plain gpt-5 remains 400000
- [x] unknown models keep their JSONL window
- [x] larger JSONL values remain larger than the verified floor
- [x] existing Claude and Gemini coverage stays green
- [x] `bun run typecheck && bun run test` (86 files, 1544 tests)
- [x] local CodeRabbit review: 0 findings across 5 files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Codex context_pct is computed for gpt-5.6, which can affect orchestrated seat retirement; scope is narrow, behavior is tested, and unknown models are unchanged.
> 
> **Overview**
> Adds a **verified 1.05M** context window for the **gpt-5.6** Codex family in the harness model table, screen-parser fallback (`MODEL_MAX_TOKENS`), and the canonical harness JSONL field map.
> 
> **Codex window precedence** changes: instead of always trusting `model_context_window` from JSONL, **versioned rules marked with a JSONL floor** (currently gpt-5.6 only) set the denominator to **`max(JSONL, verified floor)`** so stale CLI values (e.g. 353400) do not inflate `context_pct` and wrongly retire orchestrated seats. **Unknown models** still use JSONL only; **larger JSONL windows** still win over the floor.
> 
> Regression tests cover gpt-5.6 over stale JSONL, unknown-model JSONL authority, and JSONL larger than the floor; plain gpt-5.x remains **400K**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ccd5c519cc87baeab9979735c9011dc84b53c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gpt-5.6 family context window to 1,050,000 with JSONL floor precedence
> - Adds a `gpt-5.6` rule in `MODEL_WINDOW_RULES` ([src/harness-session.ts](https://github.com/EtanHey/cmuxlayer/pull/274/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36)) with a 1,050,000 token window and a new `jsonlFloor` flag, plus a matching entry in the fallback table in [src/screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/274/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50).
> - Introduces `modelContextWindowJsonlFloor` to find floor-flagged rules, and updates `parseCodex` to set `context_window` to the larger of the JSONL-reported value and the verified floor.
> - Behavioral Change: for gpt-5.6 sessions where the CLI reports a smaller window than 1,050,000, `context_window` and derived `context_pct` will now reflect the verified floor instead of the stale JSONL value.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 01ccd5c. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved context-window detection for Codex sessions by using verified model limits when they exceed stale CLI-reported values.
  * Added support for the GPT-5.6 model family with a 1,050,000-token context window.
  * Preserved larger context-window values reported directly by the session data.
  * Improved fallback behavior when session context information is unavailable, while retaining support for unknown models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->