### PR TITLE
feat(health): socket-write-liveness signal — classify dead-PTY panes unhealthy

### DIFF
--- a/docs/plans/2026-07-11-pty-liveness-design.md
+++ b/docs/plans/2026-07-11-pty-liveness-design.md
@@ -1,0 +1,31 @@
+# PTY Write-Liveness Health Design
+
+## Problem
+
+A terminal surface can keep rendering a stale active spinner after its PTY socket has died. The current health path parses that stale frame as `working` or `thinking`, downgrades `registry_screen_disagreement` to informational, and therefore reports a false-green agent even after real writes fail with `EPIPE`/errno 32.
+
+## Chosen approach
+
+Record the outcome of top-level real surface-write operations at the existing `withSurfaceWrite` boundary. Store a bounded, per-surface sequence of timestamped outcomes in the shared server context. Classify a surface as PTY-dead only when the latest configurable number of write operations all failed with a broken-pipe-class error and all fall inside a configurable time window. A successful write or a non-broken-pipe failure interrupts the consecutive broken-pipe sequence.
+
+This avoids synthetic terminal input, avoids counting internal retries from one user operation as multiple independent failures, and covers both public write tools and agent-engine writes that already share the wrapper.
+
+## Health data flow
+
+`withSurfaceWrite` records success or the caught error. `evaluateServerAgentHealth` reads the surface observation and threads it through `buildAgentHealthInput`. `evaluateAgentHealth` adds blocking issue `pane_pty_dead` only when the screen still parses active and the observation meets the repeated-failure policy. When this evidence exists, `registry_screen_disagreement` remains at its normal degraded severity rather than being downgraded to info.
+
+The existing `list_agents` and other health-bearing responses already serialize the full health object, so the new issue code, message, and severity surface without a new response shape.
+
+## Error recognition and anti-flapping policy
+
+Broken-pipe recognition accepts structured `code: EPIPE`, structured `errno: 32`/`-32`, and broken-pipe/EPIPE text from wrapped errors. Defaults are two failed top-level writes within 30 seconds. The tracker accepts an injected clock, threshold, and window for hermetic tests.
+
+## Tests
+
+- Pure tracker tests prove structured/text EPIPE recognition, threshold behavior, success reset, non-EPIPE interruption, and time-window expiry.
+- Health tests prove an active spinner plus repeated recent EPIPE evidence produces blocking `pane_pty_dead`, a single transient does not, healthy writes preserve behavior, and binary status remains unhealthy only because of the new blocking code.
+- Input-builder tests prove the observation is threaded into health input.
+
+## Scope
+
+Do not modify `src/proxy.ts` or `src/doctor.ts`. Do not change the existing severity tiers beyond adding `pane_pty_dead` as blocking.

