### PR TITLE
test: fix leaked timer non-determinism in agent-engine.test.ts

### DIFF
--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4500,26 +4500,33 @@ To continue this session, run codex resume ${sessionId}`,
     });
 
     it("detects state change via sweep", async () => {
-      stateMgr.writeState(
-        makeRecord({
-          agent_id: "agent-boot",
-          state: "booting",
-          surface_id: "surface:42",
-        }),
-      );
-      liveSurfaces = [makeSurface("surface:42")];
-      await engine.getRegistry().reconstitute();
+      vi.useFakeTimers();
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-boot",
+            state: "booting",
+            surface_id: "surface:42",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:42")];
+        await engine.getRegistry().reconstitute();
 
-      // Simulate another process transitioning the state after 200ms
-      setTimeout(() => {
-        stateMgr.transition("agent-boot", "ready");
-      }, 200);
+        // Simulate another process transitioning the state after 200ms.
+        const pending = engine.waitFor("agent-boot", "ready", 5000);
+        setTimeout(() => {
+          stateMgr.transition("agent-boot", "ready");
+        }, 200);
 
-      const result = await engine.waitFor("agent-boot", "ready", 5000);
-      expect(result.matched).toBe(true);
-      expect(result.source).toBe("sweep");
-      expect(result.agent?.agent_id).toBe("agent-boot");
-      expect(result.agent?.state).toBe("ready");
+        await vi.advanceTimersByTimeAsync(1_000);
+        const result = await pending;
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("sweep");
+        expect(result.agent?.agent_id).toBe("agent-boot");
+        expect(result.agent?.state).toBe("ready");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("promotes booting agents to ready when their CLI prompt appears", async () => {


### PR DESCRIPTION
## Summary
- replace the real 200 ms state-transition timer in `detects state change via sweep` with Vitest fake timers
- start `waitFor` before advancing the fake clock so the 1,000 ms sweep deterministically observes the transition
- restore real timers in `finally`, keeping the change test-only and preventing timer state from leaking into sibling tests

## Verification

Specific test, 10 fresh isolated runs:

```text
isolation 1: Tests  1 passed | 194 skipped (195)
isolation 2: Tests  1 passed | 194 skipped (195)
isolation 3: Tests  1 passed | 194 skipped (195)
isolation 4: Tests  1 passed | 194 skipped (195)
isolation 5: Tests  1 passed | 194 skipped (195)
isolation 6: Tests  1 passed | 194 skipped (195)
isolation 7: Tests  1 passed | 194 skipped (195)
isolation 8: Tests  1 passed | 194 skipped (195)
isolation 9: Tests  1 passed | 194 skipped (195)
isolation 10: Tests  1 passed | 194 skipped (195)
```

Full `bun run test` in six fresh processes while two CPU-saturation workers ran in parallel:

```text
cold run 1: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  11.06s
cold run 2: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  9.56s
cold run 3: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  9.49s
cold run 4: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  9.55s
cold run 5: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  9.50s
cold run 6: Test Files  90 passed (90) | Tests  1671 passed (1671) | Duration  9.54s
```

- `bun run typecheck` — passed
- `bun run build` — passed
- pre-push hook — 90 test files / 1,671 tests passed
- `git diff --check` — passed

## Review note

The local CodeRabbit pre-commit review was attempted, but its public OSS quota was exhausted (`rate_limit`, reset estimate 18 minutes). PR-level review is requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test harness timing in one spec; no runtime code paths change.
> 
> **Overview**
> **Test-only change** in `agent-engine.test.ts` for **`detects state change via sweep`**.
> 
> The test used a real **200ms** `setTimeout` to simulate an external state transition while `waitFor` ran on wall clock time, which could flake or leave timers affecting other tests. It now wraps the case in **`vi.useFakeTimers()`** / **`finally` + `vi.useRealTimers()`**, starts **`waitFor`** before advancing time, fires the transition at 200ms on the fake clock, and uses **`vi.advanceTimersByTimeAsync(1_000)`** so periodic sweep polling can observe **`booting` → `ready`** with **`source: "sweep"`**.
> 
> No production or `AgentEngine` behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4092d184f7c126a662dd9571cb77767d77e85acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix non-deterministic timer leak in `agent-engine.test.ts` sweep test
> The `detects state change via sweep test` test previously relied on real timers, causing non-determinism. The test now uses `vi.useFakeTimers()` with a `try/finally` block to restore real timers, schedules the state transition via `setTimeout`, and advances time with `vi.advanceTimersByTimeAsync(1000)` before awaiting the pre-created `waitFor` promise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4092d18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->