### PR TITLE
test: harden CI timing and add nightly contract job

### DIFF
--- a/docs/plans/2026-07-11-r7-continuous-ci-design.md
+++ b/docs/plans/2026-07-11-r7-continuous-ci-design.md
@@ -1,0 +1,64 @@
+# R7 Continuous CI Design
+
+## Scope
+
+SEAT A has two related deliverables: remove the remaining CI-sensitive timing
+race in `tests/server.test.ts`, and package the real-cmux contract lane as an
+Etan-gated nightly LaunchAgent for the M4 NIGHTLY instance. SEAT B placement
+work and SEAT C daemon/fixture hygiene are explicitly out of scope.
+
+## A1: fake-time progress must follow async progress
+
+The existing `runWithFakeTimers` helper spends its fixed fake-time allowance on
+every loop iteration, even when the tool handler is still crossing non-timer
+async boundaries and has not scheduled its next poll. On a loaded runner the
+helper can exhaust 1,000 ms of fake time first, then await a handler whose timer
+was scheduled after the fake clock stopped. Vitest eventually kills the test at
+its real ten-second ceiling.
+
+The harness will yield real event-loop turns while no fake timer is pending and
+will snapshot pre-existing timers before the handler starts. Fake time advances
+only while the handler has added a timer above that baseline, so unrelated
+lifecycle intervals cannot consume its budget. It retains a bounded fake
+deadline and bounded turn count so a broken handler fails immediately rather
+than hanging against Vitest's wall clock.
+
+The loaded run exposed two sibling harness races as well. Update-menu/relaunch
+tests still used real wall time and are moved onto the same fake-clock driver.
+The persisted-registry assertion raced the server's documented async startup
+reconstitution and now awaits that promise explicitly. Finally, every static
+`/tmp/cmuxlayer-*` fixture root in this file is scoped by process and Vitest
+worker ID; concurrent test processes can no longer delete or overwrite one
+another's prompt, state, or event-log files. Production polling and timeout
+values remain unchanged.
+
+## A2: nightly LaunchAgent and ancestry finding
+
+The bundle mirrors `launchd/cmux-caffeinate`: a small Bash entrypoint, a plist,
+shell tests, and an operator README. The script pins
+`CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock`, runs `bun run test:contract` from the
+canonical checkout, classifies the existing terminal marker as `pass`, `fail`,
+or `skip`, and writes `~/.local/state/cmux/contract-nightly-YYYY-MM-DD.json`.
+Raw stdout/stderr remains in a sibling durable log referenced by the receipt.
+Pass and skip require exactly one terminal marker as the final non-empty line;
+duplicates or trailing output are failures.
+
+A plain LaunchAgent is descended from launchd, not from a cmux terminal. The
+contract lane deliberately verifies that detached/orphan callers are denied by
+cmux's ancestry access control, so launchd cannot manufacture the required pane
+ancestry. The job is therefore best-effort: a `skip` is recorded distinctly and
+means the runner was not admitted, never that the contract passed. Installation
+stays Etan-gated; this change will not call `launchctl bootstrap`.
+
+## Verification
+
+- Add a regression case whose handler crosses many real event-loop turns before
+  scheduling its fake timeout while an unrelated interval exists, and observe
+  it fail with the old helper.
+- Add shell tests for pass/fail/skip JSON receipts, the nightly socket pin,
+  plist scheduling, syntax, and executable bits.
+- Run the affected server tests ten fresh processes under fork pooling while a
+  CPU load is active.
+- Run the full server file in concurrent fresh processes to prove fixture roots
+  do not collide.
+- Run the shell tests, full suite, typecheck, and build.

