### PR TITLE
fix(daemon): per-bundle daemon socket + reap on upstream death (RC7)

### DIFF
--- a/docs/plans/2026-07-12-rc7-per-bundle-daemon-socket.md
+++ b/docs/plans/2026-07-12-rc7-per-bundle-daemon-socket.md
@@ -1,0 +1,48 @@
+# RC7 Per-Bundle Daemon Socket Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Isolate production and Nightly cmux instances behind separate cmuxlayer daemons, and retire a daemon whose upstream cmux-app socket remains unreachable.
+
+**Architecture:** Resolve the daemon socket and upstream candidates from the selected cmux instance axis: explicit socket pins first, then Nightly detection from `CMUX_SOCKET_PATH` or `CMUX_BUNDLE_ID`, otherwise the backward-compatible production paths. Extend the self-healing timer to probe active and degraded transports, and reuse its three-failure/60-second retirement circuit for ordinary upstream connection failures rather than only access-control denial failures.
+
+**Tech Stack:** TypeScript, Node.js Unix sockets, Vitest, Bun scripts.
+
+---
+
+### Task 1: Namespace daemon sockets by cmux axis
+
+**Files:**
+- Create: `tests/daemon-socket-path.test.ts`
+- Modify: `src/daemon-socket-path.ts`
+- Modify: `src/cmux-socket-path.ts`
+- Modify: `src/cmux-socket-probe.ts`
+- Modify: `tests/cmux-client-factory.test.ts`
+
+1. Add tests for unset/production, Nightly bundle, Nightly upstream socket, explicit daemon override, and bundle-only upstream alignment.
+2. Run `bunx vitest run tests/daemon-socket-path.test.ts` and confirm the Nightly cases fail.
+3. Add the minimal production/Nightly axis resolver while retaining `cmuxlayer-stated.sock` for production.
+4. Re-run the focused test and confirm it passes.
+
+### Task 2: Retire after sustained upstream death
+
+**Files:**
+- Modify: `tests/cmux-transport-self-heal.test.ts`
+- Modify: `src/cmux-transport-self-heal.ts`
+
+1. Add tests where consecutive unreachable upstream probes reach the configured threshold, including an idle active socket whose app disappears.
+2. Run the focused self-heal test and confirm the new test fails because ordinary upstream failures are not counted.
+3. Generalize the existing retirement evidence from access-control denial to upstream unreachability, retaining the default three-failure/60-second threshold and reset-on-success behavior; probe active sockets so idle daemons also retire.
+4. Re-run the focused test and existing self-heal suite.
+
+### Task 3: Verify and publish for review
+
+**Files:**
+- Verify all modified source and test files.
+
+1. Run `bun run test`.
+2. Run `bun run typecheck`.
+3. Build and exercise a real daemon/proxy client path with isolated sockets for production and Nightly.
+4. Run bounded CodeRabbit pre-commit review if available.
+5. Commit, push `fix/rc7-per-bundle-daemon-socket`, open a ready PR, and request reviewers.
+6. Stop without merging, per the RC7 brief.

--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -39,11 +39,11 @@ export interface CreateCmuxClientOptions extends SocketProbeOptions {
   reprobeCapMs?: number;
   /** Injectable random source for deterministic jitter tests */
   random?: () => number;
-  /** Called after sustained socket-denial and CLI-denial failures. */
+  /** Called after the upstream cmux socket remains unreachable past the threshold. */
   onIrrecoverableTransport?: () => void;
-  /** Consecutive denial failures required on both transports. */
+  /** Consecutive upstream socket failures required before signaling. */
   irrecoverableMinFailures?: number;
-  /** Minimum duration of sustained socket denial before signaling. */
+  /** Minimum duration of sustained upstream unreachability before signaling. */
   irrecoverableMinDurationMs?: number;
 }
 

--- a/src/cmux-socket-path.ts
+++ b/src/cmux-socket-path.ts
@@ -21,6 +21,10 @@ export function lastSocketPathFile(stateDir = defaultStateDir()): string {
   return join(stateDir, "last-socket-path");
 }
 
