### PR TITLE
fix: setStatuses CLI fallback fans out per-item instead of silently dropping (ES-1)

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -604,11 +604,27 @@ export class CmuxClient {
   }
 
   async setStatuses(updates: CmuxStatusUpdate[]): Promise<boolean> {
-    if (updates.length === 0) return true;
-    console.error(
-      `[cmuxlayer] skipped ${updates.length} sidebar status pushes while socket batching is unavailable`,
-    );
-    return false;
+    const failures: Array<{ key: string; error: Error }> = [];
+    for (const update of updates) {
+      try {
+        await this.setStatus(update.key, update.value, update);
+      } catch (error) {
+        failures.push({
+          key: update.key,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+      }
+    }
+    if (failures.length > 0) {
+      const failedKeys = failures.map(({ key }) => key).join(", ");
+      const details = failures
+        .map(({ key, error }) => `${key}: ${error.message}`)
+        .join("; ");
+      throw new Error(
+        `cmux set-status failed for keys [${failedKeys}]: ${details}`,
+      );
+    }
+    return true;
   }
 
   async clearStatus(key: string, opts?: { workspace?: string }): Promise<void> {

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -804,6 +804,70 @@ describe("CmuxClient.setStatus", () => {
   });
 });
 
+describe("CmuxClient.setStatuses", () => {
+  it("fans CLI updates out through set-status and returns true", async () => {
+    const { client, exec } = mockClient({});
+
+    const result = await client.setStatuses([
+      {
+        key: "agent-a",
+        value: "working",
+        icon: "bolt.fill",
+        workspace: "workspace:1",
+      },
+      {
+        key: "agent-b",
+        value: "done",
+        color: "#00ff00",
+        workspace: "workspace:1",
+      },
+    ]);
+
+    expect(result).toBe(true);
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec).toHaveBeenNthCalledWith(1, "cmux", [
+      "--json",
+      "set-status",
+      "agent-a",
+      "working",
+      "--icon",
+      "bolt.fill",
+      "--workspace",
+      "workspace:1",
+    ]);
+    expect(exec).toHaveBeenNthCalledWith(2, "cmux", [
+      "--json",
+      "set-status",
+      "agent-b",
+      "done",
+      "--color",
+      "#00ff00",
+      "--workspace",
+      "workspace:1",
+    ]);
+  });
+
+  it("attempts every update and throws an error naming all failed keys", async () => {
+    const exec: ExecFn = vi.fn().mockImplementation(async (_cmd, args) => {
+      const key = args[2];
+      if (key === "agent-a" || key === "agent-c") {
+        throw new Error(`rejected ${key}`);
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const client = new CmuxClient({ exec, existsSync: () => false });
+
+    const result = client.setStatuses([
+      { key: "agent-a", value: "working" },
+      { key: "agent-b", value: "done" },
+      { key: "agent-c", value: "error" },
+    ]);
+
+    await expect(result).rejects.toThrow(/agent-a.*agent-c/);
+    expect(exec).toHaveBeenCalledTimes(3);
+  });
+});
+
 describe("CmuxClient.clearStatus", () => {
   it("calls cmux clear-status with key", async () => {
     const { client, exec } = mockClient({});

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -279,7 +279,7 @@ function startEngineServer(
 }
 
 describe("Phase 10 painpoint e2e replay", () => {
-  it("sidebar-scale sweeps skip degraded-CLI status bursts", async () => {
+  it("sidebar-scale CLI sweeps fan out once and persist snapshots", async () => {
     const dir = tempDir("sidebar-scale");
     const stateMgr = new StateManager(dir);
     const agentCount = 25;
@@ -309,7 +309,10 @@ describe("Phase 10 painpoint e2e replay", () => {
 
       await engine.runSweep();
 
-      expect(statusCalls).toEqual([]);
+      expect(statusCalls).toHaveLength(agentCount);
+      expect(statusCalls.map(({ key }) => key)).toEqual(
+        expect.arrayContaining(agentIds),
+      );
 
       statusCalls.length = 0;
       await engine.runSweep();


### PR DESCRIPTION
## Summary
- fan CLI-fallback `setStatuses` batches out through the existing per-item `setStatus` transport
- continue attempting remaining updates after an item fails, then throw one normalized error naming every failed key
- persist agent-engine sidebar snapshots after successful CLI batches so unchanged rows are not resent indefinitely

## Context
Red-team workflow `wf_94547a7a-de6` found that the CLI fallback returned `false` without applying any status updates, making the drop invisible over stdio MCP and leaving sidebar snapshots dirty. This implements the signed 2026-07-12 ES-1 setStatuses fix brief; ES-2, socket transport, self-heal behavior, and tool schemas remain out of scope.

## Test plan
- [x] RED-first CLI success regression: N updates produce N `set-status` exec calls and return `true`
- [x] RED-first partial-failure regression: all items are attempted and the thrown error names every failed key
- [x] CLI engine replay: 25 rows fan out on the first sweep and the persisted snapshots suppress a second sweep
- [x] `npm test` — 1,759 passed
- [x] `npm run pre-pr` — typecheck + 61 harness tests passed
- [x] `npm run build`
- [x] CodeRabbit pre-commit review — 0 findings across 3 files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sidebar status delivery at scale (many CLI execs per sweep) and changes failure semantics from silent false to thrown errors, which callers that relied on the old stub may now see.
> 
> **Overview**
> **CLI batch sidebar updates now apply instead of being skipped.** `CmuxClient.setStatuses` no longer logs and returns `false` for every batch; it runs each update through the existing `setStatus` path (one `cmux set-status` exec per item, including icon/color/workspace).
> 
> On partial failure it still tries every item, then throws one error listing all failed keys and their messages. On full success it returns `true`, which lets the agent engine treat the batch as applied and **persist sidebar snapshots** so a follow-up sweep does not resend unchanged rows.
> 
> Tests cover N-for-N CLI fan-out, partial-failure aggregation, and a 25-agent sweep replay (first sweep pushes all keys, second sweep sends none).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a1f4aee73d28d876604e43c279cd240c9ea3f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CmuxClient.setStatuses` to fan out per-item instead of silently dropping updates
> - Previously, `setStatuses` short-circuited and returned `false` without issuing any CLI calls; it now iterates over each `CmuxStatusUpdate` and calls `setStatus` individually.
> - All updates are attempted regardless of earlier failures; if any fail, a single aggregated error naming all failed keys is thrown.
> - Tests in [cmux-client.test.ts](https://github.com/EtanHey/cmuxlayer/pull/303/files#diff-52c559d9df416e9f527a81ec926c7657acd1c532310121cf9d3edbe43af42ec6) and the `sidebar-scale` e2e replay in [painpoint-e2e.test.ts](https://github.com/EtanHey/cmuxlayer/pull/303/files#diff-bc90ffb33b06a54a1563b0e95a9978eaa86c922be83f2f321774545177a5dc8c) are updated to match the new behavior.
> - Behavioral Change: callers that previously received `false` on failure now receive a thrown `Error`; callers that expected no CLI calls to be made will now see one call per update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42a1f4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status updates can now be applied to multiple entries in a single operation.
  * All requested updates are attempted, with failures reported together for easier troubleshooting.

* **Bug Fixes**
  * Resolved an issue where multi-status updates were skipped instead of being sent.

* **Tests**
  * Added coverage for successful multi-entry updates and aggregated failures.
  * Updated end-to-end validation to confirm status updates are sent for every worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->