### PR TITLE
fix(layout): worker placement col-0 recurrence — real dispatch path (reopen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "pre-pr": "bun run typecheck && bun run pre-pr:harness",
     "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/live-agent-harness-replay.test.ts tests/pre-pr-scripts.test.ts",
     "pre-pr:live": "bun run live:harness",
+    "live:worker-placement": "tsx scripts/run-live-worker-placement-repro.ts",
     "bench:daemon": "node scripts/bench-daemon.mjs",
     "test:watch": "vitest",
     "live:harness": "node scripts/run-live-agent-harness.mjs"

--- a/scripts/run-live-worker-placement-repro.ts
+++ b/scripts/run-live-worker-placement-repro.ts
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+type ToolPayload = Record<string, unknown>;
+
+function requiredArg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function stringEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function payload(result: Awaited<ReturnType<Client["callTool"]>>): ToolPayload {
+  if (result.structuredContent && typeof result.structuredContent === "object") {
+    return result.structuredContent as ToolPayload;
+  }
+  const text = result.content.find(
+    (item): item is Extract<typeof item, { type: "text" }> =>
+      item.type === "text",
+  )?.text;
+  if (!text) throw new Error("tool returned no structured or text payload");
+  return JSON.parse(text) as ToolPayload;
+}
+
+async function connect(
+  entry: string,
+  caller?: { workspace: string; surface: string },
+): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: process.cwd(),
+    env: stringEnv({
+      ...process.env,
+      CMUXLAYER_DEV: "1",
+      CMUXLAYER_FORCE_INPROCESS: "1",
+      ...(caller
+        ? {
+            CMUX_WORKSPACE_ID: caller.workspace,
+            CMUX_SURFACE_ID: caller.surface,
+          }
+        : {}),
+    }),
+    stderr: "inherit",
+  });
+  const client = new Client({
+    name: "cmuxlayer-live-worker-placement-repro",
+    version: "1",
+  });
+  await client.connect(transport);
+  return client;
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolPayload> {
+  const result = await client.callTool(
+    { name, arguments: args },
+    undefined,
+    { timeout: 30_000 },
+  );
+  const parsed = payload(result);
+  if (parsed.ok !== true) {
+    throw new Error(`${name} failed: ${JSON.stringify(parsed)}`);
+  }
+  return parsed;
+}
+
+function surfacesIn(
+  topology: ToolPayload,
+  workspace: string,
+): Array<Record<string, unknown>> {
+  const surfaces = Array.isArray(topology.surfaces) ? topology.surfaces : [];
+  return surfaces.filter(
+    (surface): surface is Record<string, unknown> =>
+      typeof surface === "object" &&
+      surface !== null &&
+      surface.workspace_ref === workspace,
+  );
+}
+
+async function main(): Promise<void> {
+  const entry = resolve(requiredArg("--entry"));
+  if (!existsSync(entry)) throw new Error(`entry does not exist: ${entry}`);
+  if (!process.env.CMUX_SOCKET_PATH) {
+    throw new Error("CMUX_SOCKET_PATH must pin the real cmux instance");
+  }
+
+  const cleanup: Array<{ surface: string; workspace: string }> = [];
+  let cleanupSink: { pane: string; workspace: string } | null = null;
+  let setupClient: Client | null = null;
+  let callerClient: Client | null = null;
+  let receipt: Record<string, unknown> | null = null;
+  try {
+    setupClient = await connect(entry);
+    const baseline = await call(setupClient, "list_surfaces", {});
+    const baselineSurface = Array.isArray(baseline.surfaces)
+      ? baseline.surfaces.find(
+          (surface): surface is Record<string, unknown> =>
+            typeof surface === "object" &&
+            surface !== null &&
+            typeof surface.pane_ref === "string" &&
+            typeof surface.workspace_ref === "string",
+        )
+      : undefined;
+    if (baselineSurface) {
+      cleanupSink = {
+        pane: String(baselineSurface.pane_ref),
+        workspace: String(baselineSurface.workspace_ref),
+      };
+    }
+    const occupiedWorkspaces = new Set(
+      (Array.isArray(baseline.surfaces) ? baseline.surfaces : []).flatMap(
+        (surface) =>
+          typeof surface === "object" &&
+          surface !== null &&
+          typeof surface.workspace_ref === "string"
+            ? [surface.workspace_ref]
+            : [],
+      ),
+    );
+    const reusableWorkspace = (
+      Array.isArray(baseline.workspaces) ? baseline.workspaces : []
+    ).find(
+      (workspace): workspace is Record<string, unknown> =>
+        typeof workspace === "object" &&
+        workspace !== null &&
+        typeof workspace.ref === "string" &&
+        typeof workspace.title === "string" &&
+        workspace.title.startsWith("placement-reopen-") &&
+        !occupiedWorkspaces.has(workspace.ref),
+    );
+    const workspace = reusableWorkspace && cleanupSink
+      ? String(reusableWorkspace.ref)
+      : String(
+          (
+            await call(setupClient, "create_workspace", {
+              title: `placement-reopen-${process.pid}`,
+            })
+          ).workspace,
+        );
+    let initial = surfacesIn(
+      await call(setupClient, "list_surfaces", {}),
+      workspace,
+    )[0];
+    if (!initial) {
+      if (!cleanupSink) {
+        throw new Error("cannot seed an empty fixture workspace without a sink pane");
+      }
+      const seeded = await call(setupClient, "new_surface", {
+        pane: cleanupSink.pane,
+        workspace: cleanupSink.workspace,
+        title: "placement-fixture-left-shell",
+      });
+      const moved = await call(setupClient, "move_surface", {
+        surface: seeded.surface,
+        workspace,
+        focus: true,
+      });
+      initial = {
+        ref: moved.surface,
+        pane_ref: moved.pane,
+      };
+    }
+    const initialSurface = String(initial.ref);
+    const leftPane = String(initial.pane_ref);
+    cleanup.push({ surface: initialSurface, workspace });
+    await call(setupClient, "rename_tab", {
+      surface: initialSurface,
+      workspace,
+      title: "placement-fixture-leftClaude",
+    });
+
+    const right = await call(setupClient, "new_split", {
+      direction: "right",
+      workspace,
+      surface: initialSurface,
+      title: "placement-fixture-right-shell",
+    });
+    const rightSurface = String(right.surface);
+    cleanup.unshift({ surface: rightSurface, workspace });
+    await call(setupClient, "rename_tab", {
+      surface: rightSurface,
+      workspace,
+      title: "placement-fixture-rightClaude",
+    });
+
+    const caller = await call(setupClient, "new_surface", {
+      pane: leftPane,
+      workspace,
+      title: "placement-fixture-callerClaude",
+    });
+    const callerSurface = String(caller.surface);
+    cleanup.unshift({ surface: callerSurface, workspace });
+    callerClient = await connect(entry, {
+      workspace,
+      surface: callerSurface,
+    });
+    await setupClient.close();
+    setupClient = null;
+    const before = await call(callerClient, "list_surfaces", {});
+    const spawn = await call(callerClient, "new_split", {
+      direction: "right",
+      workspace,
+      role: "worker",
+      title: "placement-reopen-live-worker",
+    });
+    const workerSurface = String(spawn.surface);
+    cleanup.unshift({ surface: workerSurface, workspace });
+    const after = await call(callerClient, "list_surfaces", {});
+    const worker = surfacesIn(after, workspace).find(
+      (surface) => surface.ref === workerSurface,
+    );
+    if (!worker) throw new Error("spawned worker missing from immediate topology");
+
+    const callerColumn = surfacesIn(before, workspace).find(
+      (surface) => surface.ref === callerSurface,
+    )?.column;
+    const workerColumn = worker.column;
+    if (
+      typeof callerColumn !== "number" ||
+      typeof workerColumn !== "number"
+    ) {
+      throw new Error("caller or worker topology is missing a numeric column");
+    }
+    const passed = workerColumn === callerColumn + 1;
+
+    receipt = {
+      entry,
+      workspace,
+      caller_surface: callerSurface,
+      caller_column: callerColumn,
+      column_count_before: before.column_count,
+      spawn,
+      worker_surface: workerSurface,
+      worker_column_at_spawn: workerColumn,
+      passed,
+    };
+    process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+    if (!passed) {
+      throw new Error(
+        `worker landed in column ${workerColumn}; expected ${callerColumn + 1}`,
+      );
+    }
+  } finally {
+    const cleanupClient = callerClient ?? setupClient;
+    if (cleanupClient) {
+      for (const target of cleanup) {
+        try {
+          await call(cleanupClient, "close_surface", target);
+        } catch (closeError) {
+          if (!cleanupSink) {
+            console.error("surface cleanup failed", target, closeError);
+            process.exitCode = 1;
+            continue;
+          }
+          try {
+            await call(cleanupClient, "move_surface", {
+              surface: target.surface,
+              pane: cleanupSink.pane,
+              workspace: cleanupSink.workspace,
+              focus: false,
+            });
+            await call(cleanupClient, "close_surface", {
+              surface: target.surface,
+              workspace: cleanupSink.workspace,
+            });
+          } catch (fallbackError) {
+            console.error("fallback cleanup failed", target, fallbackError);
+            process.exitCode = 1;
+          }
+        }
+      }
+      await cleanupClient.close().catch((error) => {
+        console.error("cleanup client close failed", error);
+        process.exitCode = 1;
+      });
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -322,11 +322,29 @@ export class CmuxSocketClient {
     workspace?: string;
     pane: string;
   }): Promise<string | undefined> {
-    const paneSurfaces = await this.listPaneSurfaces({
-      workspace: opts.workspace,
-      pane: opts.pane,
-    });
-    const surfaces = paneSurfaces.surfaces ?? [];
+    const [paneList, paneSurfaces] = await Promise.all([
+      this.listPanes({ workspace: opts.workspace }),
+      this.listPaneSurfaces({
+        workspace: opts.workspace,
+        pane: opts.pane,
+      }),
+    ]);
+    const targetPane = paneList.panes.find(
+      (pane) => pane.ref === opts.pane || pane.id === opts.pane,
+    );
+    if (!targetPane) return undefined;
+
+    // The socket's surface.list response is workspace-wide even when pane_id
+    // is supplied. Filter it through pane.list membership before choosing the
+    // selected tab, otherwise a focused lead surface can anchor a worker split
+    // in the left column despite placement naming a right-column pane.
+    const surfaceRefs = new Set(targetPane.surface_refs ?? []);
+    const surfaceIds = new Set(targetPane.surface_ids ?? []);
+    const surfaces = (paneSurfaces.surfaces ?? []).filter(
+      (surface) =>
+        surfaceRefs.has(surface.ref) ||
+        (surface.id !== undefined && surfaceIds.has(surface.id)),
+    );
     return (
       surfaces.find((surface) => surface.selected)?.ref ?? surfaces[0]?.ref
     );

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -523,6 +523,74 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(lastV2Request?.params).not.toHaveProperty("pane_id");
   });
 
+  it("anchors a pane-targeted split inside that pane when surface.list ignores pane_id", async () => {
+    const savedPaneList = MOCK_RESPONSES["pane.list"];
+    const savedSurfaceList = MOCK_RESPONSES["surface.list"];
+    MOCK_RESPONSES["pane.list"] = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: "pane:left",
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: ["surface:lead"],
+        },
+        {
+          ref: "pane:right",
+          index: 1,
+          focused: false,
+          surface_count: 1,
+          surface_refs: ["surface:right"],
+        },
+      ],
+    };
+    // Production surface.list is workspace-wide even when pane_id is passed.
+    // The globally selected lead surface must not override the requested pane.
+    MOCK_RESPONSES["surface.list"] = {
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      surfaces: [
+        {
+          ref: "surface:lead",
+          title: "orcClaude",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+        {
+          ref: "surface:right",
+          title: "driverBuddy",
+          type: "terminal",
+          index: 1,
+          selected: false,
+        },
+      ],
+    };
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.newSplit("down", {
+        workspace: "workspace:1",
+        pane: "pane:right",
+      });
+
+      expect(lastV2Request).toEqual({
+        method: "surface.split",
+        params: {
+          direction: "down",
+          workspace_id: "workspace:1",
+          surface_id: "surface:right",
+        },
+      });
+    } finally {
+      MOCK_RESPONSES["pane.list"] = savedPaneList;
+      MOCK_RESPONSES["surface.list"] = savedSurfaceList;
+    }
+  });
+
   it("newSplit omits the pane anchor when the pane has no surfaces", async () => {
     const saved = MOCK_RESPONSES["surface.list"];
     MOCK_RESPONSES["surface.list"] = {


### PR DESCRIPTION
## Summary

- Fix the H1 production decision-to-execution gap at the socket pane-anchor boundary.
- Resolve a requested pane's actual `surface_refs` / `surface_ids` from `pane.list` before choosing the split anchor.
- Add a regression where `surface.list` ignores `pane_id`, returns both columns, and marks the col-0 lead globally selected.
- Add a real MCP/live-cmux harness that asserts the worker's column immediately after `new_split(role:"worker")`, before any resync or reflow.

## Root cause: H1, not H2

`chooseAgentSpawnPlacement` correctly selected `{ kind: "split", direction: "down", pane: <right pane> }` for the failing topology. The loss happened afterward in `CmuxSocketClient.resolvePaneAnchorSurface` (`src/cmux-socket-client.ts`): production `surface.list` is workspace-wide even when `pane_id` is supplied. The old code chose `surfaces.find(selected)`, so when orc's col-0 lead was globally selected it replaced the requested right-pane anchor. `surface.split` therefore executed `down` from the lead pane and created the worker in column 0.

H2 was checked empirically. Long-lived affected MCP children carry `CMUXLAYER_SELF_REEXECED=0.3.42->0.3.43`, so the proxy self-reexec did fire. The failure was also fill/focus-dependent rather than version-consistent. H2 is not the dominant cause of this recurrence.

## Why #297's tests missed it

The mocked-away real-path variable was **cross-pane global selection/focus under an unfiltered `surface.list` response**. The existing socket mock had one pane and one selected surface, implicitly behaving as if `pane_id` were honored. #297's layout-policy tests proved the chooser returned the right pane, but never drove the subsequent production socket resolver with a col-0 lead selected and a different target pane. Thus the correct policy decision was silently re-anchored to column 0 after the tested boundary.

## Live RED → GREEN

Same real cmux instance, disposable two-column fixture, lead caller in column 0, right pane lead-owned, immediate topology read (no resync/reflow):

### Installed v0.3.43 — RED

`bun run live:worker-placement --entry /opt/homebrew/Cellar/cmuxlayer/0.3.43/libexec/dist/index.js`

- caller column: `0`
- placement: `split`, direction: `down`
- worker column at spawn: `0`
- exit: `1`

### This branch — GREEN

`bun run build && bun run live:worker-placement --entry dist/index.js`

- caller column: `0`
- placement: `split`, direction: `down`
- worker column at spawn: `1`
- `passed: true`
- exit: `0`

Independent visible reviewer pane `surface:248` reran typecheck, focused socket tests, build, and the live harness: **PASS** with caller `0` → worker `1` at spawn.

## Test plan

- [x] Regression test RED on old resolver: expected `surface:right`, received `surface:lead`
- [x] `bun run test` — 92 files, 1,719 tests passed
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Live installed-v0.3.43 RED
- [x] Live branch GREEN at spawn time
- [x] Independent visible reviewer reran the live acceptance
- [x] Local CodeRabbit findings addressed; follow-up review hit the free OSS rate limit

Do not merge; Etan will decide after review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes split anchoring on the production socket path for all pane-targeted splits; behavior is narrowed and covered by new tests, but layout spawn correctness is user-visible.
> 
> **Overview**
> Fixes **worker surfaces landing in column 0** when spawn placement names a right-column pane but the socket path picks the wrong split anchor.
> 
> **`resolvePaneAnchorSurface`** now loads **`pane.list`** alongside **`surface.list`**, restricts surfaces to the target pane’s **`surface_refs` / `surface_ids`**, then picks the selected tab. That stops a **globally selected lead surface in another column** from overriding the requested pane when **`surface.list` ignores `pane_id`**.
> 
> Adds a **mock regression** for that two-column / global-selection case and a **`live:worker-placement`** MCP script that asserts **`new_split(role: "worker")`** puts the worker in **`callerColumn + 1`** immediately after spawn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f95fa489baa1f51ea7412b08515c541463b9c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pane-targeted split anchor selection in `CmuxSocketClient.resolvePaneAnchorSurface`
> - Fixes a bug where pane-targeted splits could anchor to a surface from the wrong pane. `resolvePaneAnchorSurface` now concurrently fetches the pane list and surface list, then filters surfaces down to those belonging to the target pane using `surface_refs`/`surface_ids` before selecting.
> - Adds a test in [cmux-socket-client.test.ts](https://github.com/EtanHey/cmuxlayer/pull/300/files#diff-07ac6f3227ee83fa6f31a7a58db84f9e0ae1a9bf7ac6761a592a7042338a1792) that verifies the correct surface is chosen when a workspace-wide surface list includes surfaces from multiple panes.
> - Adds [run-live-worker-placement-repro.ts](https://github.com/EtanHey/cmuxlayer/pull/300/files#diff-c0713f32cf20b851b6de81c0b9b79277e73c18546e664395eb2f3c991f86a885), a CLI script that connects to a live MCP server, seeds a workspace, spawns a worker split, and validates column placement invariants to reproduce the original bug.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f95fa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->