### PR TITLE
fix: restart-safe daemon lifecycle (autostart on reconnect, stale self-retire, doctor §5)

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -39,6 +39,12 @@ export interface CreateCmuxClientOptions extends SocketProbeOptions {
   reprobeCapMs?: number;
   /** Injectable random source for deterministic jitter tests */
   random?: () => number;
+  /** Called after sustained socket-denial and CLI-denial failures. */
+  onIrrecoverableTransport?: () => void;
+  /** Consecutive denial failures required on both transports. */
+  irrecoverableMinFailures?: number;
+  /** Minimum duration of sustained socket denial before signaling. */
+  irrecoverableMinDurationMs?: number;
 }
 
 async function probeUsableSocketWithRetry(
@@ -128,6 +134,9 @@ export async function createCmuxClient(
         random: opts?.random,
         logger,
         sleep: opts?.sleep,
+        onIrrecoverableTransport: opts?.onIrrecoverableTransport,
+        irrecoverableMinFailures: opts?.irrecoverableMinFailures,
+        irrecoverableMinDurationMs: opts?.irrecoverableMinDurationMs,
       }) as unknown as CmuxSocketClient;
     } catch {
       // Socket reachable but not usable — try next candidate before CLI.
@@ -157,6 +166,9 @@ export async function createCmuxClient(
       : undefined,
     logger,
     sleep: opts?.sleep,
+    onIrrecoverableTransport: opts?.onIrrecoverableTransport,
+    irrecoverableMinFailures: opts?.irrecoverableMinFailures,
+    irrecoverableMinDurationMs: opts?.irrecoverableMinDurationMs,
   }) as unknown as CmuxClient;
 }
 

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -28,6 +28,7 @@ export const DEFAULT_INTERACTIVE_RETRY_CAP_MS = 400;
 export const DEFAULT_IRRECOVERABLE_MIN_FAILURES = 3;
 export const DEFAULT_IRRECOVERABLE_MIN_DURATION_MS = 60_000;
 const UPGRADE_FAILURE_LOG_INTERVAL_MS = 30_000;
