### PR TITLE
feat(monitors): daemon-side failover for pty-dead / wedged monitor owners

### DIFF
--- a/docs/plans/2026-07-11-monitor-owner-failover-design.md
+++ b/docs/plans/2026-07-11-monitor-owner-failover-design.md
@@ -1,0 +1,44 @@
+# Monitor Owner Failover Design
+
+## Problem
+
+The durable monitor reconciler restores a stale watcher by writing a `monitor-rearm` task to the owning agent. A readable screen is not sufficient proof that the owner can process that task: repeated broken-pipe writes can classify the surface as `pane_pty_dead` while the last rendered frame remains readable. Dispatching to that owner leaves the monitor in `rearming` even though no process can act on the message.
+
+## Options considered
+
+### Execute every stored re-arm command in the daemon
+
+This would restore some file watchers without an owner, but `rearm_command` is opaque shell text. It may depend on the owner's working directory, environment, credentials, process state, or cursor. Executing it in the daemon would cross a trust boundary and could recreate the wrong watcher.
+
+### Infer owner independence from mechanism and absolute targets
+
+An `event` or `offset-poll` mechanism with absolute file targets looks like a pure watch, but those fields describe intent rather than the executable contract. They do not prove that the command is side-effect-free, daemon-safe, or independent of owner-local state.
+
+### Collapse and escalate loudly
+
+Treat all current-schema monitors as owner-bound unless future registration metadata explicitly proves a daemon-safe watcher contract. When the shared write-liveness tracker reports the owner's surface as PTY-dead, atomically collapse the stale monitor with `owner-pty-dead`, do not dispatch to the owner's inbox, and emit a high-priority daemon notification. This is the chosen safe default.
+
+## State and data flow
+
+The registry reconciliation API accepts an injected owner-PTY-dead predicate in addition to the existing owner-alive probe. For each stale `alive` monitor (or expired `rearming` lease), reconciliation validates the re-arm command and watch targets, then evaluates owner viability. A PTY-dead result takes precedence over the screen-read liveness result and claims the monitor under the existing registry write lock as:
+
+```text
+state: collapsed
+collapsed_reason: owner-pty-dead
+```
+
+Only the process that wins that transition emits the escalation callback. Later reconcile ticks ignore the collapsed record, so they neither notify again nor enqueue an inbox re-arm. Healthy owners continue through the existing `rearming` claim and deterministic inbox message path unchanged.
+
+The daemon resolves the owner from the file-backed agent registry and reads `context.surfaceWriteLiveness.observe(owner.surface_id).pty_dead`. It does not duplicate broken-pipe thresholds or parsing. The production escalation adapter sends a high-priority notification that names the monitor, owner, and watched targets. Notification delivery remains best-effort, matching the existing monitor deadman notifier, while the durable collapsed state makes the failure visible through `list_monitors` and agent health even if the HTTP notification sink is unavailable.
+
+## Idempotency and races
+
+The existing lock and candidate-state checks remain the single claim boundary. A stale monitor can transition from `alive` or an expired `rearming` lease only once. The escalation callback runs only after that successful claim. Concurrent or later reconciliation passes see `collapsed` and do nothing, preventing both inbox double-delivery and notification storms.
+
+## Tests
+
+- A stale monitor with a PTY-dead owner collapses as `owner-pty-dead` and never invokes owner re-arm.
+- The loud escalation callback receives the collapsed monitor exactly once across repeated reconciliation ticks.
+- A healthy owner retains the v0.3.37 re-arm behavior.
+- Daemon tests inject the shared `SurfaceWriteLivenessTracker`, record the threshold broken-pipe failures, and prove the default reconciler emits one injected high-priority escalation without inbox dispatch.
+- Focused tests, typecheck, build, and five cold full-suite runs must pass before the PR opens.

