### PR TITLE
fix(contract): nightly receipt names the failing step + preserves output_log

### DIFF
--- a/docs/plans/2026-07-13-nightly-contract-diagnostics.md
+++ b/docs/plans/2026-07-13-nightly-contract-diagnostics.md
@@ -1,0 +1,67 @@
+# Nightly Contract Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make nightly contract failures identify their exact step and preserve full output, while accepting both legacy EPIPE and the nightly app's explicit ancestry-denial wire response.
+
+**Architecture:** The contract runner will attach a logical step name to failures and emit one machine-readable marker before the stack. The receipt wrapper will extract that marker and persist failed output without altering successful or skipped receipts. A shared access-control predicate will classify both denial generations, and the persistent socket parser will surface raw denial frames to the transport probe instead of timing out.
+
+**Tech Stack:** TypeScript, Node Unix sockets, Vitest, Bash integration tests, Bun scripts.
+
+---
+
+### Task 1: Pin the failing receipt behavior
+
+**Files:**
+- Modify: `scripts/tests/nightly-contract-run.test.sh`
+- Modify: `tests/real-cmux-contract-runner.test.ts`
+
+1. Add a fake contract failure whose marker names `detached-orphan ancestry denial`, followed by unrelated stack output.
+2. Assert the wrapper receipt reason equals the marker payload, `output_log` names an existing file, and that file contains the full failure output.
+3. Assert PASS and SKIP receipts do not gain an `output_log` field.
+4. Add a runner test proving a named step failure formats one single-line marker.
+5. Run the focused tests and verify they fail for the missing behavior.
+
+### Task 2: Pin both ancestry-denial wire generations
+
+**Files:**
+- Modify: `tests/real-cmux-contract-runner.test.ts`
+- Modify: `tests/cmux-persistent-socket.test.ts`
+- Modify: `tests/cmux-client.test.ts`
+- Modify: `tests/cmux-transport-self-heal.test.ts`
+
+1. Add an orphan receipt with `ERROR: Access denied — only processes started inside cmux can connect` and assert it is accepted while unrelated errors remain rejected.
+2. Add a persistent V2 socket test that returns the raw nightly denial line and assert the request rejects immediately with the raw text preserved.
+3. Add a CLI normalization test asserting the explicit denial has a stable access-denied error class.
+4. Change the transport denial server fixture to the raw nightly line and assert the factory reports `denied_reason: access-control`.
+5. Run the focused tests and verify each new assertion fails for the expected reason.
+
+### Task 3: Implement the minimal diagnostics and compatibility changes
+
+**Files:**
+- Modify: `scripts/run-real-cmux-contract.ts`
+- Modify: `scripts/nightly-contract-run.sh`
+- Modify: `src/cmux-socket-probe.ts`
+- Modify: `src/cmux-persistent-socket.ts`
+- Modify: `src/cmux-client.ts`
+- Modify: `src/cmux-transport-self-heal.ts`
+
+1. Track the active logical contract step, wrap failures with that step, and emit `[contract] FAIL: <step>: <message>` before the stack.
+2. Preserve non-JSON probe frames in the probe receipt so explicit denial text remains classifiable.
+3. Extract the exact final failure marker in the wrapper, atomically preserve failed output, and emit `output_log` only on failure.
+4. Broaden and reuse the shared access-control predicate for `Access denied` and `only processes started inside cmux` text.
+5. Reject unexpected raw V2 frames immediately with their content preserved.
+6. Normalize explicit CLI denial as `CmuxSocketError` code `access_denied` and use the shared predicate in self-heal classification.
+7. Run focused tests until green, then refactor only duplicated denial checks.
+
+### Task 4: Verify, document, and deliver
+
+**Files:**
+- Create: `docs.local/design/2026-07-13-nightly-contract-rootcause.md`
+
+1. Run Bash syntax/integration tests, focused Vitest files, typecheck, build, and the full test suite.
+2. Confirm the stable/main wrapper edit was adopted into this branch, then restore only `scripts/nightly-contract-run.sh` in the primary checkout; preserve unrelated user files.
+3. Compare stable and nightly CLI metadata/help plus the captured failure evidence and write the root-cause/disposition report with the complete sweep results.
+4. Run the local CodeRabbit gate, commit the scoped files, push, and create the required ready-for-review PR.
+5. Invoke reviewers, read and address feedback, wait for CI, and stop at the mission's merged-ready PR endpoint unless explicit merge authority is provided.
+6. Post the PR URL and root-cause conclusion to the driver channel/in-pane, then store the verified milestone and rationale in BrainLayer.

