### PR TITLE
fix(spawn): eliminate launcher double-emit at pane bootstrap (real injection point)

### DIFF
--- a/docs/plans/2026-07-13-echo-reinjection-p0.md
+++ b/docs/plans/2026-07-13-echo-reinjection-p0.md
@@ -1,0 +1,76 @@
+# Echo Reinjection P0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure `spawn_agent` emits a repoGolem launcher command exactly once when the transport loses or delays the acknowledgement for the initial pane write.
+
+**Architecture:** Keep pane creation and launcher submission separate. Treat a retryable launcher-text write failure as ambiguous: observe the pane for the already-applied command, but never replay that non-idempotent text mutation. If the command cannot be observed, fail explicitly so a caller can retry on a fresh pane instead of concatenating two launchers.
+
+**Tech Stack:** TypeScript, cmux CLI/socket clients, Vitest fixtures and integration tests.
+
+---
+
+### Task 1: Preserve the real surface 530 recurrence
+
+**Files:**
+- Create: `tests/fixtures/spawn/surface-530-stale-probe-double-emit.json`
+- Modify: `tests/server.test.ts`
+
+**Step 1: Add the captured shell command and clean same-pane comparison**
+
+Record the verbatim corrupt command `skillcreatorCodex -sskillcreatorCodex -s`, the intended launcher, and the later clean manual command from the mission capture.
+
+**Step 2: Write a failing replay test**
+
+Model a launcher write that reaches the pane but loses its response. Return one stale shell screen before exposing the pending launcher on the next read.
+
+**Step 3: Run the focused test and verify RED**
+
+Run: `bunx vitest run tests/server.test.ts -t "surface-530"`
+
+Expected: FAIL because v0.4.5 sends the launcher twice and submits the concatenated command.
+
+### Task 2: Make launcher text delivery at-most-once
+
+**Files:**
+- Modify: `src/server.ts` (`sendChunkWithRetry` launcher ambiguity branch)
+- Test: `tests/server.test.ts`
+
+**Step 1: Observe rather than replay**
+
+On a retryable `spawn_agent` text-write error, perform bounded screen observations for the pending launcher. Return success if it becomes visible. If it does not, throw an explicit ambiguous-write error without issuing a second text write.
+
+**Step 2: Run the focused test and verify GREEN**
+
+Run: `bunx vitest run tests/server.test.ts -t "surface-530"`
+
+Expected: PASS with one launcher send and one submitted launcher command.
+
+**Step 3: Re-run the adjacent historical regressions**
+
+Run: `bunx vitest run tests/server.test.ts -t "surface-489|sandbox launcher-name injection|Codex update|relaunch"`
+
+Expected: PASS for the #306/#308/#310 launcher update, submit, and relaunch cases.
+
+### Task 3: Verify and deliver
+
+**Files:**
+- Verify: `src/server.ts`
+- Verify: `tests/server.test.ts`
+- Verify: `tests/fixtures/spawn/surface-530-stale-probe-double-emit.json`
+
+**Step 1: Run repository verification**
+
+Run: `bun run typecheck`
+
+Run: `bun run test`
+
+Expected: all checks pass.
+
+**Step 2: Run the live client gate**
+
+Build/install the branch for a fresh 0.4.x client session, spawn `skillcreatorCodex`, and immediately capture `read_screen(raw=true)`. The shell history must contain one `skillcreatorCodex -s` emission and no concatenated copy.
+
+**Step 3: Complete the PR loop**
+
+Commit the focused source, fixture, test, and plan changes; push `fix/echo-reinjection-p0`; open the required ready-for-review PR; invoke reviewers; address findings; verify CI; and post the PR URL plus the exact injection point to the driver-buddy channel and in-pane.

--- a/docs/plans/2026-07-13-echo-reinjection-p0.md
+++ b/docs/plans/2026-07-13-echo-reinjection-p0.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Preserve the real surface 530 recurrence
+## Task 1: Preserve the real surface 530 recurrence
 
 **Files:**
 - Create: `tests/fixtures/spawn/surface-530-stale-probe-double-emit.json`
@@ -30,7 +30,7 @@ Run: `bunx vitest run tests/server.test.ts -t "surface-530"`
 
 Expected: FAIL because v0.4.5 sends the launcher twice and submits the concatenated command.
 
-### Task 2: Make launcher text delivery at-most-once
+## Task 2: Make launcher text delivery at-most-once
 
 **Files:**
 - Modify: `src/server.ts` (`sendChunkWithRetry` launcher ambiguity branch)
