### PR TITLE
feat(ci): pane-descended nightly contract runner + dumb-proof runbook

### DIFF
--- a/docs/runbooks/nightly-contract-gemini.md
+++ b/docs/runbooks/nightly-contract-gemini.md
@@ -1,0 +1,34 @@
+# Nightly contract — Gemini runbook
+
+Follow these steps exactly. Do not edit files. Do not investigate failures. Do
+not run any command except the command in step 2.
+
+1. Run only inside a Gemini terminal pane in the **cmux NIGHTLY** instance. The
+   Gemini process must have been started from that pane.
+2. Run this one command:
+
+   ```bash
+   bash /Users/etanheyman/Gits/cmuxlayer/scripts/nightly-contract-run.sh
+   ```
+
+3. Read the first word of the one output line. It is exactly `PASS`, `FAIL`, or
+   `SKIP`.
+4. If it is `PASS`, the command has already posted that one line to
+   `~/.local/state/cmux/nightly-contract-gemini.log`. Stop.
+5. If it is `FAIL`, the command has already posted one line containing the
+   failure reason and receipt path to
+   `~/.local/state/cmux/nightly-contract-gemini.log`. Do not fix, edit, retry,
+   or investigate anything. Stop.
+6. If it is `SKIP`, the NIGHTLY instance was unavailable or the Gemini process
+   was not descended from a NIGHTLY pane. This is **not a pass**. The command
+   has already posted the skip reason and receipt path to
+   `~/.local/state/cmux/nightly-contract-gemini.log`. Do not retry. Stop.
+
+The receipt is the durable evidence for the run. Its path is
+`~/.local/state/cmux/contract-nightly-<UTC-date>.json` and is printed in the
+single output line.
+
+Etan or an orchestrator is responsible for spawning or keeping one Gemini in a
+cmux NIGHTLY pane and having it run step 2 on the nightly cadence. Do not
+install a system cron or LaunchAgent. Those processes are not pane-descended
+and cannot prove this contract.