--- a/scripts/nightly-contract-run.sh
+++ b/scripts/nightly-contract-run.sh
@@ -29,8 +29,9 @@ json_escape() {
 mkdir -p "$state_dir"
 output_tmp="$(mktemp "$state_dir/.nightly-contract-output.XXXXXX")"
 receipt_tmp="$receipt.tmp.$$"
+output_log_tmp=""
 cleanup() {
-  rm -f "${output_tmp:-}" "$receipt_tmp"
+  rm -f "${output_tmp:-}" "$receipt_tmp" "${output_log_tmp:-}"
 }
 trap cleanup EXIT
 
@@ -60,12 +61,27 @@ elif [[ "$command_exit" -eq 0 ]]; then
   exit_code=1
   reason="contract command exited zero without exactly one final PASS or SKIP marker"
 else
-  reason="${last_nonempty_line#\[contract\] FAIL: }"
+  failure_line="$(awk '/^\[contract\] FAIL: / { line = $0 } END { print line }' "$output_tmp")"
+  if [[ -n "$failure_line" ]]; then
+    reason="${failure_line#\[contract\] FAIL: }"
+  else
+    reason="$last_nonempty_line"
+  fi
   [[ -n "$reason" ]] || reason="contract command exited $command_exit"
+  output_log="$state_dir/contract-nightly-$run_date.output.log"
+  output_log_tmp="$(mktemp "$state_dir/.contract-nightly-$run_date.output.XXXXXX")"
+  cp "$output_tmp" "$output_log_tmp"
+  mv "$output_log_tmp" "$output_log"
+  output_log_tmp=""
 fi
 
 version="$(node -e 'const fs = require("node:fs"); const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (typeof pkg.version === "string") process.stdout.write(pkg.version);' "$repo/package.json" 2>/dev/null)"
 [[ -n "$version" ]] || version="unknown"
+
+output_log_field=""
+if [[ -n "${output_log:-}" ]]; then
+  output_log_field="$(printf ',\n  "output_log": "%s"' "$(json_escape "$output_log")")"
+fi
 
 cat >"$receipt_tmp" <<JSON
 {
@@ -74,7 +90,7 @@ cat >"$receipt_tmp" <<JSON
   "reason": "$(json_escape "$reason")",
   "timestamp": "$timestamp",
   "socket_path": "$socket_path",
-  "command": "bun run test:contract"
+  "command": "bun run test:contract"${output_log_field}
 }
 JSON
 mv "$receipt_tmp" "$receipt"

--- a/scripts/nightly-contract-run.sh
+++ b/scripts/nightly-contract-run.sh
@@ -68,6 +68,9 @@ else
     reason="$last_nonempty_line"
   fi
   [[ -n "$reason" ]] || reason="contract command exited $command_exit"
+fi
+
+if [[ "$result" == "fail" ]]; then
   output_log="$state_dir/contract-nightly-$run_date.output.log"
   output_log_tmp="$(mktemp "$state_dir/.contract-nightly-$run_date.output.XXXXXX")"
   cp "$output_tmp" "$output_log_tmp"

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -14,6 +14,7 @@ import net from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isCmuxAccessControlDenied } from "../src/cmux-access-control.js";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const ORPHAN_PARENT_MODE = "--orphan-parent";
@@ -114,7 +115,12 @@ export function probeSystemPing(
         }
         settle({ ok: true, result: response.result });
       } catch (error) {
-        settle(errorReceipt(error));
+        const detail = error instanceof Error ? error.message : String(error);
+        settle({
+          ok: false,
+          code: "EPROTO",
+          message: `system.ping returned non-JSON frame ${JSON.stringify(line)}: ${detail}`,
+        });
       }
     });
     socket.once("error", (error) => settle(errorReceipt(error)));
@@ -250,8 +256,26 @@ export function isAncestryDenial(receipt: OrphanProbeReceipt): boolean {
   return (
     receipt.code === "EPIPE" ||
     receipt.errno === 32 ||
-    /\b(?:EPIPE|broken pipe|errno\s*32)\b/i.test(receipt.message ?? "")
+    /\b(?:EPIPE|broken pipe|errno\s*32)\b/i.test(receipt.message ?? "") ||
+    isCmuxAccessControlDenied(receipt.message ?? "")
   );
+}
+
+export class ContractStepError extends Error {
+  constructor(
+    readonly step: string,
+    readonly underlying: unknown,
+  ) {
+    super(underlying instanceof Error ? underlying.message : String(underlying));
+    this.name = "ContractStepError";
+  }
+}
+
+export function formatContractFailure(step: string, error: unknown): string {
+  const message = (error instanceof Error ? error.message : String(error))
+    .replace(/\s+/g, " ")
+    .trim();
+  return `[contract] FAIL: ${step}: ${message || "unknown error"}`;
 }
 
 function toolText(result: Record<string, unknown>): string {
@@ -863,7 +887,10 @@ async function addPidReceiptToSet(
   }
 }
 