@@ -52,7 +52,7 @@ Run: `bunx vitest run tests/server.test.ts -t "surface-489|sandbox launcher-name
 
 Expected: PASS for the #306/#308/#310 launcher update, submit, and relaunch cases.
 
-### Task 3: Verify and deliver
+## Task 3: Verify and deliver
 
 **Files:**
 - Verify: `src/server.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -2962,23 +2962,42 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
         if (avoidDuplicateOnAmbiguousRetry) {
-          try {
-            const snapshot = await readParsedSurface(
-              surface,
-              opts.workspace,
-              { throwOnSurfaceGone: true },
-            );
-            if (
-              snapshot &&
-              (screenShowsPendingInput(snapshot.text, chunk) ||
-                screenShowsPendingShellInput(snapshot.text, chunk))
-            ) {
-              return;
+          const observationStartedAt = Date.now();
+          while (
+            Date.now() - observationStartedAt <
+            SEND_INPUT_SAFE_RETRY_OBSERVE_MS
+          ) {
+            try {
+              const snapshot = await readParsedSurface(
+                surface,
+                opts.workspace,
+                { throwOnSurfaceGone: true },
+              );
+              if (
+                snapshot &&
+                (screenShowsPendingInput(snapshot.text, chunk) ||
+                  screenShowsPendingShellInput(snapshot.text, chunk))
+              ) {
+                return;
+              }
+            } catch {
+              // Keep observing until the bounded deadline. Retrying the text
+              // mutation after an unreadable pane can concatenate launchers.
             }
-          } catch {
-            // The delivery error remains authoritative when the ambiguity
-            // probe cannot read the surface; continue the bounded retry.
+
+            const remainingMs =
+              SEND_INPUT_SAFE_RETRY_OBSERVE_MS -
+              (Date.now() - observationStartedAt);
+            if (remainingMs <= 0) break;
+            await delay(Math.min(SEND_INPUT_SUBMIT_VERIFY_POLL_MS, remainingMs));
           }
+
+          const message =
+            error instanceof Error ? error.message : String(error);
+          throw new DeliveryError(
+            `chunk ${chunkNumber}/${totalChunks} acknowledgement was ambiguous and launcher text was not retried: ${message}`,
+            chunkNumber,
+          );
         }
         await delay(SEND_INPUT_RETRY_DELAY_MS);
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2980,7 +2980,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ) {
                 return;
               }
-            } catch {
+            } catch (observeError) {
+              if (observeError instanceof SurfaceGoneError) {
+                throw observeError;
+              }
               // Keep observing until the bounded deadline. Retrying the text
               // mutation after an unreadable pane can concatenate launchers.
             }
@@ -7727,6 +7730,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               submit_verified: e.submit_verified,
               screen: e.screen,
             });
+          }
+          if (e instanceof SurfaceGoneError) {
+            return err(e, surfaceGonePayload(e));
           }
           return err(e);
         }

