### PR TITLE
fix(layout): enforce worker panes out of the leftmost lead column

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -282,13 +282,15 @@ export function formatResync(diff: {
   added: string[];
   evicted: string[];
   repaired?: unknown[];
+  reflowed?: unknown[];
   mismatches: string[];
   orphaned?: string[];
 }): string {
   const added = diff.added.length;
   const evicted = diff.evicted.length;
   const repaired = diff.repaired?.length ?? 0;
+  const reflowed = diff.reflowed?.length ?? 0;
   const mismatches = diff.mismatches.length;
   const orphaned = diff.orphaned?.length ?? 0;
-  return `✔ resync_agents — added: ${added}  repaired: ${repaired}  evicted: ${evicted}  mismatches: ${mismatches}  orphaned: ${orphaned}`;
+  return `✔ resync_agents — added: ${added}  repaired: ${repaired}  reflowed: ${reflowed}  evicted: ${evicted}  mismatches: ${mismatches}  orphaned: ${orphaned}`;
 }

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -464,19 +464,22 @@ export function chooseAgentSpawnPlacement(
       : { kind: "split", direction: "left" };
   }
 
-  const hasLeadColumn =
-    layouts.some(isLeadMajorityPane) ||
-    context.parentRole === "orchestrator" ||
-    context.parentRole === "ic";
-  // A worker from a lead-owned single-column workspace has no classified
-  // destination surface yet. Seed the right worker column without anchoring the
-  // split to the lead pane.
-  if (
-    role === "worker" &&
-    columnCount < 2 &&
-    hasLeadColumn
-  ) {
-    return { kind: "split", direction: "right" };
+  // Column 0 is reserved for leads. A worker in any single-column workspace
+  // must seed the right worker column, even when the existing pane is already
+  // worker-owned or role classification is sparse. Docking into that pane would
+  // make the bad placement fill-dependent and permanent.
+  if (role === "worker" && columnCount < 2) {
+    const hasLeadColumn =
+      layouts.some(isLeadMajorityPane) ||
+      context.parentRole === "orchestrator" ||
+      context.parentRole === "ic";
+    return hasLeadColumn
+      ? { kind: "split", direction: "right" }
+      : {
+          kind: "split",
+          direction: "right",
+          pane: rightmostByColumn(layouts)?.pane.ref,
+        };
   }
 
   const workerPanes = layouts.filter(isDedicatedWorkerPane);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8044,7 +8044,92 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const surfacelessEvicted = await registry.evictSurfaceless();
           engine.evictDeadProcessAgents();
           discovery.invalidate();
-          const after = await registry.listMerged(discovery, { force: true });
+          let after = await registry.listMerged(discovery, { force: true });
+          const topologyBeforeReflow = await collectSurfaceTopology();
+          const reflowed: Array<{
+            agent_id: string;
+            surface_id: string;
+            from_column: number;
+            to_column: number;
+            pane: string;
+          }> = [];
+
+          if (topologyBeforeReflow) {
+            const panesByWorkspace = new Map<
+              string,
+              Awaited<ReturnType<typeof client.listPanes>>
+            >();
+
+            for (const agent of after) {
+              if (inferRecordRoleOrNull(agent) !== "worker") continue;
+              const current = topologyBeforeReflow.topologyBySurface.get(
+                agent.surface_id,
+              );
+              if (current?.column !== 0 || (current.column_count ?? 0) < 2) {
+                continue;
+              }
+
+              const workspace =
+                topologyBeforeReflow.workspaceBySurface.get(agent.surface_id) ??
+                agent.workspace_id;
+              if (!workspace) {
+                throw new Error(
+                  `Cannot reflow worker ${agent.agent_id}: live workspace is unknown`,
+                );
+              }
+
+              let panes = panesByWorkspace.get(workspace);
+              if (!panes) {
+                panes = await client.listPanes({ workspace });
+                panesByWorkspace.set(workspace, panes);
+              }
+              const columns = deriveColumnIndex(panes.panes);
+              const target = [...panes.panes]
+                .filter((pane) => (columns.get(pane.ref) ?? 0) > 0)
+                .sort((a, b) => {
+                  const columnDelta =
+                    (columns.get(a.ref) ?? 0) - (columns.get(b.ref) ?? 0);
+                  return columnDelta || a.index - b.index;
+                })
+                .at(-1);
+              if (!target) {
+                throw new Error(
+                  `Cannot reflow worker ${agent.agent_id}: no non-leftmost pane exists in ${workspace}`,
+                );
+              }
+
+              await client.moveSurface({
+                surface: agent.surface_id,
+                pane: target.ref,
+                workspace,
+                focus: false,
+              });
+              reflowed.push({
+                agent_id: agent.agent_id,
+                surface_id: agent.surface_id,
+                from_column: current.column,
+                to_column: columns.get(target.ref) ?? 1,
+                pane: target.ref,
+              });
+            }
+          }
+
+          if (reflowed.length > 0) {
+            const topologyAfterReflow = await collectSurfaceTopology();
+            for (const repair of reflowed) {
+              const actual = topologyAfterReflow?.topologyBySurface.get(
+                repair.surface_id,
+              );
+              if (actual?.column === 0 || actual?.column == null) {
+                throw new Error(
+                  `Worker placement repair failed for ${repair.agent_id}: surface ${repair.surface_id} remains in column ${actual?.column ?? "unknown"}`,
+                );
+              }
+              repair.to_column = actual.column;
+            }
+            discovery.invalidate();
+            after = await registry.listMerged(discovery, { force: true });
+          }
           const discovered = await discovery.scan();
           const afterIds = new Set(after.map((agent) => agent.agent_id));
           const managedSurfaceIds = new Set(
@@ -8070,6 +8155,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             added: [...afterIds].filter((id) => !beforeIds.has(id)),
             evicted,
             repaired: repair.repaired,
+            reflowed,
             mismatches: after
               .filter((agent) => agent.parsed_cli_mismatch)
               .map((agent) => agent.agent_id),

--- a/src/server.ts
+++ b/src/server.ts
@@ -8065,68 +8065,85 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               const current = topologyBeforeReflow.topologyBySurface.get(
                 agent.surface_id,
               );
-              if (current?.column !== 0 || (current.column_count ?? 0) < 2) {
+              if (current?.column !== 0) continue;
+
+              let seededSurface: string | null = null;
+              let workspace: string | null = null;
+              try {
+                workspace =
+                  topologyBeforeReflow.workspaceBySurface.get(
+                    agent.surface_id,
+                  ) ?? agent.workspace_id ?? null;
+                if (!workspace) continue;
+
+                let targetPane: string | null = null;
+                if ((current.column_count ?? 0) < 2) {
+                  const seed = await client.newSplit("right", {
+                    workspace,
+                    surface: agent.surface_id,
+                    type: "terminal",
+                  });
+                  targetPane = seed.pane;
+                  seededSurface = seed.surface;
+                  panesByWorkspace.delete(workspace);
+                } else {
+                  let panes = panesByWorkspace.get(workspace);
+                  if (!panes) {
+                    panes = await client.listPanes({ workspace });
+                    panesByWorkspace.set(workspace, panes);
+                  }
+                  const columns = deriveColumnIndex(panes.panes);
+                  targetPane = [...panes.panes]
+                    .filter((pane) => (columns.get(pane.ref) ?? 0) > 0)
+                    .sort((a, b) => {
+                      const columnDelta =
+                        (columns.get(a.ref) ?? 0) -
+                        (columns.get(b.ref) ?? 0);
+                      return columnDelta || a.index - b.index;
+                    })
+                    .at(-1)?.ref ?? null;
+                }
+                if (!targetPane) continue;
+
+                await client.moveSurface({
+                  surface: agent.surface_id,
+                  pane: targetPane,
+                  workspace,
+                  focus: false,
+                });
+
+                const topologyAfterMove = await collectSurfaceTopology(workspace);
+                const actual = topologyAfterMove?.topologyBySurface.get(
+                  agent.surface_id,
+                );
+                if (actual?.column == null || actual.column === 0) continue;
+
+                reflowed.push({
+                  agent_id: agent.agent_id,
+                  surface_id: agent.surface_id,
+                  from_column: current.column,
+                  to_column: actual.column,
+                  pane: targetPane,
+                });
+              } catch {
+                // Reflow is self-healing best effort. One stale workspace, pane,
+                // or topology read must not abort the registry-wide resync.
                 continue;
+              } finally {
+                if (seededSurface) {
+                  try {
+                    await client.closeSurface(seededSurface, {
+                      ...(workspace ? { workspace } : {}),
+                    });
+                  } catch {
+                    // A seed cleanup race is isolated to this worker as well.
+                  }
+                }
               }
-
-              const workspace =
-                topologyBeforeReflow.workspaceBySurface.get(agent.surface_id) ??
-                agent.workspace_id;
-              if (!workspace) {
-                throw new Error(
-                  `Cannot reflow worker ${agent.agent_id}: live workspace is unknown`,
-                );
-              }
-
-              let panes = panesByWorkspace.get(workspace);
-              if (!panes) {
-                panes = await client.listPanes({ workspace });
-                panesByWorkspace.set(workspace, panes);
-              }
-              const columns = deriveColumnIndex(panes.panes);
-              const target = [...panes.panes]
-                .filter((pane) => (columns.get(pane.ref) ?? 0) > 0)
-                .sort((a, b) => {
-                  const columnDelta =
-                    (columns.get(a.ref) ?? 0) - (columns.get(b.ref) ?? 0);
-                  return columnDelta || a.index - b.index;
-                })
-                .at(-1);
-              if (!target) {
-                throw new Error(
-                  `Cannot reflow worker ${agent.agent_id}: no non-leftmost pane exists in ${workspace}`,
-                );
-              }
-
-              await client.moveSurface({
-                surface: agent.surface_id,
-                pane: target.ref,
-                workspace,
-                focus: false,
-              });
-              reflowed.push({
-                agent_id: agent.agent_id,
-                surface_id: agent.surface_id,
-                from_column: current.column,
-                to_column: columns.get(target.ref) ?? 1,
-                pane: target.ref,
-              });
             }
           }
 
           if (reflowed.length > 0) {
-            const topologyAfterReflow = await collectSurfaceTopology();
-            for (const repair of reflowed) {
-              const actual = topologyAfterReflow?.topologyBySurface.get(
-                repair.surface_id,
-              );
-              if (actual?.column === 0 || actual?.column == null) {
-                throw new Error(
-                  `Worker placement repair failed for ${repair.agent_id}: surface ${repair.surface_id} remains in column ${actual?.column ?? "unknown"}`,
-                );
-              }
-              repair.to_column = actual.column;
-            }
             discovery.invalidate();
             after = await registry.listMerged(discovery, { force: true });
           }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1151,7 +1151,7 @@ describe("AgentEngine", () => {
       expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
 
-    it("rehydrates persisted role surfaces before placing after reconnect", async () => {
+    it("does not reuse a persisted worker surface in column 0 after reconnect", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "existing-worker",
@@ -1191,12 +1191,12 @@ describe("AgentEngine", () => {
         workspace: "ws:1",
       });
 
-      expect(mockClient.newSurface).toHaveBeenCalledWith({
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
         pane: "pane:worker",
         type: "terminal",
         workspace: "ws:1",
       });
-      expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
 
     it("partitions unfiltered surface lists by pane membership when placing spawned agents", async () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -552,7 +552,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "split", direction: "left" });
   });
 
-  it("docks workers into launcher-title Codex panes without registry state", () => {
+  it("keeps a worker spawn out of column 0 when the only pane is worker-owned", () => {
     const panes = [makePane("pane:worker", 0, ["surface:cmuxlayer-worker"])];
     const paneSurfaces = [
       makeTitledPaneSurfaces("pane:worker", [
@@ -574,7 +574,20 @@ describe("layout policy", () => {
       { role: "worker" },
     );
 
-    expect(placement).toEqual({ kind: "surface", pane: "pane:worker" });
+    const columns = deriveColumnIndex(panes);
+    const resolvedColumn =
+      placement.kind === "surface"
+        ? columns.get(placement.pane)
+        : placement.direction === "right"
+          ? 1
+          : columns.get(placement.pane ?? "pane:worker");
+
+    expect(resolvedColumn).not.toBe(0);
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+      pane: "pane:worker",
+    });
   });
 
   it("places the first IC in the right column above existing workers", () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -877,6 +877,140 @@ function makeRegistryRepairExec(
   });
 }
 
+function makeLeftColumnWorkerExec(): ExecFn {
+  let workerPane = "pane:left";
+
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("move-surface")) {
+      workerPane = String(args[args.indexOf("--pane") + 1]);
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          pane: workerPane,
+          surface: "surface:worker-left",
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Active",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:left",
+              index: 0,
+              focused: true,
+              surface_count: workerPane === "pane:left" ? 2 : 1,
+              surface_refs:
+                workerPane === "pane:left"
+                  ? ["surface:lead", "surface:worker-left"]
+                  : ["surface:lead"],
+              selected_surface_ref: "surface:lead",
+              pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+            },
+            {
+              ref: "pane:right",
+              index: 1,
+              focused: false,
+              surface_count: workerPane === "pane:right" ? 2 : 1,
+              surface_refs:
+                workerPane === "pane:right"
+                  ? ["surface:shell", "surface:worker-left"]
+                  : ["surface:shell"],
+              selected_surface_ref: "surface:shell",
+              pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      const pane = String(args[args.indexOf("--pane") + 1]);
+      const base =
+        pane === "pane:left"
+          ? [
+              {
+                ref: "surface:lead",
+                title: "cmuxlayerClaude-LEAD",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ]
+          : [
+              {
+                ref: "surface:shell",
+                title: "notes",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ];
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces:
+            workerPane === pane
+              ? [
+                  ...base,
+                  {
+                    ref: "surface:worker-left",
+                    title: "stalkerCodex",
+                    type: "terminal",
+                    index: 1,
+                    selected: false,
+                  },
+                ]
+              : base,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      const surface = String(args[args.indexOf("--surface") + 1]);
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text:
+            surface === "surface:worker-left"
+              ? "gpt-5.5 · Working (1m 03s • esc to interrupt)"
+              : "Claude Code\n✻ Working…\n🤖 Opus 4.8",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return { stdout: JSON.stringify({}), stderr: "" };
+  });
+}
+
 describe("resync_agents tool", () => {
   beforeEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
@@ -947,6 +1081,35 @@ describe("resync_agents tool", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.diff.added).toHaveLength(1);
     expect(parsed.count).toBe(1);
+  });
+
+  it("resync_agents moves an auto-discovered worker out of the leftmost lead column", async () => {
+    const exec = makeLeftColumnWorkerExec();
+    const server = createServer({ exec, stateDir: TEST_DIR });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "move-surface",
+        "--surface",
+        "surface:worker-left",
+        "--pane",
+        "pane:right",
+      ]),
+    );
+    expect(parsed.diff.reflowed).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:worker-left",
+        from_column: 0,
+        to_column: 1,
+      }),
+    ]);
   });
 
   it("list_agents persists live state updates for existing auto-discovered agents", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -877,10 +877,33 @@ function makeRegistryRepairExec(
   });
 }
 
