### PR TITLE
feat(tools): land thin-core 11-tool palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ To keep only a per-session resident subset of tools, set
 `CMUXLAYER_DEFAULT_PALETTE` to comma-separated bare tool names, for example
 `list_surfaces,spawn_agent,send_to`. The server also exposes `expand_palette`,
 which makes every deferred tool available for the rest of that MCP session.
-Unset or blank values preserve the full tool list; unknown names are warned and
-ignored while valid names still load.
+When unset or blank, the signed 12-tool thin-core default applies. When set, the
+environment value overrides that default for the session. Unknown names are
+warned and ignored while valid names still load.
 
 > **Config locations:** Codex CLI / T3 Code `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) | Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
 
@@ -66,30 +67,36 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer exposes 35 MCP tools for terminal control, screen reading, layout management, and multi-agent orchestration. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
+Under the hood, cmuxLayer keeps 42 MCP tools callable for terminal control, screen reading, layout management, and multi-agent orchestration. The default palette is intentionally limited to 12; the remaining tools are loaded through ToolSearch. `reorder_surface` is the single approved deletion. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
 ## Agent Routing Workflow
 
-For managed agents, use the agent-first path: `list_agents` to find the target, `send_to` to deliver work by `agent_id`, then `wait_for` when you need completion. Raw surface tools such as `send_input`, `send_command`, and `send_key` are still available for shells, launch/resume commands, stuck-pane recovery, and explicit terminal UI operations.
+For managed agents, use the agent-first path: `list_agents` to find the target, `send_to` to deliver work by `agent_id`, then `wait_for` when you need completion. `send_to` also preserves the registry-independent escape hatch: use `mode:"surface"`, `mode:"command"`, or `mode:"key"` with a raw surface ref for shells, launch/resume commands, and stuck-pane recovery.
 
 See [Agent Routing and Handling Workflow](docs/agent-routing-and-handling.md) for the full operator playbook, including stuck surface recovery and safe `/mcp` menu reconnects.
 
-## MCP Tools (35)
+## MCP Tools (42 registered, 12 default)
 
 All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
 
-**Terminal control** — `list_surfaces` `control_health` `select_workspace` `create_workspace` `new_split` `new_surface` `move_surface` `reorder_surface` `send_input` `send_command` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
+**Default palette** — `spawn_agent` `send_to` `wait_for` `read_screen` `my_agents` `list_agents` `broadcast` `close_surface` `dispatch_to_agent` `list_surfaces` `control_health` `stop_agent`
 
-**Agent lifecycle** — `spawn_agent` `new_worktree_split` `spawn_in_workspace` `resync_agents` `send_to` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill`
+The other 30 definitions, including `interact`, are interim ToolSearch-deferred and remain callable. This metadata split is deliberately reversible while the project decides which low-frequency operations belong in MCP versus CLI/programmatic surfaces.
+
+**Terminal control** — `list_surfaces` `control_health` `select_workspace` `create_workspace` `delete_workspace` `new_split` `new_surface` `move_surface` `send_input` `send_command` `send_key` `read_screen` `rename_tab` `close_surface` `browser_surface`
+
+**Agent lifecycle** — `spawn_agent` `new_worktree_split` `spawn_in_workspace` `resync_agents` `send_to` `send_to_agent` `wait_for` `wait_for_all` `interact` `stop_agent` `kill` `supersede_agent_goal` `broadcast`
 
 **Metacomm (agent inbox)** — `dispatch_to_agent` `inbox_check`
 
 **Workspace state** — `list_agents` `my_agents` `get_agent_state` `read_agent_output` `notify` `set_status` `set_progress`
 
-<details>
-<summary>Full tool reference (35 tools)</summary>
+**Monitor registry** — `register_monitor` `signal_monitor` `deregister_monitor` `list_monitors` `query_monitor_registry`
 
-### Read-only (8)
+<details>
+<summary>Full tool reference</summary>
+
+### Read-only (10)
 
 | Tool | What it does |
 |------|-------------|
@@ -101,35 +108,42 @@ All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specificat
 | `my_agents` | Children of a parent agent with live screen status |
 | `read_agent_output` | Structured output between delimiter markers |
 | `inbox_check` | Inspect an agent's inbox channel: pending messages, monitor liveness, stale dispatches |
+| `list_monitors` | List shared monitor-registry records |
+| `query_monitor_registry` | Query monitor gates and liveness metadata |
 
-### Mutating (24)
+### Mutating (29)
 
 | Tool | What it does |
 |------|-------------|
 | `select_workspace` | Switch the active workspace |
 | `create_workspace` | Create a new named workspace |
-| `new_split` | Create a terminal or browser split pane |
+| `delete_workspace` | Delete a workspace after live-agent and caller-workspace safety checks |
+| `new_split` | Deprecated one-release alias; use `spawn_agent(placement:...)` for managed agents |
 | `new_surface` | Create a tab in an existing pane |
 | `move_surface` | Move a surface to another pane or position |
-| `reorder_surface` | Reorder tabs within a pane |
-| `send_input` | Send text to a raw surface; use `send_to` for tracked agents |
-| `send_command` | Atomically send a command and press return on the same surface |
-| `send_key` | Send key press (return, escape, ctrl-c, etc.) to a raw surface |
+| `send_input` | Deprecated one-release alias for `send_to(mode:"surface")` |
+| `send_command` | Deprecated one-release alias for `send_to(mode:"command")` |
+| `send_key` | Deprecated one-release alias for `send_to(mode:"key")` |
 | `rename_tab` | Rename a surface tab |
 | `notify` | Show a cmux notification banner |
 | `set_status` | Set sidebar status key-value pair |
 | `set_progress` | Set progress indicator (0.0-1.0) |
 | `browser_surface` | Interact with browser surfaces |
 | `spawn_agent` | Spawn a CLI agent and return an `agent_id` for routing |
-| `new_worktree_split` | Create or reuse a git worktree and spawn a worker there |
-| `spawn_in_workspace` | Create a workspace and spawn a multi-agent team into a clean grid |
+| `new_worktree_split` | Deprecated one-release alias; use `spawn_agent(worktree:true, placement:"worker")` |
+| `spawn_in_workspace` | Deprecated one-release alias; create/reuse a workspace and call `spawn_agent` for each managed agent |
 | `resync_agents` | Re-sync the agent registry from live surfaces |
 | `dispatch_to_agent` | Append a task to an agent's inbox file (deterministic write channel) |
-| `send_to` | Preferred path for sending text to a tracked agent by `agent_id` |
-| `send_to_agent` | Legacy/internal agent send path; prefer `send_to` |
-| `wait_for` | Block until agent reaches a target state (defaults to `done`) |
-| `wait_for_all` | Block until multiple agents finish |
+| `send_to` | Send by agent ID or raw surface using `mode:"agent"|"surface"|"command"|"key"` |
+| `send_to_agent` | Deprecated one-release alias for `send_to(mode:"agent")` |
+| `wait_for` | Wait for one `agent_id` or several `ids` (defaults to `done`) |
+| `wait_for_all` | Deprecated one-release alias for `wait_for(ids:[...])` |
 | `interact` | Send interactive input (confirm, cancel, resume) |