--- a/tests/fixtures/spawn/surface-530-stale-probe-double-emit.json
+++ b/tests/fixtures/spawn/surface-530-stale-probe-double-emit.json
@@ -1,0 +1,14 @@
+{
+  "source": "Etan-captured cmuxlayer read_screen(raw=true), surface:530, 2026-07-13 21:48; the same pane and shell path produced a clean manual launch seconds later",
+  "connected_cmuxlayer_version": "0.4.5",
+  "codex_version": "0.144.3",
+  "launcher_command": "skillcreatorCodex -s",
+  "captured_corrupted_command": "skillcreatorCodex -sskillcreatorCodex -s",
+  "clean_manual_command": "skillcreatorCodex -s -E ultra",
+  "captured_failure": "the second launcher copy became the --sandbox value and Codex exited with status 2",
+  "replay": {
+    "transport_error": "socket closed before receiving response",
+    "stale_probe_screen": "etanheyman ~ $",
+    "pending_probe_screen": "etanheyman ~ $ skillcreatorCodex -s"
+  }
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7065,6 +7065,151 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
+  it("does not replay the real surface-530 launcher when the ambiguity probe is one screen behind", async () => {
+    const stateDir = join(
+      CHANNEL_TEST_DIR,
+      "surface-530-stale-probe-double-emit-state",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          "./fixtures/spawn/surface-530-stale-probe-double-emit.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as {
+      launcher_command: string;
+      captured_corrupted_command: string;
+      replay: {
+        transport_error: string;
+        stale_probe_screen: string;
+        pending_probe_screen: string;
+      };
+    };
+
+    let composer = "";
+    let launcherSendAttempts = 0;
+    let launcherWriteBecameAmbiguous = false;
+    let ambiguityProbeReads = 0;
+    const submittedCommands: string[] = [];
+
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:2",
+                title: "skillcreatorClaude",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:2",
+            window_ref: "window:1",
+            panes: [],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:2",
+            surface: "surface:530",
+            pane: "pane:19",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("send")) {
+        const text = String(args.at(-1) ?? "");
+        if (text === fixture.launcher_command) {
+          launcherSendAttempts += 1;
+          composer += text;
+          if (launcherSendAttempts === 1) {
+            launcherWriteBecameAmbiguous = true;
+            throw new Error(fixture.replay.transport_error);
+          }
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        submittedCommands.push(composer);
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        let text = fixture.replay.stale_probe_screen;
+        if (submittedCommands.length > 0) {
+          text = "OpenAI Codex\nmodel: gpt-5.6-sol xhigh\n\n›";
+        } else if (launcherWriteBecameAmbiguous) {
+          ambiguityProbeReads += 1;
+          text =
+            ambiguityProbeReads === 1
+              ? fixture.replay.stale_probe_screen
+              : fixture.replay.pending_probe_screen;
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:530",
+            text,
+            lines: 80,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      disableSpawnPreflight: true,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    try {
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            {
+              repo: "skillcreator",
+              cli: "codex",
+              workspace: "workspace:2",
+            },
+            {} as any,
+          ),
+        2_000,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(true);
+      expect(launcherSendAttempts).toBe(1);
+      expect(ambiguityProbeReads).toBeGreaterThanOrEqual(2);
+      expect(submittedCommands).toEqual([fixture.launcher_command]);
+      expect(submittedCommands).not.toContain(
+        fixture.captured_corrupted_command,
+      );
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it("spawn_agent accepts the default interactive Codex update and never selects Skip", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7065,7 +7065,35 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
-  it("does not replay the real surface-530 launcher when the ambiguity probe is one screen behind", async () => {
+  it.each([
+    {
+      name: "does not replay the real surface-530 launcher when the ambiguity probe is one screen behind",
+      probe: "delayed-visible" as const,
+      expectedOk: true,
+      expectedErrorCode: undefined,
+      expectedError: undefined,
+    },
+    {
+      name: "fails closed without replaying the surface-530 launcher when ambiguity never resolves",
+      probe: "always-stale" as const,
+      expectedOk: false,
+      expectedErrorCode: undefined,
+      expectedError:
+        "acknowledgement was ambiguous and launcher text was not retried",
+    },
+    {
+      name: "preserves pane_died when the surface disappears during ambiguity observation",
+      probe: "surface-gone" as const,
+      expectedOk: false,
+      expectedErrorCode: "pane_died",
+      expectedError: "surface surface:530 disappeared - respawn",
+    },
+  ])("$name", async ({
+    probe,
+    expectedOk,
+    expectedErrorCode,
+    expectedError,
+  }) => {
     const stateDir = join(
       CHANNEL_TEST_DIR,
       "surface-530-stale-probe-double-emit-state",
@@ -7157,10 +7185,14 @@ describe("tool handler integration", () => {
           text = "OpenAI Codex\nmodel: gpt-5.6-sol xhigh\n\n›";
         } else if (launcherWriteBecameAmbiguous) {
           ambiguityProbeReads += 1;
-          text =
-            ambiguityProbeReads === 1
-              ? fixture.replay.stale_probe_screen
-              : fixture.replay.pending_probe_screen;
+          if (probe === "surface-gone") {
+            throw new Error(
+              "cmux read-screen failed: surface_not_found surface surface:530",
+            );
+          }
+          if (probe === "delayed-visible" && ambiguityProbeReads > 1) {
+            text = fixture.replay.pending_probe_screen;
+          }
         }
         return {
           stdout: JSON.stringify({
@@ -7193,15 +7225,25 @@ describe("tool handler integration", () => {
             },
             {} as any,
           ),
-        2_000,
+        4_000,
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
 
-      expect(parsed.ok).toBe(true);
+      expect(parsed.ok).toBe(expectedOk);
+      if (expectedErrorCode) {
+        expect(parsed.error_code).toBe(expectedErrorCode);
+      }
+      if (expectedError) {
+        expect(parsed.error).toContain(expectedError);
+      }
       expect(launcherSendAttempts).toBe(1);
-      expect(ambiguityProbeReads).toBeGreaterThanOrEqual(2);
-      expect(submittedCommands).toEqual([fixture.launcher_command]);
+      expect(ambiguityProbeReads).toBeGreaterThanOrEqual(
+        probe === "delayed-visible" ? 2 : 1,
+      );
+      expect(submittedCommands).toEqual(
+        probe === "delayed-visible" ? [fixture.launcher_command] : [],
+      );
       expect(submittedCommands).not.toContain(
         fixture.captured_corrupted_command,
       );


### PR DESCRIPTION
## Summary

- fixes the actual duplicate injection point in `src/server.ts` `sendChunkWithRetry`: a lost write acknowledgement plus a stale first screen probe caused the same non-idempotent launcher text to be replayed
- observes the pane for bounded delayed visibility and preserves at-most-once launcher mutation; if delivery remains unknowable, spawn fails instead of emitting a second launcher copy
- adds the real surface-530 corruption shape and a deterministic stale-probe regression

## Root cause

`AgentEngine.spawnAgent` creates the pane and calls `sendLaunchCommand` once. Pane creation itself does not carry the command. The second emission came from `sendChunkWithRetry`: after the text had reached the pane but the response was lost, the prior one-shot ambiguity probe could see stale shell output and then retry the same text. With no separator, `skillcreatorCodex -s` became `skillcreatorCodex -sskillcreatorCodex -s`.

## Verification

- RED: the new surface-530 focused regression failed on the previous behavior with two launcher sends
- GREEN: surface-530 focused regression — 1 passed
- adjacent #306/#308/#310 selection — 9 passed
- full suite — 99 files, 1863 tests passed
- pre-PR harness — 4 files, 61 tests passed
- typecheck, build, and staged diff checks passed
- fresh branch-built 0.4.5 stdio MCP live spawn on surface:551 — launcher count 1, corrupted command absent

## Review status

Local CodeRabbit: SKIPPED — remained in summarizing for 3 minutes and was terminated. A fallback red-team/blue-team review of the staged diff found no actionable correctness, concurrency, or security blockers. PR-level reviewers are requested below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn bootstrap delivery semantics: ambiguous failures may surface as errors instead of silent retries, but avoids corrupt double-launcher commands in a critical spawn path.
> 
> **Overview**
> Fixes **duplicate launcher injection** during `spawn_agent` when the initial pane text write succeeds on the transport but the acknowledgement is lost and the first screen read is stale (surface-530: concatenated `skillcreatorCodex -s`).
> 
> In **`sendChunkWithRetry`**, the **`avoidDuplicateOnAmbiguousRetry`** path no longer falls through to a second text send after a one-shot probe misses the command. It **polls the pane** for up to **`SEND_INPUT_SAFE_RETRY_OBSERVE_MS`**, treating visible pending launcher/shell input as success. If the command never appears, it **fails closed** with an explicit ambiguous-ack **`DeliveryError`** instead of replaying the non-idempotent write.
> 
> **`spawn_agent`** now maps **`SurfaceGoneError`** during that observation to the existing **`pane_died`**-style error payload.
> 
> Adds a **surface-530 fixture** and **parameterized server tests** (delayed visibility, never resolves, pane gone) plus an implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaeddf18e5c85465f4d58c6584e03431c60372a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-emit of launcher text on ambiguous pane bootstrap retry
> - Replaces a single-shot observation attempt in `sendChunkWithRetry` with a bounded polling loop that reads the terminal surface until a deadline when a retryable write error occurs with `avoidDuplicateOnAmbiguousRetry` set.
> - If the pending launcher input becomes visible during the loop, the function returns without replaying the text; if the deadline expires, a `DeliveryError` is thrown instead of retrying, preventing corrupted command concatenation.
> - `SurfaceGoneError` during the observation loop now aborts immediately and is rethrown, and `spawn_agent` catches it to return a structured `pane_died` error payload instead of a generic error.
> - Adds integration tests covering delayed-visible ambiguity, always-stale ambiguity, and surface-gone-during-observation scenarios via a new fixture at [`tests/fixtures/spawn/surface-530-stale-probe-double-emit.json`](https://github.com/EtanHey/cmuxlayer/pull/314/files#diff-6501c9b7f8bbc890772b8543f7a8844f35f5af027073ff45844a0c68634f700d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aaeddf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented launcher commands from being submitted twice when transport acknowledgements are delayed or ambiguous.
  - Added bounded observation and verification to distinguish pending launcher text from failed delivery.
  - Reports an explicit delivery error when launcher status cannot be confirmed.

- **Tests**
  - Added coverage for stale screen probes and corrupted command prevention.
  - Updated spawn fixtures to validate exactly-once launcher delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->