-function makeLeftColumnWorkerExec(): ExecFn {
+function makeLeftColumnWorkerExec(
+  opts: {
+    singleColumn?: boolean;
+    failPostMoveTopologyOnce?: boolean;
+  } = {},
+): ExecFn {
   let workerPane = "pane:left";
+  let rightPaneExists = !opts.singleColumn;
+  let seedSurfaceOpen = false;
+  let postMoveTopologyFailed = false;
 
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("new-split")) {
+      rightPaneExists = true;
+      seedSurfaceOpen = true;
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          pane: "pane:right",
+          surface: "surface:worker-column-seed",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    }
+
     if (args.includes("move-surface")) {
       workerPane = String(args[args.indexOf("--pane") + 1]);
       return {
@@ -891,6 +914,11 @@ function makeLeftColumnWorkerExec(): ExecFn {
         }),
         stderr: "",
       };
+    }
+
+    if (args.includes("close-surface")) {
+      seedSurfaceOpen = false;
+      return { stdout: JSON.stringify({ ok: true }), stderr: "" };
     }
 
     if (args.includes("list-workspaces")) {
@@ -911,6 +939,14 @@ function makeLeftColumnWorkerExec(): ExecFn {
     }
 
     if (args.includes("list-panes")) {
+      if (
+        opts.failPostMoveTopologyOnce &&
+        workerPane === "pane:right" &&
+        !postMoveTopologyFailed
+      ) {
+        postMoveTopologyFailed = true;
+        throw new Error("transient pane topology failure");
+      }
       return {
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
@@ -928,18 +964,36 @@ function makeLeftColumnWorkerExec(): ExecFn {
               selected_surface_ref: "surface:lead",
               pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
             },
-            {
-              ref: "pane:right",
-              index: 1,
-              focused: false,
-              surface_count: workerPane === "pane:right" ? 2 : 1,
-              surface_refs:
-                workerPane === "pane:right"
-                  ? ["surface:shell", "surface:worker-left"]
-                  : ["surface:shell"],
-              selected_surface_ref: "surface:shell",
-              pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
-            },
+            ...(rightPaneExists
+              ? [
+                  {
+                    ref: "pane:right",
+                    index: 1,
+                    focused: false,
+                    surface_count:
+                      Number(seedSurfaceOpen) +
+                      Number(workerPane === "pane:right") ||
+                      1,
+                    surface_refs: [
+                      ...(seedSurfaceOpen
+                        ? ["surface:worker-column-seed"]
+                        : []),
+                      ...(workerPane === "pane:right"
+                        ? ["surface:worker-left"]
+                        : []),
+                      ...(!seedSurfaceOpen && workerPane !== "pane:right"
+                        ? ["surface:shell"]
+                        : []),
+                    ],
+                    selected_surface_ref: seedSurfaceOpen
+                      ? "surface:worker-column-seed"
+                      : workerPane === "pane:right"
+                        ? "surface:worker-left"
+                        : "surface:shell",
+                    pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+                  },
+                ]
+              : []),
           ],
         }),
         stderr: "",
