### PR TITLE
test: real-cmux contract lane (live-instance smoke, opt-in)

### DIFF
--- a/docs/plans/2026-07-11-real-cmux-contract-lane.md
+++ b/docs/plans/2026-07-11-real-cmux-contract-lane.md
@@ -191,3 +191,9 @@ Expected: no whitespace errors, no monitor-registry diff, and only planned files
 **Step 5: Commit, push, and open the PR**
 
 Commit the verified changes, push `test/r4-real-cmux-ci`, and create a ready PR titled `test: real-cmux contract lane (live-instance smoke, opt-in)` with exact verification receipts and any unavailable-live limitation stated explicitly.
+
+## Follow-up: production socket guard
+
+Before probing `system.ping`, canonicalize the requested `CMUX_SOCKET_PATH` and compare it with both production identities: `$HOME/.local/state/cmux/cmux-501.sock` and the path stored in `$HOME/.local/state/cmux/last-socket-path` when that marker exists. A production match must print the specified warn-only skip and exit 0. The deliberate `CMUX_CONTRACT_ALLOW_PROD=1` override bypasses only this production classification; normal reachability and contract assertions still apply.
+
+Use TDD for three cases: default production path skips, `/tmp/cmux-nightly.sock` is admitted by the guard, and production plus the exact override is admitted. Perform this guard before any live socket request so routine releases from production-descended panes do not touch the production cmux socket at all.

--- a/docs/plans/2026-07-11-real-cmux-contract-lane.md
+++ b/docs/plans/2026-07-11-real-cmux-contract-lane.md
@@ -197,3 +197,11 @@ Commit the verified changes, push `test/r4-real-cmux-ci`, and create a ready PR 
 Before probing `system.ping`, canonicalize the requested `CMUX_SOCKET_PATH` and compare it with both production identities: `$HOME/.local/state/cmux/cmux-501.sock` and the path stored in `$HOME/.local/state/cmux/last-socket-path` when that marker exists. A production match must print the specified warn-only skip and exit 0. The deliberate `CMUX_CONTRACT_ALLOW_PROD=1` override bypasses only this production classification; normal reachability and contract assertions still apply.
 
 Use TDD for three cases: default production path skips, `/tmp/cmux-nightly.sock` is admitted by the guard, and production plus the exact override is admitted. Perform this guard before any live socket request so routine releases from production-descended panes do not touch the production cmux socket at all.
+
+## Follow-up: deterministic helper imports and cleanup
+
+Keep every helper exercised by `tests/real-cmux-contract-runner.test.ts` as an explicit top-level export of the runner module, whose guarded entrypoint remains inert on import. The runner has no dependency on the test module, so the import graph stays one-way and load-order independent.
+
+The MCP fixture must also be disposable: closing it rejects and clears pending requests, removes its child/stdout/stderr listeners, and ends stdin. Tests destroy their synthetic streams after use. Replacement and direct child PIDs are removed from the cleanup set as soon as an exit receipt/event is observed, preventing later cleanup from signaling a recycled PID.
+
+Prove determinism with three isolated runner-test executions followed by three complete `bun run test` executions from the final tree.

--- a/docs/plans/2026-07-11-real-cmux-contract-lane.md
+++ b/docs/plans/2026-07-11-real-cmux-contract-lane.md
@@ -1,0 +1,193 @@
+# Real cmux Contract Lane Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an opt-in `bun run test:contract` lane that verifies cmuxlayer against a live, explicitly pinned cmux instance without mutating that instance or touching fleet daemon state.
+
+**Architecture:** A standalone TypeScript runner performs the live assertions so Vitest's default discovery can never execute them. The runner first probes the explicit `CMUX_SOCKET_PATH`; absence or an unreachable/denied socket prints a clear skip and exits 0. Once admitted, it drives only read-only cmux/MCP operations, uses a temporary `CMUXLAYER_DAEMON_SOCKET` for all lifecycle checks, records every spawned PID, and sends signals only to those recorded PIDs during the isolated retire/autostart assertion and cleanup.
+
+**Tech Stack:** TypeScript/tsx, Node Unix sockets and child processes, MCP JSON-RPC over stdio, Vitest for hermetic runner-unit tests, Bash release gating.
+
+---
+
+## Design
+
+### Alternatives considered
+
+1. **Recommended: standalone contract runner plus hermetic unit tests.** This keeps the live lane wholly outside default Vitest discovery, permits a precise skip message/exit code, and makes PID/socket safety explicit. The trade-off is a small MCP harness in the runner.
+2. **Dedicated Vitest config and live test file.** This provides familiar assertions, but top-level reachability/skip reporting and detached-helper cleanup become harder to reason about, and an exclude/include configuration regression could leak the lane into `bun run test`.
+3. **Shell-only smoke script.** This is easy to invoke from releases, but JSON-RPC framing, response-shape validation, timeouts, and process cleanup are substantially more fragile in Bash.
+
+### Runtime flow
+
+1. Require a non-empty `CMUX_SOCKET_PATH` and send a bounded `system.ping` directly to that exact socket. Missing, unreachable, or access-denied pins produce `SKIP` and exit 0.
+2. Assert the admitted pane-descended process receives the expected `{ pong: true }` shape.
+3. Spawn a short-lived helper that launches a detached grandchild, exits, and leaves the grandchild reparented. The grandchild sends `system.ping` to the same socket and writes a result receipt into the contract temp directory. Assert the real daemon rejects it with the EPIPE/broken-pipe ancestry-denial signature. Record both helper and grandchild PIDs and clean up only those PIDs if still alive.
+4. Spawn `node dist/index.js` with the live cmux pin, a unique temp `CMUXLAYER_DAEMON_SOCKET`, a temp `HOME`, and piped MCP stdio. Initialize MCP, call `control_health`, and record the daemon PID returned by the real dist daemon.
+5. Call `list_surfaces`, choose a terminal surface from its structured response, then call `read_screen` for that exact surface/workspace. Assert both real-daemon calls return structured, non-error results.
+6. Run `node dist/index.js doctor --json` under the same isolated environment and assert exit 0 plus `healthy: true` and the expected daemon/cmux socket pins.
+7. Send SIGTERM only to the recorded isolated daemon PID, wait for it to exit, then issue another MCP request through the still-running proxy. Assert a replacement daemon is autostarted on the same isolated socket, returns healthy, and has a different recorded PID.
+8. Close the proxy and SIGTERM any still-live recorded child PID. Remove only the temp contract directory. Never unlink or write to `CMUX_SOCKET_PATH`.
+
+### Error handling and safety
+
+- All socket and MCP calls have finite timeouts and include captured stderr in failures.
+- The live cmux socket is used only for `system.ping`, `workspace.list`, `pane.list`, `surface.list`, and `surface.read_text` (directly or through read-only MCP tools).
+- Every lifecycle operation is guarded by an assertion that the daemon socket resides inside the freshly created temp root.
+- Cleanup iterates the recorded PID set; broad `pkill`, process-name matching, production socket cleanup, and fleet daemon signals are forbidden.
+- Contract assertion failures exit non-zero. Lack of a reachable explicit live pin is the only skip path and exits 0.
+
+## Implementation Tasks
+
+### Task 1: Specify runner contracts with failing hermetic tests
+
+**Files:**
+- Create: `tests/real-cmux-contract-runner.test.ts`
+- Create: `scripts/run-real-cmux-contract.ts`
+
+**Step 1: Write failing tests**
+
+Add focused tests for ping-shape validation, ancestry-denial classification, structured MCP payload extraction, terminal-surface selection, and refusal to signal a PID when the daemon socket is outside the owned temp root.
+
+**Step 2: Run tests to verify RED**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: FAIL because the runner exports do not exist yet.
+
+**Step 3: Implement the minimal pure helpers**
+
+Export only the validation/classification helpers needed by the tests. Guard the executable entrypoint with an is-main check so imports never start the live lane.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: PASS.
+
+### Task 2: Implement live socket and access-control assertions
+
+**Files:**
+- Modify: `scripts/run-real-cmux-contract.ts`
+- Test: `tests/real-cmux-contract-runner.test.ts`
+
+**Step 1: Add failing tests**
+
+Test missing/unreachable pin classification and orphan receipt parsing with temp fixtures.
+
+**Step 2: Run tests to verify RED**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: FAIL on the newly specified behavior.
+
+**Step 3: Add the bounded ping and orphan helper**
+
+Use Node's Unix-socket APIs for direct `system.ping`. Launch the orphan probe through a recorded helper process, persist its PID/result receipt inside the owned temp root, and assert the EPIPE-class denial.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: PASS.
+
+### Task 3: Implement the dist MCP round-trip and isolated lifecycle cycle
+
+**Files:**
+- Modify: `scripts/run-real-cmux-contract.ts`
+- Test: `tests/real-cmux-contract-runner.test.ts`
+
+**Step 1: Add failing tests**
+
+Specify MCP response parsing, daemon PID extraction, read-screen target extraction, and owned-socket lifecycle guards.
+
+**Step 2: Run tests to verify RED**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: FAIL on missing response/lifecycle helpers.
+
+**Step 3: Add the minimal live MCP harness**
+
+Spawn the built dist entrypoint under isolated environment pins, initialize JSON-RPC, call read-only tools, run doctor JSON, SIGTERM the recorded isolated daemon, and assert proxy-driven replacement autostart.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `bunx vitest run tests/real-cmux-contract-runner.test.ts`
+
+Expected: PASS.
+
+### Task 4: Wire package and release gates
+
+**Files:**
+- Modify: `package.json`
+- Modify: `scripts/release.sh`
+- Modify: `tests/pre-pr-scripts.test.ts`
+
+**Step 1: Add failing tests**
+
+Assert `test:contract` builds dist then runs the standalone runner, default `test` does not include it, and `release.sh` invokes the contract command after hermetic gates.
+
+**Step 2: Run tests to verify RED**
+
+Run: `bunx vitest run tests/pre-pr-scripts.test.ts`
+
+Expected: FAIL because the script and release gate are not wired yet.
+
+**Step 3: Add minimal wiring**
+
+Add `test:contract` and invoke it from the release preflight. The runner's skip contract makes unavailable live cmux warn-only; any real assertion failure remains non-zero and stops `set -e` release execution.
+
+**Step 4: Run tests to verify GREEN**
+
+Run: `bunx vitest run tests/pre-pr-scripts.test.ts tests/real-cmux-contract-runner.test.ts`
+
+Expected: PASS.
+
+### Task 5: Document the operator lane
+
+**Files:**
+- Create: `docs/runbooks/contract-lane.md`
+
+**Step 1: Write the one-page runbook**
+
+Document pre-release timing, the preferred NIGHTLY pin (`CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock`), the required launch-from-inside-NIGHTLY ancestry, the automatic isolated daemon socket, skip/pass/fail meanings, read-only fleet guarantees, and troubleshooting evidence to capture.
+
+**Step 2: Verify documentation commands and paths**
+
+Run: `rg -n "test:contract|/tmp/cmux-nightly.sock|CMUXLAYER_DAEMON_SOCKET|EPIPE|pre-release" docs/runbooks/contract-lane.md`
+
+Expected: every required operator concept is present.
+
+### Task 6: Full verification and PR loop
+
+**Files:**
+- Verify all changed files; do not modify `src/monitor-registry.ts`.
+
+**Step 1: Verify the skip path**
+
+Run: `env -u CMUX_SOCKET_PATH bun run test:contract`
+
+Expected: clear `SKIP`, exit 0, and no daemon lifecycle process started.
+
+**Step 2: Verify the live path when reachable**
+
+Run from a pane descended from the chosen cmux instance: `CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock bun run test:contract`
+
+Expected: ping, ancestry denial, list/read round-trip, doctor, and isolated retire/autostart assertions all PASS. If NIGHTLY is not running/reachable, record the explicit skip rather than claiming live coverage.
+
+**Step 3: Verify hermetic gates**
+
+Run: `bun run typecheck && bun run test && bun run build`
+
+Expected: all commands exit 0 with zero failed tests.
+
+**Step 4: Audit safety and scope**
+
+Run: `git diff --check && git diff -- src/monitor-registry.ts && git status --short`
+
+Expected: no whitespace errors, no monitor-registry diff, and only planned files changed.
+
+**Step 5: Commit, push, and open the PR**
+
+Commit the verified changes, push `test/r4-real-cmux-ci`, and create a ready PR titled `test: real-cmux contract lane (live-instance smoke, opt-in)` with exact verification receipts and any unavailable-live limitation stated explicitly.

