### PR TITLE
fix: harden fixture cleanup and cmux compatibility

### DIFF
--- a/docs/runbooks/cmux-version-compatibility.md
+++ b/docs/runbooks/cmux-version-compatibility.md
@@ -1,0 +1,29 @@
+# Internal cmux app compatibility record
+
+Status: internal-only operational contract. Do not file or coordinate this
+record upstream without a separate owner decision.
+
+cmuxlayer's socket protocol and ancestry-sensitive behavior are currently tested
+against:
+
+- cmux `0.64.17` (production)
+- cmux `0.64.14-nightly` (including build-qualified versions on that nightly line)
+
+The executable record lives in `src/cmux-version-compatibility.ts`. Update that
+record only after the real-cmux contract lane verifies socket calls, detached
+orphan denial, list/read, doctor, and daemon retire/autostart behavior against
+the candidate app version.
+
+`cmuxlayer doctor` reads the selected app CLI's `--version` output when
+available. A tested version emits `INFO`; an untested version emits `WARN` with
+"behavior unverified". Compatibility never changes overall doctor health:
+untested does not mean broken.
+
+## Ancestry access-control finding
+
+The real-cmux contract lane depends on cmux rejecting a detached, reparented
+socket client with the observed `EPIPE`/errno-32 ancestry contract while allowing
+pane-descended clients. This is retained as an internal compatibility finding,
+not an upstream request. A change in that behavior is evidence to investigate
+and update this record; it is not grounds to fail closed solely because the app
+version is new.

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -849,6 +849,20 @@ async function terminateRecordedPid(
   recordedPids.delete(pid);
 }
 
