### PR TITLE
test: make restart topology version independent

### DIFF
--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import {
   cpSync,
   mkdirSync,
+  readFileSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -103,6 +104,16 @@ async function startFakeCmuxSocket(path: string): Promise<void> {
 
 function packageJson(version: string): string {
   return `${JSON.stringify({ name: "cmuxlayer", version, type: "module" })}\n`;
+}
+
+function runningPackageVersion(): string {
+  const metadata: unknown = JSON.parse(
+    readFileSync(resolve("package.json"), "utf8"),
+  );
+  if (!isRecord(metadata) || typeof metadata.version !== "string") {
+    throw new Error("package.json must contain a string version");
+  }
+  return metadata.version;
 }
 
 function createFormulaFixture(root: string, version: string): {
@@ -218,7 +229,9 @@ describe("live daemon-first restart topology", () => {
       ROOTS.add(root);
       const daemonSocket = join(root, "stated.sock");
       const cmuxSocket = join(root, "cmux.sock");
-      const formula = createFormulaFixture(root, "0.3.33");
+      const runningVersion = runningPackageVersion();
+      const upgradedVersion = `${runningVersion}-live-topology-upgrade`;
+      const formula = createFormulaFixture(root, runningVersion);
       await startFakeCmuxSocket(cmuxSocket);
 
       const stderr: string[] = [];
@@ -261,8 +274,8 @@ describe("live daemon-first restart topology", () => {
       const initialDaemonPid = daemonPidFromHealth(initialHealth);
       expect(processExists(initialDaemonPid)).toBe(true);
 
-      writeFileSync(formula.rootPackage, packageJson("0.3.34"));
-      writeFileSync(formula.libexecPackage, packageJson("0.3.34"));
+      writeFileSync(formula.rootPackage, packageJson(upgradedVersion));
+      writeFileSync(formula.libexecPackage, packageJson(upgradedVersion));
       await waitFor(
         () => !processExists(initialDaemonPid),
         5_000,


### PR DESCRIPTION
## Summary
- derive the live fixture's initial installed version from the running package version
- derive a guaranteed-different upgrade version for stale retirement
- remove the hardcoded 0.3.33/0.3.34 release coupling

## Verification
- reproduced the retirement timeout with package.json temporarily at 0.3.34 before the fix
- with package.json temporarily at 0.3.34: `bun run test` (88 files, 1578 tests passed), then restored to 0.3.33
- `bun run typecheck`
- `bun run test -- tests/live-topology-restart.test.ts`
- pre-push hook: 88 files, 1578 tests passed
- CodeRabbit local review: 0 findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic; reduces flaky or misleading failures when the package version drifts from hardcoded values.
> 
> **Overview**
> The live restart topology test no longer hardcodes **0.3.33** / **0.3.34** for the Homebrew-style fixture. It reads the repo **`package.json`** version at runtime and simulates an upgrade with a suffix that is always different from the installed version.
> 
> That keeps stale-build retirement and daemon replacement behavior testable without tying the suite to specific release numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064a7173e30186191cc79a25180a37837293ee44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make restart topology test version-independent by reading version from package.json
> Replaces hardcoded version strings (e.g. `0.3.34`) in [live-topology-restart.test.ts](https://github.com/EtanHey/cmuxlayer/pull/277/files#diff-39f3decd65c411e6a990177655fbda20dd097f8f1921e961871fa22ee29bdc15) with a dynamic approach. A new `runningPackageVersion()` helper reads the current version from `package.json` at runtime, and the test derives an upgrade version by appending `-live-topology-upgrade` to it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 064a717.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->