--- a/docs/plans/2026-07-11-pty-liveness.md
+++ b/docs/plans/2026-07-11-pty-liveness.md
@@ -1,0 +1,65 @@
+# PTY Write-Liveness Health Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Classify stale-active panes as unhealthy after repeated recent real writes fail with broken-pipe errors.
+
+**Architecture:** Add a small per-surface write-liveness tracker with injectable policy and clock, record outcomes at the shared `withSurfaceWrite` boundary, and pass its observation through the existing health-input builder. Health classification adds one blocking issue without changing the established tier model.
+
+**Tech Stack:** TypeScript, Vitest, Bun, MCP server context.
+
+---
+
+### Task 1: Specify the write-liveness tracker
+
+**Files:**
+- Create: `tests/surface-write-liveness.test.ts`
+- Create: `src/surface-write-liveness.ts`
+
+1. Write failing tests for repeated EPIPE, one EPIPE, success reset, other-error interruption, and expiry using an injected clock.
+2. Run `bunx vitest run tests/surface-write-liveness.test.ts` and confirm the missing module/behavior fails.
+3. Implement the minimal bounded per-surface tracker and broken-pipe classifier.
+4. Re-run the focused test and confirm it passes.
+
+### Task 2: Specify health classification
+
+**Files:**
+- Modify: `tests/agent-health.test.ts`
+- Modify: `src/agent-health.ts`
+
+1. Add failing tests for active screen plus dead-PTY evidence, single transient evidence, healthy observation, severity, and disagreement downgrade behavior.
+2. Run `bunx vitest run tests/agent-health.test.ts` and confirm failures are caused by the absent issue/input.
+3. Add `pane_pty_dead` as blocking and evaluate it only for active screens with qualifying evidence.
+4. Re-run the focused test and confirm it passes.
+
+### Task 3: Thread observations into health input
+
+**Files:**
+- Modify: `tests/agent-health-input.test.ts`
+- Modify: `src/agent-health-input.ts`
+
+1. Add a failing test showing the liveness observation dependency reaches `AgentHealthInput`.
+2. Run `bunx vitest run tests/agent-health-input.test.ts` and confirm the expected failure.
+3. Add the dependency/override and return field.
+4. Re-run the focused test and confirm it passes.
+
+### Task 4: Record real server writes and expose them through health
+
+**Files:**
+- Modify: `tests/server-agent-tools.test.ts`
+- Modify: `src/server.ts`
+
+1. Add a hermetic server test that performs two failed broken-pipe top-level writes against an active managed agent and observes `pane_pty_dead` in `list_agents`.
+2. Run the focused server test and confirm it fails for the absent tracking.
+3. Put the tracker in shared server context, record `withSurfaceWrite` outcomes, and supply observations to health evaluation.
+4. Re-run focused server and health suites.
+
+### Task 5: Verify and publish
+
+**Files:**
+- Review all changed files; do not touch `src/proxy.ts` or `src/doctor.ts`.
+
+1. Run `bun run typecheck && bun run test && bun run build`.
+2. Review `git diff --check`, `git diff`, and `git status`.
+3. Commit intentionally, push `feat/r2-pty-liveness`, and open the requested titled PR.
+4. Store the implementation decision and verification milestone in BrainLayer.

--- a/src/agent-health-input.ts
+++ b/src/agent-health-input.ts
@@ -4,6 +4,7 @@ import type {
   AgentTopologyHealthInput,
 } from "./agent-health.js";
 import type { WorkerHarvestability } from "./agent-engine.js";
