### PR TITLE
feat(seat): write per-seat expected-state manifest at spawn/pin (A3 resume-integrity)

### DIFF
--- a/docs/plans/2026-07-12-seat-manifest-design.md
+++ b/docs/plans/2026-07-12-seat-manifest-design.md
@@ -1,0 +1,32 @@
+# Per-seat Expected-state Manifest Design
+
+## Purpose
+
+Activate orchestrator's A3 resume-integrity watcher by publishing the state that cmuxlayer intentionally established for each managed seat.
+
+## Design
+
+Add a small `seat-manifest` module that owns the JSON contract, surface-id filename sanitization, the default orchestrator directory, and an atomic filesystem writer. Server construction accepts an injected writer; production server construction defaults to the filesystem writer, while Vitest construction defaults to a no-op so the test suite cannot touch `~/Gits/orchestrator`.
+
+After a managed spawn is registered and renamed, the server publishes the agent record plus its actual tab title, pinned model, `-s` permission mode, launch cwd/repo, CLI session id, and timestamp. Deliberate `rename_tab` and `interact(action=model)` mutations refresh the existing manifest only after their surface operation succeeds. Both `spawn_agent` and `new_worktree_split` share the same publishing helper.
+
+Writer failures are best-effort and logged because manifest publication must not turn a successfully created/control-plane seat into an API failure. Tests inject an in-memory writer and assert exact payloads and refresh behavior; the filesystem writer is tested only against a temporary directory.
+
+## JSON contract
+
+```json
+{
+  "surface_id": "surface:42",
+  "agent_id": "cmuxlayer-codex",
+  "tab_name": "cmuxlayerCodex [surface:42]",
+  "session_name": "019...",
+  "model": "fable-5",
+  "permission_mode": "skip-permissions",
+  "cwd": "/Users/etanheyman/Gits/cmuxlayer",
+  "repo": "cmuxlayer",
+  "cli": "codex",
+  "updated_at": "2026-07-12T12:00:00.000Z"
+}
+```
+
+The default path is `~/Gits/orchestrator/docs.local/monitor-state/seat-manifests/<surface>.json`; `CMUXLAYER_SEAT_MANIFEST_DIR` overrides the directory and `:` is sanitized to `-` in filenames.

