### PR TITLE
fix: place workers and dedupe seat titles

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -491,6 +491,11 @@ interface AgentEngineClient {
     title?: string;
     url?: string;
   }): Promise<CmuxNewSurfaceResult>;
+  renameTab(
+    surface: string,
+    title: string,
+    opts?: { workspace?: string },
+  ): Promise<void>;
   selectWorkspace(workspace: string): Promise<void>;
   listPanes(opts?: { workspace?: string }): Promise<{
     workspace_ref?: string;
@@ -3206,6 +3211,14 @@ export class AgentEngine {
       },
     );
     try {
+      const launcherName =
+        preflight?.launcherName ??
+        launcherNameForCli(spawnParams.repo, spawnParams.cli);
+      await this.client.renameTab(
+        surface.surface,
+        `${launcherName} [${surface.surface}]`,
+        { workspace: surface.actual_workspace ?? surface.workspace },
+      );
       await this.sendLaunchCommand(
         surface.surface,
         surface.actual_workspace ?? surface.workspace,

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -178,6 +178,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       clearProgress: async () => {},
       newSplit: (direction, splitOpts) => this.client.newSplit(direction, splitOpts),
       newSurface: (surfaceOpts) => this.client.newSurface(surfaceOpts),
+      renameTab: (surface, title, renameOpts) =>
+        this.client.renameTab(surface, title, renameOpts),
       selectWorkspace: (workspace) => this.client.selectWorkspace(workspace),
       listPanes: (paneOpts) => this.client.listPanes(paneOpts),
       listPaneSurfaces: (surfaceOpts) => this.client.listPaneSurfaces(surfaceOpts),

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -468,16 +468,13 @@ export function chooseAgentSpawnPlacement(
     layouts.some(isLeadMajorityPane) ||
     context.parentRole === "orchestrator" ||
     context.parentRole === "ic";
-  const hasLeadCaller =
-    context.parentRole === "orchestrator" || context.parentRole === "ic";
   // A worker from a lead-owned single-column workspace has no classified
   // destination surface yet. Seed the right worker column without anchoring the
   // split to the lead pane.
   if (
     role === "worker" &&
     columnCount < 2 &&
-    hasLeadColumn &&
-    (context.worktree || hasLeadCaller)
+    hasLeadColumn
   ) {
     return { kind: "split", direction: "right" };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6372,6 +6372,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           newSplit: (direction, splitOpts) =>
             client.newSplit(direction, splitOpts),
           newSurface: (surfaceOpts) => client.newSurface(surfaceOpts),
+          renameTab: (surface, title, renameOpts) =>
+            typeof client.renameTab === "function"
+              ? client.renameTab(surface, title, renameOpts)
+              : Promise.resolve(),
           selectWorkspace: (workspace) => client.selectWorkspace(workspace),
           listPanes: (paneOpts) => client.listPanes(paneOpts),
           listPaneSurfaces: (surfaceOpts) =>

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -248,6 +248,51 @@ describe("AgentEngine", () => {
       expect(result.state).toBe("booting");
     });
 
+    it("assigns each managed surface a launcher-preserving unique seat title", async () => {
+      (
+        mockClient.newSplit as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({
+        workspace: "ws:1",
+        surface: "surface:first-worker",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      });
+      (
+        mockClient.newSplit as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({
+        workspace: "ws:1",
+        surface: "surface:second-worker",
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      });
+
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        cli: "codex",
+        prompt: "First worker",
+      });
+      await engine.spawnAgent({
+        repo: "brainlayer",
+        cli: "codex",
+        prompt: "Second worker",
+      });
+
+      expect(mockClient.renameTab).toHaveBeenNthCalledWith(
+        1,
+        "surface:first-worker",
+        "brainlayerCodex [surface:first-worker]",
+        { workspace: "ws:1" },
+      );
+      expect(mockClient.renameTab).toHaveBeenNthCalledWith(
+        2,
+        "surface:second-worker",
+        "brainlayerCodex [surface:second-worker]",
+        { workspace: "ws:1" },
+      );
+    });
+
     it("enforces max children when parent and children are rehydrated from disk", async () => {
       const parent = makeRecord({
         agent_id: "parent-claude",

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -1247,7 +1247,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
-  it("anchors the parentless worker fallback to the rightmost pane", () => {
+  it("seeds a parentless managed worker without anchoring to the lead pane", () => {
     const panes = [makePane("pane:lead", 0, ["surface:orchestrator"])];
     const paneSurfaces = [
       makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
@@ -1267,7 +1267,6 @@ describe("layout policy", () => {
     expect(placement).toEqual({
       kind: "split",
       direction: "right",
-      pane: "pane:lead",
     });
   });
 


### PR DESCRIPTION
## Summary
- seed every managed worker into an unanchored right split when a lead owns the workspace's only column
- assign each managed spawn a launcher-preserving, surface-qualified tab title so same-repo seats remain visually distinct
- forward managed title assignment through both server runtimes while retaining compatibility with narrow injected clients

## Test plan
- [x] TDD red/green: parentless worker placement and duplicate managed seat titles
- [x] `bun run test -- tests/layout-policy.test.ts tests/agent-engine.test.ts` — 250/250 passed
- [x] `bun run test -- tests/server-agent-tools.test.ts` — 101/101 passed
- [x] `bun run pre-pr` — typecheck + 61/61 harness tests passed
- [x] `bun run typecheck && bun run build`
- [x] pre-push full suite — 90 files / 1661 tests passed
- [x] `coderabbit review --agent` — 0 findings across 6 changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn layout and tab naming paths used on every managed agent creation; behavior is covered by tests but misplacement could still affect live terminal UX.
> 
> **Overview**
> Managed agent spawns now **rename cmux tabs** before launch to `{launcherName} [{surfaceId}]` so same-repo seats stay distinct, with `renameTab` on the engine client and forwarding in app-server and MCP server runtimes (server no-ops if the injected client lacks `renameTab`).
> 
> **Worker placement** in a single-column workspace that already has a lead pane now always seeds an **unanchored right split** when spawning a worker—dropping the extra gates (parent orchestrator/IC caller, worktree) and no longer pinning the split to the lead pane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17afd79c5cdf3f3e9bd8fc1b656bd914eb05945d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worker placement and assign unique seat titles to managed surfaces
> - In [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/287/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed), relaxes the condition for splitting a worker into the right column: a lead column alone is now sufficient; a worktree or lead caller is no longer required.
> - In [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/287/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5), calls `client.renameTab` after spawning each agent to set a unique tab title in the format `<launcherName> [<surfaceId>]`.
> - Adds `renameTab` to the bridge client in both [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/287/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/287/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595); the server-side implementation is a no-op when the underlying client does not support it.
> - Behavioral Change: worker panes in single-column layouts with a lead column will now always split right, regardless of worktree or caller context.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 17afd79. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent-created tabs now receive descriptive, launcher-based titles.
  - Generated worker tabs receive unique “seat” labels for easier identification.
  - Tab renaming works across supported runtime configurations.

- **Layout Improvements**
  - Worker panes in single-column layouts are placed more consistently, without requiring anchoring to a lead pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->