### PR TITLE
fix(parser): require structured queued-picker evidence

### DIFF
--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -183,6 +183,8 @@ const BARE_READY_PROMPT_RE = /^\s*(?:[>❯›]|codex\s*>)\s*$/i;
 const PICKER_BLOCK_WINDOW_LINES = 32;
 const PICKER_NUMBERED_OPTION_RE =
   /^\s*(?:[>❯›]\s*)?(?:[☐☑◉○●◯✓✔]\s*)?\d+\.\s+\S.+$/;
+const PICKER_SELECTED_NUMBERED_OPTION_RE =
+  /^\s*[>❯›]\s*(?:[☐☑◉○●◯✓✔]\s*)?\d+\.\s+\S.+$/;
 const PICKER_NAVIGATION_FOOTER_RE =
   /(?:Enter to (?:select|confirm).{0,60}(?:↑\/↓|↑↓).{0,30}navigate|(?:↑\/↓|↑↓)\s+to navigate|Press up to edit queued messages)/i;
 const CLAUDE_PICKER_HEADER_RE = /^\s*[☐☑]\s+\S.+$/;
@@ -714,16 +716,23 @@ function hasPickerNavigationBlock(text: string): boolean {
     const isQueuedMessageFooter = /Press up to edit queued messages/i.test(
       footer,
     );
-    const hasClaudePickerChrome = block.some(
-      (line) =>
-        CLAUDE_PICKER_HEADER_RE.test(line) ||
-        CLAUDE_PICKER_AUX_OPTION_RE.test(line),
+    const hasClaudePickerHeader = block.some((line) =>
+      CLAUDE_PICKER_HEADER_RE.test(line),
     );
+    const claudePickerAuxOptions = block.filter((line) =>
+      CLAUDE_PICKER_AUX_OPTION_RE.test(line),
+    ).length;
+    const hasSelectedNumberedOption = block.some((line) =>
+      PICKER_SELECTED_NUMBERED_OPTION_RE.test(line),
+    );
+    const hasStructuredClaudePicker =
+      (hasClaudePickerHeader && hasSelectedNumberedOption) ||
+      claudePickerAuxOptions >= 2;
 
     if (
       (numberedOptions >= 2 ||
         (!isQueuedMessageFooter && hasSelector)) &&
-      (!isQueuedMessageFooter || hasClaudePickerChrome)
+      (!isQueuedMessageFooter || hasStructuredClaudePicker)
     ) {
       return true;
     }

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -246,6 +246,34 @@ Claude Code
     expect(isPickerOrMenuScreen(queuedComposer, "claude")).toBe(false);
   });
 
+  it("does not combine ordinary checklist transcript with Claude's queued-message footer", () => {
+    const queuedComposer = `
+Claude Code
+
+☐ Delivery follow-up
+
+1. Added the shared preflight.
+2. Verified the regression suite.
+
+❯ Send the final status after CI completes.
+────────────────────────────────────────────────────────────────────────────────
+❯ Press up to edit queued messages
+`;
+
+    expect(isPickerOrMenuScreen(queuedComposer, "claude")).toBe(false);
+  });
+
+  it("recognizes a structured Claude picker with a queued-message footer", () => {
+    const picker = readFixture(
+      "painpoints/claude-ask-user-question-picker-2026-07-13.txt",
+    ).replace(
+      "Enter to select · ↑/↓ to navigate · Esc to cancel",
+      "❯ Press up to edit queued messages",
+    );
+
+    expect(isPickerOrMenuScreen(picker, "claude")).toBe(true);
+  });
+
   it.each(["codex", "cursor", "gemini"] as const)(
     "recognizes a footer-driven %s select list without numbered options",
     (cli) => {


### PR DESCRIPTION
## Summary

- prevent ordinary Claude checklist/numbered transcript above a queued-message composer from being misclassified as an open picker
- keep blocking a genuine AskUserQuestion picker that renders the same queued-message footer by requiring stronger structural evidence

## Context

PR #311 merged externally at `579c814` while its final Codex review was still surfacing this false-positive case. This follow-up contains only the reviewed fix commit `8fb0abc`; the branch diff against current `main` is two files, 42 additions and 5 deletions.

## Test plan

- [x] RED regression: ordinary checklist/numbered transcript plus `Press up to edit queued messages` returns `false`
- [x] positive regression: structured AskUserQuestion picker with that footer returns `true`
- [x] `bunx vitest run --silent` — 98 files, 1,829 tests passed
- [x] `bun run pre-pr` — typecheck plus 61 harness tests passed
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] push hook `run_tests.sh` — 98 files, 1,829 tests passed

## Review provenance

Fixes the final Codex review thread from #311: https://github.com/EtanHey/cmuxlayer/pull/311#discussion_r3573215749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized heuristic change in screen parsing with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Tightens **picker/menu detection** when Claude shows the **“Press up to edit queued messages”** footer so normal transcript content (checklists, numbered bullets) is not treated as an active picker.
> 
> `hasPickerNavigationBlock` no longer treats any Claude picker chrome (checkbox header or a single aux line) as enough in that footer case. It adds **`PICKER_SELECTED_NUMBERED_OPTION_RE`** and **`hasStructuredClaudePicker`**: either a checkbox header plus a **cursor-selected** numbered option, or **two or more** “Type something” / “Chat about this” aux lines.
> 
> **Tests** cover checklist + queued footer → not a picker, and a real AskUserQuestion fixture with that footer swapped in → still a picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb0aabe43c443f0235f09ffce49010a35a04c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `hasPickerNavigationBlock` to require structured picker evidence when a queued-message footer is present
> - Ordinary checklists followed by Claude's queued-message footer were being misclassified as active pickers; this PR tightens the detection logic in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/312/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50).
> - Introduces `PICKER_SELECTED_NUMBERED_OPTION_RE` to match currently-selected numbered options (lines beginning with `>`, `❯`, or `›`).
> - A "structured Claude picker" now requires either a Claude picker header plus a selected numbered option, or at least two auxiliary options. The queued-message footer path requires this stricter check.
> - Adds two tests covering the regression case (checklist + queued footer → not a picker) and the valid case (structured picker + queued footer → still recognized).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7fb0aab. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->