### PR TITLE
feat(self-heal): auto-remediate stale MCP stdio children on version bump

### DIFF
--- a/docs/plans/2026-07-11-mcp-child-self-remediation.md
+++ b/docs/plans/2026-07-11-mcp-child-self-remediation.md
@@ -1,0 +1,52 @@
+# MCP Child Self-Remediation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace a stale Homebrew-managed cmuxlayer MCP stdio child with the freshly installed entrypoint without losing its stdio transport or silently dropping requests.
+
+**Architecture:** The existing proxy version watcher will enter a one-shot drain state when `detectStaleBuild` reports a mismatch. It will reject new requests explicitly, wait up to a bounded deadline for existing requests, reject any remainder, serialize the MCP initialization handshake into an environment handoff, and call `process.execve` with the realpath-resolved installed `dist/index.js`. Canonical provenance and a cross-exec marker prevent source/dev execution and re-exec storms.
+
+**Tech Stack:** TypeScript, Node.js 22.15+ `process.execve`, MCP JSON-RPC stdio, Vitest.
+
+---
+
+### Task 1: Resolve and gate the installed MCP entrypoint
+
+**Files:**
+- Modify: `src/version.ts`
+- Test: `tests/version.test.ts`
+
+1. Write failing tests for a realpath-resolved installed `dist/index.js` path.
+2. Run `bunx vitest run tests/version.test.ts` and confirm the new test fails.
+3. Add `resolveInstalledEntryScript`, sharing the daemon resolver's canonical-path behavior.
+4. Re-run the focused test and confirm it passes.
+
+### Task 2: Add one-shot drain and in-place re-exec
+
+**Files:**
+- Modify: `src/is-main.ts`
+- Modify: `src/proxy.ts`
+- Modify: `src/entry.ts`
+- Test: `tests/proxy-version-bump.test.ts`
+
+1. Write failing tests for exactly-once exec, dev/source gating, cross-exec storm prevention, and explicit rejection of work remaining at the drain deadline.
+2. Run `bunx vitest run tests/proxy-version-bump.test.ts` and confirm failures are caused by the missing remediation API.
+3. Export the existing canonical-path helper and inject the running/installed entrypoints, execve operation, environment, and drain timeout into the proxy.
+4. On self-stale detection, enter drain mode, reject new requests, wait for pending requests, track every daemon-to-client frame, reject remaining requests at the deadline, and await every JSON-RPC rejection/response transport flush before proceeding.
+5. Bound the serialized handshake state before placing it in the environment. If it exceeds the bound, keep the current session alive and log the blocked remediation instead of risking an `E2BIG` exec failure.
+6. Persist an in-bounds handshake in the environment, then exec the installed entrypoint.
+7. Hydrate the handshake in the replacement proxy so it can replay initialization to the daemon.
+8. Re-run the focused suite and keep the existing daemon-reconnect behavior green when self-remediation is ineligible.
+
+Transient transport-flush or exec failures re-enable the watcher behind a bounded in-process attempt guard. The cross-exec marker is scoped to one running→installed transition, so it blocks a loop without suppressing the next release upgrade.
+
+### Task 3: Verify determinism and PR readiness
+
+**Files:**
+- Modify only files required by failures.
+
+1. Run typecheck, build, and the full deterministic test suite.
+2. Run the deterministic suite five times from cold process starts.
+3. Exercise the built entrypoint with a real MCP client session as required by the MCP runtime gate.
+4. Run bounded CodeRabbit review and address actionable findings.
+5. Commit, push `feat/r8-mcp-child-remediation`, and open the requested ready-for-review PR with the design rationale and verification evidence.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "orchestration"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15"
   },
   "files": [
     "dist",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -247,6 +247,7 @@ export async function runDaemonFirstEntry(
       input,
       output: opts.output,
       logger,
+      env,
       spawnDaemonForVersionBump: spawnDaemon,
     });
     bindProxyStdioLifecycle({ input, proxy, logger, exit });

