### PR TITLE
feat(monitors): fail over monitors whose owner pane is alive but wedged

### DIFF
--- a/docs/plans/2026-07-11-monitor-wedged-owner-design.md
+++ b/docs/plans/2026-07-11-monitor-wedged-owner-design.md
@@ -1,0 +1,61 @@
+# Monitor Wedged Owner Design
+
+## Problem
+
+The monitor reconciler can prove that an owner pane exists and accepts screen reads, dispatch a durable `monitor-rearm` inbox task, and then wait forever for an owner agent that is alive but no longer processing work. The existing re-arm claim is only a retry lease, so an unacknowledged dispatch is eventually sent again instead of becoming an observable failure.
+
+## Options considered
+
+### Redispatch every expired claim
+
+This preserves the current behavior but cannot distinguish delivery failure from an owner agent that is wedged. It leaves the monitor in `rearming` limbo and can repeatedly nudge an owner that will never act.
+
+### Infer daemon-safe commands from watch metadata
+
+File targets and `event`/`offset-poll` mechanisms look owner-independent, but the stored command is opaque and may depend on owner-local state. The v0.3.38 safety decision therefore remains: current-schema monitors are owner-bound unless an injected caller can explicitly prove daemon-safe ownership independence.
+
+### Time-bound acknowledgement and escalate or fall back
+
+Use the existing `rearm_claimed_at` lease as the dispatch timestamp. On a later tick, an expired claim with no monitor signal is an unacknowledged dispatch. If an injected owner-progress probe shows activity after the claim, retry normally. If it does not, atomically transition to `owner-wedged`; an explicitly owner-independent monitor uses an injected daemon fallback instead. This is the chosen approach.
+
+## State transitions
+
+```text
+stale alive --claim + owner dispatch--> rearming(rearm_claimed_at)
+rearming --signal_monitor-------------> alive (acknowledged)
+rearming --timeout + owner progress---> rearming (fresh retry claim)
+rearming --timeout + no progress------> collapsed(owner-wedged)
+rearming --timeout + independent------> alive (daemon fallback completed)
+collapsed(owner-wedged) --signal------> alive (recovery clears collapse)
+```
+
+The registry write lock and current-state recheck remain the single transition boundary. Only the winning transition invokes escalation or fallback, so concurrent and later ticks cannot create storms. `owner-wedged` remains visible through existing `list_monitors`, gate-query, agent-health, and `control_health.self_heal.monitor_registry` paths.
+
+## Acknowledgement and timeout
+
+Monitor progress is authoritative: `signal_monitor` returns a `rearming` record to `alive` and clears the claim. The daemon also checks the exact deterministic inbox message ID in the owner's ACK file and accepts an agent monitor heartbeat strictly newer than `rearm_claimed_at`; either prevents a wedged classification and permits a normal retry. Generic agent lifecycle timestamps are deliberately not treated as acknowledgement. The default acknowledgement timeout is twice the daemon reconcile interval; direct registry callers retain a deterministic 60-second default.
+
+## Owner-independent fallback
+
+The registry exposes injected `ownerIndependent` and `fallbackRearm` seams. A successful fallback atomically finalizes the claimed record to `alive` with a fresh signal timestamp, preventing another fallback on the next expired tick. The production daemon does not infer independence for opaque current-schema commands, preserving the prior safe default. A future caller with a genuinely daemon-safe watcher contract can opt in without changing the lease or idempotency machinery.
+
+## Terminal quieting and abandoned-monitor reaping
+
+`dead`, `collapsed`, and `deadman-fired` are terminal for reconciliation and never re-enter collapse, re-arm, fallback, or notification transitions. Before considering live/rearming candidates, reconciliation performs an age-bounded reap pass: any non-dead record whose newest durable activity (`armed_at` or `last_signal_at`) is older than the injectable reap threshold (24 hours by default) and whose owner is not alive is atomically marked `dead`. Reaping is silent and idempotent; a later tick sees `dead` and performs no work.
+
+Notifications are edge-triggered by the durable transition claim. Deadman delivery carries `monitor_id:deadman-fired`; collapse delivery carries `monitor_id:<collapse-reason>`. The key lets the HTTP notification layer deduplicate transport retries while the registry lock prevents duplicate transition producers.
+
+Notification transport is dependency-injected and fail-closed for tests. Constructing `CmuxLayerDaemon` directly never selects the live registry or HTTP notifier; only the production `runDaemon` entrypoint wires those dependencies, and it substitutes no-ops whenever `VITEST=true` or `NODE_ENV=test`. Reconciler tests capture notification payloads in spies, and every daemon with a reconciliation interval is registered for async shutdown in test teardown.
+
+## Tests
+
+- A pane-alive owner with no progress past the acknowledgement timeout collapses once as `owner-wedged` and escalates once.
+- A timely signal acknowledgement restores `alive` and does not escalate.
+- Owner progress after dispatch permits the normal re-arm retry.
+- An explicitly owner-independent monitor invokes daemon fallback once instead of collapsing.
+- Repeated ticks are idempotent, and a later genuine monitor signal clears an `owner-wedged` collapse.
+- Existing health surfaces include the new collapse reason without a parallel observability path.
+- Already-terminal monitors remain quiet across ten reconciliation ticks.
+- Ancient dead-owner monitors are reaped to `dead` exactly once without notification.
+- Deadman and collapse payloads expose stable transition dedupe keys.
+- Targeted daemon/reconciler tests cannot reach the live notification bridge and leave no interval workers behind.

