### PR TITLE
fix(socket): skip interleaved sidebar status frames in the persistent-socket reader (unblock close_surface)

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
+import { parseCmuxStatusFrame } from "./cmux-status-frame.js";
 import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 
 const execFileAsync = promisify(execFile);
@@ -169,20 +170,11 @@ export class CmuxClient {
     }
 
     return trimmed.split(/\r?\n/).map((line) => {
-      const match = line.match(
-        /^([^=]+)=(.*?)(?:\s+icon=([^\s]+))?(?:\s+color=(#[0-9a-fA-F]{6}))?$/,
-      );
-      if (!match) {
+      const frame = parseCmuxStatusFrame(line);
+      if (!frame) {
         throw new Error(`cmux returned an unparseable status entry: ${line}`);
       }
-
-      const [, key, value, icon, color] = match;
-      return {
-        key,
-        value: value.trim(),
-        ...(icon ? { icon } : {}),
-        ...(color ? { color } : {}),
-      };
+      return frame;
     });
   }
 

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -11,6 +11,7 @@ import * as crypto from "node:crypto";
 import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
+import { isCmuxSidebarStatusFrame } from "./cmux-status-frame.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_IN_FLIGHT = 256;
@@ -256,6 +257,9 @@ export class CmuxPersistentSocket {
         } else if (this.pendingV1.length > 0) {
           this.resolveNextV1(line);
         } else if (this.pending.size > 0) {
+          if (isCmuxSidebarStatusFrame(line)) {
+            continue;
+          }
           this.rejectUnexpectedV2Frame(line);
         }
       }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -27,6 +27,7 @@ import { normalizeKeyName } from "./key-names.js";
 import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
+import { parseCmuxStatusFrame } from "./cmux-status-frame.js";
 export { CmuxSocketError } from "./cmux-socket-error.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
@@ -730,17 +731,7 @@ export class CmuxSocketClient {
         .split(/\r?\n/)
         .filter(Boolean)
         .map((line) => {
-          const match = line.match(
-            /^([^=]+)=(.*?)(?:\s+icon=([^\s]+))?(?:\s+color=(#[0-9a-fA-F]{6}))?$/,
-          );
-          if (!match) return { key: line, value: "" };
-          const [, key, value, icon, color] = match;
-          return {
-            key: key ?? "",
-            value: value?.trim() ?? "",
-            ...(icon ? { icon } : {}),
-            ...(color ? { color } : {}),
-          };
+          return parseCmuxStatusFrame(line) ?? { key: line, value: "" };
         });
     }
   }

--- a/src/cmux-status-frame.ts
+++ b/src/cmux-status-frame.ts
@@ -1,0 +1,30 @@
+import type { CmuxStatusEntry } from "./types.js";
+
+const CMUX_STATUS_FRAME_PATTERN =
+  /^([^=]+)=(.*?)(?:\s+icon=([^\s]+))?(?:\s+color=(#[0-9a-fA-F]{6}))?$/;
+
+export function parseCmuxStatusFrame(
+  line: string,
+): CmuxStatusEntry | null {
+  const match = line.match(CMUX_STATUS_FRAME_PATTERN);
+  if (!match) return null;
+
+  const [, key, value, icon, color] = match;
+  return {
+    key: key ?? "",
+    value: value?.trim() ?? "",
+    ...(icon ? { icon } : {}),
+    ...(color ? { color } : {}),
+  };
+}
+
+export function isCmuxSidebarStatusFrame(line: string): boolean {
+  const frame = parseCmuxStatusFrame(line);
+  if (!frame) return false;
+
+  return (
+    frame.key.startsWith("agent-surface:") ||
+    frame.icon !== undefined ||
+    frame.color !== undefined
+  );
+}

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -1,12 +1,16 @@
 import net from "node:net";
 import { EventEmitter } from "node:events";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
 import { CmuxSocketError } from "../src/cmux-socket-error.js";
 
 const TEST_ROOT = join("/tmp", "cmux-persistent-socket-test");
+const INTERLEAVED_STATUS_FRAME = readFileSync(
+  new URL("./fixtures/cmux-interleaved-sidebar-status-frame.txt", import.meta.url),
+  "utf8",
+).trim();
 const servers: net.Server[] = [];
 
 function socketPath(name: string): string {
@@ -177,6 +181,58 @@ describe("CmuxPersistentSocket V1 demux", () => {
         }),
       ]);
       expect(received).toHaveLength(2);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("skips an interleaved sidebar status frame before a V2 response", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("interleaved-status-v2");
+    await startLineServer(path, (line, conn) => {
+      const request = JSON.parse(line) as { id: string };
+      conn.write(`${INTERLEAVED_STATUS_FRAME}\n`);
+      conn.write("skill-creator=working icon=hammer color=#abcdef\n");
+      conn.write(
+        `${JSON.stringify({
+          id: request.id,
+          ok: true,
+          result: { closed: true },
+        })}\n`,
+      );
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      await expect(
+        socket.call("surface.close", { surface_id: "surface:155" }),
+      ).resolves.toEqual({ closed: true });
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("still rejects a malformed non-status frame before a V2 response", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("unexpected-v2");
+    await startLineServer(path, (_line, conn) => {
+      conn.write("unexpected=frame\n");
+    });
+
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
+
+    try {
+      await expect(socket.call("surface.close")).rejects.toMatchObject({
+        code: "protocol_error",
+        message: expect.stringContaining("Unexpected cmux socket frame"),
+      });
     } finally {
       socket.disconnect();
     }

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -18,7 +18,7 @@ import {
 } from "vitest";
 import * as net from "node:net";
 import * as fs from "node:fs";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CmuxSocketClient } from "../src/cmux-socket-client.js";
@@ -30,6 +30,10 @@ import { getTransportHealth } from "../src/cmux-transport-self-heal.js";
 
 const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
 const MOCK_SOCKET_PATH = "/tmp/cmux-test-mock.sock";
+const INTERLEAVED_STATUS_FRAME = readFileSync(
+  new URL("./fixtures/cmux-interleaved-sidebar-status-frame.txt", import.meta.url),
+  "utf8",
+).trim();
 const MOCK_WORKSPACE_ID = "8481D6A0-CE17-4B7C-8695-7A722D30FEE2";
 const MOCK_SECOND_WORKSPACE_ID = "7335E54B-6E88-4B19-BE8C-71C39F4E9D10";
 
@@ -272,6 +276,41 @@ function startSocketServer(socketPath: string): Promise<net.Server> {
               ok: true,
               result: { pong: true },
             }) + "\n",
+          );
+        }
+      });
+    });
+    helperServerConnections.set(server, connections);
+
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function startInterleavedStatusServer(socketPath: string): Promise<net.Server> {
+  return new Promise((resolve) => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+
+    const connections = new Set<net.Socket>();
+    const server = net.createServer((conn) => {
+      connections.add(conn);
+      conn.on("close", () => connections.delete(conn));
+      let buffer = "";
+      conn.on("data", (chunk) => {
+        buffer += chunk.toString("utf-8");
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line.trim()) continue;
+
+          const request = JSON.parse(line) as MockV2Request;
+          conn.write(`${INTERLEAVED_STATUS_FRAME}\n`);
+          conn.write(
+            `${JSON.stringify({ id: request.id, ok: true, result: {} })}\n`,
           );
         }
       });
@@ -1124,6 +1163,23 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
         collapse_pane: true,
       },
     });
