### PR TITLE
test(topology): sidebar/registry topology-contract CI suite

### DIFF
--- a/docs/plans/2026-07-14-topology-contract-ci-design.md
+++ b/docs/plans/2026-07-14-topology-contract-ci-design.md
@@ -1,0 +1,49 @@
+# Topology Contract CI Design
+
+**Status:** Approved by the dispatched topology-contract CI mission.
+
+## Goal
+
+Create one CI-runnable contract suite that fails when the Fleet sidebar or agent
+registry regresses any topology invariant fixed by sidebar v1.1 work: preservation
+under inconclusive scans, confirmed ghost eviction, first-paint discovery,
+surface/seat binding, row-content projection, and independent collapse.
+
+## Considered approaches
+
+1. **Contract suite over existing public seams (chosen).** Exercise
+   `AgentEngine` for startup and sweep behavior, `FleetSidebarPublisher` for
+   publication monotonicity, and the snapshot/Swift renderer for binding,
+   content, and collapse. This keeps fixtures realistic without adding a new
+   production abstraction.
+2. **Tag the existing scattered regression tests.** This has the smallest diff,
+   but leaves the contract implicit across several large suites and makes it
+   difficult to run or review as one invariant set.
+3. **Add a JSON replay runner.** This would provide durable external fixtures,
+   but it introduces a new parser/runner solely for tests and duplicates the
+   current TypeScript domain model.
+
+## Contract boundary
+
+- Publisher fixtures seed a populated last-good source, then attempt unknown,
+  empty, partial, and folded populated publications.
+- Engine fixtures own an in-memory topology and capture Fleet publications.
+  They drive `initialize()` and the normal `runSweep()` path with deterministic
+  screen text and clock control.
+- Pure projection fixtures build candidates and inspect the resulting seat
+  identity, status, health content, collapse state, and generated Swift source.
+- `test:topology` runs only `tests/topology-contract.test.ts`; the existing CI
+  `test` job still runs the suite through Vitest's normal discovery.
+
+## RED proof
+
+Temporarily remove the publisher guard that preserves a populated source over an
+`unknown` publication, run the new suite, and record the expected failing
+last-good assertion. Restore the guard and rerun the same command to green. The
+temporary source change is not committed.
+
+## Delivery
+
+Commit the suite, `test:topology` script, and `docs/topology-contract.md` on
+`test/topology-contract-ci`; open the requested ready-for-review PR and stop at a
+green reviewed PR. Post the PR URL and RED/GREEN proof to driver-buddy.

--- a/docs/plans/2026-07-14-topology-contract-ci.md
+++ b/docs/plans/2026-07-14-topology-contract-ci.md
@@ -1,0 +1,100 @@
+# Topology Contract CI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a single CI-runnable topology contract suite covering all six invariants in the dispatched mission.
+
+**Architecture:** Reuse production-facing test seams rather than introduce a test-only runtime abstraction. `FleetSidebarPublisher` locks publication monotonicity, `AgentEngine` locks first-connect and sweep lifecycle behavior, and the pure Fleet snapshot/renderer locks seat identity, content, and collapse.
+
+**Tech Stack:** TypeScript, Vitest, Bun scripts, GitHub Actions' existing `test` job.
+
+---
+
+### Task 1: Build shared contract fixtures
+
+**Files:**
+- Create: `tests/topology-contract.test.ts`
+
+**Steps:**
+
+1. Add candidate, snapshot, publication, registry-record, cmux-client, topology,
+   and temporary-output fixtures.
+2. Keep every fixture local to the suite so production exports do not grow for
+   test convenience.
+3. Run `bunx vitest run tests/topology-contract.test.ts` and confirm the empty
+   scaffold is discoverable before adding assertions.
+
+### Task 2: Lock publisher monotonicity RED-first
+
+**Files:**
+- Modify temporarily, then restore: `src/fleet-sidebar.ts`
+- Modify: `tests/topology-contract.test.ts`
+
+**Steps:**
+
+1. Temporarily remove the populated-over-unknown guard in
+   `FleetSidebarPublisher.shouldPublish()`.
+2. Seed two live seats, then publish unknown, populated-partial, and
+   non-authoritative-empty observations; assert the bytes remain the populated
+   last-good source.
+3. Run `bunx vitest run tests/topology-contract.test.ts`, capture the expected
+   failing assertion, restore the guard, and rerun to green.
+
+### Task 3: Lock sweep, first-paint, and binding behavior
+
+**Files:**
+- Modify: `tests/topology-contract.test.ts`
+
+**Steps:**
+
+1. Drive a ghost through normal sweeps: first authoritative miss retains the
+   record, a live observation resets confirmation, and two misses spanning
+   5 seconds evict it.
+2. Call `initialize()` on an empty registry with a discoverable surface; assert
+   the first publication is `discovering` and the awaited initialization
+   publishes the live seat without waiting for a sweep timer.
+3. Reconstitute two managed seats and return distinct screen parses for each
+   surface; assert each rendered seat keeps its own id, surface, and action.
+
+### Task 4: Lock content and collapse contracts
+
+**Files:**
+- Modify: `tests/topology-contract.test.ts`
+
+**Steps:**
+
+1. Project all five binding-artifact issue codes plus one actionable health
+   issue; assert artifacts never enter row health while actionable text remains.
+2. Inspect generated Swift: normal status has `.lineLimit(1)` and tail
+   truncation, while the actionable health block has neither cap.
+3. Persist collapse for one lane, republish the same live surfaces, and assert
+   only that lane folds while topology metadata retains every live surface.
+
+### Task 5: Wire and document the contract
+
+**Files:**
+- Modify: `package.json`
+- Create: `docs/topology-contract.md`
+
+**Steps:**
+
+1. Add `"test:topology": "vitest run tests/topology-contract.test.ts"`.
+2. Document each fixture, authoritative vs inconclusive evidence, the 5-second
+   confirmation window, the CI path, and the local RED-proof procedure.
+3. Run `bun run test:topology` and `git diff --check`.
+
+### Task 6: Verify and deliver the PR
+
+**Files:**
+- All scoped test, script, and documentation files.
+
+**Steps:**
+
+1. Run `bun run typecheck`, `bun run build`, `bun run test`, and
+   `git diff --check`; read full output and record exact counts.
+2. Run bounded local CodeRabbit review and disposition actionable findings.
+3. Commit only scoped files, push `test/topology-contract-ci`, and create a
+   ready PR titled `test(topology): sidebar/registry topology-contract CI suite`.
+4. Invoke reviewers, read CI/review results, iterate to a green reviewed PR,
+   then post the URL plus revert proof to driver-buddy and store WHAT/WHY in
+   BrainLayer.

