### PR TITLE
fix: version-bump reconnect requeue, reconnectLoop race, doctor launcher probe

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -15,7 +15,8 @@
  *       `brew trust etanhey/layers`; cmuxlayer is a formula, not gated.
  *   (c) CMUX_SOCKET_PATH if set, else "unset (auto-discover)";
  *   (d) read-only `.mcp.json` drift detection for stale `cmux` keys or entries
- *       that bypass `~/.golems/bin/cmuxlayer-mcp`.
+ *       that bypass `~/.golems/bin/cmuxlayer-mcp`, plus existence, symlink-target,
+ *       and executable-bit checks for every referenced launcher.
  *
  * Non-interactivity invariants (§ headline / conformance checks):
  *   - exit 0 when healthy; runs cleanly under `</dev/null` with NONINTERACTIVE=1;
@@ -24,8 +25,16 @@
  */
 
 import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
 import net from "node:net";
-import { readdir, readFile } from "node:fs/promises";
+import {
+  access,
+  lstat,
+  readdir,
+  readFile,
+  realpath,
+  stat,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -81,8 +90,21 @@ export interface McpConfigDriftEntry {
 export interface McpConfigDriftReport {
   scanned: number;
   drifted: McpConfigDriftEntry[];
+  launcherOk: boolean;
+  launchers: McpLauncherProbeReport[];
   note: string;
 }
+
+export interface McpLauncherProbeReport {
+  path: string;
+  resolvedPath: string | null;
+  ok: boolean;
+  note: string;
+}
+
+export type McpLauncherProbe = (
+  path: string,
+) => Promise<McpLauncherProbeReport> | McpLauncherProbeReport;
 
 export type RuntimeMode = "dist" | "source" | "launcher" | "unknown";
 
@@ -117,6 +139,7 @@ export type McpConfigFileReader = (path: string) => Promise<string> | string;
 export interface CheckMcpConfigDriftOptions {
   listMcpConfigPaths?: McpConfigPathLister;
   readMcpConfigFile?: McpConfigFileReader;
+  probeLauncher?: McpLauncherProbe;
 }
 
 export interface DoctorReport {
@@ -663,6 +686,94 @@ function serverReferencesLauncher(server: unknown): boolean {
   return [command, ...args].some(isCmuxlayerMcpLauncher);
 }
 
+function serverLauncherReference(server: unknown): string | null {
+  if (!isRecord(server)) {
+    return null;
+  }
+  const command = typeof server.command === "string" ? server.command : "";
+  const args = Array.isArray(server.args)
+    ? server.args.filter((arg): arg is string => typeof arg === "string")
+    : [];
+  return [command, ...args].find(isCmuxlayerMcpLauncher) ?? null;
+}
+
+function resolveLauncherReference(reference: string): string {
+  if (reference === "cmuxlayer-mcp") {
+    return join(homedir(), ".golems", "bin", "cmuxlayer-mcp");
+  }
+  if (reference === "~/.golems/bin/cmuxlayer-mcp") {
+    return join(homedir(), ".golems", "bin", "cmuxlayer-mcp");
+  }
+  return reference;
+}
+
+async function realMcpLauncherProbe(
+  path: string,
+): Promise<McpLauncherProbeReport> {
+  let linkInfo: Awaited<ReturnType<typeof lstat>>;
+  try {
+    linkInfo = await lstat(path);
+  } catch {
+    return {
+      path,
+      resolvedPath: null,
+      ok: false,
+      note: `launcher missing at ${path}; reinstall cmuxlayer launcher`,
+    };
+  }
+
+  let resolvedPath = path;
+  if (linkInfo.isSymbolicLink()) {
+    try {
+      resolvedPath = await realpath(path);
+    } catch {
+      return {
+        path,
+        resolvedPath: null,
+        ok: false,
+        note: `launcher has a dangling symlink at ${path}; reinstall cmuxlayer launcher`,
+      };
+    }
+  }
+
+  try {
+    const target = await stat(resolvedPath);
+    if (!target.isFile()) {
+      return {
+        path,
+        resolvedPath,
+        ok: false,
+        note: `launcher target is not a file at ${resolvedPath}; reinstall cmuxlayer launcher`,
+      };
+    }
+  } catch {
+    return {
+      path,
+      resolvedPath,
+      ok: false,
+      note: `launcher target is missing at ${resolvedPath}; reinstall cmuxlayer launcher`,
+    };
+  }
+
+  try {
+    await access(path, fsConstants.X_OK);
+  } catch {
+    return {
+      path,
+      resolvedPath,
+      ok: false,
+      note: `launcher is not executable at ${path}; reinstall cmuxlayer launcher or restore its executable bit`,
+    };
+  }
+
+  return {
+    path,
+    resolvedPath,
+    ok: true,
+    note: `launcher resolves to executable file ${resolvedPath}`,
+  };
+}
+
 function driftReason(serverKey: string, server: unknown): string | null {
   const reasons: string[] = [];
 
@@ -684,6 +795,7 @@ export async function checkMcpConfigDrift(
     opts.listMcpConfigPaths ?? realMcpConfigPathLister;
   const readMcpConfigFile =
     opts.readMcpConfigFile ?? realMcpConfigFileReader;
+  const probeLauncher = opts.probeLauncher ?? realMcpLauncherProbe;
 
   let paths: string[];
   try {
@@ -693,6 +805,7 @@ export async function checkMcpConfigDrift(
   }
 
   const drifted: McpConfigDriftEntry[] = [];
+  const launcherProbes = new Map<string, McpLauncherProbeReport>();
   let scanned = 0;
 
   for (const path of paths) {
@@ -714,17 +827,35 @@ export async function checkMcpConfigDrift(
         continue;
       }
 
-      const reason = driftReason(serverKey, server);
+      const reasons = [driftReason(serverKey, server)].filter(
+        (reason): reason is string => reason !== null,
+      );
+      const launcherReference = serverLauncherReference(server);
+      if (launcherReference) {
+        const launcherPath = resolveLauncherReference(launcherReference);
+        let launcherProbe = launcherProbes.get(launcherPath);
+        if (!launcherProbe) {
+          launcherProbe = await probeLauncher(launcherPath);
+          launcherProbes.set(launcherPath, launcherProbe);
+        }
+        if (!launcherProbe.ok) {
+          reasons.push(launcherProbe.note);
+        }
+      }
+      const reason = reasons.length > 0 ? reasons.join("; ") : null;
       if (reason) {
         drifted.push({ path, serverKey, reason });
       }
     }
   }
 
+  const launchers = [...launcherProbes.values()];
   return {
     scanned,
     drifted,
-    note: "scanned ~/Gits/*/.mcp.json for cmux/cmuxlayer entries expected to reference launcher cmuxlayer-mcp; read-only, skipped missing/unreadable/invalid JSON",
+    launcherOk: launchers.every((launcher) => launcher.ok),
+    launchers,
+    note: "scanned ~/Gits/*/.mcp.json for cmux/cmuxlayer entries expected to reference an existing executable launcher cmuxlayer-mcp; read-only, skipped missing/unreadable/invalid JSON",
   };
 }
 
@@ -782,10 +913,9 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
   });
   const daemon = await checkDaemonIntegrity(opts, env);
 
-  // Health: only the version must resolve. Brew/tap gaps are reported but, per
-  // the standard's "brew best-effort" rule, must NOT make the doctor unhealthy
-  // (so it exits 0 on machines without brew or without the tap added yet).
-  const healthy = versionOk && daemon.ok;
+  // Brew/tap gaps stay best-effort, but an unusable referenced launcher is an
+  // operational failure: configs can look correct while every MCP launch fails.
+  const healthy = versionOk && daemon.ok && mcpConfigDrift.launcherOk;
 
   return {
     healthy,
@@ -860,6 +990,12 @@ export function renderDoctorText(report: DoctorReport): string {
   lines.push(`│      ${report.runtimeProvenance.note}`);
 
   lines.push(`│ — MCP reconnect probe: ${report.mcpReconnectProcedure.note}`);
+
+  for (const launcher of report.mcpConfigDrift.launchers) {
+    lines.push(
+      `│ ${mark(launcher.ok)} launcher: ${launcher.path} — ${launcher.note}`,
+    );
+  }
 
   if (report.mcpConfigDrift.drifted.length === 0) {
     lines.push(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -251,6 +251,7 @@ export class CmuxLayerProxy {
   private daemonSocket: net.Socket | null = null;
   private running = false;
   private connecting = false;
+  private reconnectLoopActive = false;
   private daemonReady = false;
   private flushing = false;
   private replayingInitialize = false;
@@ -442,10 +443,16 @@ export class CmuxLayerProxy {
   }
 
   private ensureConnecting(): void {
-    if (!this.running || this.connecting || this.daemonSocket) {
+    if (
+      !this.running ||
+      this.connecting ||
+      this.reconnectLoopActive ||
+      this.daemonSocket
+    ) {
       return;
     }
     this.connecting = true;
+    this.reconnectLoopActive = true;
     void this.reconnectLoop();
   }
 
@@ -466,37 +473,42 @@ export class CmuxLayerProxy {
   }
 
   private async reconnectLoop(): Promise<void> {
-    while (this.running && !this.daemonSocket) {
-      try {
-        const socket = await this.openDaemonSocket();
+    try {
+      while (this.running && !this.daemonSocket) {
+        try {
+          const socket = await this.openDaemonSocket();
+          this.attachDaemonSocket(socket);
+          return;
+        } catch (error) {
+          const attempt = this.reconnectAttempt++;
+          const message = error instanceof Error ? error.message : String(error);
+          const errorClass =
+            error && typeof error === "object" && "code" in error
+              ? String((error as { code: unknown }).code)
+              : /\b(?:ENOENT|ECONNREFUSED|ECONNRESET|EPIPE)\b/i.exec(message)?.[0] ??
+                (error instanceof Error ? error.name : "Error");
+          this.logReconnect(
+            "attempt-failed",
+            `[cmuxlayer-proxy] reconnect attempt ${attempt} failed (${errorClass}): ${message}`,
+          );
+          await this.spawnInstalledDaemonAfterReconnectFailure(attempt);
+          this.startBufferedRequestTimer();
+          const delayMs = computeReconnectDelay(attempt, {
+            initialBackoffMs: this.initialBackoffMs,
+            maxBackoffMs: this.maxBackoffMs,
+            jitterRatio: this.reconnectJitterRatio,
+            random: this.random,
+          });
+          this.onReconnectDelay?.(delayMs, attempt);
+          await this.delay(delayMs);
+        }
+      }
+    } finally {
+      this.reconnectLoopActive = false;
+      if (!this.reconnectTimer) {
         this.connecting = false;
-        this.attachDaemonSocket(socket);
-        return;
-      } catch (error) {
-        const attempt = this.reconnectAttempt++;
-        const message = error instanceof Error ? error.message : String(error);
-        const errorClass =
-          error && typeof error === "object" && "code" in error
-            ? String((error as { code: unknown }).code)
-            : /\b(?:ENOENT|ECONNREFUSED|ECONNRESET|EPIPE)\b/i.exec(message)?.[0] ??
-              (error instanceof Error ? error.name : "Error");
-        this.logReconnect(
-          "attempt-failed",
-          `[cmuxlayer-proxy] reconnect attempt ${attempt} failed (${errorClass}): ${message}`,
-        );
-        await this.spawnInstalledDaemonAfterReconnectFailure(attempt);
-        this.startBufferedRequestTimer();
-        const delayMs = computeReconnectDelay(attempt, {
-          initialBackoffMs: this.initialBackoffMs,
-          maxBackoffMs: this.maxBackoffMs,
-          jitterRatio: this.reconnectJitterRatio,
-          random: this.random,
-        });
-        this.onReconnectDelay?.(delayMs, attempt);
-        await this.delay(delayMs);
       }
     }
-    this.connecting = false;
   }
 
   private openDaemonSocket(): Promise<net.Socket> {
@@ -581,6 +593,12 @@ export class CmuxLayerProxy {
   private attachDaemonSocket(socket: net.Socket): void {
     if (!this.running) {
       socket.destroy();
+      return;
+    }
+    if (this.daemonSocket) {
+      if (this.daemonSocket !== socket) {
+        socket.destroy();
+      }
       return;
     }
     this.daemonSocket = socket;
@@ -1040,12 +1058,12 @@ export class CmuxLayerProxy {
           );
         }
       }
-      const reconnectLoopWillResume = this.reconnectTimerResolve !== null;
+      const reconnectLoopWillResume = this.reconnectLoopActive;
       this.clearReconnectTimer();
-      this.disconnectDaemon();
-      this.daemonReady = false;
+      this.handleDaemonDrop();
       this.reconnectAttempt = 0;
       if (!reconnectLoopWillResume) {
+        this.clearReconnectTimer();
         this.connecting = false;
       }
       this.ensureConnecting();

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,5 +1,13 @@
 import net from "node:net";
-import { rmSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -113,6 +121,7 @@ const doctorServers: Array<{
   path: string;
   sockets: Set<net.Socket>;
 }> = [];
+const doctorTempDirs: string[] = [];
 
 afterEach(async () => {
   for (const { server, path, sockets } of doctorServers.splice(0)) {
@@ -120,7 +129,31 @@ afterEach(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     rmSync(path, { force: true });
   }
+  for (const path of doctorTempDirs.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
 });
+
+function launcherFixture(
+  kind: "missing" | "dangling" | "non-executable" | "healthy",
+): string {
+  const root = mkdtempSync(join(tmpdir(), "cmuxlayer-doctor-launcher-"));
+  doctorTempDirs.push(root);
+  const binDir = join(root, ".golems", "bin");
+  mkdirSync(binDir, { recursive: true });
+  const launcherPath = join(binDir, "cmuxlayer-mcp");
+  if (kind === "missing") return launcherPath;
+  if (kind === "dangling") {
+    symlinkSync(join(root, "missing-target"), launcherPath);
+    return launcherPath;
+  }
+
+  const target = join(root, "cmuxlayer-mcp-target");
+  writeFileSync(target, "#!/bin/sh\nexit 0\n");
+  chmodSync(target, kind === "healthy" ? 0o755 : 0o644);
+  symlinkSync(target, launcherPath);
+  return launcherPath;
+}
 
 async function startDoctorDaemon(
   path: string,
@@ -547,6 +580,23 @@ describe("runDoctor — report shape", () => {
     ]);
   });
 
+  it("marks doctor unhealthy when a referenced launcher is unusable", async () => {
+    const launcherPath = launcherFixture("missing");
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+      ...fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/missing-launcher/.mcp.json": mcpConfig({
+          mcpServers: { cmuxlayer: { command: launcherPath, args: [] } },
+        }),
+      }),
+    });
+
+    expect(report.healthy).toBe(false);
+    expect(renderDoctorText(report)).toMatch(/✗ launcher:.*reinstall/i);
+  });
+
   it("reports the running dist entrypoint path as runtime provenance", async () => {
     const report = await runDoctorForTest({
       version: "0.3.1",
@@ -711,12 +761,13 @@ describe("parseSystemSleepPrevented", () => {
 
 describe("checkMcpConfigDrift", () => {
   it("treats a launcher-pointing cmuxlayer entry as clean", async () => {
+    const launcherPath = launcherFixture("healthy");
     const report = await checkMcpConfigDrift(
       fakeMcpConfigReaders({
         "/Users/etanheyman/Gits/clean/.mcp.json": mcpConfig({
           mcpServers: {
             cmuxlayer: {
-              command: "/Users/etanheyman/.golems/bin/cmuxlayer-mcp",
+              command: launcherPath,
               args: [],
             },
           },
@@ -726,7 +777,54 @@ describe("checkMcpConfigDrift", () => {
 
     expect(report.scanned).toBe(1);
     expect(report.drifted).toEqual([]);
+    expect(report.launcherOk).toBe(true);
+    expect(report.launchers).toEqual([
+      expect.objectContaining({ path: launcherPath, ok: true }),
+    ]);
     expect(report.note).toMatch(/launcher/i);
+  });
+
+  it("flags a referenced launcher that is missing", async () => {
+    const launcherPath = launcherFixture("missing");
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/missing-launcher/.mcp.json": mcpConfig({
+          mcpServers: { cmuxlayer: { command: launcherPath, args: [] } },
+        }),
+      }),
+    );
+
+    expect(report.launcherOk).toBe(false);
+    expect(report.drifted[0]?.reason).toMatch(/launcher.*missing/i);
+    expect(report.drifted[0]?.reason).toMatch(/reinstall/i);
+  });
+
+  it("flags a referenced launcher with a dangling symlink", async () => {
+    const launcherPath = launcherFixture("dangling");
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/dangling-launcher/.mcp.json": mcpConfig({
+          mcpServers: { cmuxlayer: { command: launcherPath, args: [] } },
+        }),
+      }),
+    );
+
+    expect(report.launcherOk).toBe(false);
+    expect(report.drifted[0]?.reason).toMatch(/dangling symlink/i);
+  });
+
+  it("flags a referenced launcher that is not executable", async () => {
+    const launcherPath = launcherFixture("non-executable");
+    const report = await checkMcpConfigDrift(
+      fakeMcpConfigReaders({
+        "/Users/etanheyman/Gits/non-executable-launcher/.mcp.json": mcpConfig({
+          mcpServers: { cmuxlayer: { command: launcherPath, args: [] } },
+        }),
+      }),
+    );
+
+    expect(report.launcherOk).toBe(false);
+    expect(report.drifted[0]?.reason).toMatch(/not executable/i);
   });
 
   it("flags a cmuxlayer entry that bypasses the launcher via node dist/index.js", async () => {
@@ -876,6 +974,8 @@ describe("renderDoctorText", () => {
       mcpConfigDrift: {
         scanned: 0,
         drifted: [],
+        launcherOk: true,
+        launchers: [],
         note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
       },
     };
@@ -927,6 +1027,8 @@ describe("renderDoctorText", () => {
       mcpConfigDrift: {
         scanned: 1,
         drifted: [],
+        launcherOk: true,
+        launchers: [],
         note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
       },
     });
@@ -946,6 +1048,8 @@ describe("renderDoctorText", () => {
             reason: "does not reference launcher cmuxlayer-mcp",
           },
         ],
+        launcherOk: true,
+        launchers: [],
         note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
       },
     });
@@ -1008,6 +1112,8 @@ describe("renderDoctorJson", () => {
             reason: "does not reference launcher cmuxlayer-mcp",
           },
         ],
+        launcherOk: true,
+        launchers: [],
         note: "scanned ~/Gits/*/.mcp.json for cmuxlayer launcher drift",
       },
     };

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -63,13 +63,18 @@ function createCollector(stream: NodeJS.ReadableStream) {
 class FakeDaemon {
   private server: net.Server | null = null;
   readonly connections: net.Socket[] = [];
+  readonly messages: JSONRPCMessage[][] = [];
 
-  constructor(private readonly path: string) {}
+  constructor(
+    private readonly path: string,
+    private readonly opts: { holdFirstToolsList?: boolean } = {},
+  ) {}
 
   async start(): Promise<void> {
     rmSync(this.path, { force: true });
     this.server = net.createServer((socket) => {
-      this.connections.push(socket);
+      const connectionIndex = this.connections.push(socket) - 1;
+      const messages = (this.messages[connectionIndex] = []);
       let buffer = "";
       socket.on("data", (chunk) => {
         buffer += chunk.toString("utf8");
@@ -78,7 +83,11 @@ class FakeDaemon {
           const line = buffer.slice(0, newlineIndex);
           buffer = buffer.slice(newlineIndex + 1);
           if (!line.trim()) continue;
-          const req = JSON.parse(line);
+          const req = JSON.parse(line) as JSONRPCMessage & {
+            id?: string | number;
+            method?: string;
+          };
+          messages.push(req);
           if (req.method === "initialize") {
             socket.write(
               serializeMessage({
@@ -94,6 +103,9 @@ class FakeDaemon {
             return;
           }
           if (req.method === "tools/list") {
+            if (this.opts.holdFirstToolsList && connectionIndex === 0) {
+              continue;
+            }
             socket.write(
               serializeMessage({
                 jsonrpc: "2.0",
@@ -210,6 +222,83 @@ describe("proxy version-bump auto-reconnect", () => {
     );
   });
 
+  it("requeues an in-flight request across a version-bump reconnect", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("in-flight-bump");
+    const daemon = new FakeDaemon(path, { holdFirstToolsList: true });
+    daemons.push(daemon);
+    await daemon.start();
+
+    let stale = false;
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const collector = createCollector(output);
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      reconnectJitterRatio: 0,
+      requestTimeoutMs: 500,
+      staleRecheckIntervalMs: 10,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.33", installed: "0.3.34" }
+          : { stale: false, running: "0.3.33", installed: "0.3.33" },
+      spawnDaemonForVersionBump: vi.fn().mockResolvedValue(undefined),
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() =>
+      collector.messages.some((message) => "id" in message && message.id === 1),
+    );
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    await waitFor(() =>
+      daemon.messages[0]?.some(
+        (message) => "method" in message && message.method === "tools/list",
+      ),
+    );
+
+    stale = true;
+
+    await waitFor(() => daemon.connections.length >= 2, 1_000);
+    await waitFor(
+      () =>
+        collector.messages.some(
+          (message) =>
+            "id" in message &&
+            message.id === 2 &&
+            "result" in message,
+        ),
+      1_000,
+    );
+    expect(
+      daemon.messages[1].filter((message) => "method" in message),
+    ).toEqual([
+      expect.objectContaining({ method: "initialize" }),
+      expect.objectContaining({ method: "notifications/initialized" }),
+      expect.objectContaining({ id: 2, method: "tools/list" }),
+    ]);
+  });
+
   it("reconnects an idle proxy after a version bump with zero agent requests", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("idle-bump");
@@ -284,6 +373,38 @@ describe("proxy version-bump auto-reconnect", () => {
         ),
       500,
     );
+  });
+
+  it("does not start a second reconnect loop while the first socket open is pending", async () => {
+    const sockets: net.Socket[] = [];
+    const connect = vi.fn(() => {
+      const socket = new net.Socket();
+      sockets.push(socket);
+      return socket;
+    });
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect,
+      staleRecheckIntervalMs: 60_000,
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.33",
+        installed: "0.3.34",
+      }),
+      installedDaemonScriptPath: () => null,
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    for (const socket of sockets) socket.destroy();
   });
 
   it("trips the reconnect-storm guard after repeated version-bump attempts", () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -818,6 +818,23 @@ describe("CmuxLayerProxy", () => {
     ).toBe(true);
   });
 
+  it("destroys a stray socket instead of replacing an attached daemon socket", async () => {
+    const attached = new net.Socket();
+    const { proxy } = createProxy(socketPath("duplicate-attach"), {
+      connect: () => attached,
+    });
+    attached.emit("connect");
+    await waitFor(() => attached.listenerCount("data") > 0);
+
+    const stray = new net.Socket();
+    (
+      proxy as unknown as { attachDaemonSocket(socket: net.Socket): void }
+    ).attachDaemonSocket(stray);
+
+    expect(stray.destroyed).toBe(true);
+    expect(attached.destroyed).toBe(false);
+  });
+
   it("spawns the installed daemon after the second refused reconnect attempt", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("reconnect-spawn");


### PR DESCRIPTION
## Summary
- route version-bump reconnect teardown through daemon-drop semantics so sent requests are requeued and replayed
- track reconnect-loop liveness across socket-open awaits and reject stray duplicate socket attachments
- probe referenced cmuxlayer launchers for existence, resolved symlink target, regular-file target, and executable access; surface actionable doctor failures

## Test plan
- [x] `bun run typecheck && bun run test && bun run build`
- [x] 88 Vitest files / 1,585 tests pass
- [x] pre-push regression hook passes without bypass
- [x] CodeRabbit pre-commit review: 0 findings across 5 changed files

## Verification note
Two initial push-hook runs collided with a sibling worktree's concurrent Vitest process using shared fixed `/tmp` fixtures; after that sibling run finished, the unchanged normal hook passed all 1,585 tests and pushed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core proxy reconnect/version-bump logic and doctor exit semantics; misbehavior could drop or duplicate MCP traffic or block healthy installs when launchers are probed incorrectly.
> 
> **Overview**
> **Doctor** now validates every `cmuxlayer-mcp` launcher referenced in scanned `.mcp.json` files (missing path, dangling symlink, non-file target, non-executable). Results appear as per-launcher lines in text output and in drift reasons; **`healthy` fails when any probed launcher is unusable**, even if config drift alone would still look fine.
> 
> **Proxy** hardens reconnect/version-bump behavior: a **`reconnectLoopActive`** flag blocks overlapping reconnect loops while a socket connect is pending; **`attachDaemonSocket`** destroys stray sockets instead of replacing an already-attached daemon. Version-bump reconnect teardown goes through **`handleDaemonDrop`** (requeue in-flight sent requests) rather than a bare disconnect, so requests like in-flight `tools/list` can complete after bump-driven reconnect.
> 
> Tests cover launcher probe edge cases, in-flight request replay across version bump, duplicate reconnect loop prevention, and duplicate socket attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97fe5868cebf4de44307dd16ebd1c8b2475fdc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix reconnect loop race, requeue in-flight requests on version-bump, and add launcher probe to doctor
> - Adds a `reconnectLoopActive` guard in [`src/proxy.ts`](https://github.com/EtanHey/cmuxlayer/pull/278/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2) to prevent a second reconnect loop from starting while a connection attempt is in-flight or a timer is pending.
> - Fixes the version-bump reconnect path to requeue in-flight requests on the new connection and use `handleDaemonDrop()` for consistent state cleanup.
> - Makes `attachDaemonSocket` idempotent: if a socket is already attached, stray sockets are destroyed instead of replacing the active one.
> - Extends the doctor drift check in [`src/doctor.ts`](https://github.com/EtanHey/cmuxlayer/pull/278/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068) to probe each referenced cmuxlayer launcher executable for presence, symlink integrity, and executability; overall health is now `false` when any launcher is unusable.
> - Risk: doctor now fails health checks that previously passed if a referenced launcher binary is missing, a dangling symlink, or non-executable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b97fe58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Doctor checks now detect missing, broken, or non-executable MCP launchers and report specific issues.
  * Health checks now identify unusable MCP launchers as unhealthy, with remediation guidance.
  * Improved proxy reconnection handling to prevent overlapping reconnect attempts.
  * Preserved in-flight requests during version-change reconnects.
  * Stray daemon connections are now safely rejected without disrupting the active connection.

* **Diagnostics**
  * Doctor output now includes the status of each checked MCP launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->