### PR TITLE
test: make the suite deterministic (fix cold-run/parallel flake)

### DIFF
--- a/docs/plans/2026-07-11-suite-determinism-design.md
+++ b/docs/plans/2026-07-11-suite-determinism-design.md
@@ -1,0 +1,40 @@
+# Suite Determinism Design
+
+## Root cause
+
+Vitest file parallelism exposes test-harness races rather than product defects:
+
+- `enter-reliability.test.ts` models a slow composer by clearing after a fixed
+  number of `readScreen` calls, while production verification stops against a
+  real five-second deadline. Scheduler delay under parallel load changes whether
+  the final read occurs before the deadline. Its routing-only server also starts
+  an unrelated lifecycle sweep at the same five-second boundary.
+- `server.test.ts` drives submit and boot-prompt polling with real timers,
+  including a negative case that consumes the full production deadline. These
+  tests compete for wall-clock budget with other workers.
+- `inbox-nudge.test.ts` creates lifecycle servers without disposing their agent
+  engines, leaving background sweep timers behind after each test.
+
+The default-parallel three-file run reproduced one failure among 177 tests. The
+same files passed 177/177 with file parallelism disabled, localizing the trigger
+to scheduler contention.
+
+## Fix
+
+Keep production timing behavior unchanged. Make tests control time explicitly:
+
+1. Use Vitest fake timers to advance submit-verification and boot-prompt polling
+   without consuming wall-clock budget.
+2. Stop lifecycle sweeps immediately in routing-only test servers; the engine's
+   registry and routing behavior remain available.
+3. Close or dispose every lifecycle server during teardown.
+4. Keep default Vitest file parallelism and do not add retries or blanket timeout
+   increases.
+
+## Verification
+
+- Confirm the previously failing parallel reproduction is green.
+- Run the three formerly flaky files ten fresh-process times.
+- Run the entire suite five fresh-process times.
+- Run typecheck and build.
+

--- a/docs/plans/2026-07-11-suite-determinism-design.md
+++ b/docs/plans/2026-07-11-suite-determinism-design.md
@@ -37,4 +37,3 @@ Keep production timing behavior unchanged. Make tests control time explicitly:
 - Run the three formerly flaky files ten fresh-process times.
 - Run the entire suite five fresh-process times.
 - Run typecheck and build.
-

