### PR TITLE
fix(spawn): codex 0.144.3 readiness + relaunch double-type + sandbox launcher injection (3 heads, fixture per head)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1338,6 +1338,7 @@ export class AgentEngine {
       if (
         !evidence.ready ||
         (targetState === "ready" &&
+          !evidence.activeCodex &&
           this.screenShowsPendingBootPrompt(agent, screen.text))
       ) {
         waitForReadyPatternMatches.delete(agent.agent_id);
@@ -1691,14 +1692,23 @@ export class AgentEngine {
     screenText: string,
   ): {
     ready: boolean;
+    activeCodex: boolean;
     consecutive: number;
   } {
     const parsed = parseScreen(screenText);
     const match = matchReadyPattern(agent.cli, screenText);
+    const hasIdentity = screenHasReadyAgentIdentity(
+      agent.cli,
+      screenText,
+      parsed,
+    );
+    const activeCodex =
+      agent.cli === "codex" &&
+      hasIdentity &&
+      screenHasActiveAgentMarker(agent.cli, screenText, parsed);
     return {
-      ready:
-        match.matched &&
-        screenHasReadyAgentIdentity(agent.cli, screenText, parsed),
+      ready: hasIdentity && (match.matched || activeCodex),
+      activeCodex,
       consecutive: match.consecutive,
     };
   }
@@ -1956,7 +1966,8 @@ export class AgentEngine {
         const evidence = this.readReadyEvidence(agent, screen.text);
         if (
           evidence.ready &&
-          !this.screenShowsPendingBootPrompt(agent, screen.text)
+          (evidence.activeCodex ||
+            !this.screenShowsPendingBootPrompt(agent, screen.text))
         ) {
           const count = (this.readyPatternMatches.get(agent.agent_id) ?? 0) + 1;
           this.readyPatternMatches.set(agent.agent_id, count);

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1335,8 +1335,10 @@ export class AgentEngine {
         workspace: agent.workspace_id ?? undefined,
       });
       const evidence = this.readReadyEvidence(agent, screen.text);
+      const hasTargetEvidence =
+        evidence.ready || (targetState === "ready" && evidence.activeCodex);
       if (
-        !evidence.ready ||
+        !hasTargetEvidence ||
         (targetState === "ready" &&
           !evidence.activeCodex &&
           this.screenShowsPendingBootPrompt(agent, screen.text))
@@ -1707,7 +1709,7 @@ export class AgentEngine {
       hasIdentity &&
       screenHasActiveAgentMarker(agent.cli, screenText, parsed);
     return {
-      ready: hasIdentity && (match.matched || activeCodex),
+      ready: hasIdentity && match.matched,
       activeCodex,
       consecutive: match.consecutive,
     };
@@ -1965,7 +1967,7 @@ export class AgentEngine {
         const screen = await this.readSweepScreen(agent, ctx);
         const evidence = this.readReadyEvidence(agent, screen.text);
         if (
-          evidence.ready &&
+          (evidence.ready || evidence.activeCodex) &&
           (evidence.activeCodex ||
             !this.screenShowsPendingBootPrompt(agent, screen.text))
         ) {
@@ -2026,7 +2028,7 @@ export class AgentEngine {
     try {
       const screen = await this.readSweepScreen(agent, ctx);
       const evidence = this.readReadyEvidence(agent, screen.text);
-      if (!evidence.ready) {
+      if (!evidence.ready && !evidence.activeCodex) {
         this.readyPatternMatches.delete(agent.agent_id);
         return agent;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1631,6 +1631,30 @@ function screenShowsPendingInput(
   );
 }
 
+function screenShowsPendingShellInput(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  const trimmed = submittedText.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const lines = normalizeTerminalText(screenText).split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trimEnd() ?? "";
+    if (!line.trim()) continue;
+    const prompt = line.match(/[$%#]\s*(.*)$/);
+    if (!prompt) return false;
+    const pending = prompt[1]?.trimEnd() ?? "";
+    return (
+      pending === trimmed ||
+      pending.replace(/\s+/g, "") === trimmed.replace(/\s+/g, "")
+    );
+  }
+  return false;
+}
+
 function parseRawSubmitEvidenceMetrics(
   screenText: string,
 ): RawSubmitEvidenceMetrics {
@@ -2826,6 +2850,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     chunkNumber: number,
     totalChunks: number,
     shouldPaste: boolean,
+    avoidDuplicateOnAmbiguousRetry: boolean,
   ) => {
     let attempt = 0;
     let lastError: unknown;
@@ -2866,6 +2891,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             `chunk ${chunkNumber}/${totalChunks} failed: ${message}`,
             chunkNumber,
           );
+        }
+        if (avoidDuplicateOnAmbiguousRetry) {
+          try {
+            const snapshot = await readParsedSurface(
+              surface,
+              opts.workspace,
+              { throwOnSurfaceGone: true },
+            );
+            if (
+              snapshot &&
+              (screenShowsPendingInput(snapshot.text, chunk) ||
+                screenShowsPendingShellInput(snapshot.text, chunk))
+            ) {
+              return;
+            }
+          } catch {
+            // The delivery error remains authoritative when the ambiguity
+            // probe cannot read the surface; continue the bounded retry.
+          }
         }
         await delay(SEND_INPUT_RETRY_DELAY_MS);
       }
@@ -3262,6 +3306,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         batch.firstChunkNumber,
         opts.chunks.length,
         shouldPaste,
+        opts.source_event === "spawn_agent",
       );
       for (const sentChunks of batch.deliveredChunkCounts) {
         opts.onChunkDelivered?.(sentChunks);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3578,6 +3578,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     surface: string;
     workspace?: string;
     timeout_ms?: number;
+    require_fresh_shell_prompt?: boolean;
   }): Promise<void> => {
     const timeoutMs = opts.timeout_ms ?? LAUNCH_SHELL_READY_TIMEOUT_MS;
     const start = Date.now();
@@ -3593,9 +3594,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         lastText = screen.text;
         if (
           matchesShellPrompt(screen.text) ||
-          READY_PATTERN_CLIS.some(
-            (cli) => matchReadyPattern(cli, screen.text).matched,
-          )
+          (!opts.require_fresh_shell_prompt &&
+            READY_PATTERN_CLIS.some(
+              (cli) => matchReadyPattern(cli, screen.text).matched,
+            ))
         ) {
           return;
         }
@@ -3756,6 +3758,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     surface: string;
     workspace?: string;
     command: string;
+    relaunch?: boolean;
   }): Promise<void> => {
     const sanitizedCommand = sanitizeTerminalInput(opts.command);
     const chunks =
@@ -3763,12 +3766,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         ? chunkTerminalInput(sanitizedCommand, SEND_INPUT_CHUNK_THRESHOLD)
         : [sanitizedCommand];
 
-    await waitForLaunchShellReady({
-      surface: opts.surface,
-      workspace: opts.workspace,
-    });
+    if (!opts.relaunch) {
+      await waitForLaunchShellReady({
+        surface: opts.surface,
+        workspace: opts.workspace,
+      });
+    }
     await withSurfaceWrite(opts.surface, async () => {
+      const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {
+        await sendKeyWithRetry(opts.surface, "ctrl-c", opts.workspace);
+        await waitForLaunchShellReady({
+          surface: opts.surface,
+          workspace: opts.workspace,
+          require_fresh_shell_prompt: true,
+        });
+      };
+      if (opts.relaunch) {
+        await clearAndVerifyFreshShellPrompt();
+      }
       const relaunchOriginalCommand = async (): Promise<void> => {
+        await clearAndVerifyFreshShellPrompt();
         await deliverInputChunks({
           surface: opts.surface,
           workspace: opts.workspace,
@@ -5130,6 +5147,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       undefined,
                       launcher.launcherName,
                     ),
+                    relaunch: true,
                   })
               : undefined,
           });
@@ -5274,6 +5292,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       undefined,
                       launcher.launcherName,
                     ),
+                    relaunch: true,
                   })
               : undefined,
           });
@@ -5654,6 +5673,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 surface: args.surface,
                 workspace: args.workspace,
                 command: sanitizedCommand,
+                relaunch: true,
               }),
           });
         }