--- a/docs/plans/2026-07-11-r7-continuous-ci.md
+++ b/docs/plans/2026-07-11-r7-continuous-ci.md
@@ -1,0 +1,118 @@
+# R7 Continuous CI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make SEAT A's integration timing deterministic under CI load and package the NIGHTLY real-cmux contract lane as an Etan-gated M4 LaunchAgent.
+
+**Architecture:** Repair the test-only fake-clock driver so fake time advances only when a timer is pending, leaving production timing untouched. Add a caffeinate-pattern launchd bundle whose wrapper pins the NIGHTLY socket and emits explicit pass/fail/skip JSON receipts while documenting the pane-ancestry limitation.
+
+**Tech Stack:** TypeScript, Vitest 3, Bun, Bash, macOS launchd.
+
+---
+
+### Task 1: Reproduce and fix residual fake-timer starvation
+
+**Files:**
+- Modify: `tests/server.test.ts`
+
+**Step 1: Write the failing regression test**
+
+Add a test-only handler that crosses more real event-loop turns than the current
+helper's fixed fake-time loop before scheduling a fake timeout. Assert that
+`runWithFakeTimers` returns the handler result.
+
+**Step 2: Run RED**
+
+Run:
+
+```bash
+bunx vitest run tests/server.test.ts -t "waits for non-timer async progress"
+```
+
+Expected: FAIL by timing out with the current helper.
+
+**Step 3: Implement the minimal harness fix**
+
+Capture the real `setImmediate`, snapshot the pre-handler timer count, yield one
+real event-loop turn per iteration, and advance fake time only when the handler
+has added a timer above that baseline. Throw a deterministic helper-budget error
+if the handler never settles.
+
+**Step 4: Run GREEN**
+
+Run the new regression and the historical token-evidence test. Expected: both
+pass without increasing their Vitest timeout.
+
+**Step 5: Convert sibling timing assumptions**
+
+Drive update-menu/relaunch cases with the same helper, await lifecycle startup
+before asserting persisted registry state, and scope every static server-test
+temporary directory by process and Vitest worker ID.
+
+### Task 2: Specify the nightly launchd contract
+
+**Files:**
+- Create: `launchd/cmux-contract-nightly/tests/cmux-contract-nightly.sh`
+- Create: `launchd/cmux-contract-nightly/tests/run-tests.sh`
+
+**Step 1: Write failing shell tests**
+
+Use fake `bun` binaries to cover terminal pass, command failure, and explicit
+contract skip. Assert the wrapper pins `/tmp/cmux-nightly.sock`, writes a valid
+dated JSON receipt, preserves a raw log, returns nonzero only for failure, and
+that the plist contains a nightly calendar interval without `RunAtLoad` or
+`KeepAlive`.
+
+**Step 2: Run RED**
+
+Run:
+
+```bash
+bash launchd/cmux-contract-nightly/tests/run-tests.sh
+```
+
+Expected: FAIL because the wrapper and plist do not exist.
+
+### Task 3: Implement the nightly LaunchAgent bundle
+
+**Files:**
+- Create: `launchd/cmux-contract-nightly/bin/cmux-contract-nightly.sh`
+- Create: `launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist`
+- Create: `launchd/cmux-contract-nightly/README.md`
+
+**Step 1: Write the wrapper**
+
+Run the canonical repository command with the NIGHTLY socket pin, capture raw
+output, classify the existing final marker, and atomically publish a JSON
+receipt with date, timestamp, outcome, exit code, socket, command, and log path.
+
+**Step 2: Write the plist and README**
+
+Schedule one nightly run, use durable stdout/stderr paths, provide only the
+Etan-gated bootstrap/reload commands, explain all three outcomes, and state the
+plain-launchd ancestry limitation.
+
+**Step 3: Run GREEN**
+
+Run the shell test entrypoint and `plutil -lint`.
+
+### Task 4: Verify under load and publish
+
+**Files:**
+- Modify: PR body only
+
+**Step 1: Run ten loaded processes**
+
+Start a bounded CPU load and run the affected server timing tests ten times with
+`--pool=forks`, recording each fresh-process summary.
+
+**Step 2: Run repository verification**
+
+Run the launchd shell tests, `bun run test`, `bun run typecheck`, and
+`bun run build`.
+
+**Step 3: Review and publish**
+
+Read the full diff, run the bounded local review gate, commit only SEAT A files,
+push `test/r7-continuous-ci`, and open a ready-for-review PR with the exact
+verification evidence and the ancestry finding.

--- a/launchd/cmux-contract-nightly/README.md
+++ b/launchd/cmux-contract-nightly/README.md
@@ -1,0 +1,67 @@
+# cmux NIGHTLY Contract Job
+
+This LaunchAgent schedules `bun run test:contract` at 03:30 each night against
+the isolated NIGHTLY cmux socket:
+
+```bash
+CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock
+```
+
+It does not install itself and it never opts into the production-socket
+override.
+
+## Result receipts
+
+Each run writes a raw log and a structured receipt:
+
+```text
+~/.local/state/cmux/contract-nightly-YYYY-MM-DD.log
+~/.local/state/cmux/contract-nightly-YYYY-MM-DD.json
+```
+
+The JSON `outcome` has three possible values:
+
+- `pass`: the runner ended with exactly one real-cmux contract pass marker.
+- `fail`: the command failed or exited without a terminal pass/skip marker.
+- `skip`: the existing contract runner refused to run, typically because the
+  NIGHTLY socket was absent or the caller was rejected by ancestry policy. The
+  skip marker must likewise be the only terminal marker and final log line.
+
+Multiple terminal markers or any output after a pass/skip marker are recorded
+as `fail`; trailing cleanup errors cannot be hidden behind an earlier pass.
+
+A `skip` is not green. It means no continuous contract evidence was produced
+that night and the log explains which infrastructure precondition was missing.
+
+## Ancestry limitation
+
+cmux socket access is restricted to cmux-pane descendants. A plain LaunchAgent
+is descended from launchd, so it cannot create genuine pane ancestry merely by
+setting `CMUX_SOCKET_PATH`. The contract lane also asserts that detached/orphan
+callers are denied, which prevents this job from safely bypassing that rule.
+
+This bundle is therefore a best-effort scheduler and records that context in
+every receipt as `plain-launchd-best-effort`. A fully admitted nightly run still
+requires an Etan-gated mechanism that starts the command from a NIGHTLY cmux
+terminal descendant (or an upstream cmux capability for authenticated scheduled
+jobs). Do not interpret a launchd `skip` as a contract pass.
+
+## Install (Etan-gated)
+
+Do not arm this from automation. After reviewing the ancestry finding and the
+canonical checkout path, Etan can install it with:
+
+```bash
+launchctl bootstrap gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist
+```
+
+To reload after changes:
+
+```bash
+launchctl bootout gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist 2>/dev/null || true
+launchctl bootstrap gui/$UID /Users/etanheyman/Gits/cmuxlayer/launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist
+```
+
+Inspect the last receipt first. A `fail` means an admitted contract check found
+a regression or the wrapper could not complete; a `skip` means the continuous
+lane itself was not admitted and needs infrastructure attention.

