### PR TITLE
fix: survive brew cleanup — cached running version, realpath spawn, symlink-faithful live test

### DIFF
--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -1,9 +1,19 @@
 import { execFile } from "node:child_process";
 import { getTransportHealth } from "./cmux-transport-self-heal.js";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, realpathSync } from "node:fs";
 import { access, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+
+const RUNNING_SCRIPT_PATH = (() => {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) return null;
+  try {
+    return realpathSync(entrypoint);
+  } catch {
+    return resolve(entrypoint);
+  }
+})();
 
 export interface ControlHealthExecResult {
   stdout: string;
@@ -22,6 +32,7 @@ export interface ControlHealthOptions {
   pid?: number;
   ppid?: number;
   cwd?: string;
+  scriptPath?: string | null;
   client?: unknown;
   execFile?: ControlHealthExecFile;
   readFile?: typeof readFile;
@@ -74,6 +85,7 @@ export interface ControlHealth {
     cmux_resolution: ExecutableStatus[];
     ps?: string;
     ps_error?: string;
+    script_path?: string | null;
   };
   selected_transport: {
     client_class: string | null;
@@ -484,6 +496,8 @@ export async function collectControlHealth(
       pid: opts.pid ?? process.pid,
       ppid: opts.ppid ?? process.ppid,
       cwd: opts.cwd ?? process.cwd(),
+      script_path:
+        opts.scriptPath === undefined ? RUNNING_SCRIPT_PATH : opts.scriptPath,
       stdin_is_tty: process.stdin.isTTY === true,
       env: envSnapshot,
       path_entries: pathEntries,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,7 +3,6 @@
 import net from "node:net";
 import { lstat, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { pathToFileURL } from "node:url";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
   Transport,
@@ -40,6 +39,7 @@ import {
   type DetectStaleBuildDeps,
   type StaleBuildResult,
 } from "./version.js";
+import { isMainModule } from "./is-main.js";
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const DEFAULT_STALE_CHECK_INTERVAL_MS = 30_000;
@@ -783,10 +783,7 @@ export async function runDaemon(
   return daemon;
 }
 
-const isMain =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-
-if (isMain) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   runDaemon().catch((error) => {
     console.error("[cmuxlayer-daemon] fatal", error);
     process.exit(1);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -25,7 +25,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, existsSync } from "node:fs";
 import net from "node:net";
 import {
   access,
@@ -159,6 +159,7 @@ export interface DoctorReport {
     installedVersion?: string;
     transportDegraded?: boolean;
     currentSocketPath?: string | null;
+    runningScriptPath?: string;
   };
   /** §3 tap — best-effort report; brew may be absent. */
   tap: {
@@ -211,6 +212,8 @@ export interface RunDoctorOptions {
   ) => Promise<SocketProbeResult>;
   /** Bound for daemon connect/initialize/control_health (default 1500ms). */
   daemonProbeTimeoutMs?: number;
+  /** Injectable path existence check for daemon provenance tests. */
+  pathExists?: (path: string) => boolean;
 }
 
 type DaemonMcpProbeResult =
@@ -220,11 +223,16 @@ type DaemonMcpProbeResult =
       version: string;
       transportDegraded: boolean;
       currentSocketPath: string | null;
+      scriptPath: string | null;
     }
   | { kind: "error"; error: string };
 
 function daemonProbeError(message: unknown): string {
   return message instanceof Error ? message.message : String(message);
+}
+
+function daemonScriptPathFromPs(ps: string): string | null {
+  return ps.match(/(?:^|\s)(\/[^\s]*\/daemon\.js)(?:\s|$)/)?.[1] ?? null;
 }
 
 function probeDaemonMcp(
@@ -333,6 +341,16 @@ function probeDaemonMcp(
               health && isRecord(health.selected_transport)
                 ? health.selected_transport
                 : null;
+            const currentProcess =
+              health && isRecord(health.current_process)
+                ? health.current_process
+                : null;
+            const scriptPath =
+              currentProcess && typeof currentProcess.script_path === "string"
+                ? currentProcess.script_path
+                : currentProcess && typeof currentProcess.ps === "string"
+                  ? daemonScriptPathFromPs(currentProcess.ps)
+                  : null;
             if (!version || !selected) {
               settle({
                 kind: "error",
@@ -348,6 +366,7 @@ function probeDaemonMcp(
                 typeof selected.current_socket_path === "string"
                   ? selected.current_socket_path
                   : null,
+              scriptPath,
             });
           }
         } catch (error) {
@@ -415,7 +434,21 @@ async function checkDaemonIntegrity(
     ...(stale ? { installedVersion: stale.installed } : {}),
     transportDegraded: probe.transportDegraded,
     currentSocketPath: probe.currentSocketPath,
+    ...(probe.scriptPath ? { runningScriptPath: probe.scriptPath } : {}),
   };
+  if (probe.scriptPath) {
+    try {
+      if (!(opts.pathExists ?? existsSync)(probe.scriptPath)) {
+        return {
+          ...base,
+          ok: false,
+          note: "daemon running from a deleted install (brew cleanup?) — stale detection is blind; retire it",
+        };
+      }
+    } catch {
+      // Provenance checks are best-effort; other daemon checks still run.
+    }
+  }
   if (stale?.stale) {
     return {
       ...base,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,9 @@
  */
 
 import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";
-import { readVersion } from "./version.js";
+import { RUNNING_VERSION } from "./version.js";
 import { runDaemonFirstEntry } from "./entry.js";
+import { isMainModule } from "./is-main.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 
@@ -53,7 +54,7 @@ Environment:
 async function main() {
   const arg = process.argv[2];
   if (arg === "--version" || arg === "-v") {
-    process.stdout.write(`cmuxlayer ${readVersion()}\n`);
+    process.stdout.write(`cmuxlayer ${RUNNING_VERSION}\n`);
     return;
   }
   if (arg === "--help" || arg === "-h") {
@@ -65,7 +66,7 @@ async function main() {
     // Best-effort brew probes; exits 0 when healthy, 1 otherwise — so a runbook
     // can branch on the code. No bare sudo; never prompts.
     const json = process.argv.includes("--json");
-    const report = await runDoctor({ version: readVersion() });
+    const report = await runDoctor({ version: RUNNING_VERSION });
     process.stdout.write(
       (json ? renderDoctorJson(report) : renderDoctorText(report)) + "\n",
     );
@@ -76,7 +77,9 @@ async function main() {
   await runDaemonFirstEntry();
 }
 
-main().catch((error) => {
-  console.error("[cmuxlayer] fatal", error);
-  process.exit(1);
-});
+if (isMainModule(import.meta.url, process.argv[1])) {
+  main().catch((error) => {
+    console.error("[cmuxlayer] fatal", error);
+    process.exit(1);
+  });
+}

--- a/src/is-main.ts
+++ b/src/is-main.ts
@@ -1,0 +1,26 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+/** Compare ESM identity without trusting symlink spelling; never throws. */
+export function isMainModule(
+  importMetaUrl: string,
+  argvEntry: string | undefined,
+): boolean {
+  if (!argvEntry) return false;
+  try {
+    return (
+      canonicalPath(fileURLToPath(importMetaUrl)) === canonicalPath(argvEntry)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import net from "node:net";
-import { pathToFileURL } from "node:url";
 import type { Readable, Writable } from "node:stream";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
@@ -27,6 +26,7 @@ import {
   type StaleBuildResult,
   resolveInstalledDaemonScript,
 } from "./version.js";
+import { isMainModule } from "./is-main.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
@@ -40,6 +40,29 @@ const DEFAULT_RECONNECT_DAEMON_SPAWN_MAX_ATTEMPTS = 3;
 const DEFAULT_BUFFERED_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 5_000;
 const PROXY_ERROR_CODE = -32001;
+const SUSPICIOUS_DAEMON_EXIT_MS = 5_000;
+
+function instrumentSpawnedDaemon(
+  spawned: unknown,
+  startedAt: number,
+  logger: Pick<Console, "error">,
+): void {
+  if (
+    !spawned ||
+    typeof spawned !== "object" ||
+    !("once" in spawned) ||
+    typeof spawned.once !== "function"
+  ) {
+    return;
+  }
+  spawned.once("exit", (code: number | null) => {
+    if (code === 0 && Date.now() - startedAt <= SUSPICIOUS_DAEMON_EXIT_MS) {
+      logger.error(
+        "[cmuxlayer-proxy] daemon spawn suspicious quick-exit (isMain/symlink mismatch?)",
+      );
+    }
+  });
+}
 
 export interface ReconnectDelayOptions {
   initialBackoffMs: number;
@@ -565,12 +588,14 @@ export class CmuxLayerProxy {
         );
         return;
       }
+      const spawnStartedAt = Date.now();
       const spawned = await this.spawnDaemonForVersionBump({
         socketPath: this.socketPath,
         env: process.env,
         logger: this.logger,
         daemonScriptPath,
       });
+      instrumentSpawnedDaemon(spawned, spawnStartedAt, this.logger);
       const pid =
         spawned &&
         typeof spawned === "object" &&
@@ -1034,12 +1059,14 @@ export class CmuxLayerProxy {
       const daemonScriptPath = this.installedDaemonScriptPath();
       if (daemonScriptPath && this.spawnDaemonForVersionBump) {
         try {
+          const spawnStartedAt = Date.now();
           const spawned = await this.spawnDaemonForVersionBump({
             socketPath: this.socketPath,
             env: process.env,
             logger: this.logger,
             daemonScriptPath,
           });
+          instrumentSpawnedDaemon(spawned, spawnStartedAt, this.logger);
           const pid =
             spawned &&
             typeof spawned === "object" &&
@@ -1081,10 +1108,7 @@ export async function runProxy(
   return proxy;
 }
 
-const isMain =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-
-if (isMain) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   runProxy({ spawnDaemonForVersionBump: spawnDaemonProcess }).catch((error) => {
     console.error("[cmuxlayer-proxy] fatal", error);
     process.exit(1);

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
-import { createStaleBuildWarner, readVersion } from "./version.js";
+import { createStaleBuildWarner, RUNNING_VERSION } from "./version.js";
 import { StateManager } from "./state-manager.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import {
@@ -2373,7 +2373,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const server = new McpServer(
     {
       name: "cmuxlayer",
-      version: readVersion(),
+      version: RUNNING_VERSION,
     },
     enableClaudeChannels
       ? { instructions: CLAUDE_CHANNEL_INSTRUCTIONS }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +17,9 @@ export function readVersion(): string {
     return "unknown";
   }
 }
+
+/** Process identity is immutable even if Homebrew deletes this Cellar tree. */
+export const RUNNING_VERSION = readVersion();
 
 export interface BuildVersionCheck {
   /** True when the running build matches `expected`. */
@@ -38,7 +41,7 @@ export function assertBuildVersion(
   expected: string,
   opts?: { throwOnMismatch?: boolean; running?: string },
 ): BuildVersionCheck {
-  const running = opts?.running ?? readVersion();
+  const running = opts?.running ?? RUNNING_VERSION;
   const ok = running === expected;
   if (!ok && opts?.throwOnMismatch) {
     throw new Error(
@@ -128,7 +131,12 @@ export function resolveInstalledDaemonScript(
 ): string | null {
   const optPackageJson = optPackageJsonPath;
   if (!optPackageJson) return null;
-  return join(dirname(optPackageJson), "dist", "daemon.js");
+  const script = join(dirname(optPackageJson), "dist", "daemon.js");
+  try {
+    return realpathSync(script);
+  } catch {
+    return script;
+  }
 }
 
 /**
@@ -148,8 +156,14 @@ export function detectStaleBuild(
     const isDev = deps.isDev ?? process.env.CMUXLAYER_DEV === "1";
     if (isDev) return null;
 
-    const running = deps.running ?? readVersion();
+    const running = deps.running ?? RUNNING_VERSION;
     if (!running || running === "unknown") return null;
+
+    if (deps.running === undefined && readVersion() === "unknown") {
+      // Homebrew cleanup can unlink the package.json backing this still-live
+      // process. The cached version remains authoritative; the unreadable
+      // running tree corroborates an upgrade instead of making it unjudgeable.
+    }
 
     const optPath =
       deps.optPackageJsonPath === undefined

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,14 +1,16 @@
 import net from "node:net";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkMcpConfigDrift,
@@ -162,6 +164,8 @@ async function startDoctorDaemon(
     degraded?: boolean;
     cmuxSocketPath?: string;
     unresponsive?: boolean;
+    ps?: string;
+    scriptPath?: string;
   } = {},
 ): Promise<void> {
   rmSync(path, { force: true });
@@ -210,6 +214,10 @@ async function startDoctorDaemon(
                 content: [],
                 structuredContent: {
                   health: {
+                    current_process: {
+                      ps: opts.ps ?? "",
+                      script_path: opts.scriptPath ?? null,
+                    },
                     selected_transport: {
                       transport_mode: opts.degraded ? "cli" : "socket",
                       transport_degraded: opts.degraded ?? false,
@@ -322,6 +330,47 @@ describe("runDoctor — report shape", () => {
     expect(report.daemon.ok).toBe(false);
     expect(report.daemon.note).toMatch(
       /stale daemon v0\.3\.31 serving \(installed v0\.3\.33\).*proxies respawn/i,
+    );
+    expect(report.healthy).toBe(false);
+  });
+
+  it("flags a daemon whose running script was deleted by brew cleanup", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-deleted-${process.pid}.sock`);
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-doctor-deleted-tree-"));
+    doctorTempDirs.push(root);
+    const oldRoot = join(root, "Cellar", "cmuxlayer", "0.3.31");
+    const newRoot = join(root, "Cellar", "cmuxlayer", "0.3.35");
+    const optRoot = join(root, "opt", "cmuxlayer");
+    const relativeScript = join("libexec", "dist", "daemon.js");
+    mkdirSync(join(oldRoot, "libexec", "dist"), { recursive: true });
+    mkdirSync(join(newRoot, "libexec", "dist"), { recursive: true });
+    mkdirSync(dirname(optRoot), { recursive: true });
+    writeFileSync(join(oldRoot, relativeScript), "");
+    writeFileSync(join(newRoot, relativeScript), "");
+    symlinkSync(oldRoot, optRoot, "dir");
+    const runningScript = realpathSync(join(optRoot, relativeScript));
+    rmSync(optRoot);
+    symlinkSync(newRoot, optRoot, "dir");
+    rmSync(oldRoot, { recursive: true, force: true });
+
+    expect(existsSync(join(optRoot, relativeScript))).toBe(true);
+    expect(existsSync(runningScript)).toBe(false);
+    await startDoctorDaemon(path, {
+      version: "0.3.31",
+      ps: `123 1 123 0 S ?? node ${join(optRoot, relativeScript)}`,
+      scriptPath: runningScript,
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.35",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.daemon.ok).toBe(false);
+    expect(report.daemon.note).toBe(
+      "daemon running from a deleted install (brew cleanup?) — stale detection is blind; retire it",
     );
     expect(report.healthy).toBe(false);
   });

--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -117,19 +117,49 @@ function runningPackageVersion(): string {
 }
 
 function createFormulaFixture(root: string, version: string): {
+  cellarRoot: string;
+  optRoot: string;
   rootPackage: string;
   libexecPackage: string;
 } {
+  const cellarRoot = join(root, "brew", "Cellar", "cmuxlayer", version);
   const optRoot = join(root, "brew", "opt", "cmuxlayer");
-  const libexec = join(optRoot, "libexec");
+  const libexec = join(cellarRoot, "libexec");
   mkdirSync(libexec, { recursive: true });
   cpSync(resolve("dist"), join(libexec, "dist"), { recursive: true });
   symlinkSync(resolve("node_modules"), join(libexec, "node_modules"), "dir");
-  const rootPackage = join(optRoot, "package.json");
+  const rootPackage = join(cellarRoot, "package.json");
   const libexecPackage = join(libexec, "package.json");
   writeFileSync(rootPackage, packageJson(version));
   writeFileSync(libexecPackage, packageJson(version));
-  return { rootPackage, libexecPackage };
+  mkdirSync(dirname(optRoot), { recursive: true });
+  symlinkSync(cellarRoot, optRoot, "dir");
+  return { cellarRoot, optRoot, rootPackage, libexecPackage };
+}
+
+function upgradeFormulaFixture(
+  root: string,
+  oldFormula: ReturnType<typeof createFormulaFixture>,
+  version: string,
+): ReturnType<typeof createFormulaFixture> {
+  const newCellarRoot = join(root, "brew", "Cellar", "cmuxlayer", version);
+  const newLibexec = join(newCellarRoot, "libexec");
+  mkdirSync(newLibexec, { recursive: true });
+  cpSync(resolve("dist"), join(newLibexec, "dist"), { recursive: true });
+  symlinkSync(resolve("node_modules"), join(newLibexec, "node_modules"), "dir");
+  const rootPackage = join(newCellarRoot, "package.json");
+  const libexecPackage = join(newLibexec, "package.json");
+  writeFileSync(rootPackage, packageJson(version));
+  writeFileSync(libexecPackage, packageJson(version));
+  rmSync(oldFormula.optRoot);
+  symlinkSync(newCellarRoot, oldFormula.optRoot, "dir");
+  rmSync(oldFormula.cellarRoot, { recursive: true, force: true });
+  return {
+    cellarRoot: newCellarRoot,
+    optRoot: oldFormula.optRoot,
+    rootPackage,
+    libexecPackage,
+  };
 }
 
 function createMcpPeer(child: ChildProcess, stderr: string[]) {
@@ -235,20 +265,24 @@ describe("live daemon-first restart topology", () => {
       await startFakeCmuxSocket(cmuxSocket);
 
       const stderr: string[] = [];
-      const child = spawn(process.execPath, [resolve("dist", "index.js")], {
-        cwd: process.cwd(),
-        env: {
-          ...process.env,
-          HOME: root,
-          HOMEBREW_PREFIX: join(root, "brew"),
-          CMUX_SOCKET_PATH: cmuxSocket,
-          CMUXLAYER_DAEMON_SOCKET: daemonSocket,
-          CMUXLAYER_DEV: "0",
-          CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
-          CMUXLAYER_STALE_CHECK_INTERVAL_MS: "100",
+      const child = spawn(
+        process.execPath,
+        [join(formula.optRoot, "libexec", "dist", "index.js")],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            HOME: root,
+            HOMEBREW_PREFIX: join(root, "brew"),
+            CMUX_SOCKET_PATH: cmuxSocket,
+            CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+            CMUXLAYER_DEV: "0",
+            CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
+            CMUXLAYER_STALE_CHECK_INTERVAL_MS: "100",
+          },
+          stdio: ["pipe", "pipe", "pipe"],
         },
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      );
       CHILDREN.add(child);
       const peer = createMcpPeer(child, stderr);
 
@@ -274,8 +308,7 @@ describe("live daemon-first restart topology", () => {
       const initialDaemonPid = daemonPidFromHealth(initialHealth);
       expect(processExists(initialDaemonPid)).toBe(true);
 
-      writeFileSync(formula.rootPackage, packageJson(upgradedVersion));
-      writeFileSync(formula.libexecPackage, packageJson(upgradedVersion));
+      upgradeFormulaFixture(root, formula, upgradedVersion);
       await waitFor(
         () => !processExists(initialDaemonPid),
         5_000,
@@ -296,5 +329,57 @@ describe("live daemon-first restart topology", () => {
       process.kill(replacementDaemonPid, "SIGTERM");
     },
     70_000,
+  );
+
+  it(
+    "executes a daemon launched through the Homebrew opt symlink",
+    async () => {
+      const rootPath = join(
+        "/tmp",
+        `cmuxlayer-live-symlink-main-${process.pid}-${Date.now()}`,
+      );
+      mkdirSync(rootPath, { recursive: true });
+      const root = realpathSync(rootPath);
+      ROOTS.add(root);
+      const daemonSocket = join(root, "stated.sock");
+      const cmuxSocket = join(root, "cmux.sock");
+      const formula = createFormulaFixture(root, runningPackageVersion());
+      await startFakeCmuxSocket(cmuxSocket);
+
+      const child = spawn(
+        process.execPath,
+        [join(formula.optRoot, "libexec", "dist", "daemon.js")],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            HOME: root,
+            CMUX_SOCKET_PATH: cmuxSocket,
+            CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+            CMUXLAYER_DEV: "0",
+          },
+          stdio: ["ignore", "ignore", "pipe"],
+        },
+      );
+      CHILDREN.add(child);
+      const stderr: string[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk.toString()));
+
+      await waitFor(
+        () => {
+          try {
+            return (
+              processExists(child.pid ?? -1) &&
+              realpathSync(daemonSocket).length > 0
+            );
+          } catch {
+            return false;
+          }
+        },
+        5_000,
+        `symlink-launched daemon socket; stderr=${stderr.join("")}`,
+      );
+    },
+    20_000,
   );
 });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -873,6 +873,37 @@ describe("CmuxLayerProxy", () => {
     );
   });
 
+  it(
+    "logs a successful daemon spawn that exits suspiciously quickly",
+    async () => {
+      mkdirSync(TEST_ROOT, { recursive: true });
+      const path = socketPath("reconnect-spawn-quick-exit");
+      const logger = { error: vi.fn() };
+      const spawned = new EventEmitter() as EventEmitter & { pid: number };
+      spawned.pid = 4242;
+      const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(spawned);
+      const { proxy } = createProxy(path, {
+        initialBackoffMs: 5,
+        maxBackoffMs: 5,
+        installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+        logger,
+        spawnDaemonForVersionBump,
+      });
+
+      await waitFor(() => spawnDaemonForVersionBump.mock.calls.length === 1);
+      await waitFor(() => spawned.listenerCount("exit") > 0);
+      spawned.emit("exit", 0, null);
+      await waitFor(() =>
+        logger.error.mock.calls.some(([message]) =>
+          String(message).includes(
+            "daemon spawn suspicious quick-exit (isMain/symlink mismatch?)",
+          ),
+        ),
+      );
+      await proxy.stop();
+    },
+  );
+
   it("caps reconnect-driven daemon spawns within the guard window", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("reconnect-spawn-guard");

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,3 +1,13 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   assertBuildVersion,
@@ -8,12 +18,31 @@ import {
 } from "../src/version.js";
 
 describe("resolveInstalledDaemonScript", () => {
-  it("resolves the daemon beside the formula libexec package.json", () => {
+  it("falls back to the unresolved daemon path when realpath is unavailable", () => {
     expect(
       resolveInstalledDaemonScript(
-        "/opt/homebrew/opt/cmuxlayer/libexec/package.json",
+        "/missing/homebrew/opt/cmuxlayer/libexec/package.json",
       ),
-    ).toBe("/opt/homebrew/opt/cmuxlayer/libexec/dist/daemon.js");
+    ).toBe("/missing/homebrew/opt/cmuxlayer/libexec/dist/daemon.js");
+  });
+
+  it("returns the real Cellar daemon path when the opt tree is a symlink", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-version-realpath-"));
+    try {
+      const cellar = join(root, "Cellar", "cmuxlayer", "1.2.3", "libexec");
+      const opt = join(root, "opt", "cmuxlayer");
+      mkdirSync(join(cellar, "dist"), { recursive: true });
+      mkdirSync(join(root, "opt"), { recursive: true });
+      writeFileSync(join(cellar, "package.json"), "{}");
+      writeFileSync(join(cellar, "dist", "daemon.js"), "");
+      symlinkSync(join(root, "Cellar", "cmuxlayer", "1.2.3"), opt, "dir");
+
+      expect(
+        resolveInstalledDaemonScript(join(opt, "libexec", "package.json")),
+      ).toBe(realpathSync(join(cellar, "dist", "daemon.js")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- cache the running build identity before Homebrew can delete its Cellar tree
- realpath daemon spawns and make index, proxy, and daemon entrypoint checks symlink-safe
- log suspicious zero-code daemon quick exits and make doctor detect deleted canonical install provenance
- mirror Cellar plus opt symlink replacement and old-tree cleanup in the live topology test

## Verification
- RED: 5 expected failures on pre-fix behavior across live topology, realpath resolution, quick-exit logging, and doctor
- RED: symlink-faithful doctor fixture false-greened before canonical provenance capture
- GREEN: bun run typecheck && bun run test && bun run build
- Full suite: 89 test files, 1600 tests passed
- Fresh Claude client: control_health and list_agents returned structured socket-transport results

## Review
- CodeRabbit local review produced two minor test-determinism findings; both fixed. The bounded review did not terminate before timeout.
- Independent review found the mutable-opt doctor false-green; fixed with a canonical script-path fixture and process-start provenance capture.

## Scope
- No agent-health or surface-write-liveness changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon lifecycle, proxy reconnect spawns, and stale-build detection—operational paths that affect which binary runs after brew upgrade/cleanup, with broad test coverage mitigating regressions.
> 
> **Overview**
> Fixes **Homebrew cleanup / opt-symlink** cases where daemons keep running from deleted Cellar trees but stale detection and spawns go wrong.
> 
> **Entrypoints:** New **`isMainModule`** compares **`import.meta.url`** and **`argv[1]`** via **`realpathSync`**, replacing URL-string checks in **`index`**, **`daemon`**, and **`proxy`** so scripts launched through **`opt`** symlinks still run as main.
> 
> **Version identity:** **`RUNNING_VERSION`** is read once at load time; **`detectStaleBuild`** can still judge upgrades when **`package.json`** disappears after cleanup but the process is alive.
> 
> **Spawn / health:** **`resolveInstalledDaemonScript`** returns the real Cellar **`daemon.js`** path; the proxy logs a **suspicious quick-exit** when a spawned daemon exits 0 within 5s (typical **`isMain`** miss). **`control_health`** exposes **`current_process.script_path`**.
> 
> **Doctor:** Probes **`script_path`** (or parses **`ps`**) and fails when that path no longer exists, with a message that stale version checks may be blind.
> 
> **Tests:** Live topology uses Cellar + **`opt`** upgrade simulation; new cases cover deleted-install doctor, realpath resolution, quick-exit logging, and symlink-launched daemon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73dc5989b8cd27d8bb497fe11215322e686f61d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix main-module detection and staleness checks to survive Homebrew `brew cleanup`
> - Adds [`isMainModule`](https://github.com/EtanHey/cmuxlayer/pull/280/files#diff-2d2db81a0fc7ebd12b7a3cc995e0ee9c43ce22ad5255a721de950743f8c6be9d) using canonicalized `realpathSync` paths so symlinked invocations (e.g. Homebrew `opt` symlinks) correctly identify the main ESM module in `daemon.ts`, `proxy.ts`, and `index.ts`.
> - Caches `readVersion()` as `RUNNING_VERSION` at module load in [`version.ts`](https://github.com/EtanHey/cmuxlayer/pull/280/files#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087) so version reads remain correct after Homebrew cleanup deletes the old Cellar's `package.json`.
> - Adds `current_process.script_path` to the control health report and makes the doctor mark the daemon unhealthy when its running script path no longer exists on disk.
> - Resolves the realpath of the installed `daemon.js` in `resolveInstalledDaemonScript` so version comparisons use canonical paths across symlinks.
> - Adds a quick-exit diagnostic in the proxy that logs an error when a freshly spawned daemon exits within 5 seconds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73dc598.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->