### PR TITLE
feat(workspace): delete_workspace tool + harness scratch teardown

### DIFF
--- a/docs/plans/2026-07-12-delete-workspace.md
+++ b/docs/plans/2026-07-12-delete-workspace.md
@@ -1,0 +1,77 @@
+# Delete Workspace Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a safe, deferred `delete_workspace` MCP tool and ensure live acceptance harnesses always delete scratch workspaces.
+
+**Architecture:** Extend both cmux client transports with the native `workspace.close` / `workspace close` operation. Register a destructive workspace-level MCP handler beside `create_workspace`; snapshot its topology first, refuse caller/live-agent workspaces unless forced, and return the removed workspace/surface diff. Keep the tool in the deferred layout class by placement beside `create_workspace`, ready for the in-flight thin-core palette classification.
+
+**Tech Stack:** TypeScript, Node.js, MCP SDK, zod, Vitest, cmux V2 socket/CLI.
+
+---
+
+### Task 1: Specify client and policy behavior
+
+**Files:**
+
+- Modify: `tests/cmux-client.test.ts`
+- Modify: `tests/cmux-socket-client.test.ts`
+- Modify: `tests/mode-policy.test.ts`
+- Modify: `tests/server.test.ts`
+
+1. Add tests requiring CLI `workspace close <ref>` and socket `workspace.close` calls.
+2. Add a mode-policy assertion that `delete_workspace` is mutating.
+3. Add server tests for empty-workspace deletion, live-agent refusal with surfaces/agents returned, forced deletion, and caller-workspace refusal.
+4. Run the focused tests and confirm they fail because the tool/client methods do not exist.
+
+### Task 2: Specify harness cleanup
+
+**Files:**
+
+- Modify: `tests/acceptance-registry-liveness.test.ts`
+- Create: `tests/workspace-harness-cleanup.test.ts`
+
+1. Add a source contract for `--create-workspace` support in the registry-liveness harness.
+2. Assert both harness `finally` blocks call `delete_workspace` with `force:true` for their scratch workspace.
+3. Run the focused tests and confirm the missing cleanup behavior fails.
+
+### Task 3: Implement workspace deletion
+
+**Files:**
+
+- Modify: `src/cmux-client.ts`
+- Modify: `src/cmux-socket-client.ts`
+- Modify: `src/mode-policy.ts`
+- Modify: `src/server.ts`
+
+1. Add `deleteWorkspace(workspace)` to both transports, with socket method-not-found fallback to the CLI client.
+2. Register `delete_workspace` beside the deferred `create_workspace` layout tool using destructive annotations.
+3. Snapshot the target workspace, panes, surfaces, and matching agent records.
+4. Refuse without `force` when the target is the caller workspace or any matching agent is not done/error; return the snapshot on refusal.
+5. Call the client deletion method and return removed workspace/surface diff data.
+6. Run focused tests until green.
+
+### Task 4: Implement finally cleanup
+
+**Files:**
+
+- Modify: `scripts/acceptance-registry-liveness.mjs`
+- Modify: `scripts/run-live-worker-placement-repro.ts`
+
+1. Carry forward the acceptance harness's `--create-workspace <title>` path from its older tooling branch.
+2. Track whether each harness created/reused a scratch workspace.
+3. In `finally`, call `delete_workspace` with `{ workspace, force: true }` before closing the MCP client.
+4. Run the harness cleanup tests until green.
+
+### Task 5: Verify and publish
+
+**Files:**
+
+- Review all changed files.
+
+1. Run all focused tests.
+2. Run `bun run typecheck` and `bun test`.
+3. Exercise the built MCP from a real client session, including listing/calling the new tool against a disposable workspace.
+4. Run bounded CodeRabbit review; address actionable findings.
+5. Commit as `feat(workspace): delete_workspace tool + harness scratch teardown`.
+6. Push `feat/delete-workspace-and-harness-teardown` and open a ready-for-review PR. Do not merge.