--- a/launchd/cmux-contract-nightly/bin/cmux-contract-nightly.sh
+++ b/launchd/cmux-contract-nightly/bin/cmux-contract-nightly.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${CMUX_CONTRACT_NIGHTLY_REPO:-/Users/etanheyman/Gits/cmuxlayer}"
+state_dir="${CMUX_CONTRACT_NIGHTLY_STATE_DIR:-$HOME/.local/state/cmux}"
+bun_bin="${BUN_BIN:-/opt/homebrew/bin/bun}"
+jq_bin="${JQ_BIN:-/usr/bin/jq}"
+run_date="${CMUX_CONTRACT_NIGHTLY_DATE:-$(date '+%Y-%m-%d')}"
+timestamp="${CMUX_CONTRACT_NIGHTLY_TIMESTAMP:-$(date '+%Y-%m-%dT%H:%M:%S%z')}"
+socket_path="/tmp/cmux-nightly.sock"
+receipt="$state_dir/contract-nightly-$run_date.json"
+raw_log="$state_dir/contract-nightly-$run_date.log"
+receipt_tmp="$receipt.tmp.$$"
+
+mkdir -p "$state_dir"
+output_tmp="$(mktemp "$state_dir/.contract-nightly-output.XXXXXX")"
+cleanup() {
+  [[ -z "${output_tmp:-}" ]] || rm -f "$output_tmp"
+  rm -f "$receipt_tmp"
+}
+trap cleanup EXIT
+
+set +e
+(
+  cd "$repo"
+  CMUX_SOCKET_PATH="$socket_path" "$bun_bin" run test:contract
+) >"$output_tmp" 2>&1
+command_exit=$?
+set -e
+
+outcome="fail"
+exit_code="$command_exit"
+terminal_count="$(awk '/^\[contract\] PASS real-cmux contract lane$/ || /^\[contract\] SKIP: / { count += 1 } END { print count + 0 }' "$output_tmp")"
+last_nonempty_line="$(awk 'NF { line = $0 } END { print line }' "$output_tmp")"
+if [[ "$command_exit" -eq 0 && "$terminal_count" -eq 1 && "$last_nonempty_line" == "[contract] PASS real-cmux contract lane" ]]; then
+  outcome="pass"
+elif [[ "$command_exit" -eq 0 && "$terminal_count" -eq 1 && "$last_nonempty_line" == "[contract] SKIP: "* ]]; then
+  outcome="skip"
+elif [[ "$command_exit" -eq 0 ]]; then
+  exit_code=1
+  printf '%s\n' "[contract-nightly] FAIL: command exited zero without exactly one final PASS or SKIP marker" >>"$output_tmp"
+fi
+
+mv "$output_tmp" "$raw_log"
+output_tmp=""
+
+"$jq_bin" -n \
+  --arg date "$run_date" \
+  --arg timestamp "$timestamp" \
+  --arg outcome "$outcome" \
+  --argjson exit_code "$exit_code" \
+  --arg socket_path "$socket_path" \
+  --arg command "bun run test:contract" \
+  --arg repository "$repo" \
+  --arg log_path "$raw_log" \
+  --arg ancestry_context "plain-launchd-best-effort" \
+  '{
+    date: $date,
+    timestamp: $timestamp,
+    outcome: $outcome,
+    exit_code: $exit_code,
+    socket_path: $socket_path,
+    command: $command,
+    repository: $repository,
+    log_path: $log_path,
+    ancestry_context: $ancestry_context
+  }' >"$receipt_tmp"
+mv "$receipt_tmp" "$receipt"
+
+if [[ "$outcome" == "fail" ]]; then
+  exit "$exit_code"
+fi

--- a/launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist
+++ b/launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.golems.cmux-contract-nightly</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/etanheyman/Gits/cmuxlayer/launchd/cmux-contract-nightly/bin/cmux-contract-nightly.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/etanheyman/.local/state/cmux/cmux-contract-nightly.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/etanheyman/.local/state/cmux/cmux-contract-nightly.stderr.log</string>
+</dict>
+</plist>