--- a/scripts/nightly-contract-run.sh
+++ b/scripts/nightly-contract-run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="${NIGHTLY_CONTRACT_REPO:-$(cd "$script_dir/.." && pwd)}"
+if [[ -n "${NIGHTLY_CONTRACT_STATE_DIR:-}" ]]; then
+  state_dir="$NIGHTLY_CONTRACT_STATE_DIR"
+elif [[ -n "${HOME:-}" ]]; then
+  state_dir="$HOME/.local/state/cmux"
+else
+  state_dir="/var/tmp/cmux-nightly-contract-$(id -u)"
+fi
+bun_bin="${NIGHTLY_CONTRACT_BUN_BIN:-bun}"
+run_date="${NIGHTLY_CONTRACT_DATE:-$(date -u '+%Y-%m-%d')}"
+if [[ ! "$run_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  printf 'invalid NIGHTLY_CONTRACT_DATE: %s\n' "$run_date" >&2
+  exit 64
+fi
+timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+socket_path="/tmp/cmux-nightly.sock"
+receipt="$state_dir/contract-nightly-$run_date.json"
+report_log="$state_dir/nightly-contract-gemini.log"
+
+json_escape() {
+  local value="$1"
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1]).slice(1, -1))' "$value"
+}
+
+mkdir -p "$state_dir"
+output_tmp="$(mktemp "$state_dir/.nightly-contract-output.XXXXXX")"
+receipt_tmp="$receipt.tmp.$$"
+cleanup() {
+  rm -f "${output_tmp:-}" "$receipt_tmp"
+}
+trap cleanup EXIT
+
+set +e
+(
+  cd "$repo" || exit 70
+  unset CMUX_CONTRACT_ALLOW_PROD CMUXLAYER_DAEMON_SOCKET
+  export CMUX_SOCKET_PATH="$socket_path"
+  "$bun_bin" run test:contract
+) >"$output_tmp" 2>&1
+command_exit=$?
+set -e
+
+terminal_count="$(awk '/^\[contract\] PASS real-cmux contract lane$/ || /^\[contract\] SKIP: / { count += 1 } END { print count + 0 }' "$output_tmp")"
+last_nonempty_line="$(awk 'NF { line = $0 } END { print line }' "$output_tmp")"
+result="fail"
+reason=""
+exit_code="$command_exit"
+
+if [[ "$command_exit" -eq 0 && "$terminal_count" -eq 1 && "$last_nonempty_line" == "[contract] PASS real-cmux contract lane" ]]; then
+  result="pass"
+  reason="real-cmux contract lane passed"
+elif [[ "$command_exit" -eq 0 && "$terminal_count" -eq 1 && "$last_nonempty_line" == "[contract] SKIP: "* ]]; then
+  result="skip"
+  reason="${last_nonempty_line#\[contract\] SKIP: }"
+elif [[ "$command_exit" -eq 0 ]]; then
+  exit_code=1
+  reason="contract command exited zero without exactly one final PASS or SKIP marker"
+else
+  reason="${last_nonempty_line#\[contract\] FAIL: }"
+  [[ -n "$reason" ]] || reason="contract command exited $command_exit"
+fi
+
+version="$(node -e 'const fs = require("node:fs"); const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (typeof pkg.version === "string") process.stdout.write(pkg.version);' "$repo/package.json" 2>/dev/null)"
+[[ -n "$version" ]] || version="unknown"
+
+cat >"$receipt_tmp" <<JSON
+{
+  "version": "$(json_escape "$version")",
+  "result": "$result",
+  "reason": "$(json_escape "$reason")",
+  "timestamp": "$timestamp",
+  "socket_path": "$socket_path",
+  "command": "bun run test:contract"
+}
+JSON
+mv "$receipt_tmp" "$receipt"
+
+result_label="$(printf '%s' "$result" | tr '[:lower:]' '[:upper:]')"
+summary="$result_label cmux nightly contract: $reason; receipt=$receipt"
+printf '%s\n' "$summary" | tee -a "$report_log"
+
+if [[ "$result" == "fail" ]]; then
+  exit "$exit_code"
+fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,10 @@ EXPECTED_RENDER="| Waveform: [|=--]"
 export FIXTURE_PATH
 export EXPECTED_RENDER
 
+if ! bash scripts/tests/nightly-contract-run.test.sh; then
+  ((EXIT_STATUS |= 16))
+fi
+
 node --input-type=module - <<'NODE'
 import { readFileSync } from "node:fs";
 import TransformTTY from "transform-tty";