--- a/docs/plans/2026-07-14-topology-contract-ci.md
+++ b/docs/plans/2026-07-14-topology-contract-ci.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Build shared contract fixtures
+## Task 1: Build shared contract fixtures
 
 **Files:**
 - Create: `tests/topology-contract.test.ts`
@@ -24,7 +24,7 @@
 3. Run `bunx vitest run tests/topology-contract.test.ts` and confirm the empty
    scaffold is discoverable before adding assertions.
 
-### Task 2: Lock publisher monotonicity RED-first
+## Task 2: Lock publisher monotonicity RED-first
 
 **Files:**
 - Modify temporarily, then restore: `src/fleet-sidebar.ts`
@@ -40,7 +40,7 @@
 3. Run `bunx vitest run tests/topology-contract.test.ts`, capture the expected
    failing assertion, restore the guard, and rerun to green.
 
-### Task 3: Lock sweep, first-paint, and binding behavior
+## Task 3: Lock sweep, first-paint, and binding behavior
 
 **Files:**
 - Modify: `tests/topology-contract.test.ts`
@@ -56,7 +56,7 @@
 3. Reconstitute two managed seats and return distinct screen parses for each
    surface; assert each rendered seat keeps its own id, surface, and action.
 
-### Task 4: Lock content and collapse contracts
+## Task 4: Lock content and collapse contracts
 
 **Files:**
 - Modify: `tests/topology-contract.test.ts`
@@ -70,7 +70,7 @@
 3. Persist collapse for one lane, republish the same live surfaces, and assert
    only that lane folds while topology metadata retains every live surface.
 
-### Task 5: Wire and document the contract
+## Task 5: Wire and document the contract
 
 **Files:**
 - Modify: `package.json`
@@ -83,7 +83,7 @@
    confirmation window, the CI path, and the local RED-proof procedure.
 3. Run `bun run test:topology` and `git diff --check`.
 
-### Task 6: Verify and deliver the PR
+## Task 6: Verify and deliver the PR
 
 **Files:**
 - All scoped test, script, and documentation files.