+import type { SurfaceWriteLivenessObservation } from "./surface-write-liveness.js";
 import {
   channelDirDeletedAfterCreate,
   monitorAlive,
@@ -30,6 +31,7 @@ export interface AgentHealthInputOverrides {
   closure_artifact_verified?: boolean | null;
   harvestability?: WorkerHarvestability | null;
   inbox_channel_dir_deleted?: boolean | null;
+  surface_write_liveness?: SurfaceWriteLivenessObservation | null;
 }
 
 export interface AgentHealthInputDeps {
@@ -46,6 +48,9 @@ export interface AgentHealthInputDeps {
     agent: AgentRecord,
   ) => Promise<ParsedSurfaceHealthInput | null>;
   resolveSurfaceWorkspace?: (agent: AgentRecord) => Promise<string | null>;
+  observeSurfaceWriteLiveness?: (
+    agent: AgentRecord,
+  ) => SurfaceWriteLivenessObservation | null;
 }
 
 export async function buildAgentHealthInput(
@@ -107,6 +112,10 @@ export async function buildAgentHealthInput(
     overrides.surface_workspace_id !== undefined
       ? overrides.surface_workspace_id
       : await deps.resolveSurfaceWorkspace?.(agent);
+  const surfaceWriteLiveness =
+    overrides.surface_write_liveness !== undefined
+      ? overrides.surface_write_liveness
+      : deps.observeSurfaceWriteLiveness?.(agent);
 
   return {
     monitor_alive: alive,
@@ -119,5 +128,6 @@ export async function buildAgentHealthInput(
     topology,
     closure_artifact_verified: closureArtifactVerified,
     harvestability,
+    surface_write_liveness: surfaceWriteLiveness,
   };
 }

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -1,5 +1,6 @@
 import type { AgentRecord, AgentRole, AgentState } from "./agent-types.js";
 import type { WorkerHarvestability } from "./agent-engine.js";
+import type { SurfaceWriteLivenessObservation } from "./surface-write-liveness.js";
 import {
   inferAgentRole,
   inferRecordRoleOrNull,
@@ -17,6 +18,7 @@ export type AgentHealthIssueCode =
   | "inbox_monitor_not_alive"
   | "stale_inbox_dispatches"
   | "agent_wedged"
+  | "pane_pty_dead"
   | "registry_screen_disagreement"
   | "registry_surface_workspace_mismatch"
   | "closure_without_artifact"
@@ -39,6 +41,7 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   AgentHealthIssueSeverity
 > = {
   agent_wedged: "blocking",
+  pane_pty_dead: "blocking",
   closure_without_artifact: "blocking",
   pr_loop_incomplete: "blocking",
   kept_open_contract_incomplete: "blocking",
@@ -77,6 +80,7 @@ export interface AgentHealthInput {
   harvestability?: WorkerHarvestability | null;
   screen_actions?: string[] | null;
   topology?: AgentTopologyHealthInput | null;
+  surface_write_liveness?: SurfaceWriteLivenessObservation | null;
 }
 
 export interface AgentHealth {
@@ -121,6 +125,7 @@ function issueSeverity(
     inboxMonitorWithinBootGrace: boolean;
     autoDiscovered: boolean;
     lacksManagedPlacement: boolean;
+    panePtyDead: boolean;
   },
 ): AgentHealthIssueSeverity {
   if (
@@ -130,7 +135,11 @@ function issueSeverity(
   ) {
     return "info";
   }
-  if (code === "registry_screen_disagreement" && context.screenActive) {
+  if (
+    code === "registry_screen_disagreement" &&
+    context.screenActive &&
+    !context.panePtyDead
+  ) {
     return "info";
   }
   if (
@@ -149,6 +158,7 @@ function deriveIssueSeverities(
     inboxMonitorWithinBootGrace: boolean;
     autoDiscovered: boolean;
     lacksManagedPlacement: boolean;
+    panePtyDead: boolean;
   },
 ): Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>> {
   const severities: Partial<
@@ -366,6 +376,16 @@ export function evaluateAgentHealth(
 
   const screenActive =
     input.screen_status === "working" || input.screen_status === "thinking";
+  const panePtyDead =
+    screenActive && input.surface_write_liveness?.pty_dead === true;
+  if (panePtyDead) {
+    addIssue(
+      issueCodes,
+      issues,
+      "pane_pty_dead",
+      `screen parses as ${input.screen_status} but the last ${input.surface_write_liveness?.consecutive_broken_pipe_failures ?? "several"} surface writes failed with a broken pipe`,
+    );
+  }
   const screenDone = input.screen_status === "done";
   let reconciledState: AgentState | undefined;
   const registryActive =
@@ -519,6 +539,7 @@ export function evaluateAgentHealth(
     screenActive,
     autoDiscovered,
     lacksManagedPlacement: lacksManagedPlacement(agent),
+    panePtyDead,
     inboxMonitorWithinBootGrace: isWithinInboxMonitorBootGrace(
       agent,
       deps.now?.() ?? Date.now(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,7 @@ import {
   loadSeatRegistryFromConfig,
   type SeatRegistry,
 } from "./seat-identity.js";
+import { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -1807,6 +1808,8 @@ export interface CreateServerOptions {
    * entrypoint (index.ts) passes `true`.
    */
   enableCloseForensics?: boolean;
+  /** Override per-surface PTY write-liveness tracking (primarily for tests). */
+  surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -1830,6 +1833,7 @@ export interface CmuxServerContext {
   activeDeliveryBySurface: Map<string, string>;
   activeSurfaceWrites: Map<string, string>;
   readScreenInflight: Map<string, Promise<ReadScreenSnapshot>>;
+  surfaceWriteLiveness: SurfaceWriteLivenessTracker;
   enableClaudeChannels: boolean;
   skipAgentLifecycle: boolean;
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
@@ -1917,6 +1921,8 @@ export function createServerContext(
     activeDeliveryBySurface: new Map(),
     activeSurfaceWrites: new Map(),
     readScreenInflight: new Map(),
+    surfaceWriteLiveness:
+      opts?.surfaceWriteLiveness ?? new SurfaceWriteLivenessTracker(),
     enableClaudeChannels:
       opts?.enableClaudeChannels ??
       process.env.CMUXLAYER_ENABLE_CLAUDE_CHANNELS === "1",
@@ -2015,6 +2021,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const latestDeliveryBySurface = context.latestDeliveryBySurface;
   const activeDeliveryBySurface = context.activeDeliveryBySurface;
   const activeSurfaceWrites = context.activeSurfaceWrites;
+  const surfaceWriteLiveness = context.surfaceWriteLiveness;
   const enableClaudeChannels =
     opts?.enableClaudeChannels ?? context.enableClaudeChannels;
   const skipAgentLifecycle =
@@ -2503,6 +2510,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       toolName?: string;
       workspace?: string;
       owner?: string;
+      observePtyWrite?: boolean;
     } = {},
   ): Promise<T> => {
     if (opts.toolName) {
@@ -2511,7 +2519,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const owner = opts.owner ?? `surface-write:${randomUUID()}`;
     acquireSurfaceWrite(surface, owner);
     try {
-      return await fn();
+      const result = await fn();
+      if (opts.observePtyWrite) {
+        surfaceWriteLiveness.recordSuccess(surface);
+      }
+      return result;
+    } catch (error) {
+      if (opts.observePtyWrite) {
+        surfaceWriteLiveness.recordFailure(surface, error);
+      }
+      throw error;
     } finally {
       releaseSurfaceWrite(surface, owner);
     }
@@ -2553,6 +2570,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     error?: string,
     failedChunk?: number,
   ) => {
+    if (status === "delivered") {
+      surfaceWriteLiveness.recordSuccess(record.surface);
+    } else if (status === "failed") {
+      surfaceWriteLiveness.recordFailure(record.surface, error);
+    }
     record.status = status;
     record.completed_at = new Date().toISOString();
     record.error = error;
@@ -3448,7 +3470,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: opts.workspace,
         });
       }
-    }, { toolName: "send_command", workspace: opts.workspace });
+    }, {
+      toolName: "send_command",
+      workspace: opts.workspace,
+      observePtyWrite: true,
+    });
   };
 
   const deliverBootPrompt = async (opts: {
@@ -3520,7 +3546,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? Math.min(SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS, opts.timeout_ms)
               : undefined,
           }),
-        { toolName: "boot_prompt", workspace: opts.workspace },
+        {
+          toolName: "boot_prompt",
+          workspace: opts.workspace,
+          observePtyWrite: true,
+        },
       );
       return {
         ...delivery,
@@ -3901,6 +3931,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
         resolveSurfaceWorkspace: (target) =>
           resolveSurfaceWorkspace(target.surface_id),
+        observeSurfaceWriteLiveness: (target) =>
+          surfaceWriteLiveness.observe(target.surface_id),
       },
       overrides,
     );
@@ -5023,7 +5055,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_event: "send_input",
             verify_submit: shouldVerifySubmit,
           });
-        }, { toolName: "send_input", workspace: args.workspace });
+        }, {
+          toolName: "send_input",
+          workspace: args.workspace,
+          observePtyWrite: true,
+        });
 
         const identity = resolveTargetIdentity(stateMgr, args.surface);
         const data = {
@@ -5145,7 +5181,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             source_event: "send_command",
             verify_submit: bootPromptPath ? false : shouldVerifySubmit,
           });