--- a/docs/plans/2026-07-11-monitor-owner-failover.md
+++ b/docs/plans/2026-07-11-monitor-owner-failover.md
@@ -1,0 +1,69 @@
+# Monitor Owner Failover Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make stale monitors fail loudly and idempotently when their owner surface is PTY-dead, without dispatching an impossible owner inbox re-arm.
+
+**Architecture:** Extend the registry reconciler with a shared-liveness-derived PTY-dead classification and a one-shot collapse escalation callback. The daemon consumes its existing `SurfaceWriteLivenessTracker`, preserves the current healthy-owner re-arm path, and routes PTY-dead collapse through an injectable high-priority notifier.
+
+**Tech Stack:** TypeScript, Vitest, Bun, JSON file registry, cmux daemon server context.
+
+---
+
+### Task 1: Specify registry PTY-dead collapse and one-shot escalation
+
+**Files:**
+- Modify: `tests/monitor-registry.test.ts`
+- Modify: `src/monitor-registry.ts`
+
+1. Add a test registering a stale re-arm-capable monitor with an existing absolute file target.
+2. Reconcile with `ownerPtyDead` returning true, `ownerAlive` returning true, and spies for re-arm and escalation.
+3. Assert the test fails because `owner-pty-dead` and the escalation seam do not exist yet.
+4. Add `owner-pty-dead` to `MonitorCollapseReason` and add injectable `ownerPtyDead` and `escalate` dependencies.
+5. Under the existing registry lock, persist `collapsed` plus `owner-pty-dead`; invoke escalation only for the winning claim.
+6. Reconcile a second time and assert one escalation, zero re-arms, and durable collapse metadata.
+7. Run `bunx vitest run tests/monitor-registry.test.ts`.
+
+### Task 2: Preserve healthy-owner behavior
+
+**Files:**
+- Modify: `tests/monitor-registry.test.ts`
+- Modify: `src/monitor-registry.ts`
+
+1. Extend the healthy-owner regression test with `ownerPtyDead` returning false and an escalation spy.
+2. Run the focused test and verify the existing deterministic inbox/re-arm claim behavior remains green.
+3. Keep `ownerAlive`, watch-target validation, claim expiry, and deadman exclusion semantics unchanged.
+
+### Task 3: Specify daemon consumption of shared write-liveness
+
+**Files:**
+- Modify: `tests/daemon.test.ts`
+- Modify: `src/daemon.ts`
+
+1. Create a daemon test context with a real `SurfaceWriteLivenessTracker` and a file-backed owner record.
+2. Record the configured number of broken-pipe failures against the owner's existing surface.
+3. Start the daemon with an injected collapse notifier and inbox directory.
+4. Assert the test initially fails because default reconciliation does not consult the tracker or emit escalation.
+5. In the default reconciler, resolve `context.surfaceWriteLiveness.observe(owner.surface_id)?.pty_dead` without reimplementing the threshold.
+6. Pass an injected high-priority owner-PTY-dead notifier and ensure the re-arm callback is not invoked for that record.
+7. Start a second reconciliation tick and assert one notification and no inbox `monitor-rearm` message.
+8. Run the focused daemon test.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Review: `src/monitor-registry.ts`
+- Review: `src/daemon.ts`
+- Review: `tests/monitor-registry.test.ts`
+- Review: `tests/daemon.test.ts`
+- Review: both new plan documents
+
+1. Run the focused registry and daemon suites.
+2. Run `bun run typecheck` and `bun run build`.
+3. Run `bun run test` five times as separate cold processes and read every result.
+4. Run `git diff --check`, inspect the full diff, and verify no observability-seat or forbidden files changed.
+5. Run a bounded local CodeRabbit review; address actionable findings and rerun verification.
+6. Commit the scoped files, push the feature branch, and open a ready PR titled `feat(monitors): daemon-side failover for pty-dead / wedged monitor owners`.
+7. Put the design rationale, state transition, safe-default decision, and verification evidence directly in the PR body.
+8. Invoke reviewers, read every review and CI result, fix or reply to findings, request re-review, and merge only when the loop is clean.
+9. Verify the remote merge contains the latest pushed content, clean up the branch/worktree from the main checkout as safe, and store the design and milestone in BrainLayer.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -51,6 +51,7 @@ import { isMainModule } from "./is-main.js";
 const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
 const DEFAULT_STALE_CHECK_INTERVAL_MS = 30_000;
 const DEFAULT_MONITOR_RECONCILE_INTERVAL_MS = 15_000;