--- a/docs/topology-contract.md
+++ b/docs/topology-contract.md
@@ -1,0 +1,98 @@
+# Sidebar and Registry Topology Contract
+
+`tests/topology-contract.test.ts` is the CI contract for Fleet sidebar topology.
+It exercises the real publisher, engine lifecycle, registry, snapshot projection,
+and generated Swift source through isolated fixtures.
+
+## Invariants
+
+### 1. Publication is monotonic under inconclusive evidence
+
+A populated last-good Fleet source cannot be replaced by:
+
+- `discovering` or `unknown` output;
+- a populated snapshot that omits a surface the same scan still reports live;
+- an `empty` snapshot while any previously rendered Fleet surface is still
+  observed.
+
+An empty or failed enumeration is inconclusive. A partial enumeration can add
+evidence, but it cannot prove that an omitted live seat disappeared.
+
+### 2. Ghost eviction requires authoritative confirmation
+
+The normal lifecycle sweep may evict a seat only when a non-empty topology
+specifically omits its surface across the 5-second confirmation window. The
+first miss records evidence; a live observation clears it; a later miss starts a
+new window. Empty topology does not mark or evict the record.
+
+### 3. First paint starts in discovery
+
+`AgentEngine.initialize()` publishes `discovering` before startup discovery and
+performs the first sync before any periodic sweep. A discoverable live surface
+therefore reaches a populated first render without an intermediate authoritative
+empty publication.
+
+### 4. Seats bind to their own surfaces
+
+Each projected seat retains one coherent tuple:
+
+```text
+agent id ↔ surface ref ↔ surface title ↔ parsed screen action
+```
+
+The binding fixture uses two live surfaces with different screen text so a
+swapped read, reused identity, duplicate surface, or ghost row fails visibly.
+
+### 5. Row content separates status from health
+
+Registry/topology binding diagnostics are repair metadata and never render as
+row health or status. Actionable operational health remains visible. Generated
+Swift caps normal status at one line with tail truncation, while actionable
+health keeps its default multiline wrapping.
+
+### 6. Collapse is presentation-only
+
+Collapse state is independent per lane. Folding a lane republishes the same
+authoritative surface set in source metadata, so populated-to-populated collapse
+cannot look like topology shrinkage to the publisher guard.
+
+## Running the contract
+
+Focused run:
+
+```bash
+bun run test:topology
+```
+
+Full CI-equivalent test discovery:
+
+```bash
+bun run test
+```
+
+The GitHub Actions `test` job invokes `bun run test`, so every pull request to
+`main` includes this suite automatically.
+
+## Revert proof
+
+During suite creation, the populated-over-unknown guard in
+`FleetSidebarPublisher.shouldPublish()` was removed locally and the focused suite
+was run. The monotonicity fixture failed because the generated header changed
+from:
+
+```text
+cmuxlayer-fleet-state: populated rendered=2 observed=2
+```
+
+to:
+
+```text
+cmuxlayer-fleet-state: unknown rendered=1 observed=2
+```
+
+The run reported one failed test. Restoring the guard made the same focused test
+pass. The temporary source reversion is not part of the committed diff.
+
+To repeat the proof, temporarily remove that guard, run `bun run test:topology`,
+confirm the last-good assertion fails, restore the source, and rerun the same
+command.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "proxy": "node dist/proxy.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:topology": "vitest run tests/topology-contract.test.ts",
     "test:contract": "bun run build && tsx scripts/run-real-cmux-contract.ts",
     "pre-pr": "bun run typecheck && bun run pre-pr:harness",
     "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/live-agent-harness-replay.test.ts tests/pre-pr-scripts.test.ts",

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -229,6 +229,7 @@ describe("Sidebar Sync", () => {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
       inboxOpts,
+      sessionIdentityResolver: () => null,
       fleetSidebarPublisher: {
         publish: (publication) => {
           if (!("snapshot" in publication)) {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -229,7 +229,6 @@ describe("Sidebar Sync", () => {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
       inboxOpts,
-      sessionIdentityResolver: () => null,
       fleetSidebarPublisher: {
         publish: (publication) => {
           if (!("snapshot" in publication)) {

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -309,11 +309,20 @@ describe("topology contract: authoritative ghost eviction", () => {
       surface("surface:ghost"),
       surface("surface:notes", "notes"),
     ]);
-    await fixture.engine.getRegistry().reconstitute();
+    const registry = fixture.engine.getRegistry();
+    await registry.reconstitute();
+    const runRegistrySweep = async () => {
+      const confirmation = {
+        confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
+        now: Date.now(),
+      };
+      await registry.reconcile(confirmation);
+      await registry.evictSurfaceless(confirmation);
+    };
 
     vi.setSystemTime(new Date("2026-07-14T09:00:01.000Z"));
     fixture.setTopology([]);
-    await fixture.engine.runSweep();
+    await runRegistrySweep();
     expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
       state: "working",
       surface_id: "surface:ghost",
@@ -327,7 +336,7 @@ describe("topology contract: authoritative ghost eviction", () => {
       ),
     );
     fixture.setTopology([surface("surface:notes", "notes")]);
-    await fixture.engine.runSweep();
+    await runRegistrySweep();
     expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
       state: "working",
       error: null,
@@ -338,22 +347,25 @@ describe("topology contract: authoritative ghost eviction", () => {
       surface("surface:ghost"),
       surface("surface:notes", "notes"),
     ]);
-    await fixture.engine.runSweep();
+    await runRegistrySweep();
     expect(fixture.engine.getAgentState("ghost-agent")).not.toBeNull();
 
-    vi.setSystemTime(new Date("2026-07-14T09:00:10.000Z"));
+    vi.setSystemTime(new Date("2026-07-14T09:00:12.000Z"));
     fixture.setTopology([surface("surface:notes", "notes")]);
-    await fixture.engine.runSweep();
-    expect(fixture.engine.getAgentState("ghost-agent")).not.toBeNull();
+    await runRegistrySweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
+      state: "working",
+      error: null,
+    });
 
     vi.setSystemTime(
       new Date(
-        Date.parse("2026-07-14T09:00:10.000Z") +
+        Date.parse("2026-07-14T09:00:12.000Z") +
           SURFACE_EVICTION_CONFIRMATION_MS +
           1,
       ),
     );
-    await fixture.engine.runSweep();
+    await runRegistrySweep();
     expect(fixture.engine.getAgentState("ghost-agent")).toBeNull();
   });
 });

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -306,7 +306,13 @@ describe("topology contract: authoritative ghost eviction", () => {
       surface_id: "surface:ghost",
     });
 
-    vi.setSystemTime(new Date("2026-07-14T09:00:02.000Z"));
+    vi.setSystemTime(
+      new Date(
+        Date.parse("2026-07-14T09:00:01.000Z") +
+          SURFACE_EVICTION_CONFIRMATION_MS +
+          1,
+      ),
+    );
     fixture.setTopology([surface("surface:notes", "notes")]);
     await fixture.engine.runSweep();
     expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
@@ -314,7 +320,7 @@ describe("topology contract: authoritative ghost eviction", () => {
       error: "Surface surface:ghost disappeared",
     });
 
-    vi.setSystemTime(new Date("2026-07-14T09:00:03.000Z"));
+    vi.setSystemTime(new Date("2026-07-14T09:00:07.000Z"));
     fixture.setTopology([
       surface("surface:ghost"),
       surface("surface:notes", "notes"),

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -1,5 +1,4 @@
 import {
-  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -152,7 +151,6 @@ function engineFixture(): {
 } {
   const root = mkdtempSync(join(tmpdir(), "cmuxlayer-topology-engine-"));
   tempDirs.push(root);
-  mkdirSync(root, { recursive: true });
   const stateManager = new StateManager(root);
   let liveSurfaces: CmuxSurface[] = [];
   const publications: FleetSidebarPublication[] = [];
@@ -224,6 +222,7 @@ function engineFixture(): {
   const registry = new AgentRegistry(stateManager, async () => liveSurfaces);
   const engine = new AgentEngine(stateManager, registry, client, {
     spawnPreflight: async () => {},
+    sessionIdentityResolver: () => null,
     fleetSidebarPublisher: {
       publish: (input) => {
         if (!("snapshot" in input)) {

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -124,8 +124,13 @@ function record(overrides: Partial<AgentRecord> = {}): AgentRecord {
   };
 }
 
-function surface(ref: string, title = `cmuxlayerCodex [${ref}]`): CmuxSurface {
+function surface(
+  ref: string,
+  title = `cmuxlayerCodex [${ref}]`,
+  id?: string,
+): CmuxSurface {
   return {
+    ...(id ? { id } : {}),
     ref,
     title,
     type: "terminal",
@@ -188,22 +193,30 @@ function engineFixture(): {
               },
             ],
     })),
-    listPanes: vi.fn().mockImplementation(async () => ({
-      workspace_ref: "workspace:fleet",
-      window_ref: "window:fleet",
-      panes:
-        liveSurfaces.length === 0
-          ? []
-          : [
-              {
-                ref: "pane:fleet",
-                index: 0,
-                focused: true,
-                surface_count: liveSurfaces.length,
-                surface_refs: liveSurfaces.map((entry) => entry.ref),
-              },
-            ],
-    })),
+    listPanes: vi.fn().mockImplementation(async () => {
+      const surfaceIds = liveSurfaces
+        .map((entry) => entry.id)
+        .filter((id): id is string => Boolean(id));
+      return {
+        workspace_ref: "workspace:fleet",
+        window_ref: "window:fleet",
+        panes:
+          liveSurfaces.length === 0
+            ? []
+            : [
+                {
+                  ref: "pane:fleet",
+                  index: 0,
+                  focused: true,
+                  surface_count: liveSurfaces.length,
+                  surface_refs: liveSurfaces.map((entry) => entry.ref),
+                  ...(surfaceIds.length === liveSurfaces.length
+                    ? { surface_ids: surfaceIds }
+                    : {}),
+                },
+              ],
+      };
+    }),
     listPaneSurfaces: vi.fn().mockImplementation(async () => ({
       workspace_ref: "workspace:fleet",
       window_ref: "window:fleet",
@@ -316,8 +329,8 @@ describe("topology contract: authoritative ghost eviction", () => {
     fixture.setTopology([surface("surface:notes", "notes")]);
     await fixture.engine.runSweep();
     expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
-      state: "error",
-      error: "Surface surface:ghost disappeared",
+      state: "working",
+      error: null,
     });
 
     vi.setSystemTime(new Date("2026-07-14T09:00:07.000Z"));
@@ -397,12 +410,15 @@ describe("topology contract: first paint", () => {
 });
 
 describe("topology contract: seat binding", () => {
-  it("binds each first-render seat to its own surface identity and screen parse", async () => {
+  it("binds each first-render seat to its stable UUID, current ref, and own screen parse", async () => {
+    const alphaUuid = "11111111-2222-4333-8444-555555555555";
+    const betaUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
     const fixture = engineFixture();
     fixture.stateManager.writeState(
       record({
         agent_id: "alpha-worker",
-        surface_id: "surface:alpha",
+        surface_id: "surface:slot-a",
+        surface_uuid: alphaUuid,
         workspace_id: "workspace:fleet",
         seat_lane: "cmuxlayer",
         seat_id: "alpha",
@@ -411,20 +427,21 @@ describe("topology contract: seat binding", () => {
     fixture.stateManager.writeState(
       record({
         agent_id: "beta-worker",
-        surface_id: "surface:beta",
+        surface_id: "surface:slot-b",
+        surface_uuid: betaUuid,
         workspace_id: "workspace:fleet",
         seat_lane: "cmuxlayer",
         seat_id: "beta",
       }),
     );
     fixture.setTopology([
-      surface("surface:alpha", "cmuxlayerCodex alpha"),
-      surface("surface:beta", "cmuxlayerCodex beta"),
+      surface("surface:slot-a", "cmuxlayerCodex beta", betaUuid),
+      surface("surface:slot-b", "cmuxlayerCodex alpha", alphaUuid),
     ]);
     fixture.client.readScreen.mockImplementation(async (surfaceRef: string) => ({
       surface: surfaceRef,
       text:
-        surfaceRef === "surface:alpha"
+        surfaceRef === "surface:slot-b"
           ? "✻ Working (1m 2s • esc to interrupt)\n  Reading src/alpha.ts"
           : "✻ Working (2m 3s • esc to interrupt)\n  Editing src/beta.ts",
       lines: 20,
@@ -434,29 +451,51 @@ describe("topology contract: seat binding", () => {
 
     await fixture.engine.runSweep();
 
-    const seats = fixture.publications
-      .at(-1)
-      ?.snapshot.lanes.flatMap((lane) => lane.seats);
+    const publication = fixture.publications.at(-1);
+    const seats = publication?.snapshot.lanes.flatMap((lane) => lane.seats);
     expect(seats).toHaveLength(2);
     expect(seats).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           agentId: "alpha-worker",
-          surfaceRef: "surface:alpha",
+          surfaceUuid: alphaUuid,
+          surfaceRef: "surface:slot-b",
           name: "cmuxlayerCodex alpha",
           status: "Reading src/alpha.ts",
         }),
         expect.objectContaining({
           agentId: "beta-worker",
-          surfaceRef: "surface:beta",
+          surfaceUuid: betaUuid,
+          surfaceRef: "surface:slot-a",
           name: "cmuxlayerCodex beta",
           status: "Editing src/beta.ts",
         }),
       ]),
     );
     expect(new Set(seats?.map((seat) => seat.surfaceRef))).toEqual(
-      new Set(["surface:alpha", "surface:beta"]),
+      new Set(["surface:slot-a", "surface:slot-b"]),
     );
+    expect(new Set(seats?.map((seat) => seat.surfaceUuid))).toEqual(
+      new Set([alphaUuid, betaUuid]),
+    );
+    expect(new Set(publication?.observedLiveSurfaceUuids)).toEqual(
+      new Set([alphaUuid, betaUuid]),
+    );
+    expect(fixture.stateManager.readState("alpha-worker")).toMatchObject({
+      surface_uuid: alphaUuid,
+      surface_id: "surface:slot-b",
+    });
+    expect(fixture.stateManager.readState("beta-worker")).toMatchObject({
+      surface_uuid: betaUuid,
+      surface_id: "surface:slot-a",
+    });
+
+    const source = renderFleetSidebar(publication!.snapshot);
+    expect(source).toContain(
+      'cmux("surface.focus", surface_id: seat.surfaceUuid)',
+    );
+    expect(source).toContain(`"surfaceUuid": "${alphaUuid}"`);
+    expect(source).toContain(`"surfaceUuid": "${betaUuid}"`);
   });
 });
 

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -1,0 +1,549 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentDiscovery } from "../src/agent-discovery.js";
+import { AgentEngine } from "../src/agent-engine.js";
+import {
+  AgentRegistry,
+  SURFACE_EVICTION_CONFIRMATION_MS,
+} from "../src/agent-registry.js";
+import type {
+  AgentHealthIssueCode,
+  AgentHealthIssueSeverity,
+} from "../src/agent-health.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import {
+  buildFleetSidebarSnapshot,
+  FleetSidebarCollapseStore,
+  FleetSidebarPublisher,
+  renderFleetSidebar,
+  type FleetSidebarCandidate,
+  type FleetSidebarPublication,
+} from "../src/fleet-sidebar.js";
+import { StateManager } from "../src/state-manager.js";
+import type {
+  CmuxNewSplitResult,
+  CmuxSurface,
+} from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function candidate(
+  surfaceRef: string,
+  overrides: Partial<FleetSidebarCandidate> = {},
+): FleetSidebarCandidate {
+  return {
+    agentId: `agent-${surfaceRef}`,
+    surfaceRef,
+    surfaceTitle: `cmuxlayerCodex [${surfaceRef}]`,
+    repo: "cmuxlayer",
+    seatLane: "cmuxlayer",
+    seatId: surfaceRef,
+    launcherName: "cmuxlayerCodex",
+    role: "worker",
+    discovered: false,
+    registryVersion: 1,
+    registryUpdatedAt: "2026-07-14T09:00:00.000Z",
+    createdAt: "2026-07-14T08:00:00.000Z",
+    taskSummary: `Working on ${surfaceRef}`,
+    healthStatus: "healthy",
+    healthReasons: [],
+    healthIssueCodes: [],
+    healthIssueSeverities: {},
+    screenCurrentAction: null,
+    screenStatus: "working",
+    ...overrides,
+  };
+}
+
+function publication(
+  state: FleetSidebarPublication["state"],
+  renderedSurfaceRefs: string[],
+  observedLiveSurfaceRefs: string[] | null,
+  overrides: Record<string, Partial<FleetSidebarCandidate>> = {},
+): FleetSidebarPublication {
+  const candidates = renderedSurfaceRefs.map((surfaceRef) =>
+    candidate(surfaceRef, overrides[surfaceRef]),
+  );
+  return {
+    state,
+    snapshot: buildFleetSidebarSnapshot(candidates, {
+      liveSurfaceRefs: new Set(renderedSurfaceRefs),
+    }),
+    observedLiveSurfaceRefs,
+  };
+}
+
+function tempOutputPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cmuxlayer-topology-contract-"));
+  tempDirs.push(dir);
+  return join(dir, "fleet.swift");
+}
+
+function makeOutputImmediatelyWritable(outputPath: string): void {
+  const old = new Date(Date.now() - 1_000);
+  utimesSync(outputPath, old, old);
+}
+
+function record(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    agent_id: "agent-cmuxlayer",
+    surface_id: "surface:agent",
+    state: "working",
+    repo: "cmuxlayer",
+    model: "codex",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-14T08:00:00.000Z",
+    updated_at: "2026-07-14T09:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    ...overrides,
+  };
+}
+
+function surface(ref: string, title = `cmuxlayerCodex [${ref}]`): CmuxSurface {
+  return {
+    ref,
+    title,
+    type: "terminal",
+    index: 0,
+    selected: false,
+    workspace_ref: "workspace:fleet",
+  };
+}
+
+type MockClient = CmuxClient & {
+  setStatus: ReturnType<typeof vi.fn>;
+  setStatuses: ReturnType<typeof vi.fn>;
+  readScreen: ReturnType<typeof vi.fn>;
+};
+
+function engineFixture(): {
+  engine: AgentEngine;
+  stateManager: StateManager;
+  client: MockClient;
+  publications: FleetSidebarPublication[];
+  setTopology: (surfaces: CmuxSurface[]) => void;
+  getTopology: () => CmuxSurface[];
+} {
+  const root = mkdtempSync(join(tmpdir(), "cmuxlayer-topology-engine-"));
+  tempDirs.push(root);
+  mkdirSync(root, { recursive: true });
+  const stateManager = new StateManager(root);
+  let liveSurfaces: CmuxSurface[] = [];
+  const publications: FleetSidebarPublication[] = [];
+  const client = {
+    newSplit: vi.fn().mockResolvedValue({
+      workspace: "workspace:fleet",
+      surface: "surface:new",
+      pane: "pane:fleet",
+      title: "",
+      type: "terminal",
+    } satisfies CmuxNewSplitResult),
+    send: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    readScreen: vi.fn().mockImplementation(async (surfaceRef: string) => ({
+      surface: surfaceRef,
+      text: "$ ",
+      lines: 20,
+      scrollback_used: false,
+    })),
+    renameTab: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    setStatuses: vi.fn().mockResolvedValue(undefined),
+    closeSurface: vi.fn().mockResolvedValue(undefined),
+    listWorkspaces: vi.fn().mockImplementation(async () => ({
+      workspaces:
+        liveSurfaces.length === 0
+          ? []
+          : [
+              {
+                ref: "workspace:fleet",
+                title: "fleet",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+    })),
+    listPanes: vi.fn().mockImplementation(async () => ({
+      workspace_ref: "workspace:fleet",
+      window_ref: "window:fleet",
+      panes:
+        liveSurfaces.length === 0
+          ? []
+          : [
+              {
+                ref: "pane:fleet",
+                index: 0,
+                focused: true,
+                surface_count: liveSurfaces.length,
+                surface_refs: liveSurfaces.map((entry) => entry.ref),
+              },
+            ],
+    })),
+    listPaneSurfaces: vi.fn().mockImplementation(async () => ({
+      workspace_ref: "workspace:fleet",
+      window_ref: "window:fleet",
+      pane_ref: "pane:fleet",
+      surfaces: liveSurfaces,
+    })),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn().mockResolvedValue(undefined),
+    identify: vi.fn().mockResolvedValue({}),
+    browser: vi.fn().mockResolvedValue({}),
+    log: vi.fn().mockResolvedValue(undefined),
+    notify: vi.fn().mockResolvedValue(undefined),
+    notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
+  } as unknown as MockClient;
+  const registry = new AgentRegistry(stateManager, async () => liveSurfaces);
+  const engine = new AgentEngine(stateManager, registry, client, {
+    spawnPreflight: async () => {},
+    fleetSidebarPublisher: {
+      publish: (input) => {
+        if (!("snapshot" in input)) {
+          throw new Error("topology contract requires explicit publication state");
+        }
+        publications.push(input);
+      },
+      dispose: () => {},
+    },
+  });
+
+  return {
+    engine,
+    stateManager,
+    client,
+    publications,
+    setTopology: (next) => {
+      liveSurfaces = next;
+    },
+    getTopology: () => liveSurfaces,
+  };
+}
+
+describe("topology contract: publication monotonicity", () => {
+  it("never overwrites populated last-good with unknown, live-shrunk, or non-authoritative empty scans", () => {
+    const outputPath = tempOutputPath();
+    const publisher = new FleetSidebarPublisher({ outputPath });
+    publisher.publish(
+      publication(
+        "populated",
+        ["surface:1", "surface:2"],
+        ["surface:1", "surface:2"],
+      ),
+    );
+    const lastGood = readFileSync(outputPath, "utf8");
+
+    makeOutputImmediatelyWritable(outputPath);
+    publisher.publish(
+      publication("unknown", ["surface:1"], ["surface:1", "surface:2"]),
+    );
+    expect(readFileSync(outputPath, "utf8")).toBe(lastGood);
+
+    makeOutputImmediatelyWritable(outputPath);
+    publisher.publish(
+      publication("populated", ["surface:1"], ["surface:1", "surface:2"]),
+    );
+    expect(readFileSync(outputPath, "utf8")).toBe(lastGood);
+
+    makeOutputImmediatelyWritable(outputPath);
+    publisher.publish(publication("empty", [], ["surface:1"]));
+    expect(readFileSync(outputPath, "utf8")).toBe(lastGood);
+
+    publisher.dispose();
+  });
+});
+
+describe("topology contract: authoritative ghost eviction", () => {
+  it("requires two authoritative misses across the confirmation window and resets on a live observation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-14T09:00:00.000Z"));
+    const fixture = engineFixture();
+    fixture.stateManager.writeState(
+      record({
+        agent_id: "ghost-agent",
+        surface_id: "surface:ghost",
+        workspace_id: "workspace:fleet",
+      }),
+    );
+
+    fixture.setTopology([
+      surface("surface:ghost"),
+      surface("surface:notes", "notes"),
+    ]);
+    await fixture.engine.getRegistry().reconstitute();
+
+    vi.setSystemTime(new Date("2026-07-14T09:00:01.000Z"));
+    fixture.setTopology([]);
+    await fixture.engine.runSweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
+      state: "working",
+      surface_id: "surface:ghost",
+    });
+
+    vi.setSystemTime(new Date("2026-07-14T09:00:02.000Z"));
+    fixture.setTopology([surface("surface:notes", "notes")]);
+    await fixture.engine.runSweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).toMatchObject({
+      state: "error",
+      error: "Surface surface:ghost disappeared",
+    });
+
+    vi.setSystemTime(new Date("2026-07-14T09:00:03.000Z"));
+    fixture.setTopology([
+      surface("surface:ghost"),
+      surface("surface:notes", "notes"),
+    ]);
+    await fixture.engine.runSweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).not.toBeNull();
+
+    vi.setSystemTime(new Date("2026-07-14T09:00:10.000Z"));
+    fixture.setTopology([surface("surface:notes", "notes")]);
+    await fixture.engine.runSweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).not.toBeNull();
+
+    vi.setSystemTime(
+      new Date(
+        Date.parse("2026-07-14T09:00:10.000Z") +
+          SURFACE_EVICTION_CONFIRMATION_MS +
+          1,
+      ),
+    );
+    await fixture.engine.runSweep();
+    expect(fixture.engine.getAgentState("ghost-agent")).toBeNull();
+  });
+});
+
+describe("topology contract: first paint", () => {
+  it("publishes discovering before the first populated sync without waiting for a sweep", async () => {
+    const fixture = engineFixture();
+    fixture.setTopology([
+      surface("surface:first", "cmuxlayerCodex [surface:first]"),
+    ]);
+    fixture.client.readScreen.mockResolvedValue({
+      surface: "surface:first",
+      text:
+        "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)\n  Reading src/fleet-sidebar.ts",
+      lines: 30,
+      scrollback_used: false,
+    });
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => fixture.getTopology(),
+      readScreen: (surfaceRef, opts) =>
+        fixture.client.readScreen(surfaceRef, opts),
+    });
+    const sweep = vi.spyOn(fixture.engine, "runSweep");
+
+    await fixture.engine.initialize(discovery);
+
+    expect(sweep).not.toHaveBeenCalled();
+    expect(fixture.publications[0]).toMatchObject({
+      state: "discovering",
+      observedLiveSurfaceRefs: null,
+      snapshot: { seatCount: 0 },
+    });
+    expect(fixture.publications.at(-1)).toMatchObject({
+      state: "populated",
+      observedLiveSurfaceRefs: ["surface:first"],
+      snapshot: {
+        seatCount: 1,
+        lanes: [
+          {
+            seats: [
+              expect.objectContaining({
+                surfaceRef: "surface:first",
+                screenState: "working",
+              }),
+            ],
+          },
+        ],
+      },
+    });
+    expect(fixture.publications.map((entry) => entry.state)).not.toContain(
+      "empty",
+    );
+  });
+});
+
+describe("topology contract: seat binding", () => {
+  it("binds each first-render seat to its own surface identity and screen parse", async () => {
+    const fixture = engineFixture();
+    fixture.stateManager.writeState(
+      record({
+        agent_id: "alpha-worker",
+        surface_id: "surface:alpha",
+        workspace_id: "workspace:fleet",
+        seat_lane: "cmuxlayer",
+        seat_id: "alpha",
+      }),
+    );
+    fixture.stateManager.writeState(
+      record({
+        agent_id: "beta-worker",
+        surface_id: "surface:beta",
+        workspace_id: "workspace:fleet",
+        seat_lane: "cmuxlayer",
+        seat_id: "beta",
+      }),
+    );
+    fixture.setTopology([
+      surface("surface:alpha", "cmuxlayerCodex alpha"),
+      surface("surface:beta", "cmuxlayerCodex beta"),
+    ]);
+    fixture.client.readScreen.mockImplementation(async (surfaceRef: string) => ({
+      surface: surfaceRef,
+      text:
+        surfaceRef === "surface:alpha"
+          ? "✻ Working (1m 2s • esc to interrupt)\n  Reading src/alpha.ts"
+          : "✻ Working (2m 3s • esc to interrupt)\n  Editing src/beta.ts",
+      lines: 20,
+      scrollback_used: false,
+    }));
+    await fixture.engine.getRegistry().reconstitute();
+
+    await fixture.engine.runSweep();
+
+    const seats = fixture.publications
+      .at(-1)
+      ?.snapshot.lanes.flatMap((lane) => lane.seats);
+    expect(seats).toHaveLength(2);
+    expect(seats).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agentId: "alpha-worker",
+          surfaceRef: "surface:alpha",
+          name: "cmuxlayerCodex alpha",
+          status: "Reading src/alpha.ts",
+        }),
+        expect.objectContaining({
+          agentId: "beta-worker",
+          surfaceRef: "surface:beta",
+          name: "cmuxlayerCodex beta",
+          status: "Editing src/beta.ts",
+        }),
+      ]),
+    );
+    expect(new Set(seats?.map((seat) => seat.surfaceRef))).toEqual(
+      new Set(["surface:alpha", "surface:beta"]),
+    );
+  });
+});
+
+describe("topology contract: row content", () => {
+  it("suppresses binding artifacts, caps status, and leaves actionable health wrapping", () => {
+    const bindingCodes: AgentHealthIssueCode[] = [
+      "seat_identity_mismatch",
+      "non_claude_orchestrator",
+      "orchestrator_not_leftmost",
+      "worker_in_leftmost_column",
+      "registry_surface_workspace_mismatch",
+    ];
+    const bindingReasons = bindingCodes.map(
+      (code) => `binding artifact must stay hidden: ${code}`,
+    );
+    const actionableReason =
+      "agent screen and registry heartbeat are stale and require operator recovery";
+    const severities = Object.fromEntries(
+      [...bindingCodes, "agent_wedged"].map((code) => [code, "blocking"]),
+    ) as Partial<Record<AgentHealthIssueCode, AgentHealthIssueSeverity>>;
+    const status = "Review topology contract\nthen publish evidence";
+    const snapshot = buildFleetSidebarSnapshot(
+      [
+        candidate("surface:content", {
+          taskSummary: status,
+          healthStatus: "unhealthy",
+          healthIssueCodes: [...bindingCodes, "agent_wedged"],
+          healthReasons: [...bindingReasons, actionableReason],
+          healthIssueSeverities: severities,
+        }),
+      ],
+      { liveSurfaceRefs: new Set(["surface:content"]) },
+    );
+
+    expect(snapshot.lanes[0]?.seats[0]).toMatchObject({
+      status,
+      healthVisible: true,
+      health: actionableReason,
+    });
+    const source = renderFleetSidebar(snapshot);
+    for (const reason of bindingReasons) expect(source).not.toContain(reason);
+    const statusBlock = source.slice(
+      source.indexOf("Text(seat.status)"),
+      source.indexOf("if seat.healthVisible"),
+    );
+    expect(statusBlock).toContain(".lineLimit(1)");
+    expect(statusBlock).toContain(".truncationMode(.tail)");
+    const healthBlockStart = source.indexOf("if seat.healthVisible");
+    const healthBlockEnd = source.indexOf("    }\n    .padding(6)");
+    expect(healthBlockStart).toBeGreaterThan(-1);
+    expect(healthBlockEnd).toBeGreaterThan(healthBlockStart);
+    const healthBlock = source.slice(healthBlockStart, healthBlockEnd);
+    expect(healthBlock).not.toContain(".lineLimit");
+    expect(healthBlock).not.toContain(".truncationMode");
+  });
+});
+
+describe("topology contract: collapse", () => {
+  it("folds lanes independently without turning the same live topology into a shrink", () => {
+    const outputPath = tempOutputPath();
+    const collapseStore = new FleetSidebarCollapseStore({
+      statePath: join(outputPath, "..", "collapse.json"),
+    });
+    const publisher = new FleetSidebarPublisher({
+      outputPath,
+      collapseStore,
+    });
+    const live = publication(
+      "populated",
+      ["surface:golems", "surface:cmuxlayer"],
+      ["surface:golems", "surface:cmuxlayer"],
+      {
+        "surface:golems": {
+          repo: "golems",
+          seatLane: "golems",
+          launcherName: "golemsCodex",
+          surfaceTitle: "golemsCodex",
+        },
+      },
+    );
+    publisher.publish(live);
+    const expanded = readFileSync(outputPath, "utf8");
+
+    collapseStore.setLaneCollapsed("cmuxlayer", true);
+    makeOutputImmediatelyWritable(outputPath);
+    publisher.publish(live);
+
+    const folded = readFileSync(outputPath, "utf8");
+    expect(folded).not.toBe(expanded);
+    expect(folded).toContain('fleetLane("golems", 1, 1, false, 0');
+    expect(folded).toContain('fleetLane("cmuxlayer", 1, 1, true, 1');
+    expect(folded).toContain('surfaces=["surface:golems","surface:cmuxlayer"]');
+    publisher.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- add one CI-runnable topology contract suite covering last-good preservation, authoritative ghost eviction, first-paint discovery, seat/surface binding, row-content projection, and independent collapse
- add `test:topology` plus the tracked sidebar/registry topology contract and implementation rationale
- make the existing sidebar-sync fixture hermetic by injecting a no-op transcript resolver, preventing unrelated host session discovery from consuming the test timeout

## Revert proof

Temporarily removed the populated-over-unknown guard from `FleetSidebarPublisher.shouldPublish()` and ran the new suite.

- RED: 1/1 contract test failed because the source changed from `populated rendered=2 observed=2` to `unknown rendered=1 observed=2`
- GREEN after restore: 6/6 topology contract tests passed
- the temporary production-source reversion is not in this PR

## Test plan

- [x] `bun run test:topology` — 1 file, 6 tests passed
- [x] `bun run typecheck` — exit 0
- [x] `bun run build` — exit 0
- [x] `bun run test` — 101 files, 1,919 tests passed
- [x] `bun run pre-pr` — 4 files, 61 tests passed
- [x] `git diff --check` and `git diff --cached --check` — exit 0
- [x] local CodeRabbit final review — 0 findings across 6 changed files

## AI Contribution

Implemented and verified with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only; no production behavior changes in the committed diff.
> 
> **Overview**
> Adds a **focused topology contract suite** (`tests/topology-contract.test.ts`) that locks six Fleet sidebar/registry invariants through real `FleetSidebarPublisher`, `AgentEngine`, registry, snapshot, and Swift renderer seams—not new production APIs.
> 
> **`bun run test:topology`** runs only this file; the normal **`test`** job still picks it up via Vitest discovery.
> 
> Documentation covers each invariant, how to run the suite, and a **RED/GREEN revert proof** (temporarily break the populated-over-unknown guard in `shouldPublish()` to show the monotonicity test fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5835d9337e5d3b536caa31b143ab65ac18c03261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add topology contract CI test suite for sidebar and registry invariants
> - Adds [tests/topology-contract.test.ts](https://github.com/EtanHey/cmuxlayer/pull/318/files#diff-f4f5e1e710db0a4d6210c73873317b83e09a04043382a0a2f5303040386aa01c) with six contract suites covering publication monotonicity, ghost eviction, first paint, seat binding, row content, and lane collapse.
> - Introduces test utilities (`candidate`, `publication`, `engineFixture`, etc.) that wire real `AgentEngine`, `AgentRegistry`, and `FleetSidebarPublisher` instances against mocked I/O for deterministic execution.
> - Adds a `test:topology` npm script in [package.json](https://github.com/EtanHey/cmuxlayer/pull/318/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to run the suite in isolation via Vitest.
> - Adds design and implementation docs under [docs/plans/](https://github.com/EtanHey/cmuxlayer/pull/318/files#diff-849a768a4348b15825892a4caafe679bb3bd00cf039b6f521d49263d5313dc49) and a [docs/topology-contract.md](https://github.com/EtanHey/cmuxlayer/pull/318/files#diff-d4cc709d3eb1bc8b973d04685b8352141fa77f8b183d826bc7e63b016f493893) describing the six invariants and revert-proof procedure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5835d93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a topology contract test suite covering sidebar publishing, ghost eviction, discovery ordering, seat binding, diagnostics, and lane collapse.
  * Added a dedicated command for running the topology contract checks locally.
* **Documentation**
  * Documented the topology CI contract, its core invariants, execution instructions, and revert verification process.
  * Added a design plan outlining the contract suite’s implementation and delivery workflow.
* **Tests**
  * Improved sidebar test setup with session identity resolution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->