### PR TITLE
feat: CMUXLAYER_DEFAULT_PALETTE per-session resident-tool palette (E5 eval seam)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ command = "cmuxlayer"
 }
 ```
 
+To keep only a per-session resident subset of tools, set
+`CMUXLAYER_DEFAULT_PALETTE` to comma-separated bare tool names, for example
+`list_surfaces,spawn_agent,send_to`. The server also exposes `expand_palette`,
+which makes every deferred tool available for the rest of that MCP session.
+Unset or blank values preserve the full tool list; unknown names are warned and
+ignored while valid names still load.
+
 > **Config locations:** Codex CLI / T3 Code `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) | Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
 
 ## What You Can Do

--- a/docs/plans/2026-07-12-es3b-default-palette.md
+++ b/docs/plans/2026-07-12-es3b-default-palette.md
@@ -1,0 +1,56 @@
+# ES-3b Default Palette Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a per-session `CMUXLAYER_DEFAULT_PALETTE` environment seam that boots only named tools plus `expand_palette`, while preserving the unset 42-tool surface exactly.
+
+**Architecture:** Parse the environment once per `createServer()` call in a small `src/palette.ts` controller. The existing `server.tool` registration wrapper remains the single seam: selected tools register immediately, non-selected tools retain their original registration arguments for runtime expansion, and lifecycle-gated registrations are never seen when `skipAgentLifecycle` wins. Palette-bearing MCP children use the existing in-process entry path so their environment cannot leak through a shared daemon; expansion suppresses the SDK's per-tool notifications and emits one explicit `notifications/tools/list_changed` after the batch.
+
+**Tech Stack:** TypeScript, Zod, `@modelcontextprotocol/sdk` 1.x, Vitest, in-memory MCP transports.
+
+---
+
+### Task 1: Lock the MCP behavior with failing tests
+
+**Files:**
+- Create: `tests/default-palette.test.ts`
+
+1. Add an environment restore helper and an in-memory server/client fixture.
+2. Test a three-name palette lists exactly those tools plus `expand_palette`.
+3. Test expansion restores the full lifecycle-gated set, emits `notifications/tools/list_changed`, and is idempotent.
+4. Test unset and whitespace-only values preserve the existing 42-tool surface without `expand_palette`.
+5. Test unknown names warn to stderr while valid names remain resident.
+6. Test a deferred tool call fails with the standard MCP unknown-tool error before expansion.
+7. Run `bunx vitest run tests/default-palette.test.ts` and verify failures are caused by the missing palette feature.
+
+### Task 2: Implement registration-layer deferral
+
+**Files:**
+- Create: `src/palette.ts`
+- Modify: `src/entry.ts`
+- Modify: `src/server.ts`
+
+1. Add a palette controller that treats missing/blank input as disabled, normalizes comma-separated bare names, records known/selected/deferred tools, warns once for unknown names after registration, and expands deferred registrations once.
+2. Route palette-bearing children through the existing in-process entry path so selection remains per-session even when normal children share a daemon.
+3. Route calls through the existing `server.tool` wrapper after transport retry decoration. Register `expand_palette` only when palette mode is enabled.
+4. Return structured success from `expand_palette`, including whether expansion happened and the names registered; batch the registrations behind one list-changed notification, and make later calls a no-op success.
+5. Run `bunx vitest run tests/default-palette.test.ts tests/entry.test.ts` until all focused tests pass.
+
+### Task 3: Document and verify
+
+**Files:**
+- Modify: `README.md`
+
+1. Add one short configuration block explaining comma-separated bare names, unset/blank compatibility, runtime expansion, and fail-soft unknown names.
+2. Run focused tests, `bun run test`, `bun run typecheck`, and `bun run build`.
+3. Start the built server with a palette through a real stdio MCP client, list the resident tools, call `expand_palette`, and list the expanded tools.
+
+### Task 4: Publish through the PR loop
+
+**Files:**
+- Review all changed files and the final diff.
+
+1. Run bounded local CodeRabbit review and resolve substantive findings.
+2. Commit only the scoped files, push `feat/es3b-default-palette-env`, and create a ready PR titled `feat: CMUXLAYER_DEFAULT_PALETTE per-session resident-tool palette (E5 eval seam)`.
+3. Cite the ES-3b brief and E5 unblock in the PR body, invoke available reviewers, address findings, and merge only after the required review and CI gates.
+4. Verify the remote PR state and merge content, update relevant tracking, and store the milestone plus rationale in BrainLayer.

