### PR TITLE
fix(recovery): make user-closed panes terminal

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3650,9 +3650,10 @@ export class AgentEngine {
 
   /**
    * Ingest cmux's own app-level close events before lifecycle reconciliation.
-   * A `tab_close` carries the operator intent that a matching managed surface
-   * is terminal; persist that intent before absence can become a recoverable
-   * crash. Forensics remains best-effort and never breaks the sweep.
+   * A `tab_close` or `workspace_teardown` carries the operator intent that a
+   * matching managed surface is terminal; persist that intent before absence
+   * can become a recoverable crash. Forensics remains best-effort and never
+   * breaks the sweep.
    */
   private async runCloseForensicsBestEffort(): Promise<void> {
     if (!this.closeForensicsRunner) return;
@@ -3675,7 +3676,8 @@ export class AgentEngine {
       events
         .filter(
           (event) =>
-            event.origin === "tab_close" &&
+            (event.origin === "tab_close" ||
+              event.origin === "workspace_teardown") &&
             typeof event.cmux_surface_id === "string",
         )
         .map((event) => event.cmux_surface_id!.toLowerCase()),

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -44,9 +44,11 @@ import {
   type AgentRole,
   type AgentState,
   type CliType,
+  type CloseForensicsEvent,
   type PublicAgent,
   type WaitResult,
 } from "./agent-types.js";
+import type { CloseForensicsSweepResult } from "./close-forensics.js";
 import { parseScreen } from "./screen-parser.js";
 import {
   chooseAgentSpawnPlacement,
@@ -313,13 +315,15 @@ export interface AgentEngineOptions {
   monitorRegistryNow?: () => number;
   monitorRegistryNotify?: MonitorDeadmanNotify;
   /**
-   * Best-effort close-forensics ingest, run at the tail of each sweep. It reads
-   * cmux's OWN event stream (`~/.cmuxterm/events.jsonl`) and attributes
-   * app-level `tab_close` deaths that never went through an MCP tool. Defaults
-   * to DISABLED (`null`) so bare construction never reads the real cmux file;
-   * production entrypoints inject the runner. Pass an explicit runner in tests.
+   * Best-effort close-forensics ingest, run before absence reconciliation so a
+   * cmux UI `tab_close` can make the matching managed agent terminal before
+   * crash recovery evaluates it. Defaults to DISABLED (`null`) so bare
+   * construction never reads the real cmux file; production entrypoints inject
+   * the runner. Pass an explicit runner in tests.
    */
-  closeForensicsRunner?: (() => { emitted: number } | Promise<{ emitted: number }>) | null;
+  closeForensicsRunner?: (() =>
+    | CloseForensicsSweepResult
+    | Promise<CloseForensicsSweepResult>) | null;
   /**
    * Receives the reconciled registry, topology, health, and screen evidence.
    * Defaults to a NO-OP so bare engines never write operator configuration.
@@ -763,7 +767,9 @@ export class AgentEngine {
   private monitorRegistryNotify: MonitorDeadmanNotify;
   private monitorRegistrySweepInFlight = false;
   /** Best-effort close-forensics ingest; null when disabled. */
-  private closeForensicsRunner: (() => { emitted: number } | Promise<{ emitted: number }>) | null;
+  private closeForensicsRunner: (() =>
+    | CloseForensicsSweepResult
+    | Promise<CloseForensicsSweepResult>) | null;
   private closeForensicsSweepInFlight = false;
   private fleetSidebarPublisher: FleetSidebarPublisherLike;
   private startupInitializePromise: Promise<void> | null = null;
@@ -3620,6 +3626,7 @@ export class AgentEngine {
 
   private async runSweepOnce(): Promise<void> {
     this.currentSweepScreenSignatures = new Map();
+    await this.runCloseForensicsBestEffort();
     // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
     // but require one confirmation window after the surface is first observed
     // absent. The same gate also applies to terminal worker cleanup below.
@@ -3637,37 +3644,63 @@ export class AgentEngine {
 
     await this.registry.purgeTerminal(surfacelessConfirmation);
     await this.sweepMonitorRegistryBestEffort();
-    this.runCloseForensicsBestEffort();
     await this.syncSidebar();
     await this.drainOutboxBestEffort();
   }
 
   /**
-   * Ingest cmux's own app-level close events at the tail of a sweep and attribute
-   * them (see close-forensics.ts). Fully best-effort: the runner is self-guarding
-   * and never throws, and an in-flight guard prevents overlap if a sweep runs
-   * long. Forensics must never break lifecycle reconciliation.
+   * Ingest cmux's own app-level close events before lifecycle reconciliation.
+   * A `tab_close` carries the operator intent that a matching managed surface
+   * is terminal; persist that intent before absence can become a recoverable
+   * crash. Forensics remains best-effort and never breaks the sweep.
    */
-  private runCloseForensicsBestEffort(): void {
+  private async runCloseForensicsBestEffort(): Promise<void> {
     if (!this.closeForensicsRunner) return;
     if (this.closeForensicsSweepInFlight) return;
     this.closeForensicsSweepInFlight = true;
     try {
-      const result = this.closeForensicsRunner();
-      if (result && typeof (result as Promise<unknown>).then === "function") {
-        void (result as Promise<unknown>)
-          .catch(() => {
-            // Never break the sweep on a forensics failure; it retries next sweep.
-          })
-          .finally(() => {
-            this.closeForensicsSweepInFlight = false;
-          });
-        return;
-      }
+      const result = await this.closeForensicsRunner();
+      this.markIntentionalSurfaceCloses(result.events);
     } catch {
       // Never break the sweep on a forensics failure; it retries next sweep.
+    } finally {
+      this.closeForensicsSweepInFlight = false;
     }
-    this.closeForensicsSweepInFlight = false;
+  }
+
+  private markIntentionalSurfaceCloses(
+    events: CloseForensicsEvent[],
+  ): void {
+    const closedSurfaceUuids = new Set(
+      events
+        .filter(
+          (event) =>
+            event.origin === "tab_close" &&
+            typeof event.cmux_surface_id === "string",
+        )
+        .map((event) => event.cmux_surface_id!.toLowerCase()),
+    );
+    if (closedSurfaceUuids.size === 0) return;
+
+    for (const agent of this.registry.list()) {
+      const surfaceUuid = agent.surface_uuid?.toLowerCase();
+      if (
+        !surfaceUuid ||
+        !closedSurfaceUuids.has(surfaceUuid) ||
+        agent.user_killed === true
+      ) {
+        continue;
+      }
+      try {
+        const terminal = this.stateMgr.updateRecord(agent.agent_id, {
+          user_killed: true,
+        });
+        this.registry.set(agent.agent_id, terminal);
+      } catch {
+        // A concurrently removed record cannot be recovered, so no suppression
+        // is needed. Preserve best-effort lifecycle reconciliation.
+      }
+    }
   }
 
   private async sweepMonitorRegistryBestEffort(): Promise<void> {

--- a/src/close-forensics.ts
+++ b/src/close-forensics.ts
@@ -389,15 +389,20 @@ export interface CloseForensicsDeps {
   deltaMs: number;
 }
 
+export interface CloseForensicsSweepResult {
+  emitted: number;
+  events: CloseForensicsEvent[];
+}
+
 /**
  * Run one forensics ingest pass. Fully best-effort: ANY failure (missing file,
  * malformed lines, cursor I/O error, append error) is swallowed — this is
  * forensics, never a critical path, and it must never throw into the sweep.
  * Returns the count emitted for observability/tests.
  */
-export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
-  emitted: number;
-} {
+export function runCloseForensicsSweep(
+  deps: CloseForensicsDeps,
+): CloseForensicsSweepResult {
   try {
     const cursorState =
       safe(() => deps.cursor.readState?.(), undefined) ?? undefined;
@@ -439,7 +444,7 @@ export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
           }
         }
       }
-      return { emitted: 0 };
+      return { emitted: 0, events: [] };
     }
     const cmuxEvents =
       safe(() => parseCmuxEvents(text), [] as CmuxEvent[]) ?? [];
@@ -497,9 +502,9 @@ export function runCloseForensicsSweep(deps: CloseForensicsDeps): {
         // by cursor advances, so we log at-most-once per successful advance.
       }
     }
-    return { emitted: events.length };
+    return { emitted: events.length, events };
   } catch {
-    return { emitted: 0 };
+    return { emitted: 0, events: [] };
   }
 }
 
@@ -680,7 +685,7 @@ export function createDefaultCloseForensicsRunner(config: {
   listSurfacesForRefMap?: SurfaceRefMapLister;
   surfaceRefMapTtlMs?: number;
   surfaceRefMapTimeoutMs?: number;
-}): () => Promise<{ emitted: number }> {
+}): () => Promise<CloseForensicsSweepResult> {
   const eventsPath = config.eventsPath ?? defaultCmuxEventsPath();
   const deltaMs = config.deltaMs ?? DEFAULT_DELTA_MS;
   const now = config.now ?? (() => new Date().toISOString());

--- a/src/server.ts
+++ b/src/server.ts
@@ -6812,21 +6812,38 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         const collapsePane = closePolicy?.collapsePane ?? false;
+        const observedSurface = await findSurfaceByRef(
+          args.surface,
+          args.workspace,
+        );
+        const requestedSurfaceKey = args.surface.toLowerCase();
+        const observedSurfaceUuid = observedSurface?.id?.toLowerCase();
         await client.closeSurface(args.surface, {
           workspace: args.workspace,
           collapsePane,
         });
         for (const record of stateMgr.listStates()) {
-          if (
-            record.surface_id !== args.surface &&
-            record.surface_uuid !== args.surface
-          ) {
+          const matchesClosedSurface = record.surface_uuid
+            ? record.surface_uuid.toLowerCase() === requestedSurfaceKey ||
+              record.surface_uuid.toLowerCase() === observedSurfaceUuid
+            : record.surface_id === args.surface;
+          if (!matchesClosedSurface) {
             continue;
           }
-          const terminal = stateMgr.updateRecord(record.agent_id, {
-            user_killed: true,
-          });
-          context.lifecycleRegistry?.set(record.agent_id, terminal);
+          try {
+            const terminal = stateMgr.updateRecord(record.agent_id, {
+              user_killed: true,
+            });
+            context.lifecycleRegistry?.set(record.agent_id, terminal);
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.message === `Agent not found: ${record.agent_id}`
+            ) {
+              continue;
+            }
+            throw error;
+          }
         }
         appendCloseEvent({
           event: "close_surface",

--- a/src/server.ts
+++ b/src/server.ts
@@ -6831,7 +6831,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               record.surface_uuid.toLowerCase() === observedSurfaceUuid ||
               (observedSurfaceUuid === undefined &&
                 record.surface_id === args.surface)
-            : record.surface_id === args.surface;
+            : observedSurfaceUuid === undefined &&
+              record.surface_id === args.surface;
           if (!matchesClosedSurface) {
             continue;
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6816,6 +6816,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: args.workspace,
           collapsePane,
         });
+        for (const record of stateMgr.listStates()) {
+          if (
+            record.surface_id !== args.surface &&
+            record.surface_uuid !== args.surface
+          ) {
+            continue;
+          }
+          const terminal = stateMgr.updateRecord(record.agent_id, {
+            user_killed: true,
+          });
+          context.lifecycleRegistry?.set(record.agent_id, terminal);
+        }
         appendCloseEvent({
           event: "close_surface",
           target: args.surface,

--- a/src/server.ts
+++ b/src/server.ts
@@ -6823,9 +6823,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           collapsePane,
         });
         for (const record of stateMgr.listStates()) {
+          // Stable identity wins whenever cmux exposes it. On a ref-only or
+          // unavailable observation, preserve the explicit close intent by
+          // falling back to the mutable ref instead of treating it as a crash.
           const matchesClosedSurface = record.surface_uuid
             ? record.surface_uuid.toLowerCase() === requestedSurfaceKey ||
-              record.surface_uuid.toLowerCase() === observedSurfaceUuid
+              record.surface_uuid.toLowerCase() === observedSurfaceUuid ||
+              (observedSurfaceUuid === undefined &&
+                record.surface_id === args.surface)
             : record.surface_id === args.surface;
           if (!matchesClosedSurface) {
             continue;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3418,87 +3418,90 @@ describe("AgentEngine", () => {
       expect(recovered?.respawn_attempts).toBe(1);
     });
 
-    it("treats a cmux UI tab close as terminal before crash recovery", async () => {
-      engine.dispose();
-      const closedSurfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
-      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
-      let closePending = true;
-      const tabClose: CloseForensicsEvent = {
-        ts: "2026-07-14T16:23:48.900Z",
-        event_type: "close_forensics",
-        cmux_surface_id: closedSurfaceUuid,
-        cmux_pane_id: "pane-uuid",
-        window_id: null,
-        boot_id: "boot-uuid",
-        workspace_id: "workspace-uuid",
-        origin: "tab_close",
-        occurred_at: "2026-07-14T16:23:48.852Z",
-        attribution: "app-level:no-mcp-close",
-        client_context: {
-          window_key_cycle_near_close: false,
-          last_window_key_event: null,
-          boot_id_changed_since_prev: false,
-        },
-      };
-      engine = new AgentEngine(stateMgr, registry, mockClient, {
-        spawnPreflight: async () => {},
-        sessionIdentityResolver: () => null,
-        closeForensicsRunner: async () => {
-          const events = closePending ? [tabClose] : [];
-          closePending = false;
-          return { emitted: events.length, events };
-        },
-      });
-      stateMgr.writeState(
-        makeRecord({
-          agent_id: "agent-user-closed",
-          state: "working",
-          surface_id: "surface:user-closed",
-          surface_uuid: closedSurfaceUuid,
-          workspace_id: "ws:1",
-          repo: "brainlayer",
-          model: "gpt-5.4",
-          cli: "codex",
-          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
-          crash_recover: true,
-        }),
-      );
-      liveSurfaces = [
-        {
-          ...makeSurface("surface:user-closed"),
-          id: closedSurfaceUuid,
-          workspace_ref: "ws:1",
-        },
-      ];
-      await registry.reconstitute();
-
-      liveSurfaces = [
-        {
-          ...makeSurface("surface:other"),
-          id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
-          workspace_ref: "ws:1",
-        },
-      ];
-      const firstObservedAt = Date.now();
-      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstObservedAt);
-      try {
-        await engine.runSweep();
-        expect(engine.getAgentState("agent-user-closed")).toMatchObject({
-          state: "working",
-          user_killed: true,
-          surface_uuid: closedSurfaceUuid,
+    it.each(["tab_close", "workspace_teardown"] as const)(
+      "treats a cmux UI %s as terminal before crash recovery",
+      async (closeOrigin) => {
+        engine.dispose();
+        const closedSurfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        let closePending = true;
+        const tabClose: CloseForensicsEvent = {
+          ts: "2026-07-14T16:23:48.900Z",
+          event_type: "close_forensics",
+          cmux_surface_id: closedSurfaceUuid,
+          cmux_pane_id: "pane-uuid",
+          window_id: null,
+          boot_id: "boot-uuid",
+          workspace_id: "workspace-uuid",
+          origin: closeOrigin,
+          occurred_at: "2026-07-14T16:23:48.852Z",
+          attribution: "app-level:no-mcp-close",
+          client_context: {
+            window_key_cycle_near_close: false,
+            last_window_key_event: null,
+            boot_id_changed_since_prev: false,
+          },
+        };
+        engine = new AgentEngine(stateMgr, registry, mockClient, {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          closeForensicsRunner: async () => {
+            const events = closePending ? [tabClose] : [];
+            closePending = false;
+            return { emitted: events.length, events };
+          },
         });
-        nowSpy.mockReturnValue(
-          firstObservedAt + SURFACE_EVICTION_CONFIRMATION_MS + 1,
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "agent-user-closed",
+            state: "working",
+            surface_id: "surface:user-closed",
+            surface_uuid: closedSurfaceUuid,
+            workspace_id: "ws:1",
+            repo: "brainlayer",
+            model: "gpt-5.4",
+            cli: "codex",
+            cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+            crash_recover: true,
+          }),
         );
-        await engine.runSweep();
-      } finally {
-        nowSpy.mockRestore();
-      }
+        liveSurfaces = [
+          {
+            ...makeSurface("surface:user-closed"),
+            id: closedSurfaceUuid,
+            workspace_ref: "ws:1",
+          },
+        ];
+        await registry.reconstitute();
 
-      expect(mockClient.newSplit).not.toHaveBeenCalled();
-      expect(engine.getAgentState("agent-user-closed")).toBeNull();
-    });
+        liveSurfaces = [
+          {
+            ...makeSurface("surface:other"),
+            id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+            workspace_ref: "ws:1",
+          },
+        ];
+        const firstObservedAt = Date.now();
+        const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstObservedAt);
+        try {
+          await engine.runSweep();
+          expect(engine.getAgentState("agent-user-closed")).toMatchObject({
+            state: "working",
+            user_killed: true,
+            surface_uuid: closedSurfaceUuid,
+          });
+          nowSpy.mockReturnValue(
+            firstObservedAt + SURFACE_EVICTION_CONFIRMATION_MS + 1,
+          );
+          await engine.runSweep();
+        } finally {
+          nowSpy.mockRestore();
+        }
+
+        expect(mockClient.newSplit).not.toHaveBeenCalled();
+        expect(engine.getAgentState("agent-user-closed")).toBeNull();
+      },
+    );
 
     it("does not recover foreign or unowned crash records in a scoped observer", async () => {
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -36,6 +36,7 @@ import {
   MAX_RESPAWN_ATTEMPTS,
   type AgentRecord,
   type AgentRoute,
+  type CloseForensicsEvent,
 } from "../src/agent-types.js";
 import { SpawnGuard, SpawnRateLimitedError } from "../src/spawn-guard.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
@@ -3415,6 +3416,88 @@ describe("AgentEngine", () => {
         "11111111-2222-4333-8444-555555555555",
       );
       expect(recovered?.respawn_attempts).toBe(1);
+    });
+
+    it("treats a cmux UI tab close as terminal before crash recovery", async () => {
+      engine.dispose();
+      const closedSurfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      let closePending = true;
+      const tabClose: CloseForensicsEvent = {
+        ts: "2026-07-14T16:23:48.900Z",
+        event_type: "close_forensics",
+        cmux_surface_id: closedSurfaceUuid,
+        cmux_pane_id: "pane-uuid",
+        window_id: null,
+        boot_id: "boot-uuid",
+        workspace_id: "workspace-uuid",
+        origin: "tab_close",
+        occurred_at: "2026-07-14T16:23:48.852Z",
+        attribution: "app-level:no-mcp-close",
+        client_context: {
+          window_key_cycle_near_close: false,
+          last_window_key_event: null,
+          boot_id_changed_since_prev: false,
+        },
+      };
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        closeForensicsRunner: async () => {
+          const events = closePending ? [tabClose] : [];
+          closePending = false;
+          return { emitted: events.length, events };
+        },
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-user-closed",
+          state: "working",
+          surface_id: "surface:user-closed",
+          surface_uuid: closedSurfaceUuid,
+          workspace_id: "ws:1",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          crash_recover: true,
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:user-closed"),
+          id: closedSurfaceUuid,
+          workspace_ref: "ws:1",
+        },
+      ];
+      await registry.reconstitute();
+
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:other"),
+          id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+          workspace_ref: "ws:1",
+        },
+      ];
+      const firstObservedAt = Date.now();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstObservedAt);
+      try {
+        await engine.runSweep();
+        expect(engine.getAgentState("agent-user-closed")).toMatchObject({
+          state: "working",
+          user_killed: true,
+          surface_uuid: closedSurfaceUuid,
+        });
+        nowSpy.mockReturnValue(
+          firstObservedAt + SURFACE_EVICTION_CONFIRMATION_MS + 1,
+        );
+        await engine.runSweep();
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(engine.getAgentState("agent-user-closed")).toBeNull();
     });
 
     it("does not recover foreign or unowned crash records in a scoped observer", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9740,15 +9740,178 @@ describe("tool handler integration", () => {
     mkdirSync(stateDir, { recursive: true });
 
     const stateMgr = new StateManager(stateDir);
+    const stableSurfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
     stateMgr.writeState({
       agent_id: "worker-crash-recoverable",
       surface_id: "surface:worker-crash-recoverable",
+      surface_uuid: stableSurfaceUuid,
       state: "working",
       repo: "brainlayer",
       model: "codex",
       cli: "codex",
       cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
       task_summary: "mid task",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-14T00:00:00Z",
+      updated_at: "2026-07-14T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: true,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({ caller: {} }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [{ ref: "workspace:1", title: "workspace" }],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            ref: "surface:worker-crash-recoverable",
+            id: stableSurfaceUuid,
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-crash-recoverable", force: true },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(mockClient.closeSurface).toHaveBeenCalled();
+    expect(stateMgr.readState("worker-crash-recoverable")).toMatchObject({
+      user_killed: true,
+      crash_recover: true,
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface does not make a stale UUID owner terminal when its ref was recycled", async () => {
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-close-surface-recycled-ref-terminal",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-stale-ref-owner",
+      surface_id: "surface:recycled-worker",
+      surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      task_summary: "recover the original worker",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-14T00:00:00Z",
+      updated_at: "2026-07-14T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: true,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({ caller: {} }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [{ ref: "workspace:1", title: "workspace" }],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        panes: [{ ref: "pane:1" }],
+      }),
+      listPaneSurfaces: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        pane_ref: "pane:1",
+        surfaces: [
+          {
+            ref: "surface:recycled-worker",
+            id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+            type: "terminal",
+            index: 0,
+            selected: true,
+          },
+        ],
+      }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:recycled-worker", force: true },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(mockClient.closeSurface).toHaveBeenCalled();
+    expect(stateMgr.readState("worker-stale-ref-owner")).toMatchObject({
+      user_killed: false,
+      crash_recover: true,
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("close_surface ignores only a matching agent eviction after the surface closes", async () => {
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-close-surface-concurrent-agent-eviction",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-concurrently-evicted",
+      surface_id: "surface:worker-concurrently-evicted",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      task_summary: "being evicted",
       pid: null,
       version: 1,
       created_at: "2026-07-14T00:00:00Z",
@@ -9774,20 +9937,36 @@ describe("tool handler integration", () => {
       skipAgentLifecycle: true,
     });
     const tool = (server as any)._registeredTools["close_surface"];
+    const updateSpy = vi
+      .spyOn(StateManager.prototype, "updateRecord")
+      .mockImplementationOnce(() => {
+        throw new Error("Agent not found: worker-concurrently-evicted");
+      });
 
-    const result = await tool.handler(
-      { surface: "surface:worker-crash-recoverable", force: true },
-      {} as any,
-    );
+    try {
+      const result = await tool.handler(
+        { surface: "surface:worker-concurrently-evicted", force: true },
+        {} as any,
+      );
 
-    expect(result.isError).not.toBe(true);
-    expect(mockClient.closeSurface).toHaveBeenCalled();
-    expect(stateMgr.readState("worker-crash-recoverable")).toMatchObject({
-      user_killed: true,
-      crash_recover: true,
-    });
+      expect(result.isError).not.toBe(true);
+      expect(mockClient.closeSurface).toHaveBeenCalled();
 
-    rmSync(stateDir, { recursive: true, force: true });
+      updateSpy.mockImplementationOnce(() => {
+        throw new Error("state disk write failed");
+      });
+      const unexpectedFailure = await tool.handler(
+        { surface: "surface:worker-concurrently-evicted", force: true },
+        {} as any,
+      );
+      expect(unexpectedFailure.isError).toBe(true);
+      expect(unexpectedFailure.structuredContent?.error).toContain(
+        "state disk write failed",
+      );
+    } finally {
+      updateSpy.mockRestore();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("close_surface logs a durable close entry with caller, force, and target", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9846,6 +9846,14 @@ describe("tool handler integration", () => {
       respawn_attempts: 0,
       user_killed: false,
     });
+    stateMgr.writeState({
+      ...stateMgr.readState("worker-stale-ref-owner")!,
+      agent_id: "worker-legacy-stale-ref-owner",
+      surface_uuid: undefined,
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f5f",
+      version: 1,
+      user_killed: false,
+    });
 
     const mockClient = {
       identify: vi.fn().mockResolvedValue({ caller: {} }),
@@ -9888,6 +9896,10 @@ describe("tool handler integration", () => {
     expect(result.isError).not.toBe(true);
     expect(mockClient.closeSurface).toHaveBeenCalled();
     expect(stateMgr.readState("worker-stale-ref-owner")).toMatchObject({
+      user_killed: false,
+      crash_recover: true,
+    });
+    expect(stateMgr.readState("worker-legacy-stale-ref-owner")).toMatchObject({
       user_killed: false,
       crash_recover: true,
     });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9892,6 +9892,31 @@ describe("tool handler integration", () => {
       crash_recover: true,
     });
 
+    const degradedRecord = stateMgr.readState("worker-stale-ref-owner")!;
+    stateMgr.writeState({
+      ...degradedRecord,
+      agent_id: "worker-degraded-ref-owner",
+      surface_id: "surface:degraded-worker",
+      surface_uuid: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f4f",
+      version: 1,
+      user_killed: false,
+    });
+    mockClient.listWorkspaces.mockRejectedValueOnce(
+      new Error("surface enumeration unavailable"),
+    );
+
+    const degradedResult = await tool.handler(
+      { surface: "surface:degraded-worker", force: true },
+      {} as any,
+    );
+
+    expect(degradedResult.isError).not.toBe(true);
+    expect(stateMgr.readState("worker-degraded-ref-owner")).toMatchObject({
+      user_killed: true,
+      crash_recover: true,
+    });
+
     rmSync(stateDir, { recursive: true, force: true });
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9732,6 +9732,64 @@ describe("tool handler integration", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
+  it("close_surface makes a forced managed-agent close terminal for crash recovery", async () => {
+    const stateDir = processScopedTmpDir(
+      "cmuxlayer-close-surface-crash-recovery-terminal",
+    );
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "worker-crash-recoverable",
+      surface_id: "surface:worker-crash-recoverable",
+      state: "working",
+      repo: "brainlayer",
+      model: "codex",
+      cli: "codex",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      task_summary: "mid task",
+      pid: null,
+      version: 1,
+      created_at: "2026-07-14T00:00:00Z",
+      updated_at: "2026-07-14T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: true,
+      respawn_attempts: 0,
+      user_killed: false,
+    });
+
+    const mockClient = {
+      identify: vi.fn().mockResolvedValue({ caller: {} }),
+      closeSurface: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["close_surface"];
+
+    const result = await tool.handler(
+      { surface: "surface:worker-crash-recoverable", force: true },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(mockClient.closeSurface).toHaveBeenCalled();
+    expect(stateMgr.readState("worker-crash-recoverable")).toMatchObject({
+      user_killed: true,
+      crash_recover: true,
+    });
+
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
   it("close_surface logs a durable close entry with caller, force, and target", async () => {
     const stateDir = processScopedTmpDir("cmuxlayer-close-surface-eventlog");
     rmSync(stateDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- ingest cmux close-forensics before absence reconciliation, so a UI `tab_close` sets `user_killed` before crash recovery is evaluated
- return attributed close events from the forensics sweep while preserving its best-effort failure contract
- make successful `close_surface` calls terminal for matching managed agents
- preserve genuine PTY-death recovery and the existing respawn ceiling

## Root cause and reproduction

The lifecycle sweep reconciled/evicted missing surfaces and ran crash recovery before the asynchronous close-forensics tail. A user-closing a managed tab therefore looked identical to a disappeared PTY: `crash_recover=true`, a captured CLI session, and no `user_killed` marker.

The live event stream reproduced the race twice on 2026-07-14: a `surface.closed` event with `origin=tab_close` at 16:23:48.852Z was followed by a replacement surface and a crash-recovery respawn; closing the replacement at 16:24:22.664Z produced the same sequence again.

## RED / counterfactual evidence

Before the fix, the two new regressions failed:

- UI `tab_close`: `newSplit` was called once, resurrecting the agent
- forced `close_surface`: `user_killed` remained false

After implementation, temporarily disabling only the two new terminal-intent writes made both tests fail again with `user_killed=false`. Restoring them returned the paired suite to green, including the existing genuine PTY-death respawn test.

## Verification

- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run tests/agent-engine.test.ts tests/close-forensics.test.ts tests/server.test.ts`: 460/460 passed
- focused paired regressions: UI close suppressed, forced close terminal, genuine PTY death still respawns (3/3 passed)
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test`: 104/104 files, 2,129/2,129 tests passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run typecheck`: passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run build`: passed
- real-cmux read-only contract using freshly built dist + isolated daemon: ping, orphan denial, list/read, doctor, and graceful retire/autostart all passed
- `git diff --check`: passed

Pre-commit CodeRabbit CLI review was attempted with the required three-minute bound; the service produced no findings before timeout. Manual diff review found no blocker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lifecycle sweep ordering and crash-recovery eligibility via `user_killed`; incorrect surface matching could suppress legitimate recovery, though tests cover recycled refs and UUID vs ref fallbacks.
> 
> **Overview**
> Fixes a sweep ordering race where missing surfaces were reconciled and crash recovery ran before cmux close-forensics could record operator intent, so UI tab closes looked like PTY deaths and agents with `crash_recover=true` were respawned.
> 
> **Close forensics** now runs at the **start** of each sweep (awaited, not fire-and-forget at the tail). The sweep returns attributed `CloseForensicsEvent[]` in addition to the emit count. New **`markIntentionalSurfaceCloses`** sets `user_killed=true` on registry agents whose `surface_uuid` matches forensics with origin `tab_close` or `workspace_teardown`, before reconcile/evict and **`recoverCrashedAgents`**.
> 
> **`close_surface`** marks matching managed agents terminal immediately after a successful close, using stable UUID when cmux exposes it and falling back to ref when observation is degraded—without marking stale UUID owners when a ref was recycled.
> 
> Tests cover UI close vs respawn, forced close terminal intent, recycled-ref safety, and concurrent eviction handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a5ce0f72252fcc3c88fcdbc6cd49a3abde816b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark user-closed panes as terminal before crash recovery in the agent engine
> - Agents whose surfaces are closed via the cmux UI (tab close or workspace teardown) are now marked `user_killed=true` before reconciliation, preventing them from being treated as crash candidates.
> - Close forensics sweep is now awaited at the start of each sweep cycle in `AgentEngine.runSweepOnce`, replacing the previous non-awaited tail call.
> - A new `markIntentionalSurfaceCloses` method filters forensics events by origin and updates the `StateManager` and lifecycle registry for matching agents.
> - The `close_surface` tool handler in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/323/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) also marks matching agents `user_killed=true` on surface close, using stable UUID matching with a ref fallback.
> - `runCloseForensicsSweep` in [close-forensics.ts](https://github.com/EtanHey/cmuxlayer/pull/323/files#diff-f2c6509ec1163d316086dcaae2b98686183a54a84527fc006f3a12a7f06cda8a) now returns the full `CloseForensicsEvent[]` array alongside the emitted count so callers can act on individual events.
> - Behavioral Change: close forensics now blocks each sweep cycle rather than running in the background, adding latency proportional to forensics sweep duration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07a5ce0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a surface now correctly marks associated agents as user-terminated.
  * Agents whose tabs are closed are no longer incorrectly treated as crashed or automatically restarted.
  * Surface closure handling now works when matching by either surface identifier.

* **Tests**
  * Added coverage for crash recovery and forced surface closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->