+| `broadcast` | Fan out a guarded message to agents by role |
+| `supersede_agent_goal` | Replace a managed agent's active file-backed goal |
+| `register_monitor` | Register or re-arm a monitor deadman record |
+| `signal_monitor` | Refresh a monitor heartbeat |
+| `deregister_monitor` | Mark a monitor intentionally stopped |
 
 ### Destructive (3)
 

--- a/docs/agent-routing-and-handling.md
+++ b/docs/agent-routing-and-handling.md
@@ -24,13 +24,13 @@ can change after respawns, moves, reconnects, or stale terminal cleanup; an
 | Need | Use | Avoid |
 | --- | --- | --- |
 | Find available agents | `list_agents` | `list_surfaces` plus title guessing |
-| Send a prompt to a managed agent | `send_to` | `send_input` to a remembered surface |
+| Send a prompt to a managed agent | `send_to` | A remembered surface when an `agent_id` is healthy |
 | Wait for agent completion | `wait_for` | Polling `read_screen` only |
 | Inspect internal route/session data | `get_agent_state` | Adding topology fields to `list_agents` |
-| Start a new managed agent | `spawn_agent` or `spawn_in_workspace` | Raw `new_split` unless you need a shell |
-| Launch or resume with an exact shell command | `send_command` | Separate `send_input` then `send_key` |
-| Operate a raw terminal/shell | `send_input`, `send_command`, `send_key` | `send_to` without an agent |
-| Close or recover a stuck pane | `read_screen`, `close_surface`, `new_split` | Absorbing the worker task into the caller |
+| Start a new managed agent | `spawn_agent` with `placement`, `workspace`, or `worktree` | A raw split unless you need a shell |
+| Launch or resume with an exact shell command | `send_to(mode:"command")` | Separate text and key sends |
+| Operate a raw terminal/shell | `send_to(mode:"surface"|"command"|"key")` | Agent mode without an `agent_id` |
+| Close or recover a stuck pane | `read_screen`, `close_surface`, then `spawn_agent` for managed agents | Absorbing the worker task into the caller |
 
 ## Handling Existing Agents
 
@@ -39,7 +39,7 @@ When a user names a worker by role, tab, or short ref:
 1. Re-enumerate with `list_agents` and, if needed, `list_surfaces`.
 2. Match by stable facts: `agent_id`, repo, role, title, and current state.
 3. If there is a matching tracked agent, route through `send_to`.
-4. If only a raw terminal exists, use surface tools and keep the operation
+4. If only a raw terminal exists, use `send_to` with a raw-surface mode and keep the operation
    narrowly scoped to that terminal.
 5. After any respawn or close/open sequence, discard old surface refs and
    re-enumerate before sending more input.
@@ -94,7 +94,7 @@ starting the next. Do not batch menu keypresses across panes.
 
 ## When Surface Tools Are Correct
 
-Surface tools are still the right abstraction for:
+Raw-surface `send_to` modes are still the right abstraction for:
 
 - raw shells that are not tracked agents;
 - browser or terminal layout operations;

--- a/docs/inbox-hook-transport.md
+++ b/docs/inbox-hook-transport.md
@@ -2,7 +2,7 @@
 
 > Transport for the metacommlayer WRITE channel that does **not** depend on cmux
 > agent state. Born from the 2026-06-05 incident: a poisoned (error) registry
-> record killed the send_input fallback and a GO dispatch sat unread in
+> record killed the raw-surface send fallback and a GO dispatch sat unread in
 > `inbox.jsonl`.
 
 ## Two layers shipped in this PR
@@ -55,7 +55,7 @@ project's `.claude/settings.json` (or `settings.local.json`):
 
 - Hooks cannot wake a **fully idle** session (no timer events; `FileChanged`
   and `Stop` fire only around session activity). For truly idle agents the
-  `dispatch_to_agent` nudge (layer 1) or a manual `send_input` remains the
+  `dispatch_to_agent` nudge (layer 1) or manual `send_to(mode:"surface")` remains the
   wake of last resort. The durable queue is always the inbox file.
 - Codex/Cursor have no hook system — they keep the poll-on-turn convention
   (`replayUndelivered()` at turn start; see `recommendedCodexWatch`).

--- a/docs/metacommlayer-inbox.md
+++ b/docs/metacommlayer-inbox.md
@@ -1,11 +1,11 @@
 # metacommlayer WRITE channel — inbox dispatch (operations)
 
-> Sterile, deterministic dispatch that replaces `send_input`/TUI typing. Pairs with the READ
+> Sterile, deterministic dispatch that replaces raw `send_to(mode:"surface")`/TUI typing. Pairs with the READ
 > channel (`harness-session.ts`). Library: `src/inbox.ts`. MCP tools: `dispatch_to_agent`,
 > `inbox_check`. Spike proof: `orchestrator/docs.local/handoffs/2026-06-04/metacommlayer-write-channel-SPIKE-findings.md`.
 >
-> **`send_input` is KEPT as the fallback** — this channel is additive (belt-and-suspenders) until
-> proven in production. Fall back to `send_input` whenever `inbox_check` shows a wedged monitor.
+> **Raw-surface `send_to` is KEPT as the fallback** — this channel is additive (belt-and-suspenders) until
+> proven in production. Fall back to `send_to(mode:"surface")` whenever `inbox_check` shows a wedged monitor.
 
 ## Files (per agent, EPHEMERAL plumbing — NOT BrainLayer)
 - `~/.cmux/agents/<agent-id>/inbox.jsonl` — append-only dispatches.
@@ -21,7 +21,7 @@ Do NOT auto-ingest these into BrainLayer. Only messages with `persist:true` are 
 - **FM#4 — keep dispatch low-rate / batched** so the agent's Monitor doesn't trip its flood auto-stop.
 - **FM#3 — detect wedged agents:** `inbox_check { agent_id, ack_timeout_ms, heartbeat_max_age_ms }`
   → `{ monitor_alive, undelivered, stale }`. Non-empty `stale` (un-acked past the timeout) or
-  `monitor_alive:false` ⇒ the channel is down → **fall back to `send_input`** for that agent.
+  `monitor_alive:false` ⇒ the channel is down → **fall back to `send_to(mode:"surface")`** for that agent.
 - Triage: when an agent needs orc, it dispatches to `to:"orc"`; orc's own inbox monitor + its
   existing cron-tick loop catch it. No firehose, no separate buddy/local-model.
 
@@ -51,7 +51,7 @@ cadence — fine for coordination, not for sub-second control.
   act, `ack()`. This reuses the universal lib with zero Codex-specific code. `recommendedCodexWatch()`
   (bg-tail → `inbox.surfaced.log`) is OPTIONAL continuous capture only — it does NOT wake an idle
   Codex. **Residual:** a truly-idle, non-looping Codex still needs a turn trigger; that one case is