@@ -6884,6 +6904,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         surface: opts.surface,
         workspace: record.workspace_id ?? opts.workspace,
         command,
+        relaunch: true,
       });
     };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1631,7 +1631,7 @@ function screenShowsPendingInput(
   );
 }
 
-function screenShowsPendingShellInput(
+export function screenShowsPendingShellInput(
   screenText: string,
   submittedText: string,
 ): boolean {
@@ -1641,16 +1641,25 @@ function screenShowsPendingShellInput(
   }
 
   const lines = normalizeTerminalText(screenText).split("\n");
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
+  let end = lines.length;
+  while (end > 0 && !lines[end - 1]?.trim()) {
+    end -= 1;
+  }
+
+  const compactSubmitted = trimmed.replace(/\s+/g, "");
+  for (let index = end - 1; index >= 0; index -= 1) {
     const line = lines[index]?.trimEnd() ?? "";
-    if (!line.trim()) continue;
     const prompt = line.match(/[$%#]\s*(.*)$/);
-    if (!prompt) return false;
-    const pending = prompt[1]?.trimEnd() ?? "";
-    return (
+    if (!prompt) continue;
+    const pending = [prompt[1] ?? "", ...lines.slice(index + 1, end)]
+      .join("")
+      .trimEnd();
+    if (
       pending === trimmed ||
-      pending.replace(/\s+/g, "") === trimmed.replace(/\s+/g, "")
-    );
+      pending.replace(/\s+/g, "") === compactSubmitted
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3316,6 +3316,54 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("does not demote a working Codex agent to idle from the active 0.144.3 screen", async () => {
+      vi.useFakeTimers();
+      try {
+        const screenText = readFileSync(
+          join(
+            process.cwd(),
+            "tests/fixtures/spawn/codex-0.144.3-surface-489-working.txt",
+          ),
+          "utf8",
+        );
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-active-working",
+            state: "working",
+            surface_id: "surface:489",
+            workspace_id: "workspace:2",
+            cli: "codex",
+            role: "worker",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:489")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:489",
+          text: screenText,
+          lines: 80,
+          scrollback_used: true,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "cmuxlayerCodex-active-working",
+          "idle",
+          1_500,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(false);
+        expect(result.source).toBe("timeout");
+        expect(result.state).toBe("working");
+        expect(
+          engine.getAgentState("cmuxlayerCodex-active-working")?.state,
+        ).toBe("working");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("captures the boot session before waitFor marks a ready screen", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3263,6 +3263,59 @@ To continue this session, run codex resume ${sessionId}`,
       }
     });
 
+    it("resolves ready from the real Codex 0.144.3 working screen when registry is still booting", async () => {
+      vi.useFakeTimers();
+      try {
+        const screenText = readFileSync(
+          join(
+            process.cwd(),
+            "tests/fixtures/spawn/codex-0.144.3-surface-489-working.txt",
+          ),
+          "utf8",
+        );
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-pending-1783943911-ep9m",
+            state: "booting",
+            surface_id: "surface:489",
+            workspace_id: "workspace:2",
+            cli: "codex",
+            role: "worker",
+            boot_prompt_pending: true,
+            task_summary: "2026-07-13-spawn-reliability-mission.md",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:489")];
+        (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+          surface: "surface:489",
+          text: screenText,
+          lines: 80,
+          scrollback_used: true,
+        });
+        await engine.getRegistry().reconstitute();
+
+        const pending = engine.waitFor(
+          "cmuxlayerCodex-pending-1783943911-ep9m",
+          "ready",
+          1_500,
+        );
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await pending;
+
+        expect(result.matched).toBe(true);
+        expect(result.source).toBe("screen");
+        expect(result.state).toBe("ready");
+        expect(
+          engine.getAgentState("cmuxlayerCodex-pending-1783943911-ep9m"),
+        ).toMatchObject({
+          state: "ready",
+          boot_prompt_pending: false,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("captures the boot session before waitFor marks a ready screen", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/fixtures/spawn/brainlayer-sandbox-launcher-injection.json
+++ b/tests/fixtures/spawn/brainlayer-sandbox-launcher-injection.json
@@ -1,0 +1,7 @@
+{
+  "source": "Live spawn_agent failure on surface:478, captured 2026-07-13 from ~/.zsh_history and the original read_screen transcript",
+  "codex_version": "0.144.3",
+  "launcher_command": "brainlayerCodex -s",
+  "corrupted_command": "brainlayerCodex -sbrainlayerCodex -s",
+  "screen": "Shellbook: starting the agent directly.\nShellbook: run `shellbook tui` in another terminal for the social pane.\nerror: invalid value 'brainlayerCodex' for '--sandbox <SANDBOX_MODE>'\n  [possible values: read-only, workspace-write, danger-full-access]\n\nFor more information, try '--help'.\nexit status 2\netanheyman ~/Gits/brainlayer [main] $"
+}

--- a/tests/fixtures/spawn/codex-0.144.3-surface-489-working.txt
+++ b/tests/fixtures/spawn/codex-0.144.3-surface-489-working.txt
@@ -1,0 +1,117 @@
+Last login: Mon Jul 13 14:56:19 on ttys002
+etanheyman ~ [feature/coach-agent-boot-prompt-fix] $ CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'
+[4] 43007
+cmuxlayerCodex
+
+[4]  + done       ( /Applications/iTerm.app/Contents/Resources/it2profile -s Golems 2> /dev/nul)
+
+Shellbook: starting the agent directly.
+Shellbook: run `shellbook tui` in another terminal for the social pane.
+⚠ `--dangerously-bypass-hook-trust` is enabled. Enabled hooks may run without review for
+  this invocation.
+
+╭──────────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.144.3)                               │
+│                                                          │
+│ model:       gpt-5.6-sol high   /model to change         │
+│ directory:   ~/Gits/cmuxlayer.wt/spawn-reliability-3head │
+│ permissions: YOLO mode                                   │
+╰──────────────────────────────────────────────────────────╯
+
+  Tip: Use the OpenAI docs MCP for API questions; enable it with codex mcp add
+  openaiDeveloperDocs --url https://developers.openai.com/mcp.
+
+• You have 2 usage limit resets available. Run /usage to use one.
+
+
+› Read and follow /Users/etanheyman/Gits/cmuxlayer/docs.local/design/2026-07-13-spawn-
+  reliability-mission.mdRead and follow /Users/etanheyman/Gits/cmuxlayer/docs.local/
+  design/2026-07-13-spawn-reliability-mission.md
+
+
+⚠ `--dangerously-bypass-hook-trust` is enabled. Enabled hooks may run without review for
+  this invocation.
+
+• I’m reading the mission and searching BrainLayer first. I’ll apply the mission’s
+  requested workflow, then use the matching implementation and verification skills it
+  calls for.
+
+• Called
+  └ brainlayer.brain_search({"query":"cmuxlayer spawn reliability 3head mission 2026-07-
+        13 spawn agent
+        reliability","project":"cmuxlayer","detail":"full","num_results":10})
+    ## Search results for "cmuxlayer spawn reliability 3head mission 2026-07…" - 10 of 10
+        shown
+
+    ### 1. ETAN FRUSTRATION (2026-07-13, recurring): "I thought the waitfor would be
+        fixed by now." — cmuxlaye…
+    - ID: brainbar-4199e18c-27b
+    - Source: brainbar-store
+    - Date: 2026-07-13
+    - Preview: ETAN FRUSTRATION (2026-07-13, recurring): "I thought the waitfor would be
+        fixed by now." — cmuxlayer spawn reliability has a 3-head c...
+
+• Explored
+  └ Read SKILL.md (using-superpowers skill), 2026-07-13-spawn-reliability-mission.md
+
+• Ran git status --short --branch
+  └ ## fix/spawn-reliability-3head
+
+─────────────────────────────────────────────────────────────────────────────────────────
+
+• The mission is a three-head P1 bug-fix with real-capture RED→GREEN fixtures and PR
+  delivery. I’m using systematic debugging, TDD, cmux agent control, plan execution, PR-
+  loop, and verification/never-fabricate; the mission explicitly requires spawning a real
+  Codex worker for the readiness capture.
+
+• Explored
+  └ Read SKILL.md (systematic-debugging skill), SKILL.md (executing-plans skill),
+  SKILL.md
+         (verification-before-completion skill), SKILL.md (cmux-agents skill), SKILL.md
+         (never-fabricate skill), SKILL.md (test-driven-development skill), SKILL.md
+         (cmux
+         skill), SKILL.md (pr-loop skill)
+
+
+› LIVE SPECIMEN for HEAD 3: your OWN spawn just reproduced it — spawn_agent created this
+  surface (489) and you (codex 0.144.3) booted + are working, but spawn_agent returned
+  "Agent not found: cmuxlayerCodex-pending-1783943911-ep9m" (the pending→ready/registry
+  resolution failed even though you're clearly ready). Capture YOUR current booted
+  screen via read_screen(raw) as the head-3 RED fixture and run it through
+  matchReadyPattern("codex", …) to find the exact non-match. This is the real 0.144.3
+  boot you need.
+
+
+• I’m treating surface 489 as the authoritative Head 3 specimen. I’ll enumerate cmuxlayer
+  state, capture its raw screen unchanged, and save that exact output before running the
+  matcher—this is the skill-required real-screen evidence gate.
+
+• Called cmuxlayer.list_agents({"repo":"cmuxlayer"})
+  └ ┌─ cmux agents ─ 3 agents
+    │ ID                   Repo             State    Model              Session
+    ├───────────────────────────────────────────────────────────────────────────────
+    │ cmuxlayerLead        cmuxlayer        error    Opus 4.8 (1M co…   —
+    │ cmuxlayerCodex-pe…   cmuxlayer        ready    codex              —
+    │ cmuxlayerCodex-pe…   cmuxlayer        booting  codex       ...
+
+• Called
+  └ cmuxlayer.list_surfaces({"include_screen_preview":true,"preview_lines":8,"verbose":tr
+        ue})
+    ┌─ cmux surfaces ─ 16 surfaces in 2 workspaces
+    │ Ref            Type       Title                          Workspace
+    ├──────────────────────────────────────────────────────────────────────
+    │ surface:422    terminal   🎯 orc-driver v2               workspace:2
+    │   └ ✻ Churned for 9s · 1 monitor still running                 …
+    │ surface:441    terminal   golemsClaude [surface:441]     workspace:2
+    │   └ ◻ Re...
+
+• Calling
+  └ cmuxlayer.read_screen({"surface":"surface:489","raw":true,"scrollback":true,"lines":2
+        00})
+
+Working (47s • esc to interrupt)
+
+ 
+› Implement {feature}
+ 
+  gpt-5.6-sol high · ~/Gits/cmuxlayer.wt/spawn-reliability-3head

--- a/tests/fixtures/spawn/surface-489-doubled-launch-command.json
+++ b/tests/fixtures/spawn/surface-489-doubled-launch-command.json
@@ -1,0 +1,7 @@
+{
+  "source": "cmuxlayer read_screen(raw=true), surface:489, 2026-07-13",
+  "codex_version": "0.144.3",
+  "captured_shell_line": "etanheyman ~ [feature/coach-agent-boot-prompt-fix] $ CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'",
+  "launcher_command": "CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'",
+  "corrupted_command": "CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '/Users/etanheyman/Gits/cmuxlayer.wt/spawn-reliability-3head'"
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6747,6 +6747,104 @@ describe("tool handler integration", () => {
     10_000,
   );
 
+  it("does not double-type the real surface-489 launcher command when relaunch finds it unsubmitted", async () => {
+    const promptPath = join(CHANNEL_TEST_DIR, "surface-489-relaunch.md");
+    mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
+    writeFileSync(promptPath, "boot after stranded launcher", "utf8");
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          "./fixtures/spawn/surface-489-doubled-launch-command.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as {
+      launcher_command: string;
+      corrupted_command: string;
+    };
+
+    let launcherSends = 0;
+    let promptSent = false;
+    let readsAfterLaunch = 0;
+    let composer = "";
+    const submittedCommands: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        if (text === fixture.launcher_command) {
+          launcherSends += 1;
+          composer += text;
+        } else if (text === "boot after stranded launcher") {
+          promptSent = true;
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key")) {
+        const key = String(args.at(-1) ?? "");
+        if (key === "ctrl-c") {
+          composer = "";
+        } else if (key === "return" && !promptSent) {
+          if (launcherSends >= 2) {
+            submittedCommands.push(composer);
+            composer = "";
+          }
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        let text = "$ ";
+        if (promptSent) {
+          text =
+            "gpt-5.6-sol high · ~/Gits/cmuxlayer.wt/spawn-reliability-3head\nWorking (1s • esc to interrupt)";
+        } else if (launcherSends > 0) {
+          readsAfterLaunch += 1;
+          if (submittedCommands.length > 0) {
+            text = "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›";
+          } else if (readsAfterLaunch === 1) {
+            text = "Updating Codex CLI from 0.144.2 to 0.144.3";
+          } else {
+            text = "Update ran successfully! Please restart Codex.\n$ ";
+          }
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:489",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          {
+            surface: "surface:489",
+            command: fixture.launcher_command,
+            boot_prompt_path: promptPath,
+            boot_prompt_timeout_ms: 2_000,
+          },
+          {} as any,
+        ),
+      5_000,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(submittedCommands).toEqual([fixture.launcher_command]);
+    expect(submittedCommands).not.toContain(fixture.corrupted_command);
+  }, 10_000);
+
   it("spawn_agent accepts the default interactive Codex update and never selects Skip", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
@@ -7421,6 +7519,7 @@ describe("tool handler integration", () => {
     let promptSent = false;
     let returnPresses = 0;
     let reads = 0;
+    let lineCleared = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-workspaces")) {
@@ -7481,8 +7580,9 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      if (args.includes("send-key") && args.includes("return")) {
-        returnPresses += 1;
+      if (args.includes("send-key")) {
+        if (args.includes("ctrl-c")) lineCleared = true;
+        if (args.includes("return")) returnPresses += 1;
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -7497,7 +7597,9 @@ describe("tool handler integration", () => {
       if (args.includes("read-screen")) {
         reads += 1;
         const text =
-          launcherSends === 0 && reads === 1
+          launcherSends === 0 && lineCleared
+            ? "etan@mac % "
+            : launcherSends === 0 && reads === 1
             ? "Updating Codex via bun install -g @openai/codex"
             : launcherSends === 0 && reads === 2
               ? "Please restart Codex\netan@mac % "
@@ -7552,6 +7654,7 @@ describe("tool handler integration", () => {
     let promptSent = false;
     let returnPresses = 0;
     let reads = 0;
+    let lineCleared = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-workspaces")) {
@@ -7612,8 +7715,9 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      if (args.includes("send-key") && args.includes("return")) {
-        returnPresses += 1;
+      if (args.includes("send-key")) {
+        if (args.includes("ctrl-c")) lineCleared = true;
+        if (args.includes("return")) returnPresses += 1;
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -7628,7 +7732,9 @@ describe("tool handler integration", () => {
       if (args.includes("read-screen")) {
         reads += 1;
         const text =
-          launcherSends === 0 && reads === 1
+          launcherSends === 0 && lineCleared
+            ? "etan@mac % "
+            : launcherSends === 0 && reads === 1
             ? "Updating Gemini via npm install -g @google/gemini-cli"
             : launcherSends === 0 && reads === 2
               ? "Please restart Gemini\netan@mac % "
@@ -7687,6 +7793,7 @@ describe("tool handler integration", () => {
     let promptSent = false;
     let returnPresses = 0;
     let reads = 0;
+    let lineCleared = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("new-surface")) {
@@ -7701,8 +7808,9 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      if (args.includes("send-key") && args.includes("return")) {
-        returnPresses += 1;
+      if (args.includes("send-key")) {
+        if (args.includes("ctrl-c")) lineCleared = true;
+        if (args.includes("return")) returnPresses += 1;
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -7717,7 +7825,9 @@ describe("tool handler integration", () => {
       if (args.includes("read-screen")) {
         reads += 1;
         const text =
-          launcherSends === 0 && reads === 1
+          launcherSends === 0 && lineCleared
+            ? "etan@mac % "
+            : launcherSends === 0 && reads === 1
             ? "Updating Codex via bun install -g @openai/codex"
             : launcherSends === 0 && reads === 2
               ? "Please restart Codex\netan@mac % "

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -25,6 +25,10 @@ type InputDeliveryTestModule = typeof import("../src/server.js") & {
     firstChunkNumber: number;
     deliveredChunkCounts: number[];
   }>;
+  screenShowsPendingShellInput: (
+    screenText: string,
+    submittedText: string,
+  ) => boolean;
 };
 
 const openServers = new Set<ReturnType<typeof createServerImpl>>();
@@ -391,6 +395,29 @@ describe("input delivery batching helpers", () => {
         deliveredChunkCounts: [1],
       },
     ]);
+  });
+
+  it("recognizes the real surface-489 launcher while it is wrapped across shell rows", async () => {
+    const { screenShowsPendingShellInput } =
+      await loadInputDeliveryTestModule();
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          "./fixtures/spawn/surface-489-doubled-launch-command.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as { launcher_command: string };
+    const wrapAt = 72;
+    const wrappedScreen = [
+      `etanheyman ~/Gits/cmuxlayer [fix/spawn-reliability-3head] $ ${fixture.launcher_command.slice(0, wrapAt)}`,
+      fixture.launcher_command.slice(wrapAt),
+    ].join("\n");
+
+    expect(
+      screenShowsPendingShellInput(wrappedScreen, fixture.launcher_command),
+    ).toBe(true);
   });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6845,6 +6845,137 @@ describe("tool handler integration", () => {
     expect(submittedCommands).not.toContain(fixture.corrupted_command);
   }, 10_000);
 
+  it("does not turn a retry-ambiguous spawn write into the real --sandbox launcher-name injection", async () => {
+    const stateDir = join(
+      CHANNEL_TEST_DIR,
+      "spawn-sandbox-launcher-injection-state",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          "./fixtures/spawn/brainlayer-sandbox-launcher-injection.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as {
+      launcher_command: string;
+      corrupted_command: string;
+      screen: string;
+    };
+
+    let composer = "";
+    let launcherSendAttempts = 0;
+    const submittedCommands: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "brainlayer",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:478",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        if (text === fixture.launcher_command) {
+          launcherSendAttempts += 1;
+          composer += text;
+          if (launcherSendAttempts === 1) {
+            throw new Error("socket closed before receiving response");
+          }
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        submittedCommands.push(composer);
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        const submitted = submittedCommands.at(-1);
+        const text =
+          submitted === fixture.corrupted_command
+            ? fixture.screen
+            : submitted === fixture.launcher_command
+              ? "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›"
+              : composer
+                ? `etanheyman ~/Gits/brainlayer [main] $ ${composer}`
+                : "etanheyman ~/Gits/brainlayer [main] $";
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:478",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    try {
+      await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "brainlayer",
+              cli: "codex",
+              workspace: "workspace:1",
+            },
+            {} as any,
+          ),
+        2_000,
+      );
+
+      expect(submittedCommands).toEqual([fixture.launcher_command]);
+      expect(submittedCommands).not.toContain(fixture.corrupted_command);
+      expect(launcherSendAttempts).toBe(1);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it("spawn_agent accepts the default interactive Codex update and never selects Skip", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";


### PR DESCRIPTION
## Summary
- Head 3: promote a booting Codex record when the real 0.144.3 surface is already active, with the raw surface:489 screen fixture.
- Head 2: clear and verify a fresh shell prompt before update/relaunch retyping, with the exact doubled surface:489 command fixture.
- Head 1: probe an ambiguous spawn text write before retrying so a lost socket response cannot create the captured brainlayerCodex sandbox-value corruption.

## Verification
- npm test -- --run --reporter=dot: 1802/1802 passed
- npm run typecheck
- npm run build
- push hook run_tests.sh: passed, including nightly contract and VT regression runners
- CodeRabbit CLI pre-commit attempted twice; free OSS review service rate-limited both attempts (latest reset estimate: 13 minutes)

## Fixture note
The raw Codex surface fixture intentionally preserves two terminal rows containing a single space; git diff --check therefore reports those two fixture-only trailing-whitespace rows. All non-fixture diffs pass git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn/ready reconciliation and terminal input delivery; mistakes could mis-classify agent state or skip needed retries, though behavior is guarded by screen probes and extensive new tests.
> 
> **Overview**
> Improves **spawn reliability** across three failure modes seen in production (Codex 0.144.3, surface 489, and brainlayer launcher corruption).
> 
> **Readiness / registry:** `readReadyEvidence` now exposes **`activeCodex`** when the screen shows Codex identity plus an active working marker. **`waitFor`**, boot reconciliation, and **`boot_prompt_pending`** paths treat **`activeCodex`** like ready (with adjusted boot-prompt gating) so a booting agent can flip to **ready** on real 0.144.3 working screens and working agents are not pushed toward **idle** incorrectly.
> 
> **Relaunch typing:** **`sendLauncherCommandToSurface`** gains a **`relaunch`** mode that **Ctrl+C** clears the line and **`waitForLaunchShellReady`** waits for a **fresh shell prompt** (CLI ready patterns disabled when **`require_fresh_shell_prompt`** is set) before retyping. Relaunch paths (**`spawn_agent`**, splits, boot-prompt shell relaunch) pass **`relaunch: true`** to avoid concatenated/doubled launcher commands.
> 
> **Ambiguous spawn writes:** **`sendChunkWithRetry`** can **read the surface** after a failed send; for **`spawn_agent`** it skips retry when **`screenShowsPendingInput`** or new **`screenShowsPendingShellInput`** shows the chunk already pending—preventing sandbox flag corruption from a duplicate retry.
> 
> Tests add fixtures and coverage for the Codex working screen, doubled launch command, and sandbox injection scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0778abfb7b4e3307c4edbc3bddc807b464672609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex 0.144.3 readiness detection, relaunch double-type, and sandbox launcher injection
> - Adds `activeCodex` evidence to [`src/agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/308/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) so Codex agents showing an active-agent marker are treated as ready without requiring the traditional ready pattern or boot-prompt dismissal.
> - Fixes double-typed launcher commands on relaunch in [`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/308/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) by sending ctrl-c and verifying a fresh shell prompt before typing the launcher command.
> - Guards ambiguous spawn retries from resubmitting a visibly pending shell command via the new `screenShowsPendingShellInput` helper, which matches input across wrapped terminal rows.
> - Adds `require_fresh_shell_prompt` to `waitForLaunchShellReady` to prevent agent-ready UI from being misclassified as shell readiness.
> - Adds fixtures and tests covering the Codex 0.144.3 working screen, the doubled launcher command, and the sandbox launcher injection scenario.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0778abf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->