-        }, { toolName: "send_command", workspace: args.workspace });
+        }, {
+          toolName: "send_command",
+          workspace: args.workspace,
+          observePtyWrite: true,
+        });
 
         let bootPromptDelivery:
           | Awaited<ReturnType<typeof deliverBootPrompt>>
@@ -5241,7 +5281,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const key = normalizeKeyName(args.key);
         await withSurfaceWrite(args.surface, async () => {
           await sendKeyWithRetry(args.surface, key, args.workspace);
-        }, { toolName: "send_key", workspace: args.workspace });
+        }, {
+          toolName: "send_key",
+          workspace: args.workspace,
+          observePtyWrite: true,
+        });
         const data = { surface: args.surface, key };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
@@ -6191,13 +6235,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             withSurfaceWrite(
               surface,
               () => client.send(surface, text, sendOpts),
-              { toolName: "agent_engine", workspace: sendOpts?.workspace },
+              {
+                toolName: "agent_engine",
+                workspace: sendOpts?.workspace,
+                observePtyWrite: true,
+              },
             ),
           sendKey: (surface, key, keyOpts) =>
             withSurfaceWrite(
               surface,
               () => client.sendKey(surface, key, keyOpts),
-              { toolName: "send_key", workspace: keyOpts?.workspace },
+              {
+                toolName: "send_key",
+                workspace: keyOpts?.workspace,
+                observePtyWrite: true,
+              },
             ),
           setProgress: (value, progressOpts) =>
             client.setProgress(value, progressOpts),