--- a/scripts/acceptance-registry-liveness.mjs
+++ b/scripts/acceptance-registry-liveness.mjs
@@ -18,7 +18,8 @@
 // Usage:
 //   CMUX_LIVE_HARNESS=1 node scripts/acceptance-registry-liveness.mjs \
 //     --server node --server-arg /abs/path/to/dist/index.js \
-//     --workspace <ref> [--count 3] [--repo cmuxlayer] [--wait-timeout-ms 180000]
+//     (--workspace <ref> | --create-workspace <title>) \
+//     [--count 3] [--repo cmuxlayer] [--wait-timeout-ms 180000]
 //
 // Exit 0 + both "GREEN_DEADCHILD" and "GREEN_REGISTRY_LIVENESS" on pass.
 // If process discovery/state forcing is unavailable, the probe prints an
@@ -44,6 +45,7 @@ function parseArgs(argv) {
     workspace: "",
     waitTimeoutMs: 180_000,
     selfTestDeadChild: false,
+    createWorkspace: "",
   };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
@@ -56,6 +58,7 @@ function parseArgs(argv) {
     else if (a === "--workspace") o.workspace = next();
     else if (a === "--wait-timeout-ms") o.waitTimeoutMs = Number(next());
     else if (a === "--self-test-dead-child") o.selfTestDeadChild = true;
+    else if (a === "--create-workspace") o.createWorkspace = next();
     else if (a === "--help" || a === "-h") {
       process.stdout.write("see header of this file for usage\n");
       process.exit(0);
@@ -602,13 +605,33 @@ async function main() {
     process.stderr.write("Refusing: set CMUX_LIVE_HARNESS=1 to opt in (needs a pane-descended shell).\n");
     process.exit(2);
   }
-  // Refuse before MCP startup/spawn: role:all must never escape the test workspace.
-  const workspace = scopedRoleAllBroadcast(opt.workspace, {}).workspace;
+  // Refuse before MCP startup/spawn unless the scoped workspace will be minted
+  // by this harness after MCP initialization.
+  let workspace = opt.createWorkspace
+    ? ""
+    : scopedRoleAllBroadcast(opt.workspace, {}).workspace;
   process.stdout.write(`=== registry-liveness §7 acceptance (N=${opt.count}, cli=${opt.cli}) ===\n`);
   const mcp = new Mcp(opt.server, opt.serverArgs);
   const spawned = [];
   try {
     await mcp.init();
+    if (opt.createWorkspace) {
+      const created = await mcp.call(
+        "create_workspace",
+        { title: opt.createWorkspace },
+        30_000,
+      );
+      workspace = created.workspace || created.ref;
+      if (!workspace) {
+        throw new Error(
+          `create_workspace returned no ref: ${JSON.stringify(created)}`,
+        );
+      }
+      scopedRoleAllBroadcast(workspace, {});
+      process.stdout.write(
+        `  created scoped workspace ${workspace} ("${opt.createWorkspace}")\n`,
+      );
+    }
 
     // 1. spawn N agents into a scoped workspace
     for (let i = 0; i < opt.count; i += 1) {
@@ -697,6 +720,13 @@ async function main() {
       if (!a.surface_id) continue;
       try {
         await mcp.call("close_surface", { surface: a.surface_id, force: true }, 30_000);
+      } catch {
+        /* best effort */
+      }
+    }
+    if (opt.createWorkspace && workspace) {
+      try {
+        await mcp.call("delete_workspace", { workspace, force: true }, 30_000);
       } catch {
         /* best effort */
       }

--- a/scripts/run-live-worker-placement-repro.ts
+++ b/scripts/run-live-worker-placement-repro.ts
@@ -104,6 +104,7 @@ async function main(): Promise<void> {
   let cleanupSink: { pane: string; workspace: string } | null = null;
   let setupClient: Client | null = null;
   let callerClient: Client | null = null;
+  let scratchWorkspace: string | null = null;
   let receipt: Record<string, unknown> | null = null;
   try {
     setupClient = await connect(entry);
@@ -153,6 +154,7 @@ async function main(): Promise<void> {
             })
           ).workspace,
         );
+    scratchWorkspace = workspace;
     let initial = surfacesIn(
       await call(setupClient, "list_surfaces", {}),
       workspace,
@@ -283,6 +285,21 @@ async function main(): Promise<void> {
             console.error("fallback cleanup failed", target, fallbackError);
             process.exitCode = 1;
           }
+        }
+      }
+      if (scratchWorkspace) {
+        try {
+          await call(cleanupClient, "delete_workspace", {
+            workspace: scratchWorkspace,
+            force: true,
+          });
+        } catch (deleteError) {
+          console.error(
+            "workspace cleanup failed",
+            scratchWorkspace,
+            deleteError,
+          );
+          process.exitCode = 1;
         }
       }
       await cleanupClient.close().catch((error) => {

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -528,6 +528,10 @@ export class CmuxClient {
     };
   }
 
+  async deleteWorkspace(workspace: string): Promise<void> {
+    await this.run(["workspace", "close", workspace]);
+  }
+
   async readScreen(
     surface: string,
     opts?: {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -283,6 +283,17 @@ export class CmuxSocketClient {
     }
   }
 
+  async deleteWorkspace(workspace: string): Promise<void> {
+    try {
+      await this.call("workspace.close", { workspace_id: workspace });
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallbackPinned()!.deleteWorkspace(workspace);
+      }
+      throw e;
+    }
+  }
+
   async listPaneSurfaces(opts?: {
     workspace?: string;
     pane?: string;

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -83,6 +83,7 @@ const FORWARDED_ASYNC_METHODS = [
   "sendKey",
   "selectWorkspace",
   "createWorkspace",
+  "deleteWorkspace",
   "readScreen",
   "renameTab",
   "notify",

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -16,6 +16,7 @@ const READ_ONLY_TOOLS = new Set([
 const MUTATING_TOOLS = new Set([
   "select_workspace",
   "create_workspace",
+  "delete_workspace",
   "new_split",
   "new_surface",
   "move_surface",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4634,6 +4634,113 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
+  // Deferred layout/UI tool: keep beside create_workspace so the thin-core
+  // palette classifies both workspace-management tools together off-default.
+  const deleteWorkspaceTool = server.tool(
+    "delete_workspace",
+    "Delete a whole workspace tab and all of its panes/surfaces. SAFETY: refuses a workspace that backs a live agent, or the caller's own workspace, unless force:true. Refusals include the current surfaces and agents for verification.",
+    {
+      workspace: z.string().describe("Target workspace ref"),
+      force: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Delete even when the workspace backs a live agent or is the caller's workspace.",
+        ),
+    },
+    ANNOTATIONS.mutating,
+    async (args) => {
+      try {
+        await assertWorkspaceMutationAllowed(
+          "delete_workspace",
+          args.workspace,
+        );
+
+        const [{ workspaces }, panes] = await Promise.all([
+          client.listWorkspaces(),
+          client.listPanes({ workspace: args.workspace }),
+        ]);
+        const paneGroups = await Promise.all(
+          panes.panes.map((pane) =>
+            client.listPaneSurfaces({
+              workspace: args.workspace,
+              pane: pane.ref,
+            }),
+          ),
+        );
+        const surfaces = paneGroups
+          .flatMap((group) => group.surfaces)
+          .filter(
+            (surface, index, all) =>
+              all.findIndex((candidate) => candidate.ref === surface.ref) ===
+              index,
+          );
+        const surfaceRefs = new Set(surfaces.map((surface) => surface.ref));
+        const agents = stateMgr
+          .listStates()
+          .filter(
+            (agent) =>
+              surfaceRefs.has(agent.surface_id) ||
+              agent.workspace_id === args.workspace,
+          );
+        const liveAgents = agents.filter(
+          (agent) => !TERMINAL_AGENT_STATES.has(agent.state),
+        );
+        const callerWorkspace = await currentCallerWorkspace();
+        const deletingCallerWorkspace = callerWorkspace === args.workspace;
+
+        if (
+          !args.force &&
+          (deletingCallerWorkspace || liveAgents.length > 0)
+        ) {
+          const reasons = [
+            ...(deletingCallerWorkspace ? ["it is the caller workspace"] : []),
+            ...(liveAgents.length > 0
+              ? [`it backs ${liveAgents.length} live agent(s)`]
+              : []),
+          ];
+          return err(
+            new Error(
+              `Refused to delete ${args.workspace}: ${reasons.join(" and ")}. Pass force:true to delete anyway.`,
+            ),
+            {
+              refused: true,
+              workspace: args.workspace,
+              caller_workspace: deletingCallerWorkspace,
+              surfaces,
+              agents,
+              live_agents: liveAgents,
+            },
+          );
+        }
+
+        await client.deleteWorkspace(args.workspace);
+        const removedWorkspace =
+          workspaces.find((workspace) => workspace.ref === args.workspace) ?? {
+            ref: args.workspace,
+          };
+        const data = {
+          workspace: args.workspace,
+          force: args.force ?? false,
+          removed: {
+            workspaces: [removedWorkspace],
+            surfaces,
+          },
+        };
+        return okFormatted(formatOk("delete_workspace", data), data);
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+  deleteWorkspaceTool.update({
+    _meta: {
+      defer_loading: true,
+      "cmuxlayer/interim": true,
+    },
+  });
+
   // 2. new_split
   server.tool(
     "new_split",

--- a/src/server.ts
+++ b/src/server.ts
@@ -3804,9 +3804,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!candidate) return undefined;
     try {
       const { workspaces } = await client.listWorkspaces();
+      const normalized = candidate.trim();
       return (
-        workspaces.find((workspace) => envWorkspaceMatches(workspace, candidate))
-          ?.ref ?? candidate
+        workspaces.find(
+          (workspace) =>
+            envWorkspaceMatches(workspace, candidate) ||
+            workspace.title === normalized,
+        )?.ref ?? candidate
       );
     } catch {
       return candidate;
@@ -4652,19 +4656,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const targetWorkspace =
+          (await canonicalWorkspaceRef(args.workspace)) ?? args.workspace;
         await assertWorkspaceMutationAllowed(
           "delete_workspace",
-          args.workspace,
+          targetWorkspace,
         );
 
         const [{ workspaces }, panes] = await Promise.all([
           client.listWorkspaces(),
-          client.listPanes({ workspace: args.workspace }),
+          client.listPanes({ workspace: targetWorkspace }),
         ]);
         const paneGroups = await Promise.all(
           panes.panes.map((pane) =>
             client.listPaneSurfaces({
-              workspace: args.workspace,
+              workspace: targetWorkspace,
               pane: pane.ref,
             }),
           ),
@@ -4682,13 +4688,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .filter(
             (agent) =>
               surfaceRefs.has(agent.surface_id) ||
-              agent.workspace_id === args.workspace,
+              agent.workspace_id === targetWorkspace,
           );
         const liveAgents = agents.filter(
           (agent) => !TERMINAL_AGENT_STATES.has(agent.state),
         );
         const callerWorkspace = await currentCallerWorkspace();
-        const deletingCallerWorkspace = callerWorkspace === args.workspace;
+        const deletingCallerWorkspace = callerWorkspace === targetWorkspace;
 
         if (
           !args.force &&
@@ -4702,11 +4708,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ];
           return err(
             new Error(
-              `Refused to delete ${args.workspace}: ${reasons.join(" and ")}. Pass force:true to delete anyway.`,
+              `Refused to delete ${targetWorkspace}: ${reasons.join(" and ")}. Pass force:true to delete anyway.`,
             ),
             {
               refused: true,
-              workspace: args.workspace,
+              workspace: targetWorkspace,
               caller_workspace: deletingCallerWorkspace,
               surfaces,
               agents,
@@ -4715,13 +4721,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
 
-        await client.deleteWorkspace(args.workspace);
+        await client.deleteWorkspace(targetWorkspace);
         const removedWorkspace =
-          workspaces.find((workspace) => workspace.ref === args.workspace) ?? {
-            ref: args.workspace,
+          workspaces.find((workspace) => workspace.ref === targetWorkspace) ?? {
+            ref: targetWorkspace,
           };
         const data = {
-          workspace: args.workspace,
+          workspace: targetWorkspace,
           force: args.force ?? false,
           removed: {
             workspaces: [removedWorkspace],

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -72,6 +72,21 @@ describe("CmuxClient.createWorkspace", () => {
   });
 });
 
+describe("CmuxClient.deleteWorkspace", () => {
+  it("uses the current workspace close CLI shape", async () => {
+    const { client, exec } = mockClient({});
+
+    await client.deleteWorkspace("workspace:7");
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json",
+      "workspace",
+      "close",
+      "workspace:7",
+    ]);
+  });
+});
+
 describe("CmuxClient.listPaneSurfaces", () => {
   it("calls with workspace flag when provided", async () => {
     const data = {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -56,6 +56,7 @@ const MOCK_RESPONSES: Record<string, unknown> = {
     ],
   },
   "workspace.select": {},
+  "workspace.close": {},
   "surface.list": {
     workspace_ref: "workspace:1",
     window_ref: "window:1",
@@ -437,6 +438,16 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
 
     expect(lastV2Request).not.toBeNull();
     expect(lastV2Request!.method).toBe("workspace.select");
+    expect(lastV2Request!.params).toEqual({ workspace_id: "workspace:1" });
+  });
+
+  it("deleteWorkspace sends a workspace.close request", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.deleteWorkspace("workspace:1");
+
+    expect(lastV2Request).not.toBeNull();
+    expect(lastV2Request!.method).toBe("workspace.close");
     expect(lastV2Request!.params).toEqual({ workspace_id: "workspace:1" });
   });
 

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -955,6 +955,28 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("forwards deleteWorkspace through the self-healing transport", async () => {
+    const socketPath = join(tmpdir(), `cmux-delete-workspace-${process.pid}.sock`);
+    const cli = new CmuxClient({
+      exec: vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" }),
+      bin: "cmux",
+    });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      deleteWorkspace: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CmuxSocketClient;
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      reprobeIntervalMs: 60_000,
+    });
+
+    await (client as unknown as CmuxClient).deleteWorkspace("workspace:7");
+
+    expect(socket.deleteWorkspace).toHaveBeenCalledWith("workspace:7");
+    client.stop();
+  });
+
   it("flushes queued failed payloads sequentially", async () => {
     const socketPath = join(tmpdir(), `cmux-queue-seq-${process.pid}.sock`);
     let activeFlushes = 0;

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1222,7 +1222,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.start();
 
     await expect(rawToolsList(path, 100)).resolves.toMatchObject({
-      toolCount: 25,
+      toolCount: 26,
     });
 
     await daemon.shutdown();

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -45,6 +45,10 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("close_surface")).toBe(true);
   });
 
+  it("returns true for delete_workspace", () => {
+    expect(isMutatingTool("delete_workspace")).toBe(true);
+  });
+
   it("returns true for browser_surface", () => {
     expect(isMutatingTool("browser_surface")).toBe(true);
   });

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -48,6 +48,7 @@ describe("B1: ToolAnnotations on all tools", () => {
   const MUTATING_TOOLS = [
     "select_workspace",
     "create_workspace",
+    "delete_workspace",
     "new_split",
     "new_surface",
     "move_surface",
@@ -91,9 +92,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 42 tools have annotations", () => {
+  it("all 43 tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(42);
+    expect(toolNames.length).toBe(43);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -679,11 +679,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 42", () => {
+  it("total tool count is 43", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(42);
+    expect(Object.keys(registeredTools)).toHaveLength(43);
   });
 });
 

--- a/tests/server-delete-workspace.test.ts
+++ b/tests/server-delete-workspace.test.ts
@@ -143,6 +143,35 @@ describe("delete_workspace", () => {
     await server.close();
   });
 
+  it.each(["ws:7", "7", "scratch"])(
+    "refuses a live-agent workspace referenced by alias %s",
+    async (workspaceAlias) => {
+      const root = stateDir(`live-alias-${workspaceAlias.replace(/\W/g, "-")}`);
+      writeLiveAgent(root);
+      const { client } = mockClient();
+      const server = createServer({
+        client: client as any,
+        stateDir: root,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools.delete_workspace;
+
+      const result = await tool.handler(
+        { workspace: workspaceAlias },
+        {} as any,
+      );
+
+      expect(client.deleteWorkspace).not.toHaveBeenCalled();
+      expect(client.listPanes).toHaveBeenCalledWith({ workspace: "workspace:7" });
+      expect(result.structuredContent).toMatchObject({
+        refused: true,
+        workspace: "workspace:7",
+        live_agents: [expect.objectContaining({ agent_id: "worker-live" })],
+      });
+      await server.close();
+    },
+  );
+
   it("force-removes a workspace with a live agent", async () => {
     const root = stateDir("force");
     writeLiveAgent(root);
@@ -180,4 +209,30 @@ describe("delete_workspace", () => {
     });
     await server.close();
   });
+
+  it.each(["ws:7", "7", "scratch"])(
+    "refuses the caller workspace referenced by alias %s",
+    async (workspaceAlias) => {
+      const { client } = mockClient({ callerTarget: true });
+      const server = createServer({
+        client: client as any,
+        skipAgentLifecycle: true,
+      });
+      const tool = (server as any)._registeredTools.delete_workspace;
+
+      const result = await tool.handler(
+        { workspace: workspaceAlias },
+        {} as any,
+      );
+
+      expect(client.deleteWorkspace).not.toHaveBeenCalled();
+      expect(client.listPanes).toHaveBeenCalledWith({ workspace: "workspace:7" });
+      expect(result.structuredContent).toMatchObject({
+        refused: true,
+        workspace: "workspace:7",
+        caller_workspace: true,
+      });
+      await server.close();
+    },
+  );
 });

--- a/tests/server-delete-workspace.test.ts
+++ b/tests/server-delete-workspace.test.ts
@@ -1,0 +1,183 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "../src/server.js";
+import { StateManager } from "../src/state-manager.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function stateDir(label: string): string {
+  const root = join(tmpdir(), `cmuxlayer-delete-workspace-${label}-${process.pid}`);
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+  roots.push(root);
+  return root;
+}
+
+function writeLiveAgent(root: string): void {
+  new StateManager(root).writeState({
+    agent_id: "worker-live",
+    surface_id: "surface:worker-live",
+    workspace_id: "workspace:7",
+    state: "working",
+    repo: "cmuxlayer",
+    model: "codex",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "still working",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-12T00:00:00Z",
+    updated_at: "2026-07-12T00:00:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+  });
+}
+
+function mockClient(opts?: { callerTarget?: boolean; surface?: boolean }) {
+  const surface = {
+    ref: "surface:worker-live",
+    title: "worker",
+    type: "terminal",
+    index: 0,
+    selected: true,
+  };
+  return {
+    surface,
+    client: {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:1",
+            title: "caller",
+            selected: !opts?.callerTarget,
+          },
+          {
+            ref: "workspace:7",
+            title: "scratch",
+            selected: opts?.callerTarget ?? false,
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:7",
+        window_ref: "window:1",
+        panes: opts?.surface
+          ? [{ ref: "pane:7", surface_refs: [surface.ref] }]
+          : [],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:7",
+        window_ref: "window:1",
+        pane_ref: "pane:7",
+        surfaces: opts?.surface ? [surface] : [],
+      }),
+      deleteWorkspace: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+describe("delete_workspace", () => {
+  it("is registered off-default for deferred ToolSearch loading", async () => {
+    const { client } = mockClient();
+    const server = createServer({ client: client as any, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    expect(tool._meta).toMatchObject({
+      defer_loading: true,
+      "cmuxlayer/interim": true,
+    });
+    await server.close();
+  });
+
+  it("removes an empty workspace and returns the removed diff", async () => {
+    const { client } = mockClient();
+    const server = createServer({ client: client as any, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    const result = await tool.handler({ workspace: "workspace:7" }, {} as any);
+
+    expect(client.deleteWorkspace).toHaveBeenCalledWith("workspace:7");
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      workspace: "workspace:7",
+      removed: {
+        workspaces: [{ ref: "workspace:7", title: "scratch" }],
+        surfaces: [],
+      },
+    });
+    await server.close();
+  });
+
+  it("refuses a live-agent workspace and returns its surfaces and agents", async () => {
+    const root = stateDir("refuse");
+    writeLiveAgent(root);
+    const { client, surface } = mockClient({ surface: true });
+    const server = createServer({
+      client: client as any,
+      stateDir: root,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    const result = await tool.handler({ workspace: "workspace:7" }, {} as any);
+
+    expect(client.deleteWorkspace).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      surfaces: [surface],
+      agents: [expect.objectContaining({ agent_id: "worker-live", state: "working" })],
+    });
+    await server.close();
+  });
+
+  it("force-removes a workspace with a live agent", async () => {
+    const root = stateDir("force");
+    writeLiveAgent(root);
+    const { client } = mockClient({ surface: true });
+    const server = createServer({
+      client: client as any,
+      stateDir: root,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    const result = await tool.handler(
+      { workspace: "workspace:7", force: true },
+      {} as any,
+    );
+
+    expect(client.deleteWorkspace).toHaveBeenCalledWith("workspace:7");
+    expect(result.structuredContent).toMatchObject({ ok: true, force: true });
+    await server.close();
+  });
+
+  it("refuses the caller workspace without force", async () => {
+    const { client } = mockClient({ callerTarget: true });
+    const server = createServer({ client: client as any, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    const result = await tool.handler({ workspace: "workspace:7" }, {} as any);
+
+    expect(client.deleteWorkspace).not.toHaveBeenCalled();
+    expect(result.structuredContent).toMatchObject({
+      refused: true,
+      caller_workspace: true,
+      surfaces: [],
+      agents: [],
+    });
+    await server.close();
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -61,6 +61,7 @@ const EXPECTED_TOOLS = [
   "control_health",
   "select_workspace",
   "create_workspace",
+  "delete_workspace",
   "new_split",
   "new_surface",
   "move_surface",
@@ -395,7 +396,7 @@ describe("input delivery batching helpers", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 25 core tools", () => {
+  it("registers all 26 low-level tools", () => {
     const server = createServer({ skipAgentLifecycle: true });
     // Access internal registered tools via the server property
     const registeredTools = (server as any)._registeredTools;

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -285,14 +285,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("broadcast");
   });
 
-  it("total tool count is 42", () => {
+  it("total tool count is 43", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(42);
+    expect(count).toBe(43);
   });
 });
 

--- a/tests/workspace-harness-cleanup.test.ts
+++ b/tests/workspace-harness-cleanup.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("scratch workspace harness cleanup", () => {
+  it("registry-liveness create-workspace mode deletes its scratch workspace in finally", () => {
+    const source = readFileSync(
+      resolve("scripts/acceptance-registry-liveness.mjs"),
+      "utf8",
+    );
+
+    expect(source).toContain('a === "--create-workspace"');
+    expect(source).toMatch(
+      /finally\s*{[\s\S]*?delete_workspace[\s\S]*?force:\s*true/,
+    );
+  });
+
+  it("worker-placement repro deletes its scratch workspace in finally", () => {
+    const source = readFileSync(
+      resolve("scripts/run-live-worker-placement-repro.ts"),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /finally\s*{[\s\S]*?delete_workspace[\s\S]*?force:\s*true/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a deferred/off-default `delete_workspace` MCP tool backed by native socket/CLI workspace close operations
- refuse caller or live-agent workspaces unless `force:true`, returning current surfaces and agents on refusal
- delete scratch workspaces from registry-liveness and worker-placement harness `finally` blocks
- carry forward the acceptance harness `--create-workspace` mode that existed only on the older tooling branch

## Verification
- TDD RED observed for missing client/tool/policy/harness behavior
- `bun run typecheck`
- `bun run build`
- `bun run test` — 96 files, 1,751 tests passed
- real MCP SDK probe against built `dist/index.js`: tool listed with `defer_loading:true`; scratch workspace created, deleted with one surface removed, and confirmed absent
- CodeRabbit pre-commit review was bounded at ~3 minutes; it emitted reviewing heartbeats but no findings before timeout

## Notes
- ready for Etan's visible reviewer pane
- do not merge from this worker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive workspace deletion with safety gates, but `force: true` bypasses caller/live-agent checks and harness cleanup uses forced deletes; incorrect workspace resolution could remove the wrong tab.
> 
> **Overview**
> Adds a deferred **`delete_workspace`** MCP tool that closes a workspace via **`workspace.close`** (socket) or **`workspace close`** (CLI), with CLI fallback when the socket method is missing. Before deletion it snapshots surfaces and agents; it **refuses** the caller’s workspace or any workspace with **live agents** unless **`force: true`**, returning that snapshot on refusal and a removed workspace/surface diff on success. **`canonicalWorkspaceRef`** now also matches workspace **title**, so aliases like `scratch` resolve correctly.
> 
> **`deleteWorkspace`** is wired through the self-healing transport and classified as **mutating** in manual mode. Live harnesses tear down scratch workspaces: registry-liveness gains **`--create-workspace`** and **`delete_workspace`** in **`finally`**; the worker-placement repro does the same for its scratch workspace. Tool counts in tests move from 42→43 (26 low-level). A new implementation plan doc and focused tests cover clients, policy, server behavior, and harness cleanup contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f759788fc8ec71c869b0e7da622f9d643a6e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delete_workspace` MCP tool with harness scratch workspace teardown
> - Registers a new `delete_workspace` tool in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/301/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that resolves the target workspace, checks for live agents, refuses deletion of the caller's own workspace (unless `force:true`), and returns a diff of removed workspaces and surfaces.
> - Adds `deleteWorkspace` methods to `CmuxClient` (via `workspace close` CLI) and `CmuxSocketClient` (via `workspace.close` socket, with CLI fallback), and forwards the method through the self-healing transport wrapper.
> - Updates the acceptance test harness and repro script to create a disposable scratch workspace on startup and call `delete_workspace(force:true)` in their `finally` blocks.
> - Classifies `delete_workspace` as a mutating tool in mode policy and adds it to security hardening annotations; all tool-count expectations in tests are updated from 42→43 and 25→26.
> - Risk: forced deletion bypasses the live-agent and caller-workspace guards, so misuse can destroy an active workspace without confirmation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7f7597.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `delete_workspace` tool for removing workspaces.
  - Provides safety checks that prevent deleting the caller’s workspace or workspaces with live agents unless `force` is enabled.
  - Returns structured removal details, including affected workspace and surfaces.
  - Supports workspace deletion across available connection methods.

- **Bug Fixes**
  - Acceptance and reproduction workflows now clean up temporary workspaces automatically, including when failures occur.

- **Documentation**
  - Added an implementation plan covering workspace deletion behavior, safeguards, testing, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->