### PR TITLE
fix: pin boot-time CLI fallback to the instance env (ES-2)

### DIFF
--- a/src/cmux-client-factory.ts
+++ b/src/cmux-client-factory.ts
@@ -16,6 +16,7 @@ import {
 import {
   DEFAULT_PING_RETRY_ATTEMPTS,
   DEFAULT_PING_RETRY_BACKOFF_MS,
+  cliEnvForSocketPath,
   wrapCliWithSelfHeal,
   wrapSocketWithSelfHeal,
 } from "./cmux-transport-self-heal.js";
@@ -91,10 +92,15 @@ export async function createCmuxClient(
   opts?: CreateCmuxClientOptions,
 ): Promise<CmuxClient | CmuxSocketClient> {
   const logger = opts?.logger ?? console;
-  const cliFallback = new CmuxClient({ exec: opts?.exec, bin: opts?.bin });
+  const pin = instancePin(opts);
+  const cliFallback = new CmuxClient({
+    exec: opts?.exec,
+    bin: opts?.bin,
+    ...(pin ? { env: cliEnvForSocketPath(pin) } : {}),
+  });
 
   const candidates = candidateSocketPathsForOpts(opts);
-  const pinned = instancePin(opts) !== undefined;
+  const pinned = pin !== undefined;
 
   const usable: string[] = [];
   const denied: SocketProbeResult[] = [];

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -30,6 +30,13 @@ export const DEFAULT_IRRECOVERABLE_MIN_DURATION_MS = 60_000;
 const UPGRADE_FAILURE_LOG_INTERVAL_MS = 30_000;
 const DENIAL_PROGRESS_LOG_INTERVAL_MS = 30_000;
 
+export function cliEnvForSocketPath(socketPath: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CMUX_SOCKET_PATH: socketPath,
+  };
+}
+
 export interface TransportHealthSignal {
   mode: "socket" | "cli";
   degraded: boolean;
@@ -594,10 +601,7 @@ export class CmuxSelfHealingClient {
 
   private pinCliToSocket(socket: CmuxSocketClient): void {
     try {
-      this.opts.cli.setEnv({
-        ...process.env,
-        CMUX_SOCKET_PATH: socket.currentSocketPath(),
-      });
+      this.opts.cli.setEnv(cliEnvForSocketPath(socket.currentSocketPath()));
     } catch {
       // Keep the socket transport active; CLI pinning will be retried after any
       // downgrade/upgrade that has a resolved socket path.

--- a/tests/cmux-client-factory.test.ts
+++ b/tests/cmux-client-factory.test.ts
@@ -93,6 +93,81 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)(
       servers.push({ server, path });
     }
 
+    it("pins the first degraded CLI call from an explicit socketPath", async () => {
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      delete process.env.CMUX_SOCKET_PATH;
+      const socketPath = join(tmpdir(), `cmux-explicit-down-${process.pid}.sock`);
+      const exec = vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+
+      const client = await createCmuxClient({
+        socketPath,
+        exec,
+        bin: "cmux",
+        pingRetryAttempts: 1,
+        reprobeIntervalMs: 60_000,
+      });
+
+      await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+      expect(exec).toHaveBeenCalledWith(
+        "cmux",
+        ["--json", "list-workspaces"],
+        expect.objectContaining({ CMUX_SOCKET_PATH: socketPath }),
+      );
+      if ("stop" in client && typeof client.stop === "function") client.stop();
+    });
+
+    it("pins the first degraded CLI call from CMUX_SOCKET_PATH", async () => {
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      const socketPath = join(tmpdir(), `cmux-env-down-${process.pid}.sock`);
+      process.env.CMUX_SOCKET_PATH = socketPath;
+      const exec = vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+
+      const client = await createCmuxClient({
+        exec,
+        bin: "cmux",
+        pingRetryAttempts: 1,
+        reprobeIntervalMs: 60_000,
+      });
+
+      await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+      expect(exec).toHaveBeenCalledWith(
+        "cmux",
+        ["--json", "list-workspaces"],
+        expect.objectContaining({ CMUX_SOCKET_PATH: socketPath }),
+      );
+      if ("stop" in client && typeof client.stop === "function") client.stop();
+    });
+
+    it("preserves ambient env inheritance when no instance pin exists", async () => {
+      savedEnv = process.env.CMUX_SOCKET_PATH;
+      delete process.env.CMUX_SOCKET_PATH;
+      const stateDir = mkdtempSync(join(tmpdir(), "cmux-unpinned-down-"));
+      const exec = vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      });
+
+      const client = await createCmuxClient({
+        socketStateDir: stateDir,
+        exec,
+        bin: "cmux",
+        pingRetryAttempts: 1,
+        reprobeIntervalMs: 60_000,
+      });
+
+      await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+      expect(exec).toHaveBeenCalledWith("cmux", ["--json", "list-workspaces"]);
+      expect(exec.mock.calls[0]).toHaveLength(2);
+      if ("stop" in client && typeof client.stop === "function") client.stop();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
     it("pins to CMUX_SOCKET_PATH and never falls through to another live instance", async () => {
       const stateDir = mkdtempSync(join(tmpdir(), "cmux-factory-"));
       const otherInstance = join(stateDir, "cmux-other.sock");

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -810,6 +810,59 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("uses the same CLI env shape at boot and after socket re-degradation", async () => {
+    const socketPath = join(tmpdir(), `cmux-env-parity-${process.pid}.sock`);
+    const bootExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    const bootClient = await createCmuxClient({
+      socketPath,
+      exec: bootExec,
+      bin: "cmux",
+      pingRetryAttempts: 1,
+      reprobeIntervalMs: 60_000,
+    });
+    await bootClient.listWorkspaces();
+    const bootEnv = bootExec.mock.calls[0]?.[2];
+    if ("stop" in bootClient && typeof bootClient.stop === "function") {
+      bootClient.stop();
+    }
+
+    const recoveryExec = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ workspaces: [] }),
+      stderr: "",
+    });
+    const recoveryCli = new CmuxClient({ exec: recoveryExec, bin: "cmux" });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      ping: vi
+        .fn()
+        .mockRejectedValue(
+          new CmuxSocketError("Socket error: write EPIPE", "connection_error"),
+        ),
+    } as unknown as CmuxSocketClient;
+    const recoveryClient = wrapSocketWithSelfHeal(socket, recoveryCli, {
+      socketPath,
+      reprobeIntervalMs: 60_000,
+      factoryOpts: { socketPath },
+    });
+
+    await expect(recoveryClient.ping()).rejects.toThrow(/EPIPE/);
+    await recoveryClient.listWorkspaces();
+
+    const recoveryEnv = recoveryExec.mock.calls[0]?.[2];
+    expect(bootEnv).toBeDefined();
+    expect(recoveryEnv).toBeDefined();
+    expect(Object.keys(bootEnv ?? {}).sort()).toEqual(
+      Object.keys(recoveryEnv ?? {}).sort(),
+    );
+    expect(bootEnv?.CMUX_SOCKET_PATH).toBe(socketPath);
+    expect(recoveryEnv?.CMUX_SOCKET_PATH).toBe(socketPath);
+    recoveryClient.stop();
+  });
+
   it("queues and flushes a failed socket payload through CLI after EPIPE", async () => {
     const socketPath = join(tmpdir(), `cmux-queue-${process.pid}.sock`);
     const logger = { error: vi.fn() };


### PR DESCRIPTION
## Summary
- Pin the boot-time degraded CLI fallback from the first operation using the same instance resolution as socket selection: explicit `socketPath` first, then `CMUX_SOCKET_PATH`.
- Share one env-shaping helper between boot-time construction and socket-recovery pinning so both paths forward `{ ...process.env, CMUX_SOCKET_PATH: pin }` without drift.
- Preserve ambient subprocess env inheritance when no instance pin exists.

## Context
Red-team workflow `wf_94547a7a-de6` found that pure CLI-from-boot operations could inherit an ambient socket and target the wrong cmux instance before socket recovery. This implements the signed ES-2 boot CLI env-pin brief dated 2026-07-12.

## TDD evidence
- RED: explicit `socketPath` and env-derived pins reached first CLI exec with no env; boot/recovery parity observed boot env as undefined.
- GREEN: focused factory/self-heal suites: 35 passed.
- Full Vitest suite: 1,761 passed across 96 files.
- Pre-PR harness: 61 passed.
- Typecheck and build: passed.
- Push hook: 1,761 passed across 96 files.

## Review status
- Local CodeRabbit CLI: SKIPPED after the mandated 180-second timeout; it returned heartbeat-only status and no verdict.
- Fallback red-team/blue-team diff review: no actionable findings.
- PR-level bot review requested immediately after creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which cmux instance CLI subprocesses target at startup and after transport degradation; mis-pinning could misroute operations, but scope is limited to transport env wiring with strong test coverage.
> 
> **Overview**
> Fixes **boot-time degraded CLI** targeting the wrong cmux instance when socket probes fail but an instance is already pinned via explicit `socketPath` or `CMUX_SOCKET_PATH`.
> 
> `createCmuxClient` now resolves that pin once and, when present, builds the CLI fallback with env shaped as `{ ...process.env, CMUX_SOCKET_PATH: pin }` so the **first** CLI exec hits the intended instance instead of inheriting an ambient socket. When there is no pin, the CLI client is created without a custom env so subprocess inheritance stays unchanged.
> 
> A shared **`cliEnvForSocketPath`** helper replaces inline env construction in socket-recovery **`pinCliToSocket`**, keeping boot and post-downgrade CLI pinning aligned. Tests cover explicit/env pins, unpinned ambient env, and boot vs recovery env parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9bd61848574ee860a06b97a5c1ca1212f824894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin boot-time CLI fallback to the instance env when a socket path is set
> - Extracts a new `cliEnvForSocketPath` helper in [`cmux-transport-self-heal.ts`](https://github.com/EtanHey/cmuxlayer/pull/304/files#diff-fbf073b8b6f02d58f4addfd2d8fcaed58d9e495a3ec139005951626f13e03267) that returns a `ProcessEnv` clone with `CMUX_SOCKET_PATH` set to the given socket path.
> - Updates [`cmux-client-factory.ts`](https://github.com/EtanHey/cmuxlayer/pull/304/files#diff-37e2c062823d882ca9c154692047152501d1bd813787b69cf13d4a1dbbcd1342) to call `instancePin(opts)` at construction time and pass the resulting env to the `CmuxClient` constructor when a pin exists, so the first degraded CLI call inherits `CMUX_SOCKET_PATH`.
> - Previously, the CLI fallback constructed at boot time had no env, meaning `CMUX_SOCKET_PATH` was absent on the very first CLI invocation even when a socket path was explicitly configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9bd618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->