+const DEFAULT_NOTIFY_URL = "http://127.0.0.1:3847/notify";
 const MONITOR_REARM_INBOX_HEARTBEAT_MAX_AGE_MS = 60_000;
 const LISTEN_FD_START = 3;
 
@@ -68,6 +69,13 @@ export interface DaemonHotReloadPlan {
 export type DaemonHotReloadHandler = (
   plan: DaemonHotReloadPlan,
 ) => Promise<"not_implemented">;
+
+export interface MonitorOwnerPtyDeadNotification {
+  title: string;
+  body: string;
+  source: string;
+  priority: "high";
+}
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
 export type DaemonRetirementReason = "stale-build" | "irrecoverable-transport";
@@ -241,6 +249,9 @@ export interface CmuxLayerDaemonOptions extends Omit<
     monitorIds?: readonly string[];
   }) => Promise<unknown> | unknown;
   monitorReconcileIntervalMs?: number;
+  monitorOwnerPtyDeadNotify?: (
+    notification: MonitorOwnerPtyDeadNotification,
+  ) => Promise<unknown> | unknown;
   logger?: Pick<Console, "error">;
   onRetire?: (
     reason: DaemonRetirementReason,
@@ -669,6 +680,14 @@ export class CmuxLayerDaemon {
           ? { rearmClaimTimeoutMs: options.rearmClaimTimeoutMs }
           : {}),
         ...(options?.monitorIds ? { monitorIds: options.monitorIds } : {}),
+        ownerPtyDead: (ownerSeat) => {
+          const owner = findOwner(ownerSeat);
+          return (
+            owner !== null &&
+            context.surfaceWriteLiveness.observe(owner.surface_id)?.pty_dead ===
+              true
+          );
+        },
         ownerAlive: async (ownerSeat) => {
           const owner = findOwner(ownerSeat);
           if (!owner || owner.state === "done" || owner.state === "error") {
@@ -729,6 +748,18 @@ export class CmuxLayerDaemon {
             press_enter: true,
             allow_busy: true,
             source_event: "dispatch_nudge",
+          });
+        },
+        escalate: async (record) => {
+          const notify =
+            this.opts.monitorOwnerPtyDeadNotify ??
+            ((notification: MonitorOwnerPtyDeadNotification) =>
+              httpDeliver(notification, DEFAULT_NOTIFY_URL));
+          await notify({
+            title: "Monitor owner PTY dead",
+            body: `Monitor ${record.monitor_id} collapsed because owner ${record.owner_seat} cannot accept terminal writes; watch_targets=${record.watch_targets.join(", ")}`,
+            source: "cmuxlayer-monitor-registry",
+            priority: "high",
           });
         },
       });