--- a/src/is-main.ts
+++ b/src/is-main.ts
@@ -2,7 +2,7 @@ import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-function canonicalPath(path: string): string {
+export function canonicalPath(path: string): string {
   try {
     return realpathSync(path);
   } catch {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -25,8 +25,9 @@ import {
   type DetectStaleBuildDeps,
   type StaleBuildResult,
   resolveInstalledDaemonScript,
+  resolveInstalledEntryScript,
 } from "./version.js";
-import { isMainModule } from "./is-main.js";
+import { canonicalPath, isMainModule } from "./is-main.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
@@ -41,6 +42,23 @@ const DEFAULT_BUFFERED_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 5_000;
 const PROXY_ERROR_CODE = -32001;
 const SUSPICIOUS_DAEMON_EXIT_MS = 5_000;
+const DEFAULT_SELF_REEXEC_DRAIN_TIMEOUT_MS = 15_000;
+const MAX_SELF_REEXEC_HANDOFF_BYTES = 32 * 1024;
+const SELF_REEXEC_MARKER_ENV = "CMUXLAYER_SELF_REEXECED";
+const SELF_REEXEC_HANDOFF_ENV = "CMUXLAYER_SELF_REEXEC_HANDOFF";
+const BREW_ENTRYPOINT_PATTERN =
+  /\/(?:Cellar|cellar)\/cmuxlayer\/[^/]+\/(?:libexec\/)?dist\/index\.js$/;
+
+type ExecveFn = (
+  file: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+) => void;
+
+interface SelfReexecHandoff {
+  initializeRequest: JsonRpcRequest | null;
+  initializedNotification: JsonRpcNotification | null;
+}
 
 function instrumentSpawnedDaemon(
   spawned: unknown,
@@ -123,9 +141,15 @@ export interface CmuxLayerProxyOptions {
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
   versionBumpReconnectGuard?: VersionBumpReconnectGuard;
+  selfReexecGuard?: VersionBumpReconnectGuard;
   reconnectDaemonSpawnGuard?: VersionBumpReconnectGuard;
   reconnectLogIntervalMs?: number;
   reconnectLogNow?: () => number;
+  env?: NodeJS.ProcessEnv;
+  runningEntryScriptPath?: string;
+  installedEntryScriptPath?: () => string | null;
+  execve?: ExecveFn;
+  selfReexecDrainTimeoutMs?: number;
 }
 
 type JsonRpcRequest = JSONRPCMessage & {
@@ -265,9 +289,15 @@ export class CmuxLayerProxy {
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
   private readonly versionBumpReconnectGuard: VersionBumpReconnectGuard;
+  private readonly selfReexecGuard: VersionBumpReconnectGuard;
   private readonly reconnectDaemonSpawnGuard: VersionBumpReconnectGuard;
   private readonly reconnectLogIntervalMs: number;
   private readonly reconnectLogNow: () => number;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly runningEntryScriptPath: string;
+  private readonly installedEntryScriptPath: () => string | null;
+  private readonly execveFn: ExecveFn | null;
+  private readonly selfReexecDrainTimeoutMs: number;
 
   private readonly agentReadBuffer = new JsonRpcLineBuffer();
   private daemonReadBuffer: JsonRpcLineBuffer | null = null;
@@ -287,6 +317,11 @@ export class CmuxLayerProxy {
   private reconnectTimerResolve: (() => void) | null = null;
   private versionBumpTimer: NodeJS.Timeout | null = null;
   private versionBumpReconnecting = false;
+  private selfRemediationStarted = false;
+  private selfRemediationDraining = false;
+  private pendingDrainResolve: (() => void) | null = null;
+  private readonly remediationErrorWrites = new Set<Promise<void>>();
+  private readonly agentOutputWrites = new Set<Promise<void>>();
   private bufferedRequestTimer: NodeJS.Timeout | null = null;
   private readonly reconnectLogTimes = new Map<string, number>();
   private readonly queue: QueuedMessage[] = [];
@@ -303,7 +338,8 @@ export class CmuxLayerProxy {
   };
 
   constructor(opts: CmuxLayerProxyOptions = {}) {
-    this.socketPath = opts.socketPath ?? defaultDaemonSocketPath(process.env);
+    this.env = opts.env ?? process.env;
+    this.socketPath = opts.socketPath ?? defaultDaemonSocketPath(this.env);
     this.input = opts.input ?? process.stdin;
     this.output = opts.output ?? process.stdout;
     this.connect = opts.connect ?? ((path) => net.createConnection(path));
@@ -327,6 +363,8 @@ export class CmuxLayerProxy {
     this.spawnDaemonForVersionBump = opts.spawnDaemonForVersionBump;
     this.versionBumpReconnectGuard =
       opts.versionBumpReconnectGuard ?? new VersionBumpReconnectGuard();
+    this.selfReexecGuard =
+      opts.selfReexecGuard ?? new VersionBumpReconnectGuard();
     this.reconnectDaemonSpawnGuard =
       opts.reconnectDaemonSpawnGuard ??
       new VersionBumpReconnectGuard({
@@ -336,6 +374,19 @@ export class CmuxLayerProxy {
     this.reconnectLogIntervalMs =
       opts.reconnectLogIntervalMs ?? DEFAULT_RECONNECT_LOG_INTERVAL_MS;
     this.reconnectLogNow = opts.reconnectLogNow ?? Date.now;
+    this.runningEntryScriptPath = canonicalPath(
+      opts.runningEntryScriptPath ?? process.argv[1] ?? "",
+    );
+    this.installedEntryScriptPath =
+      opts.installedEntryScriptPath ?? resolveInstalledEntryScript;
+    this.execveFn =
+      opts.execve ??
+      (process.execve
+        ? (file, args, env) => process.execve?.(file, args, env)
+        : null);
+    this.selfReexecDrainTimeoutMs =
+      opts.selfReexecDrainTimeoutMs ?? DEFAULT_SELF_REEXEC_DRAIN_TIMEOUT_MS;
+    this.hydrateSelfReexecHandoff();
   }
 
   start(): void {
@@ -391,6 +442,15 @@ export class CmuxLayerProxy {
 
   private handleAgentMessage(message: JSONRPCMessage): void {
     if (isJsonRpcRequest(message)) {
+      if (this.selfRemediationDraining) {
+        this.trackRemediationErrorWrite(
+          this.sendAgentError(
+            message.id,
+            "cmuxlayer is refreshing stale MCP child; retry this request",
+          ),
+        );
+        return;
+      }
       if (message.method === "initialize") {
         this.initializeRequest = cloneMessage(message);
       }
@@ -726,13 +786,15 @@ export class CmuxLayerProxy {
       clearTimeout(pending.timeout);
       this.pendingRequests.delete(key);
       this.expiredRequestKeys.delete(key);
-      if (
+      const deliversInitialize =
         this.initializeRequest &&
-        key === requestKey(this.initializeRequest.id)
-      ) {
-        this.initializeResultDelivered = true;
-      }
-      void this.writeAgentFrame(frame);
+        key === requestKey(this.initializeRequest.id) &&
+        !metadata.hasError;
+      void this.writeAgentFrame(frame, (delivered) => {
+        if (delivered && deliversInitialize) {
+          this.initializeResultDelivered = true;
+        }
+      });
       return;
     }
 
@@ -919,6 +981,7 @@ export class CmuxLayerProxy {
       this.queue.splice(index, 1);
     }
     void this.sendAgentError(pending.id, message);
+    this.signalPendingDrainIfComplete();
   }
 
   private enforceBufferCap(): void {
@@ -987,18 +1050,35 @@ export class CmuxLayerProxy {
   }
 
   private async writeAgent(message: JSONRPCMessage): Promise<void> {
+    const write = writeMessage(this.output, message);
+    this.agentOutputWrites.add(write);
     try {
-      await writeMessage(this.output, message);
+      await write;
     } catch (error) {
       this.logger.error("[cmuxlayer-proxy] failed to write agent frame", error);
+    } finally {
+      this.agentOutputWrites.delete(write);
+      this.signalPendingDrainIfComplete();
     }
   }
 
-  private async writeAgentFrame(frame: Buffer): Promise<void> {
+  private async writeAgentFrame(
+    frame: Buffer,
+    onFlushed?: (delivered: boolean) => void,
+  ): Promise<void> {
+    let delivered = false;
+    const write = writeFrame(this.output, frame).then(() => {
+      delivered = true;
+    });
+    this.agentOutputWrites.add(write);
     try {
-      await writeFrame(this.output, frame);
+      await write;
     } catch (error) {
       this.logger.error("[cmuxlayer-proxy] failed to write agent frame", error);
+    } finally {
+      onFlushed?.(delivered);
+      this.agentOutputWrites.delete(write);
+      this.signalPendingDrainIfComplete();
     }
   }
 
@@ -1036,12 +1116,234 @@ export class CmuxLayerProxy {
     }
   }
 
+  private hydrateSelfReexecHandoff(): void {
+    const serialized = this.env[SELF_REEXEC_HANDOFF_ENV];
+    if (!serialized) {
+      return;
+    }
+    delete this.env[SELF_REEXEC_HANDOFF_ENV];
+    try {
+      const handoff = JSON.parse(serialized) as SelfReexecHandoff;
+      if (
+        handoff.initializeRequest &&
+        isJsonRpcRequest(handoff.initializeRequest) &&
+        handoff.initializeRequest.method === "initialize"
+      ) {
+        this.initializeRequest = cloneMessage(handoff.initializeRequest);
+        this.initializeResultDelivered = true;
+      }
+      if (
+        handoff.initializedNotification &&
+        isJsonRpcNotification(handoff.initializedNotification) &&
+        handoff.initializedNotification.method === "notifications/initialized"
+      ) {
+        this.initializedNotification = cloneMessage(
+          handoff.initializedNotification,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        "[cmuxlayer-proxy] invalid self-reexec handshake handoff ignored",
+        error,
+      );
+    }
+  }
+
+  private selfRemediationStatus(
+    stale: StaleBuildResult,
+    installedEntry: string | null,
+  ): "eligible" | "already-attempted" | "ineligible" {
+    const transition = `${stale.running}->${stale.installed}`;
+    if (
+      this.selfRemediationStarted ||
+      this.env[SELF_REEXEC_MARKER_ENV] === transition
+    ) {
+      return "already-attempted";
+    }
+    if (
+      this.env.CMUXLAYER_DEV === "1" ||
+      !BREW_ENTRYPOINT_PATTERN.test(this.runningEntryScriptPath) ||
+      !installedEntry ||
+      !this.execveFn
+    ) {
+      return "ineligible";
+    }
+    return "eligible";
+  }
+
+  private trackRemediationErrorWrite(write: Promise<void>): void {
+    this.remediationErrorWrites.add(write);
+    void write.finally(() => this.remediationErrorWrites.delete(write));
+  }
+
+  private signalPendingDrainIfComplete(): void {
+    if (
+      this.pendingRequests.size !== 0 ||
+      this.agentOutputWrites.size !== 0
+    ) {
+      return;
+    }
+    const resolve = this.pendingDrainResolve;
+    this.pendingDrainResolve = null;
+    resolve?.();
+  }
+
+  private async waitForPendingDrain(): Promise<boolean> {
+    if (
+      this.pendingRequests.size === 0 &&
+      this.agentOutputWrites.size === 0
+    ) {
+      return true;
+    }
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (drained: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this.pendingDrainResolve === onDrained) {
+          this.pendingDrainResolve = null;
+        }
+        resolve(drained);
+      };
+      const onDrained = () => finish(true);
+      this.pendingDrainResolve = onDrained;
+      const timer = setTimeout(
+        () => finish(false),
+        this.selfReexecDrainTimeoutMs,
+      );
+    });
+  }
+
+  private async rejectPendingForSelfRemediation(): Promise<void> {
+    const writes: Promise<void>[] = [];
+    for (const [key, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout);
+      this.pendingRequests.delete(key);
+      this.expiredRequestKeys.add(key);
+      const index = this.queue.findIndex((queued) => queued.requestKey === key);
+      if (index >= 0) this.queue.splice(index, 1);
+      writes.push(
+        this.sendAgentError(
+          pending.id,
+          "cmuxlayer is refreshing stale MCP child after drain deadline; retry this request",
+        ),
+      );
+    }
+    this.signalPendingDrainIfComplete();
+    await Promise.all(writes);
+  }
+
+  private resumeSelfRemediationChecks(): void {
+    this.selfRemediationStarted = false;
+    this.selfRemediationDraining = false;
+    if (this.running && !this.versionBumpTimer) {
+      this.startVersionBumpWatcher();
+    }
+  }
+
+  private async remediateStaleSelf(
+    stale: StaleBuildResult,
+    installedEntry: string,
+  ): Promise<void> {
+    this.selfRemediationStarted = true;
+    this.selfRemediationDraining = true;
+    this.clearVersionBumpTimer();
+    this.logger.error(
+      `[cmuxlayer-proxy] stale MCP child detected (running v${stale.running}, installed v${stale.installed}); draining before in-place re-exec`,
+    );
+
+    const drained = await this.waitForPendingDrain();
+    if (!drained) {
+      await this.rejectPendingForSelfRemediation();
+      if (this.agentOutputWrites.size > 0) {
+        this.logger.error(
+          "[cmuxlayer-proxy] client output transport still flushing at self-reexec deadline; keeping current session alive to avoid a dropped or duplicate frame",
+        );
+        this.resumeSelfRemediationChecks();
+        return;
+      }
+    }
+    await Promise.all([...this.remediationErrorWrites]);
+
+    const handoff: SelfReexecHandoff = {
+      initializeRequest: this.initializeResultDelivered
+        ? this.initializeRequest
+        : null,
+      initializedNotification: this.initializeResultDelivered
+        ? this.initializedNotification
+        : null,
+    };
+    const serializedHandoff = JSON.stringify(handoff);
+    const handoffBytes = Buffer.byteLength(serializedHandoff);
+    if (handoffBytes > MAX_SELF_REEXEC_HANDOFF_BYTES) {
+      this.logger.error(
+        `[cmuxlayer-proxy] self-reexec handshake handoff exceeds ${MAX_SELF_REEXEC_HANDOFF_BYTES} bytes (${handoffBytes}); keeping current session alive`,
+      );
+      this.resumeSelfRemediationChecks();
+      return;
+    }
+    const execEnv: NodeJS.ProcessEnv = {
+      ...this.env,
+      [SELF_REEXEC_MARKER_ENV]: `${stale.running}->${stale.installed}`,
+      [SELF_REEXEC_HANDOFF_ENV]: serializedHandoff,
+    };
+
+    try {
+      this.logger.error(
+        `[cmuxlayer-proxy] re-execing installed MCP entrypoint ${installedEntry}`,
+      );
+      this.execveFn?.(
+        process.execPath,
+        [process.execPath, installedEntry],
+        execEnv,
+      );
+      this.logger.error(
+        "[cmuxlayer-proxy] in-place stale-child re-exec returned unexpectedly; continuing current process",
+      );
+    } catch (error) {
+      this.logger.error(
+        "[cmuxlayer-proxy] in-place stale-child re-exec failed; continuing current process",
+        error,
+      );
+    } finally {
+      // Production execve never returns. This restores service only for a
+      // failed/unsupported exec (and for injected test doubles).
+      this.resumeSelfRemediationChecks();
+    }
+  }
+
   private async checkVersionBumpReconnect(): Promise<void> {
-    if (!this.running || this.versionBumpReconnecting) {
+    if (
+      !this.running ||
+      this.versionBumpReconnecting ||
+      this.selfRemediationStarted
+    ) {
       return;
     }
     const stale = this.detectStaleBuildFn();
     if (!stale?.stale) {
+      return;
+    }
+    const installedEntry = this.installedEntryScriptPath();
+    const selfRemediationStatus = this.selfRemediationStatus(
+      stale,
+      installedEntry,
+    );
+    if (selfRemediationStatus === "eligible" && installedEntry) {
+      if (!this.selfReexecGuard.allow()) {
+        this.logger.error(
+          "[cmuxlayer-proxy] stale-child self-reexec storm guard tripped; backing off",
+        );
+        return;
+      }
+      await this.remediateStaleSelf(stale, installedEntry);
+      return;
+    }
+    if (selfRemediationStatus === "already-attempted") {
+      this.logger.error(
+        "[cmuxlayer-proxy] stale MCP child remains after one self-reexec attempt; storm guard blocking another",
+      );
       return;
     }
     if (!this.versionBumpReconnectGuard.allow()) {
@@ -1085,12 +1387,19 @@ export class CmuxLayerProxy {
           );
         }
       }
-      const reconnectLoopWillResume = this.reconnectLoopActive;
       this.clearReconnectTimer();
       this.handleDaemonDrop();
       this.reconnectAttempt = 0;
-      if (!reconnectLoopWillResume) {
-        this.clearReconnectTimer();
+      // A version check can race the final microtask of the initial connect
+      // loop: the socket is attached, but reconnectLoopActive has not cleared.
+      // Let that loop settle before ensuring a replacement connection, or the
+      // drop can be left with neither a timer nor an active connector.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      if (
+        !this.reconnectLoopActive &&
+        !this.daemonSocket &&
+        !this.reconnectTimer
+      ) {
         this.connecting = false;
       }
       this.ensureConnecting();

--- a/src/version.ts
+++ b/src/version.ts
@@ -129,9 +129,23 @@ export function defaultOptPackageJsonPath(): string | null {
 export function resolveInstalledDaemonScript(
   optPackageJsonPath: string | null = defaultOptPackageJsonPath(),
 ): string | null {
+  return resolveInstalledScript("daemon.js", optPackageJsonPath);
+}
+
+/** Resolve the brew-installed MCP stdio entrypoint for in-place refresh. */
+export function resolveInstalledEntryScript(
+  optPackageJsonPath: string | null = defaultOptPackageJsonPath(),
+): string | null {
+  return resolveInstalledScript("index.js", optPackageJsonPath);
+}
+
+function resolveInstalledScript(
+  filename: string,
+  optPackageJsonPath: string | null,
+): string | null {
   const optPackageJson = optPackageJsonPath;
   if (!optPackageJson) return null;
-  const script = join(dirname(optPackageJson), "dist", "daemon.js");
+  const script = join(dirname(optPackageJson), "dist", filename);
   try {
     return realpathSync(script);
   } catch {

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -5,7 +5,7 @@ import net from "node:net";
 import { EventEmitter } from "node:events";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ReadBuffer,
@@ -67,7 +67,10 @@ class FakeDaemon {
 
   constructor(
     private readonly path: string,
-    private readonly opts: { holdFirstToolsList?: boolean } = {},
+    private readonly opts: {
+      holdFirstToolsList?: boolean;
+      holdFirstInitialize?: boolean;
+    } = {},
   ) {}
 
   async start(): Promise<void> {
@@ -89,6 +92,9 @@ class FakeDaemon {
           };
           messages.push(req);
           if (req.method === "initialize") {
+            if (this.opts.holdFirstInitialize && connectionIndex === 0) {
+              continue;
+            }
             socket.write(
               serializeMessage({
                 jsonrpc: "2.0",
@@ -417,5 +423,658 @@ describe("proxy version-bump auto-reconnect", () => {
     expect(guard.allow()).toBe(true);
     expect(guard.allow()).toBe(true);
     expect(guard.allow()).toBe(false);
+  });
+
+  it("execs the realpath-resolved installed MCP entrypoint exactly once", async () => {
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect: () => new net.Socket(),
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.38",
+        installed: "0.3.39",
+      }),
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await Promise.all([
+      (
+        proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+      ).checkVersionBumpReconnect(),
+      (
+        proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+      ).checkVersionBumpReconnect(),
+    ]);
+
+    expect(execve).toHaveBeenCalledTimes(1);
+    expect(execve).toHaveBeenCalledWith(
+      process.execPath,
+      [
+        process.execPath,
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      ],
+      expect.objectContaining({
+        CMUXLAYER_SELF_REEXECED: "0.3.38->0.3.39",
+      }),
+    );
+  });
+
+  it.each([
+    {
+      name: "dev mode",
+      env: { CMUXLAYER_DEV: "1" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+    },
+    {
+      name: "source tree",
+      env: { CMUXLAYER_DEV: "0" },
+      runningEntryScriptPath: "/Users/dev/Gits/cmuxlayer/dist/index.js",
+    },
+  ])("never self-reexecs from $name", async ({ env, runningEntryScriptPath }) => {
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect: () => new net.Socket(),
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.38",
+        installed: "0.3.39",
+      }),
+      runningEntryScriptPath,
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      execve,
+      env,
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(execve).not.toHaveBeenCalled();
+  });
+
+  it("honors the cross-exec storm marker when a version keeps mismatching", async () => {
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect: () => new net.Socket(),
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.38",
+        installed: "0.3.39",
+      }),
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      execve,
+      env: {
+        CMUXLAYER_DEV: "0",
+        CMUXLAYER_SELF_REEXECED: "0.3.38->0.3.39",
+      },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(execve).not.toHaveBeenCalled();
+  });
+
+  it("allows a later distinct version transition after an earlier self-reexec", async () => {
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect: () => new net.Socket(),
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.39",
+        installed: "0.3.40",
+      }),
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.40/libexec/dist/index.js",
+      execve,
+      env: {
+        CMUXLAYER_DEV: "0",
+        CMUXLAYER_SELF_REEXECED: "0.3.38->0.3.39",
+      },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(execve).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a request still in flight at the drain deadline before exec", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-drain");
+    const daemon = new FakeDaemon(path, { holdFirstToolsList: true });
+    daemons.push(daemon);
+    await daemon.start();
+
+    let stale = false;
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const collector = createCollector(output);
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.38", installed: "0.3.39" }
+          : { stale: false, running: "0.3.38", installed: "0.3.38" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      selfReexecDrainTimeoutMs: 10,
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() =>
+      collector.messages.some((message) => "id" in message && message.id === 1),
+    );
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    await waitFor(() =>
+      daemon.messages[0]?.some(
+        (message) => "method" in message && message.method === "tools/list",
+      ),
+    );
+
+    stale = true;
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(
+      collector.messages.find((message) => "id" in message && message.id === 2),
+    ).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: expect.stringContaining("refreshing stale MCP child"),
+        }),
+      }),
+    );
+    expect(execve).toHaveBeenCalledTimes(1);
+    const handoff = JSON.parse(
+      execve.mock.calls[0][2].CMUXLAYER_SELF_REEXEC_HANDOFF,
+    );
+    expect(handoff).toEqual(
+      expect.objectContaining({
+        initializeRequest: expect.objectContaining({ method: "initialize" }),
+        initializedNotification: expect.objectContaining({
+          method: "notifications/initialized",
+        }),
+      }),
+    );
+  });
+
+  it("hydrates the MCP handshake after exec and reinitializes the daemon", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-handoff");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input: new PassThrough(),
+      output: new PassThrough(),
+      env: {
+        CMUXLAYER_SELF_REEXECED: "0.3.38->0.3.39",
+        CMUXLAYER_SELF_REEXEC_HANDOFF: JSON.stringify({
+          initializeRequest: {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: { capabilities: {} },
+          },
+          initializedNotification: {
+            jsonrpc: "2.0",
+            method: "notifications/initialized",
+          },
+        }),
+      },
+      detectStaleBuild: () => null,
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await waitFor(
+      () =>
+        daemon.messages[0]?.some(
+          (message) =>
+            "method" in message &&
+            message.method === "notifications/initialized",
+        ) ?? false,
+    );
+
+    expect(daemon.messages[0].filter((message) => "method" in message)).toEqual([
+      expect.objectContaining({ method: "initialize" }),
+      expect.objectContaining({ method: "notifications/initialized" }),
+    ]);
+  });
+
+  it("keeps the current session alive when the handshake handoff is oversized", async () => {
+    const execve = vi.fn();
+    const logger = { error: vi.fn() };
+    const env = {
+      CMUXLAYER_DEV: "0",
+      CMUXLAYER_SELF_REEXEC_HANDOFF: JSON.stringify({
+        initializeRequest: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { capabilities: { oversized: "x".repeat(40_000) } },
+        },
+        initializedNotification: {
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        },
+      }),
+    };
+    const proxy = new CmuxLayerProxy({
+      input: new PassThrough(),
+      output: new PassThrough(),
+      connect: () => new net.Socket(),
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.3.38",
+        installed: "0.3.39",
+      }),
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      execve,
+      env,
+      logger,
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(execve).not.toHaveBeenCalled();
+    expect(proxy.isRunning()).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("handshake handoff exceeds"),
+    );
+  });
+
+  it("does not emit a duplicate error while a successful response is flushing", async () => {
+    class DelayedOutput extends Writable {
+      readonly messages: JSONRPCMessage[] = [];
+      private releaseWrite: (() => void) | null = null;
+
+      _write(
+        chunk: Buffer,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+      ) {
+        const message = JSON.parse(chunk.toString("utf8")) as JSONRPCMessage;
+        this.messages.push(message);
+        if (
+          "id" in message &&
+          message.id === 2 &&
+          "result" in message
+        ) {
+          this.releaseWrite = callback;
+          return;
+        }
+        callback();
+      }
+
+      release(): void {
+        const release = this.releaseWrite;
+        this.releaseWrite = null;
+        release?.();
+      }
+    }
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-output-flush");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    let stale = false;
+    const input = new PassThrough();
+    const output = new DelayedOutput();
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.38", installed: "0.3.39" }
+          : { stale: false, running: "0.3.38", installed: "0.3.38" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      selfReexecDrainTimeoutMs: 10,
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() => output.messages.some((message) => "id" in message && message.id === 1));
+    writeFrame(input, { jsonrpc: "2.0", method: "notifications/initialized" });
+    writeFrame(input, { jsonrpc: "2.0", id: 2, method: "tools/list" });
+    await waitFor(() =>
+      output.messages.some(
+        (message) => "id" in message && message.id === 2 && "result" in message,
+      ),
+    );
+
+    stale = true;
+    const remediation = (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(execve).not.toHaveBeenCalled();
+    expect(
+      output.messages.filter((message) => "id" in message && message.id === 2),
+    ).toHaveLength(1);
+    output.release();
+    await remediation;
+    expect(execve).not.toHaveBeenCalled();
+    expect(
+      output.messages.filter((message) => "id" in message && message.id === 2),
+    ).toHaveLength(1);
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+    expect(execve).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for a daemon notification to flush before considering re-exec", async () => {
+    class DelayedNotificationOutput extends Writable {
+      readonly messages: JSONRPCMessage[] = [];
+      private releaseWrite: (() => void) | null = null;
+
+      _write(
+        chunk: Buffer,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+      ) {
+        const message = JSON.parse(chunk.toString("utf8")) as JSONRPCMessage;
+        this.messages.push(message);
+        if (
+          "method" in message &&
+          message.method === "notifications/progress"
+        ) {
+          this.releaseWrite = callback;
+          return;
+        }
+        callback();
+      }
+
+      release(): void {
+        const release = this.releaseWrite;
+        this.releaseWrite = null;
+        release?.();
+      }
+    }
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-notification-flush");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+    let stale = false;
+    const input = new PassThrough();
+    const output = new DelayedNotificationOutput();
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.38", installed: "0.3.39" }
+          : { stale: false, running: "0.3.38", installed: "0.3.38" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      selfReexecDrainTimeoutMs: 10,
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() => output.messages.some((message) => "id" in message && message.id === 1));
+    writeFrame(input, { jsonrpc: "2.0", method: "notifications/initialized" });
+    daemon.connections[0].write(
+      serializeMessage({
+        jsonrpc: "2.0",
+        method: "notifications/progress",
+        params: { progressToken: "r8", progress: 1 },
+      }),
+    );
+    await waitFor(() =>
+      output.messages.some(
+        (message) =>
+          "method" in message && message.method === "notifications/progress",
+      ),
+    );
+
+    stale = true;
+    const remediation = (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(execve).not.toHaveBeenCalled();
+    output.release();
+    await remediation;
+    expect(execve).not.toHaveBeenCalled();
+  });
+
+  it("does not hand off initialize when its request was rejected at the drain deadline", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-initialize-timeout");
+    const daemon = new FakeDaemon(path, { holdFirstInitialize: true });
+    daemons.push(daemon);
+    await daemon.start();
+    let stale = false;
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const collector = createCollector(output);
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.38", installed: "0.3.39" }
+          : { stale: false, running: "0.3.38", installed: "0.3.38" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      selfReexecDrainTimeoutMs: 10,
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() => daemon.messages[0]?.length === 1);
+    stale = true;
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(
+      collector.messages.find((message) => "id" in message && message.id === 1),
+    ).toEqual(expect.objectContaining({ error: expect.any(Object) }));
+    const handoff = JSON.parse(
+      execve.mock.calls[0][2].CMUXLAYER_SELF_REEXEC_HANDOFF,
+    );
+    expect(handoff).toEqual({
+      initializeRequest: null,
+      initializedNotification: null,
+    });
+  });
+
+  it("waits for a backpressured timeout error before re-exec", async () => {
+    class DelayedErrorOutput extends Writable {
+      readonly messages: JSONRPCMessage[] = [];
+      private releaseWrite: (() => void) | null = null;
+
+      _write(
+        chunk: Buffer,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+      ) {
+        const message = JSON.parse(chunk.toString("utf8")) as JSONRPCMessage;
+        this.messages.push(message);
+        if ("id" in message && message.id === 2 && "error" in message) {
+          this.releaseWrite = callback;
+          return;
+        }
+        callback();
+      }
+
+      release(): void {
+        const release = this.releaseWrite;
+        this.releaseWrite = null;
+        release?.();
+      }
+    }
+
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("self-reexec-timeout-flush");
+    const daemon = new FakeDaemon(path, { holdFirstToolsList: true });
+    daemons.push(daemon);
+    await daemon.start();
+    let stale = false;
+    const input = new PassThrough();
+    const output = new DelayedErrorOutput();
+    const execve = vi.fn();
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input,
+      output,
+      requestTimeoutMs: 10,
+      selfReexecDrainTimeoutMs: 10,
+      detectStaleBuild: () =>
+        stale
+          ? { stale: true, running: "0.3.38", installed: "0.3.39" }
+          : { stale: false, running: "0.3.38", installed: "0.3.38" },
+      runningEntryScriptPath:
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.38/libexec/dist/index.js",
+      installedEntryScriptPath: () =>
+        "/opt/homebrew/Cellar/cmuxlayer/0.3.39/libexec/dist/index.js",
+      execve,
+      env: { CMUXLAYER_DEV: "0" },
+      logger: { error: vi.fn() },
+    });
+    proxies.push(proxy);
+    proxy.start();
+
+    writeFrame(input, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    });
+    await waitFor(() => output.messages.some((message) => "id" in message && message.id === 1));
+    writeFrame(input, { jsonrpc: "2.0", method: "notifications/initialized" });
+    writeFrame(input, { jsonrpc: "2.0", id: 2, method: "tools/list" });
+    await waitFor(() =>
+      output.messages.some(
+        (message) => "id" in message && message.id === 2 && "error" in message,
+      ),
+    );
+
+    stale = true;
+    const remediation = (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(execve).not.toHaveBeenCalled();
+    output.release();
+    await remediation;
+    expect(execve).not.toHaveBeenCalled();
   });
 });

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -15,6 +15,7 @@ import {
   detectStaleBuild,
   readVersion,
   resolveInstalledDaemonScript,
+  resolveInstalledEntryScript,
 } from "../src/version.js";
 
 describe("resolveInstalledDaemonScript", () => {
@@ -40,6 +41,27 @@ describe("resolveInstalledDaemonScript", () => {
       expect(
         resolveInstalledDaemonScript(join(opt, "libexec", "package.json")),
       ).toBe(realpathSync(join(cellar, "dist", "daemon.js")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveInstalledEntryScript", () => {
+  it("returns the real Cellar MCP entrypoint when the opt tree is a symlink", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmuxlayer-entry-realpath-"));
+    try {
+      const cellar = join(root, "Cellar", "cmuxlayer", "1.2.3", "libexec");
+      const opt = join(root, "opt", "cmuxlayer");
+      mkdirSync(join(cellar, "dist"), { recursive: true });
+      mkdirSync(join(root, "opt"), { recursive: true });
+      writeFileSync(join(cellar, "package.json"), "{}");
+      writeFileSync(join(cellar, "dist", "index.js"), "");
+      symlinkSync(join(root, "Cellar", "cmuxlayer", "1.2.3"), opt, "dir");
+
+      expect(
+        resolveInstalledEntryScript(join(opt, "libexec", "package.json")),
+      ).toBe(realpathSync(join(cellar, "dist", "index.js")));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- detect a stale Homebrew-managed MCP stdio child and replace it in place with the realpath-resolved installed `dist/index.js`
- drain active requests, explicitly reject work at the deadline, and track every daemon/client output frame before re-exec so no in-flight JSON-RPC message is silently dropped
- transfer a bounded MCP initialize handshake to the replacement process, prevent same-transition exec storms, and preserve later version upgrades
- keep `CMUXLAYER_DEV=1` and source-tree runtimes ineligible for self-reexec
- require Node.js 22.15+, the first supported runtime with `process.execve`

## Design-first note
The safest complete option is an in-place `process.execve(process.execPath, [process.execPath, installedEntry], env)` rather than spawning a sibling proxy. `execve` preserves the MCP child's PID and inherited stdio descriptors while replacing stale code.

Before exec, the proxy enters a bounded drain state. New requests receive an explicit retryable proxy error; existing requests may finish; remaining requests are explicitly rejected at the deadline. Every proxy-generated error and daemon-originated frame participates in the same output-flush accounting. If output is still backpressured, the handshake exceeds 32 KiB, or exec fails, the current session stays alive and bounded retry checks resume. A transition-scoped environment marker prevents re-exec loops without blocking the next release upgrade.

The fresh process receives only a successfully delivered initialize/initialized handshake and replays it to the daemon, preserving the MCP session without requiring a manual `/mcp reconnect`.

Detailed plan: `docs/plans/2026-07-11-mcp-child-self-remediation.md`.

## Test plan
- [x] TDD coverage for exactly-once remediation, realpath entry resolution, dev/source suppression, same-transition storm guard, later-upgrade eligibility, bounded handshake overflow, initialize rejection, request drain deadline, response backpressure, daemon notification backpressure, proxy timeout-error backpressure, and handshake hydration
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] full deterministic suite 5 cold processes: each 90 files / 1,684 tests passed
- [x] focused proxy/version suite independently reviewed: 38/38 passed
- [x] built-artifact real MCP stdio client: initialized cmuxlayer v0.3.39, listed 42 tools, and returned a live `list_surfaces` result (9 surfaces across 4 workspaces)
- [x] independent final review: no critical or important findings

## Review note
Local CodeRabbit's first pass produced two findings; both were fixed (explicit output flush requirement and bounded environment handoff). The required re-run hit the free OSS rate limit, so an independent red/blue review completed multiple rounds and ended clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live MCP stdio proxy behavior (drain, reject, in-place exec, handshake replay) and raises the minimum Node version; mistakes could drop or duplicate frames or break upgrades for older Node users.
> 
> **Overview**
> Adds **automatic refresh** of a stale Homebrew MCP stdio child when the running build lags the installed brew version, instead of only reconnecting the daemon.
> 
> On a version mismatch, the proxy can enter a **bounded drain**: new JSON-RPC requests get an explicit retryable error, in-flight work is waited on (or rejected at the deadline), and **client/daemon output writes must finish** before `process.execve` replaces the process with the realpath-resolved installed `dist/index.js` while keeping stdio. A **32 KiB-capped** env handoff carries a successfully delivered `initialize` / `notifications/initialized` pair into the new process, which replays it to the daemon; dev mode, non-Cellar paths, oversized handoffs, flush backpressure, and a **per-transition** `CMUXLAYER_SELF_REEXECED` marker block unsafe re-exec loops.
> 
> Also adds **`resolveInstalledEntryScript`**, passes **`env`** into the daemon-first proxy, exports **`canonicalPath`**, fixes a **version-bump vs initial-connect race** with `setImmediate` before reconnecting, and bumps **`engines.node` to >=22.15** for `process.execve`. Extensive Vitest coverage documents drain, handoff, and flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6062c207693006bf54d0783933bb33e78f1e4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-reexec remediation for stale MCP stdio child processes on version bump
> - When `CmuxLayerProxy` detects a Homebrew version bump, it now performs an in-place `execve` of the newly installed MCP stdio entrypoint instead of only reconnecting the daemon.
> - Before re-execing, the proxy enters drain mode: new agent requests are rejected with retryable JSON-RPC errors, in-flight requests are awaited up to a configurable timeout, and any still-pending requests receive explicit errors before handoff.
> - A serialized handshake (`initialize` request + `initialized` notification) is passed across the exec boundary via environment variable, allowing the new process to replay MCP initialization to the daemon without a round-trip to the agent.
> - Guards prevent re-exec storms (cross-exec marker env var), repeated attempts within a single version transition, and re-exec in dev or non-Homebrew environments.
> - `resolveInstalledEntryScript` is added to [src/version.ts](https://github.com/EtanHey/cmuxlayer/pull/293/files#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087) to locate the brew-installed `index.js` with realpath fallback, and `package.json` raises the minimum Node requirement to `>=22.15`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e6062c2. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->