+  });
+
+  it("closeSurface succeeds when a sidebar status frame precedes its response", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "cmux-close-status-"));
+    const socketPath = join(stateDir, "cmux.sock");
+    const server = await startInterleavedStatusServer(socketPath);
+    const client = new CmuxSocketClient({ socketPath, timeoutMs: 500 });
+
+    try {
+      await expect(
+        client.closeSurface("surface:155", { workspace: "workspace:1" }),
+      ).resolves.toBeUndefined();
+    } finally {
+      client.disconnect();
+      await stopSocketServer(server, socketPath);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("newSurface uses CLI fallback", async () => {

--- a/tests/fixtures/cmux-interleaved-sidebar-status-frame.txt
+++ b/tests/fixtures/cmux-interleaved-sidebar-status-frame.txt
@@ -1,0 +1,1 @@
+agent-surface:155=idle icon=circle color=#9ca3af


### PR DESCRIPTION
## Summary
- extract the cmux `key=value` sidebar status-frame parser into one shared helper used by both list-status clients
- skip only identifiable interleaved sidebar frames (`agent-surface:` keys or `icon=`/`color=` suffixes) while a persistent V2 response is pending
- preserve protocol errors for malformed or bare unexpected frames, and preserve ordinary JSON-RPC and V1 list-status behavior

## RED → GREEN evidence
- before the production change, the captured `agent-surface:155=idle icon=circle color=#9ca3af` fixture failed in both the persistent transport test and the `CmuxSocketClient.closeSurface` integration test at `rejectUnexpectedV2Frame`
- after the change, the transport skips both the captured frame and a rotating `skill-creator` status frame, then returns the correlated JSON-RPC response
- `unexpected=frame` still rejects with `protocol_error`

## Test plan
- [x] `npm test -- --run tests/cmux-persistent-socket.test.ts tests/cmux-socket-client.test.ts tests/cmux-client.test.ts` — 122 passed
- [x] `npm test -- --silent=passed-only` — 99 files, 1,865 tests passed
- [x] `npm run build`
- [x] `npm run pre-pr` — 61 tests passed
- [x] push hook `scripts/run_tests.sh` — exit 0

## Review note
- local `coderabbit review --agent` was attempted before commit but the free OSS review endpoint returned a rate-limit error; PR-level reviewers and CI are requested below

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistent socket demux for in-flight V2 RPCs; misclassification could hide real protocol errors or accept wrong frames, though scope is limited to identifiable sidebar status lines and is heavily tested.
> 
> **Overview**
> Fixes **V2 socket operations failing** when cmux pushes sidebar `key=value` status lines on the same connection (e.g. `closeSurface` / `surface.close`).
> 
> **Shared parsing:** Duplicated `key=value` status regex logic moves into `cmux-status-frame.ts` (`parseCmuxStatusFrame`, `isCmuxSidebarStatusFrame`). The CLI client, socket client `listStatus`, and the persistent reader all use it.
> 
> **Transport behavior:** While a **V2 request is pending**, `CmuxPersistentSocket` **drops** lines that look like sidebar status (`agent-surface:` keys or `icon=` / `color=` suffixes) instead of treating them as unexpected frames. Plain non-status lines like `unexpected=frame` still raise **`protocol_error`**. JSON-RPC and V1 list-status paths are unchanged.
> 
> **Tests:** Fixture-driven coverage for interleaved frames before a V2 response (transport + `CmuxSocketClient.closeSurface`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c01a7766f22c5551d485f57a9099b23c5a548a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip interleaved sidebar status frames in `CmuxPersistentSocket` to unblock `close_surface`
> - The persistent-socket data handler previously rejected any non-JSON frame received while V2 requests were pending, causing a `protocol_error` when the server sent sidebar status frames between a request and its response.
> - Adds `isCmuxSidebarStatusFrame` to [cmux-status-frame.ts](https://github.com/EtanHey/cmuxlayer/pull/313/files#diff-0746e28a1114e0c0b4f78e12826b018f76d5d95b92c5765ffedd18eeb72a8ae2) to detect frames with keys starting with `agent-surface:` or containing icon/color fields, and silently skips them in the data handler loop.
> - Extracts a shared `parseCmuxStatusFrame` utility used by both [cmux-client.ts](https://github.com/EtanHey/cmuxlayer/pull/313/files#diff-fa09fce9dc0db1d0fcfd897829a228dc976f365c0f36f4cbadacf6d03bd932d4) and [cmux-socket-client.ts](https://github.com/EtanHey/cmuxlayer/pull/313/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2) to parse `key=value` status lines.
> - Adds tests covering the skip behavior and confirming that genuinely malformed frames still reject with `protocol_error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c01a77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->