--- a/docs/plans/2026-07-12-es3b-default-palette.md
+++ b/docs/plans/2026-07-12-es3b-default-palette.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add a per-session `CMUXLAYER_DEFAULT_PALETTE` environment seam that boots only named tools plus `expand_palette`, while preserving the unset 42-tool surface exactly.
+**Goal:** Add a per-session `CMUXLAYER_DEFAULT_PALETTE` environment seam that boots only named tools plus `expand_palette`, while preserving the current unset full-tool surface exactly.
 
 **Architecture:** Parse the environment once per `createServer()` call in a small `src/palette.ts` controller. The existing `server.tool` registration wrapper remains the single seam: selected tools register immediately, non-selected tools retain their original registration arguments for runtime expansion, and lifecycle-gated registrations are never seen when `skipAgentLifecycle` wins. Palette-bearing MCP children use the existing in-process entry path so their environment cannot leak through a shared daemon; expansion suppresses the SDK's per-tool notifications and emits one explicit `notifications/tools/list_changed` after the batch.
 
@@ -18,7 +18,7 @@
 1. Add an environment restore helper and an in-memory server/client fixture.
 2. Test a three-name palette lists exactly those tools plus `expand_palette`.
 3. Test expansion restores the full lifecycle-gated set, emits `notifications/tools/list_changed`, and is idempotent.