--- a/docs/plans/2026-07-11-monitor-wedged-owner.md
+++ b/docs/plans/2026-07-11-monitor-wedged-owner.md
@@ -1,0 +1,55 @@
+# Monitor Wedged Owner Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fail over a stale monitor whose pane remains readable but whose owner never acknowledges a re-arm dispatch.
+
+**Architecture:** Extend the existing registry lease transition with an acknowledgement timeout, owner-progress probe, explicit owner-independence predicate, and one-shot fallback/escalation callbacks. The daemon derives owner progress from the exact inbox ACK and post-dispatch agent heartbeat, then sets the default acknowledgement timeout to twice its reconcile interval; existing list and health projections carry the new reason automatically.
+
+**Tech Stack:** TypeScript, Vitest, JSON file registry, cmuxlayer daemon.
+
+---
+
+### Task 1: Specify unacknowledged owner-wedged transitions
+
+**Files:** `tests/monitor-registry.test.ts`, `src/monitor-registry.ts`
+
+1. Add a stale monitor test that first dispatches re-arm, advances past the acknowledgement timeout with a pane-alive/no-progress owner, and expects one `owner-wedged` collapse and escalation.
+2. Run the focused test and confirm it fails because the expired claim is redispatched.
+3. Add the new collapse reason, acknowledgement timeout, and owner-progress predicate.
+4. Re-run the focused test and keep the existing lease claim as the atomic guard.
+
+### Task 2: Specify acknowledgement, fallback, idempotency, and recovery
+
+**Files:** `tests/monitor-registry.test.ts`, `src/monitor-registry.ts`
+
+1. Add tests for signal acknowledgement in time, owner progress with normal retry, explicit owner-independent fallback, repeated-tick idempotency, and recovery from `owner-wedged` via a genuine signal.
+2. Run each new test red before production changes.
+3. Implement only the transitions required by the tests and re-run the focused suite green.
+
+### Task 3: Wire daemon timeout/progress and observability
+
+**Files:** `tests/daemon.test.ts`, `tests/monitor-registry-mcp.test.ts`, `tests/control-health.test.ts`, `src/daemon.ts`
+
+1. Add daemon coverage proving an alive/readable owner without an inbox ACK or post-dispatch heartbeat becomes `owner-wedged` after two ticks and emits one loud notification.
+2. Add projection coverage for `list_monitors` and `control_health.self_heal`.
+3. Run the focused tests red, then pass the daemon interval-derived timeout and owner-progress callback into registry reconciliation.
+4. Re-run focused tests green.
+
+### Task 4: Quiet terminal records, reap abandoned monitors, and dedupe notifications
+
+**Files:** `tests/monitor-registry.test.ts`, `tests/daemon.test.ts`, `src/monitor-registry.ts`, `src/daemon.ts`, `src/outbox-drainer.ts`
+
+1. Add failing tests that reconcile a claimed `deadman-fired` record for ten ticks with zero callbacks and reap an ancient dead-owner record exactly once.
+2. Add failing payload assertions for `monitor_id:transition` dedupe keys on deadman and owner-collapse notifications.
+3. Implement an atomic, silent reap pre-pass with an injectable 24-hour default and preserve the existing terminal candidate exclusion.
+4. Add transition dedupe keys to the notify payload type and adapters, then re-run the focused tests.
+5. Make direct daemon construction default to no registry/network side effects, wire live delivery only in `runDaemon`, enforce test-mode no-ops, and tear down every interval daemon asynchronously.
+
+### Task 5: Verify and publish
+
+1. Run focused registry, daemon, MCP, and health tests.
+2. Run typecheck and build.
+3. Run the deterministic full suite five times in separate cold processes.
+4. Run `git diff --check`, inspect the full diff, and run a bounded local review.
+5. Commit scoped files, push `feat/r8-monitor-wedged-owner`, open the requested ready PR, invoke reviewers, and report the PR URL.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,9 +25,11 @@ import {
   reconcileMonitorRegistry,
 } from "./monitor-registry.js";
 import {
+  ackedIds,
   dispatchOnce,
   inboxPath,
   monitorAlive,
+  readLastAgentHeartbeat,
   type InboxOpts,
 } from "./inbox.js";
 import type { ExecFn } from "./cmux-client.js";
@@ -70,12 +72,15 @@ export type DaemonHotReloadHandler = (
   plan: DaemonHotReloadPlan,
 ) => Promise<"not_implemented">;
 