@@ -960,13 +1014,28 @@ function makeLeftColumnWorkerExec(): ExecFn {
               },
             ]
           : [
-              {
-                ref: "surface:shell",
-                title: "notes",
-                type: "terminal",
-                index: 0,
-                selected: true,
-              },
+              ...(seedSurfaceOpen
+                ? [
+                    {
+                      ref: "surface:worker-column-seed",
+                      title: "",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : []),
+              ...(!seedSurfaceOpen && workerPane !== "pane:right"
+                ? [
+                    {
+                      ref: "surface:shell",
+                      title: "notes",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : []),
             ];
       return {
         stdout: JSON.stringify({
@@ -1110,6 +1179,67 @@ describe("resync_agents tool", () => {
         to_column: 1,
       }),
     ]);
+  });
+
+  it("resync_agents seeds a right column for a single-column auto-discovered worker", async () => {
+    const exec = makeLeftColumnWorkerExec({ singleColumn: true });
+    const server = createServer({ exec, stateDir: TEST_DIR });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "new-split",
+        "right",
+        "--surface",
+        "surface:worker-left",
+      ]),
+    );
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "move-surface",
+        "--surface",
+        "surface:worker-left",
+        "--pane",
+        "pane:right",
+      ]),
+    );
+    expect(parsed.diff.reflowed).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:worker-left",
+        from_column: 0,
+        to_column: 1,
+      }),
+    ]);
+  });
+
+  it("resync_agents keeps its normal diff when post-move topology is transiently unavailable", async () => {
+    const exec = makeLeftColumnWorkerExec({ failPostMoveTopologyOnce: true });
+    const server = createServer({ exec, stateDir: TEST_DIR });
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diff).toEqual(
+      expect.objectContaining({
+        added: expect.any(Array),
+        evicted: expect.any(Array),
+        repaired: expect.any(Array),
+        orphaned: expect.any(Array),
+        reflowed: [],
+      }),
+    );
   });
 
   it("list_agents persists live state updates for existing auto-discovered agents", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6272,7 +6272,7 @@ describe("tool handler integration", () => {
     );
   });
 