--- a/docs/plans/2026-07-12-seat-manifest.md
+++ b/docs/plans/2026-07-12-seat-manifest.md
@@ -1,0 +1,55 @@
+# Per-seat Expected-state Manifest Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Write and refresh an injectable per-seat expected-state manifest so orchestrator's A3 resume-integrity watcher can compare deliberate state with live state.
+
+**Architecture:** A focused manifest module defines the schema and atomic filesystem adapter. `createServer` owns a shared injected/no-op writer and publishes from successful spawn, rename, and model-pin mutation paths using registered agent state plus live tab metadata.
+
+**Tech Stack:** TypeScript, Bun/Vitest, Node filesystem promises, cmuxlayer MCP tool harness.
+
+---
+
+### Task 1: Manifest contract and isolated filesystem adapter
+
+**Files:**
+- Create: `src/seat-manifest.ts`
+- Create: `tests/seat-manifest.test.ts`
+
+1. Write tests for exact schema serialization, `surface:42` filename sanitization, env/default directory resolution, and atomic writes inside an injected temporary directory.
+2. Run `bun run test tests/seat-manifest.test.ts` and confirm RED because the module does not exist.
+3. Implement the minimal types, path resolver, and filesystem writer.
+4. Re-run the focused test and confirm GREEN.
+
+### Task 2: Spawn-path publication with injection
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+1. Add a failing spawn-path test that injects a recording writer and spawns `fable-5` through the mocked server.
+2. Assert the exact manifest fields, including `permission_mode`, cwd/repo, tab/session, model pin, and that only the injected writer is called.
+3. Run the focused test and confirm RED from zero writer calls.
+4. Add the injectable server option, a best-effort publisher, and production filesystem injection.
+5. Publish after `spawn_agent` and `new_worktree_split` registration/metadata refresh, then confirm the focused tests GREEN.
+
+### Task 3: Deliberate pin and rename refresh
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+1. Add failing tests for `interact(action=model)` and `rename_tab` refreshing the manifest only after successful mutations.
+2. Run the focused tests and confirm RED.
+3. Persist the deliberate model pin in agent state, refresh the manifest, and refresh after tab rename.
+4. Re-run focused tests and confirm GREEN.
+
+### Task 4: Verification and PR handoff
+
+**Files:**
+- Modify: `docs.local/collab/driver-buddy-2026-07-12.md` in orchestrator only for the requested channel post (not part of this repository commit).
+
+1. Run `bun run test` and `bun run typecheck` and read complete results.
+2. Review the diff and run the repository's available pre-commit reviewer within its bounded timeout.
+3. Commit the scoped files, push `feat/seat-manifest-at-spawn`, and open a ready-for-review PR titled `feat(seat): write per-seat expected-state manifest at spawn/pin (A3 resume-integrity)`.
+4. Invoke reviewers, post the path/schema to the 07-12 channel for `a3-watcher-codex`, and report the PR without merging.

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -33,6 +33,8 @@ export interface AgentRecord {
   cli_session_id: string | null;
   cli_session_path?: string | null;
   launcher_name?: string | null;
+  /** Deliberately pinned tab title used by the resume-integrity manifest. */
+  tab_name?: string | null;
   seat_id?: string | null;
   seat_lane?: string | null;
   seat_role?: string | null;

--- a/src/seat-manifest.ts
+++ b/src/seat-manifest.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { CliType } from "./agent-types.js";
+
+export type SeatPermissionMode = "skip-permissions" | "default";
+
+export interface SeatManifest {
+  surface_id: string;
+  agent_id: string;
+  tab_name: string;
+  session_name: string | null;
+  model: string;
+  permission_mode: SeatPermissionMode;
+  cwd: string;
+  repo: string;
+  cli: CliType;
+  updated_at: string;
+}
+
+export type SeatManifestWriter = (manifest: SeatManifest) => Promise<void>;
+
+export function defaultSeatManifestDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_SEAT_MANIFEST_DIR?.trim();
+  if (override) return override;
+
+  const home = env.HOME?.trim() || homedir();
+  return join(
+    home,
+    "Gits",
+    "orchestrator",
+    "docs.local",
+    "monitor-state",
+    "seat-manifests",
+  );
+}
+
+export function seatManifestFileName(surfaceId: string): string {
+  return `${surfaceId.replace(/[^A-Za-z0-9._-]/g, "-")}.json`;
+}
+
+export function createFileSystemSeatManifestWriter(opts?: {
+  directory?: string;
+}): SeatManifestWriter {
+  const directory = opts?.directory ?? defaultSeatManifestDir();
+
+  return async (manifest) => {
+    await mkdir(directory, { recursive: true });
+    const fileName = seatManifestFileName(manifest.surface_id);
+    const targetPath = join(directory, fileName);
+    const temporaryPath = join(directory, `.${fileName}.${randomUUID()}.tmp`);
+    await writeFile(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporaryPath, targetPath);
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,10 @@ import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
+import {
+  createFileSystemSeatManifestWriter,
+  type SeatManifestWriter,
+} from "./seat-manifest.js";
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { createStaleBuildWarner, RUNNING_VERSION } from "./version.js";
@@ -1853,6 +1857,13 @@ export interface CreateServerOptions {
   enableCloseForensics?: boolean;
   /** Override per-surface PTY write-liveness tracking (primarily for tests). */
   surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
+  /**
+   * Publish deliberate per-seat expected state. Tests inject a recorder/no-op;
+   * production defaults to the orchestrator-backed filesystem writer.
+   */
+  seatManifestWriter?: SeatManifestWriter;
+  /** Override the manifest timestamp source for deterministic tests. */
+  seatManifestNow?: () => string;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -2099,6 +2110,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const surfaceWriteLivenessCandidates =
     context.surfaceWriteLivenessCandidates;
   const surfacePtyDeadSince = context.surfacePtyDeadSince;
+  const seatManifestWriter: SeatManifestWriter =
+    opts?.seatManifestWriter ??
+    (process.env.VITEST === "true"
+      ? async () => {}
+      : createFileSystemSeatManifestWriter());
+  const seatManifestNow =
+    opts?.seatManifestNow ?? (() => new Date().toISOString());
   const enableClaudeChannels =
     opts?.enableClaudeChannels ?? context.enableClaudeChannels;
   const skipAgentLifecycle =
@@ -2150,6 +2168,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // dispatch_to_agent nudge reuse the guarded relay path — stale-surface
   // resync + recycled-occupant identity checks — instead of raw keystrokes.
   let lifecycleAgentInputDeliverer: LifecycleAgentInputDeliverer | null = null;
+  let lifecycleSeatManifestPublisher: (input: {
+    agentId?: string;
+    surfaceId?: string;
+    tabName?: string;
+    model?: string;
+  }) => Promise<void> = async () => {};
   let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
   let lifecycleRefreshManagedMetadata:
     | ((agentId?: string) => Promise<void>)
@@ -2959,6 +2983,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const newTitle = replaceTaskSuffix(currentTitle, opts.rename_to_task);
     await client.renameTab(opts.surface, newTitle, {
       workspace: opts.workspace,
+    });
+    await lifecycleSeatManifestPublisher({
+      surfaceId: opts.surface,
+      tabName: newTitle,
     });
   };
 
@@ -5629,6 +5657,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: args.workspace,
           });
         }, { toolName: "rename_tab", workspace: args.workspace });
