### PR TITLE
fix(spawn): make launcher relaunch idempotent

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3827,6 +3827,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       });
     }
     await withSurfaceWrite(opts.surface, async () => {
+      const submitPendingLauncherCommand = async (): Promise<boolean> => {
+        try {
+          const screen = await client.readScreen(opts.surface, {
+            workspace: opts.workspace,
+            lines: 80,
+            scrollback: false,
+          });
+          if (!screenShowsPendingShellInput(screen.text, sanitizedCommand)) {
+            return false;
+          }
+          await sendKeyWithRetry(opts.surface, "return", opts.workspace);
+          return true;
+        } catch (error) {
+          if (isSurfaceGoneReadFailure(error, opts.surface)) {
+            throw new SurfaceGoneError(opts.surface, error);
+          }
+          return false;
+        }
+      };
       const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {
         await sendKeyWithRetry(opts.surface, "ctrl-c", opts.workspace);
         await waitForLaunchShellReady({
@@ -3836,6 +3855,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         });
       };
       if (opts.relaunch) {
+        if (await submitPendingLauncherCommand()) {
+          return;
+        }
         await clearAndVerifyFreshShellPrompt();
       }
       const relaunchOriginalCommand = async (): Promise<void> => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1344,14 +1344,22 @@ function inferRepoFromLauncherTitle(title?: string): string | null {
   return inferLauncherFromTitle(title)?.repo ?? null;
 }
 
-function matchShellPromptLine(line: string): { input: string } | null {
+function isLauncherShellCommand(command: string): boolean {
+  return /(?:^|\s)[\w.-]+(?:Claude|Codex|Cursor|Gemini)(?=\s|$)/.test(command);
+}
+
+function matchShellPromptLine(
+  line: string,
+  opts?: { allowRootInput?: boolean },
+): { input: string } | null {
   const normalized = line.trimEnd();
   const barePrompt = normalized.match(/^\s*([$%])(?:\s+(.*))?$/);
   if (barePrompt) {
     return { input: barePrompt[2] ?? "" };
   }
-  if (/^\s*#\s*$/.test(normalized)) {
-    return { input: "" };
+  const rootPrompt = normalized.match(/^\s*#(?:\s+(.*))?$/);
+  if (rootPrompt && (!rootPrompt[1] || opts?.allowRootInput)) {
+    return { input: rootPrompt[1] ?? "" };
   }
 
   const prefixedPrompt = normalized.match(
@@ -1669,10 +1677,13 @@ export function screenShowsPendingShellInput(
   }
 
   const compactSubmitted = trimmed.replace(/\s+/g, "");
+  const promptOptions = {
+    allowRootInput: isLauncherShellCommand(trimmed),
+  };
   let activePromptIndex = -1;
   for (let index = end - 1; index >= 0; index -= 1) {
     const line = lines[index]?.trimEnd() ?? "";
-    const prompt = matchShellPromptLine(line);
+    const prompt = matchShellPromptLine(line, promptOptions);
     if (prompt) {
       activePromptIndex = index;
       break;
@@ -1682,7 +1693,10 @@ export function screenShowsPendingShellInput(
     return false;
   }
 
-  const prompt = matchShellPromptLine(lines[activePromptIndex] ?? "");
+  const prompt = matchShellPromptLine(
+    lines[activePromptIndex] ?? "",
+    promptOptions,
+  );
   const pending = [
     prompt?.input ?? "",
     ...lines.slice(activePromptIndex + 1, end),

--- a/src/server.ts
+++ b/src/server.ts
@@ -1344,8 +1344,30 @@ function inferRepoFromLauncherTitle(title?: string): string | null {
   return inferLauncherFromTitle(title)?.repo ?? null;
 }
 
+function matchShellPromptLine(line: string): { input: string } | null {
+  const normalized = line.trimEnd();
+  const barePrompt = normalized.match(/^\s*([$%])(?:\s+(.*))?$/);
+  if (barePrompt) {
+    return { input: barePrompt[2] ?? "" };
+  }
+  if (/^\s*#\s*$/.test(normalized)) {
+    return { input: "" };
+  }
+
+  const prefixedPrompt = normalized.match(
+    /^\s*(?:(?:\S+@\S+)(?:\s+(?:~|\/)\S*)?|(?:\S+\s+)?(?:~|\/)\S*)(?:\s+\[[^\]]+\])?\s*[$%#](?:\s+(.*))?$/,
+  );
+  return prefixedPrompt ? { input: prefixedPrompt[1] ?? "" } : null;
+}
+
 function matchesShellPrompt(text: string): boolean {
-  return /(?:^|\n)[^\n]*[$%#]\s*$/.test(text);
+  const lines = normalizeTerminalText(text).split("\n");
+  let end = lines.length;
+  while (end > 0 && !lines[end - 1]?.trim()) {
+    end -= 1;
+  }
+  const prompt = end > 0 ? matchShellPromptLine(lines[end - 1] ?? "") : null;
+  return prompt?.input.trim() === "";
 }
 
 function shouldHandleCodexUpdateMenu(
@@ -1647,21 +1669,30 @@ export function screenShowsPendingShellInput(
   }
 
   const compactSubmitted = trimmed.replace(/\s+/g, "");
+  let activePromptIndex = -1;
   for (let index = end - 1; index >= 0; index -= 1) {
     const line = lines[index]?.trimEnd() ?? "";
-    const prompt = line.match(/[$%#]\s*(.*)$/);
-    if (!prompt) continue;
-    const pending = [prompt[1] ?? "", ...lines.slice(index + 1, end)]
-      .join("")
-      .trimEnd();
-    if (
-      pending === trimmed ||
-      pending.replace(/\s+/g, "") === compactSubmitted
-    ) {
-      return true;
+    const prompt = matchShellPromptLine(line);
+    if (prompt) {
+      activePromptIndex = index;
+      break;
     }
   }
-  return false;
+  if (activePromptIndex < 0) {
+    return false;
+  }
+
+  const prompt = matchShellPromptLine(lines[activePromptIndex] ?? "");
+  const pending = [
+    prompt?.input ?? "",
+    ...lines.slice(activePromptIndex + 1, end),
+  ]
+    .join("")
+    .trimEnd();
+  return (
+    pending === trimmed ||
+    pending.replace(/\s+/g, "") === compactSubmitted
+  );
 }
 
 function parseRawSubmitEvidenceMetrics(

--- a/src/server.ts
+++ b/src/server.ts
@@ -3859,22 +3859,49 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
     await withSurfaceWrite(opts.surface, async () => {
       const submitPendingLauncherCommand = async (): Promise<boolean> => {
-        try {
-          const screen = await client.readScreen(opts.surface, {
+        const readLauncherScreen = () =>
+          client.readScreen(opts.surface, {
             workspace: opts.workspace,
             lines: 80,
             scrollback: false,
           });
-          if (!screenShowsPendingShellInput(screen.text, sanitizedCommand)) {
-            return false;
-          }
-          await sendKeyWithRetry(opts.surface, "return", opts.workspace);
-          return true;
+
+        let screen;
+        try {
+          screen = await readLauncherScreen();
         } catch (error) {
           if (isSurfaceGoneReadFailure(error, opts.surface)) {
             throw new SurfaceGoneError(opts.surface, error);
           }
           return false;
+        }
+        if (!screenShowsPendingShellInput(screen.text, sanitizedCommand)) {
+          return false;
+        }
+
+        try {
+          // Return is a mutation: retrying after a lost acknowledgement can
+          // submit into the newly started CLI. Probe before any fallback.
+          await client.sendKey(opts.surface, "return", {
+            workspace: opts.workspace,
+          });
+          return true;
+        } catch (error) {
+          if (isSurfaceGoneReadFailure(error, opts.surface)) {
+            throw new SurfaceGoneError(opts.surface, error);
+          }
+          try {
+            const confirmation = await readLauncherScreen();
+            return !screenShowsPendingShellInput(
+              confirmation.text,
+              sanitizedCommand,
+            );
+          } catch (confirmationError) {
+            if (isSurfaceGoneReadFailure(confirmationError, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, confirmationError);
+            }
+            throw error;
+          }
         }
       };
       const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -135,7 +135,7 @@ function validateMcpList(values: string[] | undefined, field: string): string[] 
 
 export function formatMcpProfileEnv(profile?: McpProfile): string {
   if (!profile || profile === "inherit") {
-    return "CMUXLAYER_MCP_PROFILE=inherit";
+    return "";
   }
   if (profile === "sterile" || profile === "skill_eval") {
     return `CMUXLAYER_MCP_PROFILE=${profile}`;

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1568,7 +1568,7 @@ describe("agent lifecycle tool handlers", () => {
         "send",
         "--surface",
         "surface:new",
-        `CMUXLAYER_MCP_PROFILE=inherit cmuxlayerCodex -s -w '${worktreePath}'`,
+        `cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
   });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -419,6 +419,49 @@ describe("input delivery batching helpers", () => {
       screenShowsPendingShellInput(wrappedScreen, fixture.launcher_command),
     ).toBe(true);
   });
+
+  it("ignores a launcher in shell history above the active empty prompt", async () => {
+    const { screenShowsPendingShellInput } =
+      await loadInputDeliveryTestModule();
+    const command = "cmuxlayerCodex -s";
+    const screen = [
+      `$ ${command}`,
+      "OpenAI Codex exited after updating",
+      "$ ",
+    ].join("\n");
+
+    expect(screenShowsPendingShellInput(screen, command)).toBe(false);
+  });
+
+  it.each([
+    ["bare", "$ cmuxlayerCodex -s"],
+    ["host", "etan@mac % cmuxlayerCodex -s"],
+    ["host and path", "etan@mac ~/repo5$ cmuxlayerCodex -s"],
+    ["path", "/tmp/repo $ cmuxlayerCodex -s"],
+  ])("recognizes pending input at a %s shell prompt", async (_label, screen) => {
+    const { screenShowsPendingShellInput } =
+      await loadInputDeliveryTestModule();
+
+    expect(screenShowsPendingShellInput(screen, "cmuxlayerCodex -s")).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ["dollar amount", "price $5", "5"],
+    ["percentage prose", "progress % complete", "complete"],
+    ["percentage progress", "Downloading: 100% complete", "complete"],
+    ["path progress", "Saved /tmp/archive 100% complete", "complete"],
+    ["hash output", "# done", "done"],
+  ])(
+    "does not treat %s as pending shell input",
+    async (_label, screen, submittedText) => {
+      const { screenShowsPendingShellInput } =
+        await loadInputDeliveryTestModule();
+
+      expect(screenShowsPendingShellInput(screen, submittedText)).toBe(false);
+    },
+  );
 });
 
 describe("tool registration", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6817,7 +6817,12 @@ describe("tool handler integration", () => {
     10_000,
   );
 
-  it("does not double-type the real surface-489 launcher command when relaunch finds it unsubmitted", async () => {
+  it.each([
+    { label: "normal Return acknowledgement", loseAcknowledgement: false },
+    { label: "lost Return acknowledgement", loseAcknowledgement: true },
+  ])("does not double-type the real surface-489 launcher command with $label", async ({
+    loseAcknowledgement,
+  }) => {
     const promptPath = join(CHANNEL_TEST_DIR, "surface-489-relaunch.md");
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot after stranded launcher", "utf8");
@@ -6859,8 +6864,13 @@ describe("tool handler integration", () => {
         } else if (key === "return" && !promptSent) {
           launcherReturnPresses += 1;
           if (launcherReturnPresses >= 2) {
-            submittedCommands.push(composer);
+            if (composer) {
+              submittedCommands.push(composer);
+            }
             composer = "";
+            if (loseAcknowledgement) {
+              throw new Error("socket closed before receiving response");
+            }
           }
         }
         return { stdout: "{}", stderr: "" };

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -437,7 +437,9 @@ describe("input delivery batching helpers", () => {
     ["bare", "$ cmuxlayerCodex -s"],
     ["host", "etan@mac % cmuxlayerCodex -s"],
     ["host and path", "etan@mac ~/repo5$ cmuxlayerCodex -s"],
+    ["host colon path", "alice@server:~/repo$ cmuxlayerCodex -s"],
     ["path", "/tmp/repo $ cmuxlayerCodex -s"],
+    ["root", "# cmuxlayerCodex -s"],
   ])("recognizes pending input at a %s shell prompt", async (_label, screen) => {
     const { screenShowsPendingShellInput } =
       await loadInputDeliveryTestModule();

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6794,6 +6794,7 @@ describe("tool handler integration", () => {
     let launcherSends = 0;
     let promptSent = false;
     let readsAfterLaunch = 0;
+    let launcherReturnPresses = 0;
     let composer = "";
     const submittedCommands: string[] = [];
 
@@ -6813,7 +6814,8 @@ describe("tool handler integration", () => {
         if (key === "ctrl-c") {
           composer = "";
         } else if (key === "return" && !promptSent) {
-          if (launcherSends >= 2) {
+          launcherReturnPresses += 1;
+          if (launcherReturnPresses >= 2) {
             submittedCommands.push(composer);
             composer = "";
           }
@@ -6831,8 +6833,10 @@ describe("tool handler integration", () => {
             text = "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›";
           } else if (readsAfterLaunch === 1) {
             text = "Updating Codex CLI from 0.144.2 to 0.144.3";
-          } else {
+          } else if (readsAfterLaunch === 2) {
             text = "Update ran successfully! Please restart Codex.\n$ ";
+          } else {
+            text = `Update ran successfully! Please restart Codex.\n$ ${composer}`;
           }
         }
         return {
@@ -6868,6 +6872,7 @@ describe("tool handler integration", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(launcherSends).toBe(1);
     expect(submittedCommands).toEqual([fixture.launcher_command]);
     expect(submittedCommands).not.toContain(fixture.corrupted_command);
   }, 10_000);

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -458,11 +458,13 @@ describe("worktree helpers", () => {
   });
 
   it("formats MCP profile env hints without raw config passing", () => {
-    expect(formatMcpProfileEnv(undefined)).toBe(
-      "CMUXLAYER_MCP_PROFILE=inherit",
-    );
+    expect(formatMcpProfileEnv(undefined)).toBe("");
+    expect(formatMcpProfileEnv("inherit")).toBe("");
     expect(formatMcpProfileEnv("sterile")).toBe(
       "CMUXLAYER_MCP_PROFILE=sterile",
+    );
+    expect(formatMcpProfileEnv("skill_eval")).toBe(
+      "CMUXLAYER_MCP_PROFILE=skill_eval",
     );
     expect(
       formatMcpProfileEnv({


### PR DESCRIPTION
## Summary

- make post-update launcher relaunch idempotent by submitting an exact pending shell command instead of typing a second copy
- make that Return mutation ambiguity-safe: send it once, then re-read before any Ctrl-C/retype fallback
- constrain active-shell detection so history and ordinary dollar/percentage/path/hash output cannot trigger the fast path
- omit the redundant default MCP inheritance prefix while preserving explicit sterile, skill-eval, and custom profiles

## Test plan

- [x] RED/GREEN: surface-489 unsubmitted launcher regression, including lost Return acknowledgement after delivery
- [x] RED/GREEN: stale shell history, root prompt, and prompt false-positive regressions
- [x] RED/GREEN: unset/inherit MCP profile formatting and default worktree launch command
- [x] full suite: 98 files, 1,817 tests passed
- [x] `bun run pre-pr`: 61 tests passed plus typecheck
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] local CodeRabbit findings fixed; final local rerun rate-limited, bundled red-team/blue-team fallback completed cleanly
- [x] Codex active-prompt finding fixed in `dd0d72e`
- [x] CodeRabbit ambiguous-Return finding fixed in `1c179c7`
- [x] Codex root-prompt finding fixed in `408889f`; Macroscope colon-prompt concern reproduced as already passing

## Runtime verification

- Live installed-runtime verification remains for the lead after review/merge; this worker did not restart, deploy, or merge cmuxlayer.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make launcher relaunch idempotent by submitting already-pending commands
> - During relaunch, if the launcher command is already pending at the shell prompt (e.g. from a previous attempt), the server now presses Return to submit it instead of retyping the command.
> - Tolerates a lost Return acknowledgement by re-reading the screen state before falling back to the full relaunch flow.
> - Improves shell prompt detection in `screenShowsPendingShellInput` and `matchesShellPrompt` to target only the active prompt line, support diverse prompt formats (bare, host, host+path, root), and avoid false positives from `$`, `%`, or `#` in non-prompt contexts.
> - Fixes `formatMcpProfileEnv` in [worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/310/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d) to emit an empty string for `undefined` or `'inherit'` profiles instead of `CMUXLAYER_MCP_PROFILE=inherit`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 408889f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->