-async function runContract(): Promise<void> {
+async function runContractSteps(
+  setActiveStep: (step: string) => void,
+): Promise<void> {
+  setActiveStep("system.ping preflight");
   const requestedSocket = process.env.CMUX_SOCKET_PATH;
   const requestedPin = requestedSocket?.trim();
   if (requestedPin) {
@@ -885,6 +912,7 @@ async function runContract(): Promise<void> {
   const cmuxSocket = classification.socketPath;
   console.log(`[contract] PASS system.ping shape on ${cmuxSocket}`);
 
+  setActiveStep("contract sandbox setup");
   const root = await mkdtemp(join(tmpdir(), "cmuxlayer-real-contract-"));
   const daemonSocket = join(root, "cmuxlayer-stated.sock");
   const daemonPidReceipt = join(root, "daemon-pids.txt");
@@ -894,16 +922,18 @@ async function runContract(): Promise<void> {
   assertOwnedDaemonSocket(root, daemonSocket);
 
   try {
+    setActiveStep("detached-orphan ancestry denial");
     const orphan = await runOrphanContract(root, cmuxSocket, recordedPids);
     if (!isAncestryDenial(orphan)) {
       throw new Error(
-        `detached-orphan probe was not denied with EPIPE ancestry contract: ${JSON.stringify(orphan)}`,
+        `detached-orphan probe was not denied by cmux ancestry access control: ${JSON.stringify(orphan)}`,
       );
     }
     console.log(
       `[contract] PASS detached orphan pid=${orphan.pid} denied with ${orphan.code ?? `errno ${orphan.errno}`}`,
     );
 
+    setActiveStep("isolated daemon artifact preflight");
     const distIndex = resolve("dist", "index.js");
     const distDaemon = resolve("dist", "daemon.js");
     await Promise.all([access(distIndex), access(distDaemon)]);
@@ -916,6 +946,7 @@ async function runContract(): Promise<void> {
       CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "256",
     };
 
+    setActiveStep("isolated daemon startup");
     const initialDaemon = spawn(process.execPath, [distDaemon], {
       cwd: process.cwd(),
       env,
@@ -948,6 +979,7 @@ async function runContract(): Promise<void> {
       (pid) => recordedPids.delete(pid),
     );
 
+    setActiveStep("MCP initialization");
     await peer.request("initialize", {
       protocolVersion: "2025-03-26",
       capabilities: {},
@@ -955,6 +987,7 @@ async function runContract(): Promise<void> {
     });
     peer.sendNotification("notifications/initialized");
 
+    setActiveStep("control_health baseline");
     const healthResponse = await peer.callTool("control_health", {}, 15_000);
     const health = extractStructuredContent(healthResponse);
     assertLiveHealth(health, cmuxSocket);
@@ -965,6 +998,7 @@ async function runContract(): Promise<void> {
       );
     }
 
+    setActiveStep("list_surfaces/read_screen");
     const listResponse = await peer.callTool("list_surfaces", {}, 20_000);
     const surfaces = extractStructuredContent(listResponse);
     const target = selectTerminalSurface(surfaces);
@@ -987,9 +1021,11 @@ async function runContract(): Promise<void> {
       `[contract] PASS list_surfaces/read_screen through dist daemon pid=${initialDaemonPid}`,
     );
 
+    setActiveStep("doctor health");
     await runDoctor(distIndex, env, cmuxSocket, daemonSocket, recordedPids);
     console.log("[contract] PASS doctor --json healthy on isolated live stack");
 
+    setActiveStep("graceful retire/autostart");
     assertOwnedDaemonSocket(root, daemonSocket);
     await terminateRecordedPid(initialDaemonPid, recordedPids);
 
@@ -1036,6 +1072,17 @@ async function runContract(): Promise<void> {
   }
 }
 
+async function runContract(): Promise<void> {
+  let activeStep = "contract setup";
+  try {
+    await runContractSteps((step) => {
+      activeStep = step;
+    });
+  } catch (error) {
+    throw new ContractStepError(activeStep, error);
+  }
+}
+
 async function main(): Promise<void> {
   const mode = process.argv[2];
   if (mode === ORPHAN_PARENT_MODE) {
@@ -1051,9 +1098,16 @@ async function main(): Promise<void> {
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(SCRIPT_PATH)) {
   main().catch((error) => {
-    console.error(
-      `[contract] FAIL: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
-    );
+    if (error instanceof ContractStepError) {
+      console.error(formatContractFailure(error.step, error.underlying));
+      if (error.underlying instanceof Error && error.underlying.stack) {
+        console.error(error.underlying.stack);
+      }
+    } else {
+      console.error(
+        `[contract] FAIL: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+      );
+    }
     process.exitCode = 1;
   });
 }

--- a/scripts/tests/nightly-contract-run.test.sh
+++ b/scripts/tests/nightly-contract-run.test.sh
@@ -45,6 +45,9 @@ case "$NIGHTLY_TEST_MODE" in
     printf '%s\n' '    at runContract (scripts/run-real-cmux-contract.ts:900:13)' >&2
     exit 9
     ;;
+  zero_fail)
+    printf '%s\n' 'contract output without a terminal marker' >&2
+    ;;
   *)
     exit 64
     ;;
@@ -92,12 +95,16 @@ run_case() {
   assert_eq "9.5.0-test" "$(json_field "$receipt" version)"
   assert_eq "$expected_result" "$(json_field "$receipt" result)"
   assert_eq "$expected_reason" "$(json_field "$receipt" reason)"
-  if [[ "$mode" == "fail" ]]; then
+  if [[ "$expected_result" == "fail" ]]; then
     assert_eq "yes" "$(json_has_field "$receipt" output_log)"
     output_log="$(json_field "$receipt" output_log)"
     [[ -f "$output_log" ]] || fail "missing output log: $output_log"
-    grep -F '[contract] FAIL: detached-orphan ancestry denial: injected contract failure' "$output_log" >/dev/null || fail "output log omits failure marker"
-    grep -F 'at runContract' "$output_log" >/dev/null || fail "output log omits stack"
+    if [[ "$mode" == "fail" ]]; then
+      grep -F '[contract] FAIL: detached-orphan ancestry denial: injected contract failure' "$output_log" >/dev/null || fail "output log omits failure marker"
+      grep -F 'at runContract' "$output_log" >/dev/null || fail "output log omits stack"
+    else
+      grep -F 'contract output without a terminal marker' "$output_log" >/dev/null || fail "output log omits zero-exit failure output"
+    fi
   else
     assert_eq "no" "$(json_has_field "$receipt" output_log)"
     timestamp="$(json_field "$receipt" timestamp)"
@@ -148,5 +155,6 @@ run_case pass pass 0 "real-cmux contract lane passed"
 run_case skip skip 0 "NIGHTLY socket is not reachable"
 run_case skip_controls skip 0 $'control ESC=\033 BS=\b FF=\f'
 run_case fail fail 9 "detached-orphan ancestry denial: injected contract failure"
+run_case zero_fail fail 1 "contract command exited zero without exactly one final PASS or SKIP marker"
 run_invalid_environment_cases
 printf 'PASS: nightly contract runner receipts and exits\n'

--- a/scripts/tests/nightly-contract-run.test.sh
+++ b/scripts/tests/nightly-contract-run.test.sh
@@ -19,6 +19,10 @@ json_field() {
   node -e 'const fs = require("node:fs"); const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))[process.argv[2]]; if (value != null) process.stdout.write(String(value));' "$1" "$2"
 }
 
+json_has_field() {
+  node -e 'const fs = require("node:fs"); const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(Object.hasOwn(value, process.argv[2]) ? "yes" : "no");' "$1" "$2"
+}
+
 make_fake_bun() {
   local path="$1"
   cat >"$path" <<'FAKE'
@@ -27,6 +31,9 @@ set -euo pipefail
 printf '%s\n' "$CMUX_SOCKET_PATH" >"$NIGHTLY_TEST_CAPTURE/socket"
 printf '%s\n' "$*" >"$NIGHTLY_TEST_CAPTURE/args"
 case "$NIGHTLY_TEST_MODE" in
+  pass)
+    printf '%s\n' '[contract] PASS real-cmux contract lane'
+    ;;
   skip)
     printf '%s\n' '[contract] SKIP: NIGHTLY socket is not reachable' >&2
     ;;
@@ -34,7 +41,8 @@ case "$NIGHTLY_TEST_MODE" in
     printf '[contract] SKIP: control ESC=\033 BS=\b FF=\f\n' >&2
     ;;
   fail)
-    printf '%s\n' '[contract] FAIL: injected contract failure' >&2
+    printf '%s\n' '[contract] FAIL: detached-orphan ancestry denial: injected contract failure' >&2
+    printf '%s\n' '    at runContract (scripts/run-real-cmux-contract.ts:900:13)' >&2
     exit 9
     ;;
   *)
@@ -49,9 +57,10 @@ run_case() {
   local mode="$1"
   local expected_result="$2"
   local expected_exit="$3"
+  local expected_reason="$4"
   local expected_summary
   expected_summary="$(printf '%s' "$expected_result" | tr '[:lower:]' '[:upper:]')"
-  local root repo state capture fake_bun receipt output actual_exit
+  local root repo state capture fake_bun receipt output actual_exit timestamp escaped_reason expected_receipt expected_output
   root="$(mktemp -d)"
   repo="$root/repo"
   state="$root/state"
@@ -82,10 +91,25 @@ run_case() {
   [[ -f "$receipt" ]] || fail "missing receipt: $receipt"
   assert_eq "9.5.0-test" "$(json_field "$receipt" version)"
   assert_eq "$expected_result" "$(json_field "$receipt" result)"
-  [[ -n "$(json_field "$receipt" reason)" ]] || fail "receipt reason is empty"
-  [[ "$output" == "$expected_summary"* ]] || fail "summary does not start with $expected_summary: $output"
+  assert_eq "$expected_reason" "$(json_field "$receipt" reason)"
+  if [[ "$mode" == "fail" ]]; then
+    assert_eq "yes" "$(json_has_field "$receipt" output_log)"
+    output_log="$(json_field "$receipt" output_log)"
+    [[ -f "$output_log" ]] || fail "missing output log: $output_log"
+    grep -F '[contract] FAIL: detached-orphan ancestry denial: injected contract failure' "$output_log" >/dev/null || fail "output log omits failure marker"
+    grep -F 'at runContract' "$output_log" >/dev/null || fail "output log omits stack"
+  else
+    assert_eq "no" "$(json_has_field "$receipt" output_log)"
+    timestamp="$(json_field "$receipt" timestamp)"
+    escaped_reason="$(node -e 'process.stdout.write(JSON.stringify(process.argv[1]).slice(1, -1))' "$expected_reason")"
+    printf -v expected_receipt '{\n  "version": "9.5.0-test",\n  "result": "%s",\n  "reason": "%s",\n  "timestamp": "%s",\n  "socket_path": "/tmp/cmux-nightly.sock",\n  "command": "bun run test:contract"\n}' \
+      "$expected_result" "$escaped_reason" "$timestamp"
+    assert_eq "$expected_receipt" "$(cat "$receipt")"
+  fi
+  expected_output="$expected_summary cmux nightly contract: $expected_reason; receipt=$receipt"
+  assert_eq "$expected_output" "$output"
   [[ -f "$state/nightly-contract-gemini.log" ]] || fail "missing report log"
-  grep -F -- "$receipt" "$state/nightly-contract-gemini.log" >/dev/null || fail "report log omits receipt path"
+  assert_eq "$expected_output" "$(cat "$state/nightly-contract-gemini.log")"
 
   rm -rf "$root"
 }
@@ -120,8 +144,9 @@ run_invalid_environment_cases() {
 
 [[ -x "$SCRIPT_PATH" ]] || fail "runner is missing or not executable: $SCRIPT_PATH"
 bash -n "$SCRIPT_PATH"
-run_case skip skip 0
-run_case skip_controls skip 0
-run_case fail fail 9
+run_case pass pass 0 "real-cmux contract lane passed"
+run_case skip skip 0 "NIGHTLY socket is not reachable"
+run_case skip_controls skip 0 $'control ESC=\033 BS=\b FF=\f'
+run_case fail fail 9 "detached-orphan ancestry denial: injected contract failure"
 run_invalid_environment_cases
 printf 'PASS: nightly contract runner receipts and exits\n'

--- a/src/cmux-access-control.ts
+++ b/src/cmux-access-control.ts
@@ -1,0 +1,7 @@
+const ACCESS_CONTROL_DENIED_RE =
+  /(?:\bAccess denied\b|only processes started inside cmux can connect)/i;
+
+export function isCmuxAccessControlDenied(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return ACCESS_CONTROL_DENIED_RE.test(message);
+}

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
+import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 
 const execFileAsync = promisify(execFile);
 const STANDARD_BUNDLED_CMUX =
@@ -203,6 +204,11 @@ export class CmuxClient {
 
     const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
     const message = `cmux ${args[0]} failed: ${error.message}${suffix}`;
+    if (isCmuxAccessControlDenied(message)) {
+      return new CmuxSocketError(message, "access_denied", {
+        transportPhase: "response",
+      });
+    }
     if (/\b(?:EPIPE|ECONNRESET|broken pipe|errno\s*32)\b/i.test(message)) {
       const stdout =
         "stdout" in error && typeof error.stdout === "string"

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -8,6 +8,7 @@
 
 import * as net from "node:net";
 import * as crypto from "node:crypto";
+import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 
@@ -222,7 +223,6 @@ export class CmuxPersistentSocket {
       this.buffer = this.buffer.slice(newlineIdx + 1);
 
       if (!line.trim()) continue;
-
       try {
         const parsed = JSON.parse(line) as Partial<V2Response>;
         if (typeof parsed.id === "string") {
@@ -237,6 +237,16 @@ export class CmuxPersistentSocket {
           this.resolveNextV1(line);
         }
       } catch (error) {
+        if (!this.isJsonLikeFrame(line) && isCmuxAccessControlDenied(line)) {
+          this.rejectAllPending(
+            new CmuxSocketError(
+              `cmux access-control denial: ${line.slice(0, 120)}`,
+              "access_denied",
+              { transportPhase: "response" },
+            ),
+          );
+          continue;
+        }
         if (this.isJsonLikeFrame(line)) {
           if (line.trimStart().startsWith("[") && this.pendingV1.length > 0) {
             this.resolveNextV1(line);
@@ -245,6 +255,8 @@ export class CmuxPersistentSocket {
           this.rejectMalformedFrame(line, error);
         } else if (this.pendingV1.length > 0) {
           this.resolveNextV1(line);
+        } else if (this.pending.size > 0) {
+          this.rejectUnexpectedV2Frame(line);
         }
       }
     }
@@ -277,6 +289,15 @@ export class CmuxPersistentSocket {
     if (this.pending.size > 0) {
       this.rejectPendingV2(socketError);
     }
+  }
+
+  private rejectUnexpectedV2Frame(line: string): void {
+    this.rejectPendingV2(
+      new CmuxSocketError(
+        `Unexpected cmux socket frame: frame=${line.slice(0, 120)}`,
+        "protocol_error",
+      ),
+    );
   }
 
   private resolveNextV1(line: string): void {

--- a/src/cmux-socket-probe.ts
+++ b/src/cmux-socket-probe.ts
@@ -3,6 +3,7 @@
  */
 
 import * as net from "node:net";
+import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
 import {
   cmuxSocketPathCandidates,
@@ -30,13 +31,7 @@ export interface SocketProbeResult {
  * hung instance. The probe only needs a liveness yes/no, so cap it short.
  */
 const PROBE_PING_TIMEOUT_MS = 2000;
-const ACCESS_CONTROL_DENIED_RE =
-  /Access denied\s*[—-]\s*only processes started inside cmux can connect/i;
-
-export function isCmuxAccessControlDenied(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return ACCESS_CONTROL_DENIED_RE.test(message);
-}
+export { isCmuxAccessControlDenied };
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -6,6 +6,7 @@
  */
 
 import { CmuxClient } from "./cmux-client.js";
+import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 import { CmuxSocketClient } from "./cmux-socket-client.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import type { CreateCmuxClientOptions } from "./cmux-client-factory.js";
@@ -451,10 +452,10 @@ export class CmuxSelfHealingClient {
       (error.code === "connection_error" ||
         error.code === "connection_closed");
     const message = error instanceof Error ? error.message : String(error);
-    const hasBrokenPipeSignal = /\b(?:EPIPE|ECONNRESET|broken pipe)\b/i.test(
-      message,
-    );
-    return isTransportError || hasBrokenPipeSignal;
+    const hasRecoverableSignal =
+      /\b(?:EPIPE|ECONNRESET|broken pipe)\b/i.test(message) ||
+      isCmuxAccessControlDenied(error);
+    return isTransportError || hasRecoverableSignal;
   }
 
   private recoverFailedPayload(
@@ -700,13 +701,18 @@ export class CmuxSelfHealingClient {
 
   private isDenialClassError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
-    return /(?:\bEPIPE\b|broken pipe|errno\s*32|access denied)/i.test(message);
+    return (
+      /(?:\bEPIPE\b|broken pipe|errno\s*32)/i.test(message) ||
+      isCmuxAccessControlDenied(error)
+    );
   }
 
   private isUpstreamUnreachableError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
-    return /(?:\bEPIPE\b|\bECONNREFUSED\b|\bECONNRESET\b|\bENOENT\b|broken pipe|errno\s*32|access denied|timed?\s*out|timeout)/i.test(
-      message,
+    return (
+      /(?:\bEPIPE\b|\bECONNREFUSED\b|\bECONNRESET\b|\bENOENT\b|broken pipe|errno\s*32|timed?\s*out|timeout)/i.test(
+        message,
+      ) || isCmuxAccessControlDenied(error)
     );
   }
 

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { CmuxClient, type ExecFn } from "../src/cmux-client.js";
+import { CmuxSocketError } from "../src/cmux-socket-error.js";
 
 const STANDARD_BUNDLED_CMUX =
   "/Applications/cmux.app/Contents/Resources/bin/cmux";
@@ -979,6 +980,24 @@ describe("CmuxClient.closeSurface", () => {
 });
 
 describe("CmuxClient CLI error handling", () => {
+  it("classifies explicit cmux ancestry denial", async () => {
+    const denial =
+      "ERROR: Access denied — only processes started inside cmux can connect";
+    const exec: ExecFn = vi.fn().mockRejectedValue(
+      Object.assign(new Error("Command failed"), {
+        code: 1,
+        stderr: denial,
+      }),
+    );
+    const client = new CmuxClient({ exec, existsSync: () => false });
+
+    const error = await client.listWorkspaces().catch((value) => value);
+
+    expect(error).toBeInstanceOf(CmuxSocketError);
+    expect(error).toMatchObject({ code: "access_denied" });
+    expect(error.message).toContain(denial);
+  });
+
   it("throws on non-zero exit code", async () => {
     const exec: ExecFn = vi.fn().mockRejectedValue(
       Object.assign(new Error("Command failed"), {

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -182,6 +182,76 @@ describe("CmuxPersistentSocket V1 demux", () => {
     }
   });
 
+  it("rejects every pending request on a raw access-control denial", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("raw-access-denial");
+    const denial =
+      "ERROR: Access denied — only processes started inside cmux can connect";
+    const received: string[] = [];
+    await startLineServer(path, (line, conn) => {
+      received.push(line);
+      if (received.length === 2) conn.write(`${denial}\n`);
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 300,
+    });
+
+    try {
+      const results = await Promise.allSettled([
+        socket.sendLine("set_status agent active"),
+        socket.call("system.ping"),
+      ]);
+      expect(results).toEqual([
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({
+            code: "access_denied",
+            message: expect.stringContaining(denial),
+          }),
+        }),
+        expect.objectContaining({
+          status: "rejected",
+          reason: expect.objectContaining({
+            code: "access_denied",
+            message: expect.stringContaining(denial),
+          }),
+        }),
+      ]);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("does not classify access-control words inside a correlated V2 result as a raw denial", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("access-denial-text-in-v2-result");
+    await startLineServer(path, (line, conn) => {
+      const request = JSON.parse(line) as { id: string };
+      conn.write(
+        `${JSON.stringify({
+          id: request.id,
+          ok: true,
+          result: { message: "Access denied is displayed in pane output" },
+        })}\n`,
+      );
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      await expect(socket.call("read_screen")).resolves.toEqual({
+        message: "Access denied is displayed in pane output",
+      });
+    } finally {
+      socket.disconnect();
+    }
+  });
+
   it("does not let late V2 responses complete a queued V1 request after malformed V2 rejection", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("late-v2-after-malformed");

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -100,17 +100,8 @@ function startAccessDeniedPingServer(
           const line = buffer.slice(0, idx);
           buffer = buffer.slice(idx + 1);
           if (!line.trim()) continue;
-          const req = JSON.parse(line);
-          conn.write(
-            JSON.stringify({
-              id: req.id,
-              ok: false,
-              error: {
-                code: "access_denied",
-                message: ACCESS_CONTROL_DENIED_TEXT,
-              },
-            }) + "\n",
-          );
+          JSON.parse(line);
+          conn.write(`ERROR: ${ACCESS_CONTROL_DENIED_TEXT}\n`);
         }
       });
     });

--- a/tests/real-cmux-contract-runner.test.ts
+++ b/tests/real-cmux-contract-runner.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   mkdirSync,
@@ -24,6 +24,7 @@ import {
   daemonExitPidFromLog,
   daemonSpawnPidFromLog,
   extractStructuredContent,
+  formatContractFailure,
   isAncestryDenial,
   McpPeer,
   parseOrphanReceipt,
@@ -208,7 +209,42 @@ describe("real cmux contract runner helpers", () => {
     );
   });
 
+  it("preserves a raw access-control denial from system.ping", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmux-contract-denial-probe-"));
+    tempRoots.push(root);
+    const socketPath = join(root, "cmux.sock");
+    const denial =
+      "ERROR: Access denied — only processes started inside cmux can connect";
+    const server = net.createServer((socket) => {
+      socket.once("data", () => socket.end(`${denial}\n`));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    await expect(probeSystemPing(socketPath, 500)).resolves.toMatchObject({
+      ok: false,
+      code: "EPROTO",
+      message: expect.stringContaining(denial),
+    });
+  });
+
   it("recognizes the detached-orphan EPIPE ancestry contract", () => {
+    expect(
+      isAncestryDenial({
+        pid: 42,
+        ppid: 1,
+        ok: false,
+        code: "ERROR",
+        message:
+          "ERROR: Access denied — only processes started inside cmux can connect",
+      }),
+    ).toBe(true);
     expect(
       isAncestryDenial({
         pid: 42,
@@ -245,6 +281,85 @@ describe("real cmux contract runner helpers", () => {
         message: "connect refused",
       }),
     ).toBe(false);
+  });
+
+  it("formats a single-line failure marker with the active contract step", () => {
+    expect(
+      formatContractFailure(
+        "detached-orphan ancestry denial",
+        new Error("injected failure\nwith trailing detail"),
+      ),
+    ).toBe(
+      "[contract] FAIL: detached-orphan ancestry denial: injected failure with trailing detail",
+    );
+  });
+
+  it("emits the active step when the detached orphan is unexpectedly admitted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmux-contract-step-marker-"));
+    tempRoots.push(root);
+    const socketPath = join(root, "cmux.sock");
+    const server = net.createServer((socket) => {
+      let buffer = "";
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const newline = buffer.indexOf("\n");
+        if (newline < 0) return;
+        const request = JSON.parse(buffer.slice(0, newline)) as { id: string };
+        socket.end(
+          `${JSON.stringify({ id: request.id, ok: true, result: { pong: true } })}\n`,
+        );
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    const result = await new Promise<{
+      code: number | null;
+      stdout: string;
+      stderr: string;
+    }>((resolveResult, reject) => {
+      const child = spawn(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          join(process.cwd(), "scripts", "run-real-cmux-contract.ts"),
+        ],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, CMUX_SOCKET_PATH: socketPath },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      child.stdout.on("data", (chunk: Buffer) =>
+        stdout.push(chunk.toString("utf8")),
+      );
+      child.stderr.on("data", (chunk: Buffer) =>
+        stderr.push(chunk.toString("utf8")),
+      );
+      child.once("error", reject);
+      child.once("exit", (code) =>
+        resolveResult({
+          code,
+          stdout: stdout.join(""),
+          stderr: stderr.join(""),
+        }),
+      );
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("[contract] PASS system.ping shape");
+    expect(result.stderr).toContain(
+      "[contract] FAIL: detached-orphan ancestry denial: detached-orphan probe was not denied by cmux ancestry access control",
+    );
   });
 
   it("parses a complete orphan receipt", () => {


### PR DESCRIPTION
## Summary

- emit deterministic `[contract] FAIL: <step>: <message>` markers and preserve the complete failed command output in an atomic `output_log` receipt artifact
- keep PASS/SKIP receipts, summaries, and report-log bytes unchanged, with exact regression assertions
- accept both legacy EPIPE ancestry denial and nightly's explicit raw `ERROR: Access denied — only processes started inside cmux can connect` response across the contract probe, persistent transport, CLI normalization, and self-healing classification
- reject a raw denial connection-wide for pending V1/V2 requests without misclassifying valid correlated JSON that merely contains the same words

## Root cause

The nightly-descended contract passed `system.ping` and failed the detached-orphan ancestry probe. Nightly correctly denied the orphan, but changed the wire shape from EPIPE/errno 32 to a raw non-JSON access-denied line. The probe discarded that raw line as a JSON parse error and the EPIPE-only assertion rejected the correct denial. Disposition: cmuxlayer adapts to both denial generations.

The EPIPE sweep also checked socket-client delegation, PTY-write liveness, and the internal proxy-to-daemon socket; those sites either inherit this shared fix or use EPIPE for a distinct transport and remain intentionally unchanged.

## Verification

- `git diff --check`
- `bun run typecheck`
- `bun run build`
- `bash scripts/tests/nightly-contract-run.test.sh`
- focused Vitest: 4 files, 112 tests passed
- full Vitest: 98 files, 1,799 tests passed
- push hook `run_tests.sh`: exit 0, 98 files / 1,799 tests passed
- independent review: no remaining findings

## Review note

The bounded local CodeRabbit CLI review timed out after 180 seconds and produced only stale findings in untouched files. Manual independent review found two real parser edge cases and two step-boundary gaps; all were reproduced, fixed, and re-reviewed clean before publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contract semantics, socket framing, and transport denial handling on paths used by nightly CI and live cmux connectivity; behavior is heavily tested but touches security-sensitive access control.
> 
> **Overview**
> **Nightly contract diagnostics** now tie failures to a named step and keep full logs, while **ancestry access control** is recognized for both legacy EPIPE and nightly’s raw denial line.
> 
> The real-cmux contract runner tracks an active logical step, wraps failures in `ContractStepError`, and prints a single-line `[contract] FAIL: <step>: <message>` before the stack. The nightly wrapper picks the **last** such marker for the receipt `reason`, atomically writes failed runs to `output_log`, and adds that field to the JSON receipt only on **fail** (PASS/SKIP unchanged).
> 
> A shared `isCmuxAccessControlDenied` predicate replaces scattered regex checks. **Contract** `isAncestryDenial` and `probeSystemPing` treat non-JSON denial frames as `EPROTO` with preserved text. **Persistent socket** rejects raw access-control lines connection-wide as `access_denied` without misclassifying correlated JSON that merely mentions “Access denied”; other unexpected raw V2 frames fail fast as `protocol_error`. **CLI** maps explicit denial stderr to `CmuxSocketError` `access_denied`; **transport self-heal** uses the same predicate for denial/recovery classification. Bash and Vitest coverage pins receipt shape, both wire generations, and step markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d179d2166b0763960d8b55291b66a61c829faaa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly contract receipts to name the failing step and preserve output log
> - The nightly contract runner ([scripts/run-real-cmux-contract.ts](https://github.com/EtanHey/cmuxlayer/pull/307/files#diff-d69c2f6c09a7869995df79e531fec9361348264ae911f5b3e2e4138e7e75f98b)) now tracks the active logical step throughout execution; on failure, it emits a single-line `[contract] FAIL: <step>: <message>` marker before any stack trace.
> - [scripts/nightly-contract-run.sh](https://github.com/EtanHey/cmuxlayer/pull/307/files#diff-c11e134220e292dafcc2d37ddc2890cc61e3ddc67bdab9fba9d03afae72c7df0) extracts the failure reason from that marker using `awk` and writes the full output to a stable `output_log` file, appended to failure receipts only.
> - A shared `isCmuxAccessControlDenied` predicate is extracted to [src/cmux-access-control.ts](https://github.com/EtanHey/cmuxlayer/pull/307/files#diff-41e8afcb6a386243f203d4950b154427fcbed4133560dae8f42d3319eb6aebd0) and used consistently across the socket probe, persistent socket, CLI client, and self-heal transport to classify explicit access-denial errors.
> - Behavioral Change: PASS and SKIP receipts are unchanged; only FAIL receipts gain the `output_log` field and a structured reason string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d179d21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->