+        await lifecycleSeatManifestPublisher({
+          surfaceId: args.surface,
+          tabName: finalTitle,
+        });
         const data = { surface: args.surface, title: finalTitle };
         return okFormatted(formatOk("rename_tab", data), data);
       } catch (e) {
@@ -6476,6 +6508,52 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           seatRegistryPath: opts?.seatRegistryPath,
         },
       );
+    lifecycleSeatManifestPublisher = async (input) => {
+      try {
+        const existing = input.agentId
+          ? engine.getAgentState(input.agentId)
+          : registry.list().find(
+              (record) => record.surface_id === input.surfaceId,
+            ) ?? null;
+        if (!existing) return;
+
+        const updated =
+          input.tabName !== undefined || input.model !== undefined
+            ? stateMgr.updateRecord(existing.agent_id, {
+                ...(input.tabName !== undefined
+                  ? { tab_name: input.tabName }
+                  : {}),
+                ...(input.model !== undefined ? { model: input.model } : {}),
+              })
+            : existing;
+        if (updated !== existing) {
+          registry.set(updated.agent_id, updated);
+        }
+
+        const tabName =
+          updated.tab_name ??
+          `${updated.launcher_name ?? launcherNameForCli(updated.repo, updated.cli)} [${updated.surface_id}]`;
+        await seatManifestWriter({
+          surface_id: updated.surface_id,
+          agent_id: updated.agent_id,
+          tab_name: tabName,
+          session_name: updated.cli_session_id,
+          model: updated.model,
+          permission_mode:
+            updated.cli === "kiro" ? "default" : "skip-permissions",
+          cwd:
+            updated.launch_cwd ?? join(homedir(), "Gits", updated.repo),
+          repo: updated.repo,
+          cli: updated.cli,
+          updated_at: seatManifestNow(),
+        });
+      } catch (error) {
+        console.error(
+          "[cmuxlayer] seat manifest publish failed:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    };
     context.lifecycleSweepEngine = engine;
     lifecycleHealthEngine = engine;
 
@@ -7098,6 +7176,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           await refreshManagedMetadataBestEffort(result.agent_id);
+          await lifecycleSeatManifestPublisher({
+            agentId: result.agent_id,
+          });
           const currentAgent = engine.getAgentState(result.agent_id);
           const role =
             currentAgent?.role ??
@@ -7294,6 +7375,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             spawnDeliveryWorkspace(result, mutationWorkspace),
           );
           await refreshManagedMetadataBestEffort(result.agent_id);
+          await lifecycleSeatManifestPublisher({
+            agentId: result.agent_id,
+          });
           const currentAgent = engine.getAgentState(result.agent_id);
           const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
@@ -8661,6 +8745,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 text: modelCmd,
                 press_enter: true,
                 source_event: "interact",
+              });
+              await lifecycleSeatManifestPublisher({
+                agentId: args.agent,
+                model: args.model,
               });
               const d = {
                 agent_id: args.agent,

--- a/tests/seat-manifest.test.ts
+++ b/tests/seat-manifest.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFileSystemSeatManifestWriter,
+  defaultSeatManifestDir,
+  seatManifestFileName,
+  type SeatManifest,
+} from "../src/seat-manifest.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("seat manifest", () => {
+  it("uses the orchestrator monitor-state directory unless the env override is set", () => {
+    expect(defaultSeatManifestDir({ HOME: "/Users/test" })).toBe(
+      "/Users/test/Gits/orchestrator/docs.local/monitor-state/seat-manifests",
+    );
+    expect(
+      defaultSeatManifestDir({
+        HOME: "/Users/test",
+        CMUXLAYER_SEAT_MANIFEST_DIR: "/tmp/seat-state",
+      }),
+    ).toBe("/tmp/seat-state");
+  });
+
+  it("sanitizes colon-delimited surface ids for the manifest filename", () => {
+    expect(seatManifestFileName("surface:42")).toBe("surface-42.json");
+  });
+
+  it("atomically writes the exact expected-state schema to an injected directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmux-seat-manifest-"));
+    roots.push(dir);
+    const writer = createFileSystemSeatManifestWriter({ directory: dir });
+    const manifest: SeatManifest = {
+      surface_id: "surface:42",
+      agent_id: "cmuxlayer-codex",
+      tab_name: "cmuxlayerCodex [surface:42]",
+      session_name: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      model: "fable-5",
+      permission_mode: "skip-permissions",
+      cwd: "/Users/test/Gits/cmuxlayer",
+      repo: "cmuxlayer",
+      cli: "codex",
+      updated_at: "2026-07-12T12:00:00.000Z",
+    };
+
+    await writer(manifest);
+
+    expect(
+      JSON.parse(readFileSync(join(dir, "surface-42.json"), "utf8")),
+    ).toEqual(manifest);
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -15,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import {
   createServer,
   createServerContext,
@@ -27,6 +28,7 @@ import {
 import type { ExecFn } from "../src/cmux-client.js";
 import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { ParsedScreenResult } from "../src/types.js";
+import type { SeatManifest } from "../src/seat-manifest.js";
 import {
   reconcileMonitorRegistry,
   registerMonitor,
@@ -216,6 +218,66 @@ function createLifecycleServer(exec: ExecFn) {
 }
 
 describe("lean spawn tool responses", () => {
+  it("spawn_agent publishes the exact expected-state manifest through the injected writer", async () => {
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: makeLifecycleExec(),
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      seatManifestWriter: async (manifest) => {
+        manifests.push(manifest);
+      },
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(manifests).toEqual([
+      {
+        surface_id: "surface:new",
+        agent_id: parsed.agent_id,
+        tab_name: "cmuxlayerClaude [surface:new]",
+        session_name: null,
+        model: "fable-5",
+        permission_mode: "skip-permissions",
+        cwd: join(homedir(), "Gits", "cmuxlayer"),
+        repo: "cmuxlayer",
+        cli: "claude",
+        updated_at: "2026-07-12T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("spawn_agent manifest uses the launcher name resolved by preflight", async () => {
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: makeLifecycleExec(),
+      stateDir: TEST_DIR,
+      spawnPreflight: async () => ({ launcherName: "registeredClaude" }),
+      sessionIdentityResolver: () => null,
+      seatManifestWriter: async (manifest) => manifests.push(manifest),
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    await spawn.handler(
+      { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
+      {} as any,
+    );
+
+    expect(manifests[0]?.tab_name).toBe(
+      "registeredClaude [surface:new]",
+    );
+  });
+
   it("spawn_agent defaults to the lean payload in text and structured content", async () => {
     const server = createLifecycleServer(makeLifecycleExec());
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -1545,6 +1607,186 @@ describe("agent lifecycle tool handlers", () => {
         `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
+  });
+
+  it("new_worktree_split publishes its worktree cwd through the injected manifest writer", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
+    const worktreePath = join(gitsDir, "cmuxlayer.wt", "manifest-worker");
+    const worktreeExec = vi.fn().mockImplementation(async () => {
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+      seatManifestWriter: async (manifest) => manifests.push(manifest),
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const tool = (server as any)._registeredTools["new_worktree_split"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        worktree: { name: "manifest worker" },
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(manifests).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:new",
+        agent_id: parsed.agent_id,
+        tab_name: "cmuxlayerCodex [surface:new]",
+        model: "codex",
+        permission_mode: "skip-permissions",
+        cwd: worktreePath,
+        repo: "cmuxlayer",
+        cli: "codex",
+      }),
+    ]);
+  });
+
+  it("interact model refreshes the manifest with the deliberate model pin", async () => {
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      seatManifestWriter: async (manifest) => manifests.push(manifest),
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const interact = (server as any)._registeredTools["interact"];
+    const spawnResult = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "start model-pin test",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    manifests.length = 0;
+
+    await interact.handler(
+      { agent: agentId, action: "model", model: "fable-5" },
+      {} as any,
+    );
+
+    expect(manifests).toEqual([
+      expect.objectContaining({
+        agent_id: agentId,
+        tab_name: "cmuxlayerClaude [surface:new]",
+        model: "fable-5",
+      }),
+    ]);
+  });
+
+  it("rename_tab refreshes the manifest with the deliberate tab title", async () => {
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      seatManifestWriter: async (manifest) => manifests.push(manifest),
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const rename = (server as any)._registeredTools["rename_tab"];
+    const spawnResult = await spawn.handler(
+      { repo: "cmuxlayer", model: "sonnet", cli: "claude" },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    manifests.length = 0;
+
+    await rename.handler(
+      { surface: "surface:new", title: "cmuxlayerClaude [review-seat]" },
+      {} as any,
+    );
+
+    expect(manifests).toEqual([
+      expect.objectContaining({
+        agent_id: agentId,
+        tab_name: "cmuxlayerClaude [review-seat]",
+        model: "sonnet",
+      }),
+    ]);
+  });
+
+  it("send_input rename_to_task refreshes the manifest after the task rename", async () => {
+    const manifests: SeatManifest[] = [];
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      seatManifestWriter: async (manifest) => manifests.push(manifest),
+      seatManifestNow: () => "2026-07-12T12:00:00.000Z",
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendInput = (server as any)._registeredTools["send_input"];
+    await spawn.handler(
+      { repo: "cmuxlayer", model: "sonnet", cli: "claude" },
+      {} as any,
+    );
+    manifests.length = 0;
+
+    await sendInput.handler(
+      {
+        surface: "surface:new",
+        text: "status",
+        press_enter: false,
+        rename_to_task: "audit",
+      },
+      {} as any,
+    );
+
+    expect(manifests).toEqual([
+      expect.objectContaining({
+        surface_id: "surface:new",
+        tab_name: "agent-pane: audit",
+      }),
+    ]);
+  });
+
+  it("a bare Vitest server never writes to the real or overridden manifest directory", async () => {
+    const manifestDir = join(TEST_DIR, "must-stay-absent");
+    const previous = process.env.CMUXLAYER_SEAT_MANIFEST_DIR;
+    process.env.CMUXLAYER_SEAT_MANIFEST_DIR = manifestDir;
+    try {
+      const server = createLifecycleServer(mockExec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+      await spawn.handler(
+        { repo: "cmuxlayer", model: "sonnet", cli: "claude" },
+        {} as any,
+      );
+
+      expect(existsSync(manifestDir)).toBe(false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CMUXLAYER_SEAT_MANIFEST_DIR;
+      } else {
+        process.env.CMUXLAYER_SEAT_MANIFEST_DIR = previous;
+      }
+    }
   });
 
   it("new_worktree_split defaults to the caller workspace instead of the selected workspace", async () => {


### PR DESCRIPTION
## Summary
- add an atomic per-seat expected-state manifest writer at `~/Gits/orchestrator/docs.local/monitor-state/seat-manifests/<surface>.json`, with `CMUXLAYER_SEAT_MANIFEST_DIR` override
- publish exact tab/session/model-pin/permission/cwd-repo state after `spawn_agent` and `new_worktree_split`, then refresh after deliberate model-pin and tab-title changes
- keep filesystem effects injectable; Vitest defaults to a no-op and an explicit integration test proves the suite does not create the overridden manifest directory

## Manifest schema

```json
{
  "surface_id": "surface:42",
  "agent_id": "cmuxlayer-codex",
  "tab_name": "cmuxlayerCodex [surface:42]",
  "session_name": "019...",
  "model": "fable-5",
  "permission_mode": "skip-permissions",
  "cwd": "/Users/etanheyman/Gits/cmuxlayer",
  "repo": "cmuxlayer",
  "cli": "codex",
  "updated_at": "2026-07-12T12:00:00.000Z"
}
```

Filename sanitizes `:` to `-` (for example `surface:42` becomes `surface-42.json`).

## TDD evidence
- RED: writer module import failed before `src/seat-manifest.ts` existed
- RED: spawn/new-worktree/model/rename tests each failed with zero injected-writer calls before wiring
- RED: resolved-launcher regression received `cmuxlayerClaude` instead of the preflight-resolved `registeredClaude`
- GREEN: `bun run test` — 93 files, 1,728 tests passed
- GREEN: `bun run typecheck` — exit 0
- GREEN: `git diff --check` — exit 0
- Push hook: `run_tests.sh` exit 0, including 1,728 Vitest tests

## Review disposition
- Local CodeRabbit: `Status: SKIPPED — recoverable OSS rate limit; CLI reported a 13-minute reset window.`
- Red-team/blue-team fallback: no HIGH/MEDIUM findings; atomic write, sanitization, persisted expected model/tab state, and test-only no-op boundary reviewed.
- Accepted tradeoff: a manifest write failure is logged and does not roll back an already-successful seat spawn/control action.

## Merge
Do not merge this PR. A visible reviewer pane/review loop is required first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle spawn/control paths and writes outside the repo to orchestrator monitor state; failures are best-effort and do not roll back successful seat operations.
> 
> **Overview**
> Adds **per-seat expected-state JSON manifests** so orchestrator’s A3 resume-integrity watcher can compare deliberate cmuxlayer state to live seats.
> 
> A new **`seat-manifest` module** defines the schema, default path under orchestrator’s `monitor-state/seat-manifests`, `CMUXLAYER_SEAT_MANIFEST_DIR` override, sanitized filenames, and **atomic** filesystem writes. **`createServer`** accepts an injectable writer; production uses the filesystem adapter, **Vitest defaults to a no-op** so tests never touch real paths.
> 
> After successful **`spawn_agent`** / **`new_worktree_split`**, and after deliberate **`interact(action=model)`**, **`rename_tab`**, and **`send_input` `rename_to_task`**, the server publishes or refreshes manifests (tab title, model pin, session, permission mode, cwd/repo, CLI). **`AgentRecord`** gains optional **`tab_name`** for pinned titles. Write failures are **logged only** and do not fail the underlying MCP action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c554ecf33fb24dee4d142a93e6fdce46a49bc70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write per-seat expected-state manifest to disk on spawn, rename, and model pin
> - Adds [`src/seat-manifest.ts`](https://github.com/EtanHey/cmuxlayer/pull/298/files#diff-21529debbee1082a4518601a193488c28c508332d526cb18800b27644a5b2a69) defining the `SeatManifest` schema and `createFileSystemSeatManifestWriter`, which writes JSON atomically (temp file + rename) with `0600` permissions. The manifest directory defaults to `~/Gits/orchestrator/docs.local/monitor-state/seat-manifests` but can be overridden via `CMUXLAYER_SEAT_MANIFEST_DIR`.
> - Hooks manifest publication into `createServer` after `spawn_agent`, `new_worktree_split`, `rename_tab`, `send_input` (with `rename_to_task`), and `interact(action='model')`.
> - Adds `seatManifestWriter` and `seatManifestNow` injection points to `CreateServerOptions` for testing; under Vitest the default writer is a no-op.
> - Adds `tab_name` field to `AgentRecord` to persist the deliberately pinned tab title for manifest generation.
> - Risk: manifest writes are best-effort (errors are caught and logged), so failures are silent in production.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c554ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->