--- a/src/monitor-registry.ts
+++ b/src/monitor-registry.ts
@@ -112,15 +112,18 @@ export interface MonitorRegistrySweepOptions extends MonitorRegistryOptions {
 
 export type MonitorCollapseReason =
   | "owner-not-alive"
+  | "owner-pty-dead"
   | "watch-target-missing"
   | "rearm-command-missing";
 
 export interface MonitorRegistryReconcileOptions extends MonitorRegistryOptions {
   ownerAlive: (ownerSeat: string) => Promise<boolean> | boolean;
+  ownerPtyDead?: (ownerSeat: string) => Promise<boolean> | boolean;
   watchTargetExists?: (target: string) => boolean;
   rearmClaimTimeoutMs?: number;
   monitorIds?: readonly string[];
   rearm: (record: MonitorRegistryRecord) => Promise<unknown> | unknown;
+  escalate?: (record: MonitorRegistryRecord) => Promise<unknown> | unknown;
 }
 
 export interface MonitorRegistryReconcileResult {
@@ -429,6 +432,7 @@ function monitorIdForInvalid(record: RawMonitorRecord): string {
 function isMonitorCollapseReason(value: unknown): value is MonitorCollapseReason {
   return (
     value === "owner-not-alive" ||
+    value === "owner-pty-dead" ||
     value === "watch-target-missing" ||
     value === "rearm-command-missing"
   );
@@ -850,6 +854,8 @@ export async function reconcileMonitorRegistry(
       candidate.watch_targets.some((target) => !watchTargetExists(target))
     ) {
       collapseReason = "watch-target-missing";
+    } else if (await opts.ownerPtyDead?.(candidate.owner_seat)) {
+      collapseReason = "owner-pty-dead";
     } else if (!(await opts.ownerAlive(candidate.owner_seat))) {
       collapseReason = "owner-not-alive";
     }
@@ -891,6 +897,9 @@ export async function reconcileMonitorRegistry(
     if (!claimed) continue;
     if (collapseReason) {
       collapsed.push({ monitor_id: candidate.monitor_id, reason: collapseReason });
+      if (collapseReason === "owner-pty-dead") {
+        await opts.escalate?.(claimed);
+      }
       continue;
     }
 

--- a/src/monitor-registry.ts
+++ b/src/monitor-registry.ts
@@ -898,7 +898,11 @@ export async function reconcileMonitorRegistry(
     if (collapseReason) {
       collapsed.push({ monitor_id: candidate.monitor_id, reason: collapseReason });
       if (collapseReason === "owner-pty-dead") {
-        await opts.escalate?.(claimed);
+        try {
+          await opts.escalate?.(claimed);
+        } catch {
+          // The durable collapsed state is canonical; notification is best-effort.
+        }
       }
       continue;
     }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -810,6 +810,93 @@ describe("CmuxLayerDaemon", () => {
     expect(clients[0]?.sendKey).not.toHaveBeenCalled();
   });
 
+  it("collapses and loudly escalates a pty-dead monitor owner without inbox re-arm", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const registryPath = join(TEST_ROOT, "pty-dead-monitor-registry.json");
+    const watchedFile = join(TEST_ROOT, "pty-dead-collab.md");
+    const inboxBaseDir = join(TEST_ROOT, "pty-dead-inbox");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "pty-dead-monitor",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath, now: () => 1_000 },
+    );
+
+    const context = createServerContext({
+      client: createPlacementClient([]) as any,
+      stateDir: stateDir("pty-dead-state"),
+      skipAgentLifecycle: true,
+    });
+    context.stateMgr.writeState({
+      agent_id: "worker-wedged",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "session-wedged",
+      task_summary: "watch collab",
+      pid: 123,
+      version: 1,
+      created_at: new Date(1_000).toISOString(),
+      updated_at: new Date(1_000).toISOString(),
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "verified",
+      max_cost_per_agent: null,
+    });
+    context.surfaceWriteLiveness.recordFailure("surface:caller", {
+      code: "EPIPE",
+    });
+    context.surfaceWriteLiveness.recordFailure("surface:caller", {
+      code: "EPIPE",
+    });
+    const guardedRelay = vi.fn().mockResolvedValue(undefined);
+    context.setLifecycleAgentInputDeliverer(guardedRelay);
+    const monitorOwnerPtyDeadNotify = vi.fn().mockResolvedValue(true);
+    const daemon = new CmuxLayerDaemon({
+      socketPath: socketPath("monitor-owner-pty-dead"),
+      context,
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => 62_000,
+      monitorReconcileIntervalMs: 5,
+      monitorOwnerPtyDeadNotify,
+      inboxBaseDir,
+    });
+
+    await daemon.start();
+    await waitUntil(
+      () => readMonitorRegistry({ registryPath }).monitors[0]?.state !== "alive",
+    );
+    await delay(20);
+    await daemon.shutdown();
+
+    expect(readMonitorRegistry({ registryPath }).monitors[0]).toMatchObject({
+      monitor_id: "pty-dead-monitor",
+      state: "collapsed",
+      collapsed_reason: "owner-pty-dead",
+    });
+    expect(monitorOwnerPtyDeadNotify).toHaveBeenCalledTimes(1);
+    expect(monitorOwnerPtyDeadNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Monitor owner PTY dead",
+        body: expect.stringContaining("pty-dead-monitor"),
+        priority: "high",
+      }),
+    );
+    expect(readInbox("worker-wedged", { baseDir: inboxBaseDir })).toEqual([]);
+    expect(guardedRelay).not.toHaveBeenCalled();
+  });
+
   it("retries a claimed monitor as soon as the guarded relay becomes ready", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const registryPath = join(TEST_ROOT, "relay-ready-monitor-registry.json");

--- a/tests/monitor-registry-mcp.test.ts
+++ b/tests/monitor-registry-mcp.test.ts
@@ -154,7 +154,7 @@ describe("monitor registry MCP tools", () => {
     });
   });
 
