### PR TITLE
test: isolate stale build checks from host brew

### DIFF
--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -230,6 +230,7 @@ describe("live daemon-first restart topology", () => {
           HOMEBREW_PREFIX: join(root, "brew"),
           CMUX_SOCKET_PATH: cmuxSocket,
           CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+          CMUXLAYER_DEV: "0",
           CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
           CMUXLAYER_STALE_CHECK_INTERVAL_MS: "100",
         },

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,0 +1,3 @@
+// The release script bumps package.json before its pre-push Vitest rerun.
+// Keep unit tests from comparing that temporary version with the host brew tree.
+process.env.CMUXLAYER_DEV = "1";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { configDefaults, defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, "**/.worktrees/**"],
+    setupFiles: ["./tests/vitest.setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- set `CMUXLAYER_DEV=1` in global Vitest setup so unit tests never inspect the host brew tree
- explicitly opt the live restart topology into stale detection with `CMUXLAYER_DEV=0`
- document the release-bump/pre-push regression in the setup file

## Verification
- package version temporarily changed from 0.3.33 to 9.9.9: `bun run test` (88 files, 1578 tests passed), then restored
- `bun run typecheck && bun run test`
- pre-push hook: 88 files, 1578 tests passed
- CodeRabbit local review: 0 findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only env wiring with no production behavior changes.
> 
> **Overview**
> Unit tests now default to **`CMUXLAYER_DEV=1`** via a global Vitest setup file, so they no longer compare the repo’s `package.json` version against the host Homebrew install—covering the release script bumping the version before the pre-push Vitest rerun.
> 
> The **live daemon restart topology** test explicitly sets **`CMUXLAYER_DEV=0`** so it still exercises real stale-build detection and daemon retirement against the fake brew fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41be7bd1c22f0c7673fa73615c2f92562c85689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate stale build checks from host brew in tests via `CMUXLAYER_DEV` env var
> Sets `CMUXLAYER_DEV=1` in the Vitest process via a new [vitest.setup.ts](https://github.com/EtanHey/cmuxlayer/pull/276/files#diff-93eb310abfe57eda4f26a00fb18fb508e2df0f4d0b8fe0270928ec62c2da7068) setup file so tests run in dev mode by default. Spawned child processes in [live-topology-restart.test.ts](https://github.com/EtanHey/cmuxlayer/pull/276/files#diff-39f3decd65c411e6a990177655fbda20dd097f8f1921e961871fa22ee29bdc15) explicitly receive `CMUXLAYER_DEV=0` to prevent the dev-mode flag from leaking into subprocesses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e41be7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->