@@ -6510,6 +6562,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         {
           toolName: args.source_event,
           workspace: route.workspace_id ?? undefined,
+          observePtyWrite: true,
         },
       );
     };
@@ -8210,6 +8263,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 {
                   toolName: "interact",
                   workspace: agent.workspace_id ?? undefined,
+                  observePtyWrite: true,
                 },
               );
               const d = { agent_id: args.agent, action: "interrupt" };

--- a/src/surface-write-liveness.ts
+++ b/src/surface-write-liveness.ts
@@ -1,0 +1,106 @@
+export const DEFAULT_PTY_DEAD_FAILURE_THRESHOLD = 2;
+export const DEFAULT_PTY_DEAD_FAILURE_WINDOW_MS = 30_000;
+
+export interface SurfaceWriteLivenessObservation {
+  pty_dead: boolean;
+  consecutive_broken_pipe_failures: number;
+  last_attempt_at: number;
+}
+
+export interface SurfaceWriteLivenessTrackerOptions {
+  now?: () => number;
+  failureThreshold?: number;
+  failureWindowMs?: number;
+}
+
+interface SurfaceWriteState {
+  consecutiveBrokenPipeFailures: number;
+  firstBrokenPipeFailureAt: number | null;
+  lastAttemptAt: number;
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function isBrokenPipeError(error: unknown): boolean {
+  const record =
+    typeof error === "object" && error !== null
+      ? (error as { code?: unknown; errno?: unknown })
+      : null;
+  if (record?.code === "EPIPE") return true;
+  if (record?.errno === 32 || record?.errno === -32) return true;
+  return /\b(?:EPIPE|broken[ -]pipe|errno\s*32)\b/i.test(errorText(error));
+}
+
+export class SurfaceWriteLivenessTracker {
+  private readonly now: () => number;
+  private readonly failureThreshold: number;
+  private readonly failureWindowMs: number;
+  private readonly stateBySurface = new Map<string, SurfaceWriteState>();
+
+  constructor(options: SurfaceWriteLivenessTrackerOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.failureThreshold =
+      options.failureThreshold ?? DEFAULT_PTY_DEAD_FAILURE_THRESHOLD;
+    this.failureWindowMs =
+      options.failureWindowMs ?? DEFAULT_PTY_DEAD_FAILURE_WINDOW_MS;
+  }
+
+  recordSuccess(surface: string): void {
+    this.stateBySurface.set(surface, {
+      consecutiveBrokenPipeFailures: 0,
+      firstBrokenPipeFailureAt: null,
+      lastAttemptAt: this.now(),
+    });
+  }
+
+  recordFailure(surface: string, error: unknown): void {
+    const at = this.now();
+    const previous = this.stateBySurface.get(surface);
+    if (!isBrokenPipeError(error)) {
+      this.stateBySurface.set(surface, {
+        consecutiveBrokenPipeFailures: 0,
+        firstBrokenPipeFailureAt: null,
+        lastAttemptAt: at,
+      });
+      return;
+    }
+    const continuesChain =
+      previous !== undefined &&
+      previous.consecutiveBrokenPipeFailures > 0 &&
+      previous.firstBrokenPipeFailureAt !== null &&
+      at - previous.firstBrokenPipeFailureAt <= this.failureWindowMs;
+    this.stateBySurface.set(surface, {
+      consecutiveBrokenPipeFailures: continuesChain
+        ? previous.consecutiveBrokenPipeFailures + 1
+        : 1,
+      firstBrokenPipeFailureAt: continuesChain
+        ? previous.firstBrokenPipeFailureAt
+        : at,
+      lastAttemptAt: at,
+    });
+  }
+
+  observe(surface: string): SurfaceWriteLivenessObservation | null {
+    const state = this.stateBySurface.get(surface);
+    if (!state) return null;
+    const withinWindow =
+      state.firstBrokenPipeFailureAt !== null &&
+      this.now() - state.firstBrokenPipeFailureAt <= this.failureWindowMs;
+    return {
+      pty_dead:
+        withinWindow &&
+        state.consecutiveBrokenPipeFailures >= this.failureThreshold,
+      consecutive_broken_pipe_failures:
+        state.consecutiveBrokenPipeFailures,
+      last_attempt_at: state.lastAttemptAt,
+    };
+  }
+}

--- a/tests/agent-health-input.test.ts
+++ b/tests/agent-health-input.test.ts
@@ -59,4 +59,19 @@ describe("buildAgentHealthInput", () => {
     expect(input.screen_status).toBeUndefined();
     expect(input.screen_actions).toBeUndefined();
   });
+
+  it("threads the latest surface write-liveness observation into health input", async () => {
+    const observation = {
+      pty_dead: true,
+      consecutive_broken_pipe_failures: 2,
+      last_attempt_at: 2_000,
+    };
+
+    const input = await buildAgentHealthInput(makeAgent(), {
+      observeSurfaceWriteLiveness: (agent) =>
+        agent.surface_id === "surface:1" ? observation : null,
+    });
+
+    expect(input.surface_write_liveness).toEqual(observation);
+  });
 });

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -218,6 +218,65 @@ describe("agent lifecycle health", () => {
     expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
   });
 
