### PR TITLE
feat(observability): expose pty-liveness + monitor-reconcile state in doctor and control_health

### DIFF
--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -207,8 +207,18 @@ export function collectSelfHealHealth(opts: {
       monitors = readMonitorRegistry(opts.monitorRegistry).monitors;
       monitorRegistryAvailable = true;
     } catch (error) {
-      monitorRegistryError =
-        error instanceof Error ? error.message : String(error);
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        monitors = readMonitorRegistry(opts.monitorRegistry).monitors;
+        monitorRegistryAvailable = true;
+      } else {
+        monitorRegistryError =
+          error instanceof Error ? error.message : String(error);
+      }
     }
   } else {
     monitorRegistryError = "monitor registry path is not configured";

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -734,7 +734,8 @@ export function formatControlHealth(health: ControlHealth): string {
     ...formatInstance(health.cmux_instances.nightly),
     `pane_pty_dead: ${health.self_heal.pane_pty_dead.count}`,
     ...health.self_heal.pane_pty_dead.surfaces.map(
-      (surface) => `  ${surface.surface_id} since ${surface.since_at}`,
+      (surface) =>
+        `  ${surface.surface_id} since ${surface.since_at ?? surface.last_attempt_at}`,
     ),
     ...(health.self_heal.monitor_registry.available
       ? [

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -1,9 +1,23 @@
 import { execFile } from "node:child_process";
 import { getTransportHealth } from "./cmux-transport-self-heal.js";
-import { constants as fsConstants, realpathSync } from "node:fs";
+import {
+  constants as fsConstants,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { access, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import {
+  queryMonitorRegistryForGates,
+  readMonitorRegistry,
+  type MonitorRegistryOptions,
+} from "./monitor-registry.js";
+import type { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
+
+const MAX_SELF_HEAL_DETAILS = 100;
+const MAX_MONITOR_REGISTRY_BYTES = 1024 * 1024;
 
 const RUNNING_SCRIPT_PATH = (() => {
   const entrypoint = process.argv[1];
@@ -39,6 +53,31 @@ export interface ControlHealthOptions {
   stat?: typeof stat;
   access?: typeof access;
   now?: () => Date;
+  surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
+  surfaceIds?: readonly string[];
+  panePtyDeadSince?: ReadonlyMap<string, number>;
+  monitorRegistryPath?: string;
+}
+
+export interface ControlHealthSelfHeal {
+  pane_pty_dead: {
+    count: number;
+    surfaces: Array<{
+      surface_id: string;
+      since_at?: string;
+      last_attempt_at: string;
+    }>;
+    truncated: boolean;
+  };
+  monitor_registry: {
+    available: boolean;
+    error?: string;
+    total: number;
+    rearming: number;
+    collapsed: number;
+    collapsed_monitors: Array<{ monitor_id: string; reason: string }>;
+    truncated: boolean;
+  };
 }
 
 export interface PathStatus {
@@ -99,7 +138,104 @@ export interface ControlHealth {
     production: CmuxInstanceHealth;
     nightly: CmuxInstanceHealth;
   };
+  self_heal: ControlHealthSelfHeal;
   warnings: string[];
+}
+
+export function collectSelfHealHealth(opts: {
+  surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
+  surfaceIds?: readonly string[];
+  panePtyDeadSince?: ReadonlyMap<string, number>;
+  monitorRegistry?: MonitorRegistryOptions;
+} = {}): ControlHealthSelfHeal {
+  const surfaceIds = [...new Set(opts.surfaceIds ?? [])];
+  const deadSurfaces: ControlHealthSelfHeal["pane_pty_dead"]["surfaces"] = [];
+  let deadSurfaceCount = 0;
+  if (opts.surfaceWriteLiveness) {
+    for (const surfaceId of surfaceIds) {
+      try {
+        const observation = opts.surfaceWriteLiveness.observe(surfaceId);
+        if (!observation?.pty_dead) continue;
+        deadSurfaceCount += 1;
+        if (deadSurfaces.length >= MAX_SELF_HEAL_DETAILS) continue;
+        const sinceAt = opts.panePtyDeadSince?.get(surfaceId);
+        deadSurfaces.push({
+          surface_id: surfaceId,
+          ...(sinceAt === undefined
+            ? {}
+            : { since_at: new Date(sinceAt).toISOString() }),
+          last_attempt_at: new Date(
+            observation.last_attempt_at,
+          ).toISOString(),
+        });
+      } catch {
+        // One malformed/stale surface observation must not break control_health.
+      }
+    }
+  }
+
+  let monitors: ReturnType<typeof readMonitorRegistry>["monitors"] = [];
+  let monitorRegistryAvailable = false;
+  let monitorRegistryError: string | undefined;
+  const registryPath = opts.monitorRegistry?.registryPath;
+  if (registryPath) {
+    try {
+      const registryStat = statSync(registryPath);
+      if (registryStat.size > MAX_MONITOR_REGISTRY_BYTES) {
+        throw new Error(
+          `monitor registry exceeds ${MAX_MONITOR_REGISTRY_BYTES} bytes`,
+        );
+      }
+      const parsed = JSON.parse(readFileSync(registryPath, "utf8")) as unknown;
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        !Array.isArray((parsed as { monitors?: unknown }).monitors)
+      ) {
+        throw new Error("monitor registry JSON has invalid shape");
+      }
+      const registryQuery = queryMonitorRegistryForGates(
+        opts.monitorRegistry,
+      );
+      if (
+        registryQuery.monitors.some(
+          (monitor) => monitor.liveness === "invalid",
+        )
+      ) {
+        throw new Error("monitor registry contains invalid records");
+      }
+      monitors = readMonitorRegistry(opts.monitorRegistry).monitors;
+      monitorRegistryAvailable = true;
+    } catch (error) {
+      monitorRegistryError =
+        error instanceof Error ? error.message : String(error);
+    }
+  } else {
+    monitorRegistryError = "monitor registry path is not configured";
+  }
+  const collapsedMonitors = monitors
+    .filter((monitor) => monitor.state === "collapsed")
+    .map((monitor) => ({
+      monitor_id: monitor.monitor_id,
+      reason: monitor.collapsed_reason ?? "unknown",
+    }));
+
+  return {
+    pane_pty_dead: {
+      count: deadSurfaceCount,
+      surfaces: deadSurfaces,
+      truncated: deadSurfaceCount > deadSurfaces.length,
+    },
+    monitor_registry: {
+      available: monitorRegistryAvailable,
+      ...(monitorRegistryError ? { error: monitorRegistryError } : {}),
+      total: monitors.length,
+      rearming: monitors.filter((monitor) => monitor.state === "rearming").length,
+      collapsed: collapsedMonitors.length,
+      collapsed_monitors: collapsedMonitors.slice(0, MAX_SELF_HEAL_DETAILS),
+      truncated: collapsedMonitors.length > MAX_SELF_HEAL_DETAILS,
+    },
+  };
 }
 
 const ENV_KEYS = [
@@ -532,6 +668,14 @@ export async function collectControlHealth(
         ),
       },
     },
+    self_heal: collectSelfHealHealth({
+      surfaceWriteLiveness: opts.surfaceWriteLiveness,
+      surfaceIds: opts.surfaceIds,
+      panePtyDeadSince: opts.panePtyDeadSince,
+      monitorRegistry: opts.monitorRegistryPath
+        ? { registryPath: opts.monitorRegistryPath }
+        : undefined,
+    }),
   };
 
   return { ...base, warnings: buildWarnings(base) };
@@ -588,6 +732,20 @@ export function formatControlHealth(health: ControlHealth): string {
       }),
     ...formatInstance(health.cmux_instances.production),
     ...formatInstance(health.cmux_instances.nightly),
+    `pane_pty_dead: ${health.self_heal.pane_pty_dead.count}`,
+    ...health.self_heal.pane_pty_dead.surfaces.map(
+      (surface) => `  ${surface.surface_id} since ${surface.since_at}`,
+    ),
+    ...(health.self_heal.monitor_registry.available
+      ? [
+          `monitor registry: total=${health.self_heal.monitor_registry.total} rearming=${health.self_heal.monitor_registry.rearming} collapsed=${health.self_heal.monitor_registry.collapsed}`,
+        ]
+      : [
+          `monitor registry: unavailable (${health.self_heal.monitor_registry.error ?? "unknown error"})`,
+        ]),
+    ...health.self_heal.monitor_registry.collapsed_monitors.map(
+      (monitor) => `  ${monitor.monitor_id}: ${monitor.reason}`,
+    ),
   ];
 
   if (health.current_process.cmux_resolution.length === 0) {

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -188,9 +188,10 @@ export function collectSelfHealHealth(opts: {
       }
       const parsed = JSON.parse(readFileSync(registryPath, "utf8")) as unknown;
       if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        !Array.isArray((parsed as { monitors?: unknown }).monitors)
+        !Array.isArray(parsed) &&
+        (typeof parsed !== "object" ||
+          parsed === null ||
+          !Array.isArray((parsed as { monitors?: unknown }).monitors))
       ) {
         throw new Error("monitor registry JSON has invalid shape");
       }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -161,6 +161,8 @@ export interface DoctorReport {
     currentSocketPath?: string | null;
     runningScriptPath?: string;
   };
+  /** Additive §5 visibility into PTY write-liveness and monitor reconciliation. */
+  selfHeal: DoctorSelfHealReport;
   /** §3 tap — best-effort report; brew may be absent. */
   tap: {
     brewAvailable: boolean;
@@ -183,6 +185,30 @@ export interface DoctorReport {
   mcpReconnectProcedure: McpReconnectProcedureReport;
   /** Read-only `.mcp.json` drift report; does NOT affect health. */
   mcpConfigDrift: McpConfigDriftReport;
+}
+
+export interface DoctorSelfHealReport {
+  available: boolean;
+  ok: boolean;
+  panePtyDead: {
+    count: number;
+    surfaces: Array<{
+      surfaceId: string;
+      sinceAt?: string;
+      lastAttemptAt: string;
+    }>;
+    truncated: boolean;
+  };
+  monitorRegistry: {
+    available: boolean;
+    error?: string;
+    total: number;
+    rearming: number;
+    collapsed: number;
+    collapsedMonitors: Array<{ monitorId: string; reason: string }>;
+    truncated: boolean;
+  };
+  note: string;
 }
 
 export interface RunDoctorOptions {
@@ -224,8 +250,145 @@ type DaemonMcpProbeResult =
       transportDegraded: boolean;
       currentSocketPath: string | null;
       scriptPath: string | null;
+      selfHeal: DoctorSelfHealReport;
     }
   | { kind: "error"; error: string };
+
+function unavailableSelfHeal(note: string): DoctorSelfHealReport {
+  return {
+    available: false,
+    ok: true,
+    panePtyDead: { count: 0, surfaces: [], truncated: false },
+    monitorRegistry: {
+      available: false,
+      error: note,
+      total: 0,
+      rearming: 0,
+      collapsed: 0,
+      collapsedMonitors: [],
+      truncated: false,
+    },
+    note,
+  };
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0
+    ? value
+    : null;
+}
+
+function parseDoctorSelfHeal(value: unknown): DoctorSelfHealReport {
+  if (!isRecord(value)) {
+    return unavailableSelfHeal("self-heal state unavailable from control_health");
+  }
+  const pane = isRecord(value.pane_pty_dead) ? value.pane_pty_dead : null;
+  const registry = isRecord(value.monitor_registry)
+    ? value.monitor_registry
+    : null;
+  if (!pane || !registry) {
+    return unavailableSelfHeal("self-heal state unavailable from control_health");
+  }
+
+  const paneCount = nonNegativeInteger(pane.count);
+  const registryAvailable = registry.available;
+  const total = nonNegativeInteger(registry.total);
+  const rearming = nonNegativeInteger(registry.rearming);
+  const collapsed = nonNegativeInteger(registry.collapsed);
+  if (
+    paneCount === null ||
+    typeof registryAvailable !== "boolean" ||
+    total === null ||
+    rearming === null ||
+    collapsed === null ||
+    rearming > total ||
+    collapsed > total ||
+    rearming + collapsed > total
+  ) {
+    return unavailableSelfHeal("self-heal state malformed in control_health");
+  }
+
+  const rawSurfaces = Array.isArray(pane.surfaces) ? pane.surfaces : [];
+  const surfaces = rawSurfaces
+    .slice(0, 100)
+    .flatMap((surface) => {
+      if (!isRecord(surface)) return [];
+      if (
+        typeof surface.surface_id !== "string" ||
+        typeof surface.last_attempt_at !== "string" ||
+        (surface.since_at !== undefined &&
+          typeof surface.since_at !== "string")
+      ) {
+        return [];
+      }
+      return [
+        {
+          surfaceId: surface.surface_id,
+          ...(typeof surface.since_at === "string"
+            ? { sinceAt: surface.since_at }
+            : {}),
+          lastAttemptAt: surface.last_attempt_at,
+        },
+      ];
+    });
+  const rawCollapsedMonitors = Array.isArray(registry.collapsed_monitors)
+    ? registry.collapsed_monitors
+    : [];
+  const collapsedMonitors = rawCollapsedMonitors
+    .slice(0, 100)
+    .flatMap((monitor) => {
+      if (!isRecord(monitor)) return [];
+      if (
+        typeof monitor.monitor_id !== "string" ||
+        typeof monitor.reason !== "string"
+      ) {
+        return [];
+      }
+      return [{ monitorId: monitor.monitor_id, reason: monitor.reason }];
+    });
+  if (
+    surfaces.length !== Math.min(rawSurfaces.length, 100) ||
+    collapsedMonitors.length !== Math.min(rawCollapsedMonitors.length, 100) ||
+    paneCount < rawSurfaces.length ||
+    collapsed < rawCollapsedMonitors.length
+  ) {
+    return unavailableSelfHeal("self-heal state malformed in control_health");
+  }
+  const registryError =
+    typeof registry.error === "string" ? registry.error : undefined;
+  const ok = paneCount === 0 && registryAvailable && collapsed === 0;
+  return {
+    available: true,
+    ok,
+    panePtyDead: {
+      count: paneCount,
+      surfaces,
+      truncated:
+        pane.truncated === true ||
+        rawSurfaces.length > 100 ||
+        paneCount > surfaces.length,
+    },
+    monitorRegistry: {
+      available: registryAvailable,
+      ...(registryError ? { error: registryError } : {}),
+      total,
+      rearming,
+      collapsed,
+      collapsedMonitors,
+      truncated:
+        registry.truncated === true ||
+        rawCollapsedMonitors.length > 100 ||
+        collapsed > collapsedMonitors.length,
+    },
+    note: ok
+      ? "pane write-liveness and monitor reconciliation healthy"
+      : registryAvailable
+        ? "pane write-liveness or monitor reconciliation requires attention"
+        : `monitor registry unavailable: ${registryError ?? "unknown error"}`,
+  };
+}
 
 function daemonProbeError(message: unknown): string {
   return message instanceof Error ? message.message : String(message);
@@ -367,6 +530,7 @@ function probeDaemonMcp(
                   ? selected.current_socket_path
                   : null,
               scriptPath,
+              selfHeal: parseDoctorSelfHeal(health?.self_heal),
             });
           }
         } catch (error) {
@@ -399,7 +563,10 @@ function probeDaemonMcp(
 async function checkDaemonIntegrity(
   opts: RunDoctorOptions,
   env: NodeJS.ProcessEnv,
-): Promise<DoctorReport["daemon"]> {
+): Promise<{
+  daemon: DoctorReport["daemon"];
+  selfHeal: DoctorSelfHealReport;
+}> {
   const socketPath = defaultDaemonSocketPath(env);
   const probe = await probeDaemonMcp(
     socketPath,
@@ -407,20 +574,26 @@ async function checkDaemonIntegrity(
   );
   if (probe.kind === "not-listening") {
     return {
-      applicable: true,
-      ok: true,
-      listening: false,
-      socketPath,
-      note: "no daemon running (starts on demand)",
+      daemon: {
+        applicable: true,
+        ok: true,
+        listening: false,
+        socketPath,
+        note: "no daemon running (starts on demand)",
+      },
+      selfHeal: unavailableSelfHeal("no daemon running (starts on demand)"),
     };
   }
   if (probe.kind === "error") {
     return {
-      applicable: true,
-      ok: false,
-      listening: true,
-      socketPath,
-      note: `daemon probe failed: ${probe.error}`,
+      daemon: {
+        applicable: true,
+        ok: false,
+        listening: true,
+        socketPath,
+        note: `daemon probe failed: ${probe.error}`,
+      },
+      selfHeal: unavailableSelfHeal("daemon control_health probe failed"),
     };
   }
 
@@ -440,9 +613,12 @@ async function checkDaemonIntegrity(
     try {
       if (!(opts.pathExists ?? existsSync)(probe.scriptPath)) {
         return {
-          ...base,
-          ok: false,
-          note: "daemon running from a deleted install (brew cleanup?) — stale detection is blind; retire it",
+          daemon: {
+            ...base,
+            ok: false,
+            note: "daemon running from a deleted install (brew cleanup?) — stale detection is blind; retire it",
+          },
+          selfHeal: probe.selfHeal,
         };
       }
     } catch {
@@ -451,9 +627,12 @@ async function checkDaemonIntegrity(
   }
   if (stale?.stale) {
     return {
-      ...base,
-      ok: false,
-      note: `stale daemon v${stale.running} serving (installed v${stale.installed}) — kill it; proxies respawn the installed daemon`,
+      daemon: {
+        ...base,
+        ok: false,
+        note: `stale daemon v${stale.running} serving (installed v${stale.installed}) — kill it; proxies respawn the installed daemon`,
+      },
+      selfHeal: probe.selfHeal,
     };
   }
 
@@ -472,20 +651,26 @@ async function checkDaemonIntegrity(
       // A failed probe is the socket-down branch, but degraded is always red.
     }
     return {
-      ...base,
-      ok: false,
-      note: cmuxSocketUsable
-        ? "daemon transport degraded while cmux socket alive (access-control denial class; stale-daemon-on-dead-socket class)"
-        : "daemon transport degraded while cmux socket down (app not running)",
+      daemon: {
+        ...base,
+        ok: false,
+        note: cmuxSocketUsable
+          ? "daemon transport degraded while cmux socket alive (access-control denial class; stale-daemon-on-dead-socket class)"
+          : "daemon transport degraded while cmux socket down (app not running)",
+      },
+      selfHeal: probe.selfHeal,
     };
   }
 
   return {
-    ...base,
-    ok: true,
-    note: stale
-      ? `daemon v${probe.version} healthy (installed v${stale.installed})`
-      : `daemon v${probe.version} healthy (installed version unavailable)`,
+    daemon: {
+      ...base,
+      ok: true,
+      note: stale
+        ? `daemon v${probe.version} healthy (installed v${stale.installed})`
+        : `daemon v${probe.version} healthy (installed version unavailable)`,
+    },
+    selfHeal: probe.selfHeal,
   };
 }
 
@@ -944,11 +1129,12 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     listMcpConfigPaths: opts.listMcpConfigPaths,
     readMcpConfigFile: opts.readMcpConfigFile,
   });
-  const daemon = await checkDaemonIntegrity(opts, env);
+  const { daemon, selfHeal } = await checkDaemonIntegrity(opts, env);
 
   // Brew/tap gaps stay best-effort, but an unusable referenced launcher is an
   // operational failure: configs can look correct while every MCP launch fails.
-  const healthy = versionOk && daemon.ok && mcpConfigDrift.launcherOk;
+  const healthy =
+    versionOk && daemon.ok && selfHeal.ok && mcpConfigDrift.launcherOk;
 
   return {
     healthy,
@@ -958,6 +1144,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
       note: "not-applicable: stdio MCP, no cask (§1 account-rename self-heal)",
     },
     daemon,
+    selfHeal,
     tap,
     socketPath: socketSet
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
@@ -986,6 +1173,40 @@ export function renderDoctorText(report: DoctorReport): string {
   lines.push(`│ — §1 ${report.caskSelfHeal.note}`);
 
   lines.push(`│ ${mark(report.daemon.ok)} §5 ${report.daemon.note}`);
+  if (!report.selfHeal.available) {
+    lines.push(`│ — §5 self-heal observability: ${report.selfHeal.note}`);
+  } else {
+    const paneDetails = report.selfHeal.panePtyDead.surfaces
+      .map((surface) =>
+        surface.sinceAt
+          ? `${surface.surfaceId} since ${surface.sinceAt} (last attempt ${surface.lastAttemptAt})`
+          : `${surface.surfaceId} last attempt ${surface.lastAttemptAt}`,
+      )
+      .join(", ");
+    lines.push(
+      `│ ${mark(report.selfHeal.panePtyDead.count === 0)}    pane_pty_dead: ${
+        report.selfHeal.panePtyDead.count === 0
+          ? "none"
+          : `${report.selfHeal.panePtyDead.count} (${paneDetails || "details unavailable"})`
+      }${report.selfHeal.panePtyDead.truncated ? " [details truncated]" : ""}`,
+    );
+    if (!report.selfHeal.monitorRegistry.available) {
+      lines.push(
+        `│ ✗    monitor registry: unavailable (${report.selfHeal.monitorRegistry.error ?? "unknown error"})`,
+      );
+    } else {
+      const collapsedDetails = report.selfHeal.monitorRegistry.collapsedMonitors
+        .map((monitor) => `${monitor.monitorId}: ${monitor.reason}`)
+        .join(", ");
+      lines.push(
+        `│ ${mark(report.selfHeal.monitorRegistry.collapsed === 0)}    monitor registry: total=${report.selfHeal.monitorRegistry.total} rearming=${report.selfHeal.monitorRegistry.rearming} collapsed=${report.selfHeal.monitorRegistry.collapsed}${
+          report.selfHeal.monitorRegistry.collapsed > 0
+            ? `; collapsed monitors: ${collapsedDetails || "details unavailable"}`
+            : ""
+        }${report.selfHeal.monitorRegistry.truncated ? " [details truncated]" : ""}`,
+      );
+    }
+  }
 
   // (b) §3 tap
   if (!report.tap.brewAvailable) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,7 @@ import {
 import { reposEquivalent, resolveWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
+  collectSelfHealHealth,
   collectControlHealth,
   formatControlHealth,
   type ControlHealth,
@@ -1844,6 +1845,8 @@ export interface CmuxServerContext {
   latestDeliveryBySurface: Map<string, string>;
   activeDeliveryBySurface: Map<string, string>;
   activeSurfaceWrites: Map<string, string>;
+  surfaceWriteLivenessCandidates: Set<string>;
+  surfacePtyDeadSince: Map<string, number>;
   readScreenInflight: Map<string, Promise<ReadScreenSnapshot>>;
   surfaceWriteLiveness: SurfaceWriteLivenessTracker;
   enableClaudeChannels: boolean;
@@ -1937,6 +1940,8 @@ export function createServerContext(
     latestDeliveryBySurface: new Map(),
     activeDeliveryBySurface: new Map(),
     activeSurfaceWrites: new Map(),
+    surfaceWriteLivenessCandidates: new Set(),
+    surfacePtyDeadSince: new Map(),
     readScreenInflight: new Map(),
     surfaceWriteLiveness:
       opts?.surfaceWriteLiveness ?? new SurfaceWriteLivenessTracker(),
@@ -2053,6 +2058,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const activeDeliveryBySurface = context.activeDeliveryBySurface;
   const activeSurfaceWrites = context.activeSurfaceWrites;
   const surfaceWriteLiveness = context.surfaceWriteLiveness;
+  const surfaceWriteLivenessCandidates =
+    context.surfaceWriteLivenessCandidates;
+  const surfacePtyDeadSince = context.surfacePtyDeadSince;
   const enableClaudeChannels =
     opts?.enableClaudeChannels ?? context.enableClaudeChannels;
   const skipAgentLifecycle =
@@ -2543,6 +2551,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
+  const recordSurfaceWriteSuccess = (surface: string): void => {
+    surfaceWriteLiveness.recordSuccess(surface);
+    surfaceWriteLivenessCandidates.delete(surface);
+    surfacePtyDeadSince.delete(surface);
+  };
+
+  const recordSurfaceWriteFailure = (
+    surface: string,
+    error: unknown,
+  ): void => {
+    surfaceWriteLiveness.recordFailure(surface, error);
+    const observation = surfaceWriteLiveness.observe(surface);
+    if (!observation || observation.consecutive_broken_pipe_failures === 0) {
+      surfaceWriteLivenessCandidates.delete(surface);
+      surfacePtyDeadSince.delete(surface);
+      return;
+    }
+    if (!observation.pty_dead) {
+      surfaceWriteLivenessCandidates.delete(surface);
+      surfacePtyDeadSince.delete(surface);
+      return;
+    }
+    surfaceWriteLivenessCandidates.add(surface);
+    if (!surfacePtyDeadSince.has(surface)) {
+      surfacePtyDeadSince.set(surface, observation.last_attempt_at);
+    }
+  };
+
   const withSurfaceWrite = async <T>(
     surface: string,
     fn: () => Promise<T>,
@@ -2561,12 +2597,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     try {
       const result = await fn();
       if (opts.observePtyWrite) {
-        surfaceWriteLiveness.recordSuccess(surface);
+        recordSurfaceWriteSuccess(surface);
       }
       return result;
     } catch (error) {
       if (opts.observePtyWrite) {
-        surfaceWriteLiveness.recordFailure(surface, error);
+        recordSurfaceWriteFailure(surface, error);
       }
       throw error;
     } finally {
@@ -2611,9 +2647,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     failedChunk?: number,
   ) => {
     if (status === "delivered") {
-      surfaceWriteLiveness.recordSuccess(record.surface);
+      recordSurfaceWriteSuccess(record.surface);
     } else if (status === "failed") {
-      surfaceWriteLiveness.recordFailure(record.surface, error);
+      recordSurfaceWriteFailure(record.surface, error);
     }
     record.status = status;
     record.completed_at = new Date().toISOString();
@@ -2753,13 +2789,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const rawHealth = controlHealthCollector
       ? await controlHealthCollector()
       : await collectControlHealth({ client });
+    const knownSurfaceIds = [
+      ...stateMgr.listStates().map((record) => record.surface_id),
+      ...roleSurfaceOverrides.keys(),
+      ...latestDeliveryBySurface.keys(),
+      ...activeSurfaceWrites.keys(),
+      ...surfaceWriteLivenessCandidates,
+    ];
+    const healthWithSelfHeal: ControlHealth = {
+      ...rawHealth,
+      self_heal: collectSelfHealHealth({
+        surfaceWriteLiveness,
+        surfaceIds: knownSurfaceIds,
+        panePtyDeadSince: surfacePtyDeadSince,
+        monitorRegistry: opts?.monitorRegistryPath
+          ? monitorRegistryOptions()
+          : undefined,
+      }),
+    };
     const health =
       controlHealthWarnings.length > 0
         ? {
-            ...rawHealth,
-            warnings: [...rawHealth.warnings, ...controlHealthWarnings],
+            ...healthWithSelfHeal,
+            warnings: [
+              ...healthWithSelfHeal.warnings,
+              ...controlHealthWarnings,
+            ],
           }
-        : rawHealth;
+        : healthWithSelfHeal;
     eventLog.appendControlHealth({
       ts: health.generated_at,
       event_type: "control_health",

--- a/src/server.ts
+++ b/src/server.ts
@@ -154,7 +154,10 @@ import {
   loadSeatRegistryFromConfig,
   type SeatRegistry,
 } from "./seat-identity.js";
-import { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
+import {
+  isBrokenPipeError,
+  SurfaceWriteLivenessTracker,
+} from "./surface-write-liveness.js";
 
 type TextContent = { type: "text"; text: string };
 type ToolReturn = {
@@ -2561,6 +2564,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     surface: string,
     error: unknown,
   ): void => {
+    if (!isBrokenPipeError(error)) return;
     surfaceWriteLiveness.recordFailure(surface, error);
     const observation = surfaceWriteLiveness.observe(surface);
     if (!observation || observation.consecutive_broken_pipe_failures === 0) {

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -350,6 +350,32 @@ describe("control health", () => {
     expect(formatControlHealth(health)).toMatch(/monitor registry: unavailable/i);
   });
 
+  it("treats an absent monitor registry as an empty healthy registry", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-absent-registry");
+    const tmp = join(TEST_ROOT, "tmp-absent-registry");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-absent.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.monitor_registry).toEqual({
+      available: true,
+      total: 0,
+      rearming: 0,
+      collapsed: 0,
+      collapsed_monitors: [],
+      truncated: false,
+    });
+  });
+
   it("reports structurally invalid monitor records as unavailable", async () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-invalid-monitor-record");

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -376,6 +376,51 @@ describe("control health", () => {
     });
   });
 
+  it("accepts the public registry API's legacy top-level array shape", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-array-registry");
+    const tmp = join(TEST_ROOT, "tmp-array-registry");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-array.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(
+      monitorRegistryPath,
+      JSON.stringify([
+        {
+          monitor_id: "monitor-collapsed-array",
+          owner_seat: "seat-array",
+          watch_targets: ["/tmp/array-target"],
+          mechanism: "event",
+          deadman_timeout_s: 60,
+          armed_at: "2026-07-11T11:55:00.000Z",
+          last_signal_at: "2026-07-11T11:57:00.000Z",
+          state: "collapsed",
+          collapsed_reason: "watch-target-missing",
+        },
+      ]),
+    );
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.monitor_registry).toMatchObject({
+      available: true,
+      total: 1,
+      collapsed: 1,
+      collapsed_monitors: [
+        {
+          monitor_id: "monitor-collapsed-array",
+          reason: "watch-target-missing",
+        },
+      ],
+    });
+  });
+
   it("reports structurally invalid monitor records as unavailable", async () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-invalid-monitor-record");

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -317,6 +317,10 @@ describe("control health", () => {
     expect(health.self_heal.pane_pty_dead.surfaces).toEqual([
       expect.objectContaining({ surface_id: "surface:100" }),
     ]);
+    expect(formatControlHealth(health)).toContain(
+      "surface:100 since 2026-07-11T12:00:00.000Z",
+    );
+    expect(formatControlHealth(health)).not.toContain("since undefined");
   });
 
   it("reports a malformed monitor registry as unavailable", async () => {

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -465,9 +465,12 @@ describe("control health", () => {
     });
     let nowMs = Date.parse("2026-07-11T12:00:00.000Z");
     const tracker = new SurfaceWriteLivenessTracker({ now: () => nowMs });
+    let writeError: Error = Object.assign(new Error("broken pipe"), {
+      code: "EPIPE",
+    });
     const client = {
       sendKey: vi.fn(async () => {
-        throw Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+        throw writeError;
       }),
     };
     const server = createServer({
@@ -504,6 +507,24 @@ describe("control health", () => {
       expect(secondHealth.surfaces[0].since_at).toBe(
         firstHealth.surfaces[0].since_at,
       );
+
+      writeError = new Error("submit verification failed");
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
+      const afterNonPtyFailure = await controlHealth.handler({}, {} as any);
+      expect(
+        afterNonPtyFailure.structuredContent.health.self_heal.pane_pty_dead,
+      ).toMatchObject({
+        count: 1,
+        surfaces: [
+          expect.objectContaining({
+            since_at: firstHealth.surfaces[0].since_at,
+          }),
+        ],
+      });
+      writeError = Object.assign(new Error("broken pipe"), { code: "EPIPE" });
 
       nowMs += 31_000;
       await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -11,6 +11,7 @@ import type { ControlHealth } from "../src/control-health.js";
 import { AgentEngine } from "../src/agent-engine.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { StateManager } from "../src/state-manager.js";
+import { SurfaceWriteLivenessTracker } from "../src/surface-write-liveness.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-control-health-test");
 const ACCESS_CONTROL_DENIED_TEXT =
@@ -185,6 +186,262 @@ describe("control health", () => {
     expect(formatControlHealth(health)).toContain("cmuxlayer control_health");
 
     rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("reports pane_pty_dead surfaces and monitor recovery state", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-observability");
+    const tmp = join(TEST_ROOT, "tmp-observability");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    let nowMs = Date.parse("2026-07-11T12:00:00.000Z");
+    const tracker = new SurfaceWriteLivenessTracker({ now: () => nowMs });
+    tracker.recordFailure("surface:pty-dead", { code: "EPIPE" });
+    nowMs += 1_000;
+    tracker.recordFailure("surface:pty-dead", { code: "EPIPE" });
+    tracker.recordSuccess("surface:healthy");
+    writeFileSync(
+      monitorRegistryPath,
+      JSON.stringify({
+        version: 1,
+        monitors: [
+          {
+            monitor_id: "monitor-alive",
+            owner_seat: "seat-a",
+            watch_targets: ["/tmp/alive"],
+            mechanism: "event",
+            deadman_timeout_s: 60,
+            armed_at: "2026-07-11T11:55:00.000Z",
+            last_signal_at: "2026-07-11T11:59:00.000Z",
+            state: "alive",
+          },
+          {
+            monitor_id: "monitor-rearming",
+            owner_seat: "seat-b",
+            watch_targets: ["/tmp/rearming"],
+            mechanism: "event",
+            deadman_timeout_s: 60,
+            armed_at: "2026-07-11T11:55:00.000Z",
+            last_signal_at: "2026-07-11T11:58:00.000Z",
+            state: "rearming",
+            rearm_command: "resume monitor-rearming",
+            rearm_claimed_at: "2026-07-11T11:59:30.000Z",
+          },
+          {
+            monitor_id: "monitor-collapsed",
+            owner_seat: "seat-c",
+            watch_targets: ["/tmp/collapsed"],
+            mechanism: "event",
+            deadman_timeout_s: 60,
+            armed_at: "2026-07-11T11:55:00.000Z",
+            last_signal_at: "2026-07-11T11:57:00.000Z",
+            state: "collapsed",
+            collapsed_reason: "watch-target-missing",
+          },
+        ],
+      }),
+    );
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      now: () => new Date(nowMs),
+      surfaceWriteLiveness: tracker,
+      surfaceIds: ["surface:pty-dead", "surface:healthy"],
+      panePtyDeadSince: new Map([
+        ["surface:pty-dead", Date.parse("2026-07-11T12:00:01.000Z")],
+      ]),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.pane_pty_dead).toEqual({
+      count: 1,
+      surfaces: [
+        {
+          surface_id: "surface:pty-dead",
+          since_at: "2026-07-11T12:00:01.000Z",
+          last_attempt_at: "2026-07-11T12:00:01.000Z",
+        },
+      ],
+      truncated: false,
+    });
+    expect(health.self_heal.monitor_registry).toEqual({
+      available: true,
+      total: 3,
+      rearming: 1,
+      collapsed: 1,
+      collapsed_monitors: [
+        {
+          monitor_id: "monitor-collapsed",
+          reason: "watch-target-missing",
+        },
+      ],
+      truncated: false,
+    });
+    expect(formatControlHealth(health)).toMatch(
+      /pane_pty_dead: 1.*surface:pty-dead.*2026-07-11T12:00:01.000Z/s,
+    );
+    expect(formatControlHealth(health)).toMatch(
+      /monitor registry: total=3 rearming=1 collapsed=1.*monitor-collapsed: watch-target-missing/s,
+    );
+  });
+
+  it("counts pane_pty_dead surfaces beyond the bounded detail limit", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-bounded");
+    const tmp = join(TEST_ROOT, "tmp-bounded");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-bounded.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(monitorRegistryPath, JSON.stringify({ version: 1, monitors: [] }));
+    const tracker = new SurfaceWriteLivenessTracker({
+      now: () => Date.parse("2026-07-11T12:00:00.000Z"),
+    });
+    tracker.recordFailure("surface:100", { code: "EPIPE" });
+    tracker.recordFailure("surface:100", { code: "EPIPE" });
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      surfaceWriteLiveness: tracker,
+      surfaceIds: Array.from({ length: 101 }, (_, index) => `surface:${index}`),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.pane_pty_dead.count).toBe(1);
+    expect(health.self_heal.pane_pty_dead.surfaces).toEqual([
+      expect.objectContaining({ surface_id: "surface:100" }),
+    ]);
+  });
+
+  it("reports a malformed monitor registry as unavailable", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-malformed-registry");
+    const tmp = join(TEST_ROOT, "tmp-malformed-registry");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-malformed.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(monitorRegistryPath, "{not-json");
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.monitor_registry).toMatchObject({
+      available: false,
+      total: 0,
+      rearming: 0,
+      collapsed: 0,
+      error: expect.stringMatching(/malformed|json/i),
+    });
+    expect(formatControlHealth(health)).toMatch(/monitor registry: unavailable/i);
+  });
+
+  it("reports structurally invalid monitor records as unavailable", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-invalid-monitor-record");
+    const tmp = join(TEST_ROOT, "tmp-invalid-monitor-record");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-invalid-record.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(
+      monitorRegistryPath,
+      JSON.stringify({ version: 1, monitors: [{}] }),
+    );
+
+    const health = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      monitorRegistryPath,
+    });
+
+    expect(health.self_heal.monitor_registry).toMatchObject({
+      available: false,
+      total: 0,
+      error: expect.stringMatching(/invalid/i),
+    });
+  });
+
+  it("retains untracked PTY failures and the first detected-at time in control_health", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    const home = join(TEST_ROOT, "home-untracked-surface");
+    const tmp = join(TEST_ROOT, "tmp-untracked-surface");
+    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-untracked.json");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(monitorRegistryPath, JSON.stringify({ version: 1, monitors: [] }));
+    const rawHealth = await collectControlHealth({
+      homeDir: home,
+      tmpDir: tmp,
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+      monitorRegistryPath,
+    });
+    let nowMs = Date.parse("2026-07-11T12:00:00.000Z");
+    const tracker = new SurfaceWriteLivenessTracker({ now: () => nowMs });
+    const client = {
+      sendKey: vi.fn(async () => {
+        throw Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+      }),
+    };
+    const server = createServer({
+      client: client as any,
+      stateDir: join(TEST_ROOT, "untracked-state"),
+      skipAgentLifecycle: true,
+      surfaceWriteLiveness: tracker,
+      controlHealthCollector: async () => rawHealth,
+      monitorRegistryPath,
+    });
+    const sendKey = (server as any)._registeredTools["send_key"];
+    const controlHealth = (server as any)._registeredTools["control_health"];
+
+    try {
+      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      nowMs += 1_000;
+      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      const first = await controlHealth.handler({}, {} as any);
+      nowMs += 1_000;
+      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      const second = await controlHealth.handler({}, {} as any);
+      const firstHealth = first.structuredContent.health.self_heal.pane_pty_dead;
+      const secondHealth = second.structuredContent.health.self_heal.pane_pty_dead;
+
+      expect(firstHealth).toMatchObject({
+        count: 1,
+        surfaces: [
+          expect.objectContaining({
+            surface_id: "surface:untracked",
+            since_at: "2026-07-11T12:00:01.000Z",
+          }),
+        ],
+      });
+      expect(secondHealth.surfaces[0].since_at).toBe(
+        firstHealth.surfaces[0].since_at,
+      );
+
+      nowMs += 31_000;
+      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      nowMs += 1_000;
+      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      const nextEpisode = await controlHealth.handler({}, {} as any);
+      expect(
+        nextEpisode.structuredContent.health.self_heal.pane_pty_dead.surfaces[0]
+          .since_at,
+      ).toBe("2026-07-11T12:00:34.000Z");
+    } finally {
+      await server.close();
+    }
   });
 
   it("control_health tool appends prod and Nightly snapshot data to events.jsonl", async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -166,6 +166,20 @@ async function startDoctorDaemon(
     unresponsive?: boolean;
     ps?: string;
     scriptPath?: string;
+    selfHeal?: {
+      pane_pty_dead: {
+        count: number;
+        surfaces: Array<{ surface_id: string; since_at: string }>;
+        truncated: boolean;
+      };
+      monitor_registry: {
+        total: number;
+        rearming: number;
+        collapsed: number;
+        collapsed_monitors: Array<{ monitor_id: string; reason: string }>;
+        truncated: boolean;
+      };
+    };
   } = {},
 ): Promise<void> {
   rmSync(path, { force: true });
@@ -224,6 +238,27 @@ async function startDoctorDaemon(
                       current_socket_path:
                         opts.cmuxSocketPath ?? "/tmp/cmux-test.sock",
                     },
+                    ...(opts.selfHeal
+                      ? {
+                          self_heal: {
+                            ...opts.selfHeal,
+                            pane_pty_dead: {
+                              ...opts.selfHeal.pane_pty_dead,
+                              surfaces:
+                                opts.selfHeal.pane_pty_dead.surfaces.map(
+                                  (surface) => ({
+                                    ...surface,
+                                    last_attempt_at: surface.since_at,
+                                  }),
+                                ),
+                            },
+                            monitor_registry: {
+                              available: true,
+                              ...opts.selfHeal.monitor_registry,
+                            },
+                          },
+                        }
+                      : {}),
                   },
                 },
               },
@@ -310,6 +345,233 @@ describe("runDoctor — report shape", () => {
       installedVersion: "0.3.33",
     });
     expect(report.healthy).toBe(true);
+  });
+
+  it("reports pane_pty_dead surfaces from daemon control_health", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-pty-dead-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: {
+          count: 1,
+          surfaces: [
+            {
+              surface_id: "surface:pty-dead",
+              since_at: "2026-07-11T12:00:01.000Z",
+            },
+          ],
+          truncated: false,
+        },
+        monitor_registry: {
+          total: 2,
+          rearming: 0,
+          collapsed: 0,
+          collapsed_monitors: [],
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal).toMatchObject({ available: true, ok: false });
+    expect(report.healthy).toBe(false);
+    expect(renderDoctorText(report)).toMatch(
+      /✗.*pane_pty_dead.*surface:pty-dead.*2026-07-11T12:00:01.000Z/i,
+    );
+  });
+
+  it("reports collapsed monitors with their reasons from daemon control_health", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-collapsed-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: { count: 0, surfaces: [], truncated: false },
+        monitor_registry: {
+          total: 3,
+          rearming: 1,
+          collapsed: 1,
+          collapsed_monitors: [
+            {
+              monitor_id: "monitor-collapsed",
+              reason: "owner-not-alive",
+            },
+          ],
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal).toMatchObject({ available: true, ok: false });
+    expect(report.healthy).toBe(false);
+    expect(renderDoctorText(report)).toMatch(
+      /✗.*collapsed monitors.*monitor-collapsed: owner-not-alive/i,
+    );
+  });
+
+  it("reports healthy pane liveness and monitor reconciliation state", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-self-heal-green-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: { count: 0, surfaces: [], truncated: false },
+        monitor_registry: {
+          total: 4,
+          rearming: 1,
+          collapsed: 0,
+          collapsed_monitors: [],
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal).toMatchObject({ available: true, ok: true });
+    expect(report.healthy).toBe(true);
+    expect(renderDoctorText(report)).toMatch(/✔.*pane_pty_dead: none/i);
+    expect(renderDoctorText(report)).toMatch(
+      /✔.*monitor registry: total=4 rearming=1 collapsed=0/i,
+    );
+  });
+
+  it("rejects impossible monitor summary counters as unavailable", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-self-heal-invalid-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: { count: 0, surfaces: [], truncated: false },
+        monitor_registry: {
+          total: 1,
+          rearming: 2,
+          collapsed: 0,
+          collapsed_monitors: [],
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal).toMatchObject({
+      available: false,
+      ok: true,
+      note: expect.stringMatching(/malformed/i),
+    });
+  });
+
+  it("preserves and renders truncation when daemon detail arrays exceed the bound", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-self-heal-truncated-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: {
+          count: 101,
+          surfaces: Array.from({ length: 101 }, (_, index) => ({
+            surface_id: `surface:${index}`,
+            since_at: "2026-07-11T12:00:01.000Z",
+          })),
+          truncated: false,
+        },
+        monitor_registry: {
+          total: 101,
+          rearming: 0,
+          collapsed: 101,
+          collapsed_monitors: Array.from({ length: 101 }, (_, index) => ({
+            monitor_id: `monitor:${index}`,
+            reason: "owner-not-alive",
+          })),
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal.panePtyDead).toMatchObject({
+      count: 101,
+      truncated: true,
+    });
+    expect(report.selfHeal.panePtyDead.surfaces).toHaveLength(100);
+    expect(report.selfHeal.monitorRegistry).toMatchObject({
+      collapsed: 101,
+      truncated: true,
+    });
+    expect(report.selfHeal.monitorRegistry.collapsedMonitors).toHaveLength(100);
+    expect(renderDoctorText(report)).toMatch(/pane_pty_dead: 101.*truncated/i);
+    expect(renderDoctorText(report)).toMatch(
+      /collapsed monitors:.*truncated/i,
+    );
+  });
+
+  it("rejects self-heal counters that contradict their detail rows", async () => {
+    const path = join("/tmp", `cmuxlayer-doctor-self-heal-contradiction-${process.pid}.sock`);
+    await startDoctorDaemon(path, {
+      version: "0.3.33",
+      selfHeal: {
+        pane_pty_dead: {
+          count: 0,
+          surfaces: [
+            {
+              surface_id: "surface:unexpected",
+              since_at: "2026-07-11T12:00:01.000Z",
+            },
+          ],
+          truncated: false,
+        },
+        monitor_registry: {
+          total: 1,
+          rearming: 0,
+          collapsed: 0,
+          collapsed_monitors: [
+            {
+              monitor_id: "monitor:unexpected",
+              reason: "owner-not-alive",
+            },
+          ],
+          truncated: false,
+        },
+      },
+    });
+
+    const report = await runDoctorForTest({
+      version: "0.3.33",
+      env: { CMUXLAYER_DAEMON_SOCKET: path },
+      brew: makeBrew({}),
+      detectStaleBuild: () => null,
+    });
+
+    expect(report.selfHeal).toMatchObject({
+      available: false,
+      note: expect.stringMatching(/malformed/i),
+    });
   });
 
   it("flags a stale daemon version mismatch", async () => {
@@ -993,6 +1255,20 @@ describe("renderDoctorText", () => {
         listening: false,
         note: "no daemon running (starts on demand)",
       },
+      selfHeal: {
+        available: false,
+        ok: true,
+        panePtyDead: { count: 0, surfaces: [], truncated: false },
+        monitorRegistry: {
+          available: false,
+          total: 0,
+          rearming: 0,
+          collapsed: 0,
+          collapsedMonitors: [],
+          truncated: false,
+        },
+        note: "no daemon running (starts on demand)",
+      },
       tap: {
         brewAvailable: true,
         tapPresent: true,
@@ -1123,6 +1399,20 @@ describe("renderDoctorJson", () => {
         applicable: true,
         ok: true,
         listening: false,
+        note: "no daemon running (starts on demand)",
+      },
+      selfHeal: {
+        available: false,
+        ok: true,
+        panePtyDead: { count: 0, surfaces: [], truncated: false },
+        monitorRegistry: {
+          available: false,
+          total: 0,
+          rearming: 0,
+          collapsed: 0,
+          collapsedMonitors: [],
+          truncated: false,
+        },
         note: "no daemon running (starts on demand)",
       },
       tap: {


### PR DESCRIPTION
## Summary
- expose live pane PTY-dead counts and bounded details, including stable first-detected and last-attempt timestamps
- expose bounded monitor-registry reconcile state with explicit unavailable/corrupt handling
- surface both subsystems in doctor without changing agent-health classification
- preserve public registry semantics for absent files and legacy top-level arrays
- preserve confirmed PTY-dead episodes across unrelated non-EPIPE delivery failures

## Test plan
- [x] bun run typecheck
- [x] bun run build
- [x] targeted observability tests: 68 passed
- [x] five consecutive cold final-code full-suite runs: 90 files / 1,657 tests each
- [x] pre-push hook: race fixture 1/1, terminal regression 1/1, full suite 90 files / 1,657 tests
- [x] fresh Claude client in a new cmux pane: control_health and list_surfaces returned live structured results over socket transport
- [x] real-cmux contract from branch dist: ping, orphan EPIPE denial, list/read, healthy doctor, and isolated daemon retire/autostart passed

## Review
- completed three review rounds
- all actionable PTY, timestamp, bounds, corruption, compatibility, and doctor validation findings addressed with regressions
- single-snapshot monitor parsing requires a new public API forbidden by this task scope; tracked in #286


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose PTY liveness and monitor-reconcile state in doctor and control_health
> - Adds a `self_heal` section to `ControlHealth` (in [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/285/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d)) that summarizes per-surface PTY-dead counts (via EPIPE detection) and monitor registry reconciliation state (rearming/collapsed counts, collapsed reasons).
> - Extends the doctor report (in [doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/285/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068)) with a `DoctorSelfHealReport` field; overall `healthy` now requires `selfHeal.ok`, and the text renderer prints PTY-dead and monitor registry sections.
> - Tracks EPIPE-based write failures per surface in the server (in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/285/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595)), recording first-detected timestamps and merging `self_heal` into `control_health` snapshots.
> - Behavioral Change: `runDoctor` healthy status now also depends on self-heal ok, so a degraded monitor registry or PTY-dead surfaces can flip healthy to false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 080d614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->