--- a/docs/runbooks/contract-lane.md
+++ b/docs/runbooks/contract-lane.md
@@ -1,0 +1,35 @@
+# Real-cmux contract lane
+
+Run `bun run test:contract` before a release whenever a disposable or NIGHTLY cmux instance is available. The release script runs the same gate automatically: an unavailable live socket prints a warning and skips with exit 0; a reachable socket with any failed contract exits non-zero and stops the release.
+
+## Preferred NIGHTLY setup
+
+Use cmux NIGHTLY so the production fleet is never part of lifecycle QA. Start the command from a terminal pane inside NIGHTLY, because cmux authorizes socket clients by process ancestry:
+
+```bash
+CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock bun run test:contract
+```
+
+The NIGHTLY app must be running and `/tmp/cmux-nightly.sock` must be its socket. Do not substitute the production socket merely to make the lane run. The more detailed isolation background is in `docs.local/tasks/2026-07-11-nightly-restart-qa.md`.
+
+Do not set `CMUXLAYER_DAEMON_SOCKET` for this command. The runner always overrides it with a unique socket inside a fresh temporary directory. It also gives the contract stack a temporary `HOME`, starts the daemon from the repository's freshly built `dist`, records every spawned PID, and signals only those recorded PIDs.
+
+## What it proves
+
+The lane is read-only against the pinned cmux instance. It checks:
+
+- `system.ping` returns the expected `{ pong: true }` response to a pane-descended process;
+- a detached, reparented orphan is denied with the EPIPE/errno-32 ancestry contract;
+- `list_surfaces` and `read_screen` round-trip through a real cmuxlayer daemon launched from `dist`;
+- `doctor --json` reports healthy against the live cmux plus isolated daemon stack;
+- SIGTERM gracefully retires only the recorded isolated daemon, and the still-running dist proxy autostarts a different healthy daemon PID on the same isolated socket.
+
+It never creates, closes, renames, selects, types into, or otherwise mutates a cmux surface. It never kills, replaces, or unlinks a fleet daemon or fleet daemon socket.
+
+## Reading the result
+
+- `PASS real-cmux contract lane`: all live assertions completed, including the isolated retire/autostart cycle.
+- `SKIP`: `CMUX_SOCKET_PATH` was unset or could not answer the bounded ping from this process. This is CI-safe and exit 0, but it is not live coverage. For a pre-release run, launch the command from inside the target NIGHTLY pane and retry.
+- `FAIL`: treat this as an environment-fidelity regression. Do not release. Capture the full output, the pinned socket path, cmux/NIGHTLY version, cmuxlayer commit, spawned PID receipts, and whether the failure was ping shape, EPIPE denial, list/read, doctor, or retire/autostart.
+
+An EPIPE assertion failure usually means cmux's ancestry policy changed or the helper did not become a true orphan (`ppid` must be 1). A list/read or doctor failure means unit tests are no longer representative of the real daemon/socket stack. A retire/autostart failure means the release could strand persistent MCP clients after a daemon restart.

--- a/docs/runbooks/contract-lane.md
+++ b/docs/runbooks/contract-lane.md
@@ -12,6 +12,8 @@ CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock bun run test:contract
 
 The NIGHTLY app must be running and `/tmp/cmux-nightly.sock` must be its socket. Do not substitute the production socket merely to make the lane run. The more detailed isolation background is in `docs.local/tasks/2026-07-11-nightly-restart-qa.md`.
 
+The runner refuses the production fleet socket before sending even `system.ping`. It recognizes both `$HOME/.local/state/cmux/cmux-501.sock` and the canonical target recorded in `$HOME/.local/state/cmux/last-socket-path`. This makes the automatic release gate warn-only when a release is launched from a production-descended pane. For deliberate diagnostic work only, `CMUX_CONTRACT_ALLOW_PROD=1` bypasses this guard; all read-only and isolated-daemon constraints still apply.
+
 Do not set `CMUXLAYER_DAEMON_SOCKET` for this command. The runner always overrides it with a unique socket inside a fresh temporary directory. It also gives the contract stack a temporary `HOME`, starts the daemon from the repository's freshly built `dist`, records every spawned PID, and signals only those recorded PIDs.
 
 ## What it proves
@@ -29,7 +31,7 @@ It never creates, closes, renames, selects, types into, or otherwise mutates a c
 ## Reading the result
 
 - `PASS real-cmux contract lane`: all live assertions completed, including the isolated retire/autostart cycle.
-- `SKIP`: `CMUX_SOCKET_PATH` was unset or could not answer the bounded ping from this process. This is CI-safe and exit 0, but it is not live coverage. For a pre-release run, launch the command from inside the target NIGHTLY pane and retry.
+- `SKIP`: `CMUX_SOCKET_PATH` was unset, was recognized as production, or could not answer the bounded ping from this process. This is CI-safe and exit 0, but it is not live coverage. For a pre-release run, launch the command from inside the target NIGHTLY pane and retry.
 - `FAIL`: treat this as an environment-fidelity regression. Do not release. Capture the full output, the pinned socket path, cmux/NIGHTLY version, cmuxlayer commit, spawned PID receipts, and whether the failure was ping shape, EPIPE denial, list/read, doctor, or retire/autostart.
 
 An EPIPE assertion failure usually means cmux's ancestry policy changed or the helper did not become a true orphan (`ppid` must be 1). A list/read or doctor failure means unit tests are no longer representative of the real daemon/socket stack. A retire/autostart failure means the release could strand persistent MCP clients after a daemon restart.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "proxy": "node dist/proxy.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:contract": "bun run build && tsx scripts/run-real-cmux-contract.ts",
     "pre-pr": "bun run typecheck && bun run pre-pr:harness",
     "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/live-agent-harness-replay.test.ts tests/pre-pr-scripts.test.ts",
     "pre-pr:live": "bun run live:harness",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,6 +51,8 @@ fi
 echo "release: gating on typecheck + tests…"
 run "bun run typecheck"
 run "bun run test"