--- a/launchd/cmux-contract-nightly/tests/cmux-contract-nightly.sh
+++ b/launchd/cmux-contract-nightly/tests/cmux-contract-nightly.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/bin/cmux-contract-nightly.sh"
+PLIST_PATH="$ROOT_DIR/launchd/com.golems.cmux-contract-nightly.plist"
+DEPLOY_SCRIPT_PATH="/Users/etanheyman/Gits/cmuxlayer/launchd/cmux-contract-nightly/bin/cmux-contract-nightly.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  [[ -f "$file" ]] || fail "missing file: $file"
+  grep -F -- "$needle" "$file" >/dev/null || fail "expected '$needle' in $file"
+}
+
+json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)
+print(value[sys.argv[2]])
+PY
+}
+
+make_fake_bun() {
+  local path="$1"
+  cat >"$path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$CMUX_SOCKET_PATH" >"$FAKE_CAPTURE_DIR/socket"
+printf '%s\n' "$PWD" >"$FAKE_CAPTURE_DIR/cwd"
+printf '%s\n' "$*" >"$FAKE_CAPTURE_DIR/args"
+case "$FAKE_CONTRACT_MODE" in
+  pass)
+    printf '%s\n' '[contract] PASS real-cmux contract lane'
+    ;;
+  skip)
+    printf '%s\n' '[contract] SKIP: write EPIPE from plain launchd ancestry' >&2
+    ;;
+  fail)
+    printf '%s\n' '[contract] FAIL: live read contract broke' >&2
+    exit 7
+    ;;
+  pass_then_noise)
+    printf '%s\n' '[contract] PASS real-cmux contract lane'
+    printf '%s\n' 'cleanup warning after pass' >&2
+    ;;
+  double_terminal)
+    printf '%s\n' '[contract] SKIP: first terminal marker'
+    printf '%s\n' '[contract] PASS real-cmux contract lane'
+    ;;
+  *)
+    printf 'unknown fake mode: %s\n' "$FAKE_CONTRACT_MODE" >&2
+    exit 64
+    ;;
+esac
+EOF
+  chmod +x "$path"
+}
+
+run_outcome_case() {
+  local mode="$1"
+  local expected_outcome="$2"
+  local expected_exit="$3"
+  local root repo state fake_bun receipt raw_log actual_exit
+  root="$(mktemp -d)"
+  repo="$root/repo"
+  state="$root/state"
+  fake_bun="$root/bun"
+  mkdir -p "$repo" "$state" "$root/capture"
+  make_fake_bun "$fake_bun"
+
+  set +e
+  FAKE_CONTRACT_MODE="$mode" \
+    FAKE_CAPTURE_DIR="$root/capture" \
+    BUN_BIN="$fake_bun" \
+    CMUX_CONTRACT_NIGHTLY_REPO="$repo" \
+    CMUX_CONTRACT_NIGHTLY_STATE_DIR="$state" \
+    CMUX_CONTRACT_NIGHTLY_DATE="2026-07-11" \
+    CMUX_CONTRACT_NIGHTLY_TIMESTAMP="2026-07-11T03:30:00+0300" \
+    "$SCRIPT_PATH"
+  actual_exit=$?
+  set -e
+
+  assert_eq "$expected_exit" "$actual_exit"
+  assert_eq "/tmp/cmux-nightly.sock" "$(cat "$root/capture/socket")"
+  assert_eq "$repo" "$(cat "$root/capture/cwd")"
+  assert_eq "run test:contract" "$(cat "$root/capture/args")"
+
+  receipt="$state/contract-nightly-2026-07-11.json"
+  raw_log="$state/contract-nightly-2026-07-11.log"
+  [[ -f "$receipt" ]] || fail "missing receipt: $receipt"
+  [[ -f "$raw_log" ]] || fail "missing raw log: $raw_log"
+  assert_eq "$expected_outcome" "$(json_field "$receipt" outcome)"
+  assert_eq "$expected_exit" "$(json_field "$receipt" exit_code)"
+  assert_eq "/tmp/cmux-nightly.sock" "$(json_field "$receipt" socket_path)"
+  assert_eq "$raw_log" "$(json_field "$receipt" log_path)"
+  assert_eq "bun run test:contract" "$(json_field "$receipt" command)"
+  [[ ! -e "$receipt.tmp" ]] || fail "temporary receipt survived atomic publish"
+
+  case "$mode" in
+    pass) assert_file_contains "$raw_log" "PASS real-cmux contract lane" ;;
+    skip) assert_file_contains "$raw_log" "SKIP: write EPIPE" ;;
+    fail) assert_file_contains "$raw_log" "FAIL: live read contract broke" ;;
+  esac
+
+  printf 'PASS: nightly contract records %s\n' "$expected_outcome"
+  rm -rf "$root"
+}
+
+run_plist_case() {
+  assert_file_contains "$PLIST_PATH" "<string>com.golems.cmux-contract-nightly</string>"
+  assert_file_contains "$PLIST_PATH" "$DEPLOY_SCRIPT_PATH"
+  assert_file_contains "$PLIST_PATH" "<key>StartCalendarInterval</key>"
+  assert_file_contains "$PLIST_PATH" "<key>Hour</key>"
+  assert_file_contains "$PLIST_PATH" "<integer>3</integer>"
+  assert_file_contains "$PLIST_PATH" "<key>Minute</key>"
+  assert_file_contains "$PLIST_PATH" "<integer>30</integer>"
+  assert_file_contains "$PLIST_PATH" "<key>StandardOutPath</key>"
+  assert_file_contains "$PLIST_PATH" "<key>StandardErrorPath</key>"
+  if grep -F -- "<key>RunAtLoad</key>" "$PLIST_PATH" >/dev/null; then
+    fail "nightly job must not run at install time"
+  fi
+  if grep -F -- "<key>KeepAlive</key>" "$PLIST_PATH" >/dev/null; then
+    fail "nightly job must not be kept alive"
+  fi
+  plutil -lint "$PLIST_PATH" >/dev/null
+  printf 'PASS: launchd plist schedules one nightly run\n'
+}
+
+run_syntax_case() {
+  [[ -x "$SCRIPT_PATH" ]] || fail "script is missing or not executable: $SCRIPT_PATH"
+  bash -n "$SCRIPT_PATH"
+  printf 'PASS: nightly contract script is executable and syntax-valid\n'
+}
+
+run_outcome_case pass pass 0
+run_outcome_case skip skip 0
+run_outcome_case fail fail 7
+run_outcome_case pass_then_noise fail 1
+run_outcome_case double_terminal fail 1
+run_plist_case
+run_syntax_case

