### PR TITLE
test(sidebar): preserve fleet through mass reconnect

### DIFF
--- a/docs/plans/2026-07-14-clickable-collapsed-leads-mm-lane.md
+++ b/docs/plans/2026-07-14-clickable-collapsed-leads-mm-lane.md
@@ -61,3 +61,11 @@
 2. Generate a fixture-backed sidebar through an injected temporary `outputPath`; render it as a uniquely named staging sidebar and inspect the screenshot pixels for a collapsed clickable lead and an `mm` lane. Never create or mutate `fleet.swift` or `fleet-dev.swift` in the live sidebar directory, and remove the staging output immediately after capture.
 3. Review the diff against the brief, commit the scoped files, push the worker branch, and open `fix(sidebar): clickable collapsed leads + mm lane normalization`.
 4. Post the PR URL to the driver-buddy hub tagged `@cmuxlayerRethink-lead`, then store WHAT changed and WHY in BrainLayer.
+
+### Task 5: Lock fleet-wide reconnect preservation
+
+**Files:**
+- Modify: `tests/fleet-sidebar.test.ts`
+
+1. Publish a 16-seat authoritative last-good snapshot, then simulate every seat entering reconnect at once as a discovering/zero-active publication while all 16 surfaces remain observed.
+2. Assert the publisher preserves the byte-identical 16-seat source and never emits the zero-seat discovery placeholder.

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -1417,6 +1417,28 @@ writeFileSync(process.argv[3], "released");`,
     publisher.dispose();
   });
 
+  it("preserves all 16 last-good seats through a fleet-wide reconnect", async () => {
+    const outputPath = tempOutputPath();
+    const publisher = new FleetSidebarPublisher({ outputPath });
+    const surfaceRefs = Array.from(
+      { length: 16 },
+      (_, index) => `surface:${index + 1}`,
+    );
+    publisher.publish(
+      publication("populated", surfaceRefs, surfaceRefs),
+    );
+    const lastGood = readFileSync(outputPath, "utf8");
+    expect(lastGood).toContain("16 live seats · 16 active");
+
+    publisher.publish(publication("discovering", [], surfaceRefs));
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    const afterReconnect = readFileSync(outputPath, "utf8");
+    expect(afterReconnect).toBe(lastGood);
+    expect(afterReconnect).not.toContain("0 live seats · 0 active");
+    publisher.dispose();
+  });
+
   it("preserves the last-good UUID topology when a complete scan has mixed identity coverage", async () => {
     const outputPath = tempOutputPath();
     const publisher = new FleetSidebarPublisher({ outputPath });


### PR DESCRIPTION
## Why this follow-up exists

PR #321 merged while this commit's guarded push was still running. The commit was pushed immediately afterward, so GitHub correctly excluded it from the already-created merge commit.

## P3 — mass-reconnect regression

- Publish an authoritative 16-seat last-good sidebar.
- Simulate every seat entering reconnect at once as a discovering/zero-active publication while all 16 surfaces remain observed.
- Require the publisher to preserve the byte-identical 16-seat source and forbid the zero-seat placeholder.

## Verification

- Focused P3 test: 1/1 passed.
- `bun run test`: 104 files / 2,128 tests passed.
- `bun run typecheck`: green.
- `bun run build`: green.
- Guarded push hook: nightly contract, terminal-state race fixture, and 2,128-test suite green.

@EtanHey this is the single missing P3 commit from the four-part v0.4.12 scope. Please merge before release; no production runtime code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation updates; no changes to publisher or sidebar runtime behavior.
> 
> **Overview**
> Adds **Task 5** to the fleet sidebar plan and a **P3 regression test** so mass reconnect cannot wipe a full fleet snapshot.
> 
> The new test publishes a populated **16-seat** sidebar, then simulates **fleet-wide reconnect** as a `discovering` publication with **zero rendered seats** while all **16 surfaces stay observed**. It requires `FleetSidebarPublisher` to keep the **byte-identical** last-good Swift output and to **never** emit the `0 live seats · 0 active` discovery placeholder.
> 
> No production/runtime changes—tests and plan documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6ca26ffae97c83ddfc99b39dbd030893d24c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression test for FleetSidebarPublisher preserving last-good seats through fleet-wide reconnect
> Adds a test in [fleet-sidebar.test.ts](https://github.com/EtanHey/cmuxlayer/pull/322/files#diff-8029c10d3545f9c6bf76a341257a4cc83975230e1985c69045a531fc31665e19) that publishes a populated 16-seat state, then simulates a fleet-wide reconnect by publishing a `discovering` state with zero active seats, and asserts the output remains byte-identical to the last-good snapshot without emitting a zero-seat placeholder. Also documents this test scenario as Task 5 in the planning doc.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d6ca26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->