-  where `send_input` (the kept fallback) remains required. Deterministic dispatch for a *looping*
+  where raw-surface `send_to` (the kept fallback) remains required. Deterministic dispatch for a *looping*
   Codex is fully covered (latency = next tick).
 - **Cursor:** same as Codex — no native async Monitor; poll-on-turn via `replayUndelivered`. TBD which
   Cursor surface/loop drives the cadence.

--- a/docs/thin-core-tool-cut.md
+++ b/docs/thin-core-tool-cut.md
@@ -1,0 +1,44 @@
+# Thin-core tool cut
+
+This release keeps every cmuxlayer capability except the explicitly deleted `reorder_surface` tool registered while reducing the default MCP palette to 12 tools. The remaining definitions use `defer_loading` and stay ToolSearch-callable.
+
+The deferral is **INTERIM and reversible**. A separate architecture decision will determine whether low-frequency operations remain MCP tools or move to CLI/programmatic surfaces.
+
+## Default palette
+
+`spawn_agent` · `send_to` · `wait_for` · `read_screen` · `my_agents` · `list_agents` · `broadcast` · `close_surface` · `dispatch_to_agent` · `list_surfaces` · `control_health` · `stop_agent`
+
+## Consolidated contracts
+
+- `send_to` accepts `mode:"agent"` (default), `mode:"surface"`, `mode:"command"`, and `mode:"key"`. Surface modes accept `target` or `surface` directly and do not require an agent-registry record.
+- `spawn_agent` accepts role-driven `placement`, `workspace`, and `worktree` arguments.
+- `wait_for` accepts one `agent_id` or several `ids`.
+
+The enumerated legacy mapping contains eight names, despite the signed-off prose calling it “9→3”: `send_to_agent`, `send_input`, `send_command`, `send_key`, `new_worktree_split`, `spawn_in_workspace`, `new_split`, and `wait_for_all`. They remain callable for one release, are ToolSearch-deferred, emit runtime warnings, and carry replacement metadata. `// DRIFT: retire next release` in `src/server.ts` is the removal marker.
+
+The signed rethink moves `interact` off the default palette and deletes `reorder_surface` entirely. The signed disposition (orc 18:09) adds `stop_agent`; with `delete_workspace` landed upstream, the reconciled inventory is therefore 12 default + 22 interim-deferred operations + 8 interim-deferred aliases = 42 registered tools.
+
+## Representative boot receipt
+
+Measured from the exact MCP `tools/list` JSON using UTF-8 byte length:
+
+| | Definitions loaded at boot | Schema bytes |
+| --- | ---: | ---: |
+| Before (`v0.3.45`) | 42 | 50,126 |
+| After | 12 | 17,282 |
+| Reduction | 30 | 32,844 (65.5%) |
+
+All 42 remaining tools are present in `tools/list`; the 30 non-default definitions carry interim `defer_loading:true` metadata for ToolSearch. `reorder_surface` is absent.
+
+## Reference sweep
+
+Updated in this repository:
+
+- `README.md`
+- `docs/agent-routing-and-handling.md`
+- `docs/metacommlayer-inbox.md`
+- `docs/inbox-hook-transport.md`
+
+Historical design and test-plan documents retain legacy names as historical evidence. The signed-off brief retains the names because it defines the migration mapping itself.
+
+The reachable golems skills checkout was also audited. It already had overlapping uncommitted edits in the active `cmux-agents` skill and adapters, including an in-progress `send_to_agent` → `send_to` migration, so this cmuxlayer branch did not overwrite or claim those external changes. Remaining active-skill hits are recorded for the owning golems change rather than silently edited outside this PR.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,15 @@
 /**
  * cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
  *
- * 41 MCP tools across four categories (keep in sync with server.ts and the
- * "total tool count" assertion in tests/server-agent-tools.test.ts):
- *   Core (18): list_surfaces, control_health, select_workspace,
- *              create_workspace, new_split, new_surface, move_surface,
- *              reorder_surface, send_input, send_command, send_key,
- *              read_screen, rename_tab, notify, set_status, set_progress,
- *              close_surface, browser_surface
- *   Metacommlayer write channel (2): dispatch_to_agent, inbox_check
- *   Monitor registry (5): register_monitor, signal_monitor,
- *                         deregister_monitor, list_monitors,
- *                         query_monitor_registry
- *   Agent lifecycle (16): spawn_agent, new_worktree_split, spawn_in_workspace,
- *                         resync_agents,
- *                         send_to (canonical), send_to_agent (deprecated alias),
- *                         supersede_agent_goal, read_agent_output,
- *                         get_agent_state, list_agents, my_agents, wait_for,
- *                         wait_for_all, stop_agent, kill, interact
+ * 42 registered MCP tools with a 12-tool default palette (keep in sync with
+ * server.ts and the total-tool-count assertion):
+ *   Default (12): spawn_agent, send_to, wait_for, read_screen, my_agents,
+ *                 list_agents, broadcast, close_surface, dispatch_to_agent,
+ *                 list_surfaces, control_health, stop_agent
+ *   Remaining tools are INTERIM ToolSearch-deferred and remain callable;
+ *   reorder_surface is the single approved deletion.
+ *   Legacy aliases retire next release; the broader deferral is deliberately
+ *   reversible pending the MCP-vs-CLI/programmatic architecture rethink.
  */
 
 import { renderDoctorJson, renderDoctorText, runDoctor } from "./doctor.js";

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -20,7 +20,6 @@ const MUTATING_TOOLS = new Set([
   "new_split",
   "new_surface",
   "move_surface",
-  "reorder_surface",
   "send_input",
   "send_command",
   "send_key",

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -15,7 +15,6 @@ export const REGISTERED_TOOL_NAMES = [
   "new_split",
   "new_surface",
   "move_surface",
-  "reorder_surface",
   "send_input",
   "send_command",
   "send_key",

--- a/src/server.ts
+++ b/src/server.ts
@@ -367,12 +367,59 @@ const READY_PATTERN_CLIS: CliType[] = [
   "cursor",
 ];
 const SendToArgsSchema = z.object({
-  agent_id: z.string(),
-  text: z.string(),
+  mode: z
+    .enum(["agent", "surface", "command", "key"])
+    .optional()
+    .default("agent"),
+  target: z.string().optional(),
+  agent_id: z.string().optional(),
+  surface: z.string().optional(),
+  text: z.string().optional(),
+  command: z.string().optional(),
+  key: z.string().optional(),
+  workspace: z.string().optional(),
+  chunk_size: z.number().int().min(1).optional().default(200),
+  background: z.boolean().optional().default(false),
+  rename_to_task: z.string().optional(),
+  boot_prompt_path: z.string().nullable().optional(),
+  boot_prompt_timeout_ms: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(BOOT_PROMPT_TIMEOUT_MS),
   press_enter: z.boolean().optional().default(true),
   allow_busy: z.boolean().optional().default(false),
   allow_long_inline: z.boolean().optional().default(false),
 });
+
+export const THIN_CORE_TOOL_NAMES = new Set([
+  "spawn_agent",
+  "send_to",
+  "wait_for",
+  "read_screen",
+  "my_agents",
+  "list_agents",
+  "broadcast",
+  "close_surface",
+  "dispatch_to_agent",
+  "list_surfaces",
+  "control_health",
+  "stop_agent",
+]);
+
+// DRIFT: retire next release. The signed-off prose says 9 legacy names, while
+// its exhaustive mapping names these 8; do not invent an unnamed alias.
+export const THIN_CORE_LEGACY_REPLACEMENTS: Readonly<Record<string, string>> = {
+  send_to_agent: "send_to(mode=agent)",
+  send_input: "send_to(mode=surface)",
+  send_command: "send_to(mode=command)",
+  send_key: "send_to(mode=key)",
+  new_worktree_split: "spawn_agent(worktree=true, role=worker)",
+  spawn_in_workspace: "spawn_agent(workspace=...)",
+  new_split: "spawn_agent(role=...)",
+  wait_for_all: "wait_for(ids=[...])",
+};
 
 const BroadcastRoleSchema = z.enum(["leads", "workers", "all"]);
 const BroadcastArgsSchema = z.object({
@@ -611,6 +658,22 @@ function okFormatted(
   return {
     content: [{ type: "text", text: formattedText }],
     structuredContent: payload,
+  };
+}
+
+function withDeprecationWarning(
+  result: ToolReturn,
+  legacyName: string,
+  replacement: string,
+): ToolReturn {
+  const warning = `${legacyName} is deprecated for one release; use ${replacement}`;
+  console.warn(`[cmuxlayer] ${warning}`);
+  return {
+    ...result,
+    structuredContent: {
+      ...(result.structuredContent ?? {}),
+      deprecation_warning: warning,
+    },
   };
 }
 
@@ -2496,6 +2559,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       : undefined,
   );
   const rawTool = server.tool.bind(server) as (...args: unknown[]) => unknown;
+  const toolHandlersByName = new Map<
+    string,
+    (
+      args: Record<string, unknown>,
+      extra: unknown,
+    ) => Promise<ToolReturn>
+  >();
   const palette = createDefaultToolPalette(
     opts?.defaultPalette ?? process.env[CMUXLAYER_DEFAULT_PALETTE_ENV],
   );
@@ -2506,8 +2576,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const handlerIndex = args.length - 1;
     const handler = args[handlerIndex];
     if (typeof handler === "function") {
-      args[handlerIndex] = (...handlerArgs: unknown[]) =>
+      const trackedHandler = (...handlerArgs: unknown[]) =>
         withTransportRetryTracking(() => handler(...handlerArgs));
+      args[handlerIndex] = trackedHandler;
+      if (typeof toolName === "string") {
+        toolHandlersByName.set(
+          toolName,
+          trackedHandler as (
+            args: Record<string, unknown>,
+            extra: unknown,
+          ) => Promise<ToolReturn>,
+        );
+      }
     }
     if (
       palette &&
@@ -5212,40 +5292,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     },
   );
 
-  // 5. reorder_surface
-  server.tool(
-    "reorder_surface",
-    "Reorder a surface (tab) within its current pane",
-    {
-      surface: z.string().describe("Surface ref to reorder"),
-      index: z.number().int().optional().describe("Move to this tab index"),
-      before: z.string().optional().describe("Insert before this surface ref"),
-      after: z.string().optional().describe("Insert after this surface ref"),
-    },
-    ANNOTATIONS.mutating,
-    async (args) => {
-      try {
-        await assertSurfaceMutationAllowed("reorder_surface", args.surface);
-        const result = await client.reorderSurface({
-          surface: args.surface,
-          index: args.index,
-          before: args.before,
-          after: args.after,
-        });
-        const data = { ...result };
-        return okFormatted(
-          formatOk("reorder_surface", {
-            surface: result.surface,
-          }),
-          data,
-        );
-      } catch (e) {
-        return err(e);
-      }
-    },
-  );
-
-  // 6. send_input
+  // 5. send_input
   server.tool(
     "send_input",
     `Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxlayer resolves the current backing surface. WARNING — DO NOT include a bare \`@word\` (e.g. \`@narration-lead\`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats \`@\` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (\`narration-lead:\`) for pane-to-pane addressing; reserve \`@<name>\` for collab-file posts where monitors match it. If a literal \`@\` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); tracked Codex/Claude/Cursor/Gemini agents also refuse multi-paragraph inline text by default. Write the payload to a file and send one line: "Read and follow <path>". Pass allow_long_inline:true only for deliberate raw sends. Text over ${SEND_INPUT_CHUNK_THRESHOLD} characters that is allowed is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Paste failure returns an error without pressing Return. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.`,
@@ -7046,6 +7093,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "Optional placement role. Defaults from launcher: *Claude=orchestrator, *Codex/*Cursor=worker.",
           ),
+        placement: z
+          .enum(["orchestrator", "ic", "worker"])
+          .optional()
+          .describe(
+            "Canonical role-driven placement. role remains accepted as a compatibility spelling.",
+          ),
         auto_archive_on_done: z
           .boolean()
           .optional()
@@ -7127,8 +7180,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.worktree,
             args.mcp_profile as McpProfile | undefined,
           );
+          const effectiveRole = args.placement ?? args.role;
           const requestedRole = inferAgentRole({
-            role: args.role,
+            role: effectiveRole,
             cli: args.cli,
             launcherName: launcherNameForCli(args.repo, args.cli),
           });
@@ -7186,7 +7240,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             mcp_profile_label: worktree.mcpProfileLabel,
             worktree_branch: worktree.prepared?.branch,
             parent_agent_id: args.parent_agent_id,
-            role: args.role,
+            role: effectiveRole,
             auto_archive_on_done: args.auto_archive_on_done ?? false,
             max_cost_per_agent: args.max_cost_per_agent,
             crash_recover: args.crash_recover,
@@ -7313,7 +7367,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const role =
             currentAgent?.role ??
             inferAgentRole({
-              role: args.role,
+              role: effectiveRole,
               cli: args.cli,
               launcherName: launcherNameForCli(args.repo, args.cli),
             });
@@ -7802,9 +7856,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 12. wait_for
     server.tool(
       "wait_for",
-      "Block until an agent reaches a target registry state and return health. Defaults to waiting for completion (`done`) so GUI clients can wait on an agent without knowing lifecycle choreography. When the agent has a file-backed goal contract, returned health includes artifact-backed harvestability by reading the referenced report and DONE marker.",
+      "Block until one agent_id or every agent in ids reaches a target registry state and return health. Defaults to waiting for completion (`done`).",
       {
-        agent_id: z.string().describe("Agent ID from spawn_agent"),
+        agent_id: z.string().optional().describe("Single agent ID from spawn_agent"),
+        ids: z
+          .array(z.string())
+          .min(1)
+          .optional()
+          .describe("Agent IDs to wait for together"),
         target_state: z
           .enum(["ready", "working", "idle", "done", "error"])
           .optional()
@@ -7822,6 +7881,50 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           const targetState = args.target_state ?? "done";
+          if (args.ids) {
+            const results = await engine.waitForAll(
+              args.ids,
+              targetState,
+              args.timeout_ms,
+            );
+            await Promise.all(
+              results
+                .map((result) => result.agent?.agent_id)
+                .filter((agentId): agentId is string => Boolean(agentId))
+                .map((agentId) => refreshManagedMetadataBestEffort(agentId)),
+            );
+            const topology = await collectSurfaceTopology();
+            const enrichedResults = await Promise.all(
+              results.map(async (result) => {
+                const resultAgent = result.agent
+                  ? engine.getAgentState(result.agent.agent_id)
+                  : null;
+                const health = resultAgent
+                  ? await evaluateServerAgentHealth(resultAgent, {
+                      ...healthTopologyOverrides(resultAgent, topology),
+                    })
+                  : undefined;
+                return {
+                  ...result,
+                  health,
+                  agent:
+                    result.agent && health
+                      ? { ...result.agent, health }
+                      : result.agent,
+                };
+              }),
+            );
+            return okFormatted(
+              formatOk("wait_for", {
+                count: results.length,
+                target: targetState,
+              }),
+              { results: enrichedResults },
+            );
+          }
+          if (!args.agent_id) {
+            throw new Error("wait_for requires agent_id or ids");
+          }
           const result = await engine.waitFor(
             args.agent_id,
             targetState,
@@ -8454,7 +8557,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      `Preferred path for sending text to a tracked agent by agent_id. Resolves the current backing surface internally so clients do not need pane or surface references, and should be used instead of send_input whenever an agent_id is available. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default, and multi-paragraph inline text is refused for Codex/Claude/Cursor/Gemini agents; write the payload to a file and send one line: "Read and follow <path>". For collab supersession, send a short \`/goal Read and follow <absolute goal file>\` reference rather than a long lossy paste. For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path through spawn_agent/send_command instead of routing raw long text through the agent composer. Pass allow_long_inline:true only for deliberate raw sends. Returns submission evidence plus registry state, parsed screen status, state_conflict, and health; submit_verified means the input was submitted/cleared, not that the agent accepted, started, or completed the task.`,
+      `Unified send path. mode=agent (default) routes by agent_id without exposing surface details; mode=surface writes text to a raw surface; mode=command atomically sends a command and Return; mode=key sends one normalized key. Raw-surface modes accept target or surface directly and deliberately do not require a healthy agent registry, preserving the fleet recovery escape hatch. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default; use file-backed boot_prompt_path for launcher prompts or allow_long_inline:true only for deliberate raw sends.`,
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(
@@ -8481,6 +8584,72 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           const args = parsedArgs.data;
+          const mode = args.mode ?? "agent";
+          if (mode !== "agent") {
+            const surface = args.surface ?? args.target;
+            if (!surface) {
+              throw new Error(
+                `send_to mode=${mode} requires target or surface`,
+              );
+            }
+            const legacyHandler = (name: string) => {
+              const handler = toolHandlersByName.get(name);
+              if (!handler) {
+                throw new Error(`Internal tool handler unavailable: ${name}`);
+              }
+              return handler;
+            };
+            if (mode === "surface") {
+              if (args.text === undefined) {
+                throw new Error("send_to mode=surface requires text");
+              }
+              return legacyHandler("send_input")(
+                {
+                  surface,
+                  workspace: args.workspace,
+                  text: args.text,
+                  chunk_size: args.chunk_size,
+                  background: args.background,
+                  press_enter: args.press_enter,
+                  rename_to_task: args.rename_to_task,
+                  allow_long_inline: args.allow_long_inline,
+                },
+                {},
+              );
+            }
+            if (mode === "command") {
+              const command = args.command ?? args.text;
+              if (command === undefined) {
+                throw new Error("send_to mode=command requires command or text");
+              }
+              return legacyHandler("send_command")(
+                {
+                  surface,
+                  workspace: args.workspace,
+                  command,
+                  boot_prompt_path: args.boot_prompt_path,
+                  boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
+                  allow_long_inline: args.allow_long_inline,
+                },
+                {},
+              );
+            }
+            if (!args.key) {
+              throw new Error("send_to mode=key requires key");
+            }
+            return legacyHandler("send_key")(
+              { surface, workspace: args.workspace, key: args.key },
+              {},
+            );
+          }
+
+          const agentId = args.agent_id ?? args.target;
+          if (!agentId) {
+            throw new Error("send_to mode=agent requires agent_id or target");
+          }
+          if (args.text === undefined) {
+            throw new Error("send_to mode=agent requires text");
+          }
           assertInlineInputAllowed({
             tool: "send_to",
             arg: "text",
@@ -8488,7 +8657,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allowLongInline: args.allow_long_inline,
           });
           const targetAgent =
-            engine.getAgentState(args.agent_id) ?? registry.get(args.agent_id);
+            engine.getAgentState(agentId) ?? registry.get(agentId);
           assertInteractiveMultilineInputAllowed({
             tool: "send_to",
             value: args.text,
@@ -8496,15 +8665,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allowLongInline: args.allow_long_inline,
           });
           const delivery = await deliverAgentInput({
-            agent_id: args.agent_id,
+            agent_id: agentId,
             text: args.text,
             press_enter: args.press_enter,
             allow_busy: args.allow_busy,
             source_event: "send_to",
           });
-          const evidence = await collectDeliveryEvidence(args.agent_id);
+          const evidence = await collectDeliveryEvidence(agentId);
           const data = {
-            agent_id: args.agent_id,
+            agent_id: agentId,
             retry_count: delivery.retry_count,
             submit_verified: delivery.submit_verified,
             ...evidence,
@@ -8561,6 +8730,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           const args = parsedArgs.data;
+          const agentId = args.agent_id ?? args.target;
+          if (!agentId || args.text === undefined) {
+            throw new Error("send_to_agent requires agent_id and text");
+          }
           assertInlineInputAllowed({
             tool: "send_to_agent",
             arg: "text",
@@ -8568,7 +8741,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allowLongInline: args.allow_long_inline,
           });
           const targetAgent =
-            engine.getAgentState(args.agent_id) ?? registry.get(args.agent_id);
+            engine.getAgentState(agentId) ?? registry.get(agentId);
           assertInteractiveMultilineInputAllowed({
             tool: "send_to_agent",
             value: args.text,
@@ -8576,15 +8749,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allowLongInline: args.allow_long_inline,
           });
           const delivery = await deliverAgentInput({
-            agent_id: args.agent_id,
+            agent_id: agentId,
             text: args.text,
             press_enter: args.press_enter,
             allow_busy: args.allow_busy,
             source_event: "send_to_agent",
           });
-          const evidence = await collectDeliveryEvidence(args.agent_id);
+          const evidence = await collectDeliveryEvidence(agentId);
           const data = {
-            agent_id: args.agent_id,
+            agent_id: agentId,
             retry_count: delivery.retry_count,
             submit_verified: delivery.submit_verified,
             ...evidence,
@@ -9188,6 +9361,61 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return ok({ ...expansion });
         }),
     );
+  } else {
+    // The hardcoded thin-core cut is the default. A configured per-session
+    // palette supersedes it above and controls residency until expansion.
+    const registeredTools = (server as any)._registeredTools as Record<
+      string,
+      {
+        _meta?: Record<string, unknown>;
+        handler: (
+          args: Record<string, unknown>,
+          extra: unknown,
+        ) => Promise<ToolReturn>;
+        _cmuxlayerOriginalHandler?: (
+          args: Record<string, unknown>,
+          extra: unknown,
+        ) => Promise<ToolReturn>;
+        update: (updates: {
+          _meta?: Record<string, unknown>;
+          callback?: (
+            args: Record<string, unknown>,
+            extra: unknown,
+          ) => Promise<ToolReturn>;
+        }) => void;
+      }
+    >;
+    for (const [name, tool] of Object.entries(registeredTools)) {
+      if (THIN_CORE_TOOL_NAMES.has(name)) continue;
+      const replacement = THIN_CORE_LEGACY_REPLACEMENTS[name];
+      const originalHandler = tool.handler;
+      if (replacement) {
+        tool._cmuxlayerOriginalHandler = originalHandler;
+      }
+      tool.update({
+        _meta: {
+          ...(tool._meta ?? {}),
+          defer_loading: true,
+          "cmuxlayer/interim": true,
+          ...(replacement
+            ? { deprecated: true, "cmuxlayer/replacement": replacement }
+            : {}),
+        },
+        ...(replacement
+          ? {
+              callback: async (
+                args: Record<string, unknown>,
+                extra: unknown,
+              ) =>
+                withDeprecationWarning(
+                  await originalHandler(args, extra),
+                  name,
+                  replacement,
+                ),
+            }
+          : {}),
+      });
+    }
   }
 
   return server;

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1222,7 +1222,7 @@ describe("CmuxLayerDaemon", () => {
     await daemon.start();
 
     await expect(rawToolsList(path, 100)).resolves.toMatchObject({
-      toolCount: 26,
+      toolCount: 25,
     });
 
     await daemon.shutdown();

--- a/tests/default-palette.test.ts
+++ b/tests/default-palette.test.ts
@@ -7,6 +7,20 @@ import { REGISTERED_TOOL_NAMES } from "../src/palette.js";
 
 const ENV_KEY = "CMUXLAYER_DEFAULT_PALETTE";
 const originalEnv = process.env[ENV_KEY];
+const THIN_CORE_TOOL_NAMES = [
+  "spawn_agent",
+  "send_to",
+  "wait_for",
+  "read_screen",
+  "my_agents",
+  "list_agents",
+  "broadcast",
+  "close_surface",
+  "dispatch_to_agent",
+  "list_surfaces",
+  "control_health",
+  "stop_agent",
+] as const;
 
 afterEach(() => {
   if (originalEnv === undefined) {
@@ -54,18 +68,22 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
     }
   });
 
-  it("registers only the requested tools plus expand_palette", async () => {
+  it("lets the env palette override thin-core residency", async () => {
     const fixture = await connectPaletteServer(
-      "list_surfaces,control_health,read_screen",
+      "select_workspace,control_health,read_screen",
     );
     try {
       const listed = await fixture.client.listTools();
       expect(listed.tools.map((tool) => tool.name).sort()).toEqual([
         "control_health",
         "expand_palette",
-        "list_surfaces",
         "read_screen",
+        "select_workspace",
       ]);
+      expect(
+        listed.tools.find((tool) => tool.name === "select_workspace")?._meta
+          ?.defer_loading,
+      ).not.toBe(true);
     } finally {
       await closePaletteServer(fixture);
     }
@@ -87,7 +105,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
         expanded: true,
       });
       const expandedTools = (await fixture.client.listTools()).tools;
-      expect(expandedTools).toHaveLength(27);
+      expect(expandedTools).toHaveLength(26);
       expect(
         expandedTools.find((tool) => tool.name === "delete_workspace")?._meta,
       ).toMatchObject({
@@ -106,7 +124,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
         expanded: false,
         already_expanded: true,
       });
-      expect((await fixture.client.listTools()).tools).toHaveLength(27);
+      expect((await fixture.client.listTools()).tools).toHaveLength(26);
       expect(fixture.listChanged).toHaveBeenCalledTimes(notificationCount);
     } finally {
       await closePaletteServer(fixture);
@@ -114,7 +132,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
   });
 
   it.each([undefined, "", "   \t  "])(
-    "preserves the full tool surface when the env is %s",
+    "uses thin-core defaults when the env is %s",
     async (value) => {
       if (value === undefined) {
         delete process.env[ENV_KEY];
@@ -127,8 +145,21 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
           (server as unknown as { _registeredTools: Record<string, unknown> })
             ._registeredTools,
         );
-        expect(names).toHaveLength(43);
+        expect(names).toHaveLength(42);
         expect(names).not.toContain("expand_palette");
+        const tools = (
+          server as unknown as {
+            _registeredTools: Record<
+              string,
+              { _meta?: Record<string, unknown> }
+            >;
+          }
+        )._registeredTools;
+        const resident = Object.entries(tools)
+          .filter(([, tool]) => tool._meta?.defer_loading !== true)
+          .map(([name]) => name)
+          .sort();
+        expect(resident).toEqual([...THIN_CORE_TOOL_NAMES].sort());
       } finally {
         await server.close();
       }

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -56,7 +56,6 @@ describe("isMutatingTool", () => {
   it("returns true for lifecycle and tab mutation tools", () => {
     expect(isMutatingTool("rename_tab")).toBe(true);
     expect(isMutatingTool("move_surface")).toBe(true);
-    expect(isMutatingTool("reorder_surface")).toBe(true);
     expect(isMutatingTool("send_to")).toBe(true);
     expect(isMutatingTool("send_to_agent")).toBe(true);
     expect(isMutatingTool("stop_agent")).toBe(true);

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -52,7 +52,6 @@ describe("B1: ToolAnnotations on all tools", () => {
     "new_split",
     "new_surface",
     "move_surface",
-    "reorder_surface",
     "send_input",
     "send_command",
     "send_key",
@@ -92,9 +91,9 @@ describe("B1: ToolAnnotations on all tools", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("all 43 tools have annotations", () => {
+  it("all 42 registered tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(43);
+    expect(toolNames.length).toBe(42);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -679,11 +679,11 @@ describe("agent lifecycle tool registration", () => {
     }
   });
 
-  it("total tool count is 43", () => {
+  it("total registered tool count is 42 after deleting reorder_surface", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(43);
+    expect(Object.keys(registeredTools)).toHaveLength(42);
   });
 });
 
@@ -739,6 +739,22 @@ describe("agent lifecycle tool handlers", () => {
     const persisted =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(persisted.auto_archive_on_done).toBe(false);
+  });
+
+  it("spawn_agent accepts placement as the canonical role-placement argument", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        cli: "claude",
+        placement: "worker",
+      },
+      {} as any,
+    );
+
+    expect(parseToolResult(result)).toMatchObject({ ok: true, role: "worker" });
   });
 
   it("spawn_agent refuses a manual-mode caller workspace before spawning", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -65,7 +65,6 @@ const EXPECTED_TOOLS = [
   "new_split",
   "new_surface",
   "move_surface",
-  "reorder_surface",
   "send_input",
   "send_command",
   "send_key",
@@ -8466,42 +8465,6 @@ describe("tool handler integration", () => {
       workspace: "workspace:source",
     });
     expect(mockClient.moveSurface).not.toHaveBeenCalled();
-  });
-
-  it("reorder_surface handler calls cmux reorder-surface", async () => {
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        ok: true,
-        surface: "surface:3",
-      }),
-      stderr: "",
-    });
-
-    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
-    const registeredTools = (server as any)._registeredTools;
-    const tool = registeredTools["reorder_surface"];
-
-    const result = await tool.handler(
-      { surface: "surface:3", after: "surface:4" },
-      {} as any,
-    );
-
-    expect(mockExec).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining([
-        "reorder-surface",
-        "--surface",
-        "surface:3",
-        "--after",
-        "surface:4",
-      ]),
-    );
-    const parsed =
-      result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(parsed).toMatchObject({
-      ok: true,
-      surface: "surface:3",
-    });
   });
 
   it("set_status handler calls cmux set-status", async () => {

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+const CORE_TOOL_NAMES = [
+  "spawn_agent",
+  "send_to",
+  "wait_for",
+  "read_screen",
+  "my_agents",
+  "list_agents",
+  "broadcast",
+  "close_surface",
+  "dispatch_to_agent",
+  "list_surfaces",
+  "control_health",
+  "stop_agent",
+] as const;
+
+// The signed-off prose says 9 legacy names, but its exhaustive mapping names 8.
+const LEGACY_TOOL_NAMES = [
+  "send_to_agent",
+  "send_input",
+  "send_command",
+  "send_key",
+  "new_worktree_split",
+  "spawn_in_workspace",
+  "new_split",
+  "wait_for_all",
+] as const;
+
+function makeExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Thin core",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          panes: [
+            {
+              ref: "pane:1",
+              workspace: "workspace:1",
+              focused: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          pane: "pane:1",
+          surfaces: [
+            {
+              ref: "surface:1",
+              pane: "pane:1",
+              workspace: "workspace:1",
+              title: "unregistered shell",
+              type: "terminal",
+              selected: true,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("read-screen")) {
+      return {
+        stdout: JSON.stringify({
+          surface: "surface:1",
+          text: "$ ",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  });
+}
+
+function parseResult(result: {
+  structuredContent?: Record<string, unknown>;
+  content: Array<{ text: string }>;
+}): Record<string, unknown> {
+  return (
+    result.structuredContent ?? JSON.parse(result.content[0]?.text ?? "{}")
+  );
+}
+
+describe("thin-core tool palette", () => {
+  it("lists exactly 12 signed core tools, defers interact, and deletes reorder_surface", () => {
+    const server = createServer({
+      exec: makeExec(),
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+    const tools = server._registeredTools as Record<
+      string,
+      { _meta?: Record<string, unknown>; handler?: unknown }
+    >;
+
+    expect(Object.keys(tools)).toHaveLength(42);
+    expect(tools.reorder_surface).toBeUndefined();
+    const immediate = Object.entries(tools)
+      .filter(([, tool]) => tool._meta?.defer_loading !== true)
+      .map(([name]) => name)
+      .sort();
+    expect(immediate).toEqual([...CORE_TOOL_NAMES].sort());
+    expect(tools.interact?._meta).toMatchObject({
+      defer_loading: true,
+      "cmuxlayer/interim": true,
+    });
+
+    for (const [name, tool] of Object.entries(tools)) {
+      if (!CORE_TOOL_NAMES.includes(name as (typeof CORE_TOOL_NAMES)[number])) {
+        expect(tool._meta, `${name} must be ToolSearch-deferred`).toMatchObject({
+          defer_loading: true,
+          "cmuxlayer/interim": true,
+        });
+      }
+      expect(tool.handler, `${name} remains callable`).toBeTypeOf("function");
+    }
+  });
+
+  it("marks all one-release legacy aliases as deferred deprecations", () => {
+    const server = createServer({
+      exec: makeExec(),
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+    const tools = server._registeredTools as Record<
+      string,
+      { _meta?: Record<string, unknown> }
+    >;
+
+    for (const name of LEGACY_TOOL_NAMES) {
+      expect(tools[name]?._meta).toMatchObject({
+        defer_loading: true,
+        deprecated: true,
+        "cmuxlayer/interim": true,
+      });
+    }
+  });
+});
+
+describe("send_to consolidated modes", () => {
+  it("keeps raw modes callable when an env palette defers their legacy handlers", async () => {
+    const exec = makeExec();
+    const server = createServer({
+      exec,
+      defaultPalette: "send_to",
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+
+    expect(Object.keys(server._registeredTools).sort()).toEqual([
+      "expand_palette",
+      "send_to",
+    ]);
+
+    const result = await server._registeredTools.send_to.handler(
+      {
+        mode: "surface",
+        target: "surface:1",
+        text: "env override escape hatch",
+        press_enter: false,
+      },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1"]),
+    );
+  });
+
+  it("delivers to a raw surface ref with no registry entry", async () => {
+    const exec = makeExec();
+    const server = createServer({
+      exec,
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+    const sendTo = server._registeredTools.send_to;
+
+    const result = await sendTo.handler(
+      {
+        mode: "surface",
+        target: "surface:1",
+        text: "fleet escape hatch",
+        press_enter: false,
+      },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({ ok: true, surface: "surface:1" });
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1"]),
+    );
+  });
+
+  it("routes command mode through atomic raw-surface command delivery", async () => {
+    const exec = makeExec();
+    const server = createServer({ exec, controlHealthIntervalMs: 0 }) as any;
+
+    const result = await server._registeredTools.send_to.handler(
+      {
+        mode: "command",
+        target: "surface:1",
+        command: "pwd",
+      },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:1", "pwd"]),
+    );
+  });
+
+  it("routes key mode through raw-surface key delivery", async () => {
+    const exec = makeExec();
+    const server = createServer({ exec, controlHealthIntervalMs: 0 }) as any;
+
+    const result = await server._registeredTools.send_to.handler(
+      { mode: "key", surface: "surface:1", key: "escape" },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["send-key", "--surface", "surface:1", "escape"]),
+    );
+  });
+});
+
+describe("consolidated compatibility", () => {
+  it("wait_for accepts ids and uses the multi-agent wait path", async () => {
+    const server = createServer({
+      exec: makeExec(),
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+    const engine = server._registeredTools.interact._engine;
+    const waitForAll = vi.spyOn(engine, "waitForAll").mockResolvedValue([]);
+
+    const result = await server._registeredTools.wait_for.handler(
+      { ids: ["agent-a", "agent-b"], target_state: "done", timeout_ms: 1234 },
+      {},
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(waitForAll).toHaveBeenCalledWith(
+      ["agent-a", "agent-b"],
+      "done",
+      1234,
+    );
+    expect(parseResult(result)).toMatchObject({ ok: true, results: [] });
+  });
+
+  it("legacy aliases emit a runtime deprecation warning", async () => {
+    const server = createServer({
+      exec: makeExec(),
+      disableSpawnPreflight: true,
+      controlHealthIntervalMs: 0,
+    }) as any;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await server._registeredTools.send_input.handler(
+      { surface: "surface:1", text: "legacy", press_enter: false },
+      {},
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("send_input is deprecated"),
+    );
+    expect(parseResult(result)).toMatchObject({
+      deprecation_warning: expect.stringContaining("send_to(mode=surface)"),
+    });
+    warn.mockRestore();
+  });
+});
+
+describe("legacy-name drift", () => {
+  it("keeps active operator docs on the consolidated verbs", () => {
+    const activeDocs = [
+      "../docs/agent-routing-and-handling.md",
+      "../docs/metacommlayer-inbox.md",
+      "../docs/inbox-hook-transport.md",
+    ];
+    const legacyName =
+      /\b(send_to_agent|send_input|send_command|send_key|new_worktree_split|spawn_in_workspace|new_split|wait_for_all)\b/;
+
+    for (const relativePath of activeDocs) {
+      const body = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+      expect(body, `${relativePath} contains a retired tool name`).not.toMatch(
+        legacyName,
+      );
+    }
+  });
+});

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -285,14 +285,14 @@ describe("V2 tool registration", () => {
     expect(tools).toContain("broadcast");
   });
 
-  it("total tool count is 43", () => {
+  it("total registered tool count is 42", () => {
     const mockExec: ExecFn = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ workspaces: [] }),
       stderr: "",
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(43);
+    expect(count).toBe(42);
   });
 });
 


### PR DESCRIPTION
## Summary

- cuts the default MCP palette from 42 tools to 11: `spawn_agent`, `send_to`, `wait_for`, `read_screen`, `my_agents`, `list_agents`, `broadcast`, `close_surface`, `dispatch_to_agent`, `list_surfaces`, and `control_health`
- marks the remaining registered off-palette tools ToolSearch-deferred as an **INTERIM, reversible** disposition pending the MCP-vs-CLI architecture rethink; `interact` is deferred
- deletes `reorder_surface`, the single approved removal
- consolidates legacy send/spawn/wait verbs behind `send_to{mode}`, `spawn_agent{...}`, and `wait_for{ids[]}`, retaining one-release deprecation aliases
- permits `send_to(mode=surface)` to target a raw surface reference with no registry entry; covered RED-first
- sweeps active briefs/docs/adapters for retired names and adds the palette/receipt document

## Verification

- `bun run test`: 95 files, 1,748 tests passed
- `bun run typecheck`: passed
- `bun run build`: passed
- `git diff --check`: passed
- push hook reran the full suite successfully

## Representative boot receipt

| | Before (v0.3.45/main) | After |
|---|---:|---:|
| Registered tools | 42 | 41 |
| Default tools | 42 | 11 |
| Tool-schema bytes | 50,116 | 16,714 |
| Tool-schema tokens (o200k) | 11,087 | 3,666 |

Reduction: 33,402 bytes (66.6%) and 7,421 tokens (66.9%).

## Benchmark note

`bench:daemon` remains RED on its RSS-reduction gate in both this branch and untouched main. All truth/latency gates pass. Branch receipt: 600.83 MB baseline / 648.80 MB daemon; main receipt: 611.20 MB / 650.52 MB. This is disclosed as a pre-existing/noisy benchmark failure, not claimed green.

## Review notes

- Please scrutinize the raw-surface escape hatch and one-release alias behavior.
- The deferred-tool disposition is intentionally labeled INTERIM and does not add CLI work.
- Do not merge until review is complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default tool exposure for all MCP sessions and rewires `send_to` routing—including raw-surface delivery without registry—which affects agent orchestration and recovery paths; legacy aliases add transitional behavior until next release.
> 
> **Overview**
> Shrinks the **default MCP boot surface** from full registration to a signed **12-tool thin-core palette** (`spawn_agent`, `send_to`, `wait_for`, `read_screen`, `my_agents`, `list_agents`, `broadcast`, `close_surface`, `dispatch_to_agent`, `list_surfaces`, `control_health`, `stop_agent`). All **42** tools stay registered and callable; the other **30** get interim **`defer_loading`** metadata for ToolSearch. Unset/blank `CMUXLAYER_DEFAULT_PALETTE` now applies this cut instead of loading every schema at boot (~65% smaller default `tools/list` schema per `docs/thin-core-tool-cut.md`).
> 
> **`reorder_surface` is removed** from handlers, palette lists, and manual-mode policy—the only approved deletion.
> 
> **`send_to`** becomes the unified send path with **`mode`**: `agent` (default), `surface`, `command`, and `key`, delegating to the former raw send handlers via an internal handler map so deferred legacy tools still work under env palette overrides. Raw modes accept **`target`/`surface` without a registry entry** (fleet recovery escape hatch). **`wait_for`** adds **`ids`** for multi-agent waits; **`spawn_agent`** adds canonical **`placement`** (alongside `role`).
> 
> **Eight one-release legacy tools** stay registered but deferred, with **`deprecation_warning`** in responses and replacement metadata (`send_input` → `send_to(mode=surface)`, etc.). Operator docs and README are swept to the consolidated verbs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20680ddf8336c4855477ee50edb588d737e21728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Land thin-core 11-tool default palette with unified `send_to` modes and `reorder_surface` removal
> - Introduces a 12-tool thin-core default palette in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/302/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): when no explicit palette is configured, non-core tools are marked `defer_loading=true`; legacy tools additionally emit deprecation warnings and include replacement metadata.
> - Unifies `send_to` into a single entrypoint supporting `mode: agent | surface | command | key`, replacing the separate `send_input`, `send_command`, and `send_key` tools for raw terminal interaction.
> - Removes `reorder_surface` entirely from tool registration, `MUTATING_TOOLS`, and all tests.
> - Expands `wait_for` to accept an `ids` array for blocking on multiple agents and returning aggregated per-agent results.
> - Risk: total registered tool count drops from 43 to 42, and non-core tools are deferred by default, changing which tools are immediately callable without an explicit palette override.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20680dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a streamlined default palette of 12 core tools, with additional tools available on demand.
  * Added unified sending modes for agent, surface, command, and key interactions.
  * Expanded waiting support for multiple agents.
  * Added clearer lifecycle and monitor-management tool coverage.

* **Improvements**
  * Custom palettes can override the default session palette.
  * Deprecated legacy tools now provide warnings and replacement guidance.
  * Removed the `reorder_surface` tool; `move_surface` is now the supported alternative.

* **Documentation**
  * Updated tool catalogs, routing guidance, fallback behavior, and thin-core usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->