--- a/scripts/tests/nightly-contract-run.test.sh
+++ b/scripts/tests/nightly-contract-run.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/nightly-contract-run.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$actual" == "$expected" ]] || fail "expected '$expected', got '$actual'"
+}
+
+json_field() {
+  node -e 'const fs = require("node:fs"); const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))[process.argv[2]]; if (value != null) process.stdout.write(String(value));' "$1" "$2"
+}
+
+make_fake_bun() {
+  local path="$1"
+  cat >"$path" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$CMUX_SOCKET_PATH" >"$NIGHTLY_TEST_CAPTURE/socket"
+printf '%s\n' "$*" >"$NIGHTLY_TEST_CAPTURE/args"
+case "$NIGHTLY_TEST_MODE" in
+  skip)
+    printf '%s\n' '[contract] SKIP: NIGHTLY socket is not reachable' >&2
+    ;;
+  skip_controls)
+    printf '[contract] SKIP: control ESC=\033 BS=\b FF=\f\n' >&2
+    ;;
+  fail)
+    printf '%s\n' '[contract] FAIL: injected contract failure' >&2
+    exit 9
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+FAKE
+  chmod +x "$path"
+}
+
+run_case() {
+  local mode="$1"
+  local expected_result="$2"
+  local expected_exit="$3"
+  local expected_summary
+  expected_summary="$(printf '%s' "$expected_result" | tr '[:lower:]' '[:upper:]')"
+  local root repo state capture fake_bun receipt output actual_exit
+  root="$(mktemp -d)"
+  repo="$root/repo"
+  state="$root/state"
+  capture="$root/capture"
+  fake_bun="$root/bun"
+  mkdir -p "$repo" "$state" "$capture"
+  printf '{"version":"9.5.0-test"}\n' >"$repo/package.json"
+  make_fake_bun "$fake_bun"
+
+  set +e
+  output="$({
+    NIGHTLY_CONTRACT_REPO="$repo" \
+      NIGHTLY_CONTRACT_STATE_DIR="$state" \
+      NIGHTLY_CONTRACT_DATE="2026-07-11" \
+      NIGHTLY_CONTRACT_BUN_BIN="$fake_bun" \
+      NIGHTLY_TEST_CAPTURE="$capture" \
+      NIGHTLY_TEST_MODE="$mode" \
+      "$SCRIPT_PATH"
+  } 2>&1)"
+  actual_exit=$?
+  set -e
+
+  assert_eq "$expected_exit" "$actual_exit"
+  assert_eq "/tmp/cmux-nightly.sock" "$(cat "$capture/socket")"
+  assert_eq "run test:contract" "$(cat "$capture/args")"
+
+  receipt="$state/contract-nightly-2026-07-11.json"
+  [[ -f "$receipt" ]] || fail "missing receipt: $receipt"
+  assert_eq "9.5.0-test" "$(json_field "$receipt" version)"
+  assert_eq "$expected_result" "$(json_field "$receipt" result)"
+  [[ -n "$(json_field "$receipt" reason)" ]] || fail "receipt reason is empty"
+  [[ "$output" == "$expected_summary"* ]] || fail "summary does not start with $expected_summary: $output"
+  [[ -f "$state/nightly-contract-gemini.log" ]] || fail "missing report log"
+  grep -F -- "$receipt" "$state/nightly-contract-gemini.log" >/dev/null || fail "report log omits receipt path"
+
+  rm -rf "$root"
+}
+
+run_invalid_environment_cases() {
+  local root state output actual_exit missing_json
+  root="$(mktemp -d)"
+  state="$root/state"
+  mkdir -p "$state"
+
+  missing_json="$root/missing.json"
+  printf '{}\n' >"$missing_json"
+  assert_eq "" "$(json_field "$missing_json" reason)"
+
+  set +e
+  output="$(NIGHTLY_CONTRACT_STATE_DIR="$state" NIGHTLY_CONTRACT_DATE='../escape' "$SCRIPT_PATH" 2>&1)"
+  actual_exit=$?
+  set -e
+  assert_eq "64" "$actual_exit"
+  [[ "$output" == *"invalid NIGHTLY_CONTRACT_DATE"* ]] || fail "invalid date was not rejected clearly: $output"
+  [[ ! -e "$root/escape.json" ]] || fail "invalid date escaped the state directory"
+
+  set +e
+  output="$(env -u HOME NIGHTLY_CONTRACT_DATE='invalid' "$SCRIPT_PATH" 2>&1)"
+  actual_exit=$?
+  set -e
+  assert_eq "64" "$actual_exit"
+  [[ "$output" == *"invalid NIGHTLY_CONTRACT_DATE"* ]] || fail "unset HOME failed before date validation: $output"
+
+  rm -rf "$root"
+}
+
+[[ -x "$SCRIPT_PATH" ]] || fail "runner is missing or not executable: $SCRIPT_PATH"
+bash -n "$SCRIPT_PATH"
+run_case skip skip 0
+run_case skip_controls skip 0
+run_case fail fail 9
+run_invalid_environment_cases
+printf 'PASS: nightly contract runner receipts and exits\n'


### PR DESCRIPTION
## Summary
- add one self-contained pane-descended NIGHTLY contract command pinned to `/tmp/cmux-nightly.sock`
- publish atomic UTC-dated JSON receipts with version, pass/fail/skip result, and reason, plus one durable report line
- add a literal Gemini runbook and wire mocked skip/fail, JSON-control, date-validation, and unset-HOME cases into the shell harness

## Safety
- the runner unsets the production override and never selects a production socket
- `SKIP` remains distinct from `PASS`; only a real contract failure exits nonzero
- no delivery, daemon, monitor, or product internals changed