-  it("new_split with role=worker rejects focus=false when placement becomes a tab", async () => {
+  it("new_split with role=worker rejects focus=false while seeding the worker column", async () => {
     const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-focus-state");
     rmSync(stateDir, { recursive: true, force: true });
     const stateMgr = new StateManager(stateDir);
@@ -6378,7 +6378,7 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("focus=false");
+    expect(parsed.error).toContain("unfocused splits");
     expect(mockExec).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["new-surface"]),


### PR DESCRIPTION
## Summary
- reserve column 0 for leads by forcing every single-column worker spawn to seed a right split
- reflow managed and auto-discovered workers out of column 0 during resync and verify their post-move topology
- report reflow repairs in resync output and add RED-to-GREEN regression coverage across layout, engine, server, and resync paths

## Root cause
Worker placement was fill-dependent: a single worker-owned pane in column 0 was treated as a valid docking target, while legacy worker fallbacks could choose vertical placement. That allowed managed and discovered workers to remain in the lead column. Resync only detected worker_in_leftmost_column; it did not correct it.

## Test plan
- bun run test (92 files, 1716 tests)
- bun run typecheck
- bun run pre-pr (61 harness tests)
- local CodeRabbit pre-commit review completed with no findings emitted

## Handoff
Ready for the lead reviewer pane. Do not merge until that review is complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live spawn placement and resync now mutates cmux topology (splits/moves/closes), though errors are handled per-agent as best-effort.
> 
> **Overview**
> **Worker placement** no longer docks into column 0 when the workspace is still single-column. Every worker spawn in that case forces a **right split** (anchored to the rightmost pane when no lead column is detected), instead of reusing a worker-owned left pane or persisted column-0 surface on reconnect.
> 
> **`resync_agents`** adds a **reflow** pass after repair: managed workers sitting in column 0 are moved to the rightmost non-left column via `move-surface`, seeding a right split when the workspace has only one column. Successful moves are recorded in **`reflowed`** on the diff; **`formatResync`** prints a reflow count. Failures and seed cleanup are isolated so one bad workspace does not abort the resync.
> 
> Tests were updated to match the new spawn/reflow behavior across layout policy, agent engine, server, and resync tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd103d882929e55aa5dec5c1310ae1ede6c22bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce worker panes out of the leftmost column during agent resync
> - Updates `chooseAgentSpawnPlacement` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/297/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) so workers always split right in single-column workspaces, anchoring to the rightmost pane when no lead column exists.
> - Adds a reflow step to the `resync_agents` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/297/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): after repair and eviction, any worker surface found in column 0 is moved to a right-column pane, seeding a right split if the workspace has only one column.
> - Reflow results are collected in a `reflowed` array and surfaced in the resync summary via an updated `formatResync` in [format.ts](https://github.com/EtanHey/cmuxlayer/pull/297/files#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36b).
> - Reflow errors are caught and non-fatal; the registry is refreshed only if at least one move succeeds.
> - Behavioral Change: persisted worker surfaces in column 0 are no longer reused on reconnect — a right split is created instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdd103d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->