+export function nightlyLastSocketPathFile(stateDir = defaultStateDir()): string {
+  return join(stateDir, "nightly-last-socket-path");
+}
+
 export interface CmuxSocketPathCandidateOptions {
   env?: NodeJS.ProcessEnv;
   stateDir?: string;
@@ -33,6 +37,33 @@ export function readLastSocketPath(stateDir = defaultStateDir()): string | null 
   } catch {
     return null;
   }
+}
+
+export function readNightlyLastSocketPath(
+  stateDir = defaultStateDir(),
+): string | null {
+  try {
+    const value = fs
+      .readFileSync(nightlyLastSocketPathFile(stateDir), "utf-8")
+      .trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function nightlySocketPathCandidates(
+  opts: CmuxSocketPathCandidateOptions = {},
+): string[] {
+  const env = opts.env ?? process.env;
+  const stateDir = opts.stateDir ?? defaultStateDir();
+  const candidates = [
+    env.CMUX_SOCKET_PATH,
+    readNightlyLastSocketPath(stateDir),
+    join("/tmp", "cmux-nightly.sock"),
+  ].filter((path): path is string => Boolean(path));
+
+  return [...new Set(candidates)];
 }
 
 export function cmuxSocketPathCandidates(

--- a/src/cmux-socket-probe.ts
+++ b/src/cmux-socket-probe.ts
@@ -4,7 +4,10 @@
 
 import * as net from "node:net";
 import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
-import { cmuxSocketPathCandidates } from "./cmux-socket-path.js";
+import {
+  cmuxSocketPathCandidates,
+  nightlySocketPathCandidates,
+} from "./cmux-socket-path.js";
 
 export interface SocketProbeOptions {
   socketPath?: string;
@@ -74,6 +77,9 @@ export function candidateSocketPathsForOpts(
 ): string[] {
   const pinned = instancePin(opts);
   if (pinned) return [pinned];
+  if (/(?:^|\.)nightly$/i.test(process.env.CMUX_BUNDLE_ID?.trim() ?? "")) {
+    return nightlySocketPathCandidates({ stateDir: opts?.socketStateDir });
+  }
   return cmuxSocketPathCandidates({ stateDir: opts?.socketStateDir });
 }
 

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -181,20 +181,20 @@ export class CmuxSelfHealingClient {
   private flushingFailedPayloadQueue: Promise<void> | null = null;
   private transportDenial: TransportDenialSignal | null = null;
   private completedRetryCount = 0;
-  private denialProbeFailures = 0;
-  private denialProbeStartedAt: number | null = null;
+  private upstreamProbeFailures = 0;
+  private upstreamProbeStartedAt: number | null = null;
   private cliDenialFailures = 0;
   private irrecoverableSignaled = false;
   private lastUpgradeFailureLogAt = Number.NEGATIVE_INFINITY;
-  private lastDenialProgressLogAt = Number.NEGATIVE_INFINITY;
+  private lastUpstreamFailureLogAt = Number.NEGATIVE_INFINITY;
 
   constructor(private readonly opts: CmuxSelfHealingClientOptions) {
     this.socketClient = opts.socket ?? null;
     this.delegate = opts.socket ?? opts.cli;
     this.transportDenial = opts.initialDenial ?? null;
     if (opts.initialDenial) {
-      this.denialProbeFailures = 1;
-      this.denialProbeStartedAt = (opts.now ?? Date.now)();
+      this.upstreamProbeFailures = 1;
+      this.upstreamProbeStartedAt = (opts.now ?? Date.now)();
     }
     if (this.socketClient) {
       this.pinCliToSocket(this.socketClient);
@@ -207,8 +207,8 @@ export class CmuxSelfHealingClient {
       opts.logger?.error(
         "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
       );
-      this.startReprobe();
     }
+    this.startReprobe();
   }
 
   getTransportHealth(): TransportHealthSignal {
@@ -342,15 +342,78 @@ export class CmuxSelfHealingClient {
   }
 
   private startReprobe(): void {
-    if (this.reprobeTimer || this.stopped || this.socketClient) {
+    if (this.reprobeTimer || this.stopped) {
       return;
     }
     const delayMs = this.nextReprobeDelayMs();
     this.reprobeTimer = setTimeout(() => {
       this.reprobeTimer = null;
-      void this.tryUpgrade();
+      void this.runReprobeCycle();
     }, delayMs);
     this.reprobeTimer.unref?.();
+  }
+
+  private async runReprobeCycle(): Promise<void> {
+    if (this.socketClient) {
+      await this.verifyActiveSocket();
+      return;
+    }
+    await this.tryUpgrade();
+  }
+
+  private async verifyActiveSocket(): Promise<void> {
+    if (this.stopped || this.upgrading) {
+      return;
+    }
+    if (this.inFlight > 0) {
+      this.startReprobe();
+      return;
+    }
+
+    const activeSocket = this.socketClient;
+    if (!activeSocket) {
+      this.startReprobe();
+      return;
+    }
+
+    this.upgrading = true;
+    try {
+      const socketPath = activeSocket.currentSocketPath();
+      const probeResult = await this.checkSocketHealth(
+        socketPath,
+        this.opts.factoryOpts,
+      );
+      if (this.socketClient !== activeSocket) {
+        return;
+      }
+      if (this.inFlight > 0) {
+        return;
+      }
+      const denialClass = this.recordProbeResult(probeResult);
+      if (denialClass) {
+        this.recordAccessControlDenial(probeResult);
+      }
+      if (!probeResult.usable) {
+        this.downgradeToCli();
+      }
+    } catch (error) {
+      if (this.inFlight > 0) {
+        return;
+      }
+      this.recordProbeFailure(error);
+      this.logUpgradeFailure(error);
+      if (
+        this.socketClient === activeSocket &&
+        this.isUpstreamUnreachableError(error)
+      ) {
+        this.downgradeToCli();
+      }
+    } finally {
+      this.upgrading = false;
+      if (!this.stopped) {
+        this.startReprobe();
+      }
+    }
   }
 
   private nextReprobeDelayMs(): number {
@@ -597,7 +660,7 @@ export class CmuxSelfHealingClient {
       // Stay on CLI until the next re-probe tick.
     } finally {
       this.upgrading = false;
-      if (!this.socketClient && !this.stopped) {
+      if (!this.stopped) {
         this.startReprobe();
       }
     }
@@ -635,42 +698,47 @@ export class CmuxSelfHealingClient {
     return /(?:\bEPIPE\b|broken pipe|errno\s*32|access denied)/i.test(message);
   }
 
+  private isUpstreamUnreachableError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /(?:\bEPIPE\b|\bECONNREFUSED\b|\bECONNRESET\b|\bENOENT\b|broken pipe|errno\s*32|access denied|timed?\s*out|timeout)/i.test(
+      message,
+    );
+  }
+
   private recordProbeResult(result: SocketProbeResult): boolean {
     const denialClass =
       result.denied_reason === "access-control" ||
       (typeof result.error === "string" &&
         this.isDenialClassError(result.error));
-    if (!denialClass) {
-      if (result.usable) {
-        this.resetDenialEvidence();
-      }
+    if (result.usable) {
+      this.resetUpstreamFailureEvidence();
       return false;
     }
-    this.recordProbeDenial();
-    return true;
+    this.recordUpstreamProbeFailure();
+    return denialClass;
   }
 
   private recordProbeFailure(error: unknown): void {
-    if (this.isDenialClassError(error)) {
-      this.recordProbeDenial();
+    if (this.isUpstreamUnreachableError(error)) {
+      this.recordUpstreamProbeFailure();
     }
   }
 
-  private recordProbeDenial(): void {
+  private recordUpstreamProbeFailure(): void {
     const now = (this.opts.now ?? Date.now)();
-    if (this.denialProbeFailures === 0) {
-      this.denialProbeStartedAt = now;
+    if (this.upstreamProbeFailures === 0) {
+      this.upstreamProbeStartedAt = now;
     }
-    this.denialProbeFailures += 1;
-    this.logDenialProgress(now);
+    this.upstreamProbeFailures += 1;
+    this.logUpstreamFailureProgress(now);
     this.maybeSignalIrrecoverable(now);
   }
 
-  private resetDenialEvidence(): void {
-    this.denialProbeFailures = 0;
-    this.denialProbeStartedAt = null;
+  private resetUpstreamFailureEvidence(): void {
+    this.upstreamProbeFailures = 0;
+    this.upstreamProbeStartedAt = null;
     this.cliDenialFailures = 0;
-    this.lastDenialProgressLogAt = Number.NEGATIVE_INFINITY;
+    this.lastUpstreamFailureLogAt = Number.NEGATIVE_INFINITY;
   }
 
   private recordCliFailure(error: unknown): void {
@@ -679,26 +747,26 @@ export class CmuxSelfHealingClient {
     }
     this.cliDenialFailures += 1;
     const now = (this.opts.now ?? Date.now)();
-    this.logDenialProgress(now);
+    this.logUpstreamFailureProgress(now);
     this.maybeSignalIrrecoverable(now);
   }
 
-  private logDenialProgress(now: number): void {
+  private logUpstreamFailureProgress(now: number): void {
     if (
-      now - this.lastDenialProgressLogAt <
+      now - this.lastUpstreamFailureLogAt <
       DENIAL_PROGRESS_LOG_INTERVAL_MS
     ) {
       return;
     }
-    this.lastDenialProgressLogAt = now;
+    this.lastUpstreamFailureLogAt = now;
     const minFailures =
       this.opts.irrecoverableMinFailures ?? DEFAULT_IRRECOVERABLE_MIN_FAILURES;
     const elapsedSeconds = Math.max(
       0,
-      Math.floor((now - (this.denialProbeStartedAt ?? now)) / 1_000),
+      Math.floor((now - (this.upstreamProbeStartedAt ?? now)) / 1_000),
     );
     this.opts.logger?.error(
-      `[cmuxlayer] denial evidence ${this.denialProbeFailures}/${minFailures} probes, ${this.cliDenialFailures}/${minFailures} cli, ${elapsedSeconds}s`,
+      `[cmuxlayer] upstream failure evidence ${this.upstreamProbeFailures}/${minFailures} probes, ${this.cliDenialFailures} cli denials, ${elapsedSeconds}s`,
     );
   }
 
@@ -712,10 +780,9 @@ export class CmuxSelfHealingClient {
       this.opts.irrecoverableMinDurationMs ??
       DEFAULT_IRRECOVERABLE_MIN_DURATION_MS;
     if (
-      this.denialProbeStartedAt === null ||
-      this.denialProbeFailures < minFailures ||
-      this.cliDenialFailures < minFailures ||
-      now - this.denialProbeStartedAt < minDurationMs
+      this.upstreamProbeStartedAt === null ||
+      this.upstreamProbeFailures < minFailures ||
+      now - this.upstreamProbeStartedAt < minDurationMs
     ) {
       return;
     }

--- a/src/daemon-socket-path.ts
+++ b/src/daemon-socket-path.ts
@@ -1,7 +1,24 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 export const DAEMON_SOCKET_FILENAME = "cmuxlayer-stated.sock";
+export const NIGHTLY_DAEMON_SOCKET_FILENAME =
+  "cmuxlayer-stated-nightly.sock";
+
+function isNightlyAxis(env: NodeJS.ProcessEnv): boolean {
+  const upstreamSocket = env.CMUX_SOCKET_PATH?.trim();
+  if (upstreamSocket) {
+    const socketName = basename(upstreamSocket);
+    if (/nightly/i.test(socketName)) {
+      return true;
+    }
+    if (/^cmux-\d+\.sock$/i.test(socketName)) {
+      return false;
+    }
+  }
+
+  return /(?:^|\.)nightly$/i.test(env.CMUX_BUNDLE_ID?.trim() ?? "");
+}
 
 export function defaultDaemonSocketPath(
   env: NodeJS.ProcessEnv = process.env,
@@ -15,6 +32,8 @@ export function defaultDaemonSocketPath(
     ".local",
     "state",
     "cmux",
-    DAEMON_SOCKET_FILENAME,
+    isNightlyAxis(env)
+      ? NIGHTLY_DAEMON_SOCKET_FILENAME
+      : DAEMON_SOCKET_FILENAME,
   );
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -897,7 +897,7 @@ export class CmuxLayerDaemon {
       );
     } else {
       this.logger.error(
-        "[cmuxlayer-daemon] transport irrecoverably denied (orphaned ancestry); retiring so a pane-descended respawn can reconnect",
+        "[cmuxlayer-daemon] upstream cmux transport remained unreachable; retiring so a pane-descended respawn can reconnect",
       );
     }
     this.retirementPromise = this.shutdown(reason)

--- a/tests/cmux-client-factory.test.ts
+++ b/tests/cmux-client-factory.test.ts
@@ -68,6 +68,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
   "createCmuxClient instance selection",
   () => {
     let savedEnv: string | undefined;
+    let savedBundleEnv: string | undefined;
     const servers: Array<{ server: net.Server; path: string }> = [];
 
     afterEach(async () => {
@@ -77,6 +78,12 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
         process.env.CMUX_SOCKET_PATH = savedEnv;
       }
       savedEnv = undefined;
+      if (savedBundleEnv === undefined) {
+        delete process.env.CMUX_BUNDLE_ID;
+      } else {
+        process.env.CMUX_BUNDLE_ID = savedBundleEnv;
+      }
+      savedBundleEnv = undefined;
       for (const { server, path } of servers.splice(0)) {
         await stopPingServer(server, path);
       }
@@ -139,6 +146,40 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
       expect(logger.error).not.toHaveBeenCalledWith(
         expect.stringContaining("live cmux sockets found"),
       );
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    it("uses the Nightly upstream marker for an unpinned Nightly bundle", async () => {
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-nightly-"));
+      const production = join(stateDir, "cmux-production.sock");
+      const nightly = join(stateDir, "cmux-nightly.sock");
+      fs.writeFileSync(
+        join(stateDir, "last-socket-path"),
+        `${production}\n`,
+        "utf-8",
+      );
+      fs.writeFileSync(
+        join(stateDir, "nightly-last-socket-path"),
+        `${nightly}\n`,
+        "utf-8",
+      );
+      track(await startPingServer(production), production);
+      track(await startPingServer(nightly), nightly);
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      savedBundleEnv = process.env.CMUX_BUNDLE_ID;
+      delete process.env.CMUX_SOCKET_PATH;
+      process.env.CMUX_BUNDLE_ID = "com.cmuxterm.app.nightly";
+
+      const client = await createCmuxClient({ socketStateDir: stateDir });
+
+      expect(getTransportHealth(client)).toMatchObject({
+        mode: "socket",
+        degraded: false,
+        current_socket_path: nightly,
+      });
+      if ("stop" in client && typeof client.stop === "function") {
+        client.stop();
+      }
       fs.rmSync(stateDir, { recursive: true, force: true });
     });
 

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -291,7 +291,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
-  it("signals irrecoverable transport only after repeated socket and CLI denial failures", async () => {
+  it("signals irrecoverable transport after repeated upstream denial failures", async () => {
     const socketPath = join(tmpdir(), `cmux-irrecoverable-${process.pid}.sock`);
     const onIrrecoverableTransport = vi.fn();
     const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
@@ -326,6 +326,133 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("signals retirement after repeated upstream connection failures", async () => {
+    const socketPath = join(
+      tmpdir(),
+      `cmux-upstream-dead-${process.pid}.sock`,
+    );
+    let probeCountAtRetirement: number | undefined;
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: false,
+      socketPath,
+      error: "connect ECONNREFUSED",
+    });
+    const onIrrecoverableTransport = vi.fn(() => {
+      probeCountAtRetirement = probeSocketHealth.mock.calls.length;
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+      irrecoverableMinFailures: 3,
+      irrecoverableMinDurationMs: 0,
+      onIrrecoverableTransport,
+    });
+
+    await waitForExpectation(
+      async () => expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+
+    expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1);
+    expect(probeCountAtRetirement).toBe(3);
+    client.stop();
+  });
+
+  it("signals retirement when an idle active upstream socket dies", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-idle-upstream-death-"));
+    const socketPath = join(stateDir, "cmux.sock");
+    const { server } = await startPingServer(socketPath);
+    const onIrrecoverableTransport = vi.fn();
+    const client = await createCmuxClient({
+      socketPath,
+      pingRetryAttempts: 1,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      irrecoverableMinFailures: 3,
+      irrecoverableMinDurationMs: 0,
+      onIrrecoverableTransport,
+    });
+
+    await stopPingServer(server, socketPath);
+    await waitForExpectation(
+      async () => expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+    });
+    if ("stop" in client && typeof client.stop === "function") {
+      client.stop();
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("does not downgrade an active socket when a request starts during its health probe", async () => {
+    const socketPath = join(tmpdir(), `cmux-probe-race-${process.pid}.sock`);
+    let resolveProbe!: (result: {
+      usable: boolean;
+      socketPath: string;
+      error?: string;
+    }) => void;
+    const probeSocketHealth = vi.fn(
+      () =>
+        new Promise<{
+          usable: boolean;
+          socketPath: string;
+          error?: string;
+        }>((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+    let resolveRequest!: (value: { workspaces: [] }) => void;
+    const request = new Promise<{ workspaces: [] }>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      listWorkspaces: vi.fn(() => request),
+    } as unknown as CmuxSocketClient;
+    const client = wrapSocketWithSelfHeal(socket, new CmuxClient(), {
+      socketPath,
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+    });
+
+    await waitForExpectation(
+      async () => expect(probeSocketHealth).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    const requestPromise = client.listWorkspaces();
+    await waitForExpectation(
+      async () => expect(socket.listWorkspaces).toHaveBeenCalledTimes(1),
+      { timeout: 1_000, interval: 5 },
+    );
+    resolveProbe({
+      usable: false,
+      socketPath,
+      error: "connect ECONNREFUSED",
+    });
+    await waitForExpectation(
+      async () => expect((client as any).upgrading).toBe(false),
+      { timeout: 1_000, interval: 5 },
+    );
+
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(getTransportHealth(client)?.mode).toBe("socket");
+    resolveRequest({ workspaces: [] });
+    await expect(requestPromise).resolves.toEqual({ workspaces: [] });
+    client.stop();
+  });
+
   it("preserves the transport error when the irrecoverable callback throws", async () => {
     const socketPath = join(tmpdir(), `cmux-callback-throw-${process.pid}.sock`);
     const logger = { error: vi.fn() };
@@ -353,7 +480,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     await waitForExpectation(
       async () =>
         expect(
-          (client as any).denialProbeFailures,
+          (client as any).upstreamProbeFailures,
         ).toBeGreaterThanOrEqual(1),
       { timeout: 1_000, interval: 5 },
     );
@@ -435,7 +562,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
-  it("preserves denial evidence across non-denial failures until a usable socket probe", () => {
+  it("counts upstream probe failures until a usable socket probe resets them", () => {
     const client = wrapCliWithSelfHeal(new CmuxClient(), {
       socketPath: "/tmp/cmux-preserve-denial.sock",
       reprobeIntervalMs: 60_000,
@@ -457,7 +584,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     internals.recordProbeFailure(new Error("probe timeout"));
     internals.recordCliFailure(new Error("connect ENOENT"));
 
-    expect(internals.denialProbeFailures).toBe(1);
+    expect(internals.upstreamProbeFailures).toBe(3);
     expect(internals.cliDenialFailures).toBe(1);
 
     internals.recordProbeResult({
@@ -465,13 +592,13 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       socketPath: "/tmp/cmux-preserve-denial.sock",
     });
 
-    expect(internals.denialProbeFailures).toBe(0);
-    expect(internals.denialProbeStartedAt).toBeNull();
+    expect(internals.upstreamProbeFailures).toBe(0);
+    expect(internals.upstreamProbeStartedAt).toBeNull();
     expect(internals.cliDenialFailures).toBe(0);
     client.stop();
   });
 
-  it("rate-limits denial evidence progress logs", () => {
+  it("rate-limits upstream failure progress logs", () => {
     let now = 1_000;
     const logger = { error: vi.fn() };
     const client = wrapCliWithSelfHeal(new CmuxClient(), {
@@ -485,9 +612,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     const internals = client as any;
     logger.error.mockClear();
 
-    internals.recordProbeDenial();
+    internals.recordUpstreamProbeFailure();
     expect(logger.error).toHaveBeenCalledWith(
-      "[cmuxlayer] denial evidence 1/3 probes, 0/3 cli, 0s",
+      "[cmuxlayer] upstream failure evidence 1/3 probes, 0 cli denials, 0s",
     );
 
     now += 1_000;
@@ -497,7 +624,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     now += 29_000;
     internals.recordCliFailure(new Error("write EPIPE"));
     expect(logger.error).toHaveBeenLastCalledWith(
-      "[cmuxlayer] denial evidence 1/3 probes, 2/3 cli, 30s",
+      "[cmuxlayer] upstream failure evidence 1/3 probes, 2 cli denials, 30s",
     );
     client.stop();
   });
@@ -541,7 +668,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
-  it("does not signal irrecoverable transport when the cmux app is down", async () => {
+  it("signals irrecoverable transport when the cmux app remains down", async () => {
     const socketPath = join(tmpdir(), `cmux-app-down-${process.pid}.sock`);
     const onIrrecoverableTransport = vi.fn();
     const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
@@ -569,7 +696,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(onIrrecoverableTransport).not.toHaveBeenCalled();
+    expect(onIrrecoverableTransport).toHaveBeenCalledTimes(1);
     client.stop();
   });
 

--- a/tests/daemon-socket-path.test.ts
+++ b/tests/daemon-socket-path.test.ts
@@ -1,0 +1,51 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { defaultDaemonSocketPath } from "../src/daemon-socket-path.js";
+
+const stateSocket = (filename: string): string =>
+  join(homedir(), ".local", "state", "cmux", filename);
+
+describe("defaultDaemonSocketPath", () => {
+  it.each([
+    ["unset", {}],
+    ["production bundle", { CMUX_BUNDLE_ID: "com.cmuxterm.app" }],
+    ["production upstream", { CMUX_SOCKET_PATH: "/tmp/cmux-501.sock" }],
+    [
+      "production upstream pinned from Nightly",
+      {
+        CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly",
+        CMUX_SOCKET_PATH: "/tmp/cmux-501.sock",
+      },
+    ],
+  ])("keeps the legacy production socket for %s", (_label, env) => {
+    expect(defaultDaemonSocketPath(env)).toBe(
+      stateSocket("cmuxlayer-stated.sock"),
+    );
+  });
+
+  it.each([
+    ["Nightly bundle", { CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly" }],
+    [
+      "Nightly upstream pinned from production",
+      {
+        CMUX_BUNDLE_ID: "com.cmuxterm.app",
+        CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+      },
+    ],
+  ])("uses a separate socket for %s", (_label, env) => {
+    expect(defaultDaemonSocketPath(env)).toBe(
+      stateSocket("cmuxlayer-stated-nightly.sock"),
+    );
+  });
+
+  it("lets the explicit daemon socket override win", () => {
+    expect(
+      defaultDaemonSocketPath({
+        CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly",
+        CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+        CMUXLAYER_DAEMON_SOCKET: "/custom/cmuxlayer.sock",
+      }),
+    ).toBe("/custom/cmuxlayer.sock");
+  });
+});

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -532,7 +532,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.shutdown();
   });
 
-  it("retires exactly once when the self-healing client signals irrecoverable denial", async () => {
+  it("retires exactly once when the self-healing client signals an unreachable upstream", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("transport-retire");
     let signalIrrecoverable: (() => void) | undefined;
@@ -561,6 +561,7 @@ describe("CmuxLayerDaemon", () => {
       "irrecoverable-transport",
       expect.objectContaining({ forced: false }),
     );
+    expect(existsSync(path)).toBe(false);
   });
 
   it("clears the stale-build timer after shutdown", async () => {


### PR DESCRIPTION
## Summary
- namespace the cmuxlayer daemon socket by cmux instance axis while preserving `cmuxlayer-stated.sock` for production and honoring `CMUXLAYER_DAEMON_SOCKET` first
- align unpinned Nightly upstream discovery with Nightly marker/default sockets so the Nightly daemon cannot attach to production
- continuously health-probe active upstream sockets and retire the daemon after sustained unreachability, without interrupting in-flight requests

## Socket derivation
- explicit `CMUXLAYER_DAEMON_SOCKET` wins
- a recognized `CMUX_SOCKET_PATH` pin defines production (`cmux-<uid>.sock`) or Nightly (`*nightly*`) axis
- otherwise `CMUX_BUNDLE_ID=com.cmuxterm.app.nightly` selects Nightly
- production/unset stays `~/.local/state/cmux/cmuxlayer-stated.sock`
- Nightly uses `~/.local/state/cmux/cmuxlayer-stated-nightly.sock`

## Retirement policy
- active and degraded transports are probed by the self-heal loop
- usable probes reset the failure episode
- default retirement gate remains 3 upstream failures sustained for 60 seconds
- retirement shuts down the listener and removes its owned daemon socket

## TDD evidence
- RED: Nightly daemon socket cases returned the production socket
- RED: ordinary `ECONNREFUSED` probes never signaled retirement
- RED: an idle active socket did not retire after its upstream server disappeared
- RED: bundle-only Nightly selected the production upstream marker
- RED: a failed health probe could disconnect a request that began while the probe was in flight
- GREEN: focused RC7 suite passed 73/73 before final full verification

## Verification
- `bun run test` — 93 files, 1,729 tests passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `git diff --check` — passed
- isolated real MCP runtime — distinct production/Nightly daemon PIDs, both derived daemon sockets listening concurrently; Nightly discovered its upstream from bundle + Nightly marker with no `CMUX_SOCKET_PATH` pin

## Review disposition
- CodeRabbit local review: partial (bounded run did not complete); one minor threshold-assertion race found and fixed
- fallback adversarial review: two HIGH and one MEDIUM findings fixed; re-review confirmed closure and found one additional in-flight polling race, fixed with a RED concurrency regression
- no unresolved CRITICAL/HIGH findings at push time

## Test plan
- [x] daemon socket path RED→GREEN
- [x] upstream-death/self-heal RED→GREEN
- [x] active-idle upstream death
- [x] in-flight request concurrency
- [x] full suite/typecheck/build
- [x] isolated real MCP dual-daemon runtime

Do not merge yet — reviewer pane will be opened by the owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon socket routing and when processes self-retire—core MCP connectivity—but behavior is heavily tested and defaults preserve the production socket path.
> 
> **Overview**
> **Isolates production and Nightly** so each cmux axis gets its own cmuxlayer daemon socket and upstream discovery, while keeping `cmuxlayer-stated.sock` for production and honoring `CMUXLAYER_DAEMON_SOCKET` when set.
> 
> Nightly is chosen from bundle id or a nightly-named upstream pin; unpinned Nightly clients probe `nightly-last-socket-path` and `/tmp/cmux-nightly.sock` instead of production markers, so a Nightly daemon should not attach to a live production cmux socket.
> 
> **Self-healing transport** now keeps periodic health probes on active socket mode (not only degraded CLI). Sustained upstream failures (`ECONNREFUSED`, timeouts, etc.) accumulate toward the existing 3-failure / 60s gate and call `onIrrecoverableTransport` without requiring matching CLI denial counts—so the daemon can retire when the cmux app socket stays dead, including idle connections. Active-socket verify avoids downgrading mid-probe when a request starts during the check.
> 
> Adds an RC7 implementation plan doc and Vitest coverage for socket paths, Nightly upstream selection, upstream-death retirement, and the probe/request race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4498f1f89eec95c7a6876fb0de87f9fb6e0b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-bundle daemon socket paths and reap daemon on upstream death
> - Introduces a separate daemon socket filename (`cmuxlayer-stated-nightly.sock`) for the Nightly axis, selected automatically via `isNightlyAxis()` in [`daemon-socket-path.ts`](https://github.com/EtanHey/cmuxlayer/pull/299/files#diff-2af0269c3bd35bd30fdb009bc1cbfafa44f9332f801f3244bae27e07a94cd4d0) based on `CMUX_BUNDLE_ID` or `CMUX_SOCKET_PATH`.
> - Adds Nightly-specific socket path candidates in [`cmux-socket-path.ts`](https://github.com/EtanHey/cmuxlayer/pull/299/files#diff-3ab0a18c172ea9124f5a550a90c4f60bf4da7a7fa77a0cbbfc44e23e626ded74), falling back through `CMUX_SOCKET_PATH`, a state file, and `/tmp/cmux-nightly.sock`.
> - Extends `CmuxSelfHealingClient` in [`cmux-transport-self-heal.ts`](https://github.com/EtanHey/cmuxlayer/pull/299/files#diff-fbf073b8b6f02d58f4addfd2d8fcaed58d9e495a3ec139005951626f13e03267) to run health checks even while on an active socket, downgrading to CLI and signaling irrecoverable transport when the upstream remains unreachable past configured thresholds.
> - Broadens irrecoverable evidence to include `ECONNREFUSED`, `EPIPE`, `ECONNRESET`, and `ENOENT` errors, independent of CLI denial counts.
> - Behavioral Change: the self-heal reprobe timer now fires continuously in socket mode, where previously it was skipped; sustained upstream unreachability alone can now trigger daemon retirement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe4498f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->