### PR TITLE
fix(sidebar): make active and stalled state truthful

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -47,7 +47,7 @@ import {
   type PublicAgent,
   type WaitResult,
 } from "./agent-types.js";
-import { parseScreen } from "./screen-parser.js";
+import { cleanScreenText, parseScreen } from "./screen-parser.js";
 import {
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
@@ -129,6 +129,7 @@ import {
 import type { InboxOpts } from "./inbox.js";
 import {
   buildFleetSidebarSnapshot,
+  DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS,
   type FleetSidebarCandidate,
   type FleetSidebarPublisherLike,
 } from "./fleet-sidebar.js";
@@ -325,6 +326,8 @@ export interface AgentEngineOptions {
    * Defaults to a NO-OP so bare engines never write operator configuration.
    */
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
+  /** Render-only timeout for a working seat whose transcript/output stops advancing. */
+  fleetWorkingNoProgressTimeoutMs?: number;
 }
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
@@ -385,6 +388,11 @@ interface SidebarStatusSnapshot {
   surfaceId: string | null;
   workspaceId: string | null;
   healthSignature: string;
+}
+
+interface FleetScreenProgressSnapshot {
+  signature: string;
+  lastProgressAtMs: number;
 }
 
 export interface SweepTimingOptions {
@@ -744,6 +752,8 @@ export class AgentEngine {
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
   private currentSweepScreenSignatures = new Map<string, string>();
+  /** agentId → last material (de-chromed) screen output change. */
+  private fleetScreenProgress = new Map<string, FleetScreenProgressSnapshot>();
   /** agentId → last-pushed status target/value */
   private sidebarSnapshot = new Map<string, SidebarStatusSnapshot>();
   /** e.g. "a1:spawned", "a1:done", "a1:error" */
@@ -766,6 +776,7 @@ export class AgentEngine {
   private closeForensicsRunner: (() => { emitted: number } | Promise<{ emitted: number }>) | null;
   private closeForensicsSweepInFlight = false;
   private fleetSidebarPublisher: FleetSidebarPublisherLike;
+  private fleetWorkingNoProgressTimeoutMs: number;
   private startupInitializePromise: Promise<void> | null = null;
   private lifecycleMutationTail: Promise<void> = Promise.resolve();
   constructor(
@@ -807,6 +818,12 @@ export class AgentEngine {
       publish: () => {},
       dispose: () => {},
     };
+    this.fleetWorkingNoProgressTimeoutMs =
+      opts?.fleetWorkingNoProgressTimeoutMs ??
+      parseNonNegativeInteger(
+        process.env.CMUXLAYER_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS,
+        DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS,
+      );
     this.spawnGuard = opts?.spawnGuard ?? new SpawnGuard();
     this.postSpawnLivenessMs =
       opts?.postSpawnLivenessMs ??
@@ -1318,6 +1335,24 @@ export class AgentEngine {
     return agent.cli_session_id
       ? loadHarnessSessionWithMeta(harness, agent.cli_session_id)
       : null;
+  }
+
+  private lastAgentProgressAtMs(agent: AgentRecord): number | null {
+    let transcriptProgressAtMs = 0;
+    if (agent.cli_session_path) {
+      const mtimeMs = safeMtimeMs(agent.cli_session_path);
+      if (mtimeMs > 0) transcriptProgressAtMs = mtimeMs;
+    } else {
+      transcriptProgressAtMs =
+        this.loadGroundTruthSession(agent)?.mtime_ms ?? 0;
+    }
+    const screenProgressAtMs =
+      this.fleetScreenProgress.get(agent.agent_id)?.lastProgressAtMs ?? 0;
+    const lastProgressAtMs = Math.max(
+      transcriptProgressAtMs,
+      screenProgressAtMs,
+    );
+    return lastProgressAtMs > 0 ? lastProgressAtMs : null;
   }
 
   private transcriptHasSettledDone(agent: AgentRecord): boolean {
@@ -2018,6 +2053,11 @@ export class AgentEngine {
       nextAgentId,
     );
     this.rekeyAgentMapEntry(
+      this.fleetScreenProgress,
+      previousAgentId,
+      nextAgentId,
+    );
+    this.rekeyAgentMapEntry(
       this.readyPatternMatches,
       previousAgentId,
       nextAgentId,
@@ -2131,9 +2171,27 @@ export class AgentEngine {
         agent.agent_id,
         `${route.surface_id}:${screenTextSignature(screen.text)}`,
       );
+      this.recordFleetScreenProgress(agent.agent_id, screen.text);
       return screen;
     });
     return ctx.screen;
+  }
+
+  private recordFleetScreenProgress(agentId: string, screenText: string): void {
+    const parsed = parseScreen(screenText);
+    const materialOutput = cleanScreenText(
+      screenText,
+      BOOT_SESSION_CAPTURE_LINES,
+    );
+    const signature = screenTextSignature(
+      `${parsed.current_action ?? ""}\n${materialOutput}`,
+    );
+    const previous = this.fleetScreenProgress.get(agentId);
+    if (previous?.signature === signature) return;
+    this.fleetScreenProgress.set(agentId, {
+      signature,
+      lastProgressAtMs: Date.now(),
+    });
   }
 
   private async sweepReadMatchesBinding(
@@ -2760,6 +2818,7 @@ export class AgentEngine {
       }
     }
     this.deliveredLeadMonitorDeathAlerts.delete(agentId);
+    this.fleetScreenProgress.delete(agentId);
   }
 
   private isLeadWatchBlind(
@@ -3272,6 +3331,8 @@ export class AgentEngine {
         fleetCandidates.push({
           agentId: agent.agent_id,
           agentType: agent.cli,
+          agentState: state,
+          lastProgressAtMs: this.lastAgentProgressAtMs(agent),
           surfaceUuid: observedSurfaceUuid ?? undefined,
           surfaceRef: boundSurfaceRef,
           surfaceTitle:
@@ -3438,6 +3499,11 @@ export class AgentEngine {
     const currentAgentIds = new Set(
       this.registry.list().map((a) => a.agent_id),
     );
+    for (const agentId of this.fleetScreenProgress.keys()) {
+      if (!currentAgentIds.has(agentId)) {
+        this.fleetScreenProgress.delete(agentId);
+      }
+    }
     for (const [agentId, snapshot] of this.sidebarSnapshot) {
       if (!currentAgentIds.has(agentId)) {
         try {
@@ -3463,6 +3529,7 @@ export class AgentEngine {
       ...(observedLiveSurfaceUuids
         ? { liveSurfaceUuids: new Set(observedLiveSurfaceUuids) }
         : {}),
+      workingNoProgressTimeoutMs: this.fleetWorkingNoProgressTimeoutMs,
     });
     const publicationState =
       !topologyIsAuthoritative

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -17,10 +17,11 @@ import {
   type AgentHealthIssueSeverity,
   type AgentHealthStatus,
 } from "./agent-health.js";
-import type { AgentRole, CliType } from "./agent-types.js";
+import type { AgentRole, AgentState, CliType } from "./agent-types.js";
 import type { ParsedScreenStatus } from "./types.js";
 
 export type FleetScreenState = "working" | "idle" | "stalled";
+export const DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS = 120_000;
 export type FleetLaneKey =
   | "orc"
   | "golems"
@@ -33,6 +34,9 @@ export type FleetLaneKey =
 export interface FleetSidebarCandidate {
   agentId: string;
   agentType: CliType;
+  agentState: AgentState;
+  /** Latest transcript/output progress, not the registry heartbeat. */
+  lastProgressAtMs: number | null;
   /** Stable cmux UUID. Absent only for legacy/ref-only compatibility. */
   surfaceUuid?: string;
   surfaceRef: string;
@@ -150,8 +154,36 @@ const NON_ACTIONABLE_SIDEBAR_HEALTH_CODES = new Set<AgentHealthIssueCode>([
 
 export function toFleetScreenState(
   status: ParsedScreenStatus | null | undefined,
+  evidence: {
+    agentState?: AgentState;
+    lastProgressAtMs?: number | null;
+    nowMs?: number;
+    workingNoProgressTimeoutMs?: number;
+  } = {},
 ): FleetScreenState {
-  if (status === "thinking" || status === "working") return "working";
+  const hasWorkingEvidence =
+    status === "thinking" ||
+    status === "working" ||
+    (status === "idle" &&
+      evidence.agentState === "working" &&
+      evidence.lastProgressAtMs !== null &&
+      evidence.lastProgressAtMs !== undefined);
+  if (hasWorkingEvidence) {
+    const lastProgressAtMs = evidence.lastProgressAtMs;
+    const nowMs = evidence.nowMs ?? Date.now();
+    const timeoutMs =
+      evidence.workingNoProgressTimeoutMs ??
+      DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS;
+    if (
+      lastProgressAtMs !== null &&
+      lastProgressAtMs !== undefined &&
+      Number.isFinite(lastProgressAtMs) &&
+      nowMs - lastProgressAtMs > timeoutMs
+    ) {
+      return "stalled";
+    }
+    return "working";
+  }
   if (status === "idle" || status === "done") return "idle";
   return "stalled";
 }
@@ -257,7 +289,13 @@ function candidateName(candidate: FleetSidebarCandidate): string {
   );
 }
 
-function seatFor(candidate: FleetSidebarCandidate): FleetSidebarSeat {
+function seatFor(
+  candidate: FleetSidebarCandidate,
+  opts: {
+    nowMs: number;
+    workingNoProgressTimeoutMs: number;
+  },
+): FleetSidebarSeat {
   const { status, statusMissing } = statusFor(candidate);
   const createdAt = Date.parse(candidate.createdAt);
   const name = candidateName(candidate);
@@ -275,7 +313,12 @@ function seatFor(candidate: FleetSidebarCandidate): FleetSidebarSeat {
     name,
     lane: inferLane(candidate),
     role,
-    screenState: toFleetScreenState(candidate.screenStatus),
+    screenState: toFleetScreenState(candidate.screenStatus, {
+      agentState: candidate.agentState,
+      lastProgressAtMs: candidate.lastProgressAtMs,
+      nowMs: opts.nowMs,
+      workingNoProgressTimeoutMs: opts.workingNoProgressTimeoutMs,
+    }),
     status,
     statusMissing,
     healthStatus: candidate.healthStatus,
@@ -300,6 +343,8 @@ export function buildFleetSidebarSnapshot(
   opts: {
     liveSurfaceRefs: ReadonlySet<string>;
     liveSurfaceUuids?: ReadonlySet<string>;
+    nowMs?: number;
+    workingNoProgressTimeoutMs?: number;
   },
 ): FleetSidebarSnapshot {
   const candidateBySurface = new Map<string, FleetSidebarCandidate>();
@@ -320,7 +365,15 @@ export function buildFleetSidebarSnapshot(
     );
   }
 
-  const seats = [...candidateBySurface.values()].map(seatFor);
+  const seatOptions = {
+    nowMs: opts.nowMs ?? Date.now(),
+    workingNoProgressTimeoutMs:
+      opts.workingNoProgressTimeoutMs ??
+      DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS,
+  };
+  const seats = [...candidateBySurface.values()].map((candidate) =>
+    seatFor(candidate, seatOptions),
+  );
   const lanes = LANE_ORDER.flatMap((key): FleetSidebarLane[] => {
     const laneSeats = seats
       .filter((seat) => seat.lane === key)

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -943,6 +943,24 @@ function latestClaudeSpinnerAction(text: string): string | null {
   return null;
 }
 
+function hasInFlightClaudeTool(text: string): boolean {
+  const lines = text.split("\n").slice(-16);
+  let actionIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (CLAUDE_GLYPH_ACTION_RE.test(lines[index] ?? "")) {
+      actionIndex = index;
+      break;
+    }
+  }
+  if (actionIndex < 0) return false;
+
+  return !lines.slice(actionIndex + 1).some((line) =>
+    /^\s*❯(?:\s|$)/.test(line) ||
+    CLAUDE_DONE_LINE_RE.test(line) ||
+    CLAUDE_COUNTER_RE.test(line),
+  );
+}
+
 function parseCurrentAction(
   text: string,
   agentType: ParsedScreenAgentType,
@@ -1155,6 +1173,10 @@ function inferStatus(
   }
 
   if (agentType === "claude" && latestClaudeSpinnerAction(text) !== null) {
+    return "working";
+  }
+
+  if (agentType === "claude" && hasInFlightClaudeTool(text)) {
     return "working";
   }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -955,7 +955,7 @@ function hasInFlightClaudeTool(text: string): boolean {
   if (actionIndex < 0) return false;
 
   return !lines.slice(actionIndex + 1).some((line) =>
-    /^\s*❯(?:\s|$)/.test(line) ||
+    /^\s*(?:❯|>>>|\$|>)\s*$/.test(line) ||
     CLAUDE_DONE_LINE_RE.test(line) ||
     CLAUDE_COUNTER_RE.test(line),
   );

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -52,6 +52,8 @@ function candidate(
   return {
     agentId: "agent-1",
     agentType: "codex",
+    agentState: "idle",
+    lastProgressAtMs: null,
     surfaceRef: "surface:1",
     surfaceTitle: "cmuxlayerCodex [surface:1]",
     repo: "cmuxlayer",
@@ -83,6 +85,55 @@ describe("fleet sidebar reconciled snapshot", () => {
     expect(toFleetScreenState("frozen")).toBe("stalled");
     expect(toFleetScreenState(null)).toBe("stalled");
     expect(toFleetScreenState(undefined)).toBe("stalled");
+  });
+
+  it("keeps a recently progressing registry-working lead active when screen parsing briefly reports idle", () => {
+    const nowMs = Date.parse("2026-07-14T16:00:00.000Z");
+    const snapshot = buildFleetSidebarSnapshot(
+      [
+        candidate({
+          agentId: "orc-lead",
+          surfaceTitle: "orcClaude LEAD",
+          repo: "orc",
+          role: "orchestrator",
+          screenCurrentAction: "Bash(cat >> orchestra.md)",
+          screenStatus: "idle",
+          agentState: "working",
+          lastProgressAtMs: nowMs - 5_000,
+        }),
+      ],
+      {
+        liveSurfaceRefs: new Set(["surface:1"]),
+        nowMs,
+      },
+    );
+
+    expect(snapshot.lanes[0]).toMatchObject({
+      key: "orc",
+      activeCount: 1,
+      collapsed: false,
+    });
+    expect(snapshot.lanes[0]?.seats[0]?.screenState).toBe("working");
+  });
+
+  it("renders working with no progress past the timeout as stalled", () => {
+    const nowMs = Date.parse("2026-07-14T16:00:00.000Z");
+    const snapshot = buildFleetSidebarSnapshot(
+      [
+        candidate({
+          screenStatus: "working",
+          agentState: "working",
+          lastProgressAtMs: nowMs - 120_001,
+        }),
+      ],
+      {
+        liveSurfaceRefs: new Set(["surface:1"]),
+        nowMs,
+        workingNoProgressTimeoutMs: 120_000,
+      },
+    );
+
+    expect(snapshot.lanes[0]?.seats[0]?.screenState).toBe("stalled");
   });
 
   it("excludes dead-surface ghosts before computing lane counts", () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -87,6 +87,33 @@ Token usage: total=12,345 input=10,000 output=2,345
     expect(parsed.current_action).toBe("Boondoggling");
   });
 
+  it("treats an in-flight Claude Bash tool block as working", () => {
+    const parsed = parseScreen(`
+Claude Code
+⏺ Bash(cat >> /tmp/orchestra.md <<'EOF')
+  ⎿  Running command…
+🤖 Opus 4.8 (1M context) | 💰 $21.76 | ⏱️  9m | 📚 68.1%
+⏵⏵ bypass permissions on · 3 monitors · ← for agents
+`);
+
+    expect(parsed.agent_type).toBe("claude");
+    expect(parsed.status).toBe("working");
+    expect(parsed.current_action).toBe("Bash(cat >> /tmp/orchestra.md <<'EOF')");
+  });
+
+  it("does not revive a completed Claude tool block above a ready composer", () => {
+    const parsed = parseScreen(`
+Claude Code
+⏺ Bash(bun run test)
+  ⎿  Test Files 104 passed
+❯
+🤖 Opus 4.8 (1M context) | 💰 $21.76 | ⏱️  9m | 📚 68.1%
+⏵⏵ bypass permissions on · 3 monitors · ← for agents
+`);
+
+    expect(parsed.status).toBe("idle");
+  });
+
   it.each([
     "* Waiting for deploy... (5m left)",
     "* Building the release (2m elapsed)",

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -101,18 +101,21 @@ Claude Code
     expect(parsed.current_action).toBe("Bash(cat >> /tmp/orchestra.md <<'EOF')");
   });
 
-  it("does not revive a completed Claude tool block above a ready composer", () => {
-    const parsed = parseScreen(`
+  it.each(["❯", ">", ">>>", "$"])(
+    "does not revive a completed Claude tool block above a %s ready prompt",
+    (readyPrompt) => {
+      const parsed = parseScreen(`
 Claude Code
 ⏺ Bash(bun run test)
   ⎿  Test Files 104 passed
-❯
+${readyPrompt}
 🤖 Opus 4.8 (1M context) | 💰 $21.76 | ⏱️  9m | 📚 68.1%
 ⏵⏵ bypass permissions on · 3 monitors · ← for agents
 `);
 
-    expect(parsed.status).toBe("idle");
-  });
+      expect(parsed.status).toBe("idle");
+    },
+  );
 
   it.each([
     "* Waiting for deploy... (5m left)",

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -1178,8 +1178,9 @@ describe("Sidebar Sync", () => {
     ];
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:no-progress",
-      text: "gpt-5.6 xhigh · 99% left\nWorking (1s • esc to interrupt)",
-      lines: 2,
+      text:
+        "Claude Code\n✻ Baking… (1s · ↑ 4)\n🤖 Opus 4.8 | ⏱️ 1s\n⏵⏵ bypass permissions on",
+      lines: 4,
       scrollback_used: false,
     });
     await engine.getRegistry().reconstitute();
@@ -1200,8 +1201,9 @@ describe("Sidebar Sync", () => {
     vi.setSystemTime(startedAt.getTime() + 120_001);
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:no-progress",
-      text: "gpt-5.6 xhigh · 98% left\nWorking (2m 1s • esc to interrupt)",
-      lines: 2,
+      text:
+        "Claude Code\n✻ Baking… (2m 1s · ↑ 99)\n🤖 Opus 4.8 | ⏱️ 2m\n⏵⏵ bypass permissions on",
+      lines: 4,
       scrollback_used: false,
     });
 

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -1153,6 +1153,72 @@ describe("Sidebar Sync", () => {
     ]);
   });
 
+  it("marks a registry-working screen stalled after de-chromed output stops progressing", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-14T16:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "no-transcript-progress",
+        surface_id: "surface:no-progress",
+        workspace_id: "workspace:cmuxlayer",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerCodex",
+        state: "working",
+        cli_session_id: null,
+        cli_session_path: null,
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:no-progress"),
+        title: "cmuxlayerCodex [surface:no-progress]",
+        workspace_ref: "workspace:cmuxlayer",
+      },
+    ];
+    mockClient.readScreen.mockResolvedValue({
+      surface: "surface:no-progress",
+      text: "gpt-5.6 xhigh · 99% left\nWorking (1s • esc to interrupt)",
+      lines: 2,
+      scrollback_used: false,
+    });
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    expect(
+      publishedFleetPublications.at(-1)?.snapshot.lanes.flatMap(
+        (lane) => lane.seats,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        agentId: "no-transcript-progress",
+        screenState: "working",
+      }),
+    ]);
+
+    vi.setSystemTime(startedAt.getTime() + 120_001);
+    mockClient.readScreen.mockResolvedValue({
+      surface: "surface:no-progress",
+      text: "gpt-5.6 xhigh · 98% left\nWorking (2m 1s • esc to interrupt)",
+      lines: 2,
+      scrollback_used: false,
+    });
+
+    await engine.runSweep();
+
+    expect(
+      publishedFleetPublications.at(-1)?.snapshot.lanes.flatMap(
+        (lane) => lane.seats,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        agentId: "no-transcript-progress",
+        screenState: "stalled",
+      }),
+    ]);
+  });
+
   afterEach(() => {
     engine.dispose();
     vi.useRealTimers();

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -49,6 +49,8 @@ function candidate(
   return {
     agentId: `agent-${surfaceRef}`,
     agentType: "codex",
+    agentState: "working",
+    lastProgressAtMs: null,
     surfaceRef,
     surfaceTitle: `cmuxlayerCodex [${surfaceRef}]`,
     repo: "cmuxlayer",


### PR DESCRIPTION
## Summary
- treat an in-flight Claude tool block (including Bash) as working so LEAD rows and lane active counts stay truthful
- combine registry state with real transcript/output progress instead of trusting a transient idle screen parse
- render working seats as `stalled` after 120s without material progress; the timeout is render-only and tunable with `CMUXLAYER_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS`
- ignore timer/context/status chrome when detecting progress, with transcript mtime as durable evidence when available

## Root cause
The fleet candidate discarded registry state and progress evidence, then derived the rendered state and active count solely from the screen parser. Claude tool blocks without a spinner parsed idle. Conversely, a screen that kept parsing working had no bounded no-progress path to stalled.

## Counterfactual RED
Before implementation, focused tests failed with:
- running registry-working LEAD: lane `activeCount` was `0` and collapsed instead of active
- working beyond `120_000ms` without progress: rendered `working` instead of `stalled`
- in-flight Claude `Bash(...)`: parsed `idle` instead of `working`
- no-transcript screen whose only changes were timer/context chrome: remained `working` after `120_001ms` instead of `stalled`

## Verification
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 104 files, 2,132 tests passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `git diff --check` — passed

## Review disposition
- Local CodeRabbit: **SKIPPED — timeout** after 180s while summarizing; it emitted no findings.
- Fallback blue/red self-review: completed. It found and closed the no-transcript progress hole and removed stale `current_action` as independent working evidence.
- Visual verification: not performed against a deployed build; the lead should replay the round-11 sidebar scenario before merge.

## Scope boundary
No `crash_recover`, respawn, or self-resurrection behavior was changed; that remains owned by the sibling P1 worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible fleet sidebar state and screen status inference on every sweep, but scope is render/classification only with no spawn, stop, or crash-recovery mutations.
> 
> **Overview**
> **Fixes fleet sidebar `working` / `idle` / `stalled` so lane active counts match what agents are actually doing.**
> 
> `AgentEngine` now records **material screen progress** on each sweep (de-chromed output via `cleanScreenText`, ignoring timer/status chrome) and combines that with transcript mtime in `lastAgentProgressAtMs`. Fleet candidates carry `agentState` and `lastProgressAtMs`; `buildFleetSidebarSnapshot` passes a **render-only** no-progress timeout (default 120s, `CMUXLAYER_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS` or `fleetWorkingNoProgressTimeoutMs`).
> 
> `toFleetScreenState` no longer trusts a lone idle screen parse: registry-**working** seats with recent progress stay **working**; working seats with no progress past the timeout become **stalled**.
> 
> `screen-parser` adds **`hasInFlightClaudeTool`** so in-flight Claude tool blocks (e.g. Bash) parse as **working**, and completed blocks above a ready prompt do not.
> 
> Progress maps are rekeyed on agent rename and cleaned up when agents leave the registry; lifecycle/crash behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564c90a6a87e496e0fcb7d194b095c8f1fd584f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar active and stalled states to accurately reflect agent screen progress
> - Adds per-agent screen output tracking in [`agent-engine.ts`](https://github.com/EtanHey/cmuxlayer/pull/324/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5): computes a de-chromed signature of each screen's `current_action` and material output, recording a `lastProgressAtMs` timestamp only when the signature changes.
> - Extends `toFleetScreenState` in [`fleet-sidebar.ts`](https://github.com/EtanHey/cmuxlayer/pull/324/files#diff-343429a0da5bcaa0f6ab3a06fda2828c30fbea38529806483fa10ff150d7e461) to return `'stalled'` when a working agent's last progress timestamp exceeds `DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS` (120s), and to keep seats `'working'` when the screen briefly reports idle but registry state and progress evidence indicate ongoing work.
> - Adds `hasInFlightClaudeTool` in [`screen-parser.ts`](https://github.com/EtanHey/cmuxlayer/pull/324/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) so Claude screens with an unresolved tool block are classified as `'working'` even without a spinner line.
> - Behavioral Change: agents whose screen output stalls for >120s (configurable via `CMUXLAYER_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS`) will now appear as `'stalled'` in the sidebar instead of `'working'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 564c90a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->