--- a/docs/plans/2026-07-11-suite-determinism.md
+++ b/docs/plans/2026-07-11-suite-determinism.md
@@ -109,4 +109,3 @@ ready-for-review PR titled `test: make the suite deterministic (fix cold-run/par
 Include the root cause, design, all ten isolation summaries, all five full-suite
 summaries, typecheck, and build results in the PR body. Complete the bot-review
 loop before merging.
-

--- a/docs/plans/2026-07-11-suite-determinism.md
+++ b/docs/plans/2026-07-11-suite-determinism.md
@@ -1,0 +1,112 @@
+# Suite Determinism Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the cold-run and parallel Vitest flake without retries, suite serialization, or production timeout changes.
+
+**Architecture:** Keep product code unchanged and repair the test harness. Timing-sensitive tests will advance a fake clock, routing-only lifecycle engines will have their sweeps stopped, and every created lifecycle server will be closed during teardown.
+
+**Tech Stack:** TypeScript, Vitest 3, Bun, Node timers.
+
+---
+
+### Task 1: Make enter-reliability timing deterministic
+
+**Files:**
+- Modify: `tests/enter-reliability.test.ts`
+
+**Step 1: Preserve the failing reproduction**
+
+Run the three files under default file parallelism and retain the observed failure
+in the generic slow-clearing composer case as the RED evidence.
+
+**Step 2: Add a fake-timer driver**
+
+Import `vi`, enable fake timers with a fixed system time in `beforeEach`, add an
+async helper that advances timers while a tool-handler promise runs, and restore
+real timers in `afterEach`.
+
+**Step 3: Stop irrelevant lifecycle sweeps**
+
+After `createServer`, access the test-exposed lifecycle engine and call
+`dispose()`. Continue using its registry and routing methods in each test.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run tests/enter-reliability.test.ts --reporter=verbose
+```
+
+Expected: all tests pass without real five-second waits or sweep errors.
+
+### Task 2: Isolate inbox lifecycle resources
+
+**Files:**
+- Modify: `tests/inbox-nudge.test.ts`
+
+**Step 1: Close every created server**
+
+Make `afterEach` async and call `await server.close()` before deleting its state
+and inbox directories. When a test replaces `server`, close the original first.
+
+**Step 2: Verify isolation**
+
+Run:
+
+```bash
+bunx vitest run tests/inbox-nudge.test.ts --reporter=verbose
+```
+
+Expected: all tests pass and no lifecycle server survives teardown.
+
+### Task 3: Remove server-test wall-clock polling
+
+**Files:**
+- Modify: `tests/server.test.ts`
+
+**Step 1: Convert measured offenders to fake time**
+
+For `spawn_in_workspace`, boot-prompt send/cleared-composer cases, and the
+full-deadline pending `new_split` case, start the handler promise, advance the
+existing `advanceTimers` helper beyond the relevant deadline, then await the
+result.
+
+**Step 2: Verify the formerly flaky files together**
+
+Run:
+
+```bash
+bunx vitest run tests/enter-reliability.test.ts tests/server.test.ts tests/inbox-nudge.test.ts --reporter=verbose
+```
+
+Expected: 177 tests pass under default file parallelism with no timing failure.
+
+### Task 4: Prove determinism and publish
+
+**Files:**
+- Modify: PR body only
+
+**Step 1: Run ten isolation processes**
+
+Run the three formerly flaky files ten times, starting a new Vitest process for
+each iteration, and capture every summary.
+
+**Step 2: Run five cold full-suite processes**
+
+Run `bun run test` five times, starting a fresh process for each iteration, and
+capture every summary.
+
+**Step 3: Run static verification**
+
+Run `bun run typecheck` and `bun run build`.
+
+**Step 4: Review and publish**
+
+Review the diff, run the required pre-commit reviewer, commit, push, and open a
+ready-for-review PR titled `test: make the suite deterministic (fix cold-run/parallel flake)`.
+Include the root cause, design, all ten isolation summaries, all five full-suite
+summaries, typecheck, and build results in the PR body. Complete the bot-review
+loop before merging.
+

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,7 +20,9 @@ async function callTool(
   if (!tool) {
     throw new Error(`Tool not found: ${name}`);
   }
-  return tool.handler(args, {} as any);
+  const resultPromise = tool.handler(args, {} as any);
+  await vi.advanceTimersByTimeAsync(10_000);
+  return resultPromise;
 }
 
 function readEventLog(): Array<Record<string, unknown>> {
@@ -348,11 +350,16 @@ class FakeSlowClearingAgentClient extends FakeClaudeSurfaceClient {
 }
 
 function createReliabilityServer(client: FakeClaudeSurfaceClient) {
-  return createServer({
+  const server = createServer({
     client: client as any,
     stateDir: TEST_DIR,
     disableSpawnPreflight: true,
   });
+  // These tests exercise registry routing and submit verification, not the
+  // periodic reconciliation loop. Stop its wall-clock sweep so it cannot race
+  // the five-second submit deadline or add unrelated work under parallel load.
+  disposeServer(server);
+  return server;
 }
 
 function registerAgent(server: any, overrides?: Partial<AgentRecord>): AgentRecord {
@@ -403,13 +410,16 @@ describe("enter reliability", () => {
   let server: any;
 
   beforeEach(() => {
+    vi.useFakeTimers({ now: new Date("2026-07-11T12:00:00.000Z") });
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
     server = null;
   });
 
-  afterEach(() => {
-    disposeServer(server);
+  afterEach(async () => {
+    await server?.close();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -165,7 +165,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await server.close();
     rmSync(STATE_DIR, { recursive: true, force: true });
     rmSync(inboxDir, { recursive: true, force: true });
   });
@@ -260,6 +261,7 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
   });
 
   it("discovers a launcher-spawned Claude permission prompt but does not type a nudge into it", async () => {
+    await server.close();
     exec = makeExec(
       [
         "Do you want to allow this command?",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,7 +4,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer, __submitEvidenceTestHooks } from "../src/server.js";
+import {
+  createServer as createServerImpl,
+  __submitEvidenceTestHooks,
+} from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
@@ -22,6 +25,30 @@ type InputDeliveryTestModule = typeof import("../src/server.js") & {
     deliveredChunkCounts: number[];
   }>;
 };
+
+const openServers = new Set<ReturnType<typeof createServerImpl>>();
+
+function createServer(
+  ...args: Parameters<typeof createServerImpl>
+): ReturnType<typeof createServerImpl> {
+  const server = createServerImpl(...args);
+  const close = server.close.bind(server);
+  server.close = async () => {
+    try {
+      await close();
+    } finally {
+      openServers.delete(server);
+    }
+  };
+  openServers.add(server);
+  return server;
+}
+
+afterEach(async () => {
+  for (const server of [...openServers]) {
+    await server.close();
+  }
+});
 
 async function loadInputDeliveryTestModule(): Promise<InputDeliveryTestModule> {
   return (await import("../src/server.js")) as InputDeliveryTestModule;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -124,6 +124,32 @@ async function advanceTimers(ms: number): Promise<void> {
   await flush();
 }
 
+async function runWithFakeTimers<T>(
+  run: () => Promise<T>,
+  advanceMs: number,
+): Promise<T> {
+  vi.useFakeTimers();
+  const resultPromise = run();
+  let settled = false;
+  void resultPromise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  for (let elapsed = 0; elapsed < advanceMs && !settled; elapsed += 50) {
+    // Tool handlers cross several async boundaries before scheduling their
+    // first poll. Flush those jobs before advancing the next clock slice.
+    for (let flush = 0; flush < 8; flush += 1) {
+      await Promise.resolve();
+    }
+    await advanceTimers(50);
+  }
+  return resultPromise;
+}
+
 function setFakeSystemTime(now: Date): void {
   const setSystemTime = (
     vi as unknown as {
@@ -753,20 +779,29 @@ describe("tool handler integration", () => {
     });
     const tool = (server as any)._registeredTools["spawn_in_workspace"];
 
-    const result = await tool.handler(
-      {
-        workspace_title: "red-team",
-        agents: [
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
           {
-            repo: "brainlayer",
-            model: "sonnet",
-            cli: "claude",
-            role: "orchestrator",
+            workspace_title: "red-team",
+            agents: [
+              {
+                repo: "brainlayer",
+                model: "sonnet",
+                cli: "claude",
+                role: "orchestrator",
+              },
+              {
+                repo: "cmuxlayer",
+                model: "gpt-5.4",
+                cli: "codex",
+                role: "worker",
+              },
+            ],
           },
-          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
-        ],
-      },
-      {} as any,
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -782,6 +817,7 @@ describe("tool handler integration", () => {
     ]);
     expect(calls).toContain("spawn:workspace:grid:surface:2");
 
+    await server.close();
     rmSync(stateDir, { recursive: true, force: true });
   });
 
@@ -2542,13 +2578,17 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerCodex -s",
-        boot_prompt_path: promptPath,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerCodex -s",
+            boot_prompt_path: promptPath,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -2614,13 +2654,17 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerCodex -s",
-        boot_prompt_path: promptPath,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerCodex -s",
+            boot_prompt_path: promptPath,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -2663,14 +2707,18 @@ describe("tool handler integration", () => {
     const registeredTools = (server as any)._registeredTools;
     const tool = registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerClaude -s",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 700,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerClaude -s",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 700,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -2759,14 +2807,18 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerClaude -s",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 700,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerClaude -s",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 700,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -2869,14 +2921,18 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerClaude -s",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 700,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerClaude -s",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 700,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -2916,14 +2972,18 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["send_command"];
 
-    const result = await tool.handler(
-      {
-        surface: "surface:1",
-        command: "brainlayerClaude -s",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 700,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:1",
+            command: "brainlayerClaude -s",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 700,
+          },
+          {} as any,
+        ),
+      1_000,
     );
 
     const parsed =
@@ -7666,7 +7726,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("new_split fails loudly when a short boot prompt stays pending without retrying Return", async () => {
-    vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-short-dropped-return.md");
     const prompt = "short boot prompt";
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -7714,12 +7773,16 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["new_split"];
 
-    const result = await tool.handler(
-      {
-        direction: "right",
-        boot_prompt_path: promptPath,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            direction: "right",
+            boot_prompt_path: promptPath,
+          },
+          {} as any,
+        ),
+      6_000,
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);


### PR DESCRIPTION
## Design-first diagnosis

Root cause: the flake lived in the test harness, not product behavior.

- `enter-reliability.test.ts` cleared a fake composer after a fixed number of
  reads while production verification stopped on a real 5-second deadline.
  Parallel scheduler jitter decided whether the final read happened in time.
- Routing-only test servers started unrelated AgentEngine sweeps at that same
  boundary, and several suites did not close every server fixture.
- `server.test.ts` exercised submit/boot-prompt polling with real timers,
  including a negative case that consumed the entire production deadline.

The default-parallel reproduction failed 1/177 tests; the identical serialized
fork run passed 177/177, localizing the trigger to file-parallel scheduler load.

## Fix

- Drive timing assertions with Vitest fake timers while retaining the production
  polling/deadline code under test.
- Stop lifecycle sweeps in routing-only enter-reliability fixtures.
- Close every server fixture after each server/inbox test.
- Keep default file parallelism and production timeout values unchanged.
- Add no retries, suite-wide serialization, or product-code changes.

## TDD evidence

- RED: default-parallel three-file reproduction failed the generic slow-clearing
  composer assertion (`expected false to be true`), 176/177 passed.
- Localization control: `--pool=forks --no-file-parallelism` passed 177/177.
- GREEN: the same default-parallel command passes 177/177 after the harness fix.

## Determinism proof

### Formerly flaky files: 10 fresh processes

Command per run:

```bash
bunx vitest run tests/enter-reliability.test.ts tests/server.test.ts tests/inbox-nudge.test.ts
```

1. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.61s`
2. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.64s`
3. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.69s`
4. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.69s`
5. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.69s`
6. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.57s`
7. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.59s`
8. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.59s`
9. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.57s`
10. `Test Files 3 passed (3)` — `Tests 177 passed (177)` — `Duration 9.59s`

### Full suite: 5 cold runs, fresh process each

Command per run: `bun run test`

1. `Test Files 90 passed (90)` — `Tests 1644 passed (1644)` — `Duration 9.87s`
2. `Test Files 90 passed (90)` — `Tests 1644 passed (1644)` — `Duration 9.79s`
3. `Test Files 90 passed (90)` — `Tests 1644 passed (1644)` — `Duration 9.83s`
4. `Test Files 90 passed (90)` — `Tests 1644 passed (1644)` — `Duration 9.79s`
5. `Test Files 90 passed (90)` — `Tests 1644 passed (1644)` — `Duration 9.78s`

### Static verification

- `bun run typecheck` — exit 0
- `bun run build` — exit 0
- Final push hook reran the full suite: 90 files, 1644 tests, exit 0.

## Review note

The bounded local CodeRabbit pass used stale base `e2e31ee` and reported only
findings in the already-merged `scripts/run-real-cmux-contract.ts`, which this
seat was explicitly forbidden to modify. PR-level reviewers are requested below
against the correct base.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and documentation; no production code or timeout behavior is modified.
> 
> **Overview**
> Fixes Vitest **cold-run and file-parallel flake** by hardening the test harness only—**production timeouts and polling are unchanged**.
> 
> **enter-reliability:** Enables Vitest fake timers in setup/teardown, advances time in `callTool` while handlers run, **disposes** the lifecycle engine sweep on routing-only servers after `createServer`, and **closes** the server in `afterEach`.
> 
> **inbox-nudge:** **`await server.close()`** in teardown (and before recreating the server in the permission-prompt case) so lifecycle background work does not leak across tests.
> 
> **server.test:** Adds a **`runWithFakeTimers`** helper and wraps **`createServer`** with an **`openServers`** registry plus global **`afterEach`** cleanup. Timing-heavy cases (`spawn_in_workspace`, boot-prompt **`send_command`** paths, full-deadline **`new_split`**) run handlers under fake time instead of real wall-clock waits; drops an explicit **`useRealTimers`** escape on the pending **`new_split`** case.
> 
> Adds **design and implementation plan** docs describing root cause (scheduler contention vs real deadlines/sweeps) and verification steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1cb8dcba783fbf4bc7f30871a482ae526b49a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make test suite deterministic by replacing wall-clock waits with fake timers
> - Introduces a `runWithFakeTimers` helper in [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/283/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d) that advances fake time in 50ms slices while flushing microtasks, replacing real async delays in tool handler tests.
> - Adds a `createServer` tracking wrapper and global `afterEach` teardown in [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/283/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d) to guarantee no server instances leak between tests.
> - Stops periodic lifecycle sweeps via `disposeServer` in [enter-reliability.test.ts](https://github.com/EtanHey/cmuxlayer/pull/283/files#diff-5e89c52026fcdfee326f57b1efc91920f9bc47ec7a580591cebc889ffb9a21fb) and pins test time with `vi.useFakeTimers({ now: ... })` to prevent background timer interference.
> - Fixes overlapping server instances in [inbox-nudge.test.ts](https://github.com/EtanHey/cmuxlayer/pull/283/files#diff-7bd986c46b6cbccd155247c8a3227e4211a482bec9349641502016dd8c625935) by awaiting `server.close()` before reinitializing within a test and during teardown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd1cb8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test reliability and consistency during parallel and cold runs.
  - Prevented background test resources and timers from affecting other tests.
  - Reduced intermittent failures in verification, polling, server startup, and workspace scenarios.

- **Documentation**
  - Added and updated implementation plans for deterministic test execution.
  - Documented validation steps for repeated suite runs, type checking, and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->