+  it("blocks a live-spinner pane after repeated recent broken-pipe writes", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({ state: "done" }),
+      {
+        monitor_alive: true,
+        screen_status: "thinking",
+        surface_write_liveness: {
+          pty_dead: true,
+          consecutive_broken_pipe_failures: 2,
+          last_attempt_at: 2_000,
+        },
+      },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("pane_pty_dead");
+    expect(health.issue_severities?.pane_pty_dead).toBe("blocking");
+    expect(health.issue_severities?.registry_screen_disagreement).toBe(
+      "degraded",
+    );
+  });
+
+  it("does not flag one transient broken-pipe write", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({ state: "done" }),
+      {
+        monitor_alive: true,
+        screen_status: "working",
+        surface_write_liveness: {
+          pty_dead: false,
+          consecutive_broken_pipe_failures: 1,
+          last_attempt_at: 1_000,
+        },
+      },
+    );
+
+    expect(health.issue_codes).not.toContain("pane_pty_dead");
+    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
+    expect(health.status).toBe("healthy");
+  });
+
+  it("leaves active-screen health unchanged after a healthy write", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({ state: "working" }),
+      {
+        monitor_alive: true,
+        screen_status: "thinking",
+        surface_write_liveness: {
+          pty_dead: false,
+          consecutive_broken_pipe_failures: 0,
+          last_attempt_at: 1_000,
+        },
+      },
+    );
+
+    expect(health.issue_codes).not.toContain("pane_pty_dead");
+    expect(health.status).toBe("healthy");
+  });
+
   it("marks registry working while the screen parses done as degraded registry lag", () => {
     const health = evaluateAgentHealth(
       makeRecord({

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2811,6 +2811,49 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
+  it("list_agents reports an active pane unhealthy after repeated broken-pipe writes", async () => {
+    const record = makeServerAgentRecord({
+      agent_id: "codex-dead-pty",
+      surface_id: "surface:dead-pty",
+      workspace_id: "workspace:1",
+      state: "done",
+    });
+    const { server, client } = await createBroadcastServer([record]);
+    client.readScreen.mockResolvedValue({
+      surface: record.surface_id,
+      text: "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (41s - esc to interrupt)",
+      lines: 20,
+      scrollback_used: false,
+    });
+    client.send.mockRejectedValue(
+      Object.assign(
+        new Error("Failed to write to socket (Broken pipe, errno 32)"),
+        {
+          code: "EPIPE",
+          errno: 32,
+        },
+      ),
+    );
+    const sendInput = (server as any)._registeredTools["send_input"];
+    const listAgents = (server as any)._registeredTools["list_agents"];
+    const sendArgs = sendInput.inputSchema.parse({
+      surface: record.surface_id,
+      text: "ping",
+      press_enter: false,
+    });
+
+    await sendInput.handler(sendArgs, {} as any);
+    await sendInput.handler(sendArgs, {} as any);
+    const parsed = parseToolResult(await listAgents.handler({}, {} as any)) as {
+      agents: Array<{ health: { status: string; issue_codes: string[] } }>;
+    };
+
+    expect(parsed.agents[0]?.health).toMatchObject({
+      status: "unhealthy",
+      issue_codes: expect.arrayContaining(["pane_pty_dead"]),
+    });
+  });
+
   it("list_agents includes resume_command when a session id is captured", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];

--- a/tests/surface-write-liveness.test.ts
+++ b/tests/surface-write-liveness.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  SurfaceWriteLivenessTracker,
+  isBrokenPipeError,
+} from "../src/surface-write-liveness.js";
+
+describe("isBrokenPipeError", () => {
+  it("recognizes structured and textual broken-pipe errors", () => {
+    expect(
+      isBrokenPipeError(
+        Object.assign(new Error("write failed"), { code: "EPIPE" }),
+      ),
+    ).toBe(true);
+    expect(
+      isBrokenPipeError({ errno: 32, message: "socket write failed" }),
+    ).toBe(true);
+    expect(
+      isBrokenPipeError(
+        new Error("Failed to write to socket (Broken pipe, errno 32)"),
+      ),
+    ).toBe(true);
+    expect(isBrokenPipeError(new Error("surface not found"))).toBe(false);
+  });
+});
+
+describe("SurfaceWriteLivenessTracker", () => {
+  it("marks repeated recent broken-pipe writes as dead", () => {
+    let now = 1_000;
+    const tracker = new SurfaceWriteLivenessTracker({
+      now: () => now,
+      failureThreshold: 2,
+      failureWindowMs: 30_000,
+    });
+
+    tracker.recordFailure(
+      "surface:1",
+      Object.assign(new Error("write"), { code: "EPIPE" }),
+    );
+    now += 1_000;
+    tracker.recordFailure("surface:1", new Error("Broken pipe, errno 32"));
+
+    expect(tracker.observe("surface:1")).toMatchObject({
+      pty_dead: true,
+      consecutive_broken_pipe_failures: 2,
+      last_attempt_at: 2_000,
+    });
+  });
+
+  it("does not mark one transient broken-pipe write as dead", () => {
+    const tracker = new SurfaceWriteLivenessTracker({
+      failureThreshold: 2,
+      failureWindowMs: 30_000,
+      now: () => 1_000,
+    });
+
+    tracker.recordFailure(
+      "surface:1",
+      Object.assign(new Error("write"), { code: "EPIPE" }),
+    );
+
+    expect(tracker.observe("surface:1")?.pty_dead).toBe(false);
+  });
+
+  it("clears the consecutive failure chain after a healthy write", () => {
+    let now = 1_000;
+    const tracker = new SurfaceWriteLivenessTracker({
+      now: () => now,
+      failureThreshold: 2,
+    });
+
+    tracker.recordFailure("surface:1", new Error("EPIPE"));
+    now += 1;
+    tracker.recordSuccess("surface:1");
+    now += 1;
+    tracker.recordFailure("surface:1", new Error("EPIPE"));
+
+    expect(tracker.observe("surface:1")).toMatchObject({
+      pty_dead: false,
+      consecutive_broken_pipe_failures: 1,
+    });
+  });
+
+  it("interrupts the broken-pipe chain on a different write failure", () => {
+    let now = 1_000;
+    const tracker = new SurfaceWriteLivenessTracker({
+      now: () => now,
+      failureThreshold: 2,
+    });
+
+    tracker.recordFailure("surface:1", new Error("EPIPE"));
+    now += 1;
+    tracker.recordFailure("surface:1", new Error("permission denied"));
+    now += 1;
+    tracker.recordFailure("surface:1", new Error("Broken pipe"));
+
+    expect(tracker.observe("surface:1")?.pty_dead).toBe(false);
+  });
+
+  it("expires an otherwise qualifying failure chain outside the window", () => {
+    let now = 1_000;
+    const tracker = new SurfaceWriteLivenessTracker({
+      now: () => now,
+      failureThreshold: 2,
+      failureWindowMs: 10_000,
+    });
+
+    tracker.recordFailure("surface:1", new Error("EPIPE"));
+    now += 1_000;
+    tracker.recordFailure("surface:1", new Error("EPIPE"));
+    now += 10_001;
+
+    expect(tracker.observe("surface:1")?.pty_dead).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- record per-surface outcomes from real terminal write operations without synthetic probes
- classify stale active screens as blocking `pane_pty_dead` after two recent broken-pipe operations within 30 seconds
- preserve the existing binary health tier model and prevent active-screen disagreement downgrades when dead-PTY evidence exists
- surface the issue through existing health/list_agents payloads

## Test plan
- [x] TDD red/green coverage for repeated EPIPE, single transient, healthy reset, non-EPIPE interruption, and time-window expiry
- [x] hermetic list_agents integration coverage for active spinner plus repeated EPIPE writes
- [x] `bun run typecheck && bun run test && bun run build` (89 files, 1589 tests)
- [x] repository pre-push hook (89 files, 1589 tests)
- [x] CodeRabbit pre-commit review: 0 findings

## Scope
- `src/proxy.ts` and `src/doctor.ts` intentionally untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent health classification and `list_agents` semantics for active panes with write failures; mis-tuned thresholds or error matching could false-positive unhealthy or miss dead PTYs.
> 
> **Overview**
> Fixes **false-green health** when a pane still shows an active spinner but the PTY socket is already dead (writes fail with EPIPE/errno 32).
> 
> Adds a per-surface **write-liveness tracker** that records outcomes at the shared `withSurfaceWrite` boundary (and on chunked delivery completion), with defaults of **two broken-pipe failures within 30s** before marking the PTY dead. Successful writes or non–broken-pipe errors reset the streak.
> 
> Health now threads `surface_write_liveness` through `buildAgentHealthInput` and emits blocking **`pane_pty_dead`** when the screen still parses as `working`/`thinking` and the tracker says the PTY is dead. **`registry_screen_disagreement`** is no longer downgraded to info in that case—it stays **degraded** alongside the blocking issue.
> 
> Existing **`list_agents`** (and other health payloads) pick up the new issue code without API shape changes. Design/plan docs and Vitest coverage (tracker, health, server integration) are included; **`proxy.ts`** and **`doctor.ts`** are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb2054da1c7c645e8d0bbd544ee34f4c169bb7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify panes with dead PTYs as unhealthy using socket write-liveness signals
> - Adds [`SurfaceWriteLivenessTracker`](https://github.com/EtanHey/cmuxlayer/pull/279/files#diff-f06773a333c9ac53fa9a7f34760320746813665a6bb2a162f3acd0e0d8b06dbb) to record successes and broken-pipe failures on PTY writes, using a 2-failure threshold within a 30-second window to declare a surface PTY-dead.
> - Introduces a new `pane_pty_dead` health issue code with `blocking` severity in [`agent-health.ts`](https://github.com/EtanHey/cmuxlayer/pull/279/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3); active screens with a dead PTY emit this issue during health evaluation.
> - Wires the tracker into [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/279/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) so that `send_command`, `send_input`, `send_key`, and chunked delivery paths all record write outcomes; `observeSurfaceWriteLiveness` feeds the latest observation into `buildAgentHealthInput`.
> - Prevents `registry_screen_disagreement` from being downgraded to `info` severity when the pane is already classified as PTY-dead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7fb2054. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->