+echo "release: gating on real-cmux contracts (warn-only skip when no live CMUX_SOCKET_PATH is reachable)…"
+run "bun run test:contract"
 
 CURRENT="$(grep -E '^  "version":' package.json | head -1 | sed -E 's/.*"version": "([^"]+)".*/\1/')"
 echo "release: $CURRENT → $VERSION"

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -1,0 +1,889 @@
+#!/usr/bin/env node
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const ORPHAN_PARENT_MODE = "--orphan-parent";
+const ORPHAN_CHILD_MODE = "--orphan-child";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface SocketProbeReceipt {
+  ok: boolean;
+  result?: unknown;
+  code?: string;
+  errno?: number;
+  message?: string;
+}
+
+export interface OrphanProbeReceipt extends SocketProbeReceipt {
+  pid: number;
+  ppid: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function errorReceipt(error: unknown): SocketProbeReceipt {
+  const nodeError = error instanceof Error
+    ? (error as Error & { code?: string; errno?: number })
+    : null;
+  return {
+    ok: false,
+    code: nodeError?.code ?? "ERROR",
+    ...(typeof nodeError?.errno === "number" ? { errno: nodeError.errno } : {}),
+    message: nodeError?.message ?? String(error),
+  };
+}
+
+export function probeSystemPing(
+  socketPath: string,
+  timeoutMs = 2_000,
+): Promise<SocketProbeReceipt> {
+  return new Promise((resolveProbe) => {
+    const id = randomUUID();
+    const socket = net.createConnection({ path: socketPath });
+    let settled = false;
+    let buffer = "";
+    const settle = (receipt: SocketProbeReceipt) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.removeAllListeners();
+      socket.on("error", () => {});
+      socket.destroy();
+      resolveProbe(receipt);
+    };
+    const timer = setTimeout(
+      () =>
+        settle({
+          ok: false,
+          code: "ETIMEDOUT",
+          message: `system.ping timed out after ${timeoutMs}ms`,
+        }),
+      timeoutMs,
+    );
+
+    socket.once("connect", () => {
+      socket.write(
+        `${JSON.stringify({ id, method: "system.ping", params: {} })}\n`,
+        (error) => {
+          if (error) settle(errorReceipt(error));
+        },
+      );
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffer.slice(0, newline);
+      try {
+        const response: unknown = JSON.parse(line);
+        if (!isRecord(response) || response.id !== id) {
+          settle({
+            ok: false,
+            code: "EPROTO",
+            message: `system.ping returned an unexpected frame: ${line}`,
+          });
+          return;
+        }
+        if (response.ok !== true) {
+          const error = isRecord(response.error) ? response.error : {};
+          settle({
+            ok: false,
+            code: typeof error.code === "string" ? error.code : "ERROR",
+            message:
+              typeof error.message === "string"
+                ? error.message
+                : JSON.stringify(response.error),
+          });
+          return;
+        }
+        settle({ ok: true, result: response.result });
+      } catch (error) {
+        settle(errorReceipt(error));
+      }
+    });
+    socket.once("error", (error) => settle(errorReceipt(error)));
+    socket.once("close", () => {
+      settle({
+        ok: false,
+        code: "ECONNRESET",
+        message: "cmux socket closed before system.ping responded",
+      });
+    });
+  });
+}
+
+export function assertPingShape(value: unknown): asserts value is {
+  pong: true;
+} {
+  if (!isRecord(value) || value.pong !== true) {
+    throw new Error(
+      `system.ping must return { pong: true }, got ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+export function classifyLivePin(
+  socketPath: string | undefined,
+  receipt: SocketProbeReceipt | null,
+):
+  | { kind: "skip"; reason: string }
+  | { kind: "run"; socketPath: string } {
+  const pin = socketPath?.trim();
+  if (!pin) {
+    return { kind: "skip", reason: "CMUX_SOCKET_PATH is not set" };
+  }
+  if (!receipt?.ok) {
+    const detail = receipt
+      ? `${receipt.code ?? "ERROR"}: ${receipt.message ?? "unknown error"}`
+      : "not probed";
+    return {
+      kind: "skip",
+      reason: `CMUX_SOCKET_PATH is not reachable: ${pin} (${detail})`,
+    };
+  }
+  return { kind: "run", socketPath: pin };
+}
+
+export function parseOrphanReceipt(raw: string): OrphanProbeReceipt {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `invalid orphan probe receipt: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (
+    !isRecord(value) ||
+    !Number.isInteger(value.pid) ||
+    Number(value.pid) <= 0 ||
+    !Number.isInteger(value.ppid) ||
+    Number(value.ppid) < 0 ||
+    typeof value.ok !== "boolean" ||
+    (value.code !== undefined && typeof value.code !== "string") ||
+    (value.errno !== undefined && typeof value.errno !== "number") ||
+    (value.message !== undefined && typeof value.message !== "string")
+  ) {
+    throw new Error(`invalid orphan probe receipt: ${raw}`);
+  }
+  return value as unknown as OrphanProbeReceipt;
+}
+
+export function isAncestryDenial(receipt: OrphanProbeReceipt): boolean {
+  if (receipt.ok || receipt.ppid !== 1) return false;
+  return (
+    receipt.code === "EPIPE" ||
+    receipt.errno === 32 ||
+    /\b(?:EPIPE|broken pipe|errno\s*32)\b/i.test(receipt.message ?? "")
+  );
+}
+
+function toolText(result: Record<string, unknown>): string {
+  const content = result.content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (item): item is Record<string, unknown> & { text: string } =>
+        isRecord(item) && typeof item.text === "string",
+    )
+    .map((item) => item.text)
+    .join("\n");
+}
+
+export function extractStructuredContent(
+  response: unknown,
+): Record<string, unknown> {
+  if (!isRecord(response)) {
+    throw new Error(`invalid MCP response: ${JSON.stringify(response)}`);
+  }
+  if (response.error !== undefined) {
+    throw new Error(`MCP response error: ${JSON.stringify(response.error)}`);
+  }
+  if (!isRecord(response.result)) {
+    throw new Error(`MCP response missing result: ${JSON.stringify(response)}`);
+  }
+  const text = toolText(response.result);
+  if (response.result.isError === true) {
+    throw new Error(`MCP tool error: ${text || JSON.stringify(response.result)}`);
+  }
+  if (isRecord(response.result.structuredContent)) {
+    return response.result.structuredContent;
+  }
+  if (text) {
+    const parsed: unknown = JSON.parse(text);
+    if (isRecord(parsed)) return parsed;
+  }
+  throw new Error(
+    `MCP response missing structured content: ${JSON.stringify(response.result)}`,
+  );
+}
+
+export function selectTerminalSurface(payload: Record<string, unknown>): {
+  surface: string;
+  workspace: string;
+} {
+  const surfaces = Array.isArray(payload.surfaces) ? payload.surfaces : [];
+  for (const surface of surfaces) {
+    if (
+      isRecord(surface) &&
+      surface.type === "terminal" &&
+      typeof surface.ref === "string" &&
+      surface.ref.length > 0 &&
+      typeof surface.workspace_ref === "string" &&
+      surface.workspace_ref.length > 0
+    ) {
+      return { surface: surface.ref, workspace: surface.workspace_ref };
+    }
+  }
+  throw new Error("list_surfaces returned no terminal surface to read");
+}
+
+export function daemonPidFromHealth(payload: Record<string, unknown>): number {
+  const health = isRecord(payload.health) ? payload.health : null;
+  const current = health && isRecord(health.current_process)
+    ? health.current_process
+    : null;
+  const pid = current?.pid;
+  if (!Number.isInteger(pid) || Number(pid) <= 0) {
+    throw new Error(
+      `control_health response had no daemon pid: ${JSON.stringify(payload)}`,
+    );
+  }
+  return Number(pid);
+}
+
+export function daemonSpawnPidFromLog(message: string): number | null {
+  const matches = [
+    ...message.matchAll(/daemon spawn fired \([^\n]*\bpid=(\d+)\)/g),
+  ];
+  const match = matches.at(-1);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+export function assertLiveHealth(
+  payload: Record<string, unknown>,
+  cmuxSocket: string,
+): void {
+  const health = isRecord(payload.health) ? payload.health : null;
+  const transport = health && isRecord(health.selected_transport)
+    ? health.selected_transport
+    : null;
+  if (
+    !health ||
+    !transport ||
+    transport.transport_mode !== "socket" ||
+    transport.current_socket_path !== cmuxSocket ||
+    transport.transport_degraded !== false
+  ) {
+    throw new Error(
+      `control_health did not report socket-mode health on ${cmuxSocket}: ${JSON.stringify(payload)}`,
+    );
+  }
+}
+
+export function assertDoctorReport(
+  report: unknown,
+  cmuxSocket: string,
+  daemonSocket: string,
+): void {
+  const record = isRecord(report) ? report : null;
+  const daemon = record && isRecord(record.daemon) ? record.daemon : null;
+  const socketPath = record && isRecord(record.socketPath)
+    ? record.socketPath
+    : null;
+  if (
+    !record ||
+    record.healthy !== true ||
+    daemon?.ok !== true ||
+    daemon.socketPath !== daemonSocket ||
+    socketPath?.set !== true ||
+    socketPath.value !== cmuxSocket
+  ) {
+    throw new Error(
+      `doctor --json was not healthy on the isolated live stack: ${JSON.stringify(report)}`,
+    );
+  }
+}
+
+export function assertOwnedDaemonSocket(
+  ownedRoot: string,
+  daemonSocket: string,
+): void {
+  const root = resolve(ownedRoot);
+  const socket = resolve(daemonSocket);
+  if (socket === root || !socket.startsWith(`${root}${sep}`)) {
+    throw new Error(
+      `refusing daemon lifecycle action outside owned contract root: ${socket}`,
+    );
+  }
+}
+
+export function cleanupPidOrder(
+  recordedPids: ReadonlySet<number>,
+  proxyPid: number | undefined,
+): number[] {
+  const reverseSpawnOrder = [...recordedPids].reverse();
+  if (!proxyPid || !recordedPids.has(proxyPid)) return reverseSpawnOrder;
+  return [proxyPid, ...reverseSpawnOrder.filter((pid) => pid !== proxyPid)];
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${description}`);
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  await waitFor(() => !processExists(pid), timeoutMs, `process ${pid} to exit`);
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<string> {
+  let value = "";
+  await waitFor(
+    async () => {
+      try {
+        value = await readFile(path, "utf8");
+        return value.length > 0;
+      } catch {
+        return false;
+      }
+    },
+    timeoutMs,
+    `contract receipt ${path}`,
+  );
+  return value;
+}
+
+class McpPeer {
+  private nextId = 1;
+  private buffer = "";
+  private readonly pending = new Map<
+    number,
+    {
+      resolve: (message: Record<string, unknown>) => void;
+      reject: (error: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+  readonly stderr: string[] = [];
+
+  constructor(
+    readonly child: ChildProcess,
+    onSpawnedPid?: (pid: number) => void,
+  ) {
+    if (!child.stdin || !child.stdout) {
+      throw new Error("dist MCP child stdio must be piped");
+    }
+    child.stdout.on("data", (chunk: Buffer) => {
+      this.buffer += chunk.toString("utf8");
+      this.processBuffer();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      this.stderr.push(chunk.toString("utf8"));
+      const pid = daemonSpawnPidFromLog(this.stderr.join(""));
+      if (pid !== null) onSpawnedPid?.(pid);
+    });
+    child.once("exit", (code, signal) => {
+      const error = new Error(
+        `dist MCP child exited (code=${code ?? "none"}, signal=${signal ?? "none"})\n${this.stderr.join("")}`,
+      );
+      for (const pending of this.pending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  private processBuffer(): void {
+    let newline: number;
+    while ((newline = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, newline);
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line.trim()) continue;
+      let message: unknown;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        throw new Error(
+          `dist MCP emitted malformed JSON: ${line}; ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      if (!isRecord(message) || typeof message.id !== "number") continue;
+      const pending = this.pending.get(message.id);
+      if (!pending) continue;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      pending.resolve(message);
+    }
+  }
+
+  sendNotification(method: string, params: Record<string, unknown> = {}): void {
+    this.child.stdin!.write(
+      `${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`,
+    );
+  }
+
+  request(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    const id = this.nextId++;
+    return new Promise((resolveRequest, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `timed out after ${timeoutMs}ms waiting for MCP ${method}\n${this.stderr.join("")}`,
+          ),
+        );
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolveRequest, reject, timer });
+      this.child.stdin!.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+      );
+    });
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown> = {},
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    return this.request("tools/call", { name, arguments: args }, timeoutMs);
+  }
+
+  close(): void {
+    this.child.stdin?.end();
+  }
+}
+
+async function runOrphanChild(): Promise<void> {
+  const receiptPath = process.env.CMUX_CONTRACT_ORPHAN_RECEIPT;
+  const socketPath = process.env.CMUX_SOCKET_PATH;
+  if (!receiptPath || !socketPath) {
+    throw new Error("orphan child requires receipt and socket paths");
+  }
+  const deadline = Date.now() + 3_000;
+  while (process.ppid !== 1 && Date.now() < deadline) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+  }
+  const probe = await probeSystemPing(socketPath, 3_000);
+  const receipt: OrphanProbeReceipt = {
+    pid: process.pid,
+    ppid: process.ppid,
+    ...probe,
+  };
+  await writeFile(receiptPath, `${JSON.stringify(receipt)}\n`, "utf8");
+}
+
+async function runOrphanParent(): Promise<void> {
+  const pidPath = process.env.CMUX_CONTRACT_ORPHAN_PID;
+  if (!pidPath) throw new Error("orphan parent requires a pid receipt path");
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", SCRIPT_PATH, ORPHAN_CHILD_MODE],
+    {
+      detached: true,
+      env: process.env,
+      stdio: "ignore",
+    },
+  );
+  if (!child.pid) throw new Error("orphan child did not expose a pid");
+  await writeFile(pidPath, `${child.pid}\n`, "utf8");
+  child.unref();
+}
+
+async function runOrphanContract(
+  root: string,
+  socketPath: string,
+  recordedPids: Set<number>,
+): Promise<OrphanProbeReceipt> {
+  const receiptPath = join(root, "orphan-result.json");
+  const pidPath = join(root, "orphan.pid");
+  const parent = spawn(
+    process.execPath,
+    ["--import", "tsx", SCRIPT_PATH, ORPHAN_PARENT_MODE],
+    {
+      env: {
+        ...process.env,
+        CMUX_SOCKET_PATH: socketPath,
+        CMUX_CONTRACT_ORPHAN_RECEIPT: receiptPath,
+        CMUX_CONTRACT_ORPHAN_PID: pidPath,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (!parent.pid) throw new Error("orphan parent did not expose a pid");
+  recordedPids.add(parent.pid);
+  const parentErrors: string[] = [];
+  parent.stderr?.on("data", (chunk: Buffer) => {
+    parentErrors.push(chunk.toString("utf8"));
+  });
+  await new Promise<void>((resolveExit, reject) => {
+    parent.once("error", reject);
+    parent.once("exit", (code) => {
+      if (code === 0) resolveExit();
+      else
+        reject(
+          new Error(`orphan parent exited ${code}: ${parentErrors.join("")}`),
+        );
+    });
+  });
+  const orphanPid = Number((await waitForFile(pidPath, 3_000)).trim());
+  if (!Number.isInteger(orphanPid) || orphanPid <= 0) {
+    throw new Error(`orphan parent wrote invalid pid: ${orphanPid}`);
+  }
+  recordedPids.add(orphanPid);
+  return parseOrphanReceipt(await waitForFile(receiptPath, 6_000));
+}
+
+async function runDoctor(
+  distIndex: string,
+  env: NodeJS.ProcessEnv,
+  cmuxSocket: string,
+  daemonSocket: string,
+  recordedPids: Set<number>,
+): Promise<void> {
+  const child = spawn(process.execPath, [distIndex, "doctor", "--json"], {
+    cwd: process.cwd(),
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (!child.pid) throw new Error("doctor child did not expose a pid");
+  recordedPids.add(child.pid);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  child.stdout?.on("data", (chunk: Buffer) =>
+    stdout.push(chunk.toString("utf8")),
+  );
+  child.stderr?.on("data", (chunk: Buffer) =>
+    stderr.push(chunk.toString("utf8")),
+  );
+  const { code, signal } = await waitForChildExit(child, {
+    timeoutMs: 15_000,
+    killGraceMs: 2_000,
+  });
+  if (code !== 0) {
+    throw new Error(
+      `doctor --json exited code=${code ?? "none"} signal=${signal ?? "none"}: ${stderr.join("") || stdout.join("")}`,
+    );
+  }
+  let report: unknown;
+  try {
+    report = JSON.parse(stdout.join(""));
+  } catch (error) {
+    throw new Error(
+      `doctor --json returned invalid JSON: ${stdout.join("")}; ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertDoctorReport(report, cmuxSocket, daemonSocket);
+}
+
+interface ChildExitEmitter {
+  pid?: number;
+  once(event: "error", listener: (error: Error) => void): unknown;
+  once(
+    event: "exit",
+    listener: (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ) => void,
+  ): unknown;
+  off(event: "error" | "exit", listener: (...args: any[]) => void): unknown;
+}
+
+export function waitForChildExit(
+  child: ChildExitEmitter,
+  opts: {
+    timeoutMs: number;
+    killGraceMs: number;
+    processExists?: (pid: number) => boolean;
+    kill?: (pid: number, signal: NodeJS.Signals) => void;
+  },
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  const pid = child.pid;
+  if (!pid) return Promise.reject(new Error("child did not expose a pid"));
+  const exists = opts.processExists ?? processExists;
+  const kill = opts.kill ?? ((target, signal) => process.kill(target, signal));
+
+  return new Promise((resolveExit, reject) => {
+    let timedOut = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    const cleanup = () => {
+      clearTimeout(timeoutTimer);
+      if (killTimer) clearTimeout(killTimer);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    const timeoutError = () =>
+      new Error(`child ${pid} timed out after ${opts.timeoutMs}ms`);
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ) => {
+      cleanup();
+      if (timedOut) reject(timeoutError());
+      else resolveExit({ code, signal });
+    };
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        if (exists(pid)) kill(pid, "SIGTERM");
+      } catch (error) {
+        cleanup();
+        reject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      killTimer = setTimeout(() => {
+        try {
+          if (exists(pid)) kill(pid, "SIGKILL");
+        } catch (error) {
+          cleanup();
+          reject(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        cleanup();
+        reject(timeoutError());
+      }, opts.killGraceMs);
+    }, opts.timeoutMs);
+
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+}
+
+function socketAccepts(path: string): Promise<boolean> {
+  return new Promise((resolveProbe) => {
+    const socket = net.createConnection({ path });
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.removeAllListeners();
+      socket.on("error", () => {});
+      socket.destroy();
+      resolveProbe(value);
+    };
+    socket.setTimeout(250, () => settle(false));
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
+  });
+}
+
+async function terminateRecordedPid(
+  pid: number,
+  recordedPids: Set<number>,
+  signal: NodeJS.Signals = "SIGTERM",
+  forceAfterTimeout = false,
+): Promise<void> {
+  if (!recordedPids.has(pid)) {
+    throw new Error(`refusing to signal unrecorded pid ${pid}`);
+  }
+  if (!processExists(pid)) return;
+  process.kill(pid, signal);
+  try {
+    await waitForProcessExit(pid, 5_000);
+  } catch (error) {
+    if (!forceAfterTimeout || !processExists(pid)) throw error;
+    process.kill(pid, "SIGKILL");
+    await waitForProcessExit(pid, 2_000);
+  }
+}
+
+async function runContract(): Promise<void> {
+  const requestedSocket = process.env.CMUX_SOCKET_PATH;
+  const preflight = requestedSocket?.trim()
+    ? await probeSystemPing(requestedSocket.trim(), 2_000)
+    : null;
+  const classification = classifyLivePin(requestedSocket, preflight);
+  if (classification.kind === "skip") {
+    console.warn(`[contract] SKIP: ${classification.reason}`);
+    return;
+  }
+  assertPingShape(preflight?.result);
+  const cmuxSocket = classification.socketPath;
+  console.log(`[contract] PASS system.ping shape on ${cmuxSocket}`);
+
+  const root = await mkdtemp(join(tmpdir(), "cmuxlayer-real-contract-"));
+  const daemonSocket = join(root, "cmuxlayer-stated.sock");
+  const home = join(root, "home");
+  const recordedPids = new Set<number>();
+  let peer: McpPeer | null = null;
+  assertOwnedDaemonSocket(root, daemonSocket);
+
+  try {
+    const orphan = await runOrphanContract(root, cmuxSocket, recordedPids);
+    if (!isAncestryDenial(orphan)) {
+      throw new Error(
+        `detached-orphan probe was not denied with EPIPE ancestry contract: ${JSON.stringify(orphan)}`,
+      );
+    }
+    console.log(
+      `[contract] PASS detached orphan pid=${orphan.pid} denied with ${orphan.code ?? `errno ${orphan.errno}`}`,
+    );
+
+    const distIndex = resolve("dist", "index.js");
+    const distDaemon = resolve("dist", "daemon.js");
+    await Promise.all([access(distIndex), access(distDaemon)]);
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: home,
+      CMUX_SOCKET_PATH: cmuxSocket,
+      CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+      CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
+    };
+
+    const initialDaemon = spawn(process.execPath, [distDaemon], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (!initialDaemon.pid) {
+      throw new Error("dist daemon did not expose a pid");
+    }
+    recordedPids.add(initialDaemon.pid);
+    const initialDaemonErrors: string[] = [];
+    initialDaemon.stderr?.on("data", (chunk: Buffer) =>
+      initialDaemonErrors.push(chunk.toString("utf8")),
+    );
+    await waitFor(
+      () => socketAccepts(daemonSocket),
+      10_000,
+      `dist daemon ${initialDaemon.pid} to listen on ${daemonSocket}; stderr=${initialDaemonErrors.join("")}`,
+    );
+
+    const proxy = spawn(process.execPath, [distIndex], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (!proxy.pid) throw new Error("dist MCP proxy did not expose a pid");
+    recordedPids.add(proxy.pid);
+    peer = new McpPeer(proxy, (pid) => recordedPids.add(pid));
+
+    await peer.request("initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "cmuxlayer-real-contract", version: "1" },
+    });
+    peer.sendNotification("notifications/initialized");
+
+    const healthResponse = await peer.callTool("control_health", {}, 15_000);
+    const health = extractStructuredContent(healthResponse);
+    assertLiveHealth(health, cmuxSocket);
+    const initialDaemonPid = daemonPidFromHealth(health);
+    if (initialDaemonPid !== initialDaemon.pid) {
+      throw new Error(
+        `control_health daemon pid ${initialDaemonPid} did not match recorded dist daemon ${initialDaemon.pid}`,
+      );
+    }
+
+    const listResponse = await peer.callTool("list_surfaces", {}, 20_000);
+    const surfaces = extractStructuredContent(listResponse);
+    const target = selectTerminalSurface(surfaces);
+    const readResponse = await peer.callTool(
+      "read_screen",
+      {
+        surface: target.surface,
+        workspace: target.workspace,
+        lines: 20,
+      },
+      15_000,
+    );
+    const screen = extractStructuredContent(readResponse);
+    if (screen.ok !== true || screen.surface !== target.surface) {
+      throw new Error(
+        `read_screen did not round-trip ${target.surface}: ${JSON.stringify(screen)}`,
+      );
+    }
+    console.log(
+      `[contract] PASS list_surfaces/read_screen through dist daemon pid=${initialDaemonPid}`,
+    );
+
+    await runDoctor(distIndex, env, cmuxSocket, daemonSocket, recordedPids);
+    console.log("[contract] PASS doctor --json healthy on isolated live stack");
+
+    assertOwnedDaemonSocket(root, daemonSocket);
+    await terminateRecordedPid(initialDaemonPid, recordedPids);
+
+    const recoveredResponse = await peer.callTool("control_health", {}, 20_000);
+    const recoveredHealth = extractStructuredContent(recoveredResponse);
+    assertLiveHealth(recoveredHealth, cmuxSocket);
+    const replacementDaemonPid = daemonPidFromHealth(recoveredHealth);
+    recordedPids.add(replacementDaemonPid);
+    if (replacementDaemonPid === initialDaemonPid) {
+      throw new Error("isolated daemon did not autostart a replacement pid");
+    }
+    await runDoctor(distIndex, env, cmuxSocket, daemonSocket, recordedPids);
+    console.log(
+      `[contract] PASS graceful retire/autostart ${initialDaemonPid} -> ${replacementDaemonPid}`,
+    );
+    console.log("[contract] PASS real-cmux contract lane");
+  } finally {
+    peer?.close();
+    const proxyPid = peer?.child.pid;
+    for (const pid of cleanupPidOrder(recordedPids, proxyPid)) {
+      await terminateRecordedPid(pid, recordedPids, "SIGTERM", true).catch(
+        (error) => {
+          console.error(`[contract] cleanup warning for pid ${pid}:`, error);
+        },
+      );
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2];
+  if (mode === ORPHAN_PARENT_MODE) {
+    await runOrphanParent();
+    return;
+  }
+  if (mode === ORPHAN_CHILD_MODE) {
+    await runOrphanChild();
+    return;
+  }
+  await runContract();
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(SCRIPT_PATH)) {
+  main().catch((error) => {
+    console.error(
+      `[contract] FAIL: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -338,6 +338,16 @@ export function daemonSpawnPidFromLog(message: string): number | null {
   return Number.isInteger(pid) && pid > 0 ? pid : null;
 }
 
+export function daemonExitPidFromLog(message: string): number | null {
+  const matches = [
+    ...message.matchAll(/spawned daemon exited \(pid=(\d+),[^\n]*\)/g),
+  ];
+  const match = matches.at(-1);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
 export function assertLiveHealth(
   payload: Record<string, unknown>,
   cmuxSocket: string,
@@ -414,6 +424,22 @@ function processExists(pid: number): boolean {
   }
 }
 
+interface PidExitEmitter {
+  pid?: number;
+  once(event: "exit", listener: (...args: any[]) => void): unknown;
+}
+
+export function trackChildPid(
+  child: PidExitEmitter,
+  recordedPids: Set<number>,
+): number {
+  const pid = child.pid;
+  if (!pid) throw new Error("child did not expose a pid");
+  recordedPids.add(pid);
+  child.once("exit", () => recordedPids.delete(pid));
+  return pid;
+}
+
 async function waitFor(
   predicate: () => boolean | Promise<boolean>,
   timeoutMs: number,
@@ -448,7 +474,7 @@ async function waitForFile(path: string, timeoutMs: number): Promise<string> {
   return value;
 }
 
-class McpPeer {
+export class McpPeer {
   private nextId = 1;
   private buffer = "";
   private readonly pending = new Map<
@@ -459,34 +485,52 @@ class McpPeer {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  private fatalError: Error | null = null;
   readonly stderr: string[] = [];
 
   constructor(
     readonly child: ChildProcess,
-    onSpawnedPid?: (pid: number) => void,
+    private readonly onSpawnedPid?: (pid: number) => void,
+    private readonly onExitedPid?: (pid: number) => void,
   ) {
     if (!child.stdin || !child.stdout) {
       throw new Error("dist MCP child stdio must be piped");
     }
-    child.stdout.on("data", (chunk: Buffer) => {
-      this.buffer += chunk.toString("utf8");
-      this.processBuffer();
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      this.stderr.push(chunk.toString("utf8"));
-      const pid = daemonSpawnPidFromLog(this.stderr.join(""));
-      if (pid !== null) onSpawnedPid?.(pid);
-    });
-    child.once("exit", (code, signal) => {
-      const error = new Error(
-        `dist MCP child exited (code=${code ?? "none"}, signal=${signal ?? "none"})\n${this.stderr.join("")}`,
-      );
-      for (const pending of this.pending.values()) {
-        clearTimeout(pending.timer);
-        pending.reject(error);
-      }
-      this.pending.clear();
-    });
+    child.stdout.on("data", this.onStdoutData);
+    child.stderr?.on("data", this.onStderrData);
+    child.once("exit", this.onChildExit);
+  }
+
+  private readonly onStdoutData = (chunk: Buffer): void => {
+    this.buffer += chunk.toString("utf8");
+    this.processBuffer();
+  };
+
+  private readonly onStderrData = (chunk: Buffer): void => {
+    this.stderr.push(chunk.toString("utf8"));
+    const pid = daemonSpawnPidFromLog(this.stderr.join(""));
+    if (pid !== null) this.onSpawnedPid?.(pid);
+    const exitedPid = daemonExitPidFromLog(this.stderr.join(""));
+    if (exitedPid !== null) this.onExitedPid?.(exitedPid);
+  };
+
+  private readonly onChildExit = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    const error = new Error(
+      `dist MCP child exited (code=${code ?? "none"}, signal=${signal ?? "none"})\n${this.stderr.join("")}`,
+    );
+    this.failPending(error);
+  };
+
+  private failPending(error: Error): void {
+    this.fatalError ??= error;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(this.fatalError);
+    }
+    this.pending.clear();
   }
 
   private processBuffer(): void {
@@ -499,9 +543,12 @@ class McpPeer {
       try {
         message = JSON.parse(line);
       } catch (error) {
-        throw new Error(
-          `dist MCP emitted malformed JSON: ${line}; ${error instanceof Error ? error.message : String(error)}`,
+        this.failPending(
+          new Error(
+            `dist MCP emitted malformed JSON: ${line}; ${error instanceof Error ? error.message : String(error)}`,
+          ),
         );
+        return;
       }
       if (!isRecord(message) || typeof message.id !== "number") continue;
       const pending = this.pending.get(message.id);
@@ -523,6 +570,7 @@ class McpPeer {
     params: Record<string, unknown> = {},
     timeoutMs = DEFAULT_TIMEOUT_MS,
   ): Promise<Record<string, unknown>> {
+    if (this.fatalError) return Promise.reject(this.fatalError);
     const id = this.nextId++;
     return new Promise((resolveRequest, reject) => {
       const timer = setTimeout(() => {
@@ -549,6 +597,10 @@ class McpPeer {
   }
 
   close(): void {
+    this.failPending(new Error("dist MCP peer closed"));
+    this.child.stdout?.off("data", this.onStdoutData);
+    this.child.stderr?.off("data", this.onStderrData);
+    this.child.off("exit", this.onChildExit);
     this.child.stdin?.end();
   }
 }
@@ -610,27 +662,30 @@ async function runOrphanContract(
     },
   );
   if (!parent.pid) throw new Error("orphan parent did not expose a pid");
-  recordedPids.add(parent.pid);
+  trackChildPid(parent, recordedPids);
   const parentErrors: string[] = [];
   parent.stderr?.on("data", (chunk: Buffer) => {
     parentErrors.push(chunk.toString("utf8"));
   });
-  await new Promise<void>((resolveExit, reject) => {
-    parent.once("error", reject);
-    parent.once("exit", (code) => {
-      if (code === 0) resolveExit();
-      else
-        reject(
-          new Error(`orphan parent exited ${code}: ${parentErrors.join("")}`),
-        );
-    });
+  const { code, signal } = await waitForChildExit(parent, {
+    timeoutMs: 6_000,
+    killGraceMs: 2_000,
   });
+  if (code !== 0) {
+    throw new Error(
+      `orphan parent exited code=${code ?? "none"} signal=${signal ?? "none"}: ${parentErrors.join("")}`,
+    );
+  }
   const orphanPid = Number((await waitForFile(pidPath, 3_000)).trim());
   if (!Number.isInteger(orphanPid) || orphanPid <= 0) {
     throw new Error(`orphan parent wrote invalid pid: ${orphanPid}`);
   }
   recordedPids.add(orphanPid);
-  return parseOrphanReceipt(await waitForFile(receiptPath, 6_000));
+  const receipt = parseOrphanReceipt(await waitForFile(receiptPath, 6_000));
+  await waitForProcessExit(orphanPid, 2_000)
+    .then(() => recordedPids.delete(orphanPid))
+    .catch(() => {});
+  return receipt;
 }
 
 async function runDoctor(
@@ -646,7 +701,7 @@ async function runDoctor(
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (!child.pid) throw new Error("doctor child did not expose a pid");
-  recordedPids.add(child.pid);
+  trackChildPid(child, recordedPids);
   const stdout: string[] = [];
   const stderr: string[] = [];
   child.stdout?.on("data", (chunk: Buffer) =>
@@ -779,7 +834,10 @@ async function terminateRecordedPid(
   if (!recordedPids.has(pid)) {
     throw new Error(`refusing to signal unrecorded pid ${pid}`);
   }
-  if (!processExists(pid)) return;
+  if (!processExists(pid)) {
+    recordedPids.delete(pid);
+    return;
+  }
   process.kill(pid, signal);
   try {
     await waitForProcessExit(pid, 5_000);
@@ -788,6 +846,7 @@ async function terminateRecordedPid(
     process.kill(pid, "SIGKILL");
     await waitForProcessExit(pid, 2_000);
   }
+  recordedPids.delete(pid);
 }
 
 async function runContract(): Promise<void> {
@@ -849,7 +908,7 @@ async function runContract(): Promise<void> {
     if (!initialDaemon.pid) {
       throw new Error("dist daemon did not expose a pid");
     }
-    recordedPids.add(initialDaemon.pid);
+    trackChildPid(initialDaemon, recordedPids);
     const initialDaemonErrors: string[] = [];
     initialDaemon.stderr?.on("data", (chunk: Buffer) =>
       initialDaemonErrors.push(chunk.toString("utf8")),
@@ -866,8 +925,12 @@ async function runContract(): Promise<void> {
       stdio: ["pipe", "pipe", "pipe"],
     });
     if (!proxy.pid) throw new Error("dist MCP proxy did not expose a pid");
-    recordedPids.add(proxy.pid);
-    peer = new McpPeer(proxy, (pid) => recordedPids.add(pid));
+    trackChildPid(proxy, recordedPids);
+    peer = new McpPeer(
+      proxy,
+      (pid) => recordedPids.add(pid),
+      (pid) => recordedPids.delete(pid),
+    );
 
     await peer.request("initialize", {
       protocolVersion: "2025-03-26",

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -2,9 +2,16 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import net from "node:net";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -151,6 +158,66 @@ export function classifyLivePin(
     };
   }
   return { kind: "run", socketPath: pin };
+}
+
+async function canonicalSocketPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code !== "ENOENT") throw error;
+    return resolve(path);
+  }
+}
+
+function expandHomePath(path: string, homeDir: string): string {
+  if (path === "~") return homeDir;
+  if (path.startsWith(`~${sep}`)) return join(homeDir, path.slice(2));
+  return path;
+}
+
+export async function classifyProductionPin(
+  socketPath: string,
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    homeDir?: string;
+  } = {},
+): Promise<
+  | { kind: "skip"; reason: string }
+  | { kind: "admit"; socketPath: string }
+> {
+  const pin = socketPath.trim();
+  const env = opts.env ?? process.env;
+  if (env.CMUX_CONTRACT_ALLOW_PROD === "1") {
+    return { kind: "admit", socketPath: pin };
+  }
+
+  const homeDir = opts.homeDir ?? homedir();
+  const stateDir = join(homeDir, ".local", "state", "cmux");
+  const productionPaths = [join(stateDir, "cmux-501.sock")];
+  try {
+    const lastSocketPath = (
+      await readFile(join(stateDir, "last-socket-path"), "utf8")
+    ).trim();
+    if (lastSocketPath) {
+      productionPaths.push(expandHomePath(lastSocketPath, homeDir));
+    }
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code !== "ENOENT") throw error;
+  }
+
+  const canonicalPin = await canonicalSocketPath(pin);
+  const canonicalProduction = await Promise.all(
+    productionPaths.map((path) => canonicalSocketPath(path)),
+  );
+  if (canonicalProduction.includes(canonicalPin)) {
+    return {
+      kind: "skip",
+      reason: `refusing production cmux socket ${pin}; pin NIGHTLY /tmp/cmux-nightly.sock (or set CMUX_CONTRACT_ALLOW_PROD=1 to override)`,
+    };
+  }
+  return { kind: "admit", socketPath: pin };
 }
 
 export function parseOrphanReceipt(raw: string): OrphanProbeReceipt {
@@ -725,8 +792,16 @@ async function terminateRecordedPid(
 
 async function runContract(): Promise<void> {
   const requestedSocket = process.env.CMUX_SOCKET_PATH;
-  const preflight = requestedSocket?.trim()
-    ? await probeSystemPing(requestedSocket.trim(), 2_000)
+  const requestedPin = requestedSocket?.trim();
+  if (requestedPin) {
+    const productionGuard = await classifyProductionPin(requestedPin);
+    if (productionGuard.kind === "skip") {
+      console.warn(`[contract] SKIP: ${productionGuard.reason}`);
+      return;
+    }
+  }
+  const preflight = requestedPin
+    ? await probeSystemPing(requestedPin, 2_000)
     : null;
   const classification = classifyLivePin(requestedSocket, preflight);
   if (classification.kind === "skip") {

--- a/tests/pre-pr-scripts.test.ts
+++ b/tests/pre-pr-scripts.test.ts
@@ -34,6 +34,25 @@ describe("pre-PR script ladder", () => {
     expect(scripts["pre-pr:live"]).toBe("bun run live:harness");
   });
 
+  it("exposes the real-cmux contract lane without adding it to default tests", () => {
+    const scripts = packageScripts();
+
+    expect(scripts["test:contract"]).toBe(
+      "bun run build && tsx scripts/run-real-cmux-contract.ts",
+    );
+    expect(scripts.test).toBe("vitest run");
+    expect(scripts.test).not.toContain("contract");
+  });
+
+  it("runs the opt-in contract lane from the release preflight", () => {
+    const release = readFileSync(join(repoRoot, "scripts", "release.sh"), "utf8");
+    const hermeticGate = release.indexOf('run "bun run test"');
+    const contractGate = release.indexOf('run "bun run test:contract"');
+
+    expect(hermeticGate).toBeGreaterThan(-1);
+    expect(contractGate).toBeGreaterThan(hermeticGate);
+  });
+
   it("refuses the live harness unless CMUX_LIVE_HARNESS=1 is set", () => {
     const result = spawnSync(
       process.execPath,

--- a/tests/real-cmux-contract-runner.test.ts
+++ b/tests/real-cmux-contract-runner.test.ts
@@ -1,6 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
@@ -11,6 +17,7 @@ import {
   assertLiveHealth,
   assertPingShape,
   classifyLivePin,
+  classifyProductionPin,
   cleanupPidOrder,
   daemonPidFromHealth,
   daemonSpawnPidFromLog,
@@ -88,6 +95,78 @@ describe("real cmux contract runner helpers", () => {
         result: { pong: true },
       }),
     ).toEqual({ kind: "run", socketPath: "/tmp/cmux-nightly.sock" });
+  });
+
+  it("skips the default production socket before probing", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-contract-prod-home-"));
+    tempRoots.push(home);
+    const productionSocket = join(
+      home,
+      ".local",
+      "state",
+      "cmux",
+      "cmux-501.sock",
+    );
+
+    await expect(
+      classifyProductionPin(productionSocket, { homeDir: home, env: {} }),
+    ).resolves.toEqual({
+      kind: "skip",
+      reason: `refusing production cmux socket ${productionSocket}; pin NIGHTLY /tmp/cmux-nightly.sock (or set CMUX_CONTRACT_ALLOW_PROD=1 to override)`,
+    });
+  });
+
+  it("admits the NIGHTLY socket through the production guard", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-contract-nightly-home-"));
+    tempRoots.push(home);
+
+    await expect(
+      classifyProductionPin("/tmp/cmux-nightly.sock", {
+        homeDir: home,
+        env: {},
+      }),
+    ).resolves.toEqual({
+      kind: "admit",
+      socketPath: "/tmp/cmux-nightly.sock",
+    });
+  });
+
+  it("admits production only with the deliberate override", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-contract-prod-override-"));
+    tempRoots.push(home);
+    const productionSocket = join(
+      home,
+      ".local",
+      "state",
+      "cmux",
+      "cmux-501.sock",
+    );
+
+    await expect(
+      classifyProductionPin(productionSocket, {
+        homeDir: home,
+        env: { CMUX_CONTRACT_ALLOW_PROD: "1" },
+      }),
+    ).resolves.toEqual({ kind: "admit", socketPath: productionSocket });
+  });
+
+  it("treats the canonical last-socket-path target as production", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-contract-prod-marker-"));
+    tempRoots.push(home);
+    const stateDir = join(home, ".local", "state", "cmux");
+    const actualSocket = join(home, "actual-production.sock");
+    const socketAlias = join(home, "production-alias.sock");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(actualSocket, "socket fixture");
+    symlinkSync(actualSocket, socketAlias);
+    writeFileSync(join(stateDir, "last-socket-path"), `${socketAlias}\n`);
+
+    await expect(
+      classifyProductionPin(actualSocket, { homeDir: home, env: {} }),
+    ).resolves.toEqual({
+      kind: "skip",
+      reason: `refusing production cmux socket ${actualSocket}; pin NIGHTLY /tmp/cmux-nightly.sock (or set CMUX_CONTRACT_ALLOW_PROD=1 to override)`,
+    });
   });
 
   it("performs a bounded system.ping against an exact Unix socket", async () => {

--- a/tests/real-cmux-contract-runner.test.ts
+++ b/tests/real-cmux-contract-runner.test.ts
@@ -1,0 +1,387 @@
+import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertOwnedDaemonSocket,
+  assertDoctorReport,
+  assertLiveHealth,
+  assertPingShape,
+  classifyLivePin,
+  cleanupPidOrder,
+  daemonPidFromHealth,
+  daemonSpawnPidFromLog,
+  extractStructuredContent,
+  isAncestryDenial,
+  parseOrphanReceipt,
+  probeSystemPing,
+  selectTerminalSurface,
+  waitForChildExit,
+} from "../scripts/run-real-cmux-contract.js";
+
+const tempRoots: string[] = [];
+const servers: net.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("real cmux contract runner helpers", () => {
+  it("skips clearly and successfully when no live cmux pin is provided", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        join(process.cwd(), "scripts", "run-real-cmux-contract.ts"),
+      ],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, CMUX_SOCKET_PATH: "" },
+        encoding: "utf8",
+        timeout: 10_000,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toContain(
+      "SKIP: CMUX_SOCKET_PATH is not set",
+    );
+  });
+
+  it("accepts only the live system.ping response shape", () => {
+    expect(() => assertPingShape({ pong: true })).not.toThrow();
+    expect(() => assertPingShape({ pong: false })).toThrow(/pong: true/);
+    expect(() => assertPingShape({ ok: true })).toThrow(/pong: true/);
+    expect(() => assertPingShape(null)).toThrow(/pong: true/);
+  });
+
+  it("classifies only explicit reachable pins as runnable", () => {
+    expect(classifyLivePin(undefined, null)).toEqual({
+      kind: "skip",
+      reason: "CMUX_SOCKET_PATH is not set",
+    });
+    expect(
+      classifyLivePin("/tmp/cmux-nightly.sock", {
+        ok: false,
+        code: "ENOENT",
+        message: "connect ENOENT",
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason:
+        "CMUX_SOCKET_PATH is not reachable: /tmp/cmux-nightly.sock (ENOENT: connect ENOENT)",
+    });
+    expect(
+      classifyLivePin("/tmp/cmux-nightly.sock", {
+        ok: true,
+        result: { pong: true },
+      }),
+    ).toEqual({ kind: "run", socketPath: "/tmp/cmux-nightly.sock" });
+  });
+
+  it("performs a bounded system.ping against an exact Unix socket", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmux-contract-probe-"));
+    tempRoots.push(root);
+    const socketPath = join(root, "cmux.sock");
+    const server = net.createServer((socket) => {
+      let buffer = "";
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        if (!buffer.includes("\n")) return;
+        const request = JSON.parse(buffer.trim()) as { id: string };
+        socket.end(
+          `${JSON.stringify({ id: request.id, ok: true, result: { pong: true } })}\n`,
+        );
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    await expect(probeSystemPing(socketPath, 500)).resolves.toEqual({
+      ok: true,
+      result: { pong: true },
+    });
+    await expect(
+      probeSystemPing(join(root, "missing.sock"), 100),
+    ).resolves.toEqual(
+      expect.objectContaining({ ok: false, code: "ENOENT" }),
+    );
+  });
+
+  it("recognizes the detached-orphan EPIPE ancestry contract", () => {
+    expect(
+      isAncestryDenial({
+        pid: 42,
+        ppid: 1,
+        ok: false,
+        code: "EPIPE",
+        message: "write EPIPE",
+      }),
+    ).toBe(true);
+    expect(
+      isAncestryDenial({
+        pid: 42,
+        ppid: 1,
+        ok: false,
+        errno: 32,
+        message: "Broken pipe",
+      }),
+    ).toBe(true);
+    expect(
+      isAncestryDenial({
+        pid: 42,
+        ppid: 99,
+        ok: false,
+        code: "EPIPE",
+        message: "write EPIPE",
+      }),
+    ).toBe(false);
+    expect(
+      isAncestryDenial({
+        pid: 42,
+        ppid: 1,
+        ok: false,
+        code: "ECONNREFUSED",
+        message: "connect refused",
+      }),
+    ).toBe(false);
+  });
+
+  it("parses a complete orphan receipt", () => {
+    expect(
+      parseOrphanReceipt(
+        JSON.stringify({
+          pid: 42,
+          ppid: 1,
+          ok: false,
+          code: "EPIPE",
+          message: "write EPIPE",
+        }),
+      ),
+    ).toEqual({
+      pid: 42,
+      ppid: 1,
+      ok: false,
+      code: "EPIPE",
+      message: "write EPIPE",
+    });
+    expect(() => parseOrphanReceipt('{"pid":42}')).toThrow(
+      /invalid orphan probe receipt/,
+    );
+  });
+
+  it("extracts structured MCP payloads and rejects tool errors", () => {
+    expect(
+      extractStructuredContent({
+        result: {
+          structuredContent: { surfaces: [] },
+          content: [{ type: "text", text: "ignored" }],
+        },
+      }),
+    ).toEqual({ surfaces: [] });
+    expect(
+      extractStructuredContent({
+        result: {
+          content: [{ type: "text", text: '{"surfaces":[]}' }],
+        },
+      }),
+    ).toEqual({ surfaces: [] });
+    expect(() =>
+      extractStructuredContent({
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "cmux failed" }],
+        },
+      }),
+    ).toThrow(/cmux failed/);
+  });
+
+  it("selects a terminal surface with its workspace", () => {
+    expect(
+      selectTerminalSurface({
+        surfaces: [
+          {
+            ref: "surface:browser",
+            type: "browser",
+            workspace_ref: "workspace:1",
+          },
+          {
+            ref: "surface:terminal",
+            type: "terminal",
+            workspace_ref: "workspace:2",
+          },
+        ],
+      }),
+    ).toEqual({ surface: "surface:terminal", workspace: "workspace:2" });
+    expect(() => selectTerminalSurface({ surfaces: [] })).toThrow(
+      /terminal surface/,
+    );
+  });
+
+  it("extracts the daemon pid from control_health", () => {
+    expect(
+      daemonPidFromHealth({
+        health: { current_process: { pid: 9876 } },
+      }),
+    ).toBe(9876);
+    expect(() => daemonPidFromHealth({ health: {} })).toThrow(/daemon pid/);
+  });
+
+  it("records replacement daemon pids from proxy spawn receipts", () => {
+    expect(
+      daemonSpawnPidFromLog(
+        "[cmuxlayer-proxy] daemon spawn fired (script=/tmp/dist/daemon.js, pid=12345)",
+      ),
+    ).toBe(12345);
+    expect(daemonSpawnPidFromLog("transport selected: socket")).toBeNull();
+    expect(
+      daemonSpawnPidFromLog(
+        "[cmuxlayer-proxy] daemon spawn fired (script=/tmp/dist/daemon.js, pid=unknown)",
+      ),
+    ).toBeNull();
+  });
+
+  it("requires socket-mode health on the exact live cmux pin", () => {
+    const payload = {
+      health: {
+        current_process: { pid: 9876 },
+        selected_transport: {
+          transport_mode: "socket",
+          current_socket_path: "/tmp/cmux-nightly.sock",
+          transport_degraded: false,
+        },
+      },
+    };
+    expect(() =>
+      assertLiveHealth(payload, "/tmp/cmux-nightly.sock"),
+    ).not.toThrow();
+    expect(() =>
+      assertLiveHealth(
+        {
+          health: {
+            current_process: { pid: 9876 },
+            selected_transport: {
+              transport_mode: "cli",
+              current_socket_path: "/tmp/cmux-nightly.sock",
+              transport_degraded: true,
+            },
+          },
+        },
+        "/tmp/cmux-nightly.sock",
+      ),
+    ).toThrow(/socket-mode health/);
+    expect(() =>
+      assertLiveHealth(
+        {
+          health: {
+            current_process: { pid: 9876 },
+            selected_transport: {
+              transport_mode: "socket",
+              current_socket_path: "/tmp/cmux-nightly.sock",
+            },
+          },
+        },
+        "/tmp/cmux-nightly.sock",
+      ),
+    ).toThrow(/socket-mode health/);
+  });
+
+  it("requires doctor JSON to be healthy on both isolated pins", () => {
+    expect(() =>
+      assertDoctorReport(
+        {
+          healthy: true,
+          daemon: {
+            ok: true,
+            socketPath: "/tmp/contract/stated.sock",
+          },
+          socketPath: {
+            set: true,
+            value: "/tmp/cmux-nightly.sock",
+          },
+        },
+        "/tmp/cmux-nightly.sock",
+        "/tmp/contract/stated.sock",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertDoctorReport(
+        {
+          healthy: false,
+          daemon: {
+            ok: false,
+            socketPath: "/tmp/contract/stated.sock",
+          },
+          socketPath: {
+            set: true,
+            value: "/tmp/cmux-nightly.sock",
+          },
+        },
+        "/tmp/cmux-nightly.sock",
+        "/tmp/contract/stated.sock",
+      ),
+    ).toThrow(/doctor --json was not healthy/);
+  });
+
+  it("refuses daemon lifecycle actions outside the owned temp root", () => {
+    const root = "/tmp/cmuxlayer-contract-123";
+    expect(() =>
+      assertOwnedDaemonSocket(root, join(root, "stated.sock")),
+    ).not.toThrow();
+    expect(() =>
+      assertOwnedDaemonSocket(
+        root,
+        "/Users/example/.local/state/cmux/cmuxlayer-stated.sock",
+      ),
+    ).toThrow(/outside owned contract root/);
+    expect(() => assertOwnedDaemonSocket(root, root)).toThrow(
+      /outside owned contract root/,
+    );
+  });
+
+  it("cleans up the proxy before isolated daemons can respawn", () => {
+    expect(cleanupPidOrder(new Set([10, 20, 30, 40]), 30)).toEqual([
+      30,
+      40,
+      20,
+      10,
+    ]);
+    expect(cleanupPidOrder(new Set([10, 20]), undefined)).toEqual([20, 10]);
+  });
+
+  it("enforces a SIGTERM to SIGKILL deadline for stuck children", async () => {
+    const child = new EventEmitter() as EventEmitter & { pid: number };
+    child.pid = 4242;
+    const signals: Array<[number, NodeJS.Signals]> = [];
+
+    await expect(
+      waitForChildExit(child, {
+        timeoutMs: 5,
+        killGraceMs: 5,
+        processExists: () => true,
+        kill: (pid, signal) => signals.push([pid, signal]),
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(signals).toEqual([
+      [4242, "SIGTERM"],
+      [4242, "SIGKILL"],
+    ]);
+  });
+});

--- a/tests/real-cmux-contract-runner.test.ts
+++ b/tests/real-cmux-contract-runner.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   assertOwnedDaemonSocket,
@@ -20,12 +21,15 @@ import {
   classifyProductionPin,
   cleanupPidOrder,
   daemonPidFromHealth,
+  daemonExitPidFromLog,
   daemonSpawnPidFromLog,
   extractStructuredContent,
   isAncestryDenial,
+  McpPeer,
   parseOrphanReceipt,
   probeSystemPing,
   selectTerminalSurface,
+  trackChildPid,
   waitForChildExit,
 } from "../scripts/run-real-cmux-contract.js";
 
@@ -335,6 +339,71 @@ describe("real cmux contract runner helpers", () => {
         "[cmuxlayer-proxy] daemon spawn fired (script=/tmp/dist/daemon.js, pid=unknown)",
       ),
     ).toBeNull();
+    expect(
+      daemonExitPidFromLog(
+        "[cmuxlayer-proxy] spawned daemon exited (pid=12345, code=0, signal=none)",
+      ),
+    ).toBe(12345);
+  });
+
+  it("rejects MCP requests on malformed child output instead of throwing", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      stdin: PassThrough;
+      stdout: PassThrough;
+      stderr: PassThrough;
+    };
+    child.pid = 4242;
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const peer = new McpPeer(child as never);
+
+    const pending = peer.request("initialize");
+    child.stdout.write("not-json\n");
+
+    await expect(pending).rejects.toThrow(/malformed JSON/);
+    await expect(peer.request("tools/list")).rejects.toThrow(/malformed JSON/);
+    peer.close();
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.stderr.destroy();
+  });
+
+  it("disposes MCP listeners and pending timers when closed", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      stdin: PassThrough;
+      stdout: PassThrough;
+      stderr: PassThrough;
+    };
+    child.pid = 4242;
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const peer = new McpPeer(child as never);
+    const pending = peer.request("initialize", {}, 50);
+
+    peer.close();
+
+    await expect(pending).rejects.toThrow(/closed/);
+    expect(child.stdout.listenerCount("data")).toBe(0);
+    expect(child.stderr.listenerCount("data")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.stderr.destroy();
+  });
+
+  it("removes tracked child pids as soon as the child exits", () => {
+    const child = new EventEmitter() as EventEmitter & { pid: number };
+    child.pid = 4242;
+    const pids = new Set<number>();
+
+    trackChildPid(child, pids);
+    expect(pids).toEqual(new Set([4242]));
+    child.emit("exit", 0, null);
+    expect(pids).toEqual(new Set());
   });
 
   it("requires socket-mode health on the exact live cmux pin", () => {


### PR DESCRIPTION
## Summary
- add an opt-in `bun run test:contract` lane that skips cleanly without a reachable explicit cmux pin
- exercise live `system.ping`, pane-descendant vs detached-orphan/EPIPE access control, real-dist `list_surfaces`/`read_screen`, doctor JSON, and isolated daemon retire/autostart
- gate releases through the lane, with unavailable live cmux warn-only and real contract failures release-blocking
- document NIGHTLY-preferred operation and PID/socket safety boundaries

## Safety
- live cmux operations are read-only
- every lifecycle process PID is recorded
- all daemon lifecycle work uses a unique temp `CMUXLAYER_DAEMON_SOCKET`
- cleanup stops the proxy before isolated daemons and never touches fleet daemon state
- `src/monitor-registry.ts` is unchanged

## Verification
- `bun run typecheck && bun run test && bun run build` — 90 test files, 1,617 tests passed
- strict standalone TypeScript check for `scripts/run-real-cmux-contract.ts` — passed
- `env -u CMUX_SOCKET_PATH bun run test:contract` — clear SKIP, exit 0
- `bun run test:contract` from a pane descended from the explicitly pinned live cmux — PASS: ping shape, orphan EPIPE, dist list/read, doctor healthy, isolated daemon PID replacement, cleanup
- local CodeRabbit review was bounded at three minutes; all emitted findings were addressed (spawn timeout, explicit non-degraded health, SIGTERM→SIGKILL doctor deadline)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release now invokes live contract checks; a reachable non-production socket that fails assertions blocks release, though skips are exit 0. Process lifecycle and socket isolation logic is safety-critical but confined to the new runner and tests, not production `src/`.
> 
> **Overview**
> Adds an **opt-in live contract lane** (`bun run test:contract`) that smoke-tests cmuxlayer against a pinned real cmux socket without touching production fleet state.
> 
> A new standalone runner (`scripts/run-real-cmux-contract.ts`) stays outside default Vitest discovery: it **SKIP**s with exit 0 when `CMUX_SOCKET_PATH` is missing, unreachable, or classified as production (unless `CMUX_CONTRACT_ALLOW_PROD=1`), and otherwise runs read-only checks (ping shape, orphan/EPIPE ancestry denial, MCP `list_surfaces`/`read_screen`, `doctor --json`, isolated daemon retire/autostart) using a temp `HOME` and temp `CMUXLAYER_DAEMON_SOCKET`, with PID-scoped cleanup only.
> 
> **Release preflight** now runs the contract gate after hermetic typecheck/tests; failed assertions block release, while skip paths remain warn-only. Hermetic coverage lives in `tests/real-cmux-contract-runner.test.ts` and `tests/pre-pr-scripts.test.ts`; operators get `docs/runbooks/contract-lane.md` plus an implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ffd479ebf3db0897cd2c09caaba74ee52af3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in live cmux contract lane with smoke tests and release gate
> - Adds [scripts/run-real-cmux-contract.ts](https://github.com/EtanHey/cmuxlayer/pull/281/files#diff-d69c2f6c09a7869995df79e531fec9361348264ae911f5b3e2e4138e7e75f98b), a standalone contract runner that probes a pinned cmux Unix socket, spins up an isolated daemon, exercises MCP tool calls, validates health/doctor output, and tests orphan ancestry-denial behavior
> - Skips cleanly (exit 0) when no live socket is reachable or when targeting a production socket; blocks the release on contract failures
> - Adds a `test:contract` npm script and inserts it as a preflight gate in [scripts/release.sh](https://github.com/EtanHey/cmuxlayer/pull/281/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389) after typecheck and hermetic tests
> - Adds hermetic unit tests in [tests/real-cmux-contract-runner.test.ts](https://github.com/EtanHey/cmuxlayer/pull/281/files#diff-0da51a2114164df469dc479aec3a06d6f37e853ad29c8d74a6da279fb9b29c64) covering all exported helpers without requiring a live socket
> - Risk: the release gate will halt if a live socket is reachable but the contract assertions fail; operators must set `CMUX_CONTRACT_ALLOW_PROD=1` to test against a production socket
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4ffd47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `test:contract` workflow for validating integration with a live, explicitly configured cmux instance.
  * Contract checks cover connectivity, read-only MCP operations, health diagnostics, authorization behavior, and daemon recovery.
  * Unavailable or inaccessible cmux instances produce a clear `SKIP` result without failing the workflow.

* **Release Process**
  * Added contract validation to the release preflight checks.

* **Documentation**
  * Added an operator runbook describing setup, isolation requirements, outcomes, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->