-4. Test unset and whitespace-only values preserve the existing 42-tool surface without `expand_palette`.
+4. Test unset and whitespace-only values preserve the current full-tool surface without `expand_palette`.
 5. Test unknown names warn to stderr while valid names remain resident.
 6. Test a deferred tool call fails with the standard MCP unknown-tool error before expansion.
 7. Run `bunx vitest run tests/default-palette.test.ts` and verify failures are caused by the missing palette feature.

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -22,6 +22,7 @@ export { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
 
 export interface StartInProcessOptions {
   fallbackWarnings?: string[];
+  env?: NodeJS.ProcessEnv;
 }
 
 export type ExitFn = (code: number) => void;
@@ -155,6 +156,7 @@ export async function startInProcessRuntime(
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,
     enableCloseForensics: true,
+    defaultPalette: opts.env?.CMUXLAYER_DEFAULT_PALETTE,
     ...(opts.fallbackWarnings
       ? { controlHealthWarnings: opts.fallbackWarnings }
       : {}),
@@ -271,7 +273,7 @@ export async function runDaemonFirstEntry(
     // palette selection in this process so it remains session-local.
     return {
       mode: "in-process",
-      server: await startInProcess({}),
+      server: await startInProcess({ env }),
       fallbackWarnings: [],
     };
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -266,6 +266,16 @@ export async function runDaemonFirstEntry(
     };
   };
 
+  if (env.CMUXLAYER_DEFAULT_PALETTE?.trim()) {
+    // A shared daemon cannot observe a child MCP process's environment. Keep
+    // palette selection in this process so it remains session-local.
+    return {
+      mode: "in-process",
+      server: await startInProcess({}),
+      fallbackWarnings: [],
+    };
+  }
+
   if (isEnabled(env.CMUXLAYER_FORCE_INPROCESS)) {
     return fallback(
       "CMUXLAYER_FORCE_INPROCESS=1; using heavy in-process runtime instead of daemon proxy",

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -11,6 +11,7 @@ export const REGISTERED_TOOL_NAMES = [
   "query_monitor_registry",
   "select_workspace",
   "create_workspace",
+  "delete_workspace",
   "new_split",
   "new_surface",
   "move_surface",
@@ -56,7 +57,7 @@ export interface PaletteExpansion {
 
 export interface DefaultToolPalette {
   shouldRegister(toolName: string): boolean;
-  defer(toolName: string, args: unknown[]): void;
+  defer(toolName: string, args: unknown[]): unknown;
   warnAboutUnknownTools(): void;
   expand(register: ToolRegistrar): PaletteExpansion;
 }
@@ -76,7 +77,10 @@ export function createDefaultToolPalette(
       .filter(Boolean),
   );
   const known = new Set<string>(REGISTERED_TOOL_NAMES);
-  const deferred = new Map<string, unknown[]>();
+  const deferred = new Map<
+    string,
+    { args: unknown[]; updates: Array<Record<string, unknown>> }
+  >();
   let expanded = false;
 
   return {
@@ -84,7 +88,16 @@ export function createDefaultToolPalette(
       return requested.has(toolName);
     },
     defer(toolName, args) {
-      deferred.set(toolName, args);
+      const registration = {
+        args,
+        updates: [] as Array<Record<string, unknown>>,
+      };
+      deferred.set(toolName, registration);
+      return {
+        update(update: Record<string, unknown>) {
+          registration.updates.push(update);
+        },
+      };
     },
     warnAboutUnknownTools() {
       const unknown = [...requested].filter((name) => !known.has(name));
@@ -105,8 +118,18 @@ export function createDefaultToolPalette(
 
       expanded = true;
       const registeredTools = [...deferred.keys()];
-      for (const args of deferred.values()) {
-        register(...args);
+      for (const registration of deferred.values()) {
+        const registered = register(...registration.args) as {
+          update?: (update: Record<string, unknown>) => void;
+        };
+        for (const update of registration.updates) {
+          if (typeof registered?.update !== "function") {
+            throw new Error(
+              "Deferred tool registration did not return an update handle",
+            );
+          }
+          registered.update(update);
+        }
       }
       deferred.clear();
       return {

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -1,0 +1,119 @@
+export const CMUXLAYER_DEFAULT_PALETTE_ENV =
+  "CMUXLAYER_DEFAULT_PALETTE" as const;
+
+export const REGISTERED_TOOL_NAMES = [
+  "list_surfaces",
+  "control_health",
+  "register_monitor",
+  "signal_monitor",
+  "deregister_monitor",
+  "list_monitors",
+  "query_monitor_registry",
+  "select_workspace",
+  "create_workspace",
+  "new_split",
+  "new_surface",
+  "move_surface",
+  "reorder_surface",
+  "send_input",
+  "send_command",
+  "send_key",
+  "read_screen",
+  "rename_tab",
+  "notify",
+  "set_status",
+  "set_progress",
+  "close_surface",
+  "browser_surface",
+  "dispatch_to_agent",
+  "inbox_check",
+  "spawn_agent",
+  "new_worktree_split",
+  "spawn_in_workspace",
+  "wait_for",
+  "wait_for_all",
+  "get_agent_state",
+  "list_agents",
+  "broadcast",
+  "resync_agents",
+  "stop_agent",
+  "send_to",
+  "send_to_agent",
+  "supersede_agent_goal",
+  "read_agent_output",
+  "interact",
+  "kill",
+  "my_agents",
+] as const;
+
+type ToolRegistrar = (...args: unknown[]) => unknown;
+
+export interface PaletteExpansion {
+  expanded: boolean;
+  already_expanded: boolean;
+  registered_tools: string[];
+}
+
+export interface DefaultToolPalette {
+  shouldRegister(toolName: string): boolean;
+  defer(toolName: string, args: unknown[]): void;
+  warnAboutUnknownTools(): void;
+  expand(register: ToolRegistrar): PaletteExpansion;
+}
+
+export function createDefaultToolPalette(
+  rawValue: string | undefined,
+  warn: (message: string) => void = console.warn,
+): DefaultToolPalette | null {
+  if (!rawValue?.trim()) {
+    return null;
+  }
+
+  const requested = new Set(
+    rawValue
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
+  const known = new Set<string>(REGISTERED_TOOL_NAMES);
+  const deferred = new Map<string, unknown[]>();
+  let expanded = false;
+
+  return {
+    shouldRegister(toolName) {
+      return requested.has(toolName);
+    },
+    defer(toolName, args) {
+      deferred.set(toolName, args);
+    },
+    warnAboutUnknownTools() {
+      const unknown = [...requested].filter((name) => !known.has(name));
+      if (unknown.length > 0) {
+        warn(
+          `[cmuxlayer] ${CMUXLAYER_DEFAULT_PALETTE_ENV} ignored unknown tool name${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+        );
+      }
+    },
+    expand(register) {
+      if (expanded) {
+        return {
+          expanded: false,
+          already_expanded: true,
+          registered_tools: [],
+        };
+      }
+
+      expanded = true;
+      const registeredTools = [...deferred.keys()];
+      for (const args of deferred.values()) {
+        register(...args);
+      }
+      deferred.clear();
+      return {
+        expanded: true,
+        already_expanded: false,
+        registered_tools: registeredTools,
+      };
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,10 @@ import { access, readFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
+import {
+  CMUXLAYER_DEFAULT_PALETTE_ENV,
+  createDefaultToolPalette,
+} from "./palette.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import {
   createFileSystemSeatManifestWriter,
@@ -2490,14 +2494,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       : undefined,
   );
   const rawTool = server.tool.bind(server) as (...args: unknown[]) => unknown;
+  const palette = createDefaultToolPalette(
+    process.env[CMUXLAYER_DEFAULT_PALETTE_ENV],
+  );
   (
     server as unknown as { tool: (...args: unknown[]) => unknown }
   ).tool = (...args: unknown[]): unknown => {
+    const toolName = args[0];
     const handlerIndex = args.length - 1;
     const handler = args[handlerIndex];
     if (typeof handler === "function") {
       args[handlerIndex] = (...handlerArgs: unknown[]) =>
         withTransportRetryTracking(() => handler(...handlerArgs));
+    }
+    if (
+      palette &&
+      typeof toolName === "string" &&
+      !palette.shouldRegister(toolName)
+    ) {
+      palette.defer(toolName, args);
+      return undefined;
     }
     return rawTool(...args);
   };
@@ -8826,7 +8842,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
 
     // Expose engine on the tool for test access
-    (server as any)._registeredTools["interact"]._engine = engine;
+    const registeredInteract = (server as any)._registeredTools["interact"];
+    if (registeredInteract) {
+      registeredInteract._engine = engine;
+    }
 
     // 20. kill
     server.tool(
@@ -9031,6 +9050,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
     );
   } // end skipAgentLifecycle guard
+
+  if (palette) {
+    palette.warnAboutUnknownTools();
+    rawTool(
+      "expand_palette",
+      "Register the tools deferred by CMUXLAYER_DEFAULT_PALETTE for this MCP session",
+      {},
+      ANNOTATIONS.idempotentMutating,
+      async () =>
+        withTransportRetryTracking(async () => {
+          const sendToolListChanged = server.sendToolListChanged;
+          server.sendToolListChanged = () => {};
+          let expansion;
+          try {
+            expansion = palette.expand(rawTool);
+          } finally {
+            server.sendToolListChanged = sendToolListChanged;
+          }
+          if (expansion.expanded) {
+            server.sendToolListChanged();
+          }
+          return ok({ ...expansion });
+        }),
+    );
+  }
 
   return server;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1810,6 +1810,8 @@ export interface CreateServerOptions {
   stateDir?: string;
   /** Skip agent lifecycle initialization (for testing low-level tools only) */
   skipAgentLifecycle?: boolean;
+  /** Override the per-session resident-tool palette (primarily for entry wiring/tests). */
+  defaultPalette?: string;
   /** Opt into Claude Code channel notifications for lifecycle events */
   enableClaudeChannels?: boolean;
   /** Override spawn preflight checks (primarily for tests). */
@@ -2495,7 +2497,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   );
   const rawTool = server.tool.bind(server) as (...args: unknown[]) => unknown;
   const palette = createDefaultToolPalette(
-    process.env[CMUXLAYER_DEFAULT_PALETTE_ENV],
+    opts?.defaultPalette ?? process.env[CMUXLAYER_DEFAULT_PALETTE_ENV],
   );
   (
     server as unknown as { tool: (...args: unknown[]) => unknown }
@@ -2512,8 +2514,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       typeof toolName === "string" &&
       !palette.shouldRegister(toolName)
     ) {
-      palette.defer(toolName, args);
-      return undefined;
+      return palette.defer(toolName, args);
     }
     return rawTool(...args);
   };

--- a/tests/default-palette.test.ts
+++ b/tests/default-palette.test.ts
@@ -86,7 +86,14 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
         ok: true,
         expanded: true,
       });
-      expect((await fixture.client.listTools()).tools).toHaveLength(26);
+      const expandedTools = (await fixture.client.listTools()).tools;
+      expect(expandedTools).toHaveLength(27);
+      expect(
+        expandedTools.find((tool) => tool.name === "delete_workspace")?._meta,
+      ).toMatchObject({
+        defer_loading: true,
+        "cmuxlayer/interim": true,
+      });
       expect(fixture.listChanged).toHaveBeenCalledTimes(1);
 
       const notificationCount = fixture.listChanged.mock.calls.length;
@@ -99,7 +106,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
         expanded: false,
         already_expanded: true,
       });
-      expect((await fixture.client.listTools()).tools).toHaveLength(26);
+      expect((await fixture.client.listTools()).tools).toHaveLength(27);
       expect(fixture.listChanged).toHaveBeenCalledTimes(notificationCount);
     } finally {
       await closePaletteServer(fixture);
@@ -107,7 +114,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
   });
 
   it.each([undefined, "", "   \t  "])(
-    "preserves the full 42-tool surface when the env is %s",
+    "preserves the full tool surface when the env is %s",
     async (value) => {
       if (value === undefined) {
         delete process.env[ENV_KEY];
@@ -120,7 +127,7 @@ describe("CMUXLAYER_DEFAULT_PALETTE", () => {
           (server as unknown as { _registeredTools: Record<string, unknown> })
             ._registeredTools,
         );
-        expect(names).toHaveLength(42);
+        expect(names).toHaveLength(43);
         expect(names).not.toContain("expand_palette");
       } finally {
         await server.close();

--- a/tests/default-palette.test.ts
+++ b/tests/default-palette.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createServer } from "../src/server.js";
+import { REGISTERED_TOOL_NAMES } from "../src/palette.js";
+
+const ENV_KEY = "CMUXLAYER_DEFAULT_PALETTE";
+const originalEnv = process.env[ENV_KEY];
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = originalEnv;
+  }
+  vi.restoreAllMocks();
+});
+
+async function connectPaletteServer(value: string) {
+  process.env[ENV_KEY] = value;
+  const server = createServer({ skipAgentLifecycle: true });
+  const client = new Client({ name: "palette-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const listChanged = vi.fn();
+  client.setNotificationHandler(ToolListChangedNotificationSchema, listChanged);
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { client, server, listChanged };
+}
+
+async function closePaletteServer(
+  fixture: Awaited<ReturnType<typeof connectPaletteServer>>,
+) {
+  await fixture.client.close();
+  await fixture.server.close();
+}
+
+describe("CMUXLAYER_DEFAULT_PALETTE", () => {
+  it("keeps the palette validation registry aligned with the full tool surface", async () => {
+    delete process.env[ENV_KEY];
+    const server = createServer();
+    try {
+      const registered = Object.keys(
+        (server as unknown as { _registeredTools: Record<string, unknown> })
+          ._registeredTools,
+      ).sort();
+      expect(registered).toEqual([...REGISTERED_TOOL_NAMES].sort());
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("registers only the requested tools plus expand_palette", async () => {
+    const fixture = await connectPaletteServer(
+      "list_surfaces,control_health,read_screen",
+    );
+    try {
+      const listed = await fixture.client.listTools();
+      expect(listed.tools.map((tool) => tool.name).sort()).toEqual([
+        "control_health",
+        "expand_palette",
+        "list_surfaces",
+        "read_screen",
+      ]);
+    } finally {
+      await closePaletteServer(fixture);
+    }
+  });
+
+  it("expands all eligible tools, emits list_changed, and is idempotent", async () => {
+    const fixture = await connectPaletteServer(
+      "list_surfaces,control_health,read_screen",
+    );
+    try {
+      expect((await fixture.client.listTools()).tools).toHaveLength(4);
+
+      const first = await fixture.client.callTool({
+        name: "expand_palette",
+        arguments: {},
+      });
+      expect(first.structuredContent).toMatchObject({
+        ok: true,
+        expanded: true,
+      });
+      expect((await fixture.client.listTools()).tools).toHaveLength(26);
+      expect(fixture.listChanged).toHaveBeenCalledTimes(1);
+
+      const notificationCount = fixture.listChanged.mock.calls.length;
+      const second = await fixture.client.callTool({
+        name: "expand_palette",
+        arguments: {},
+      });
+      expect(second.structuredContent).toMatchObject({
+        ok: true,
+        expanded: false,
+        already_expanded: true,
+      });
+      expect((await fixture.client.listTools()).tools).toHaveLength(26);
+      expect(fixture.listChanged).toHaveBeenCalledTimes(notificationCount);
+    } finally {
+      await closePaletteServer(fixture);
+    }
+  });
+
+  it.each([undefined, "", "   \t  "])(
+    "preserves the full 42-tool surface when the env is %s",
+    async (value) => {
+      if (value === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = value;
+      }
+      const server = createServer();
+      try {
+        const names = Object.keys(
+          (server as unknown as { _registeredTools: Record<string, unknown> })
+            ._registeredTools,
+        );
+        expect(names).toHaveLength(42);
+        expect(names).not.toContain("expand_palette");
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  it("keeps deferred lifecycle tools skipped without crashing lifecycle setup", async () => {
+    process.env[ENV_KEY] = "list_surfaces,control_health,read_screen";
+    const server = createServer();
+    try {
+      expect(
+        Object.keys(
+          (
+            server as unknown as {
+              _registeredTools: Record<string, unknown>;
+            }
+          )._registeredTools,
+        ).sort(),
+      ).toEqual([
+        "control_health",
+        "expand_palette",
+        "list_surfaces",
+        "read_screen",
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("warns about unknown names and keeps the valid subset", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fixture = await connectPaletteServer(
+      "list_surfaces,not_a_cmux_tool,read_screen",
+    );
+    try {
+      expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining([
+          "list_surfaces",
+          "read_screen",
+          "expand_palette",
+        ]),
+      );
+      expect((await fixture.client.listTools()).tools).toHaveLength(3);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("not_a_cmux_tool"),
+      );
+    } finally {
+      await closePaletteServer(fixture);
+    }
+  });
+
+  it("returns the standard MCP unknown-tool error before expansion", async () => {
+    const fixture = await connectPaletteServer("list_surfaces");
+    try {
+      const result = await fixture.client.callTool({
+        name: "read_screen",
+        arguments: { surface: "surface:1" },
+      });
+      expect(result).toMatchObject({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "MCP error -32602: Tool read_screen not found",
+          },
+        ],
+      });
+    } finally {
+      await closePaletteServer(fixture);
+    }
+  });
+});

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -186,4 +186,23 @@ describe("daemon-first MCP entry", () => {
       expect.stringContaining("CMUXLAYER_FORCE_INPROCESS=1"),
     );
   });
+
+  it("keeps a nonblank default palette isolated from a shared daemon", async () => {
+    const logger = { error: vi.fn() };
+    const opts = createEntryOptions({
+      env: {
+        CMUXLAYER_DEFAULT_PALETTE:
+          "list_surfaces,control_health,read_screen",
+      },
+      logger,
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(opts.probeDaemon).not.toHaveBeenCalled();
+    expect(opts.spawnDaemon).not.toHaveBeenCalled();
+    expect(opts.runProxy).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
 });

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -203,6 +203,9 @@ describe("daemon-first MCP entry", () => {
     expect(opts.probeDaemon).not.toHaveBeenCalled();
     expect(opts.spawnDaemon).not.toHaveBeenCalled();
     expect(opts.runProxy).not.toHaveBeenCalled();
+    expect(opts.startInProcess).toHaveBeenCalledWith({
+      env: opts.env,
+    });
     expect(logger.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add the ES-3b `CMUXLAYER_DEFAULT_PALETTE` per-session resident-tool palette described in `2026-07-12-es3b-default-palette-brief.md`
- defer off-palette registrations behind idempotent `expand_palette` and emit one `notifications/tools/list_changed` event after batch expansion
- isolate palette-bearing MCP children from the shared daemon so E5 full-vs-palette eval cells cannot contaminate each other
- preserve the unset/blank full tool surface and fail soft with stderr warnings for unknown names

## E5 unblock
This is the same-day eval seam blocking skillCreator's E5 records: boot context can carry the selected resident schemas plus one tiny expansion tool while every deferred cmuxlayer tool remains reachable at runtime.

## Test plan
- [x] RED-first palette behavior tests
- [x] `bun run test` — 97 files, 1,767 tests
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run pre-pr` — 61 harness tests
- [x] real stdio MCP client against the built entrypoint: 4 resident tools, 40 deferred registrations, 44 tools after expansion, preserved `delete_workspace` metadata, exactly one list-changed notification, idempotent second call
- [x] unset in-process stdio MCP client on current main: 43 tools including `delete_workspace`, no `expand_palette`

## Review
- bounded local CodeRabbit CLI timed out in `reviewing`; fallback red/blue review completed
- independent review found the shared-daemon isolation gap; fixed with an entry-path regression test and real-client verification
- CI integration with current main found a deferred `RegisteredTool.update()` contract gap; fixed in `e997153` with metadata-preservation coverage


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-session resident-tool palette via `CMUXLAYER_DEFAULT_PALETTE` environment variable
> - When `CMUXLAYER_DEFAULT_PALETTE` is set to a comma-separated list of tool names, only those tools (plus a new `expand_palette` tool) are registered on session startup; all others are deferred.
> - `expand_palette` registers deferred tools on demand and emits a single `tools/list_changed` notification; repeated calls are no-ops.
> - When the env var is set, `runDaemonFirstEntry` bypasses daemon probing and proxy mode, running in-process so palette selection stays session-local.
> - Unknown tool names in the palette value emit a console warning and are ignored; blank/unset values preserve the full tool list with no `expand_palette` registered.
> - Behavioral Change: any session that sets `CMUXLAYER_DEFAULT_PALETTE` never connects to or spawns a shared daemon, regardless of daemon availability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e997153.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->