--- a/launchd/cmux-contract-nightly/tests/run-tests.sh
+++ b/launchd/cmux-contract-nightly/tests/run-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/tests/cmux-contract-nightly.sh"

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   createServer as createServerImpl,
+  createServerContext,
   __submitEvidenceTestHooks,
 } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
@@ -83,8 +84,12 @@ const EXPECTED_TOOLS = [
   "query_monitor_registry",
 ] as const;
 
-const CHANNEL_TEST_DIR = join(tmpdir(), "cmuxlayer-channels-server-test");
+const TEST_PROCESS_SCOPE = `${process.pid}-${process.env.VITEST_WORKER_ID ?? "0"}`;
+const processScopedTmpDir = (name: string): string =>
+  join(tmpdir(), `${name}-${TEST_PROCESS_SCOPE}`);
+const CHANNEL_TEST_DIR = processScopedTmpDir("cmuxlayer-channels-server-test");
 const BOOT_PROMPT_READY_POLL_MS_FOR_TESTS = 250;
+const REAL_SET_IMMEDIATE = setImmediate;
 const REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN = [
   "✻ Cogitated for 15s",
   "                                                                                51784 tokens",
@@ -155,7 +160,10 @@ async function runWithFakeTimers<T>(
   run: () => Promise<T>,
   advanceMs: number,
 ): Promise<T> {
-  vi.useFakeTimers();
+  if (!vi.isFakeTimers()) {
+    vi.useFakeTimers();
+  }
+  const baselineTimerCount = vi.getTimerCount();
   const resultPromise = run();
   let settled = false;
   void resultPromise.then(
@@ -166,16 +174,65 @@ async function runWithFakeTimers<T>(
       settled = true;
     },
   );
-  for (let elapsed = 0; elapsed < advanceMs && !settled; elapsed += 50) {
-    // Tool handlers cross several async boundaries before scheduling their
-    // first poll. Flush those jobs before advancing the next clock slice.
+  let elapsed = 0;
+  let idleTurns = 0;
+  const maxIdleTurns = 10_000;
+  while (!settled && elapsed < advanceMs && idleTurns < maxIdleTurns) {
+    // A handler can cross real I/O/event-loop boundaries before scheduling its
+    // next poll. Do not spend its fake-time budget until that timer exists.
+    await new Promise<void>((resolve) => REAL_SET_IMMEDIATE(resolve));
     for (let flush = 0; flush < 8; flush += 1) {
       await Promise.resolve();
     }
-    await advanceTimers(50);
+    if (settled) break;
+    if (vi.getTimerCount() <= baselineTimerCount) {
+      idleTurns += 1;
+      continue;
+    }
+    const step = Math.min(50, advanceMs - elapsed);
+    await advanceTimers(step);
+    elapsed += step;
+    idleTurns = 0;
+  }
+  if (!settled) {
+    throw new Error(
+      `fake timer operation did not settle after ${elapsed}ms and ${idleTurns} idle turns`,
+    );
   }
   return resultPromise;
 }
+
+describe("fake timer harness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for non-timer async progress before advancing the fake deadline", async () => {
+    vi.useFakeTimers();
+    const unrelatedTimer = setInterval(() => {}, 10);
+    let turns = 0;
+
+    try {
+      const result = await runWithFakeTimers(async () => {
+        while (turns < 30) {
+          await new Promise<void>((resolve) => {
+            REAL_SET_IMMEDIATE(() => {
+              turns += 1;
+              resolve();
+            });
+          });
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        return "settled";
+      }, 200);
+
+      expect(result).toBe("settled");
+      expect(turns).toBe(30);
+    } finally {
+      clearInterval(unrelatedTimer);
+    }
+  }, 1_000);
+});
 
 function setFakeSystemTime(now: Date): void {
   const setSystemTime = (
@@ -1735,7 +1792,9 @@ describe("tool handler integration", () => {
   });
 
   it("read_screen parsed_only includes the tab title and recovers model context from agent state", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-read-screen-parser-fallback");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-read-screen-parser-fallback",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -1937,7 +1996,9 @@ describe("tool handler integration", () => {
 
     // Use an isolated stateDir so enrichParsedScreen doesn't pick up live
     // agent state from the default state directory and overwrite model/cost.
-    const isolatedStateDir = join(tmpdir(), "cmux-read-screen-isolation-test");
+    const isolatedStateDir = processScopedTmpDir(
+      "cmux-read-screen-isolation-test",
+    );
     rmSync(isolatedStateDir, { recursive: true, force: true });
     mkdirSync(isolatedStateDir, { recursive: true });
     const server = createServer({
@@ -2344,7 +2405,9 @@ describe("tool handler integration", () => {
   });
 
   it("send_input background reads 'delivering' (not FAILED) while in flight (F8)", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input-background");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-f8-send-input-background",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
@@ -2406,7 +2469,7 @@ describe("tool handler integration", () => {
   });
 
   it("send_input returns delivered + cheap target identity from the state cache (F8)", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-input");
+    const stateDir = processScopedTmpDir("cmuxlayer-f8-send-input");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -2472,7 +2535,7 @@ describe("tool handler integration", () => {
   });
 
   it("send_command returns delivered + identity + submit_verified (F8)", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-f8-send-command");
+    const stateDir = processScopedTmpDir("cmuxlayer-f8-send-command");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -3926,7 +3989,9 @@ describe("tool handler integration", () => {
 
   it("send_input background press_enter verifies a cleared agent composer", async () => {
     vi.useFakeTimers();
-    const stateDir = join(tmpdir(), "cmuxlayer-background-submit-verify");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-background-submit-verify",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -4012,7 +4077,9 @@ describe("tool handler integration", () => {
 
   it("send_input does not retry Return for a Cursor queued composer that still shows the prompt", async () => {
     vi.useFakeTimers();
-    const stateDir = join(tmpdir(), "cmuxlayer-cursor-queued-submit-verify");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-cursor-queued-submit-verify",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -4097,7 +4164,9 @@ describe("tool handler integration", () => {
 
   it("send_input verifies a fast-cleared Codex composer without a retry", async () => {
     vi.useFakeTimers();
-    const stateDir = join(tmpdir(), "cmuxlayer-codex-cleared-submit-verify");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-codex-cleared-submit-verify",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -4180,7 +4249,9 @@ describe("tool handler integration", () => {
 
   it("send_input does not retry Return for a non-Cursor idle composer that may have queued input", async () => {
     vi.useFakeTimers();
-    const stateDir = join(tmpdir(), "cmuxlayer-codex-dropped-submit-retry");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-codex-dropped-submit-retry",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     const stateMgr = new StateManager(stateDir);
@@ -6352,7 +6423,6 @@ describe("tool handler integration", () => {
   });
 
   it("spawn_agent waits out a Codex auto-update, relaunches after bare shell, then delivers the boot prompt", async () => {
-    vi.useRealTimers();
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-relaunch-state");
@@ -6464,15 +6534,19 @@ describe("tool handler integration", () => {
     const tool = (server as any)._registeredTools["spawn_agent"];
 
     try {
-      const result = await tool.handler(
-        {
-          repo: "cmuxlayer",
-          model: "gpt-5.5",
-          cli: "codex",
-          boot_prompt_path: promptPath,
-          boot_prompt_timeout_ms: 2_000,
-        },
-        {} as any,
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "cmuxlayer",
+              model: "gpt-5.5",
+              cli: "codex",
+              boot_prompt_path: promptPath,
+              boot_prompt_timeout_ms: 2_000,
+            },
+            {} as any,
+          ),
+        5_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -6495,7 +6569,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("spawn_agent skips the interactive Codex update menu before delivering the boot prompt", async () => {
-    vi.useRealTimers();
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-state");
@@ -6632,15 +6705,19 @@ describe("tool handler integration", () => {
     )._registeredTools["spawn_agent"];
 
     try {
-      const result = await tool.handler(
-        {
-          repo: "cmuxlayer",
-          model: "gpt-5.5",
-          cli: "codex",
-          boot_prompt_path: promptPath,
-          boot_prompt_timeout_ms: 500,
-        },
-        {},
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "cmuxlayer",
+              model: "gpt-5.5",
+              cli: "codex",
+              boot_prompt_path: promptPath,
+              boot_prompt_timeout_ms: 500,
+            },
+            {},
+          ),
+        3_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -6660,7 +6737,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("spawn_agent keeps polling after a slow Codex update menu dismissal", async () => {
-    vi.useRealTimers();
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-slow-state");
@@ -6792,15 +6868,19 @@ describe("tool handler integration", () => {
     )._registeredTools["spawn_agent"];
 
     try {
-      const result = await tool.handler(
-        {
-          repo: "cmuxlayer",
-          model: "gpt-5.5",
-          cli: "codex",
-          boot_prompt_path: promptPath,
-          boot_prompt_timeout_ms: 500,
-        },
-        {},
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "cmuxlayer",
+              model: "gpt-5.5",
+              cli: "codex",
+              boot_prompt_path: promptPath,
+              boot_prompt_timeout_ms: 500,
+            },
+            {},
+          ),
+        3_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -6820,7 +6900,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("spawn_agent returns blocked_by_update_menu when the Codex update menu remains after dismissal", async () => {
-    vi.useRealTimers();
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-blocked-state");
@@ -6930,15 +7009,19 @@ describe("tool handler integration", () => {
     )._registeredTools["spawn_agent"];
 
     try {
-      const result = await tool.handler(
-        {
-          repo: "cmuxlayer",
-          model: "gpt-5.5",
-          cli: "codex",
-          boot_prompt_path: promptPath,
-          boot_prompt_timeout_ms: 500,
-        },
-        {},
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "cmuxlayer",
+              model: "gpt-5.5",
+              cli: "codex",
+              boot_prompt_path: promptPath,
+              boot_prompt_timeout_ms: 500,
+            },
+            {},
+          ),
+        3_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -7128,7 +7211,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("new_split relaunches a launcher-title terminal after update drops to shell", async () => {
-    vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-update-relaunch.md");
     const prompt = "boot after update";
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -7237,14 +7319,18 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["new_split"];
 
-    const result = await tool.handler(
-      {
-        direction: "right",
-        title: "cmuxlayerCodex",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 50,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            direction: "right",
+            title: "cmuxlayerCodex",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 50,
+          },
+          {} as any,
+        ),
+      2_000,
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -7256,7 +7342,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("new_split preserves enough post-update time for low-confidence ready prompts", async () => {
-    vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-update-gemini.md");
     const prompt = "boot after gemini update";
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -7366,14 +7451,18 @@ describe("tool handler integration", () => {
     const tool = (server as any)._registeredTools["new_split"];
 
     try {
-      const result = await tool.handler(
-        {
-          direction: "right",
-          title: "cmuxlayerGemini",
-          boot_prompt_path: promptPath,
-          boot_prompt_timeout_ms: 50,
-        },
-        {} as any,
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              direction: "right",
+              title: "cmuxlayerGemini",
+              boot_prompt_path: promptPath,
+              boot_prompt_timeout_ms: 50,
+            },
+            {} as any,
+          ),
+        2_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -7388,7 +7477,6 @@ describe("tool handler integration", () => {
   }, 10_000);
 
   it("new_surface relaunches a launcher-title terminal after update drops to shell", async () => {
-    vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "surface-update-relaunch.md");
     const prompt = "boot after update";
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
@@ -7451,14 +7539,18 @@ describe("tool handler integration", () => {
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools["new_surface"];
 
-    const result = await tool.handler(
-      {
-        pane: "pane:1",
-        title: "cmuxlayerCodex",
-        boot_prompt_path: promptPath,
-        boot_prompt_timeout_ms: 50,
-      },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            pane: "pane:1",
+            title: "cmuxlayerCodex",
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 50,
+          },
+          {} as any,
+        ),
+      2_000,
     );
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -8353,7 +8445,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface handler calls cmux close-surface", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-basic");
+    const stateDir = processScopedTmpDir("cmuxlayer-close-surface-basic");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
     mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
@@ -8376,7 +8468,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface reports pane collapse when closing the last dedicated worker tab", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-layout");
+    const stateDir = processScopedTmpDir("cmuxlayer-close-surface-layout");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8483,7 +8575,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface refuses a live agent without force and returns a pane read", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-guard");
+    const stateDir = processScopedTmpDir("cmuxlayer-close-surface-guard");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8551,7 +8643,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface logs a durable close entry with caller, force, and target", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-eventlog");
+    const stateDir = processScopedTmpDir("cmuxlayer-close-surface-eventlog");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8620,7 +8712,9 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface logs the attempt when a live-agent close is refused", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-refuse-eventlog");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-close-surface-refuse-eventlog",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8694,7 +8788,9 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface consolidates stale live registry when pane shows TASK_DONE", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-done-consolidate");
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-close-surface-done-consolidate",
+    );
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8768,8 +8864,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface refuses stale DONE consolidation when pane shows an active Codex marker", async () => {
-    const stateDir = join(
-      tmpdir(),
+    const stateDir = processScopedTmpDir(
       "cmuxlayer-close-surface-done-active-refuse",
     );
     rmSync(stateDir, { recursive: true, force: true });
@@ -8847,7 +8942,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface guard is fail-safe when a stale terminal record shares the surface with a live one", async () => {
-    const stateDir = join(tmpdir(), "cmuxlayer-close-surface-collision");
+    const stateDir = processScopedTmpDir("cmuxlayer-close-surface-collision");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
 
@@ -8907,8 +9002,7 @@ describe("tool handler integration", () => {
   });
 
   it("close_surface refuses after stale DONE consolidation when another live agent shares the surface", async () => {
-    const stateDir = join(
-      tmpdir(),
+    const stateDir = processScopedTmpDir(
       "cmuxlayer-close-surface-post-consolidation-live",
     );
     rmSync(stateDir, { recursive: true, force: true });
@@ -9276,14 +9370,16 @@ describe("tool handler integration", () => {
       closeSurface: vi.fn(),
       selectWorkspace: vi.fn(),
     };
-    const server = createServer({
+    const context = createServerContext({
       client: mockClient as any,
       stateDir,
       controlHealthIntervalMs: 0,
     });
+    const server = createServer({ context });
     const tool = (server as any)._registeredTools["list_agents"];
 
     try {
+      await context.lifecycleStartPromise;
       const result = await tool.handler({}, {} as any);
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);


### PR DESCRIPTION
## Summary

### A1 — CI-robust integration timing

- Fix the residual `server.test.ts` load flake by making the fake-timer driver wait for real async progress and advance only timers added above the pre-handler baseline.
- Move update-menu/relaunch polling cases off wall-clock timing.
- Await lifecycle registry reconstitution before asserting startup state.
- Scope every static server-test temp root by process and Vitest worker ID so concurrent workers/worktrees cannot delete or overwrite each other's prompt, state, or event-log fixtures.
- Keep production poll intervals and timeout values unchanged; add no CI retries or suite serialization.

### A2 — M4 NIGHTLY continuous contract bundle

- Add `launchd/cmux-contract-nightly/` following the `cmux-caffeinate` layout: wrapper, plist, shell tests, and README.
- Schedule `bun run test:contract` nightly at 03:30 with `CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock`.
- Write durable raw logs and atomic `pass`/`fail`/`skip` JSON receipts under `~/.local/state/cmux/contract-nightly-YYYY-MM-DD.*`.
- Require exactly one final PASS/SKIP marker; duplicate markers or trailing output fail closed.
- Do not auto-install or bootstrap the LaunchAgent.

## Ancestry finding

A plain LaunchAgent is descended from launchd, not from a NIGHTLY cmux terminal. It cannot manufacture the pane ancestry required by cmux socket access, and the existing contract lane deliberately verifies that detached/orphan callers are denied. The bundle is therefore explicitly best-effort: ancestry denial is recorded as `skip`, never green. A fully admitted scheduled run still needs an Etan-gated pane-descended launcher or an upstream authenticated scheduling capability.

## TDD evidence

- RED: the new fake-timer regression timed out with the old helper when an unrelated interval existed before the handler scheduled its own timer.
- RED: the launchd suite failed before the wrapper/plist existed.
- RED: trailing output after PASS and duplicate terminal markers were initially misclassified; both now produce `fail` receipts.

## Verification

- Loaded proof on final rebased SHA: 10 fresh `--pool=forks` runs with four CPU burners; every run passed `153/153` server tests.
- Concurrent isolation: simultaneous full `server.test.ts` processes passed `153/153` each; three additional two-process rounds also passed.
- Full suite: `90/90` files, `1669/1669` tests.
- Push hook: full suite `90/90` files, `1669/1669` tests, plus both regression scripts green.
- `bun run typecheck` — exit 0.
- `bun run build` — exit 0.
- `shellcheck --severity=warning` on all new Bash scripts — exit 0.
- `bash launchd/cmux-contract-nightly/tests/run-tests.sh` — pass/skip/fail/trailing-marker/duplicate-marker cases green.
- `plutil -lint launchd/cmux-contract-nightly/launchd/com.golems.cmux-contract-nightly.plist` — OK.
- `git diff --check` — exit 0.

## Review

The bounded local CodeRabbit pass found one major marker-classification issue. Fixed by requiring exactly one terminal marker as the final non-empty line, with regression coverage for trailing output and duplicate markers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are test harness, launchd ops bundle, and documentation; no production server timing or auto bootstrap of the nightly job.
> 
> **Overview**
> Hardens **server integration tests** for loaded CI and adds an **Etan-gated nightly real-cmux contract** launchd bundle (test-only harness + ops docs; production poll/timeouts unchanged).
> 
> **`runWithFakeTimers`** now yields real event-loop turns and advances fake time only when the handler adds timers above a pre-run baseline, with bounded idle turns and a deterministic settle failure. A regression test covers slow async progress with unrelated intervals. Codex update-menu/relaunch cases move off wall clock onto this helper; the persisted-registry case **awaits `lifecycleStartPromise`** via `createServerContext`. Static `/tmp` fixture roots are scoped by process and Vitest worker ID.
> 
> New **`launchd/cmux-contract-nightly/`** (caffeinate-style): wrapper runs `bun run test:contract` with `CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock`, writes dated pass/fail/skip JSON receipts and raw logs (exactly one final PASS/SKIP marker; trailing noise or duplicate markers → fail), plist at 03:30 without RunAtLoad/KeepAlive, shell tests, and README documenting plain-launchd **ancestry skip** (not auto-installed).
> 
> Design/implementation plan docs added under `docs/plans/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbb4ce9c9f5c767c9ef3cc4f812b94498a0548c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden CI timing and add nightly launchd contract job
> - Reworks `runWithFakeTimers` in [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/290/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d) to advance fake time only when new timers are pending and yield real event-loop turns otherwise, preventing handler starvation and failing fast with a clear error if unsettled.
> - Scopes test tmp directories to process/worker via `processScopedTmpDir`, preventing path collisions in concurrent runs.
> - Converts several `spawn_agent`, `new_split`, and `new_surface` tests from wall-clock timing to deterministic fake-timer execution with explicit budgets.
> - Adds a nightly LaunchAgent ([plist](https://github.com/EtanHey/cmuxlayer/pull/290/files#diff-bc0a44b12fa6743b93517cb0ff31a4452a13b564d09f13317400b9f423187e61)) that runs `test:contract` at 03:30, classifies outcomes as pass/skip/fail via terminal markers, and writes atomic JSON receipts.
> - Adds a bash test harness ([tests/cmux-contract-nightly.sh](https://github.com/EtanHey/cmuxlayer/pull/290/files#diff-703126c4128c1d50a9d3f18e68fc378a9db72a36923fe92f9a6093dfbe8f2b20)) validating receipt fields, exit-code semantics, socket pinning, and plist scheduling keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6cbb4ce. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->