+const DENIAL_PROGRESS_LOG_INTERVAL_MS = 30_000;
 
 export interface TransportHealthSignal {
   mode: "socket" | "cli";
@@ -185,6 +186,7 @@ export class CmuxSelfHealingClient {
   private cliDenialFailures = 0;
   private irrecoverableSignaled = false;
   private lastUpgradeFailureLogAt = Number.NEGATIVE_INFINITY;
+  private lastDenialProgressLogAt = Number.NEGATIVE_INFINITY;
 
   constructor(private readonly opts: CmuxSelfHealingClientOptions) {
     this.socketClient = opts.socket ?? null;
@@ -306,11 +308,7 @@ export class CmuxSelfHealingClient {
       this.socketClient !== null && delegate === this.socketClient;
     this.inFlight += 1;
     try {
-      const result = await this.callDelegate(method, args, delegate);
-      if (delegate === this.opts.cli) {
-        this.cliDenialFailures = 0;
-      }
-      return result;
+      return await this.callDelegate(method, args, delegate);
     } catch (error) {
       if (delegate === this.opts.cli) {
         this.recordCliFailure(error);
@@ -480,15 +478,11 @@ export class CmuxSelfHealingClient {
       recordTransportRetry();
       const delegate = this.delegate;
       try {
-        const result = await this.callDelegate(
+        return await this.callDelegate(
           payload.method,
           payload.args,
           delegate,
         );
-        if (delegate === this.opts.cli) {
-          this.cliDenialFailures = 0;
-        }
-        return result;
       } catch (error) {
         lastError = error;
         if (delegate === this.opts.cli) {
@@ -647,7 +641,9 @@ export class CmuxSelfHealingClient {
       (typeof result.error === "string" &&
         this.isDenialClassError(result.error));
     if (!denialClass) {
-      this.resetProbeDenial();
+      if (result.usable) {
+        this.resetDenialEvidence();
+      }
       return false;
     }
     this.recordProbeDenial();
@@ -657,9 +653,7 @@ export class CmuxSelfHealingClient {
   private recordProbeFailure(error: unknown): void {
     if (this.isDenialClassError(error)) {
       this.recordProbeDenial();
-      return;
     }
-    this.resetProbeDenial();
   }
 
   private recordProbeDenial(): void {
@@ -668,21 +662,44 @@ export class CmuxSelfHealingClient {
       this.denialProbeStartedAt = now;
     }
     this.denialProbeFailures += 1;
+    this.logDenialProgress(now);
     this.maybeSignalIrrecoverable(now);
   }
 
-  private resetProbeDenial(): void {
+  private resetDenialEvidence(): void {
     this.denialProbeFailures = 0;
     this.denialProbeStartedAt = null;
+    this.cliDenialFailures = 0;
+    this.lastDenialProgressLogAt = Number.NEGATIVE_INFINITY;
   }
 
   private recordCliFailure(error: unknown): void {
     if (!this.isDenialClassError(error)) {
-      this.cliDenialFailures = 0;
       return;
     }
     this.cliDenialFailures += 1;
-    this.maybeSignalIrrecoverable((this.opts.now ?? Date.now)());
+    const now = (this.opts.now ?? Date.now)();
+    this.logDenialProgress(now);
+    this.maybeSignalIrrecoverable(now);
+  }
+
+  private logDenialProgress(now: number): void {
+    if (
+      now - this.lastDenialProgressLogAt <
+      DENIAL_PROGRESS_LOG_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.lastDenialProgressLogAt = now;
+    const minFailures =
+      this.opts.irrecoverableMinFailures ?? DEFAULT_IRRECOVERABLE_MIN_FAILURES;
+    const elapsedSeconds = Math.max(
+      0,
+      Math.floor((now - (this.denialProbeStartedAt ?? now)) / 1_000),
+    );
+    this.opts.logger?.error(
+      `[cmuxlayer] denial evidence ${this.denialProbeFailures}/${minFailures} probes, ${this.cliDenialFailures}/${minFailures} cli, ${elapsedSeconds}s`,
+    );
   }
 
   private maybeSignalIrrecoverable(now: number): void {

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -25,6 +25,9 @@ export const DEFAULT_TRANSPORT_REPROBE_CAP_MS = 30_000;
 export const DEFAULT_INTERACTIVE_RETRY_ATTEMPTS = 3;
 export const DEFAULT_INTERACTIVE_RETRY_BASE_MS = 100;
 export const DEFAULT_INTERACTIVE_RETRY_CAP_MS = 400;
+export const DEFAULT_IRRECOVERABLE_MIN_FAILURES = 3;
+export const DEFAULT_IRRECOVERABLE_MIN_DURATION_MS = 60_000;
+const UPGRADE_FAILURE_LOG_INTERVAL_MS = 30_000;
 
 export interface TransportHealthSignal {
   mode: "socket" | "cli";
@@ -59,6 +62,10 @@ export interface CmuxSelfHealingClientOptions {
   retryAttempts?: number;
   retryBaseMs?: number;
   retryCapMs?: number;
+  irrecoverableMinFailures?: number;
+  irrecoverableMinDurationMs?: number;
+  onIrrecoverableTransport?: () => void;
+  now?: () => number;
 }
 
 const FORWARDED_ASYNC_METHODS = [
@@ -173,11 +180,20 @@ export class CmuxSelfHealingClient {
   private flushingFailedPayloadQueue: Promise<void> | null = null;
   private transportDenial: TransportDenialSignal | null = null;
   private completedRetryCount = 0;
+  private denialProbeFailures = 0;
+  private denialProbeStartedAt: number | null = null;
+  private cliDenialFailures = 0;
+  private irrecoverableSignaled = false;
+  private lastUpgradeFailureLogAt = Number.NEGATIVE_INFINITY;
 
   constructor(private readonly opts: CmuxSelfHealingClientOptions) {
     this.socketClient = opts.socket ?? null;
     this.delegate = opts.socket ?? opts.cli;
     this.transportDenial = opts.initialDenial ?? null;
+    if (opts.initialDenial) {
+      this.denialProbeFailures = 1;
+      this.denialProbeStartedAt = (opts.now ?? Date.now)();
+    }
     if (this.socketClient) {
       this.pinCliToSocket(this.socketClient);
     }
@@ -290,8 +306,15 @@ export class CmuxSelfHealingClient {
       this.socketClient !== null && delegate === this.socketClient;
     this.inFlight += 1;
     try {
-      return await this.callDelegate(method, args, delegate);
+      const result = await this.callDelegate(method, args, delegate);
+      if (delegate === this.opts.cli) {
+        this.cliDenialFailures = 0;
+      }
+      return result;
     } catch (error) {
+      if (delegate === this.opts.cli) {
+        this.recordCliFailure(error);
+      }
       const replay = this.recoverFailedPayload(
         error,
         method,
@@ -455,10 +478,22 @@ export class CmuxSelfHealingClient {
       await sleep(delayMs);
       this.completedRetryCount = retryCount;
       recordTransportRetry();
+      const delegate = this.delegate;
       try {
-        return await this.callDelegate(payload.method, payload.args);
+        const result = await this.callDelegate(
+          payload.method,
+          payload.args,
+          delegate,
+        );
+        if (delegate === this.opts.cli) {
+          this.cliDenialFailures = 0;
+        }
+        return result;
       } catch (error) {
         lastError = error;
+        if (delegate === this.opts.cli) {
+          this.recordCliFailure(error);
+        }
         if (!this.canRetryPayload(error, payload.method)) break;
       }
     }
@@ -523,28 +558,25 @@ export class CmuxSelfHealingClient {
     const factoryOpts = this.opts.factoryOpts;
     const sleep = this.opts.sleep ?? defaultSleep;
     const resolvePath = this.opts.resolvePath ?? resolveSocketPath;
-
-    let socketPath = this.opts.socketPath;
-    if (!socketPath) {
-      socketPath = await resolvePath(factoryOpts);
-    }
-    if (!socketPath) {
-      this.startReprobe();
-      return;
-    }
-    const probeResult = await this.checkSocketHealth(socketPath, factoryOpts);
-    if (probeResult.denied_reason === "access-control") {
-      this.recordAccessControlDenial(probeResult);
-      this.startReprobe();
-      return;
-    }
-    if (!probeResult.usable) {
-      this.startReprobe();
-      return;
-    }
-
     this.upgrading = true;
     try {
+      let socketPath = this.opts.socketPath;
+      if (!socketPath) {
+        socketPath = await resolvePath(factoryOpts);
+      }
+      if (!socketPath) {
+        return;
+      }
+      const probeResult = await this.checkSocketHealth(socketPath, factoryOpts);
+      const denialClass = this.recordProbeResult(probeResult);
+      if (denialClass) {
+        this.recordAccessControlDenial(probeResult);
+        return;
+      }
+      if (!probeResult.usable) {
+        return;
+      }
+
       while (this.inFlight > 0) {
         await sleep(10);
       }
@@ -565,7 +597,9 @@ export class CmuxSelfHealingClient {
       this.clearReprobe();
       this.previousReprobeDelayMs = 0;
       this.opts.logger?.error("[cmuxlayer] transport upgraded: cli -> socket");
-    } catch {
+    } catch (error) {
+      this.recordProbeFailure(error);
+      this.logUpgradeFailure(error);
       // Stay on CLI until the next re-probe tick.
     } finally {
       this.upgrading = false;
@@ -599,6 +633,103 @@ export class CmuxSelfHealingClient {
     };
     this.opts.logger?.error(
       `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}`,
+    );
+  }
+
+  private isDenialClassError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /(?:\bEPIPE\b|broken pipe|errno\s*32|access denied)/i.test(message);
+  }
+
+  private recordProbeResult(result: SocketProbeResult): boolean {
+    const denialClass =
+      result.denied_reason === "access-control" ||
+      (typeof result.error === "string" &&
+        this.isDenialClassError(result.error));
+    if (!denialClass) {
+      this.resetProbeDenial();
+      return false;
+    }
+    this.recordProbeDenial();
+    return true;
+  }
+
+  private recordProbeFailure(error: unknown): void {
+    if (this.isDenialClassError(error)) {
+      this.recordProbeDenial();
+      return;
+    }
+    this.resetProbeDenial();
+  }
+
+  private recordProbeDenial(): void {
+    const now = (this.opts.now ?? Date.now)();
+    if (this.denialProbeFailures === 0) {
+      this.denialProbeStartedAt = now;
+    }
+    this.denialProbeFailures += 1;
+    this.maybeSignalIrrecoverable(now);
+  }
+
+  private resetProbeDenial(): void {
+    this.denialProbeFailures = 0;
+    this.denialProbeStartedAt = null;
+  }
+
+  private recordCliFailure(error: unknown): void {
+    if (!this.isDenialClassError(error)) {
+      this.cliDenialFailures = 0;
+      return;
+    }
+    this.cliDenialFailures += 1;
+    this.maybeSignalIrrecoverable((this.opts.now ?? Date.now)());
+  }
+
+  private maybeSignalIrrecoverable(now: number): void {
+    if (this.irrecoverableSignaled || !this.opts.onIrrecoverableTransport) {
+      return;
+    }
+    const minFailures =
+      this.opts.irrecoverableMinFailures ?? DEFAULT_IRRECOVERABLE_MIN_FAILURES;
+    const minDurationMs =
+      this.opts.irrecoverableMinDurationMs ??
+      DEFAULT_IRRECOVERABLE_MIN_DURATION_MS;
+    if (
+      this.denialProbeStartedAt === null ||
+      this.denialProbeFailures < minFailures ||
+      this.cliDenialFailures < minFailures ||
+      now - this.denialProbeStartedAt < minDurationMs
+    ) {
+      return;
+    }
+    this.irrecoverableSignaled = true;
+    try {
+      this.opts.onIrrecoverableTransport();
+    } catch (error) {
+      this.opts.logger?.error(
+        "[cmuxlayer] irrecoverable transport callback failed",
+        error,
+      );
+    }
+  }
+
+  private logUpgradeFailure(error: unknown): void {
+    const now = (this.opts.now ?? Date.now)();
+    if (now - this.lastUpgradeFailureLogAt < UPGRADE_FAILURE_LOG_INTERVAL_MS) {
+      return;
+    }
+    this.lastUpgradeFailureLogAt = now;
+    const message = error instanceof Error ? error.message : String(error);
+    let errorClass = "Error";
+    if (error && typeof error === "object" && "code" in error) {
+      errorClass = String((error as { code: unknown }).code);
+    } else {
+      errorClass =
+        /\b(?:EPIPE|ECONNREFUSED|ECONNRESET)\b/i.exec(message)?.[0] ??
+        (error instanceof Error ? error.name : "Error");
+    }
+    this.opts.logger?.error(
+      `[cmuxlayer] transport upgrade failed (${errorClass}): ${message}`,
     );
   }
 

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -1,0 +1,40 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface SpawnDaemonOptions {
+  socketPath: string;
+  env: NodeJS.ProcessEnv;
+  daemonScriptPath?: string;
+  logger: Pick<Console, "error">;
+}
+
+function defaultDaemonScriptPath(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "daemon.js");
+}
+
+export async function spawnDaemonProcess(
+  opts: SpawnDaemonOptions,
+): Promise<ChildProcess> {
+  await mkdir(dirname(opts.socketPath), { recursive: true });
+  const daemonScriptPath = opts.daemonScriptPath ?? defaultDaemonScriptPath();
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...opts.env,
+    CMUXLAYER_DAEMON_SOCKET: opts.socketPath,
+  };
+  const nodeOptions = env.NODE_OPTIONS ?? "";
+  if (!/(^|\s)--max-old-space-size(=|\s)/.test(nodeOptions)) {
+    env.NODE_OPTIONS = `${nodeOptions} --max-old-space-size=${
+      env.CMUXLAYER_NODE_MAX_OLD_SPACE_MB ?? "1536"
+    }`.trim();
+  }
+  const child = spawn(process.execPath, [daemonScriptPath], {
+    detached: true,
+    env,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  child.unref();
+  return child;
+}

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -35,6 +35,16 @@ export async function spawnDaemonProcess(
     env,
     stdio: ["ignore", "ignore", "inherit"],
   });
+  child.once("error", (error) => {
+    opts.logger.error(
+      `[cmuxlayer-proxy] spawned daemon failed (pid=${child.pid ?? "unknown"}): ${error.message}`,
+    );
+  });
+  child.once("exit", (code, signal) => {
+    opts.logger.error(
+      `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,
+    );
+  });
   child.unref();
   return child;
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -342,6 +342,12 @@ function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
   });
 }
 
+function positiveEnvMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
 export class CmuxLayerDaemon {
   private server: net.Server | null = null;
   private context: CmuxServerContext | null;
@@ -371,7 +377,9 @@ export class CmuxLayerDaemon {
     this.drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
     this.detectStaleBuildFn = opts.detectStaleBuild ?? detectStaleBuild;
     this.staleCheckIntervalMs =
-      opts.staleCheckIntervalMs ?? DEFAULT_STALE_CHECK_INTERVAL_MS;
+      opts.staleCheckIntervalMs ??
+      positiveEnvMs(process.env.CMUXLAYER_STALE_CHECK_INTERVAL_MS) ??
+      DEFAULT_STALE_CHECK_INTERVAL_MS;
     this.logger = opts.logger ?? console;
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import net from "node:net";
-import { mkdir, unlink } from "node:fs/promises";
+import { lstat, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
@@ -362,6 +362,7 @@ export class CmuxLayerDaemon {
   ) => StaleBuildResult | null;
   private readonly staleCheckIntervalMs: number;
   private readonly logger: Pick<Console, "error">;
+  private ownedSocketIdentity: { dev: number; ino: number } | null = null;
 
   constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
     this.context = opts.context ?? null;
@@ -399,19 +400,21 @@ export class CmuxLayerDaemon {
       await this.listen({ fd: this.listenFd });
     } else {
       await this.listen(this.socketPath);
+      const stats = await lstat(this.socketPath);
+      this.ownedSocketIdentity = { dev: stats.dev, ino: stats.ino };
     }
     this.startStaleBuildWatcher();
   }
 
   async shutdown(
-    _signal: DaemonShutdownReason = "manual",
+    signal: DaemonShutdownReason = "manual",
   ): Promise<DaemonShutdownResult> {
     if (this.shutdownPromise) {
       return this.shutdownPromise;
     }
 
     this.clearStaleBuildWatcher();
-    this.shutdownPromise = this.doShutdown();
+    this.shutdownPromise = this.doShutdown(signal);
     return this.shutdownPromise;
   }
 
@@ -530,10 +533,31 @@ export class CmuxLayerDaemon {
     }
   }
 
-  private async doShutdown(): Promise<DaemonShutdownResult> {
+  private async doShutdown(
+    reason: DaemonShutdownReason,
+  ): Promise<DaemonShutdownResult> {
     this.draining = true;
     this.pauseActiveTransports();
     const listenerClosed = this.closeListener();
+
+    const retiring =
+      reason === "stale-build" || reason === "irrecoverable-transport";
+    if (retiring) {
+      const forced = this.inFlightRequests > 0;
+      for (const transport of [...this.activeTransports]) {
+        transport.destroy();
+      }
+      for (const server of [...this.activeServers]) {
+        await server.close().catch(() => {});
+      }
+      await listenerClosed;
+      this.context?.dispose();
+      return {
+        forced,
+        activeConnections: this.activeTransports.size,
+        inFlightRequests: this.inFlightRequests,
+      };
+    }
 
     const forced = !(await this.waitForDrain());
     for (const server of [...this.activeServers]) {
@@ -627,14 +651,61 @@ export class CmuxLayerDaemon {
     });
   }
 
-  private closeListener(): Promise<void> {
+  private async closeListener(): Promise<void> {
     const server = this.server;
     if (!server) {
-      return Promise.resolve();
+      return;
     }
-    return new Promise((resolve) => {
+    const detachedSocket = await this.detachOwnedSocketPath();
+    await new Promise<void>((resolve) => {
       server.close(() => resolve());
     });
+    if (detachedSocket?.restore) {
+      await rename(detachedSocket.path, this.socketPath);
+    } else if (detachedSocket) {
+      await unlink(detachedSocket.path).catch(
+        (error: NodeJS.ErrnoException) => {
+          if (error.code !== "ENOENT") {
+            throw error;
+          }
+        },
+      );
+    }
+  }
+
+  private async detachOwnedSocketPath(): Promise<{
+    path: string;
+    restore: boolean;
+  } | null> {
+    if (this.listenFd !== undefined || !this.ownedSocketIdentity) {
+      return null;
+    }
+
+    let current: Awaited<ReturnType<typeof lstat>>;
+    try {
+      current = await lstat(this.socketPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        await writeFile(this.socketPath, "", { flag: "wx" });
+        return null;
+      }
+      throw error;
+    }
+
+    if (
+      current.dev !== this.ownedSocketIdentity.dev ||
+      current.ino !== this.ownedSocketIdentity.ino
+    ) {
+      const shelteredPath = `${this.socketPath}.foreign-${process.pid}-${Date.now()}`;
+      await rename(this.socketPath, shelteredPath);
+      await writeFile(this.socketPath, "", { flag: "wx" });
+      return { path: shelteredPath, restore: true };
+    }
+
+    const detachedPath = `${this.socketPath}.closing-${process.pid}-${Date.now()}`;
+    await rename(this.socketPath, detachedPath);
+    await writeFile(this.socketPath, "", { flag: "wx" });
+    return { path: detachedPath, restore: false };
   }
 
   private waitForDrain(): Promise<boolean> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14,7 +14,10 @@ import type {
   RequestId,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createCmuxClient } from "./cmux-client-factory.js";
+import {
+  createCmuxClient,
+  type CreateCmuxClientOptions,
+} from "./cmux-client-factory.js";
 import { createServer, createServerContext } from "./server.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
 import {
@@ -32,8 +35,14 @@ import {
   callerContextFromMessage,
   runWithCallerContext,
 } from "./caller-context.js";
+import {
+  detectStaleBuild,
+  type DetectStaleBuildDeps,
+  type StaleBuildResult,
+} from "./version.js";
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
+const DEFAULT_STALE_CHECK_INTERVAL_MS = 30_000;
 const LISTEN_FD_START = 3;
 
 /**
@@ -52,6 +61,11 @@ export type DaemonHotReloadHandler = (
 ) => Promise<"not_implemented">;
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
+export type DaemonRetirementReason = "stale-build" | "irrecoverable-transport";
+export type DaemonShutdownReason =
+  | NodeJS.Signals
+  | "manual"
+  | DaemonRetirementReason;
 
 export class SocketJsonRpcTransport implements Transport {
   onclose?: () => void;
@@ -206,7 +220,18 @@ export interface CmuxLayerDaemonOptions extends Omit<
   drainTimeoutMs?: number;
   context?: CmuxServerContext;
   client?: CmuxLayerClient;
-  createClient?: () => Promise<CmuxLayerClient>;
+  createClient?: (
+    opts: Pick<CreateCmuxClientOptions, "onIrrecoverableTransport">,
+  ) => Promise<CmuxLayerClient>;
+  detectStaleBuild?: (
+    deps?: DetectStaleBuildDeps,
+  ) => StaleBuildResult | null;
+  staleCheckIntervalMs?: number;
+  logger?: Pick<Console, "error">;
+  onRetire?: (
+    reason: DaemonRetirementReason,
+    result: DaemonShutdownResult,
+  ) => Promise<void> | void;
   serverFactory?: (
     connectionListener: (socket: net.Socket) => void,
   ) => net.Server;
@@ -216,6 +241,16 @@ export interface DaemonShutdownResult {
   forced: boolean;
   activeConnections: number;
   inFlightRequests: number;
+}
+
+export function daemonExitCode(
+  reason: DaemonShutdownReason,
+  result: DaemonShutdownResult,
+): number {
+  if (reason === "stale-build" || reason === "irrecoverable-transport") {
+    return 0;
+  }
+  return result.forced ? 1 : 0;
 }
 
 function parseListenFd(env: NodeJS.ProcessEnv): number | undefined {
@@ -320,12 +355,23 @@ export class CmuxLayerDaemon {
   private inFlightRequests = 0;
   private draining = false;
   private shutdownPromise: Promise<DaemonShutdownResult> | null = null;
+  private staleCheckTimer: NodeJS.Timeout | null = null;
+  private retirementPromise: Promise<void> | null = null;
+  private readonly detectStaleBuildFn: (
+    deps?: DetectStaleBuildDeps,
+  ) => StaleBuildResult | null;
+  private readonly staleCheckIntervalMs: number;
+  private readonly logger: Pick<Console, "error">;
 
   constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
     this.context = opts.context ?? null;
     this.socketPath = opts.socketPath ?? defaultDaemonSocketPath(process.env);
     this.listenFd = opts.listenFd ?? parseListenFd(process.env);
     this.drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+    this.detectStaleBuildFn = opts.detectStaleBuild ?? detectStaleBuild;
+    this.staleCheckIntervalMs =
+      opts.staleCheckIntervalMs ?? DEFAULT_STALE_CHECK_INTERVAL_MS;
+    this.logger = opts.logger ?? console;
   }
 
   async start(): Promise<void> {
@@ -351,19 +397,20 @@ export class CmuxLayerDaemon {
 
     if (this.listenFd !== undefined) {
       await this.listen({ fd: this.listenFd });
-      return;
+    } else {
+      await this.listen(this.socketPath);
     }
-
-    await this.listen(this.socketPath);
+    this.startStaleBuildWatcher();
   }
 
   async shutdown(
-    _signal: NodeJS.Signals | "manual" = "manual",
+    _signal: DaemonShutdownReason = "manual",
   ): Promise<DaemonShutdownResult> {
     if (this.shutdownPromise) {
       return this.shutdownPromise;
     }
 
+    this.clearStaleBuildWatcher();
     this.shutdownPromise = this.doShutdown();
     return this.shutdownPromise;
   }
@@ -385,10 +432,16 @@ export class CmuxLayerDaemon {
         const client =
           this.opts.client ??
           (this.opts.createClient
-            ? await this.opts.createClient()
+            ? await this.opts.createClient({
+                onIrrecoverableTransport: () =>
+                  this.requestRetirement("irrecoverable-transport"),
+              })
             : this.opts.exec || this.opts.bin
               ? undefined
-              : await createCmuxClient());
+              : await createCmuxClient({
+                  onIrrecoverableTransport: () =>
+                    this.requestRetirement("irrecoverable-transport"),
+                }));
         this.context = createServerContext({
           exec: this.opts.exec,
           bin: this.opts.bin,
@@ -503,6 +556,48 @@ export class CmuxLayerDaemon {
     };
   }
 
+  private startStaleBuildWatcher(): void {
+    this.staleCheckTimer = setInterval(() => {
+      const stale = this.detectStaleBuildFn();
+      if (stale?.stale) {
+        this.requestRetirement("stale-build", stale);
+      }
+    }, this.staleCheckIntervalMs);
+    this.staleCheckTimer.unref?.();
+  }
+
+  private clearStaleBuildWatcher(): void {
+    if (this.staleCheckTimer) {
+      clearInterval(this.staleCheckTimer);
+      this.staleCheckTimer = null;
+    }
+  }
+
+  private requestRetirement(
+    reason: DaemonRetirementReason,
+    stale?: StaleBuildResult,
+  ): void {
+    if (this.retirementPromise) {
+      return;
+    }
+    if (reason === "stale-build" && stale) {
+      this.logger.error(
+        `[cmuxlayer-daemon] installed version bump detected (running v${stale.running}, installed v${stale.installed}); retiring`,
+      );
+    } else {
+      this.logger.error(
+        "[cmuxlayer-daemon] transport irrecoverably denied (orphaned ancestry); retiring so a pane-descended respawn can reconnect",
+      );
+    }
+    this.retirementPromise = this.shutdown(reason)
+      .then(async (result) => {
+        await this.opts.onRetire?.(reason, result);
+      })
+      .catch((error) => {
+        this.logger.error("[cmuxlayer-daemon] retirement failed", error);
+      });
+  }
+
   private pauseActiveTransports(): void {
     for (const transport of this.activeTransports) {
       transport.pauseInput();
@@ -577,21 +672,34 @@ export async function runDaemon(
 ): Promise<CmuxLayerDaemon> {
   ensureNodeMaxOldSpaceEnv();
   installHeapGuard();
-  const daemon = new CmuxLayerDaemon(opts);
-  const shutdown = (signal: NodeJS.Signals) => {
+  let exitStarted = false;
+  const exitAfterShutdown = (
+    reason: DaemonShutdownReason,
+    result: DaemonShutdownResult,
+  ) => {
+    if (exitStarted) return;
+    exitStarted = true;
+    process.exit(daemonExitCode(reason, result));
+  };
+  const daemon = new CmuxLayerDaemon({
+    ...opts,
+    onRetire: async (reason, result) => {
+      await opts.onRetire?.(reason, result);
+      exitAfterShutdown(reason, result);
+    },
+  });
+  const shutdownThenExit = (signal: NodeJS.Signals) => {
     daemon
       .shutdown(signal)
-      .then((result) => {
-        process.exit(result.forced ? 1 : 0);
-      })
+      .then((result) => exitAfterShutdown(signal, result))
       .catch((error) => {
         console.error("[cmuxlayer-daemon] shutdown failed", error);
         process.exit(1);
       });
   };
 
-  process.once("SIGTERM", shutdown);
-  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdownThenExit);
+  process.once("SIGINT", shutdownThenExit);
   await daemon.start();
   return daemon;
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -2,11 +2,11 @@
  * cmuxlayer doctor — the STDIO reference impl for the Robust Brew Layer standard
  * (~/Gits/orchestrator/standards/robust-brew-layer.md §0, §1, §3, §6).
  *
- * cmuxlayer is a stdio MCP server with NO cask and NO daemon, so two of the
- * standard's conformance classes are structurally not-applicable:
+ * cmuxlayer is a stdio MCP server with no cask and an on-demand shared daemon,
+ * so one conformance class is structurally not-applicable:
  *   - §1 (account-rename self-heal): N/A — there is no Caskroom artifact to
  *     go stale. `doctor` MUST say so explicitly, not silently no-op.
- *   - §5 (daemon integrity): N/A — there is no socket/launchd daemon.
+ *   - §5 (daemon integrity): probe the on-demand daemon when it is listening.
  *
  * The checks `doctor` actually runs:
  *   (a) version resolves/prints;
@@ -24,10 +24,21 @@
  */
 
 import { execFile } from "node:child_process";
+import net from "node:net";
 import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
+import {
+  probeSocketHealth,
+  type SocketProbeResult,
+} from "./cmux-socket-probe.js";
+import {
+  detectStaleBuild,
+  type DetectStaleBuildDeps,
+  type StaleBuildResult,
+} from "./version.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -114,8 +125,18 @@ export interface DoctorReport {
   version: { ok: boolean; value: string };
   /** §1 account-rename self-heal — not-applicable for a stdio/no-cask layer. */
   caskSelfHeal: { applicable: false; note: string };
-  /** §5 daemon integrity — not-applicable for a stdio/no-daemon layer. */
-  daemon: { applicable: false; note: string };
+  /** §5 daemon integrity — a missing daemon is healthy because it starts on demand. */
+  daemon: {
+    applicable: true;
+    ok: boolean;
+    listening: boolean;
+    socketPath: string;
+    note: string;
+    runningVersion?: string;
+    installedVersion?: string;
+    transportDegraded?: boolean;
+    currentSocketPath?: string | null;
+  };
   /** §3 tap — best-effort report; brew may be absent. */
   tap: {
     brewAvailable: boolean;
@@ -157,6 +178,253 @@ export interface RunDoctorOptions {
   readMcpConfigFile?: McpConfigFileReader;
   /** Injectable runtime provenance probe for tests. */
   runtimeProvenance?: () => RuntimeProvenanceReport;
+  /** Injectable installed-build detector for daemon version comparisons. */
+  detectStaleBuild?: (
+    deps?: DetectStaleBuildDeps,
+  ) => StaleBuildResult | null;
+  /** Injectable cmux socket health probe for degraded-daemon verification. */
+  probeCmuxSocket?: (
+    socketPath: string,
+  ) => Promise<SocketProbeResult>;
+  /** Bound for daemon connect/initialize/control_health (default 1500ms). */
+  daemonProbeTimeoutMs?: number;
+}
+
+type DaemonMcpProbeResult =
+  | { kind: "not-listening" }
+  | {
+      kind: "responding";
+      version: string;
+      transportDegraded: boolean;
+      currentSocketPath: string | null;
+    }
+  | { kind: "error"; error: string };
+
+function daemonProbeError(message: unknown): string {
+  return message instanceof Error ? message.message : String(message);
+}
+
+function probeDaemonMcp(
+  socketPath: string,
+  timeoutMs: number,
+): Promise<DaemonMcpProbeResult> {
+  return new Promise((resolveProbe) => {
+    const socket = net.createConnection(socketPath);
+    let connected = false;
+    let settled = false;
+    let buffer = "";
+    let version: string | null = null;
+    const settle = (result: DaemonMcpProbeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      socket.removeAllListeners();
+      socket.on("error", () => {});
+      socket.destroy();
+      resolveProbe(result);
+    };
+    const send = (message: Record<string, unknown>) => {
+      socket.write(`${JSON.stringify(message)}\n`);
+    };
+    const timeout = setTimeout(() => {
+      settle(
+        connected
+          ? {
+              kind: "error",
+              error: `daemon probe timed out after ${timeoutMs}ms`,
+            }
+          : { kind: "not-listening" },
+      );
+    }, timeoutMs);
+
+    socket.once("connect", () => {
+      connected = true;
+      try {
+        send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "cmuxlayer-doctor", version: "1" },
+          },
+        });
+      } catch (error) {
+        settle({ kind: "error", error: daemonProbeError(error) });
+      }
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line.trim()) continue;
+        try {
+          const message = JSON.parse(line) as Record<string, unknown>;
+          if (message.error) {
+            settle({
+              kind: "error",
+              error: `daemon RPC error: ${JSON.stringify(message.error)}`,
+            });
+            return;
+          }
+          if (message.id === 1) {
+            const result = isRecord(message.result) ? message.result : null;
+            const serverInfo =
+              result && isRecord(result.serverInfo) ? result.serverInfo : null;
+            version =
+              serverInfo && typeof serverInfo.version === "string"
+                ? serverInfo.version
+                : null;
+            if (!version) {
+              settle({
+                kind: "error",
+                error: "daemon initialize response missing serverInfo.version",
+              });
+              return;
+            }
+            send({
+              jsonrpc: "2.0",
+              method: "notifications/initialized",
+              params: {},
+            });
+            send({
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/call",
+              params: { name: "control_health", arguments: {} },
+            });
+          } else if (message.id === 2) {
+            const result = isRecord(message.result) ? message.result : null;
+            const structured =
+              result && isRecord(result.structuredContent)
+                ? result.structuredContent
+                : null;
+            const health =
+              structured && isRecord(structured.health)
+                ? structured.health
+                : null;
+            const selected =
+              health && isRecord(health.selected_transport)
+                ? health.selected_transport
+                : null;
+            if (!version || !selected) {
+              settle({
+                kind: "error",
+                error: "daemon control_health response missing selected_transport",
+              });
+              return;
+            }
+            settle({
+              kind: "responding",
+              version,
+              transportDegraded: selected.transport_degraded === true,
+              currentSocketPath:
+                typeof selected.current_socket_path === "string"
+                  ? selected.current_socket_path
+                  : null,
+            });
+          }
+        } catch (error) {
+          settle({
+            kind: "error",
+            error: `daemon probe parse failure: ${daemonProbeError(error)}`,
+          });
+          return;
+        }
+      }
+    });
+    socket.once("error", (error: NodeJS.ErrnoException) => {
+      if (!connected && (error.code === "ENOENT" || error.code === "ECONNREFUSED")) {
+        settle({ kind: "not-listening" });
+        return;
+      }
+      settle({ kind: "error", error: daemonProbeError(error) });
+    });
+    socket.once("close", () => {
+      if (!settled) {
+        settle({
+          kind: connected ? "error" : "not-listening",
+          ...(connected ? { error: "daemon closed during MCP probe" } : {}),
+        } as DaemonMcpProbeResult);
+      }
+    });
+  });
+}
+
+async function checkDaemonIntegrity(
+  opts: RunDoctorOptions,
+  env: NodeJS.ProcessEnv,
+): Promise<DoctorReport["daemon"]> {
+  const socketPath = defaultDaemonSocketPath(env);
+  const probe = await probeDaemonMcp(
+    socketPath,
+    opts.daemonProbeTimeoutMs ?? 1_500,
+  );
+  if (probe.kind === "not-listening") {
+    return {
+      applicable: true,
+      ok: true,
+      listening: false,
+      socketPath,
+      note: "no daemon running (starts on demand)",
+    };
+  }
+  if (probe.kind === "error") {
+    return {
+      applicable: true,
+      ok: false,
+      listening: true,
+      socketPath,
+      note: `daemon probe failed: ${probe.error}`,
+    };
+  }
+
+  const detect = opts.detectStaleBuild ?? detectStaleBuild;
+  const stale = detect({ running: probe.version });
+  const base = {
+    applicable: true as const,
+    listening: true,
+    socketPath,
+    runningVersion: probe.version,
+    ...(stale ? { installedVersion: stale.installed } : {}),
+    transportDegraded: probe.transportDegraded,
+    currentSocketPath: probe.currentSocketPath,
+  };
+  if (stale?.stale) {
+    return {
+      ...base,
+      ok: false,
+      note: `stale daemon v${stale.running} serving (installed v${stale.installed}) — kill it; proxies respawn the installed daemon`,
+    };
+  }
+
+  if (probe.transportDegraded && probe.currentSocketPath) {
+    try {
+      const cmuxProbe = await (
+        opts.probeCmuxSocket ?? ((path) => probeSocketHealth(path))
+      )(probe.currentSocketPath);
+      if (cmuxProbe.usable) {
+        return {
+          ...base,
+          ok: false,
+          note: "daemon transport degraded while cmux socket alive (stale-daemon-on-dead-socket class)",
+        };
+      }
+    } catch {
+      // A failed cmux probe cannot establish the specific live-socket fault.
+    }
+  }
+
+  return {
+    ...base,
+    ok: true,
+    note: stale
+      ? `daemon v${probe.version} healthy (installed v${stale.installed})`
+      : `daemon v${probe.version} healthy (installed version unavailable)`,
+  };
 }
 
 /**
@@ -506,11 +774,12 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     listMcpConfigPaths: opts.listMcpConfigPaths,
     readMcpConfigFile: opts.readMcpConfigFile,
   });
+  const daemon = await checkDaemonIntegrity(opts, env);
 
   // Health: only the version must resolve. Brew/tap gaps are reported but, per
   // the standard's "brew best-effort" rule, must NOT make the doctor unhealthy
   // (so it exits 0 on machines without brew or without the tap added yet).
-  const healthy = versionOk;
+  const healthy = versionOk && daemon.ok;
 
   return {
     healthy,
@@ -519,10 +788,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
       applicable: false,
       note: "not-applicable: stdio MCP, no cask (§1 account-rename self-heal)",
     },
-    daemon: {
-      applicable: false,
-      note: "not-applicable: stdio MCP, no daemon (§5 daemon integrity)",
-    },
+    daemon,
     tap,
     socketPath: socketSet
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
@@ -550,8 +816,7 @@ export function renderDoctorText(report: DoctorReport): string {
   // §1 — not-applicable, stated explicitly (no silent no-op)
   lines.push(`│ — §1 ${report.caskSelfHeal.note}`);
 
-  // §5 — not-applicable, stated explicitly
-  lines.push(`│ — §5 ${report.daemon.note}`);
+  lines.push(`│ ${mark(report.daemon.ok)} §5 ${report.daemon.note}`);
 
   // (b) §3 tap
   if (!report.tap.brewAvailable) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -401,21 +401,27 @@ async function checkDaemonIntegrity(
     };
   }
 
-  if (probe.transportDegraded && probe.currentSocketPath) {
+  if (probe.transportDegraded) {
+    const pinnedSocketPath = env.CMUX_SOCKET_PATH?.trim();
+    const cmuxSocketPath = pinnedSocketPath || probe.currentSocketPath;
+    let cmuxSocketUsable = false;
     try {
-      const cmuxProbe = await (
-        opts.probeCmuxSocket ?? ((path) => probeSocketHealth(path))
-      )(probe.currentSocketPath);
-      if (cmuxProbe.usable) {
-        return {
-          ...base,
-          ok: false,
-          note: "daemon transport degraded while cmux socket alive (stale-daemon-on-dead-socket class)",
-        };
+      if (cmuxSocketPath) {
+        const cmuxProbe = await (
+          opts.probeCmuxSocket ?? ((path) => probeSocketHealth(path))
+        )(cmuxSocketPath);
+        cmuxSocketUsable = cmuxProbe.usable;
       }
     } catch {
-      // A failed cmux probe cannot establish the specific live-socket fault.
+      // A failed probe is the socket-down branch, but degraded is always red.
     }
+    return {
+      ...base,
+      ok: false,
+      note: cmuxSocketUsable
+        ? "daemon transport degraded while cmux socket alive (access-control denial class; stale-daemon-on-dead-socket class)"
+        : "daemon transport degraded while cmux socket down (app not running)",
+    };
   }
 
   return {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,10 +1,5 @@
-import { spawn } from "node:child_process";
 import net from "node:net";
-import { mkdir } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Readable, Writable } from "node:stream";
-import type { ChildProcess } from "node:child_process";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CreateServerOptions } from "./server.js";
 import {
@@ -13,18 +8,17 @@ import {
   type CmuxLayerProxyOptions,
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
+import {
+  spawnDaemonProcess,
+  type SpawnDaemonOptions,
+} from "./daemon-spawn.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
 
 export { resolveDefaultDaemonSocketPath as defaultDaemonSocketPath };
 
-export interface SpawnDaemonOptions {
-  socketPath: string;
-  env: NodeJS.ProcessEnv;
-  daemonScriptPath?: string;
-  logger: Pick<Console, "error">;
-}
+export { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
 
 export interface StartInProcessOptions {
   fallbackWarnings?: string[];
@@ -84,10 +78,6 @@ function terminateSpawnedDaemon(
   }
 }
 
-function defaultDaemonScriptPath(): string {
-  return resolve(dirname(fileURLToPath(import.meta.url)), "daemon.js");
-}
-
 async function defaultSleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -110,31 +100,6 @@ export async function probeDaemonSocket(socketPath: string): Promise<boolean> {
     socket.once("connect", () => settle(true));
     socket.once("error", () => settle(false));
   });
-}
-
-export async function spawnDaemonProcess(
-  opts: SpawnDaemonOptions,
-): Promise<ChildProcess> {
-  await mkdir(dirname(opts.socketPath), { recursive: true });
-  const daemonScriptPath = opts.daemonScriptPath ?? defaultDaemonScriptPath();
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    ...opts.env,
-    CMUXLAYER_DAEMON_SOCKET: opts.socketPath,
-  };
-  const nodeOptions = env.NODE_OPTIONS ?? "";
-  if (!/(^|\s)--max-old-space-size(=|\s)/.test(nodeOptions)) {
-    env.NODE_OPTIONS = `${nodeOptions} --max-old-space-size=${
-      env.CMUXLAYER_NODE_MAX_OLD_SPACE_MB ?? "1536"
-    }`.trim();
-  }
-  const child = spawn(process.execPath, [daemonScriptPath], {
-    detached: true,
-    env,
-    stdio: ["ignore", "ignore", "inherit"],
-  });
-  child.unref();
-  return child;
 }
 
 async function waitForDaemon(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,6 +37,8 @@ const DEFAULT_STALE_RECHECK_INTERVAL_MS = 30_000;
 const DEFAULT_VERSION_BUMP_MAX_ATTEMPTS = 5;
 const DEFAULT_VERSION_BUMP_WINDOW_MS = 60_000;
 const DEFAULT_RECONNECT_DAEMON_SPAWN_MAX_ATTEMPTS = 3;
+const DEFAULT_BUFFERED_REQUEST_TIMEOUT_MS = 15_000;
+const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 5_000;
 const PROXY_ERROR_CODE = -32001;
 
 export interface ReconnectDelayOptions {
@@ -87,6 +89,7 @@ export interface CmuxLayerProxyOptions {
   reconnectJitterRatio?: number;
   random?: () => number;
   requestTimeoutMs?: number;
+  bufferedRequestTimeoutMs?: number;
   maxBufferedRequests?: number;
   onReconnectDelay?: (delayMs: number, attempt: number) => void;
   logger?: Pick<Console, "error">;
@@ -98,6 +101,8 @@ export interface CmuxLayerProxyOptions {
   ) => Promise<unknown> | unknown;
   versionBumpReconnectGuard?: VersionBumpReconnectGuard;
   reconnectDaemonSpawnGuard?: VersionBumpReconnectGuard;
+  reconnectLogIntervalMs?: number;
+  reconnectLogNow?: () => number;
 }
 
 type JsonRpcRequest = JSONRPCMessage & {
@@ -221,6 +226,7 @@ export class CmuxLayerProxy {
   private readonly reconnectJitterRatio: number;
   private readonly random: () => number;
   private readonly requestTimeoutMs: number;
+  private readonly bufferedRequestTimeoutMs: number;
   private readonly maxBufferedRequests: number;
   private readonly onReconnectDelay?: (
     delayMs: number,
@@ -237,6 +243,8 @@ export class CmuxLayerProxy {
   ) => Promise<unknown> | unknown;
   private readonly versionBumpReconnectGuard: VersionBumpReconnectGuard;
   private readonly reconnectDaemonSpawnGuard: VersionBumpReconnectGuard;
+  private readonly reconnectLogIntervalMs: number;
+  private readonly reconnectLogNow: () => number;
 
   private readonly agentReadBuffer = new JsonRpcLineBuffer();
   private daemonReadBuffer: JsonRpcLineBuffer | null = null;
@@ -255,6 +263,8 @@ export class CmuxLayerProxy {
   private reconnectTimerResolve: (() => void) | null = null;
   private versionBumpTimer: NodeJS.Timeout | null = null;
   private versionBumpReconnecting = false;
+  private bufferedRequestTimer: NodeJS.Timeout | null = null;
+  private readonly reconnectLogTimes = new Map<string, number>();
   private readonly queue: QueuedMessage[] = [];
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly expiredRequestKeys = new Set<string>();
@@ -279,6 +289,8 @@ export class CmuxLayerProxy {
       opts.reconnectJitterRatio ?? DEFAULT_RECONNECT_JITTER_RATIO;
     this.random = opts.random ?? Math.random;
     this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.bufferedRequestTimeoutMs =
+      opts.bufferedRequestTimeoutMs ?? DEFAULT_BUFFERED_REQUEST_TIMEOUT_MS;
     this.maxBufferedRequests =
       opts.maxBufferedRequests ?? DEFAULT_MAX_BUFFERED_REQUESTS;
     this.onReconnectDelay = opts.onReconnectDelay;
@@ -297,6 +309,9 @@ export class CmuxLayerProxy {
         maxAttempts: DEFAULT_RECONNECT_DAEMON_SPAWN_MAX_ATTEMPTS,
         windowMs: DEFAULT_VERSION_BUMP_WINDOW_MS,
       });
+    this.reconnectLogIntervalMs =
+      opts.reconnectLogIntervalMs ?? DEFAULT_RECONNECT_LOG_INTERVAL_MS;
+    this.reconnectLogNow = opts.reconnectLogNow ?? Date.now;
   }
 
   start(): void {
@@ -320,6 +335,7 @@ export class CmuxLayerProxy {
     this.agentReadBuffer.clear();
     this.clearReconnectTimer();
     this.clearVersionBumpTimer();
+    this.clearBufferedRequestTimer();
     this.disconnectDaemon();
     for (const pending of this.pendingRequests.values()) {
       clearTimeout(pending.timeout);
@@ -414,6 +430,9 @@ export class CmuxLayerProxy {
     };
     this.pendingRequests.set(key, pending);
     this.queue.push(pending);
+    if (!this.daemonReady) {
+      this.startBufferedRequestTimer();
+    }
     this.kickConnectionIfIdle();
     void this.flushQueue();
   }
@@ -453,9 +472,20 @@ export class CmuxLayerProxy {
         this.connecting = false;
         this.attachDaemonSocket(socket);
         return;
-      } catch {
+      } catch (error) {
         const attempt = this.reconnectAttempt++;
+        const message = error instanceof Error ? error.message : String(error);
+        const errorClass =
+          error && typeof error === "object" && "code" in error
+            ? String((error as { code: unknown }).code)
+            : /\b(?:ENOENT|ECONNREFUSED|ECONNRESET|EPIPE)\b/i.exec(message)?.[0] ??
+              (error instanceof Error ? error.name : "Error");
+        this.logReconnect(
+          "attempt-failed",
+          `[cmuxlayer-proxy] reconnect attempt ${attempt} failed (${errorClass}): ${message}`,
+        );
         await this.spawnInstalledDaemonAfterReconnectFailure(attempt);
+        this.startBufferedRequestTimer();
         const delayMs = computeReconnectDelay(attempt, {
           initialBackoffMs: this.initialBackoffMs,
           maxBackoffMs: this.maxBackoffMs,
@@ -500,24 +530,46 @@ export class CmuxLayerProxy {
   private async spawnInstalledDaemonAfterReconnectFailure(
     attempt: number,
   ): Promise<void> {
-    if (
-      attempt < 1 ||
-      !this.spawnDaemonForVersionBump ||
-      !this.reconnectDaemonSpawnGuard.allow()
-    ) {
+    if (attempt < 1 || !this.spawnDaemonForVersionBump) {
+      this.logReconnect(
+        "spawn-gate",
+        `[cmuxlayer-proxy] daemon spawn skipped (reason=gate, attempt=${attempt})`,
+      );
       return;
     }
     try {
       const daemonScriptPath = this.installedDaemonScriptPath();
       if (!daemonScriptPath) {
+        this.logReconnect(
+          "spawn-no-script",
+          `[cmuxlayer-proxy] daemon spawn skipped (reason=no-script, attempt=${attempt})`,
+        );
         return;
       }
-      await this.spawnDaemonForVersionBump({
+      if (!this.reconnectDaemonSpawnGuard.allow()) {
+        this.logReconnect(
+          "spawn-guard",
+          `[cmuxlayer-proxy] daemon spawn skipped (reason=guard, attempt=${attempt})`,
+        );
+        return;
+      }
+      const spawned = await this.spawnDaemonForVersionBump({
         socketPath: this.socketPath,
         env: process.env,
         logger: this.logger,
         daemonScriptPath,
       });
+      const pid =
+        spawned &&
+        typeof spawned === "object" &&
+        "pid" in spawned &&
+        typeof spawned.pid === "number"
+          ? spawned.pid
+          : "unknown";
+      this.logReconnect(
+        "spawn-fired",
+        `[cmuxlayer-proxy] daemon spawn fired (script=${daemonScriptPath}, pid=${pid})`,
+      );
     } catch (error) {
       this.logger.error(
         "[cmuxlayer-proxy] failed to spawn installed daemon after reconnect failure",
@@ -683,6 +735,7 @@ export class CmuxLayerProxy {
       }
     }
     this.daemonReady = true;
+    this.clearBufferedRequestTimer();
     this.reconnectAttempt = 0;
     await this.flushQueue();
   }
@@ -746,6 +799,10 @@ export class CmuxLayerProxy {
   }
 
   private handleDaemonDrop(): void {
+    this.logReconnect(
+      "daemon-drop",
+      "[cmuxlayer-proxy] daemon drop detected; reconnecting",
+    );
     if (!this.daemonSocket && !this.daemonReadBuffer) {
       this.reconnectAfterDelay();
       return;
@@ -842,6 +899,39 @@ export class CmuxLayerProxy {
     }
   }
 
+  private startBufferedRequestTimer(): void {
+    if (this.bufferedRequestTimer || this.bufferedRequestTimeoutMs < 0) {
+      return;
+    }
+    this.bufferedRequestTimer = setTimeout(() => {
+      this.bufferedRequestTimer = null;
+      this.failAllPendingRequests(
+        "cmuxlayer daemon unavailable after reconnect attempt",
+      );
+    }, this.bufferedRequestTimeoutMs);
+    this.bufferedRequestTimer.unref?.();
+  }
+
+  private clearBufferedRequestTimer(): void {
+    if (this.bufferedRequestTimer) {
+      clearTimeout(this.bufferedRequestTimer);
+      this.bufferedRequestTimer = null;
+    }
+  }
+
+  private logReconnect(key: string, message: string): void {
+    const now = this.reconnectLogNow();
+    const last = this.reconnectLogTimes.get(key);
+    if (
+      last !== undefined &&
+      now - last < this.reconnectLogIntervalMs
+    ) {
+      return;
+    }
+    this.reconnectLogTimes.set(key, now);
+    this.logger.error(message);
+  }
+
   private sendAgentError(id: RequestId, message: string): Promise<void> {
     return this.writeAgent({
       jsonrpc: "2.0",
@@ -926,12 +1016,23 @@ export class CmuxLayerProxy {
       const daemonScriptPath = this.installedDaemonScriptPath();
       if (daemonScriptPath && this.spawnDaemonForVersionBump) {
         try {
-          await this.spawnDaemonForVersionBump({
+          const spawned = await this.spawnDaemonForVersionBump({
             socketPath: this.socketPath,
             env: process.env,
             logger: this.logger,
             daemonScriptPath,
           });
+          const pid =
+            spawned &&
+            typeof spawned === "object" &&
+            "pid" in spawned &&
+            typeof spawned.pid === "number"
+              ? spawned.pid
+              : "unknown";
+          this.logReconnect(
+            "spawn-fired-version-bump",
+            `[cmuxlayer-proxy] daemon spawn fired (script=${daemonScriptPath}, pid=${pid})`,
+          );
         } catch (error) {
           this.logger.error(
             "[cmuxlayer-proxy] failed to spawn installed daemon for version bump",
@@ -939,10 +1040,14 @@ export class CmuxLayerProxy {
           );
         }
       }
+      const reconnectLoopWillResume = this.reconnectTimerResolve !== null;
       this.clearReconnectTimer();
       this.disconnectDaemon();
       this.daemonReady = false;
       this.reconnectAttempt = 0;
+      if (!reconnectLoopWillResume) {
+        this.connecting = false;
+      }
       this.ensureConnecting();
     } finally {
       this.versionBumpReconnecting = false;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,10 @@ import {
   attachCallerContextToMessage,
   callerContextFromEnv,
 } from "./caller-context.js";
-import type { SpawnDaemonOptions } from "./entry.js";
+import {
+  spawnDaemonProcess,
+  type SpawnDaemonOptions,
+} from "./daemon-spawn.js";
 import {
   detectStaleBuild,
   type DetectStaleBuildDeps,
@@ -33,6 +36,7 @@ const DEFAULT_MAX_BUFFERED_REQUESTS = 100;
 const DEFAULT_STALE_RECHECK_INTERVAL_MS = 30_000;
 const DEFAULT_VERSION_BUMP_MAX_ATTEMPTS = 5;
 const DEFAULT_VERSION_BUMP_WINDOW_MS = 60_000;
+const DEFAULT_RECONNECT_DAEMON_SPAWN_MAX_ATTEMPTS = 3;
 const PROXY_ERROR_CODE = -32001;
 
 export interface ReconnectDelayOptions {
@@ -93,6 +97,7 @@ export interface CmuxLayerProxyOptions {
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
   versionBumpReconnectGuard?: VersionBumpReconnectGuard;
+  reconnectDaemonSpawnGuard?: VersionBumpReconnectGuard;
 }
 
 type JsonRpcRequest = JSONRPCMessage & {
@@ -231,6 +236,7 @@ export class CmuxLayerProxy {
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
   private readonly versionBumpReconnectGuard: VersionBumpReconnectGuard;
+  private readonly reconnectDaemonSpawnGuard: VersionBumpReconnectGuard;
 
   private readonly agentReadBuffer = new JsonRpcLineBuffer();
   private daemonReadBuffer: JsonRpcLineBuffer | null = null;
@@ -285,6 +291,12 @@ export class CmuxLayerProxy {
     this.spawnDaemonForVersionBump = opts.spawnDaemonForVersionBump;
     this.versionBumpReconnectGuard =
       opts.versionBumpReconnectGuard ?? new VersionBumpReconnectGuard();
+    this.reconnectDaemonSpawnGuard =
+      opts.reconnectDaemonSpawnGuard ??
+      new VersionBumpReconnectGuard({
+        maxAttempts: DEFAULT_RECONNECT_DAEMON_SPAWN_MAX_ATTEMPTS,
+        windowMs: DEFAULT_VERSION_BUMP_WINDOW_MS,
+      });
   }
 
   start(): void {
@@ -443,6 +455,7 @@ export class CmuxLayerProxy {
         return;
       } catch {
         const attempt = this.reconnectAttempt++;
+        await this.spawnInstalledDaemonAfterReconnectFailure(attempt);
         const delayMs = computeReconnectDelay(attempt, {
           initialBackoffMs: this.initialBackoffMs,
           maxBackoffMs: this.maxBackoffMs,
@@ -482,6 +495,35 @@ export class CmuxLayerProxy {
       socket.once("connect", onConnect);
       socket.once("error", onError);
     });
+  }
+
+  private async spawnInstalledDaemonAfterReconnectFailure(
+    attempt: number,
+  ): Promise<void> {
+    if (
+      attempt < 1 ||
+      !this.spawnDaemonForVersionBump ||
+      !this.reconnectDaemonSpawnGuard.allow()
+    ) {
+      return;
+    }
+    try {
+      const daemonScriptPath = this.installedDaemonScriptPath();
+      if (!daemonScriptPath) {
+        return;
+      }
+      await this.spawnDaemonForVersionBump({
+        socketPath: this.socketPath,
+        env: process.env,
+        logger: this.logger,
+        daemonScriptPath,
+      });
+    } catch (error) {
+      this.logger.error(
+        "[cmuxlayer-proxy] failed to spawn installed daemon after reconnect failure",
+        error,
+      );
+    }
   }
 
   private attachDaemonSocket(socket: net.Socket): void {
@@ -920,7 +962,7 @@ const isMain =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
-  runProxy().catch((error) => {
+  runProxy({ spawnDaemonForVersionBump: spawnDaemonProcess }).catch((error) => {
     console.error("[cmuxlayer-proxy] fatal", error);
     process.exit(1);
   });

--- a/src/version.ts
+++ b/src/version.ts
@@ -116,15 +116,17 @@ function resolveBrewPrefix(): string | null {
 export function defaultOptPackageJsonPath(): string | null {
   const prefix = resolveBrewPrefix();
   if (!prefix) return null;
-  return join(prefix, "opt", "cmuxlayer", "package.json");
+  return join(prefix, "opt", "cmuxlayer", "libexec", "package.json");
 }
 
 /**
  * Resolve the brew-installed daemon entrypoint for version-bump reconnect.
  * Returns null when the opt tree cannot be resolved.
  */
-export function resolveInstalledDaemonScript(): string | null {
-  const optPackageJson = defaultOptPackageJsonPath();
+export function resolveInstalledDaemonScript(
+  optPackageJsonPath: string | null = defaultOptPackageJsonPath(),
+): string | null {
+  const optPackageJson = optPackageJsonPath;
   if (!optPackageJson) return null;
   return join(dirname(optPackageJson), "dist", "daemon.js");
 }

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -435,6 +435,73 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("preserves denial evidence across non-denial failures until a usable socket probe", () => {
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath: "/tmp/cmux-preserve-denial.sock",
+      reprobeIntervalMs: 60_000,
+    });
+    const internals = client as any;
+
+    internals.recordProbeResult({
+      usable: false,
+      socketPath: "/tmp/cmux-preserve-denial.sock",
+      error: "write EPIPE",
+    });
+    internals.recordCliFailure(new Error("Broken pipe (errno 32)"));
+
+    internals.recordProbeResult({
+      usable: false,
+      socketPath: "/tmp/cmux-preserve-denial.sock",
+      error: "connect ECONNREFUSED",
+    });
+    internals.recordProbeFailure(new Error("probe timeout"));
+    internals.recordCliFailure(new Error("connect ENOENT"));
+
+    expect(internals.denialProbeFailures).toBe(1);
+    expect(internals.cliDenialFailures).toBe(1);
+
+    internals.recordProbeResult({
+      usable: true,
+      socketPath: "/tmp/cmux-preserve-denial.sock",
+    });
+
+    expect(internals.denialProbeFailures).toBe(0);
+    expect(internals.denialProbeStartedAt).toBeNull();
+    expect(internals.cliDenialFailures).toBe(0);
+    client.stop();
+  });
+
+  it("rate-limits denial evidence progress logs", () => {
+    let now = 1_000;
+    const logger = { error: vi.fn() };
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath: "/tmp/cmux-denial-progress.sock",
+      logger,
+      now: () => now,
+      reprobeIntervalMs: 60_000,
+      irrecoverableMinFailures: 3,
+      irrecoverableMinDurationMs: 60_000,
+    });
+    const internals = client as any;
+    logger.error.mockClear();
+
+    internals.recordProbeDenial();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] denial evidence 1/3 probes, 0/3 cli, 0s",
+    );
+
+    now += 1_000;
+    internals.recordCliFailure(new Error("write EPIPE"));
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    now += 29_000;
+    internals.recordCliFailure(new Error("write EPIPE"));
+    expect(logger.error).toHaveBeenLastCalledWith(
+      "[cmuxlayer] denial evidence 1/3 probes, 2/3 cli, 30s",
+    );
+    client.stop();
+  });
+
   it("attributes retry bookkeeping to the delegate used for that attempt", async () => {
     const client = wrapCliWithSelfHeal(new CmuxClient(), {
       socketPath: "/tmp/cmux-retry-attribution.sock",

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -291,6 +291,249 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("signals irrecoverable transport only after repeated socket and CLI denial failures", async () => {
+    const socketPath = join(tmpdir(), `cmux-irrecoverable-${process.pid}.sock`);
+    const onIrrecoverableTransport = vi.fn();
+    const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: false,
+      socketPath,
+      error: "write EPIPE",
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+      irrecoverableMinFailures: 2,
+      irrecoverableMinDurationMs: 20,
+      onIrrecoverableTransport,
+    });
+
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    await waitForExpectation(
+      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    await waitForExpectation(
+      async () => expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+
+    client.stop();
+  });
+
+  it("preserves the transport error when the irrecoverable callback throws", async () => {
+    const socketPath = join(tmpdir(), `cmux-callback-throw-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const onIrrecoverableTransport = vi.fn(() => {
+      throw new Error("retirement callback failed");
+    });
+    const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      retryAttempts: 1,
+      probeSocketHealth: async () => ({
+        usable: false,
+        socketPath,
+        error: "write EPIPE",
+      }),
+      irrecoverableMinFailures: 1,
+      irrecoverableMinDurationMs: 0,
+      onIrrecoverableTransport,
+    });
+
+    await waitForExpectation(
+      async () =>
+        expect(
+          (client as any).denialProbeFailures,
+        ).toBeGreaterThanOrEqual(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer] irrecoverable transport callback failed",
+      expect.objectContaining({ message: "retirement callback failed" }),
+    );
+    client.stop();
+  });
+
+  it("logs and reschedules after the socket health probe rejects", async () => {
+    const socketPath = join(tmpdir(), `cmux-probe-reject-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const probeSocketHealth = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("write EPIPE"))
+      .mockResolvedValue({
+        usable: false,
+        socketPath,
+        error: "connect ECONNREFUSED",
+      });
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath,
+      logger,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+    });
+
+    await waitForExpectation(
+      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("transport upgrade failed"),
+    );
+    client.stop();
+  });
+
+  it("counts the factory initial denial as the first socket denial", async () => {
+    const socketPath = join(tmpdir(), `cmux-initial-denial-${process.pid}.sock`);
+    const onIrrecoverableTransport = vi.fn();
+    const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
+    const probeSocketHealth = vi
+      .fn()
+      .mockResolvedValueOnce({ usable: false, socketPath, error: "write EPIPE" })
+      .mockResolvedValue({
+        usable: false,
+        socketPath,
+        error: "connect ECONNREFUSED",
+      });
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath,
+      retryAttempts: 1,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      initialDenial: {
+        denied_reason: "access-control",
+        socketPath,
+        error: "write EPIPE",
+      },
+      probeSocketHealth,
+      irrecoverableMinFailures: 2,
+      irrecoverableMinDurationMs: 0,
+      onIrrecoverableTransport,
+    });
+
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    await waitForExpectation(
+      async () => expect(probeSocketHealth).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+
+    expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1);
+    client.stop();
+  });
+
+  it("attributes retry bookkeeping to the delegate used for that attempt", async () => {
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath: "/tmp/cmux-retry-attribution.sock",
+      retryAttempts: 2,
+      retryBaseMs: 0,
+      retryCapMs: 0,
+      sleep: async () => {},
+      reprobeIntervalMs: 60_000,
+    });
+    const internals = client as any;
+    internals.cliDenialFailures = 1;
+    internals.delegate = {
+      listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    };
+
+    await expect(
+      internals.retryPayload({
+        method: "listWorkspaces",
+        args: [],
+        error: new Error("write EPIPE"),
+      }),
+    ).resolves.toEqual({ workspaces: [] });
+    expect(internals.cliDenialFailures).toBe(1);
+
+    internals.cliDenialFailures = 0;
+    internals.delegate = {
+      listWorkspaces: vi.fn().mockRejectedValue(new Error("write EPIPE")),
+    };
+    await expect(
+      internals.retryPayload({
+        method: "listWorkspaces",
+        args: [],
+        error: new Error("write EPIPE"),
+      }),
+    ).rejects.toThrow(/EPIPE/);
+    expect(internals.cliDenialFailures).toBe(0);
+    client.stop();
+  });
+
+  it("does not signal irrecoverable transport when the cmux app is down", async () => {
+    const socketPath = join(tmpdir(), `cmux-app-down-${process.pid}.sock`);
+    const onIrrecoverableTransport = vi.fn();
+    const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: false,
+      socketPath,
+      error: "connect ECONNREFUSED",
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
+      socketPath,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+      irrecoverableMinFailures: 2,
+      irrecoverableMinDurationMs: 10,
+      onIrrecoverableTransport,
+    });
+
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    await waitForExpectation(
+      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(2),
+      { timeout: 1_000, interval: 5 },
+    );
+    await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(onIrrecoverableTransport).not.toHaveBeenCalled();
+    client.stop();
+  });
+
+  it("logs the error class when a socket upgrade attempt fails", async () => {
+    const socketPath = join(tmpdir(), `cmux-upgrade-log-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: true,
+      socketPath,
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath,
+      factoryOpts: { socketPath },
+      logger,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+    });
+
+    await waitForExpectation(
+      async () =>
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining("transport upgrade failed"),
+        ),
+      { timeout: 1_000, interval: 5 },
+    );
+
+    client.stop();
+  });
+
   it("logs and exposes cmux access-control denial instead of generic CLI fallback", async () => {
     const stateDir = mkdtempSync(join(tmpdir(), "cmux-access-denied-"));
     const socketPath = join(stateDir, "denied.sock");

--- a/tests/daemon-spawn.test.ts
+++ b/tests/daemon-spawn.test.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { spawnDaemonProcess } from "../src/daemon-spawn.js";
+
+describe("spawnDaemonProcess", () => {
+  it("logs the exit status when a spawned daemon dies", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-daemon-spawn-"));
+    const logger = { error: vi.fn() };
+    try {
+      const daemonScriptPath = join(root, "exiting-daemon.js");
+      writeFileSync(daemonScriptPath, "process.exit(7);\n");
+      const child = await spawnDaemonProcess({
+        socketPath: join(root, "daemon.sock"),
+        env: {},
+        logger,
+        daemonScriptPath,
+      });
+      await new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /spawned daemon exited \(pid=\d+, code=7, signal=none\)/,
+        ),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -7,7 +7,11 @@ import { join } from "node:path";
 import net from "node:net";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
-import { CmuxLayerDaemon, SocketJsonRpcTransport } from "../src/daemon.js";
+import {
+  CmuxLayerDaemon,
+  daemonExitCode,
+  SocketJsonRpcTransport,
+} from "../src/daemon.js";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 
@@ -264,6 +268,19 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("timed out waiting for condition");
+    }
+    await delay(5);
+  }
+}
+
 async function rawToolCall(
   path: string,
   params: Record<string, unknown>,
@@ -428,6 +445,128 @@ describe("CmuxLayerDaemon", () => {
 
     await expect(transport.start()).rejects.toThrow(/closed/i);
     socket.destroy();
+  });
+
+  it("exits zero for retirement even when draining was forced", () => {
+    const forced = {
+      forced: true,
+      activeConnections: 1,
+      inFlightRequests: 1,
+    };
+
+    expect(daemonExitCode("stale-build", forced)).toBe(0);
+    expect(daemonExitCode("irrecoverable-transport", forced)).toBe(0);
+    expect(daemonExitCode("SIGTERM", forced)).toBe(1);
+  });
+
+  it("retires exactly once when the installed build becomes stale", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("stale-retire");
+    const onRetire = vi.fn();
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+      staleCheckIntervalMs: 5,
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.31",
+        installed: "0.3.33",
+      }),
+      onRetire,
+    });
+    const shutdown = vi.spyOn(daemon, "shutdown");
+
+    await daemon.start();
+    await waitUntil(() => onRetire.mock.calls.length === 1);
+    await delay(20);
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(onRetire).toHaveBeenCalledWith(
+      "stale-build",
+      expect.objectContaining({ forced: false }),
+    );
+  });
+
+  it("does not retire for null or matching stale-build checks", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("not-stale");
+    const detectStaleBuild = vi
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValue({
+        stale: false,
+        running: "0.3.33",
+        installed: "0.3.33",
+      });
+    const onRetire = vi.fn();
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+      staleCheckIntervalMs: 5,
+      detectStaleBuild,
+      onRetire,
+    });
+
+    await daemon.start();
+    await delay(25);
+
+    expect(detectStaleBuild).toHaveBeenCalled();
+    expect(onRetire).not.toHaveBeenCalled();
+    await daemon.shutdown();
+  });
+
+  it("retires exactly once when the self-healing client signals irrecoverable denial", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("transport-retire");
+    let signalIrrecoverable: (() => void) | undefined;
+    const onRetire = vi.fn();
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      createClient: async (opts) => {
+        signalIrrecoverable = opts.onIrrecoverableTransport;
+        return {} as any;
+      },
+      skipAgentLifecycle: true,
+      staleCheckIntervalMs: 60_000,
+      detectStaleBuild: () => null,
+      onRetire,
+    });
+    const shutdown = vi.spyOn(daemon, "shutdown");
+
+    await daemon.start();
+    expect(signalIrrecoverable).toBeTypeOf("function");
+    signalIrrecoverable?.();
+    signalIrrecoverable?.();
+    await waitUntil(() => onRetire.mock.calls.length === 1);
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(onRetire).toHaveBeenCalledWith(
+      "irrecoverable-transport",
+      expect.objectContaining({ forced: false }),
+    );
+  });
+
+  it("clears the stale-build timer after shutdown", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("stale-timer-clear");
+    const detectStaleBuild = vi.fn(() => null);
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+      staleCheckIntervalMs: 5,
+      detectStaleBuild,
+    });
+
+    await daemon.start();
+    await waitUntil(() => detectStaleBuild.mock.calls.length >= 2);
+    await daemon.shutdown();
+    const callsAfterShutdown = detectStaleBuild.mock.calls.length;
+    await delay(20);
+
+    expect(detectStaleBuild).toHaveBeenCalledTimes(callsAfterShutdown);
   });
 
   it("reuses one lifecycle AgentEngine across servers sharing a context", async () => {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import net from "node:net";
 import { EventEmitter, once } from "node:events";
@@ -1390,6 +1390,84 @@ describe("CmuxLayerDaemon", () => {
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toMatch(/Connection closed|closed/i);
     await client.close().catch(() => {});
+  });
+
+  it("closes client transports promptly when retirement interrupts a hung request", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("retirement-hung-request");
+    const started = deferred<void>();
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        started.resolve();
+        return new Promise(() => {});
+      }
+      return createListSurfacesExec()(_cmd, args);
+    });
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec,
+      skipAgentLifecycle: true,
+      drainTimeoutMs: 2_000,
+    });
+
+    await daemon.start();
+    const client = await connectClient(path);
+    const pending = client
+      .callTool({
+        name: "list_surfaces",
+        arguments: { verbose: false },
+      })
+      .then(
+        () => null,
+        (error) => error,
+      );
+    await started.promise;
+
+    const shutdown = daemon.shutdown("irrecoverable-transport");
+    await expect(
+      Promise.race([
+        shutdown,
+        delay(200).then(() => {
+          throw new Error("retirement left the client hanging");
+        }),
+      ]),
+    ).resolves.toMatchObject({ forced: true });
+    const error = await pending;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatch(/Connection closed|closed/i);
+    await client.close().catch(() => {});
+  });
+
+  it("unlinks its owned socket after graceful shutdown", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("owned-cleanup");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+
+    await daemon.start();
+    expect(existsSync(path)).toBe(true);
+    await daemon.shutdown();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("does not unlink a replacement file that it does not own", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("foreign-replacement");
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: createListSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+
+    await daemon.start();
+    rmSync(path, { force: true });
+    writeFileSync(path, "replacement-owner");
+    await daemon.shutdown();
+
+    await expect(readFile(path, "utf8")).resolves.toBe("replacement-owner");
   });
 
   it("uses listen({ fd }) for socket activation without unlinking the socket path", async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import net from "node:net";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   checkMcpConfigDrift,
   detectRuntimeProvenance,
@@ -95,7 +98,108 @@ function runDoctorForTest(opts: Parameters<typeof runDoctor>[0]) {
     listMcpConfigPaths: async () => [],
     readMcpConfigFile: async () => "",
     ...opts,
+    env: {
+      CMUXLAYER_DAEMON_SOCKET: join(
+        "/tmp",
+        `cmuxlayer-doctor-no-daemon-${process.pid}.sock`,
+      ),
+      ...opts.env,
+    },
   });
+}
+
+const doctorServers: Array<{
+  server: net.Server;
+  path: string;
+  sockets: Set<net.Socket>;
+}> = [];
+
+afterEach(async () => {
+  for (const { server, path, sockets } of doctorServers.splice(0)) {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(path, { force: true });
+  }
+});
+
+async function startDoctorDaemon(
+  path: string,
+  opts: {
+    version?: string;
+    degraded?: boolean;
+    cmuxSocketPath?: string;
+    unresponsive?: boolean;
+  } = {},
+): Promise<void> {
+  rmSync(path, { force: true });
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    if (opts.unresponsive) return;
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line.trim()) continue;
+        const message = JSON.parse(line) as {
+          id?: string | number;
+          method?: string;
+          params?: { name?: string };
+        };
+        if (message.method === "initialize") {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-03-26",
+                capabilities: {},
+                serverInfo: {
+                  name: "cmuxlayer",
+                  version: opts.version ?? "0.3.33",
+                },
+              },
+            })}\n`,
+          );
+        } else if (
+          message.method === "tools/call" &&
+          message.params?.name === "control_health"
+        ) {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                content: [],
+                structuredContent: {
+                  health: {
+                    selected_transport: {
+                      transport_mode: opts.degraded ? "cli" : "socket",
+                      transport_degraded: opts.degraded ?? false,
+                      current_socket_path:
+                        opts.cmuxSocketPath ?? "/tmp/cmux-test.sock",
+                    },
+                  },
+                },
+              },
+            })}\n`,
+          );
+        }
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(path, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  doctorServers.push({ server, path, sockets });
 }
 
 describe("runDoctor — report shape", () => {
@@ -130,16 +234,114 @@ describe("runDoctor — report shape", () => {
     expect(report.caskSelfHeal.note).toMatch(/no cask/i);
   });
 
-  it("marks §5 daemon integrity as not-applicable (stdio MCP, no daemon)", async () => {
+  it("reports no daemon as healthy because it starts on demand", async () => {
     const report = await runDoctorForTest({
       version: "0.3.0",
       env: {},
       brew: makeBrew({}),
     });
-    expect(report.daemon.applicable).toBe(false);
-    expect(report.daemon.note).toMatch(/not-applicable/i);
-    expect(report.daemon.note).toMatch(/stdio MCP/i);
-    expect(report.daemon.note).toMatch(/no daemon/i);
+    expect(report.daemon.applicable).toBe(true);
+    expect(report.daemon.ok).toBe(true);
+    expect(report.daemon.listening).toBe(false);
+    expect(report.daemon.note).toMatch(/no daemon running.*starts on demand/i);
+  });
+
+  it("reports a healthy matching daemon", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-healthy-${process.pid}.sock`);
+    await startDoctorDaemon(path, { version: "0.3.33" });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: ({ running }) => ({
+        stale: false,
+        running: running ?? "unknown",
+        installed: "0.3.33",
+      }),
+    });
+
+    expect(report.daemon).toMatchObject({
+      applicable: true,
+      ok: true,
+      listening: true,
+      runningVersion: "0.3.33",
+      installedVersion: "0.3.33",
+    });
+    expect(report.healthy).toBe(true);
+  });
+
+  it("flags a stale daemon version mismatch", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-stale-${process.pid}.sock`);
+    await startDoctorDaemon(path, { version: "0.3.31" });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: ({ running }) => ({
+        stale: true,
+        running: running ?? "unknown",
+        installed: "0.3.33",
+      }),
+    });
+
+    expect(report.daemon.ok).toBe(false);
+    expect(report.daemon.note).toMatch(
+      /stale daemon v0\.3\.31 serving \(installed v0\.3\.33\).*proxies respawn/i,
+    );
+    expect(report.healthy).toBe(false);
+  });
+
+  it("flags degraded daemon transport while the reported cmux socket is live", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-degraded-${process.pid}.sock`);
+    const cmuxPath = join("/tmp", `cmuxlayer-doctor-live-cmux-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      degraded: true,
+      cmuxSocketPath: cmuxPath,
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: ({ running }) => ({
+        stale: false,
+        running: running ?? "unknown",
+        installed: "0.3.33",
+      }),
+      probeCmuxSocket: async (socketPath) => ({
+        usable: socketPath === cmuxPath,
+        socketPath,
+      }),
+    });
+
+    expect(report.daemon.ok).toBe(false);
+    expect(report.daemon.note).toMatch(
+      /daemon transport degraded while cmux socket alive.*stale-daemon-on-dead-socket class/i,
+    );
+    expect(report.healthy).toBe(false);
+  });
+
+  it("flags a listening but unresponsive daemon with the probe error", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-hung-${process.pid}.sock`);
+    await startDoctorDaemon(path, { unresponsive: true });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      daemonProbeTimeoutMs: 30,
+    });
+
+    expect(report.daemon).toMatchObject({
+      applicable: true,
+      ok: false,
+      listening: true,
+    });
+    expect(report.daemon.note).toMatch(/timed out/i);
+    expect(report.healthy).toBe(false);
   });
 
   it("reports the tap as present + formula resolvable when brew lists it", async () => {
@@ -572,8 +774,10 @@ describe("renderDoctorText", () => {
         note: "not-applicable: stdio MCP, no cask (§1 account-rename self-heal)",
       },
       daemon: {
-        applicable: false,
-        note: "not-applicable: stdio MCP, no daemon (§5 daemon integrity)",
+        applicable: true,
+        ok: true,
+        listening: false,
+        note: "no daemon running (starts on demand)",
       },
       tap: {
         brewAvailable: true,
@@ -620,9 +824,9 @@ describe("renderDoctorText", () => {
     expect(text).toMatch(/not-applicable: stdio MCP, no cask/i);
   });
 
-  it("prints the §5 not-applicable line explicitly", () => {
+  it("prints the §5 daemon integrity line", () => {
     const text = renderDoctorText(baseReport());
-    expect(text).toMatch(/not-applicable: stdio MCP, no daemon/i);
+    expect(text).toMatch(/§5.*no daemon running.*starts on demand/i);
   });
 
   it("prints the tap status and the trust note for casks", () => {
@@ -696,8 +900,10 @@ describe("renderDoctorJson", () => {
         note: "not-applicable: stdio MCP, no cask",
       },
       daemon: {
-        applicable: false,
-        note: "not-applicable: stdio MCP, no daemon",
+        applicable: true,
+        ok: true,
+        listening: false,
+        note: "no daemon running (starts on demand)",
       },
       tap: {
         brewAvailable: true,
@@ -743,7 +949,8 @@ describe("renderDoctorJson", () => {
     expect(parsed.healthy).toBe(true);
     expect(parsed.version.value).toBe("0.3.0");
     expect(parsed.caskSelfHeal.applicable).toBe(false);
-    expect(parsed.daemon.applicable).toBe(false);
+    expect(parsed.daemon.applicable).toBe(true);
+    expect(parsed.daemon.ok).toBe(true);
     expect(parsed.tap.tapPresent).toBe(true);
     expect(parsed.socketPath.set).toBe(true);
     expect(parsed.socketPath.value).toBe("/tmp/x.sock");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,7 +1,7 @@
 import net from "node:net";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkMcpConfigDrift,
   detectRuntimeProvenance,
@@ -322,6 +322,73 @@ describe("runDoctor — report shape", () => {
       /daemon transport degraded while cmux socket alive.*stale-daemon-on-dead-socket class/i,
     );
     expect(report.healthy).toBe(false);
+  });
+
+  it("never reports a degraded daemon healthy when the cmux socket is down", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-degraded-down-${process.pid}.sock`);
+    const cmuxPath = join("/tmp", `cmuxlayer-doctor-down-cmux-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      degraded: true,
+      cmuxSocketPath: cmuxPath,
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: ({ running }) => ({
+        stale: false,
+        running: running ?? "unknown",
+        installed: "0.3.33",
+      }),
+      probeCmuxSocket: async (socketPath) => ({
+        usable: false,
+        socketPath,
+        error: "connect ECONNREFUSED",
+      }),
+    });
+
+    expect(report.daemon.ok).toBe(false);
+    expect(report.daemon.note).toMatch(
+      /daemon transport degraded.*cmux socket down.*app not running/i,
+    );
+    expect(report.healthy).toBe(false);
+  });
+
+  it("probes the CMUX_SOCKET_PATH pin instead of the daemon-reported default", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-degraded-pin-${process.pid}.sock`);
+    const reportedPath = join("/tmp", `cmuxlayer-doctor-reported-${process.pid}.sock`);
+    const pinnedPath = join("/tmp", `cmuxlayer-doctor-pinned-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      degraded: true,
+      cmuxSocketPath: reportedPath,
+    });
+    const probeCmuxSocket = vi.fn(async (socketPath: string) => ({
+      usable: socketPath === pinnedPath,
+      socketPath,
+    }));
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: {
+        CMUXLAYER_DAEMON_SOCKET: path,
+        CMUX_SOCKET_PATH: pinnedPath,
+      },
+      brew: makeBrew({}),
+      detectStaleBuild: ({ running }) => ({
+        stale: false,
+        running: running ?? "unknown",
+        installed: "0.3.33",
+      }),
+      probeCmuxSocket,
+    });
+
+    expect(probeCmuxSocket).toHaveBeenCalledWith(pinnedPath);
+    expect(probeCmuxSocket).not.toHaveBeenCalledWith(reportedPath);
+    expect(report.daemon.ok).toBe(false);
+    expect(report.daemon.note).toMatch(/access-control denial class/i);
   });
 
   it("flags a listening but unresponsive daemon with the probe error", async () => {

--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -1,0 +1,286 @@
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import {
+  cpSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import net from "node:net";
+import { dirname, join, resolve } from "node:path";
+import { ReadBuffer } from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const ROOTS = new Set<string>();
+const CHILDREN = new Set<ChildProcess>();
+const SERVERS = new Set<{
+  server: net.Server;
+  sockets: Set<net.Socket>;
+}>();
+
+beforeAll(() => {
+  execFileSync(resolve("node_modules", ".bin", "tsc"), ["-p", "tsconfig.json"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function processExists(pid: number): boolean {
+  try {
+    const state = execFileSync("ps", ["-p", String(pid), "-o", "state="], {
+      encoding: "utf8",
+    }).trim();
+    return state.length > 0 && !state.startsWith("Z");
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+async function startFakeCmuxSocket(path: string): Promise<void> {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (!line.trim()) continue;
+        if (!line.startsWith("{")) {
+          socket.write("OK\n");
+          continue;
+        }
+        const request = JSON.parse(line) as {
+          id?: string;
+          method?: string;
+        };
+        const result =
+          request.method === "system.ping"
+            ? { pong: true }
+            : request.method === "list_workspaces"
+              ? { workspaces: [] }
+              : request.method === "list_panes"
+                ? { panes: [] }
+                : {};
+        socket.write(
+          `${JSON.stringify({ id: request.id, ok: true, result })}\n`,
+        );
+      }
+    });
+  });
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(path, () => {
+      server.off("error", reject);
+      resolveListen();
+    });
+  });
+  SERVERS.add({ server, sockets });
+}
+
+function packageJson(version: string): string {
+  return `${JSON.stringify({ name: "cmuxlayer", version, type: "module" })}\n`;
+}
+
+function createFormulaFixture(root: string, version: string): {
+  rootPackage: string;
+  libexecPackage: string;
+} {
+  const optRoot = join(root, "brew", "opt", "cmuxlayer");
+  const libexec = join(optRoot, "libexec");
+  mkdirSync(libexec, { recursive: true });
+  cpSync(resolve("dist"), join(libexec, "dist"), { recursive: true });
+  symlinkSync(resolve("node_modules"), join(libexec, "node_modules"), "dir");
+  const rootPackage = join(optRoot, "package.json");
+  const libexecPackage = join(libexec, "package.json");
+  writeFileSync(rootPackage, packageJson(version));
+  writeFileSync(libexecPackage, packageJson(version));
+  return { rootPackage, libexecPackage };
+}
+
+function createMcpPeer(child: ChildProcess, stderr: string[]) {
+  const output = child.stdout;
+  const input = child.stdin;
+  if (!output || !input) {
+    throw new Error("live MCP child stdio was not piped");
+  }
+  const messages: JSONRPCMessage[] = [];
+  const events = new EventEmitter();
+  const readBuffer = new ReadBuffer();
+  output.on("data", (chunk: Buffer) => {
+    readBuffer.append(chunk);
+    while (true) {
+      const message = readBuffer.readMessage();
+      if (message === null) break;
+      messages.push(message);
+      events.emit("message", message);
+    }
+  });
+  child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk.toString()));
+
+  const send = (message: Record<string, unknown>) => {
+    input.write(`${JSON.stringify(message)}\n`);
+  };
+  const waitForResponse = (id: number, timeoutMs: number) => {
+    const existing = messages.find(
+      (message) => isRecord(message) && message.id === id,
+    );
+    if (existing) return Promise.resolve(existing);
+    return new Promise<JSONRPCMessage>((resolveMessage, reject) => {
+      const timer = setTimeout(() => {
+        events.off("message", onMessage);
+        reject(
+          new Error(
+            `timed out after ${timeoutMs}ms waiting for MCP response ${id}\n--- child stderr ---\n${stderr.join("")}`,
+          ),
+        );
+      }, timeoutMs);
+      const onMessage = (message: JSONRPCMessage) => {
+        if (!isRecord(message) || message.id !== id) return;
+        clearTimeout(timer);
+        events.off("message", onMessage);
+        resolveMessage(message);
+      };
+      events.on("message", onMessage);
+    });
+  };
+  return { send, waitForResponse };
+}
+
+function daemonPidFromHealth(
+  message: JSONRPCMessage,
+  stderr: string[] = [],
+): number {
+  if (!isRecord(message) || !isRecord(message.result)) {
+    throw new Error(
+      `control_health response had no result: ${JSON.stringify(message)}\n--- child stderr ---\n${stderr.join("")}`,
+    );
+  }
+  const structured = message.result.structuredContent;
+  if (!isRecord(structured) || !isRecord(structured.health)) {
+    throw new Error("control_health response had no structured health");
+  }
+  const currentProcess = structured.health.current_process;
+  if (!isRecord(currentProcess) || typeof currentProcess.pid !== "number") {
+    throw new Error("control_health response had no daemon pid");
+  }
+  return currentProcess.pid;
+}
+
+afterEach(async () => {
+  for (const child of CHILDREN) {
+    child.stdin?.end();
+    child.kill("SIGTERM");
+  }
+  CHILDREN.clear();
+  for (const { server, sockets } of SERVERS) {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+  }
+  SERVERS.clear();
+  for (const root of ROOTS) rmSync(root, { recursive: true, force: true });
+  ROOTS.clear();
+});
+
+describe("live daemon-first restart topology", () => {
+  it(
+    "autostarts a replacement daemon after real stale-build retirement",
+    async () => {
+      const rootPath = join(
+        "/tmp",
+        `cmuxlayer-live-restart-${process.pid}-${Date.now()}`,
+      );
+      mkdirSync(rootPath, { recursive: true });
+      const root = realpathSync(rootPath);
+      ROOTS.add(root);
+      const daemonSocket = join(root, "stated.sock");
+      const cmuxSocket = join(root, "cmux.sock");
+      const formula = createFormulaFixture(root, "0.3.33");
+      await startFakeCmuxSocket(cmuxSocket);
+
+      const stderr: string[] = [];
+      const child = spawn(process.execPath, [resolve("dist", "index.js")], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          HOME: root,
+          HOMEBREW_PREFIX: join(root, "brew"),
+          CMUX_SOCKET_PATH: cmuxSocket,
+          CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+          CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
+          CMUXLAYER_STALE_CHECK_INTERVAL_MS: "100",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      CHILDREN.add(child);
+      const peer = createMcpPeer(child, stderr);
+
+      peer.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "live-topology-test", version: "1" },
+        },
+      });
+      await peer.waitForResponse(1, 10_000);
+      peer.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      peer.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "control_health", arguments: {} },
+      });
+      const initialHealth = await peer.waitForResponse(2, 10_000);
+      const initialDaemonPid = daemonPidFromHealth(initialHealth);
+      expect(processExists(initialDaemonPid)).toBe(true);
+
+      writeFileSync(formula.rootPackage, packageJson("0.3.34"));
+      writeFileSync(formula.libexecPackage, packageJson("0.3.34"));
+      await waitFor(
+        () => !processExists(initialDaemonPid),
+        5_000,
+        `daemon ${initialDaemonPid} to retire; stderr=${stderr.join("")}`,
+      );
+
+      const recoveryStartedAt = Date.now();
+      peer.send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "control_health", arguments: {} },
+      });
+      const recoveredHealth = await peer.waitForResponse(3, 15_000);
+      const replacementDaemonPid = daemonPidFromHealth(recoveredHealth, stderr);
+      expect(replacementDaemonPid).not.toBe(initialDaemonPid);
+      expect(Date.now() - recoveryStartedAt).toBeLessThan(15_000);
+      process.kill(replacementDaemonPid, "SIGTERM");
+    },
+    70_000,
+  );
+});

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -243,6 +243,49 @@ describe("proxy version-bump auto-reconnect", () => {
     expect(detectStaleBuild).toHaveBeenCalled();
   });
 
+  it("resumes connecting when a version bump cancels a daemon-drop backoff", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("drop-bump-race");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    let stale = false;
+    const logger = { error: vi.fn() };
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input: new PassThrough(),
+      output: new PassThrough(),
+      logger,
+      initialBackoffMs: 1_000,
+      maxBackoffMs: 1_000,
+      reconnectJitterRatio: 0,
+      reconnectLogIntervalMs: 0,
+      staleRecheckIntervalMs: 10,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.33", installed: "0.3.34" }
+          : { stale: false, running: "0.3.33", installed: "0.3.33" },
+      spawnDaemonForVersionBump: vi.fn().mockResolvedValue({ pid: 4242 }),
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+    });
+    proxies.push(proxy);
+    proxy.start();
+    await waitFor(() => daemon.connections.length > 0);
+
+    stale = true;
+    await daemon.stop();
+    daemons.splice(daemons.indexOf(daemon), 1);
+
+    await waitFor(
+      () =>
+        logger.error.mock.calls.some(([message]) =>
+          String(message).includes("reconnect attempt"),
+        ),
+      500,
+    );
+  });
+
   it("trips the reconnect-storm guard after repeated version-bump attempts", () => {
     const guard = new VersionBumpReconnectGuard({
       maxAttempts: 2,

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,6 +1,7 @@
 import net from "node:net";
-import { EventEmitter } from "node:events";
-import { rmSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { EventEmitter, once } from "node:events";
+import { existsSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -44,6 +45,26 @@ function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
     };
     tick();
   });
+}
+
+async function leaveRefusedUnixSocket(path: string): Promise<void> {
+  rmSync(path, { force: true });
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      `require("node:net").createServer(() => {}).listen(${JSON.stringify(path)})`,
+    ],
+    { stdio: "ignore" },
+  );
+  try {
+    await waitFor(() => existsSync(path));
+  } catch (error) {
+    child.kill("SIGKILL");
+    throw error;
+  }
+  child.kill("SIGKILL");
+  await once(child, "exit");
 }
 
 function createCollector(stream: NodeJS.ReadableStream) {
@@ -202,7 +223,7 @@ class FakeDaemon {
     });
   }
 
-  async stop(): Promise<void> {
+  async stop(opts: { leaveStaleSocket?: boolean } = {}): Promise<void> {
     for (const socket of this.sockets) {
       socket.destroy();
     }
@@ -214,7 +235,11 @@ class FakeDaemon {
       this.server.close(() => resolve());
     });
     this.server = null;
-    rmSync(this.path, { force: true });
+    if (opts.leaveStaleSocket) {
+      await leaveRefusedUnixSocket(this.path);
+    } else {
+      rmSync(this.path, { force: true });
+    }
   }
 
   releaseHeld(method: string): void {
@@ -868,6 +893,57 @@ describe("CmuxLayerProxy", () => {
     expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
     expect(
       daemon.connections[0].messages
+        .filter((message) => "method" in message)
+        .map((message) => message.method),
+    ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+  });
+
+  it("autostarts within two reconnect attempts after a connected daemon leaves a stale socket", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("connected-stale-restart");
+    const firstDaemon = new FakeDaemon(path, {
+      holdMethods: new Set(["tools/list"]),
+    });
+    daemons.push(firstDaemon);
+    await firstDaemon.start();
+
+    const secondDaemon = new FakeDaemon(path);
+    daemons.push(secondDaemon);
+    const reconnectAttempts: number[] = [];
+    const spawnDaemonForVersionBump = vi.fn(async () => secondDaemon.start());
+    const { input, collector } = createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      reconnectJitterRatio: 0,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      requestTimeoutMs: 1_000,
+      onReconnectDelay: (_delayMs, attempt) =>
+        reconnectAttempts.push(attempt),
+      spawnDaemonForVersionBump,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await collector.waitForMessage(isResponseFor(1));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+    await firstDaemon.waitForMessage(
+      0,
+      (message) => "method" in message && message.method === "tools/list",
+    );
+
+    await firstDaemon.stop({ leaveStaleSocket: true });
+    daemons.splice(daemons.indexOf(firstDaemon), 1);
+
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 1_000),
+    ).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
+    expect(reconnectAttempts.slice(0, 2)).toEqual([0, 1]);
+    expect(
+      secondDaemon.connections[0].messages
         .filter((message) => "method" in message)
         .map((message) => message.method),
     ).toEqual(["initialize", "notifications/initialized", "tools/list"]);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -821,13 +821,16 @@ describe("CmuxLayerProxy", () => {
   it("spawns the installed daemon after the second refused reconnect attempt", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("reconnect-spawn");
-    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    const logger = { error: vi.fn() };
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue({ pid: 4242 });
     const attempts: number[] = [];
     const { proxy } = createProxy(path, {
       initialBackoffMs: 10,
       maxBackoffMs: 10,
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      logger,
       onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+      reconnectLogIntervalMs: 0,
       spawnDaemonForVersionBump,
     });
 
@@ -841,6 +844,15 @@ describe("CmuxLayerProxy", () => {
         daemonScriptPath: "/opt/cmuxlayer/dist/daemon.js",
         socketPath: path,
       }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/reconnect attempt 0 failed \(ENOENT\)/),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon spawn skipped (reason=gate, attempt=0)",
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon spawn fired (script=/opt/cmuxlayer/dist/daemon.js, pid=4242)",
     );
   });
 
@@ -910,12 +922,14 @@ describe("CmuxLayerProxy", () => {
     const secondDaemon = new FakeDaemon(path);
     daemons.push(secondDaemon);
     const reconnectAttempts: number[] = [];
+    const logger = { error: vi.fn() };
     const spawnDaemonForVersionBump = vi.fn(async () => secondDaemon.start());
     const { input, collector } = createProxy(path, {
       initialBackoffMs: 5,
       maxBackoffMs: 5,
       reconnectJitterRatio: 0,
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      logger,
       requestTimeoutMs: 1_000,
       onReconnectDelay: (_delayMs, attempt) =>
         reconnectAttempts.push(attempt),
@@ -942,6 +956,9 @@ describe("CmuxLayerProxy", () => {
     });
     expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
     expect(reconnectAttempts.slice(0, 2)).toEqual([0, 1]);
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon drop detected; reconnecting",
+    );
     expect(
       secondDaemon.connections[0].messages
         .filter((message) => "method" in message)
@@ -967,6 +984,87 @@ describe("CmuxLayerProxy", () => {
 
     expect(installedDaemonScriptPath).not.toHaveBeenCalled();
     expect(proxy.isRunning()).toBe(true);
+  });
+
+  it("logs no-script and guard reasons when reconnect autostart is skipped", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const noScriptPath = socketPath("reconnect-no-script");
+    const noScriptLogger = { error: vi.fn() };
+    const spawnDaemon = vi.fn();
+    const noScript = createProxy(noScriptPath, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath: () => null,
+      logger: noScriptLogger,
+      reconnectLogIntervalMs: 0,
+      spawnDaemonForVersionBump: spawnDaemon,
+    });
+    await waitFor(() =>
+      noScriptLogger.error.mock.calls.some(([message]) =>
+        String(message).includes("reason=no-script"),
+      ),
+    );
+    await noScript.proxy.stop();
+
+    const guardPath = socketPath("reconnect-blocked-guard");
+    const guardLogger = { error: vi.fn() };
+    const guard = createProxy(guardPath, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      logger: guardLogger,
+      reconnectDaemonSpawnGuard: new VersionBumpReconnectGuard({
+        maxAttempts: 0,
+      }),
+      reconnectLogIntervalMs: 0,
+      spawnDaemonForVersionBump: spawnDaemon,
+    });
+    await waitFor(() =>
+      guardLogger.error.mock.calls.some(([message]) =>
+        String(message).includes("reason=guard"),
+      ),
+    );
+    await guard.proxy.stop();
+
+    expect(spawnDaemon).not.toHaveBeenCalled();
+  });
+
+  it("fails buffered requests within the outage bound and accepts new work after recovery", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("bounded-outage");
+    const { input, collector } = createProxy(path, {
+      bufferedRequestTimeoutMs: 30,
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      requestTimeoutMs: 1_000,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    await expect(
+      collector.waitForMessage(isResponseFor(1), 300),
+    ).resolves.toMatchObject({
+      id: 1,
+      error: expect.objectContaining({
+        code: -32001,
+        message: expect.stringMatching(/daemon unavailable.*reconnect/i),
+      }),
+    });
+
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    writeFrame(input, request(2, "initialize", { capabilities: {} }));
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 1_000),
+    ).resolves.toMatchObject({ id: 2, result: expect.any(Object) });
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(3, "tools/list"));
+    await expect(
+      collector.waitForMessage(isResponseFor(3), 1_000),
+    ).resolves.toMatchObject({
+      id: 3,
+      result: { tools: expect.any(Array) },
+    });
   });
 
   it("returns a JSON-RPC error when buffered requests exceed the cap", async () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -12,7 +12,11 @@ import type {
   JSONRPCMessage,
   JSONRPCRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import { CmuxLayerProxy, computeReconnectDelay } from "../src/proxy.js";
+import {
+  CmuxLayerProxy,
+  computeReconnectDelay,
+  VersionBumpReconnectGuard,
+} from "../src/proxy.js";
 
 const TEST_ROOT = join("/tmp", "cmuxlayer-proxy-test");
 
@@ -787,6 +791,106 @@ describe("CmuxLayerProxy", () => {
     expect(
       delays.every((delay, index) => index === 0 || delay > delays[index - 1]),
     ).toBe(true);
+  });
+
+  it("spawns the installed daemon after the second refused reconnect attempt", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-spawn");
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    const attempts: number[] = [];
+    const { proxy } = createProxy(path, {
+      initialBackoffMs: 10,
+      maxBackoffMs: 10,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+      spawnDaemonForVersionBump,
+    });
+
+    await waitFor(() => spawnDaemonForVersionBump.mock.calls.length === 1);
+    await proxy.stop();
+
+    expect(attempts.slice(0, 2)).toEqual([0, 1]);
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledWith(
+      expect.objectContaining({
+        daemonScriptPath: "/opt/cmuxlayer/dist/daemon.js",
+        socketPath: path,
+      }),
+    );
+  });
+
+  it("caps reconnect-driven daemon spawns within the guard window", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-spawn-guard");
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    const attempts: number[] = [];
+    createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+      reconnectDaemonSpawnGuard: new VersionBumpReconnectGuard({
+        maxAttempts: 2,
+        windowMs: 60_000,
+      }),
+      spawnDaemonForVersionBump,
+    });
+
+    await waitFor(() => attempts.length >= 6);
+
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(2);
+  });
+
+  it("replays queued requests after reconnect autostart brings up the daemon", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-spawn-replay");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    const spawnDaemonForVersionBump = vi.fn(async () => daemon.start());
+    const { input, collector } = createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 10,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      requestTimeoutMs: 1_000,
+      spawnDaemonForVersionBump,
+    });
+
+    writeFrame(input, request(1, "initialize", { capabilities: {} }));
+    writeFrame(input, notification("notifications/initialized"));
+    writeFrame(input, request(2, "tools/list"));
+
+    await expect(
+      collector.waitForMessage(isResponseFor(2), 1_000),
+    ).resolves.toMatchObject({
+      id: 2,
+      result: { tools: expect.any(Array) },
+    });
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
+    expect(
+      daemon.connections[0].messages
+        .filter((message) => "method" in message)
+        .map((message) => message.method),
+    ).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+  });
+
+  it("does not resolve or spawn a daemon during reconnect when no callback is set", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-no-spawn");
+    const attempts: number[] = [];
+    const installedDaemonScriptPath = vi.fn(() => {
+      throw new Error("should not resolve without a spawn callback");
+    });
+    const { proxy } = createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath,
+      onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+    });
+
+    await waitFor(() => attempts.length >= 3);
+
+    expect(installedDaemonScriptPath).not.toHaveBeenCalled();
+    expect(proxy.isRunning()).toBe(true);
   });
 
   it("returns a JSON-RPC error when buffered requests exceed the cap", async () => {

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -4,7 +4,18 @@ import {
   createStaleBuildWarner,
   detectStaleBuild,
   readVersion,
+  resolveInstalledDaemonScript,
 } from "../src/version.js";
+
+describe("resolveInstalledDaemonScript", () => {
+  it("resolves the daemon beside the formula libexec package.json", () => {
+    expect(
+      resolveInstalledDaemonScript(
+        "/opt/homebrew/opt/cmuxlayer/libexec/package.json",
+      ),
+    ).toBe("/opt/homebrew/opt/cmuxlayer/libexec/dist/daemon.js");
+  });
+});
 
 describe("assertBuildVersion", () => {
   it("returns ok when the running build matches expected", () => {


### PR DESCRIPTION
## Summary
- autostart the installed daemon after repeated proxy reconnect failures, with a separate 3-per-minute guard and standalone proxy wiring
- retire stale or irrecoverably ancestry-denied daemons through graceful drain and restart-safe exit behavior
- replace doctor §5's not-applicable result with a bounded daemon MCP integrity probe for version and transport health
- add TDD coverage for reconnect spawning/replay, retirement triggers and timer cleanup, dual-denial classification, and healthy/stale/degraded/unresponsive doctor fixtures

## Verification
- `bun run typecheck && bun run test` — 86 files, 1559 tests passed
- `bun run build` — passed
- compiled isolated daemon/proxy MCP smoke — initialize + tools/list passed (v0.3.33, 42 tools)
- local CodeRabbit review — partial (bounded at ~3 minutes); four returned findings fixed and covered by regression tests

## Safety
- all daemon, doctor, and compiled smoke tests used ephemeral `/tmp` socket paths
- no running machine daemon or cmux socket was mutated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core daemon/proxy lifecycle (forced retirement shutdown, concurrent socket handoff, autospawn on reconnect); mitigated by guards and broad tests but still affects production MCP availability during edge cases.
> 
> **Overview**
> This PR makes the shared **on-demand daemon** and **stdio proxy** recover from outages and upgrades without manual kills, and extends **doctor** to validate a running daemon instead of marking §5 N/A.
> 
> **Proxy reconnect path** now logs failed attempts, can **spawn the brew-installed `daemon.js`** after the first reconnect failure (separate **3-per-minute guard** from version-bump spawns), applies a **bounded timeout** for requests stuck while the daemon is down, and throttles reconnect logs. Standalone proxy entry wires **`spawnDaemonProcess`** for that path.
> 
> **Daemon** watches for a **newer installed build** and for **`onIrrecoverableTransport`** from the self-healing cmux client (sustained **access-control / EPIPE-class** failures on both socket probes and CLI). Either trigger **retires once**: immediate teardown of clients (no drain wait), **`onRetire` + exit 0**, and **socket path detach/rename** so a replacement can bind without clobbering foreign sockets.
> 
> **Transport self-heal** tracks denial evidence, rate-limits progress/upgrade-failure logs, and fires the irrecoverable callback only when **probe + CLI denial counts and duration** thresholds are met (not when cmux is simply down).
> 
> **Doctor §5** MCP-probes the daemon socket (`initialize`, `control_health`), flags **stale running vs installed** version and **degraded transport** (with optional cmux socket probe, honoring **`CMUX_SOCKET_PATH`**); overall health now requires **`daemon.ok`**.
> 
> **`spawnDaemonProcess`** moved to **`daemon-spawn.ts`** with spawn error/exit logging; installed daemon resolution uses **`libexec/package.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b45bb0d31a9504dab2ad9ddac86cd54e0f797f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add restart-safe daemon lifecycle with autostart on reconnect, stale-build self-retirement, and doctor §5 health check
> - The proxy ([src/proxy.ts](https://github.com/EtanHey/cmuxlayer/pull/275/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2)) now auto-spawns the installed daemon during reconnect failures (guarded to 3 attempts per window) and fails buffered requests after a configurable timeout (default 15s) instead of waiting indefinitely.
> - The daemon ([src/daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/275/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539)) periodically checks for a newer installed version and self-retires (exit 0) when stale; it also retires on irrecoverable transport signals from the self-heal layer.
> - Socket path handoff during shutdown uses dev/inode ownership checks to avoid clobbering a path already claimed by a replacement daemon.
> - The self-heal client ([src/cmux-transport-self-heal.ts](https://github.com/EtanHey/cmuxlayer/pull/275/files#diff-fbf073b8b6f02d58f4addfd2d8fcaed58d9e495a3ec139005951626f13e03267)) classifies EPIPE/access-denied errors as denial, tracks failure counts over time, and invokes an `onIrrecoverableTransport` callback after configurable thresholds.
> - Doctor §5 ([src/doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/275/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068)) now probes the running daemon over MCP to report version, staleness, and transport degradation, and sets `healthy=false` on problems.
> - A new [src/daemon-spawn.ts](https://github.com/EtanHey/cmuxlayer/pull/275/files#diff-4ce4923f025099ea7b158cda9964e58752f8b627e7c04533edc75af7fc06566c) module centralises detached daemon spawning with standardised environment setup.
> - Risk: buffered requests that previously waited indefinitely will now fail after 15s when the daemon is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b45bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic daemon health and integrity checks to Doctor, including version, connectivity, and degraded-transport reporting.
  - Added automatic daemon retirement and replacement when builds become stale or transport failures are unrecoverable.
  - Improved recovery after daemon connection failures, including queued-request timeouts and automatic restart attempts.
  - Added clearer progress and failure logging for transport recovery and reconnection.

- **Bug Fixes**
  - Improved socket cleanup during shutdown without disrupting replacement sockets.
  - Corrected installed daemon discovery for Homebrew layouts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->