-export interface MonitorOwnerPtyDeadNotification {
+export interface MonitorOwnerCollapseNotification {
   title: string;
   body: string;
   source: string;
   priority: "high";
+  dedupe_key: string;
 }
+
+export type MonitorOwnerPtyDeadNotification = MonitorOwnerCollapseNotification;
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
 export type DaemonRetirementReason = "stale-build" | "irrecoverable-transport";
@@ -251,6 +256,9 @@ export interface CmuxLayerDaemonOptions extends Omit<
   monitorReconcileIntervalMs?: number;
   monitorOwnerPtyDeadNotify?: (
     notification: MonitorOwnerPtyDeadNotification,
+  ) => Promise<unknown> | unknown;
+  monitorOwnerWedgedNotify?: (
+    notification: MonitorOwnerCollapseNotification,
   ) => Promise<unknown> | unknown;
   logger?: Pick<Console, "error">;
   onRetire?: (
@@ -438,10 +446,7 @@ export class CmuxLayerDaemon {
     }
 
     const context = await this.getContext();
-    if (
-      !this.monitorReconcileFn &&
-      (this.opts.monitorRegistryPath || process.env.VITEST !== "true")
-    ) {
+    if (!this.monitorReconcileFn && this.opts.monitorRegistryPath) {
       this.monitorReconcileFn = this.createDefaultMonitorReconciler(context);
     }
     context.lifecycleAgentInputDelivererReadyListeners.add(
@@ -543,11 +548,10 @@ export class CmuxLayerDaemon {
     const transport = new SocketJsonRpcTransport(socket);
     const mcpServer = createServer({
       context,
-      outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
-      monitorRegistryPath:
-        this.opts.monitorRegistryPath ?? defaultMonitorRegistryPath(),
+      outboxDrain: this.opts.outboxDrain,
+      monitorRegistryPath: this.opts.monitorRegistryPath,
       monitorRegistryNow: this.opts.monitorRegistryNow,
-      monitorRegistryNotify: httpNotifyMonitorDeadman,
+      monitorRegistryNotify: this.opts.monitorRegistryNotify,
     });
     const pendingRequestIds = new Set<RequestId>();
     this.activeTransports.add(transport);
@@ -676,6 +680,10 @@ export class CmuxLayerDaemon {
       reconcileMonitorRegistry({
         registryPath,
         now: this.opts.monitorRegistryNow,
+        rearmAckTimeoutMs:
+          (this.monitorReconcileIntervalMs > 0
+            ? this.monitorReconcileIntervalMs
+            : DEFAULT_MONITOR_RECONCILE_INTERVAL_MS) * 2,
         ...(options?.rearmClaimTimeoutMs !== undefined
           ? { rearmClaimTimeoutMs: options.rearmClaimTimeoutMs }
           : {}),
@@ -703,6 +711,25 @@ export class CmuxLayerDaemon {
           } catch {
             return false;
           }
+        },
+        ownerProgressedSince: (record) => {
+          const owner = findOwner(record.owner_seat);
+          if (!owner || !record.rearm_claimed_at) return false;
+          const inboxOpts: InboxOpts = {
+            ...(this.opts.inboxBaseDir
+              ? { baseDir: this.opts.inboxBaseDir }
+              : {}),
+            ...(this.opts.monitorRegistryNow
+              ? { now: this.opts.monitorRegistryNow }
+              : {}),
+          };
+          const messageId = `monitor-rearm:${record.monitor_id}:${record.last_signal_at}`;
+          if (ackedIds(owner.agent_id, inboxOpts).has(messageId)) return true;
+          const heartbeat = readLastAgentHeartbeat(owner.agent_id, inboxOpts);
+          return (
+            heartbeat !== null &&
+            heartbeat.ts_ms > Date.parse(record.rearm_claimed_at)
+          );
         },
         rearm: async (record) => {
           const owner = findOwner(record.owner_seat);
@@ -751,15 +778,22 @@ export class CmuxLayerDaemon {
           });
         },
         escalate: async (record) => {
-          const notify =
-            this.opts.monitorOwnerPtyDeadNotify ??
-            ((notification: MonitorOwnerPtyDeadNotification) =>
-              httpDeliver(notification, DEFAULT_NOTIFY_URL));
+          const ownerWedged = record.collapsed_reason === "owner-wedged";
+          const notify = ownerWedged
+            ? (this.opts.monitorOwnerWedgedNotify ??
+              (async () => false))
+            : (this.opts.monitorOwnerPtyDeadNotify ??
+              (async () => false));
           await notify({
-            title: "Monitor owner PTY dead",
-            body: `Monitor ${record.monitor_id} collapsed because owner ${record.owner_seat} cannot accept terminal writes; watch_targets=${record.watch_targets.join(", ")}`,
+            title: ownerWedged
+              ? "Monitor owner wedged"
+              : "Monitor owner PTY dead",
+            body: ownerWedged
+              ? `Monitor ${record.monitor_id} collapsed because pane-alive owner ${record.owner_seat} did not acknowledge re-arm; watch_targets=${record.watch_targets.join(", ")}`
+              : `Monitor ${record.monitor_id} collapsed because owner ${record.owner_seat} cannot accept terminal writes; watch_targets=${record.watch_targets.join(", ")}`,
             source: "cmuxlayer-monitor-registry",
             priority: "high",
+            dedupe_key: `${record.monitor_id}:${record.collapsed_reason}`,
           });
         },
       });
@@ -804,7 +838,7 @@ export class CmuxLayerDaemon {
             }
           }
         }
-        for (const key of ["rearmed", "collapsed"] as const) {
+        for (const key of ["rearmed", "collapsed", "reaped"] as const) {
           const outcomes = result[key];
           if (Array.isArray(outcomes)) {
             for (const outcome of outcomes) {
@@ -996,6 +1030,8 @@ export async function runDaemon(
 ): Promise<CmuxLayerDaemon> {
   ensureNodeMaxOldSpaceEnv();
   installHeapGuard();
+  const testProcess =
+    process.env.VITEST === "true" || process.env.NODE_ENV === "test";
   let exitStarted = false;
   const exitAfterShutdown = (
     reason: DaemonShutdownReason,
@@ -1007,6 +1043,26 @@ export async function runDaemon(
   };
   const daemon = new CmuxLayerDaemon({
     ...opts,
+    outboxDrain:
+      opts.outboxDrain ??
+      (testProcess
+        ? async () => undefined
+        : () => drainOutbox({ deliver: httpDeliver })),
+    monitorRegistryNotify:
+      opts.monitorRegistryNotify ??
+      (testProcess ? async () => undefined : httpNotifyMonitorDeadman),
+    monitorRegistryPath:
+      opts.monitorRegistryPath ?? defaultMonitorRegistryPath(),
+    monitorOwnerPtyDeadNotify:
+      opts.monitorOwnerPtyDeadNotify ??
+      (testProcess
+        ? async () => false
+        : (notification) => httpDeliver(notification, DEFAULT_NOTIFY_URL)),
+    monitorOwnerWedgedNotify:
+      opts.monitorOwnerWedgedNotify ??
+      (testProcess
+        ? async () => false
+        : (notification) => httpDeliver(notification, DEFAULT_NOTIFY_URL)),
     onRetire: async (reason, result) => {
       await opts.onRetire?.(reason, result);
       exitAfterShutdown(reason, result);

--- a/src/monitor-registry.ts
+++ b/src/monitor-registry.ts
@@ -75,6 +75,7 @@ export interface MonitorRegistryOptions {
 
 export interface MonitorDeadmanEvent {
   monitor_id: string;
+  dedupe_key: string;
   owner_seat: string;
   watch_targets: string[];
   mechanism: MonitorMechanism;
@@ -113,6 +114,7 @@ export interface MonitorRegistrySweepOptions extends MonitorRegistryOptions {
 export type MonitorCollapseReason =
   | "owner-not-alive"
   | "owner-pty-dead"
+  | "owner-wedged"
   | "watch-target-missing"
   | "rearm-command-missing";
 
@@ -121,14 +123,26 @@ export interface MonitorRegistryReconcileOptions extends MonitorRegistryOptions 
   ownerPtyDead?: (ownerSeat: string) => Promise<boolean> | boolean;
   watchTargetExists?: (target: string) => boolean;
   rearmClaimTimeoutMs?: number;
+  rearmAckTimeoutMs?: number;
+  reapAfterMs?: number;
   monitorIds?: readonly string[];
+  ownerProgressedSince?: (
+    record: MonitorRegistryRecord,
+  ) => Promise<boolean> | boolean;
+  ownerIndependent?: (
+    record: MonitorRegistryRecord,
+  ) => Promise<boolean> | boolean;
   rearm: (record: MonitorRegistryRecord) => Promise<unknown> | unknown;
+  fallbackRearm?: (
+    record: MonitorRegistryRecord,
+  ) => Promise<unknown> | unknown;
   escalate?: (record: MonitorRegistryRecord) => Promise<unknown> | unknown;
 }
 
 export interface MonitorRegistryReconcileResult {
   rearmed: string[];
   collapsed: Array<{ monitor_id: string; reason: MonitorCollapseReason }>;
+  reaped: string[];
   failed: string[];
 }
 
@@ -175,6 +189,7 @@ const STATE_VERSION = 1;
 const DEFAULT_NOTIFY_URL = "http://127.0.0.1:3847/notify";
 const DEFAULT_NOTIFY_SOURCE = "cmuxlayer-monitor-registry";
 const DEFAULT_SWEEPER_ID = "agent-engine";
+const DEFAULT_REAP_AFTER_MS = 24 * 60 * 60 * 1_000;
 
 export function defaultMonitorRegistryPath(): string {
   return join(homedir(), ".golems-zikaron", "monitor-registry.json");
@@ -433,6 +448,7 @@ function isMonitorCollapseReason(value: unknown): value is MonitorCollapseReason
   return (
     value === "owner-not-alive" ||
     value === "owner-pty-dead" ||
+    value === "owner-wedged" ||
     value === "watch-target-missing" ||
     value === "rearm-command-missing"
   );
@@ -743,7 +759,12 @@ export async function signalMonitor(
       const valid = toValidRecord(record);
       if (
         !valid ||
-        (valid.state !== "alive" && valid.state !== "rearming")
+        (valid.state !== "alive" &&
+          valid.state !== "rearming" &&
+          !(
+            valid.state === "collapsed" &&
+            valid.collapsed_reason === "owner-wedged"
+          ))
       ) {
         return record;
       }
@@ -823,6 +844,17 @@ function isRearmClaimExpired(
   return claimedAtMs !== null && nowMs - claimedAtMs >= timeoutMs;
 }
 
+function isMonitorAncient(
+  record: MonitorRegistryRecord,
+  nowMs: number,
+  reapAfterMs: number,
+): boolean {
+  const armedAtMs = parseTimeMs(record.armed_at);
+  const lastSignalAtMs = parseTimeMs(record.last_signal_at);
+  if (armedAtMs === null || lastSignalAtMs === null) return false;
+  return nowMs - Math.max(armedAtMs, lastSignalAtMs) >= reapAfterMs;
+}
+
 export async function reconcileMonitorRegistry(
   opts: MonitorRegistryReconcileOptions,
 ): Promise<MonitorRegistryReconcileResult> {
@@ -830,14 +862,48 @@ export async function reconcileMonitorRegistry(
   const nowMs = (opts.now ?? Date.now)();
   const claimedAt = new Date(nowMs).toISOString();
   const watchTargetExists = opts.watchTargetExists ?? existsSync;
-  const rearmClaimTimeoutMs = opts.rearmClaimTimeoutMs ?? 60_000;
+  const rearmAckTimeoutMs = opts.rearmAckTimeoutMs ?? 60_000;
+  const reapAfterMs = opts.reapAfterMs ?? DEFAULT_REAP_AFTER_MS;
+  const rearmClaimTimeoutMs =
+    opts.rearmClaimTimeoutMs ?? opts.rearmAckTimeoutMs ?? 60_000;
   const monitorIds = opts.monitorIds ? new Set(opts.monitorIds) : null;
   const rearmed: string[] = [];
   const collapsed: Array<{
     monitor_id: string;
     reason: MonitorCollapseReason;
   }> = [];
+  const reaped: string[] = [];
   const failed: string[] = [];
+  const reapCandidates = readMonitorRegistry({ registryPath: path }).monitors.filter(
+    (record) =>
+      (!monitorIds || monitorIds.has(record.monitor_id)) &&
+      record.state !== "dead" &&
+      isMonitorAncient(record, nowMs, reapAfterMs),
+  );
+
+  for (const candidate of reapCandidates) {
+    if (await opts.ownerAlive(candidate.owner_seat)) continue;
+    let claimed = false;
+    withRegistryWriteLock(path, () => {
+      const registry = readRawRegistry(path);
+      const monitors = registry.monitors.map((raw) => {
+        const current = toValidRecord(raw);
+        if (
+          !current ||
+          current.monitor_id !== candidate.monitor_id ||
+          current.state === "dead" ||
+          !isMonitorAncient(current, nowMs, reapAfterMs)
+        ) {
+          return raw;
+        }
+        claimed = true;
+        return { ...current, state: "dead" as const };
+      });
+      if (claimed) writeRawRegistry(path, monitors);
+    });
+    if (claimed) reaped.push(candidate.monitor_id);
+  }
+
   const candidates = readMonitorRegistry({ registryPath: path }).monitors.filter(
     (record) =>
       (!monitorIds || monitorIds.has(record.monitor_id)) &&
@@ -848,6 +914,25 @@ export async function reconcileMonitorRegistry(
 
   for (const candidate of candidates) {
     let collapseReason: MonitorCollapseReason | null = null;
+    const rearmClaimAgeMs = candidate.rearm_claimed_at
+      ? nowMs - (parseTimeMs(candidate.rearm_claimed_at) ?? nowMs)
+      : 0;
+    const acknowledgementExpired =
+      candidate.state === "rearming" &&
+      !!candidate.rearm_claimed_at &&
+      rearmClaimAgeMs >= rearmAckTimeoutMs;
+    const ownerProgressed =
+      acknowledgementExpired && opts.ownerProgressedSince
+        ? await opts.ownerProgressedSince(candidate)
+        : false;
+    const ownerWedged =
+      acknowledgementExpired &&
+      !!opts.ownerProgressedSince &&
+      !ownerProgressed;
+    const useFallback =
+      ownerWedged &&
+      !!opts.fallbackRearm &&
+      (await opts.ownerIndependent?.(candidate));
     if (!candidate.rearm_command) {
       collapseReason = "rearm-command-missing";
     } else if (
@@ -858,6 +943,8 @@ export async function reconcileMonitorRegistry(
       collapseReason = "owner-pty-dead";
     } else if (!(await opts.ownerAlive(candidate.owner_seat))) {
       collapseReason = "owner-not-alive";
+    } else if (ownerWedged && !useFallback) {
+      collapseReason = "owner-wedged";
     }
 
     let claimed: MonitorRegistryRecord | null = null;
@@ -903,19 +990,56 @@ export async function reconcileMonitorRegistry(
         } catch {
           // The durable collapsed state is canonical; notification is best-effort.
         }
+      } else if (collapseReason === "owner-wedged") {
+        try {
+          await opts.escalate?.(claimed);
+        } catch {
+          // The durable collapsed state is canonical; notification is best-effort.
+        }
       }
       continue;
     }
 
     try {
-      await opts.rearm(claimed);
+      if (useFallback) {
+        await opts.fallbackRearm!(claimed);
+        withRegistryWriteLock(path, () => {
+          const registry = readRawRegistry(path);
+          let completed = false;
+          const monitors = registry.monitors.map((raw) => {
+            const current = toValidRecord(raw);
+            if (
+              !current ||
+              current.monitor_id !== claimed!.monitor_id ||
+              current.state !== "rearming" ||
+              current.rearm_claimed_at !== claimed!.rearm_claimed_at
+            ) {
+              return raw;
+            }
+            const {
+              rearm_claimed_at: _rearmClaimedAt,
+              collapsed_reason: _collapsedReason,
+              ...rest
+            } = current;
+            completed = true;
+            return {
+              ...rest,
+              state: "alive" as const,
+              last_signal_at: claimedAt,
+            };
+          });
+          if (completed) writeRawRegistry(path, monitors);
+        });
+      } else {
+        await opts.rearm(claimed);
+      }
       rearmed.push(candidate.monitor_id);
     } catch {
       failed.push(candidate.monitor_id);
     }
   }
 
-  return { rearmed, collapsed, failed };
+  return { rearmed, collapsed, reaped, failed };
 }
 
 const noopNotify: MonitorDeadmanNotify = async () => {};
@@ -949,6 +1073,7 @@ export async function sweepMonitorRegistry(
       const firedAt = new Date(nowMs).toISOString();
       fired.push({
         monitor_id: valid.monitor_id,
+        dedupe_key: `${valid.monitor_id}:deadman-fired`,
         owner_seat: valid.owner_seat,
         watch_targets: valid.watch_targets,
         mechanism: valid.mechanism,
@@ -1017,6 +1142,7 @@ export async function httpNotifyMonitorDeadman(
       )}s; watch_targets=${event.watch_targets.join(", ")}`,
       source: DEFAULT_NOTIFY_SOURCE,
       priority: "high",
+      dedupe_key: event.dedupe_key,
     },
     notifyUrl,
   );

--- a/src/outbox-drainer.ts
+++ b/src/outbox-drainer.ts
@@ -38,6 +38,7 @@ export interface NotifyPayload {
   body: string;
   source: string;
   priority: string;
+  dedupe_key?: string;
 }
 
 /** A single pending outbox message. */

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -237,7 +237,7 @@ describe("control health", () => {
             armed_at: "2026-07-11T11:55:00.000Z",
             last_signal_at: "2026-07-11T11:57:00.000Z",
             state: "collapsed",
-            collapsed_reason: "watch-target-missing",
+            collapsed_reason: "owner-wedged",
           },
         ],
       }),
@@ -276,7 +276,7 @@ describe("control health", () => {
       collapsed_monitors: [
         {
           monitor_id: "monitor-collapsed",
-          reason: "watch-target-missing",
+          reason: "owner-wedged",
         },
       ],
       truncated: false,
@@ -285,7 +285,7 @@ describe("control health", () => {
       /pane_pty_dead: 1.*surface:pty-dead.*2026-07-11T12:00:01.000Z/s,
     );
     expect(formatControlHealth(health)).toMatch(
-      /monitor registry: total=3 rearming=1 collapsed=1.*monitor-collapsed: watch-target-missing/s,
+      /monitor registry: total=3 rearming=1 collapsed=1.*monitor-collapsed: owner-wedged/s,
     );
   });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -18,7 +18,7 @@ import {
   readMonitorRegistry,
   registerMonitor,
 } from "../src/monitor-registry.js";
-import { readInbox } from "../src/inbox.js";
+import { ack, readInbox } from "../src/inbox.js";
 
 const TEST_ROOT = join("/tmp", "cmuxlayer-daemon-test");
 
@@ -438,7 +438,17 @@ async function readOnce(path: string): Promise<string> {
 }
 
 describe("CmuxLayerDaemon", () => {
-  afterEach(() => {
+  const intervalDaemons = new Set<CmuxLayerDaemon>();
+  const trackIntervalDaemon = (daemon: CmuxLayerDaemon): CmuxLayerDaemon => {
+    intervalDaemons.add(daemon);
+    return daemon;
+  };
+
+  afterEach(async () => {
+    await Promise.all(
+      [...intervalDaemons].map((daemon) => daemon.shutdown().catch(() => {})),
+    );
+    intervalDaemons.clear();
     rmSync(TEST_ROOT, { recursive: true, force: true });
   });
 
@@ -598,13 +608,13 @@ describe("CmuxLayerDaemon", () => {
       .fn()
       .mockImplementationOnce(() => firstPass.promise)
       .mockResolvedValue(undefined);
-    const daemon = new CmuxLayerDaemon({
+    const daemon = trackIntervalDaemon(new CmuxLayerDaemon({
       socketPath: socketPath("monitor-reconcile-overlap"),
       exec: createListSurfacesExec(),
       skipAgentLifecycle: true,
       monitorReconcile,
       monitorReconcileIntervalMs: 5,
-    });
+    }));
 
     await daemon.start();
     await delay(20);
@@ -691,13 +701,13 @@ describe("CmuxLayerDaemon", () => {
   it("clears the monitor reconciliation timer during shutdown", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const monitorReconcile = vi.fn().mockResolvedValue(undefined);
-    const daemon = new CmuxLayerDaemon({
+    const daemon = trackIntervalDaemon(new CmuxLayerDaemon({
       socketPath: socketPath("monitor-reconcile-clear"),
       exec: createListSurfacesExec(),
       skipAgentLifecycle: true,
       monitorReconcile,
       monitorReconcileIntervalMs: 5,
-    });
+    }));
 
     await daemon.start();
     await waitUntil(() => monitorReconcile.mock.calls.length >= 2);
@@ -729,6 +739,7 @@ describe("CmuxLayerDaemon", () => {
 
     const clients: ReturnType<typeof createPlacementClient>[] = [];
     const guardedRelays: Array<ReturnType<typeof vi.fn>> = [];
+    const monitorOwnerWedgedNotify = vi.fn().mockResolvedValue(true);
     const createContext = () => {
       const client = createPlacementClient([]);
       clients.push(client);
@@ -771,6 +782,7 @@ describe("CmuxLayerDaemon", () => {
       monitorRegistryPath: registryPath,
       monitorRegistryNow: () => 62_000,
       monitorReconcileIntervalMs: 0,
+      monitorOwnerWedgedNotify,
       inboxBaseDir,
     });
     await first.start();
@@ -782,6 +794,7 @@ describe("CmuxLayerDaemon", () => {
       monitorRegistryPath: registryPath,
       monitorRegistryNow: () => 123_001,
       monitorReconcileIntervalMs: 0,
+      monitorOwnerWedgedNotify,
       inboxBaseDir,
     });
     await second.start();
@@ -795,8 +808,10 @@ describe("CmuxLayerDaemon", () => {
     });
     expect(readMonitorRegistry({ registryPath }).monitors[0]).toMatchObject({
       monitor_id: "restart-monitor",
-      state: "rearming",
+      state: "collapsed",
+      collapsed_reason: "owner-wedged",
     });
+    expect(monitorOwnerWedgedNotify).toHaveBeenCalledTimes(1);
     expect(guardedRelays[0]).toHaveBeenCalledWith(
       expect.objectContaining({
         agent_id: "worker-a",
@@ -863,7 +878,7 @@ describe("CmuxLayerDaemon", () => {
     const guardedRelay = vi.fn().mockResolvedValue(undefined);
     context.setLifecycleAgentInputDeliverer(guardedRelay);
     const monitorOwnerPtyDeadNotify = vi.fn().mockResolvedValue(true);
-    const daemon = new CmuxLayerDaemon({
+    const daemon = trackIntervalDaemon(new CmuxLayerDaemon({
       socketPath: socketPath("monitor-owner-pty-dead"),
       context,
       monitorRegistryPath: registryPath,
@@ -871,7 +886,7 @@ describe("CmuxLayerDaemon", () => {
       monitorReconcileIntervalMs: 5,
       monitorOwnerPtyDeadNotify,
       inboxBaseDir,
-    });
+    }));
 
     await daemon.start();
     await waitUntil(
@@ -891,10 +906,186 @@ describe("CmuxLayerDaemon", () => {
         title: "Monitor owner PTY dead",
         body: expect.stringContaining("pty-dead-monitor"),
         priority: "high",
+        dedupe_key: "pty-dead-monitor:owner-pty-dead",
       }),
     );
     expect(readInbox("worker-wedged", { baseDir: inboxBaseDir })).toEqual([]);
     expect(guardedRelay).not.toHaveBeenCalled();
+  });
+
+  it("collapses and loudly escalates a pane-alive owner that never acknowledges re-arm", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const registryPath = join(TEST_ROOT, "wedged-monitor-registry.json");
+    const watchedFile = join(TEST_ROOT, "wedged-collab.md");
+    const inboxBaseDir = join(TEST_ROOT, "wedged-inbox");
+    let now = 62_000;
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "wedged-monitor",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath, now: () => 1_000 },
+    );
+
+    const context = createServerContext({
+      client: createPlacementClient([]) as any,
+      stateDir: stateDir("wedged-state"),
+      skipAgentLifecycle: true,
+    });
+    context.stateMgr.writeState({
+      agent_id: "worker-wedged",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "session-wedged",
+      task_summary: "watch collab",
+      pid: 123,
+      version: 1,
+      created_at: new Date(1_000).toISOString(),
+      updated_at: new Date(1_000).toISOString(),
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "verified",
+      max_cost_per_agent: null,
+    });
+    const guardedRelay = vi.fn().mockResolvedValue(undefined);
+    context.setLifecycleAgentInputDeliverer(guardedRelay);
+    const monitorOwnerWedgedNotify = vi.fn().mockResolvedValue(true);
+    const daemon = trackIntervalDaemon(new CmuxLayerDaemon({
+      socketPath: socketPath("monitor-owner-wedged"),
+      context,
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
+      monitorReconcileIntervalMs: 5,
+      monitorOwnerWedgedNotify,
+      inboxBaseDir,
+    }));
+
+    await daemon.start();
+    await waitUntil(
+      () => readMonitorRegistry({ registryPath }).monitors[0]?.state === "rearming",
+    );
+    now = 72_001;
+    await waitUntil(
+      () => readMonitorRegistry({ registryPath }).monitors[0]?.state === "collapsed",
+    );
+    await delay(20);
+    await daemon.shutdown();
+
+    expect(readMonitorRegistry({ registryPath }).monitors[0]).toMatchObject({
+      monitor_id: "wedged-monitor",
+      state: "collapsed",
+      collapsed_reason: "owner-wedged",
+    });
+    expect(monitorOwnerWedgedNotify).toHaveBeenCalledTimes(1);
+    expect(monitorOwnerWedgedNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Monitor owner wedged",
+        body: expect.stringContaining("wedged-monitor"),
+        priority: "high",
+        dedupe_key: "wedged-monitor:owner-wedged",
+      }),
+    );
+    expect(readInbox("worker-wedged", { baseDir: inboxBaseDir })).toHaveLength(1);
+    expect(guardedRelay).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps normal re-arm flow when the pane-alive owner acknowledges in time", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const registryPath = join(TEST_ROOT, "acked-monitor-registry.json");
+    const watchedFile = join(TEST_ROOT, "acked-collab.md");
+    const inboxBaseDir = join(TEST_ROOT, "acked-inbox");
+    let now = 62_000;
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "acked-monitor",
+        owner_seat: "worker-live",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath, now: () => 1_000 },
+    );
+
+    const context = createServerContext({
+      client: createPlacementClient([]) as any,
+      stateDir: stateDir("acked-state"),
+      skipAgentLifecycle: true,
+    });
+    context.stateMgr.writeState({
+      agent_id: "worker-live",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "session-live",
+      task_summary: "watch collab",
+      pid: 123,
+      version: 1,
+      created_at: new Date(1_000).toISOString(),
+      updated_at: new Date(1_000).toISOString(),
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "verified",
+      max_cost_per_agent: null,
+    });
+    const guardedRelay = vi.fn().mockResolvedValue(undefined);
+    context.setLifecycleAgentInputDeliverer(guardedRelay);
+    const monitorOwnerWedgedNotify = vi.fn();
+    const daemon = trackIntervalDaemon(new CmuxLayerDaemon({
+      socketPath: socketPath("monitor-owner-acked"),
+      context,
+      monitorRegistryPath: registryPath,
+      monitorRegistryNow: () => now,
+      monitorReconcileIntervalMs: 5,
+      monitorOwnerWedgedNotify,
+      inboxBaseDir,
+    }));
+
+    await daemon.start();
+    await waitUntil(
+      () => readMonitorRegistry({ registryPath }).monitors[0]?.state === "rearming",
+    );
+    now = 65_000;
+    ack(
+      "worker-live",
+      `monitor-rearm:acked-monitor:${new Date(1_000).toISOString()}`,
+      "rearmed",
+      { baseDir: inboxBaseDir, now: () => now },
+    );
+    now = 72_001;
+    await waitUntil(
+      () =>
+        readMonitorRegistry({ registryPath }).monitors[0]?.rearm_claimed_at ===
+        new Date(72_001).toISOString(),
+    );
+    await daemon.shutdown();
+
+    const record = readMonitorRegistry({ registryPath }).monitors[0];
+    expect(record).toMatchObject({
+      monitor_id: "acked-monitor",
+      state: "rearming",
+    });
+    expect(record).not.toHaveProperty("collapsed_reason");
+    expect(monitorOwnerWedgedNotify).not.toHaveBeenCalled();
+    expect(readInbox("worker-live", { baseDir: inboxBaseDir })).toHaveLength(1);
+    expect(guardedRelay).toHaveBeenCalledTimes(1);
   });
 
   it("retries a claimed monitor as soon as the guarded relay becomes ready", async () => {
@@ -947,6 +1138,7 @@ describe("CmuxLayerDaemon", () => {
       monitorRegistryPath: registryPath,
       monitorRegistryNow: () => 62_000,
       monitorReconcileIntervalMs: 0,
+      monitorOwnerWedgedNotify: vi.fn(),
       inboxBaseDir,
     });
 

--- a/tests/monitor-registry-mcp.test.ts
+++ b/tests/monitor-registry-mcp.test.ts
@@ -196,6 +196,54 @@ describe("monitor registry MCP tools", () => {
     });
   });
 
+  it("surfaces owner-wedged recovery metadata through list and gate queries", async () => {
+    const watchedFile = join(TEST_DIR, "wedged.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    const server = createMonitorServer();
+    await callTool(server, "register_monitor", {
+      monitor_id: "seat-a-wedged",
+      owner_seat: "seat-a",
+      watch_targets: [watchedFile],
+      mechanism: "event",
+      deadman_timeout_s: 60,
+      rearm_command: `tail -n0 -F ${watchedFile}`,
+    });
+    await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm: vi.fn(),
+    });
+    await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 72_001,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm: vi.fn(),
+    });
+
+    const listed = await callTool(server, "list_monitors", {
+      monitor_id: "seat-a-wedged",
+    });
+    const queried = await callTool(server, "query_monitor_registry", {
+      gate: "gate-9",
+      monitor_id: "seat-a-wedged",
+    });
+
+    expect(listed.monitors[0]).toMatchObject({
+      state: "collapsed",
+      collapsed_reason: "owner-wedged",
+    });
+    expect(queried.monitors[0]).toMatchObject({
+      state: "collapsed",
+      liveness: "collapsed",
+      collapsed_reason: "owner-wedged",
+    });
+  });
+
   it("signal_monitor updates last_signal_at without moving an alive monitor out of alive", async () => {
     const server = createMonitorServer();
     await callTool(server, "register_monitor", {

--- a/tests/monitor-registry.test.ts
+++ b/tests/monitor-registry.test.ts
@@ -102,6 +102,7 @@ describe("monitor registry deadman core", () => {
         monitor_id: "scd-lapsed",
         owner_seat: "skillcreatorLead",
         fired_by_agent_id: "second-agent",
+        dedupe_key: "scd-lapsed:deadman-fired",
       }),
     ]);
     expect(second.fired).toEqual([]);
@@ -467,6 +468,92 @@ describe("monitor registry deadman core", () => {
     });
   });
 
+  it("keeps an already claimed deadman-fired monitor quiet across ten reconcile ticks", async () => {
+    await registerMonitor(
+      {
+        monitor_id: "terminal-quiet",
+        owner_seat: "old-owner",
+        watch_targets: ["/tmp/terminal-quiet"],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      notify: vi.fn(),
+      sweeperAgentId: "sweeper",
+    });
+    const rearm = vi.fn();
+    const escalate = vi.fn();
+
+    for (let tick = 0; tick < 10; tick += 1) {
+      const result = await reconcileMonitorRegistry({
+        registryPath: registryPath(),
+        now: () => 63_000 + tick * 1_000,
+        ownerAlive: async () => false,
+        rearm,
+        escalate,
+      });
+      expect(result).toMatchObject({
+        rearmed: [],
+        collapsed: [],
+        reaped: [],
+        failed: [],
+      });
+    }
+
+    expect(rearm).not.toHaveBeenCalled();
+    expect(escalate).not.toHaveBeenCalled();
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      state: "deadman-fired",
+      firing_claimed_by_agent_id: "sweeper",
+    });
+  });
+
+  it("silently reaps an ancient dead-owner monitor exactly once", async () => {
+    await registerMonitor(
+      {
+        monitor_id: "ancient-abandoned",
+        owner_seat: "gone-owner",
+        watch_targets: ["/tmp/ancient-abandoned"],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    await sweepMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      notify: vi.fn(),
+      sweeperAgentId: "sweeper",
+    });
+    const rearm = vi.fn();
+    const escalate = vi.fn();
+    const reaped: string[] = [];
+
+    for (let tick = 0; tick < 10; tick += 1) {
+      const result = await reconcileMonitorRegistry({
+        registryPath: registryPath(),
+        now: () => 172_801_001 + tick * 1_000,
+        reapAfterMs: 86_400_000,
+        ownerAlive: async () => false,
+        rearm,
+        escalate,
+      });
+      reaped.push(...result.reaped);
+    }
+
+    expect(reaped).toEqual(["ancient-abandoned"]);
+    expect(rearm).not.toHaveBeenCalled();
+    expect(escalate).not.toHaveBeenCalled();
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      monitor_id: "ancient-abandoned",
+      state: "dead",
+    });
+  });
+
   it("collapses a pty-dead owner's monitor and escalates exactly once", async () => {
     const watchedFile = join(TEST_DIR, "owner-pty-dead.md");
     writeFileSync(watchedFile, "# collab\n", "utf8");
@@ -526,6 +613,250 @@ describe("monitor registry deadman core", () => {
       state: "collapsed",
       collapsed_reason: "owner-pty-dead",
     });
+  });
+
+  it("collapses an unacknowledged re-arm for a pane-alive wedged owner exactly once", async () => {
+    const watchedFile = join(TEST_DIR, "owner-wedged.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "owner-wedged",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const rearm = vi.fn().mockResolvedValue(undefined);
+    const escalate = vi.fn().mockResolvedValue(undefined);
+    const common = {
+      registryPath: registryPath(),
+      rearmAckTimeoutMs: 10_000,
+      ownerPtyDead: async () => false,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm,
+      escalate,
+    };
+
+    const dispatched = await reconcileMonitorRegistry({
+      ...common,
+      now: () => 62_000,
+    });
+    const wedged = await reconcileMonitorRegistry({
+      ...common,
+      now: () => 72_001,
+    });
+    const repeated = [];
+    for (let tick = 0; tick < 10; tick += 1) {
+      repeated.push(
+        await reconcileMonitorRegistry({
+          ...common,
+          now: () => 82_002 + tick * 10_000,
+        }),
+      );
+    }
+
+    expect(dispatched.rearmed).toEqual(["owner-wedged"]);
+    expect(wedged.collapsed).toEqual([
+      { monitor_id: "owner-wedged", reason: "owner-wedged" },
+    ]);
+    expect(repeated).toEqual(
+      Array.from({ length: 10 }, () =>
+        expect.objectContaining({
+          rearmed: [],
+          collapsed: [],
+          reaped: [],
+          failed: [],
+        }),
+      ),
+    );
+    expect(rearm).toHaveBeenCalledTimes(1);
+    expect(escalate).toHaveBeenCalledTimes(1);
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      state: "collapsed",
+      collapsed_reason: "owner-wedged",
+    });
+  });
+
+  it("accepts timely monitor progress without owner-wedged escalation", async () => {
+    const watchedFile = join(TEST_DIR, "owner-acks.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "owner-acks",
+        owner_seat: "worker-live",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const escalate = vi.fn();
+    await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      rearm: vi.fn(),
+      escalate,
+    });
+
+    const acknowledged = await signalMonitor("owner-acks", {
+      registryPath: registryPath(),
+      now: () => 65_000,
+    });
+    const next = await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 72_001,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm: vi.fn(),
+      escalate,
+    });
+
+    expect(acknowledged).toMatchObject({ state: "alive" });
+    expect(next.collapsed).toEqual([]);
+    expect(escalate).not.toHaveBeenCalled();
+  });
+
+  it("retries normally when the owner progressed after re-arm dispatch", async () => {
+    const watchedFile = join(TEST_DIR, "owner-progressed.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "owner-progressed",
+        owner_seat: "worker-live",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const rearm = vi.fn().mockResolvedValue(undefined);
+    const escalate = vi.fn();
+    await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 62_000,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm,
+      escalate,
+    });
+    const retried = await reconcileMonitorRegistry({
+      registryPath: registryPath(),
+      now: () => 72_001,
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async (record) =>
+        record.rearm_claimed_at === iso(62_000),
+      rearm,
+      escalate,
+    });
+
+    expect(retried.rearmed).toEqual(["owner-progressed"]);
+    expect(retried.collapsed).toEqual([]);
+    expect(rearm).toHaveBeenCalledTimes(2);
+    expect(escalate).not.toHaveBeenCalled();
+  });
+
+  it("uses daemon fallback once for an explicitly owner-independent wedged monitor", async () => {
+    const watchedFile = join(TEST_DIR, "independent-wedged.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "independent-wedged",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const rearm = vi.fn().mockResolvedValue(undefined);
+    const fallbackRearm = vi.fn().mockResolvedValue(undefined);
+    const escalate = vi.fn();
+    const common = {
+      registryPath: registryPath(),
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      ownerIndependent: async () => true,
+      fallbackRearm,
+      rearm,
+      escalate,
+    };
+
+    await reconcileMonitorRegistry({ ...common, now: () => 62_000 });
+    const fallback = await reconcileMonitorRegistry({
+      ...common,
+      now: () => 72_001,
+    });
+    const repeated = await reconcileMonitorRegistry({
+      ...common,
+      now: () => 82_002,
+    });
+
+    expect(fallback.rearmed).toEqual(["independent-wedged"]);
+    expect(fallback.collapsed).toEqual([]);
+    expect(repeated.rearmed).toEqual([]);
+    expect(rearm).toHaveBeenCalledTimes(1);
+    expect(fallbackRearm).toHaveBeenCalledTimes(1);
+    expect(escalate).not.toHaveBeenCalled();
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      state: "alive",
+      last_signal_at: iso(72_001),
+    });
+  });
+
+  it("clears an owner-wedged collapse when genuine monitor progress resumes", async () => {
+    const watchedFile = join(TEST_DIR, "wedged-recovers.md");
+    writeFileSync(watchedFile, "# collab\n", "utf8");
+    await registerMonitor(
+      {
+        monitor_id: "wedged-recovers",
+        owner_seat: "worker-wedged",
+        watch_targets: [watchedFile],
+        mechanism: "event",
+        deadman_timeout_s: 60,
+        rearm_command: `tail -n0 -F ${watchedFile}`,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const common = {
+      registryPath: registryPath(),
+      rearmAckTimeoutMs: 10_000,
+      ownerAlive: async () => true,
+      ownerProgressedSince: async () => false,
+      rearm: vi.fn(),
+      escalate: vi.fn(),
+    };
+    await reconcileMonitorRegistry({ ...common, now: () => 62_000 });
+    await reconcileMonitorRegistry({ ...common, now: () => 72_001 });
+    expect(readMonitorRegistry({ registryPath: registryPath() }).monitors[0]).toMatchObject({
+      state: "collapsed",
+      collapsed_reason: "owner-wedged",
+    });
+
+    const recovered = await signalMonitor("wedged-recovers", {
+      registryPath: registryPath(),
+      now: () => 73_000,
+    });
+
+    expect(recovered).toMatchObject({
+      monitor_id: "wedged-recovers",
+      state: "alive",
+      last_signal_at: iso(73_000),
+    });
+    expect(recovered).not.toHaveProperty("collapsed_reason");
+    expect(recovered).not.toHaveProperty("rearm_claimed_at");
   });
 
   it("continues reconciling later monitors when collapse escalation rejects", async () => {


### PR DESCRIPTION
## Summary
- classify pane-alive owners as `owner-wedged` when a durable monitor re-arm remains unacknowledged past the injected timeout
- use exact inbox ACKs/post-dispatch heartbeats, preserve one-shot daemon fallback seams, and allow genuine monitor progress to clear the collapse
- keep terminal monitors quiet, silently reap ancient gone-owner monitors after 24h, and add `monitor_id:transition` notification dedupe keys
- make direct daemon/test construction notification-safe; live registry and HTTP delivery are wired only by `runDaemon`, with hard no-ops under `VITEST`/`NODE_ENV=test`

## Live flood incident guard
- claimed `deadman-fired`, `collapsed`, and `dead` records never re-enter notification transitions
- interval daemon fixtures are captured and force-shutdown in async teardown
- grep audit found no monitor test importing `httpNotifyMonitorDeadman`; remaining `3847` test references are fake-curl/no-delivery regressions

## Verification
- [x] focused daemon/registry/health/outbox suites: 113/113
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] five consecutive isolated cold suites before rebase: 90 files / 1,694 tests each
- [x] post-rebase suite: 91 files / 1,704 tests
- [x] pre-push hook: 91 files / 1,704 tests
- [x] `git diff --check`

## Review disposition
- CodeRabbit local CLI: SKIPPED after the required ~3 minute bound; it remained in `reviewing` and emitted no findings
- red-team/blue-team fallback: no unresolved critical/high findings
- manual review finding fixed before commit: lifecycle `updated_at` was replaced with canonical inbox ACK/agent-heartbeat evidence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core monitor reconciliation, escalation, and notification paths in the daemon; behavior is heavily tested but mis-tuned timeouts or progress detection could misclassify live owners.
> 
> **Overview**
> Monitor reconciliation no longer redispatches re-arm forever when the owner pane is readable but never acknowledges. After **`rearmAckTimeoutMs`** (daemon default: 2× reconcile interval), an expired **`rearming`** claim with no owner progress collapses once as **`owner-wedged`** and triggers a dedicated escalation notification; timely **`signal_monitor`**, inbox ACK for the deterministic re-arm message ID, or a post-claim agent heartbeat still allow normal retry or recovery.
> 
> The daemon wires **`ownerProgressedSince`** from inbox ACKs and heartbeats, adds **`monitorOwnerWedgedNotify`**, and attaches **`dedupe_key`** on collapse notifications. The registry gains optional **`ownerIndependent`** / **`fallbackRearm`**, a silent pre-pass that reaps ancient non-dead monitors whose owner is not alive to **`dead`**, and **`reaped`** in reconcile results; **`signal_monitor`** can clear **`owner-wedged`** collapse back to **`alive`**.
> 
> Deadman and collapse HTTP payloads now include stable **`monitor_id:transition`** dedupe keys via **`NotifyPayload.dedupe_key`**. Live registry/outbox/notify wiring is confined to **`runDaemon`** with test-mode no-ops; direct **`CmuxLayerDaemon`** construction no longer auto-enables default reconciler or HTTP delivery, and interval daemon tests shut down asynchronously in teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a189ccf31b88a09938b79a338b90d64bd5f39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail over monitors whose owner pane is alive but wedged in the monitor registry
> - Adds `owner-wedged` as a new `MonitorCollapseReason` in [monitor-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/295/files#diff-31e50deaff71fd7c2f67d754a4e883322f6e1888d19e5b0708d1813cd7c115c0): when a re-arm goes unacknowledged past `rearmAckTimeoutMs`, the reconciler classifies the owner as wedged rather than dead and escalates with a distinct notification.
> - Monitors marked as owner-independent can fall back to a daemon-provided re-arm instead of collapsing, and a genuine signal from the monitor recovers it back to alive.
> - Reconciliation now also silently reaps abandoned monitors (non-dead owner, no recent activity) after `DEFAULT_REAP_AFTER_MS` (24 hours), reporting reaped IDs in the result.
> - Deadman notifications gain a `dedupe_key` field in [outbox-drainer.ts](https://github.com/EtanHey/cmuxlayer/pull/295/files#diff-c99dfc4088f2d0bdd9610c2f62d96ba7848d6882dab69a484652d8000e5fb49d), [monitor-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/295/files#diff-31e50deaff71fd7c2f67d754a4e883322f6e1888d19e5b0708d1813cd7c115c0), and [daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/295/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539) to prevent duplicate alerts.
> - Behavioral Change: `runDaemon` now disables live HTTP side-effects (outbox drain, deadman notify) when running under test mode; production daemons use real network calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b0a189c. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and handling for monitors with pane-alive but unresponsive owners.
  * Monitors can now transition to a visible `owner-wedged` collapsed state with notifications.
  * Added recovery when owner progress resumes, including safe fallback reactivation.
  * Added deduplication keys for monitor and deadman notifications.
  * Added silent cleanup for abandoned monitors after a configurable age.

* **Bug Fixes**
  * Prevented repeated escalation, rearming, and notifications for terminal monitor states.
  * Improved monitor health surfaces with owner-wedged recovery details.

* **Tests**
  * Expanded coverage for escalation, recovery, retries, idempotency, cleanup, and notification deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->