## Test plan
- [x] `bash scripts/run_tests.sh` — 90 files, 1671 tests passed
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bash -n scripts/nightly-contract-run.sh scripts/tests/nightly-contract-run.test.sh scripts/run_tests.sh`
- [x] `shellcheck scripts/nightly-contract-run.sh scripts/tests/nightly-contract-run.test.sh`
- [x] `git diff --check`

## Local review dispositions
- MAJOR JSON control-character serialization — FIXED with `JSON.stringify` plus ESC/backspace/form-feed regression
- MAJOR date path traversal — FIXED with exact UTC date-format validation
- MAJOR unset `HOME` — FIXED with a service-safe `/var/tmp` fallback
- MINOR missing JSON test properties — FIXED so absent/null fields read empty
- MAJOR repository-relative runbook command — WAIVED because the task explicitly requires one literal zero-inference command for the canonical `/Users/etanheyman/Gits/cmuxlayer` checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CI/operator shell scripts and docs only; no changes to daemon, monitor, or product runtime paths beyond invoking existing `test:contract` with the nightly socket pinned.
> 
> **Overview**
> Adds a **pane-descended nightly contract** path so Gemini in a cmux **NIGHTLY** pane runs one pinned command against `/tmp/cmux-nightly.sock`, without cron/LaunchAgent (those cannot satisfy pane ancestry).
> 
> **`scripts/nightly-contract-run.sh`** unsets production socket overrides, runs `bun run test:contract`, classifies output into **pass / skip / fail** from a single terminal `[contract]` marker, writes an atomic UTC-dated JSON receipt under `~/.local/state/cmux`, and appends one summary line to `nightly-contract-gemini.log`. **Skip** exits 0 but is not a pass; only **fail** exits nonzero. Receipt reasons use `JSON.stringify` escaping; `NIGHTLY_CONTRACT_DATE` is validated to block path traversal; missing `HOME` falls back to `/var/tmp`.
> 
> **`docs/runbooks/nightly-contract-gemini.md`** is a strict operator runbook: one literal bash command, interpret first word `PASS`/`FAIL`/`SKIP`, no retries or investigation.
> 
> **`scripts/run_tests.sh`** now runs **`scripts/tests/nightly-contract-run.test.sh`**, which mocks contract output (skip, control chars in reasons, fail), checks socket pinning and receipts, and rejects bad dates / unset `HOME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5289bc68ed3614db0a69a76925bc04a901f70cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nightly contract runner script and runbook for CI execution
> - Adds [nightly-contract-run.sh](https://github.com/EtanHey/cmuxlayer/pull/292/files#diff-c11e134220e292dafcc2d37ddc2890cc61e3ddc67bdab9fba9d03afae72c7df0), a Bash script that runs the contract test suite via `bun run test:contract`, parses output for PASS/SKIP/FAIL markers, writes a JSON receipt to the state directory, and appends a summary line to a report log.
> - Validates `NIGHTLY_CONTRACT_DATE` (YYYY-MM-DD format) on entry, exiting with code 64 on invalid input; exits 0 on pass/skip and non-zero on fail.
> - Adds [nightly-contract-run.test.sh](https://github.com/EtanHey/cmuxlayer/pull/292/files#diff-35fe2e286a4ed59905970f1bf09bbbbf2fdf4a9b8b8d403bc4ae7239a0cec7ee) covering environment handling, date validation, receipt structure, summary output format, report logging, and exit codes; integrated into [run_tests.sh](https://github.com/EtanHey/cmuxlayer/pull/292/files#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2) with a dedicated exit status bit.
> - Adds a [runbook](https://github.com/EtanHey/cmuxlayer/pull/292/files#diff-6f4db49c01849609d0eea18c65c76513adf1e4b4ef36030250c1efc95b876c44) documenting where to run the script, the exact command, and how to interpret output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5289bc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a nightly Gemini contract runner that records PASS, FAIL, or SKIP results.
  * Added JSON receipts and readable logs for each nightly contract run.
  * Added a runbook covering execution steps, result interpretation, and operational guidance.

* **Tests**
  * Added automated coverage for successful, skipped, failed, and invalid environment scenarios.
  * Included nightly contract validation in the standard test sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->