### PR TITLE
feat(spawn): lean-by-default responses — drop expected-state info noise

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,10 @@ import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { createStaleBuildWarner, RUNNING_VERSION } from "./version.js";
+import {
+  buildSpawnToolReturn,
+  shapeSpawnResponse,
+} from "./spawn-response.js";
 import { StateManager } from "./state-manager.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import {
@@ -6762,7 +6766,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      `Spawn a managed AI agent in a terminal surface and return an agent_id plus health for future routing. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.`,
+      `Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.`,
       {
         repo: z
           .string()
@@ -6854,6 +6858,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(false)
           .describe(
             "Bypass the inline prompt length cap for a deliberate raw boot-prompt send. Prefer boot_prompt_path for large prompts.",
+          ),
+        verbose: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Return the full legacy spawn response instead of the lean default.",
           ),
       },
       ANNOTATIONS.mutating,
@@ -7099,8 +7110,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               )
             : undefined;
 
-          return okFormatted(
-            formatOk("spawn_agent", {
+          const formattedData = {
               agent_id: result.agent_id,
               repo: args.repo,
               model: result.model ?? args.model,
@@ -7115,8 +7125,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               duplicate_spawn_warning: duplicateSpawnWarning,
               monitor_boot: monitorBoot,
               boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
-            }),
-            {
+            };
+          const responseData = {
               ...result,
               worktree: worktree.prepared,
               mcp_profile: worktree.mcpProfileLabel,
@@ -7129,7 +7139,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               boot_prompt_bytes: bootPromptDelivery?.bytes,
               boot_prompt_submit_verified:
                 bootPromptDelivery?.submit_verified ?? null,
+            };
+          return buildSpawnToolReturn(
+            {
+              retry_count: currentTransportRetryCount(),
+              ...responseData,
             },
+            args.verbose,
+            formatOk("spawn_agent", formattedData),
           );
         } catch (e) {
           if (e instanceof DeliverySafetyGateError) {
@@ -7146,7 +7163,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "new_worktree_split",
-      "Create or reuse a git worktree and spawn one worker agent into a right-side cmux split. Defaults to inherited MCPs and preserves the existing worker layout policy.",
+      "Create or reuse a git worktree and spawn one worker agent into a right-side cmux split. Returns a lean response by default; pass verbose:true for the full legacy health and worktree bookkeeping. Defaults to inherited MCPs and preserves the existing worker layout policy.",
       {
         repo: z.string().describe("Repository name"),
         model: z.string().describe("Model name"),
@@ -7172,6 +7189,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         parent_agent_id: z.string().optional(),
         auto_archive_on_done: z.boolean().optional().default(false),
         crash_recover: z.boolean().optional(),
+        verbose: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Return the full legacy spawn response instead of the lean default.",
+          ),
       },
       ANNOTATIONS.mutating,
       async (args) => {
@@ -7271,15 +7295,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               )
             : undefined;
 
-          return okFormatted(
-            formatOk("new_worktree_split", {
+          const formattedData = {
               agent_id: result.agent_id,
               surface: result.surface_id,
               worktree: worktree.prepared?.path ?? "",
               mcp_profile: worktree.mcpProfileLabel ?? "inherit",
               health,
-            }),
-            {
+            };
+          const responseData = {
               ...result,
               role: "worker",
               health,
@@ -7289,7 +7312,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               boot_prompt_bytes: bootPromptDelivery?.bytes,
               boot_prompt_submit_verified:
                 bootPromptDelivery?.submit_verified ?? null,
+            };
+          return buildSpawnToolReturn(
+            {
+              retry_count: currentTransportRetryCount(),
+              ...responseData,
             },
+            args.verbose,
+            formatOk("new_worktree_split", formattedData),
           );
         } catch (e) {
           if (e instanceof DeliverySafetyGateError) {
@@ -7312,7 +7342,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "spawn_in_workspace",
-      "Create a workspace and spawn a set of agents into it as a clean 2-pane grid (commanders LEFT, workers RIGHT). Handles workspace creation, selection, and role-based pane placement atomically. Use this instead of repeated spawn_agent calls when standing up a multi-agent team.",
+      "Create a workspace and spawn a set of agents into it as a clean 2-pane grid (commanders LEFT, workers RIGHT). Returns lean per-agent responses by default; pass verbose:true for the full legacy response. Handles workspace creation, selection, and role-based pane placement atomically. Use this instead of repeated spawn_agent calls when standing up a multi-agent team.",
       {
         workspace_title: z
           .string()
@@ -7334,6 +7364,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .describe(
             "Ref of an existing workspace to use instead of creating a new one",
+          ),
+        verbose: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Return the full legacy spawn response instead of the lean default.",
           ),
       },
       ANNOTATIONS.mutating,
@@ -7368,6 +7405,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             boot_prompt_delivered?: boolean;
             boot_prompt_submit_verified?: boolean | null;
           }> = [];
+          const leanSpawnedAgents: Record<string, unknown>[] = [];
 
           for (const agent of args.agents) {
             const hasPrompt = hasInlinePrompt(agent.prompt);
@@ -7463,6 +7501,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ? (bootPromptDelivery?.submit_verified ?? null)
                 : undefined,
             });
+            leanSpawnedAgents.push(
+              shapeSpawnResponse({
+                ...result,
+                role,
+                health,
+                boot_prompt_delivered: hasPrompt
+                  ? isBootPromptDelivered(bootPromptDelivery)
+                  : false,
+                boot_prompt_submit_verified: hasPrompt
+                  ? (bootPromptDelivery?.submit_verified ?? null)
+                  : null,
+              }),
+            );
           }
 
           const lastSurface =
@@ -7476,16 +7527,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const staleWarning = staleBuildWarning();
           const workspaceWarnings = staleWarning ? [staleWarning] : [];
 
-          return okFormatted(
-            formatOk("spawn_in_workspace", {
+          const formattedData = {
               workspace,
               agents: spawnedAgents.length,
               ...(staleWarning ? { warning: staleWarning } : {}),
-            }),
-            {
+            };
+          const responseData = {
               workspace,
               title: workspaceResult.title,
               agents: spawnedAgents,
+              ...(workspaceWarnings.length > 0
+                ? { warnings: workspaceWarnings }
+                : {}),
+            };
+          return buildSpawnToolReturn(
+            {
+              retry_count: currentTransportRetryCount(),
+              ...responseData,
+            },
+            args.verbose,
+            formatOk("spawn_in_workspace", formattedData),
+            {
+              workspace,
+              title: workspaceResult.title,
+              agents: leanSpawnedAgents,
               ...(workspaceWarnings.length > 0
                 ? { warnings: workspaceWarnings }
                 : {}),

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -1,0 +1,141 @@
+const FRESH_SPAWN_INFO_CODES = new Set([
+  "missing_cli_session_id",
+  "non_resumable",
+  "inbox_monitor_not_alive",
+  "registry_screen_disagreement",
+]);
+
+const ESSENTIAL_FIELDS = [
+  "agent_id",
+  "surface_id",
+  "workspace_id",
+  "state",
+  "model",
+  "requested_model",
+  "role",
+  "cwd",
+  "boot_prompt_delivered",
+  "boot_prompt_submit_verified",
+] as const;
+
+type JsonObject = Record<string, unknown>;
+
+export interface SpawnToolReturn {
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: JsonObject;
+}
+
+function record(value: unknown): JsonObject | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : null;
+}
+
+function leanHealth(value: unknown): JsonObject | undefined {
+  const health = record(value);
+  if (!health || health.status === "healthy") return undefined;
+
+  const codeEntries = Array.isArray(health.issue_codes)
+    ? health.issue_codes
+        .map((code, index) => ({ code, index }))
+        .filter(
+          (entry): entry is { code: string; index: number } =>
+            typeof entry.code === "string",
+        )
+    : [];
+  const issues = Array.isArray(health.issues) ? health.issues : [];
+  const severities = record(health.issue_severities) ?? {};
+  const realIndexes = codeEntries
+    .map(({ code, index }) => ({ code, index, severity: severities[code] }))
+    .filter(({ code, severity }) =>
+      !(FRESH_SPAWN_INFO_CODES.has(code) && severity === "info"),
+    );
+
+  if (
+    !realIndexes.some(
+      ({ severity }) => severity === "degraded" || severity === "blocking",
+    )
+  ) {
+    return undefined;
+  }
+
+  const issueCodes = realIndexes.map(({ code }) => code);
+  const issueSeverities = Object.fromEntries(
+    realIndexes.map(({ code, severity }) => [code, severity]),
+  );
+  return {
+    ...health,
+    issue_codes: issueCodes,
+    issues: realIndexes.map(({ index }) => issues[index]).filter(Boolean),
+    issue_severities: issueSeverities,
+  };
+}
+
+function leanWorktree(value: unknown): JsonObject | undefined {
+  const worktree = record(value);
+  if (!worktree) return undefined;
+  return Object.fromEntries(
+    ["path", "name", "branch", "created", "reused"]
+      .filter((key) => worktree[key] !== undefined)
+      .map((key) => [key, worktree[key]]),
+  );
+}
+
+export function shapeSpawnResponse(
+  full: JsonObject,
+  verbose = false,
+): JsonObject {
+  if (verbose) return full;
+
+  const lean: JsonObject = {};
+  if (full.ok !== undefined) lean.ok = full.ok;
+  for (const field of ESSENTIAL_FIELDS) {
+    if (full[field] !== undefined) lean[field] = full[field];
+  }
+
+  const worktree = leanWorktree(full.worktree);
+  if (worktree) lean.worktree = worktree;
+
+  const warnings = Array.isArray(full.warnings) ? [...full.warnings] : [];
+  if (
+    typeof full.duplicate_spawn_warning === "string" &&
+    full.duplicate_spawn_warning.length > 0
+  ) {
+    warnings.push(full.duplicate_spawn_warning);
+  }
+  if (warnings.length > 0) {
+    lean.warnings = warnings;
+  }
+
+  const health = leanHealth(full.health);
+  if (health) lean.health = health;
+
+  const modelPolicy = record(full.model_policy);
+  if (modelPolicy?.coerced === true) lean.model_policy = full.model_policy;
+
+  return lean;
+}
+
+export function buildSpawnToolReturn(
+  data: JsonObject,
+  verbose = false,
+  legacyText?: string,
+  leanData?: JsonObject,
+): SpawnToolReturn {
+  const full = { ok: true, ...data };
+  const payload = verbose
+    ? full
+    : leanData
+      ? { ok: true, ...leanData }
+      : shapeSpawnResponse(full);
+  return {
+    content: [
+      {
+        type: "text",
+        text: verbose && legacyText ? legacyText : JSON.stringify(payload),
+      },
+    ],
+    structuredContent: payload,
+  };
+}

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -215,6 +215,69 @@ function createLifecycleServer(exec: ExecFn) {
   });
 }
 
+describe("lean spawn tool responses", () => {
+  it("spawn_agent defaults to the lean payload in text and structured content", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      { repo: "cmuxlayer", cli: "codex" },
+      {} as any,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed).toEqual(result.structuredContent);
+    expect(parsed).toMatchObject({
+      ok: true,
+      agent_id: expect.any(String),
+      surface_id: "surface:new",
+      workspace_id: "workspace:1",
+      state: "booting",
+      model: "codex",
+      role: "worker",
+      boot_prompt_delivered: false,
+      boot_prompt_submit_verified: null,
+    });
+    expect(parsed).not.toHaveProperty("health");
+    expect(parsed).not.toHaveProperty("model_policy");
+    expect(parsed).not.toHaveProperty("retry_count");
+    expect(parsed).not.toHaveProperty("monitor_boot");
+  });
+
+  it("spawn_agent preserves the full legacy payload with verbose true", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      { repo: "cmuxlayer", cli: "codex", verbose: true },
+      {} as any,
+    );
+
+    expect(result.structuredContent).toHaveProperty("health");
+    expect(result.structuredContent).toHaveProperty("model_policy");
+    expect(result.structuredContent).toHaveProperty("retry_count", 0);
+    expect(result.content[0].text).not.toBe(
+      JSON.stringify(result.structuredContent),
+    );
+  });
+
+  it("spawn_agent surfaces a real model coercion in lean mode", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      { repo: "cmuxlayer", model: "gpt-5.5", cli: "codex" },
+      {} as any,
+    );
+
+    expect(result.structuredContent.model_policy).toMatchObject({
+      coerced: true,
+      effective_model: "codex",
+    });
+    expect(result.structuredContent.warnings).not.toHaveLength(0);
+  });
+});
+
 function moveOnlyAgentStateDir(prefix: string) {
   const entries = readdirSync(TEST_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -604,13 +667,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agent_id).toMatch(/^brainlayerClaude-pending-\d+-[a-z0-9]+$/);
     expect(parsed.surface_id).toBe("surface:new");
     expect(parsed.state).toBe("ready");
-    expect(parsed.health).toMatchObject({
-      status: "healthy",
-      issue_codes: expect.arrayContaining([
-        "missing_cli_session_id",
-        "non_resumable",
-      ]),
-    });
+    expect(parsed.health).toBeUndefined();
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -1057,16 +1114,13 @@ describe("agent lifecycle tool handlers", () => {
       secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
 
     expect(second.ok).toBe(true);
-    expect(second.duplicate_spawn_warning).toMatch(/Existing same-lane agent/);
-    expect(second.existing_same_lane_agents).toEqual([
-      expect.objectContaining({
-        agent_id: first.agent_id,
-        surface_id: first.surface_id,
-        workspace_id: "workspace:1",
-        state: "idle",
-        role: "worker",
-      }),
-    ]);
+    expect(second.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/Existing same-lane agent/),
+      ]),
+    );
+    expect(second.duplicate_spawn_warning).toBeUndefined();
+    expect(second.existing_same_lane_agents).toBeUndefined();
   });
 
   it("spawn_agent force_new suppresses same-lane duplicate warnings", async () => {
@@ -1104,8 +1158,13 @@ describe("agent lifecycle tool handlers", () => {
       secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
 
     expect(second.ok).toBe(true);
+    expect(second.warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/Existing same-lane agent/),
+      ]),
+    );
     expect(second.duplicate_spawn_warning).toBeUndefined();
-    expect(second.existing_same_lane_agents).toEqual([]);
+    expect(second.existing_same_lane_agents).toBeUndefined();
   });
 
   it("spawn_agent accepts an omitted model and resolves the CLI default", async () => {
@@ -1160,7 +1219,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("ic");
-    expect(parsed.health.status).toBe("healthy");
+    expect(parsed.health).toBeUndefined();
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
     const stateResult = await stateTool.handler(
@@ -1232,7 +1291,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.workspace_id).toBe("workspace:1");
-    expect(parsed.actual_workspace_id).toBe("ws:1");
+    expect(parsed.actual_workspace_id).toBeUndefined();
 
     const promptSendCall = mockExec.mock.calls.find(([, args]) => {
       const argv = args as string[];
@@ -1412,7 +1471,9 @@ describe("agent lifecycle tool handlers", () => {
       created: true,
       reused: false,
     });
-    expect(parsed.mcp_profile).toBe("inherit");
+    expect(parsed.mcp_profile).toBeUndefined();
+    expect(parsed.worktree).not.toHaveProperty("node_modules_linked");
+    expect(parsed.worktree).not.toHaveProperty("mcp_json_copied");
     expect(worktreeExec).toHaveBeenCalledWith("git", [
       "-C",
       repoRoot,
@@ -1461,6 +1522,7 @@ describe("agent lifecycle tool handlers", () => {
         cli: "codex",
         worktree: { name: "sterile worker" },
         mcp_profile: "sterile",
+        verbose: true,
       },
       {} as any,
     );
@@ -1471,6 +1533,8 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("worker");
     expect(parsed.mcp_profile).toBe("sterile");
+    expect(parsed.worktree).toHaveProperty("node_modules_linked");
+    expect(parsed.worktree).toHaveProperty("mcp_json_copied");
     expect(parsed.worktree.path).toBe(worktreePath);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -893,6 +893,19 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.workspace).toBe("workspace:grid");
     expect(parsed.agents).toHaveLength(2);
+    expect(parsed).not.toHaveProperty("retry_count");
+    expect(parsed.agents[0]).toMatchObject({
+      agent_id: expect.any(String),
+      surface_id: "surface:1",
+      workspace_id: "workspace:grid",
+      state: "booting",
+      model: expect.any(String),
+      role: "orchestrator",
+      boot_prompt_delivered: false,
+      boot_prompt_submit_verified: null,
+    });
+    expect(parsed.agents[0]).not.toHaveProperty("health");
+    expect(parsed.agents[0]).not.toHaveProperty("monitor_boot");
     expect(calls.slice(0, 4)).toEqual([
       "create:red-team",
       "select:workspace:grid",
@@ -900,6 +913,32 @@ describe("tool handler integration", () => {
       "spawn:workspace:grid:surface:1",
     ]);
     expect(calls).toContain("spawn:workspace:grid:surface:2");
+
+    const verboseResult = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            workspace_title: "red-team",
+            reuse_workspace: "workspace:grid",
+            verbose: true,
+            agents: [
+              {
+                repo: "cmuxlayer",
+                model: "gpt-5.4",
+                cli: "codex",
+                role: "worker",
+              },
+            ],
+          },
+          {} as any,
+        ),
+      1_000,
+    );
+    expect(verboseResult.structuredContent).toHaveProperty("retry_count", 0);
+    expect(verboseResult.structuredContent.agents[0]).toHaveProperty("health");
+    expect(verboseResult.structuredContent.agents[0]).toHaveProperty(
+      "monitor_boot",
+    );
 
     await server.close();
     rmSync(stateDir, { recursive: true, force: true });

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -136,6 +136,7 @@ describe("spawn monitor boot", () => {
         model: "sonnet",
         cli: "claude",
         role: "orchestrator",
+        verbose: true,
       },
       {} as any,
     );
@@ -200,6 +201,7 @@ describe("spawn monitor boot", () => {
           model: "sonnet",
           cli: "claude",
           role: "orchestrator",
+          verbose: true,
         },
         {} as any,
       );

--- a/tests/spawn-response.test.ts
+++ b/tests/spawn-response.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSpawnToolReturn,
+  shapeSpawnResponse,
+} from "../src/spawn-response.js";
+
+const base = {
+  agent_id: "agent-1",
+  surface_id: "surface:1",
+  workspace_id: "workspace:1",
+  state: "booting",
+  model: "codex",
+  role: "worker",
+  cwd: "/tmp/cmuxlayer",
+  boot_prompt_delivered: false,
+  boot_prompt_submit_verified: null,
+};
+
+describe("spawn response shaping", () => {
+  it("omits healthy fresh-spawn health, non-coerced policy, and empty warnings", () => {
+    const shaped = shapeSpawnResponse({
+      ...base,
+      warnings: [],
+      health: {
+        status: "healthy",
+        issue_codes: [
+          "missing_cli_session_id",
+          "non_resumable",
+          "inbox_monitor_not_alive",
+          "registry_screen_disagreement",
+        ],
+        issues: ["missing session", "cannot resume", "monitor booting", "screen ahead"],
+        issue_severities: {
+          missing_cli_session_id: "info",
+          non_resumable: "info",
+          inbox_monitor_not_alive: "info",
+          registry_screen_disagreement: "info",
+        },
+      },
+      model_policy: { coerced: false, effective_model: "codex" },
+    });
+
+    expect(shaped).toEqual({ ...base });
+  });
+
+  it("keeps only real health issues when a spawn is degraded", () => {
+    const shaped = shapeSpawnResponse({
+      ...base,
+      health: {
+        status: "degraded",
+        issue_codes: ["missing_cli_session_id", "missing_managed_lead_agent_id"],
+        issues: ["missing session", "lead is missing"],
+        issue_severities: {
+          missing_cli_session_id: "info",
+          missing_managed_lead_agent_id: "degraded",
+        },
+        recommended_actions: ["spawn_lead"],
+      },
+    });
+
+    expect(shaped.health).toEqual({
+      status: "degraded",
+      issue_codes: ["missing_managed_lead_agent_id"],
+      issues: ["lead is missing"],
+      issue_severities: { missing_managed_lead_agent_id: "degraded" },
+      recommended_actions: ["spawn_lead"],
+    });
+  });
+
+  it("preserves issue-message alignment when an invalid code precedes a real issue", () => {
+    const shaped = shapeSpawnResponse({
+      ...base,
+      health: {
+        status: "degraded",
+        issue_codes: [null, "missing_managed_lead_agent_id"],
+        issues: ["invalid entry", "lead is missing"],
+        issue_severities: {
+          missing_managed_lead_agent_id: "degraded",
+        },
+      },
+    });
+
+    expect(shaped.health).toMatchObject({
+      issue_codes: ["missing_managed_lead_agent_id"],
+      issues: ["lead is missing"],
+    });
+  });
+
+  it("includes a coerced model policy and non-empty warnings", () => {
+    const policy = { coerced: true, effective_model: "codex" };
+    const shaped = shapeSpawnResponse({
+      ...base,
+      warnings: ["model coerced"],
+      model_policy: policy,
+    });
+
+    expect(shaped.warnings).toEqual(["model coerced"]);
+    expect(shaped.model_policy).toBe(policy);
+  });
+
+  it("keeps only essential worktree fields in lean mode", () => {
+    const shaped = shapeSpawnResponse({
+      ...base,
+      worktree: {
+        path: "/tmp/cmuxlayer",
+        name: "lean-response",
+        branch: "feat/lean-response",
+        created: false,
+        reused: true,
+        node_modules_linked: true,
+        mcp_json_copied: true,
+      },
+    });
+
+    expect(shaped.worktree).toEqual({
+      path: "/tmp/cmuxlayer",
+      name: "lean-response",
+      branch: "feat/lean-response",
+      created: false,
+      reused: true,
+    });
+  });
+
+  it("returns the full legacy object unchanged in verbose mode", () => {
+    const full = {
+      ...base,
+      retry_count: 0,
+      mcp_env: "MCP_PROFILE=inherit",
+      model_policy: { coerced: false },
+      warnings: [],
+      monitor_boot: { alive: false },
+    };
+
+    expect(shapeSpawnResponse(full, true)).toBe(full);
+  });
+
+  it("uses the same lean payload for text and structured content", () => {
+    const result = buildSpawnToolReturn({ ...base, retry_count: 0 });
+
+    expect(JSON.parse(result.content[0]!.text)).toEqual(result.structuredContent);
+    expect(result.structuredContent).not.toHaveProperty("retry_count");
+  });
+});

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -165,6 +165,7 @@ describe("workspace spawn tools", () => {
     const result = await tool.handler(
       {
         workspace_title: "red-team",
+        verbose: true,
         agents: [
           { repo: "brainlayer", model: "sonnet", cli: "claude", role: "orchestrator" },
           { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },


### PR DESCRIPTION
## Summary
- make spawn_agent, new_worktree_split, and spawn_in_workspace responses lean by default
- retain actionable warnings, real degraded/blocking health, and model coercion details
- preserve the full legacy response behind verbose:true for all three tools
- keep text and structuredContent payloads aligned

## Test plan
- [x] TDD regression coverage for lean, degraded, coercion, warnings, worktree, verbose, and payload parity
- [x] Full deterministic suite passed 5 consecutive cold runs: 91 files, 1,694 tests each
- [x] bun run typecheck
- [x] bun run build
- [x] bun run pre-pr: 61 tests

## Review
- CodeRabbit found one minor issue-message index alignment bug; fixed with a red-green regression test
- CodeRabbit re-review was rate-limited; local blue-team fallback review found no additional issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default API contracts for three heavily used spawn tools; callers depending on omitted fields need verbose:true, but behavior is opt-in backward compatible.
> 
> **Overview**
> **Spawn MCP tools now return smaller default payloads** for `spawn_agent`, `new_worktree_split`, and `spawn_in_workspace`, with **`verbose:true`** restoring the previous full response shape.
> 
> A new **`spawn-response`** helper strips expected fresh-spawn noise (healthy health with info-only codes like missing session / non-resumable, extra worktree bookkeeping, duplicate-lane fields folded into **`warnings`**) while keeping routing essentials, real degraded/blocking health, coerced model policy, and non-empty warnings. **Text and `structuredContent` stay aligned** on the lean JSON by default; verbose mode keeps legacy formatted text plus the full object.
> 
> **`spawn_in_workspace`** applies the same shaping per agent in the default **`agents`** array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158f439d941a28069a1a01bc4428a50ec75f9800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make spawn tool responses lean by default, with full payload via `verbose:true`
> - The `spawn_agent`, `new_worktree_split`, and `spawn_in_workspace` tool handlers now return a minimal payload by default: informational health codes, non-coerced model policy, `monitor_boot`, `retry_count`, and bookkeeping lists are omitted.
> - Adds a `verbose` boolean argument (default `false`) to each tool; setting `verbose:true` restores the previous full response.
> - Introduces [spawn-response.ts](https://github.com/EtanHey/cmuxlayer/pull/294/files#diff-8e32bbd194555438af0bcd530b415445a30a3fa1c3eb8ef3a2a05d9204d01445) with `shapeSpawnResponse`, `buildSpawnToolReturn`, `leanHealth`, and `leanWorktree` helpers that centralize lean-shaping logic across all three handlers.
> - Both `text` and `structuredContent` in the tool return mirror the lean payload in default mode; verbose mode uses the legacy formatted text.
> - Behavioral Change: existing callers that rely on fields like `health`, `monitor_boot`, `retry_count`, or `existing_same_lane_agents` in the default response will no longer receive them unless they pass `verbose:true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 158f439.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->