+async function addPidReceiptToSet(
+  receiptPath: string,
+  recordedPids: Set<number>,
+): Promise<void> {
+  try {
+    for (const line of (await readFile(receiptPath, "utf8")).split(/\r?\n/)) {
+      const pid = Number(line.trim());
+      if (Number.isInteger(pid) && pid > 0) recordedPids.add(pid);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
 async function runContract(): Promise<void> {
   const requestedSocket = process.env.CMUX_SOCKET_PATH;
   const requestedPin = requestedSocket?.trim();
@@ -873,6 +887,7 @@ async function runContract(): Promise<void> {
 
   const root = await mkdtemp(join(tmpdir(), "cmuxlayer-real-contract-"));
   const daemonSocket = join(root, "cmuxlayer-stated.sock");
+  const daemonPidReceipt = join(root, "daemon-pids.txt");
   const home = join(root, "home");
   const recordedPids = new Set<number>();
   let peer: McpPeer | null = null;
@@ -897,6 +912,7 @@ async function runContract(): Promise<void> {
       HOME: home,
       CMUX_SOCKET_PATH: cmuxSocket,
       CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+      CMUXLAYER_DAEMON_PID_RECEIPT: daemonPidReceipt,
       CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
     };
 
@@ -993,7 +1009,23 @@ async function runContract(): Promise<void> {
   } finally {
     peer?.close();
     const proxyPid = peer?.child.pid;
-    for (const pid of cleanupPidOrder(recordedPids, proxyPid)) {
+    if (proxyPid && recordedPids.has(proxyPid)) {
+      await terminateRecordedPid(proxyPid, recordedPids, "SIGTERM", true).catch(
+        (error) => {
+          console.error(
+            `[contract] cleanup warning for pid ${proxyPid}:`,
+            error,
+          );
+        },
+      );
+    }
+    await addPidReceiptToSet(daemonPidReceipt, recordedPids).catch((error) => {
+      console.error(
+        "[contract] cleanup warning reading daemon pid receipt:",
+        error,
+      );
+    });
+    for (const pid of cleanupPidOrder(recordedPids, undefined)) {
       await terminateRecordedPid(pid, recordedPids, "SIGTERM", true).catch(
         (error) => {
           console.error(`[contract] cleanup warning for pid ${pid}:`, error);

--- a/src/cmux-version-compatibility.ts
+++ b/src/cmux-version-compatibility.ts
@@ -1,0 +1,66 @@
+export const TESTED_CMUX_APP_VERSIONS = ["0.64.17", "0.64.14-nightly"] as const;
+
+export interface CmuxVersionCompatibilityReport {
+  available: boolean;
+  liveVersion: string | null;
+  severity: "info" | "warn";
+  tested: boolean | null;
+  testedVersions: string[];
+  note: string;
+}
+
+export interface CmuxVersionCommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  notFound?: boolean;
+}
+
+export type CmuxVersionRunner = (
+  env: NodeJS.ProcessEnv,
+) => Promise<CmuxVersionCommandResult>;
+
+function parseCmuxVersion(output: string): string | null {
+  return output.match(/(?:^|\s)cmux\s+v?([^\s(]+)/i)?.[1] ?? null;
+}
+
+function isTestedVersion(version: string): boolean {
+  return TESTED_CMUX_APP_VERSIONS.some(
+    (tested) =>
+      version === tested ||
+      (tested.endsWith("-nightly") && version.startsWith(`${tested}.`)),
+  );
+}
+
+export function assessCmuxVersionCompatibility(
+  result: CmuxVersionCommandResult,
+): CmuxVersionCompatibilityReport {
+  const testedVersions = [...TESTED_CMUX_APP_VERSIONS];
+  const testedLabel = testedVersions.map((version) => `v${version}`).join(", ");
+  const liveVersion = result.ok
+    ? parseCmuxVersion(`${result.stdout}\n${result.stderr}`)
+    : null;
+
+  if (!liveVersion) {
+    return {
+      available: false,
+      liveVersion: null,
+      severity: "info",
+      tested: null,
+      testedVersions,
+      note: `running cmux version unavailable; tested against ${testedLabel}`,
+    };
+  }
+
+  const tested = isTestedVersion(liveVersion);
+  return {
+    available: true,
+    liveVersion,
+    severity: tested ? "info" : "warn",
+    tested,
+    testedVersions,
+    note: `running cmux v${liveVersion}; tested against ${testedLabel}${
+      tested ? "" : " — behavior unverified"
+    }`,
+  };
+}

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -45,6 +45,16 @@ export async function spawnDaemonProcess(
       `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,
     );
   });
+  const pidReceipt = env.CMUXLAYER_DAEMON_PID_RECEIPT?.trim();
+  if (pidReceipt && child.pid) {
+    try {
+      await mkdir(dirname(pidReceipt), { recursive: true });
+      await appendFile(pidReceipt, `${child.pid}\n`, "utf8");
+    } catch (error) {
+      child.kill("SIGKILL");
+      throw error;
+    }
+  }
   child.unref();
   return child;
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,7 +14,8 @@
  *       resolves (`brew info etanhey/layers/cmuxlayer`). Tap CASKS need
  *       `brew trust etanhey/layers`; cmuxlayer is a formula, not gated.
  *   (c) CMUX_SOCKET_PATH if set, else "unset (auto-discover)";
- *   (d) read-only `.mcp.json` drift detection for stale `cmux` keys or entries
+ *   (d) live cmux app version compatibility against the internal tested set;
+ *   (e) read-only `.mcp.json` drift detection for stale `cmux` keys or entries
  *       that bypass `~/.golems/bin/cmuxlayer-mcp`, plus existence, symlink-target,
  *       and executable-bit checks for every referenced launcher.
  *
@@ -39,6 +40,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
+import {
+  assessCmuxVersionCompatibility,
+  type CmuxVersionCompatibilityReport,
+  type CmuxVersionRunner,
+} from "./cmux-version-compatibility.js";
 import {
   probeSocketHealth,
   type SocketProbeResult,
@@ -172,6 +178,8 @@ export interface DoctorReport {
   };
   /** CMUX_SOCKET_PATH pin (auto-discover when unset). */
   socketPath: { set: boolean; value: string | null; note: string };
+  /** Best-effort internal cmux app compatibility note; never affects health. */
+  cmuxCompatibility: CmuxVersionCompatibilityReport;
   /** Durable sleep-survival guard: pmset assertion plus launchd KeepAlive job. */
   sleepGuard: {
     systemSleepPrevented: boolean;
@@ -236,6 +244,8 @@ export interface RunDoctorOptions {
   probeCmuxSocket?: (
     socketPath: string,
   ) => Promise<SocketProbeResult>;
+  /** Injectable `cmux --version` runner for the selected app CLI. */
+  cmuxVersion?: CmuxVersionRunner;
   /** Bound for daemon connect/initialize/control_health (default 1500ms). */
   daemonProbeTimeoutMs?: number;
   /** Injectable path existence check for daemon provenance tests. */
@@ -764,6 +774,28 @@ export const realLaunchctlRunner: LaunchctlRunner = async () => {
   }
 };
 
+export const realCmuxVersionRunner: CmuxVersionRunner = async (env) => {
+  const bin = env.CMUX_BUNDLED_CLI_PATH?.trim() || "cmux";
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, ["--version"], {
+      env,
+      timeout: 1_500,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      ok: false,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? failure.message,
+      ...(failure.code === "ENOENT" ? { notFound: true } : {}),
+    };
+  }
+};
+
 export const realMcpConfigPathLister: McpConfigPathLister = async () => {
   try {
     const entries = await readdir(join(homedir(), "Gits"), {
@@ -1125,6 +1157,9 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
   const runtimeProvenance = (
     opts.runtimeProvenance ?? (() => detectRuntimeProvenance({ env }))
   )();
+  const cmuxCompatibility = assessCmuxVersionCompatibility(
+    await (opts.cmuxVersion ?? realCmuxVersionRunner)(env),
+  );
   const mcpConfigDrift = await checkMcpConfigDrift({
     listMcpConfigPaths: opts.listMcpConfigPaths,
     readMcpConfigFile: opts.readMcpConfigFile,
@@ -1149,6 +1184,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     socketPath: socketSet
       ? { set: true, value: socketRaw, note: "pinned via CMUX_SOCKET_PATH" }
       : { set: false, value: null, note: "unset (auto-discover)" },
+    cmuxCompatibility,
     sleepGuard,
     runtimeProvenance,
     mcpReconnectProcedure: mcpReconnectProcedure(),
@@ -1232,6 +1268,10 @@ export function renderDoctorText(report: DoctorReport): string {
     `│ — CMUX_SOCKET_PATH: ${
       report.socketPath.set ? report.socketPath.value : report.socketPath.note
     }`,
+  );
+
+  lines.push(
+    `│ — cmux compatibility ${report.cmuxCompatibility.severity.toUpperCase()}: ${report.cmuxCompatibility.note}`,
   );
 
   lines.push(

--- a/tests/daemon-spawn.test.ts
+++ b/tests/daemon-spawn.test.ts
@@ -1,10 +1,31 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { spawnDaemonProcess } from "../src/daemon-spawn.js";
 
 describe("spawnDaemonProcess", () => {
+  it("records the detached daemon pid before returning when a receipt is configured", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-daemon-receipt-"));
+    const receiptPath = join(root, "daemon-pids.txt");
+    let child: Awaited<ReturnType<typeof spawnDaemonProcess>> | undefined;
+    try {
+      const daemonScriptPath = join(root, "waiting-daemon.js");
+      writeFileSync(daemonScriptPath, "setTimeout(() => {}, 60_000);\n");
+      child = await spawnDaemonProcess({
+        socketPath: join(root, "daemon.sock"),
+        env: { CMUXLAYER_DAEMON_PID_RECEIPT: receiptPath },
+        logger: { error: vi.fn() },
+        daemonScriptPath,
+      });
+
+      expect(readFileSync(receiptPath, "utf8")).toBe(`${child.pid}\n`);
+    } finally {
+      child?.kill("SIGKILL");
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("logs the exit status when a spawned daemon dies", async () => {
     const root = mkdtempSync(join(tmpdir(), "cmuxlayer-daemon-spawn-"));
     const logger = { error: vi.fn() };
@@ -17,7 +38,9 @@ describe("spawnDaemonProcess", () => {
         logger,
         daemonScriptPath,
       });
-      await new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+      await new Promise<void>((resolveExit) =>
+        child.once("exit", () => resolveExit()),
+      );
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringMatching(

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -16,6 +16,7 @@ import {
   checkMcpConfigDrift,
   detectRuntimeProvenance,
   parseSystemSleepPrevented,
+  realCmuxVersionRunner,
   runDoctor,
   renderDoctorText,
   renderDoctorJson,
@@ -107,6 +108,11 @@ function runDoctorForTest(opts: Parameters<typeof runDoctor>[0]) {
     launchctl: missingLaunchctl,
     listMcpConfigPaths: async () => [],
     readMcpConfigFile: async () => "",
+    cmuxVersion: async () => ({
+      ok: false,
+      stdout: "",
+      stderr: "cmux version unavailable in test",
+    }),
     ...opts,
     env: {
       CMUXLAYER_DAEMON_SOCKET: join(
@@ -279,6 +285,110 @@ async function startDoctorDaemon(
 }
 
 describe("runDoctor — report shape", () => {
+  it("reads the selected cmux app CLI version when available", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-cmux-version-"));
+    doctorTempDirs.push(root);
+    const cmuxBin = join(root, "cmux");
+    writeFileSync(
+      cmuxBin,
+      "#!/bin/sh\nprintf '%s\\n' 'cmux 0.64.17 (97) [test]'\n",
+    );
+    chmodSync(cmuxBin, 0o755);
+
+    await expect(
+      realCmuxVersionRunner({
+        ...process.env,
+        CMUX_BUNDLED_CLI_PATH: cmuxBin,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      stdout: "cmux 0.64.17 (97) [test]\n",
+    });
+  });
+
+  it("reports tested cmux app versions as informational", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+      cmuxVersion: async () => ({
+        ok: true,
+        stdout: "cmux 0.64.17 (97) [9ed29d81a]",
+        stderr: "",
+      }),
+    });
+
+    expect(report.cmuxCompatibility).toMatchObject({
+      available: true,
+      liveVersion: "0.64.17",
+      severity: "info",
+      tested: true,
+      testedVersions: ["0.64.17", "0.64.14-nightly"],
+    });
+    expect(report.cmuxCompatibility.note).toMatch(
+      /running cmux v0\.64\.17; tested against v0\.64\.17, v0\.64\.14-nightly/i,
+    );
+    expect(report.healthy).toBe(true);
+  });
+
+  it("warns without failing health when the live cmux app version is untested", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+      cmuxVersion: async () => ({
+        ok: true,
+        stdout: "cmux 0.65.0 (101) [abcdef]",
+        stderr: "",
+      }),
+    });
+
+    expect(report.cmuxCompatibility).toMatchObject({
+      available: true,
+      liveVersion: "0.65.0",
+      severity: "warn",
+      tested: false,
+    });
+    expect(report.cmuxCompatibility.note).toMatch(
+      /running cmux v0\.65\.0; tested against v0\.64\.17, v0\.64\.14-nightly — behavior unverified/i,
+    );
+    expect(report.healthy).toBe(true);
+  });
+
+  it("accepts build-qualified versions from the tested nightly line", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+      cmuxVersion: async () => ({
+        ok: true,
+        stdout: "cmux 0.64.14-nightly.2912634120001 (2912634120001) [abcdef]",
+        stderr: "",
+      }),
+    });
+
+    expect(report.cmuxCompatibility.tested).toBe(true);
+    expect(report.cmuxCompatibility.severity).toBe("info");
+    expect(report.healthy).toBe(true);
+  });
+
+  it("does not broaden a tested production version into a version family", async () => {
+    const report = await runDoctorForTest({
+      version: "0.3.0",
+      env: {},
+      brew: makeBrew({}),
+      cmuxVersion: async () => ({
+        ok: true,
+        stdout: "cmux 0.64.17.1 (98) [abcdef]",
+        stderr: "",
+      }),
+    });
+
+    expect(report.cmuxCompatibility.tested).toBe(false);
+    expect(report.cmuxCompatibility.severity).toBe("warn");
+    expect(report.healthy).toBe(true);
+  });
+
   it("reports the version when it resolves", async () => {
     const report = await runDoctorForTest({
       version: "0.3.0",
@@ -1276,6 +1386,14 @@ describe("renderDoctorText", () => {
         note: "tap CASKS need `brew trust etanhey/layers`; cmuxlayer is a formula, not gated",
       },
       socketPath: { set: false, value: null, note: "unset (auto-discover)" },
+      cmuxCompatibility: {
+        available: true,
+        liveVersion: "0.64.17",
+        severity: "info",
+        tested: true,
+        testedVersions: ["0.64.17", "0.64.14-nightly"],
+        note: "running cmux v0.64.17; tested against v0.64.17, v0.64.14-nightly",
+      },
       sleepGuard: {
         systemSleepPrevented: false,
         keepAliveLoaded: false,
@@ -1331,6 +1449,21 @@ describe("renderDoctorText", () => {
     const text = renderDoctorText(baseReport());
     expect(text).toMatch(/CMUX_SOCKET_PATH/);
     expect(text).toMatch(/unset \(auto-discover\)/i);
+  });
+
+  it("prints the cmux compatibility severity and note", () => {
+    const text = renderDoctorText({
+      ...baseReport(),
+      cmuxCompatibility: {
+        available: true,
+        liveVersion: "0.65.0",
+        severity: "warn",
+        tested: false,
+        testedVersions: ["0.64.17", "0.64.14-nightly"],
+        note: "running cmux v0.65.0; tested against v0.64.17, v0.64.14-nightly — behavior unverified",
+      },
+    });
+    expect(text).toMatch(/WARN.*running cmux v0\.65\.0/i);
   });
 
   it("prints sleep guard status and install hint when not durable", () => {
@@ -1422,6 +1555,14 @@ describe("renderDoctorJson", () => {
         note: "ok",
       },
       socketPath: { set: true, value: "/tmp/x.sock", note: "set" },
+      cmuxCompatibility: {
+        available: true,
+        liveVersion: "0.64.17",
+        severity: "info",
+        tested: true,
+        testedVersions: ["0.64.17", "0.64.14-nightly"],
+        note: "running cmux v0.64.17; tested against v0.64.17, v0.64.14-nightly",
+      },
       sleepGuard: {
         systemSleepPrevented: true,
         keepAliveLoaded: true,
@@ -1466,6 +1607,7 @@ describe("renderDoctorJson", () => {
     expect(parsed.tap.tapPresent).toBe(true);
     expect(parsed.socketPath.set).toBe(true);
     expect(parsed.socketPath.value).toBe("/tmp/x.sock");
+    expect(parsed.cmuxCompatibility.tested).toBe(true);
     expect(parsed.sleepGuard.durable).toBe(true);
     expect(parsed.runtimeProvenance.mode).toBe("dist");
     expect(parsed.mcpReconnectProcedure.automation).toBe(false);

--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 const ROOTS = new Set<string>();
 const CHILDREN = new Set<ChildProcess>();
+const DAEMON_PID_RECEIPTS = new Set<string>();
 const SERVERS = new Set<{
   server: net.Server;
   sockets: Set<net.Socket>;
@@ -55,6 +56,40 @@ async function waitFor(
     await new Promise((resolveWait) => setTimeout(resolveWait, 25));
   }
   throw new Error(`timed out waiting for ${description}`);
+}
+
+function readRecordedDaemonPids(): Set<number> {
+  const pids = new Set<number>();
+  for (const receiptPath of DAEMON_PID_RECEIPTS) {
+    try {
+      for (const line of readFileSync(receiptPath, "utf8").split(/\r?\n/)) {
+        const pid = Number(line.trim());
+        if (Number.isInteger(pid) && pid > 0) pids.add(pid);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  return pids;
+}
+
+async function terminateFixturePid(pid: number): Promise<void> {
+  if (!processExists(pid)) return;
+  process.kill(pid, "SIGTERM");
+  try {
+    await waitFor(
+      () => !processExists(pid),
+      2_000,
+      `fixture pid ${pid} to exit`,
+    );
+  } catch {
+    if (processExists(pid)) process.kill(pid, "SIGKILL");
+    await waitFor(
+      () => !processExists(pid),
+      2_000,
+      `fixture pid ${pid} to exit after SIGKILL`,
+    );
+  }
 }
 
 async function startFakeCmuxSocket(path: string): Promise<void> {
@@ -232,11 +267,28 @@ function daemonPidFromHealth(
 }
 
 afterEach(async () => {
+  const cleanupErrors: unknown[] = [];
+  const directPids = [...CHILDREN]
+    .map((child) => child.pid)
+    .filter((pid): pid is number => typeof pid === "number");
   for (const child of CHILDREN) {
     child.stdin?.end();
     child.kill("SIGTERM");
   }
   CHILDREN.clear();
+  for (const pid of directPids) {
+    await terminateFixturePid(pid).catch((error) => cleanupErrors.push(error));
+  }
+  let recordedDaemonPids = new Set<number>();
+  try {
+    recordedDaemonPids = readRecordedDaemonPids();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  for (const pid of recordedDaemonPids) {
+    await terminateFixturePid(pid).catch((error) => cleanupErrors.push(error));
+  }
+  DAEMON_PID_RECEIPTS.clear();
   for (const { server, sockets } of SERVERS) {
     for (const socket of sockets) socket.destroy();
     await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
@@ -244,6 +296,9 @@ afterEach(async () => {
   SERVERS.clear();
   for (const root of ROOTS) rmSync(root, { recursive: true, force: true });
   ROOTS.clear();
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, "fixture process cleanup failed");
+  }
 });
 
 describe("live daemon-first restart topology", () => {
@@ -258,6 +313,8 @@ describe("live daemon-first restart topology", () => {
       const root = realpathSync(rootPath);
       ROOTS.add(root);
       const daemonSocket = join(root, "stated.sock");
+      const daemonPidReceipt = join(root, "daemon-pids.txt");
+      DAEMON_PID_RECEIPTS.add(daemonPidReceipt);
       const cmuxSocket = join(root, "cmux.sock");
       const runningVersion = runningPackageVersion();
       const upgradedVersion = `${runningVersion}-live-topology-upgrade`;
@@ -276,6 +333,7 @@ describe("live daemon-first restart topology", () => {
             HOMEBREW_PREFIX: join(root, "brew"),
             CMUX_SOCKET_PATH: cmuxSocket,
             CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+            CMUXLAYER_DAEMON_PID_RECEIPT: daemonPidReceipt,
             CMUXLAYER_DEV: "0",
             CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
             CMUXLAYER_STALE_CHECK_INTERVAL_MS: "100",
@@ -326,7 +384,6 @@ describe("live daemon-first restart topology", () => {
       const replacementDaemonPid = daemonPidFromHealth(recoveredHealth, stderr);
       expect(replacementDaemonPid).not.toBe(initialDaemonPid);
       expect(Date.now() - recoveryStartedAt).toBeLessThan(15_000);
-      process.kill(replacementDaemonPid, "SIGTERM");
     },
     70_000,
   );


### PR DESCRIPTION
## Summary
- record every detached fixture daemon PID at spawn time, then stop the proxy and TERM→KILL sweep recorded PIDs in live-topology and real-cmux contract teardown
- add an internal tested-cmux-app record for 0.64.17 production and the 0.64.14-nightly line; `doctor` emits non-blocking INFO/WARN compatibility notes
- document the ancestry access-control finding internally only; no upstream engagement
- verify the existing Node/Homebrew Cellar MCP reaper matcher and execute path (already landed on main via #206) still select and reap orphaned `node .../cmuxlayer/.../dist/index.js` processes

## Test plan
- [x] `bun run typecheck`
- [x] Seat C suite: 112/112 (`mcp-reaper`, painpoint e2e, daemon spawn, live topology, real contract runner, doctor)
- [x] `bun run pre-pr`: 61/61
- [x] pre-push full Vitest suite on rebased branch: 1668/1668
- [x] real cmux contract diagnostic: system.ping, detached EPIPE denial, list/read, doctor, retire/autostart all PASS; spawned PIDs confirmed absent afterward
- [x] built `doctor --json`: selected cmux 0.64.17 reported INFO/tested and overall healthy

## Review notes
- Local CodeRabbit connected and analyzed but returned no verdict payload; treated as inconclusive. Red/blue fallback review found and fixed strict production-version matching plus two cleanup error paths before push.
- `/tmp/cmux-nightly.sock` was absent, so the live contract used the runner's explicit production diagnostic override while keeping the cmuxlayer daemon/socket stack isolated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly diagnostic notes and test/contract cleanup; doctor health logic is unchanged except for additive compatibility reporting.
> 
> **Overview**
> Adds an **internal cmux app compatibility** layer: a tested-version list in `cmux-version-compatibility.ts`, a runbook, and **doctor** output that runs the selected `cmux --version`, compares against that list, and prints **INFO** or **WARN** without changing overall health. Matching is **exact** for production (`0.64.17`); only the **nightly line** accepts build-qualified suffixes (e.g. `0.64.14-nightly.*`).
> 
> **Fixture cleanup** is tightened by appending each detached daemon PID to **`CMUXLAYER_DAEMON_PID_RECEIPT`** at spawn time. The real-cmux contract runner and live-topology tests read that receipt on teardown, terminate the MCP proxy first, then TERM→KILL sweep all recorded PIDs so autostarted daemons are not left behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3964ff5e82ca1bc3b22f0803472a93f23f4582e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cmux version compatibility reporting to doctor and harden daemon PID cleanup
> - Adds `assessCmuxVersionCompatibility` in [src/cmux-version-compatibility.ts](https://github.com/EtanHey/cmuxlayer/pull/288/files#diff-81923ea93ca721c55e5833bcd026fcfb8e2e1db9f07a6879ea4bafbea6fd9514) to parse live cmux CLI version output and classify it as tested or untested, reporting INFO or WARN severity without affecting overall doctor health.
> - Integrates cmux version checks into `runDoctor` and `renderDoctorText` in [src/doctor.ts](https://github.com/EtanHey/cmuxlayer/pull/288/files#diff-1f70118ca54082607e282e2def0725ca39c7b03913dca09d39660eed955f0068), adding a `cmuxCompatibility` field to `DoctorReport`.
> - Hardens daemon PID tracking: `spawnDaemonProcess` in [src/daemon-spawn.ts](https://github.com/EtanHey/cmuxlayer/pull/288/files#diff-4ce4923f025099ea7b158cda9964e58752f8b627e7c04533edc75af7fc06566c) now writes the daemon PID to a receipt file (via `CMUXLAYER_DAEMON_PID_RECEIPT`) before unref; on write failure it kills the child and throws.
> - Improves test fixture cleanup in [tests/live-topology-restart.test.ts](https://github.com/EtanHey/cmuxlayer/pull/288/files#diff-39f3decd65c411e6a990177655fbda20dd097f8f1921e961871fa22ee29bdc15) by reading PID receipt files in `afterEach` and sending SIGTERM/SIGKILL to recorded daemon PIDs.
> - Risk: if `CMUXLAYER_DAEMON_PID_RECEIPT` is set and the receipt write fails, the daemon launch is aborted — this is a new failure mode for daemon startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3964ff5. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->