### PR TITLE
fix(delivery): refuse keystroke sends into an open picker/menu (never type as menu keystrokes)

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -683,13 +683,12 @@ function hasPickerNavigationBlock(text: string): boolean {
 
     // A ready composer below copied/stale menu output means the picker is no
     // longer active. Terminal status chrome may still follow the live footer.
+    const afterFooter = lines.slice(footerIndex + 1);
     if (
-      lines
-        .slice(footerIndex + 1)
-        .some(
-          (line) =>
-            BARE_READY_PROMPT_RE.test(line) || CURSOR_FOLLOWUP_RE.test(line),
-        )
+      afterFooter.some(
+        (line) =>
+          BARE_READY_PROMPT_RE.test(line) || CURSOR_FOLLOWUP_RE.test(line),
+      ) || hasShellPrompt(afterFooter.join("\n"))
     ) {
       continue;
     }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -4,6 +4,7 @@ import type {
   ParsedScreenResult,
   ParsedScreenStatus,
 } from "./types.js";
+import type { CliType } from "./agent-types.js";
 // AIDEV-NOTE: Single source of truth for per-model context windows lives in
 // harness-session.ts (MODEL_WINDOW_RULES). screen-parser delegates versioned lookups to it
 // (via modelContextWindow) so the fallback table below never drifts from the JSONL path.
@@ -175,9 +176,17 @@ const PROMPT_BLOCK_WINDOW_LINES = 8;
 const INTERACTIVE_PROMPT_TOOL_RE = /^\s*(AskUserQuestion|ask-tool)\s*$/i;
 const INTERACTIVE_PROMPT_CLARIFICATION_RE =
   /agent is asking for clarification/i;
-const MENU_SELECTOR_RE = /^\s*[>❯]\s+\S.+$/m;
+const MENU_SELECTOR_RE = /^\s*[>❯›]\s+\S.+$/m;
 const MENU_OPTION_RE = /^\s*\d+\.\s+\S.+$/m;
 const BARE_READY_PROMPT_RE = /^\s*(?:[>❯›]|codex\s*>)\s*$/i;
+const PICKER_BLOCK_WINDOW_LINES = 32;
+const PICKER_NUMBERED_OPTION_RE =
+  /^\s*(?:[>❯›]\s*)?(?:[☐☑◉○●◯✓✔]\s*)?\d+\.\s+\S.+$/;
+const PICKER_NAVIGATION_FOOTER_RE =
+  /(?:Enter to (?:select|confirm).{0,60}(?:↑\/↓|↑↓).{0,30}navigate|(?:↑\/↓|↑↓)\s+to navigate|Press up to edit queued messages)/i;
+const CLAUDE_PICKER_HEADER_RE = /^\s*[☐☑]\s+\S.+$/;
+const CLAUDE_PICKER_AUX_OPTION_RE =
+  /^\s*\d+\.\s+(?:Type something\.?|Chat about this)\s*$/i;
 const CODEX_UPDATE_MENU_WINDOW_LINES = 12;
 const PERMISSION_PROMPT_PRIMARY_RE = /approve command\?|do you want to allow/i;
 const PERMISSION_PROMPT_MARKER_RE =
@@ -664,6 +673,70 @@ function hasInteractivePromptBlock(text: string): boolean {
   return hasMenuBlock(text, { tailOnly: true });
 }
 
+function hasPickerNavigationBlock(text: string): boolean {
+  const lines = text.split("\n");
+  for (let footerIndex = lines.length - 1; footerIndex >= 0; footerIndex -= 1) {
+    const footer = lines[footerIndex] ?? "";
+    if (!PICKER_NAVIGATION_FOOTER_RE.test(footer)) {
+      continue;
+    }
+
+    // A ready composer below copied/stale menu output means the picker is no
+    // longer active. Terminal status chrome may still follow the live footer.
+    if (
+      lines
+        .slice(footerIndex + 1)
+        .some((line) => BARE_READY_PROMPT_RE.test(line))
+    ) {
+      continue;
+    }
+
+    const block = lines.slice(
+      Math.max(0, footerIndex - PICKER_BLOCK_WINDOW_LINES),
+      footerIndex + 1,
+    );
+    const numberedOptions = block.filter((line) =>
+      PICKER_NUMBERED_OPTION_RE.test(line),
+    ).length;
+    const hasSelector = block.some((line) => MENU_SELECTOR_RE.test(line));
+    const isQueuedMessageFooter = /Press up to edit queued messages/i.test(
+      footer,
+    );
+    const hasClaudePickerChrome = block.some(
+      (line) =>
+        CLAUDE_PICKER_HEADER_RE.test(line) ||
+        CLAUDE_PICKER_AUX_OPTION_RE.test(line),
+    );
+
+    if (
+      (numberedOptions >= 2 ||
+        (!isQueuedMessageFooter && hasSelector)) &&
+      (!isQueuedMessageFooter || hasClaudePickerChrome)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Detect an active terminal picker/menu whose next text bytes would be
+ * interpreted as navigation or selection keystrokes instead of composer text.
+ */
+export function isPickerOrMenuScreen(text: string, cli?: CliType): boolean {
+  const normalized = normalizeText(text);
+  if (
+    (cli === undefined || cli === "codex") &&
+    isCodexUpdateMenuScreenNormalized(normalized, { tailOnly: true })
+  ) {
+    return true;
+  }
+  return (
+    hasInteractivePromptBlock(normalized) ||
+    hasPickerNavigationBlock(normalized)
+  );
+}
+
 function parseErrors(text: string): string[] {
   const errors: string[] = [];
 
@@ -671,15 +744,7 @@ function parseErrors(text: string): string[] {
     errors.push("permission_prompt");
   }
 
-  if (!errors.includes("permission_prompt") && hasInteractivePromptBlock(text)) {
-    errors.push("interactive_prompt");
-  }
-
-  if (
-    !errors.includes("permission_prompt") &&
-    !errors.includes("interactive_prompt") &&
-    hasActiveCodexUpdateMenuScreen(text)
-  ) {
+  if (!errors.includes("permission_prompt") && isPickerOrMenuScreen(text)) {
     errors.push("interactive_prompt");
   }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -686,7 +686,10 @@ function hasPickerNavigationBlock(text: string): boolean {
     if (
       lines
         .slice(footerIndex + 1)
-        .some((line) => BARE_READY_PROMPT_RE.test(line))
+        .some(
+          (line) =>
+            BARE_READY_PROMPT_RE.test(line) || CURSOR_FOLLOWUP_RE.test(line),
+        )
     ) {
       continue;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,6 +90,7 @@ import {
   cleanScreenText,
   inferContextWindow,
   isCodexUpdateMenuScreen,
+  isPickerOrMenuScreen,
   parseScreen,
 } from "./screen-parser.js";
 import {
@@ -483,6 +484,7 @@ class SubmitVerificationError extends Error {
 }
 
 class DeliverySafetyGateError extends Error {
+  readonly delivered = false;
   readonly submit_verified = false;
 
   constructor(
@@ -494,7 +496,7 @@ class DeliverySafetyGateError extends Error {
     super(
       error_code === "blocked_by_permission_prompt"
         ? "delivery blocked by active permission prompt"
-        : "delivery blocked by active interactive prompt",
+        : "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
     );
     this.name = "DeliverySafetyGateError";
   }
@@ -689,6 +691,15 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
           control: error.control,
         }
       : {};
+  const deliverySafetyExtra =
+    error instanceof DeliverySafetyGateError
+      ? {
+          delivered: error.delivered,
+          error_code: error.error_code,
+          submit_verified: error.submit_verified,
+          screen: error.screen,
+        }
+      : {};
   const retryMeta =
     error && typeof error === "object"
       ? {
@@ -713,6 +724,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     error: message,
     ...retryMeta,
     ...modeExtra,
+    ...deliverySafetyExtra,
     ...extra,
   };
   return {
@@ -3133,6 +3145,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const assertDeliveryTargetIsSafe = async (
     surface: string,
     workspace?: string,
+    cli?: CliType,
   ): Promise<void> => {
     const snapshot = await readParsedSurface(surface, workspace, {
       throwOnSurfaceGone: true,
@@ -3148,7 +3161,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
     }
 
-    if (snapshot.parsed.control_state === "interactive_overlay") {
+    if (isPickerOrMenuScreen(snapshot.text, cli)) {
       throw new DeliverySafetyGateError(
         "blocked_by_interactive_prompt",
         snapshot.parsed,
@@ -3345,6 +3358,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     retry_count: number;
     submit_verified: boolean | null;
   }> => {
+    await assertDeliveryTargetIsSafe(opts.surface, opts.workspace);
     const deliveryBatches = buildInputDeliveryBatches(opts.chunks);
     const shouldPaste = shouldPasteInputDelivery(
       opts.chunks,
@@ -4287,7 +4301,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const run = async () => {
       try {
-        await assertDeliveryTargetIsSafe(record.surface, record.workspace);
         const delivery = await deliverInputChunks({
           surface: record.surface,
           workspace: record.workspace,
@@ -5662,7 +5675,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         const delivery = await withSurfaceWrite(args.surface, async () => {
-          await assertDeliveryTargetIsSafe(args.surface, args.workspace);
           return deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
@@ -5789,7 +5801,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !!targetRecord && INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
         const delivery = await withSurfaceWrite(args.surface, async () => {
-          await assertDeliveryTargetIsSafe(args.surface, args.workspace);
           return deliverInputChunks({
             surface: args.surface,
             workspace: args.workspace,
@@ -7232,10 +7243,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return withSurfaceWrite(
         route.surface_id,
         async () => {
-          await assertDeliveryTargetIsSafe(
-            route.surface_id,
-            route.workspace_id ?? undefined,
-          );
           return deliverInputChunks({
             surface: route.surface_id,
             workspace: route.workspace_id ?? undefined,
@@ -8844,7 +8851,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
-          "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior). Use to interject while an agent is working — e.g., to cancel, steer, or stack an instruction.",
+          "If true, bypass the lifecycle-state gate so a working agent can receive an interjection. Picker/menu and permission-prompt safety gates still refuse text; use mode=key for deliberate menu driving.",
         ),
         allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",

--- a/tests/fixtures/painpoints/claude-ask-user-question-picker-2026-07-13.txt
+++ b/tests/fixtures/painpoints/claude-ask-user-question-picker-2026-07-13.txt
@@ -1,0 +1,21 @@
+▐▛███▜▌ Claude Code v2.1.207
+▝▜█████▛▘ Sonnet 5 with low effort · Claude Max
+  ▘▘ ▝▝   ~/Gits/cmuxlayer.wt/picker-blocked-delivery
+
+❯ Render the requested AskUserQuestion picker now.
+────────────────────────────────────────────────────────────────────────────────
+ ☐ Delivery safety
+
+Where should this message go?
+
+❯ 1. Current pane
+     Send the message to the currently active pane.
+  2. Inbox file
+     Write the message to the inbox file instead of sending directly.
+  3. Cancel send
+     Do not send the message anywhere.
+  4. Type something.
+
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -14,7 +14,7 @@
  *   - nudge="never" → file append only.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -305,6 +305,51 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     expect(sendCalls(exec).length).toBe(before);
     expect(
       readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
+    ).toContain("GO");
+  });
+
+  it("keeps the inbox message but does not nudge into a real Claude picker", async () => {
+    await server.close();
+    const pickerText = readFileSync(
+      new URL(
+        "./fixtures/painpoints/claude-ask-user-question-picker-2026-07-13.txt",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    exec = makeExec(pickerText, "agenthtmlhostClaude");
+    server = createServer({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+    });
+
+    const agentId = "auto-claude-surface-new";
+    const before = sendCalls(exec).length;
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(false);
+    expect(parsed.nudge.error_code).toBe("blocked_by_interactive_prompt");
+    expect(parsed.nudge.reason).toContain("open picker/menu");
+    expect(sendCalls(exec)).toHaveLength(before);
+    expect(
+      readInbox(agentId, { baseDir: inboxDir }).map((message) => message.task),
     ).toContain("GO");
   });
 

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -65,6 +65,7 @@ function readPainpointFixture(fileName: string): PainpointFixture {
   const id = basename(fileName, extname(fileName));
   const expectedById: Record<string, string> = {
     "claude-ask-user-question-overlay": "interactive_overlay",
+    "claude-ask-user-question-picker-2026-07-13": "interactive_overlay",
     "claude-permission-confirmation": "permission_prompt",
     "codex-update-menu": "interactive_overlay",
     "bare-shell-and-bare-gemini-prompt": "shell",
@@ -170,6 +171,7 @@ describe("Phase 0 painpoint replay corpus", () => {
       "bare-shell-and-bare-gemini-prompt",
       "boot-prompt-typed-not-submitted",
       "claude-ask-user-question-overlay",
+      "claude-ask-user-question-picker-2026-07-13",
       "claude-permission-confirmation",
       "codex-update-menu",
       "empty-dead-pane-submit",

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -334,6 +334,54 @@ describe("pane input pointer discipline", () => {
     ).toBe(false);
   });
 
+  it("send_to refuses the real Claude AskUserQuestion picker before typing anything", async () => {
+    const pickerText = readPainpointFixture(
+      "claude-ask-user-question-picker-2026-07-13.txt",
+    );
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n❯ ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const tool = (server as any)._registeredTools["send_to"];
+    screenText = pickerText;
+    mockExec.mockClear();
+
+    const result = await tool.handler(
+      { agent_id: agentId, text: "new fleet message", press_enter: false },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      delivered: false,
+      error_code: "blocked_by_interactive_prompt",
+      submit_verified: false,
+      error:
+        "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
+    });
+    expect(parsed.screen).toMatchObject({
+      control_state: "interactive_overlay",
+      errors: expect.arrayContaining(["interactive_prompt"]),
+    });
+    expect(
+      mockExec.mock.calls.some(([, args]) =>
+        args.some((arg: string) =>
+          ["send", "set-buffer", "paste-buffer", "send-key"].includes(arg),
+        ),
+      ),
+    ).toBe(false);
+    context.dispose();
+  });
+
   it("send_input allows prose that only mentions AskUserQuestion", async () => {
     const proseText = [
       "Claude Code",

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -164,6 +164,22 @@ ${selector} Opus
     },
   );
 
+  it("treats a Cursor picker above a live follow-up composer as stale", () => {
+    const screen = `
+Select a model
+
+› Opus
+  Sonnet
+  Haiku
+
+↑↓ to navigate · Enter to confirm · Esc to cancel
+
+→ Add a follow-up
+`;
+
+    expect(isPickerOrMenuScreen(screen, "cursor")).toBe(false);
+  });
+
   it("recognizes generic active choice menus as interactive overlays", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -5,6 +5,7 @@ import {
   MODEL_MAX_TOKENS,
   resolveModelMax,
   inferContextWindow,
+  isPickerOrMenuScreen,
 } from "../src/screen-parser.js";
 
 const readFixture = (name: string) =>
@@ -117,6 +118,51 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.errors).toContain("interactive_prompt");
     expect(parsed.control_state).toBe("interactive_overlay");
   });
+
+  it("recognizes the real Claude Code AskUserQuestion picker as an active menu", () => {
+    // Normalized from a live Claude Code v2.1.207 PTY capture on 2026-07-13.
+    const screen = readFixture(
+      "painpoints/claude-ask-user-question-picker-2026-07-13.txt",
+    );
+    expect(isPickerOrMenuScreen(screen, "claude")).toBe(true);
+    expect(parseScreen(screen)).toMatchObject({
+      agent_type: "claude",
+      status: "frozen",
+      control_state: "interactive_overlay",
+      errors: expect.arrayContaining(["interactive_prompt"]),
+    });
+  });
+
+  it("does not confuse Claude's queued-message composer with a picker", () => {
+    const queuedComposer = `
+Claude Code
+
+❯ Finish the review and post the verdict.
+────────────────────────────────────────────────────────────────────────────────
+❯ Press up to edit queued messages
+────────────────────────────────────────────────────────────────────────────────
+  🤖 Opus 4.8 (1M context) | 💰 $1.90 | ⏱️ 4m | 📚 89%
+`;
+    expect(isPickerOrMenuScreen(queuedComposer, "claude")).toBe(false);
+  });
+
+  it.each(["codex", "cursor", "gemini"] as const)(
+    "recognizes a footer-driven %s select list without numbered options",
+    (cli) => {
+      const selector = cli === "cursor" ? "›" : "❯";
+      const screen = `
+Select a model
+
+${selector} Opus
+  Sonnet
+  Haiku
+
+↑↓ to navigate · Enter to confirm · Esc to cancel
+`;
+
+      expect(isPickerOrMenuScreen(screen, cli)).toBe(true);
+    },
+  );
 
   it("recognizes generic active choice menus as interactive overlays", () => {
     const parsed = parseScreen(`

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -180,6 +180,21 @@ Select a model
     expect(isPickerOrMenuScreen(screen, "cursor")).toBe(false);
   });
 
+  it("treats a picker above a live shell prompt as stale", () => {
+    const screen = `
+Choose a runtime
+
+❯ Bun
+  Node
+
+↑↓ to navigate · Enter to confirm · Esc to cancel
+
+etanheyman@mac ~/repo$
+`;
+
+    expect(isPickerOrMenuScreen(screen)).toBe(false);
+  });
+
   it("recognizes generic active choice menus as interactive overlays", () => {
     const parsed = parseScreen(`
 Claude Code

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3554,8 +3554,10 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(readsWhenBootPromptSent).toBe(3);
-    expect(reads).toBe(4);
+    // Two readiness matches, launch-command preflight, boot-prompt preflight,
+    // then post-submit verification.
+    expect(readsWhenBootPromptSent).toBe(4);
+    expect(reads).toBe(5);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
@@ -7403,7 +7405,9 @@ describe("tool handler integration", () => {
         result.structuredContent ?? JSON.parse(result.content[0].text);
       expect(parsed.ok).toBe(true);
       expect(parsed.boot_prompt_delivered).toBe(true);
-      expect(postDismissMenuReads).toBe(2);
+      // Poll the repaint, confirm readiness, then preflight once more at the
+      // shared text-delivery boundary before typing the boot prompt.
+      expect(postDismissMenuReads).toBe(3);
       expect(sentKeys).not.toContain("down");
       expect(sentKeys).toContain("return");
       expect(sentTexts.filter((text) => text === prompt)).toHaveLength(1);


### PR DESCRIPTION
## Summary

- detect active terminal pickers/menus from real footer and selector affordances across Claude, Codex, Cursor, and Gemini shapes
- refuse all text delivery at the shared chunk-delivery boundary before any send, paste, or Return can become menu keystrokes
- preserve inbox durability when an automatic dispatch nudge is refused, while keeping `mode=key` available for deliberate menu interaction

## Root cause

The existing safety gate relied on parsed `control_state`, but the real Claude Code AskUserQuestion picker no longer matched the older simulated fixture shape. Text delivery could therefore reach `cmux send` and be interpreted by the picker as selection/navigation keystrokes. The regression fixture in this PR is normalized from a live Claude Code v2.1.207 PTY capture made on 2026-07-13.

## Test plan

- [x] RED-first parser regression for the real Claude AskUserQuestion picker
- [x] RED-first `send_to` regression proving `delivered:false` and zero send/paste/key calls
- [x] RED-first inbox nudge regression proving the message remains durable while the nudge is refused
- [x] generic footer-driven picker coverage for Codex, Cursor, and Gemini selector styles
- [x] stale Cursor picker scrollback followed by a live `→ Add a follow-up` composer does not false-block delivery
- [x] stale picker scrollback followed by a live shell prompt does not false-block delivery
- [x] ordinary Claude checklist transcript plus queued-message composer does not false-block, while a structurally complete queued picker still blocks
- [x] `bunx vitest run --silent` — 98 files, 1,829 tests passed
- [x] `bun run pre-pr` — typecheck plus 61 harness tests passed
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] push hook `run_tests.sh` — 98 files, 1,829 tests passed

## Local review

Status: SKIPPED — CodeRabbit CLI was bounded to three minutes and timed out. Its only emitted finding referenced an unrelated historical base fixture (`tests/fixtures/spawn/surface-489-doubled-launch-command.json`), outside this diff. The changed production and test regions were then reviewed directly against the mission invariants.

Macroscope's stale-Cursor-picker finding was reproduced RED, fixed in `a711108`, verified against the full suite, and answered in its inline review thread.

Codex's stale-picker-above-shell finding was reproduced RED, fixed in `579c814`, verified against the full suite, and answered in its inline review thread.

Codex's queued-composer false-positive finding was reproduced RED, fixed in `8fb0abc` with stronger structural picker evidence, verified against the full suite, and answered in its inline review thread.