-  it("surfaces collapsed recovery metadata through list and gate queries", async () => {
+  it("surfaces owner-pty-dead recovery metadata through list and gate queries", async () => {
     const watchedFile = join(TEST_DIR, "collapsed.md");
     writeFileSync(watchedFile, "# collab\n", "utf8");
     const server = createMonitorServer();
@@ -170,7 +170,8 @@ describe("monitor registry MCP tools", () => {
     await reconcileMonitorRegistry({
       registryPath: registryPath(),
       now: () => now,
-      ownerAlive: async () => false,
+      ownerPtyDead: async () => true,
+      ownerAlive: async () => true,
       rearm: vi.fn(),
     });
 
@@ -185,13 +186,13 @@ describe("monitor registry MCP tools", () => {
     expect(listed.monitors[0]).toMatchObject({
       monitor_id: "seat-a-collapsed",
       state: "collapsed",
-      collapsed_reason: "owner-not-alive",
+      collapsed_reason: "owner-pty-dead",
     });
     expect(queried.monitors[0]).toMatchObject({
       monitor_id: "seat-a-collapsed",
       state: "collapsed",
       liveness: "collapsed",
-      collapsed_reason: "owner-not-alive",
+      collapsed_reason: "owner-pty-dead",
     });
   });
 

--- a/tests/monitor-registry.test.ts
+++ b/tests/monitor-registry.test.ts
@@ -423,12 +423,15 @@ describe("monitor registry deadman core", () => {
       { registryPath: registryPath(), now: () => 1_000 },
     );
     const rearm = vi.fn().mockResolvedValue(undefined);
+    const escalate = vi.fn();
 
     const first = await reconcileMonitorRegistry({
       registryPath: registryPath(),
       now: () => 62_000,
+      ownerPtyDead: async () => false,
       ownerAlive: async (ownerSeat) => ownerSeat === "worker-a",
       rearm,
+      escalate,
     });
     const second = await reconcileMonitorRegistry({
       registryPath: registryPath(),
@@ -446,6 +449,7 @@ describe("monitor registry deadman core", () => {
     expect(first.rearmed).toEqual(["stale-live-owner"]);
     expect(second.rearmed).toEqual([]);
     expect(rearm).toHaveBeenCalledTimes(1);
+    expect(escalate).not.toHaveBeenCalled();
     expect(swept.fired).toEqual([]);
     expect(notify).not.toHaveBeenCalled();
     expect(rearm).toHaveBeenCalledWith(
@@ -460,6 +464,67 @@ describe("monitor registry deadman core", () => {
       monitor_id: "stale-live-owner",
       state: "rearming",
       rearm_claimed_at: iso(62_000),
+    });
+  });
+
+  it("collapses a pty-dead owner's monitor and escalates exactly once", async () => {
+    const watchedFile = join(TEST_DIR, "owner-pty-dead.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "owner-pty-dead",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const rearm = vi.fn();
+    const escalate = vi.fn().mockResolvedValue(undefined);
+
+    const first = await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      ownerPtyDead: async (ownerSeat) => ownerSeat === "worker-wedged",
+      ownerAlive: async () => true,
+      rearm,
+      escalate,
+    });
+    const second = await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 63_000,
+      ownerPtyDead: async () => true,
+      ownerAlive: async () => true,
+      rearm,
+      escalate,
+    });
+
+    expect(first).toMatchObject({
+      rearmed: [],
+      collapsed: [
+        { monitor_id: "owner-pty-dead", reason: "owner-pty-dead" },
+      ],
+      failed: [],
+    });
+    expect(second).toMatchObject({ rearmed: [], collapsed: [], failed: [] });
+    expect(rearm).not.toHaveBeenCalled();
+    expect(escalate).toHaveBeenCalledTimes(1);
+    expect(escalate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitor_id: "owner-pty-dead",
+        owner_seat: "worker-wedged",
+        state: "collapsed",
+        collapsed_reason: "owner-pty-dead",
+      }),
+    );
+    expect(
+      readMonitorRegistry({ registryPath: registryPath() }).monitors[0],
+    ).toMatchObject({
+      monitor_id: "owner-pty-dead",
+      state: "collapsed",
+      collapsed_reason: "owner-pty-dead",
     });
   });
 

--- a/tests/monitor-registry.test.ts
+++ b/tests/monitor-registry.test.ts
@@ -528,6 +528,49 @@ describe("monitor registry deadman core", () => {
     });
   });
 
+  it("continues reconciling later monitors when collapse escalation rejects", async () => {
+    const watchedFile = join(TEST_DIR, "escalation-failure.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    for (const [monitorId, ownerSeat] of [
+      ["escalation-fails", "worker-wedged"],
+      ["healthy-after-failure", "worker-healthy"],
+    ] as const) {
+      await registerMonitor(
+        {
+          monitor_id: monitorId,
+          owner_seat: ownerSeat,
+          watch_targets: [watchedFile],
+          mechanism: "event",
+          deadman_timeout_s: 60,
+          rearm_command: `tail -n0 -F ${watchedFile}`,
+        },
+        { registryPath: registryPath(), now: () => 1_000 },
+      );
+    }
+    const rearm = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      reconcileMonitorRegistry({
+        registryPath: registryPath(),
+        now: () => 62_000,
+        ownerPtyDead: async (ownerSeat) => ownerSeat === "worker-wedged",
+        ownerAlive: async () => true,
+        rearm,
+        escalate: vi.fn().mockRejectedValue(new Error("notify unavailable")),
+      }),
+    ).resolves.toMatchObject({
+      rearmed: ["healthy-after-failure"],
+      collapsed: [
+        { monitor_id: "escalation-fails", reason: "owner-pty-dead" },
+      ],
+      failed: [],
+    });
+    expect(rearm).toHaveBeenCalledTimes(1);
+    expect(rearm).toHaveBeenCalledWith(
+      expect.objectContaining({ monitor_id: "healthy-after-failure" }),
+    );
+  });
+
   it("rejects relative file targets for re-arm-capable monitors", async () => {
     await expect(
       registerMonitor(


### PR DESCRIPTION
## Summary

- classify a stale monitor whose owner has shared `pty_dead` write-liveness as `collapsed` with the distinct reason `owner-pty-dead`
- suppress the impossible owner inbox re-arm and emit one high-priority daemon notification instead
- preserve healthy-owner re-arm behavior and the existing durable claim/lease guard
- contain best-effort notification failures so later monitor candidates still reconcile
- document the design and TDD implementation plan in committed artifacts

## Design

### Decision

Current monitor records do not prove that a watcher is owner-independent. An absolute file target and `event`/`offset-poll` mechanism describe intent, while `rearm_command` remains opaque shell text that may depend on the owner's working directory, environment, credentials, in-memory cursor, or process state.

Therefore all current-schema monitors default to **owner-bound**. When the existing shared `SurfaceWriteLivenessTracker` reports `pty_dead`, the daemon does not execute the command and does not dispatch to the wedged owner. It atomically persists:

```text
state: collapsed
collapsed_reason: owner-pty-dead
```

Then it emits a high-priority notification containing the monitor id, owner, and watch targets. A future owner-independent path requires explicit daemon-safe registration metadata; it is not inferred from paths or mechanism.

### Alternatives rejected

1. **Execute every stored command in the daemon** — unsafe because commands are opaque and may rely on owner-local state.
2. **Infer purity from mechanism plus absolute targets** — those fields do not certify side-effect freedom or a daemon-safe execution contract.
3. **Loud collapse escalation** — chosen safe default; failure remains durable and visible even if notification delivery is unavailable.

### Data flow and idempotency

The reconciler accepts an injected owner-PTY-dead predicate alongside the existing owner-alive probe. The daemon reads `context.surfaceWriteLiveness.observe(owner.surface_id)?.pty_dead`; it does not duplicate broken-pipe parsing or thresholds.

The existing registry lock is the claim boundary. Only the pass that wins the transition from stale `alive` (or an expired `rearming` lease) to `collapsed` runs the escalation callback. Later ticks ignore `collapsed`, preventing notification storms and inbox double-delivery. A best-effort notification rejection is contained after the durable claim so unrelated candidates continue reconciling. Healthy owners continue through the v0.3.37 `rearming` flow unchanged.

Committed design: `docs/plans/2026-07-11-monitor-owner-failover-design.md`

## Verification

Final head: `1f4182826ae15805effbfbb24c8efcc497bb5946`

- `bunx vitest run tests/monitor-registry.test.ts tests/monitor-registry-mcp.test.ts tests/daemon.test.ts` — 60/60 passed
- `bun run typecheck` — exit 0
- `bun run build` — exit 0
- five consecutive uncontended final-code full-suite processes — each 90 files, 1,647 tests, 0 failures
- pre-push hook after review fix — 2 Bun regression tests passed; full 1,647-test Vitest suite passed
- `git diff --cached --check` / `git diff --check` — clean

A pre-gate attempt overlapped the parallel observability worktree's Vitest process and reproduced the documented baseline CPU-contention timing failures. Public process/surface state identified the overlap; the five-run count was reset and all five uncontended final-code processes passed.

### Final daemon runtime receipt

A fresh Claude client loaded only the final worktree MCP config and called real `control_health` and `list_monitors` tools:

- result: `FINAL_RUNTIME_OK`
- calls: 2/2 succeeded
- commit: `1f4182826ae15805effbfbb24c8efcc497bb5946`
- daemon: PID 41910, `/Users/etanheyman/Gits/cmuxlayer.wt/r6-monitor-failover/dist/daemon.js`
- transport: unique `/tmp/cmuxlayer-r6-runtime-final.sock`
- cleanup: probe surface closed, daemon terminated, socket removed

## Test coverage

- PTY-dead owner → `owner-pty-dead`, zero owner re-arm calls
- loud escalation fires exactly once across repeated reconcile ticks
- rejected escalation does not abort a later healthy monitor's re-arm
- healthy owner → unchanged durable re-arm behavior
- `list_monitors` and gate query surface the new collapse reason
- daemon consumes the shared write-liveness tracker and leaves the owner inbox untouched

## Review disposition

- CodeRabbit local/PR review: **SKIPPED — review rate limit**
- Cursor Bugbot: **SKIPPED — usage/spend limit**
- fallback red-team + blue-team diff review: no HIGH/CRITICAL or major actionable findings
- Macroscope medium: escalation rejection aborted later candidates — **FIXED** in `1f41828`, regression test added, inline thread replied and resolved
- CI `test` and `build-site`: green on round 1; round-2 checks required on final head before merge
