### PR TITLE
fix(sidebar): attribute coach and matchmat lanes

### DIFF
--- a/src/fleet-sidebar-cli.ts
+++ b/src/fleet-sidebar-cli.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import {
   defaultFleetSidebarPath,
+  fleetLaneLabel,
   FleetSidebarCollapseStore,
   type FleetLaneKey,
 } from "./fleet-sidebar.js";
@@ -14,15 +15,19 @@ const LANE_KEYS: FleetLaneKey[] = [
   "voicelayer",
   "skillCreator",
   "cmuxlayer",
+  "coach",
   "mm",
   "other",
 ];
 
 const LANE_BY_INPUT = new Map<string, FleetLaneKey>(
-  LANE_KEYS.flatMap((key) => {
-    const normalized = normalizeLaneInput(key);
-    return [[normalized, key] as const];
-  }),
+  [
+    ...LANE_KEYS.flatMap((key) => {
+      const normalized = normalizeLaneInput(key);
+      return [[normalized, key] as const];
+    }),
+    ["matchmat", "mm"] as const,
+  ],
 );
 
 export interface FleetSidebarCommandResult {
@@ -100,7 +105,7 @@ function readRenderedLaneState(
 ): boolean | undefined {
   try {
     const source = readFileSync(sidebarPath, "utf8");
-    const label = JSON.stringify(lane);
+    const label = JSON.stringify(fleetLaneLabel(lane));
     const match = source.match(
       new RegExp(
         `fleetLane\\(${escapeRegExp(label)},\\s*\\d+,\\s*\\d+,\\s*(true|false),`,

--- a/src/fleet-sidebar-cli.ts
+++ b/src/fleet-sidebar-cli.ts
@@ -105,17 +105,18 @@ function readRenderedLaneState(
 ): boolean | undefined {
   try {
     const source = readFileSync(sidebarPath, "utf8");
-    const label = JSON.stringify(fleetLaneLabel(lane));
-    const match = source.match(
-      new RegExp(
-        `fleetLane\\(${escapeRegExp(label)},\\s*\\d+,\\s*\\d+,\\s*(true|false),`,
-      ),
-    );
-    return match?.[1] === "true"
-      ? true
-      : match?.[1] === "false"
-        ? false
-        : undefined;
+    const renderedLabels = new Set([fleetLaneLabel(lane), lane]);
+    for (const renderedLabel of renderedLabels) {
+      const label = JSON.stringify(renderedLabel);
+      const match = source.match(
+        new RegExp(
+          `fleetLane\\(${escapeRegExp(label)},\\s*\\d+,\\s*\\d+,\\s*(true|false),`,
+        ),
+      );
+      if (match?.[1] === "true") return true;
+      if (match?.[1] === "false") return false;
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -27,6 +27,7 @@ export type FleetLaneKey =
   | "voicelayer"
   | "skillCreator"
   | "cmuxlayer"
+  | "coach"
   | "mm"
   | "other";
 
@@ -117,6 +118,7 @@ const LANE_ORDER: FleetLaneKey[] = [
   "voicelayer",
   "skillCreator",
   "cmuxlayer",
+  "coach",
   "mm",
   "other",
 ];
@@ -132,9 +134,14 @@ const LANE_LABELS: Record<FleetLaneKey, string> = {
   voicelayer: "voicelayer",
   skillCreator: "skillCreator",
   cmuxlayer: "cmuxlayer",
-  mm: "mm",
+  coach: "coach",
+  mm: "matchmat",
   other: "other",
 };
+
+export function fleetLaneLabel(key: FleetLaneKey): string {
+  return LANE_LABELS[key];
+}
 
 const NON_ACTIONABLE_SIDEBAR_HEALTH_CODES = new Set<AgentHealthIssueCode>([
   "auto_discovered_agent",
@@ -160,13 +167,14 @@ function normalizedIdentity(value: string | null | undefined): string {
   return (value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
-function isMmIdentity(value: string | null | undefined): boolean {
+function isMatchmatIdentity(value: string | null | undefined): boolean {
   const identity = value?.trim().toLowerCase();
   if (!identity) return false;
   return (
-    /^(?:mm|mm(?:claude|codex|gemini|cursor|kiro))(?:$|[^a-z0-9])/.test(
+    /^(?:(?:mm|matchmat)|(?:mm|matchmat)(?:claude|codex|gemini|cursor|kiro))(?:$|[^a-z0-9])/.test(
       identity,
-    ) || /(?:^|[/\\])mm(?:\.wt)?(?:[/\\]|$)/.test(identity)
+    ) ||
+    /(?:^|[/\\])(?:mm|matchmat)(?:\.wt)?(?:[/\\]|$)/.test(identity)
   );
 }
 
@@ -179,7 +187,7 @@ function inferLane(candidate: FleetSidebarCandidate): FleetLaneKey {
     candidate.agentId,
     candidate.surfaceTitle,
   ];
-  if (rawIdentities.some(isMmIdentity)) return "mm";
+  if (rawIdentities.some(isMatchmatIdentity)) return "mm";
   const identities = rawIdentities.map(normalizedIdentity);
 
   for (const value of identities) {
@@ -187,6 +195,7 @@ function inferLane(candidate: FleetSidebarCandidate): FleetLaneKey {
     if (value.includes("voicelayer")) return "voicelayer";
     if (value.includes("skillcreator")) return "skillCreator";
     if (value.includes("cmuxlayer")) return "cmuxlayer";
+    if (value === "coach" || value.startsWith("coach")) return "coach";
     if (value === "orc" || value.startsWith("orc")) return "orc";
   }
   return "other";
@@ -332,7 +341,7 @@ export function buildFleetSidebarSnapshot(
     return [
       {
         key,
-        label: LANE_LABELS[key],
+        label: fleetLaneLabel(key),
         liveCount: laneSeats.length,
         activeCount,
         collapsed: activeCount === 0,

--- a/tests/fleet-sidebar-cli.test.ts
+++ b/tests/fleet-sidebar-cli.test.ts
@@ -100,6 +100,23 @@ describe("fleet-sidebar CLI fallback", () => {
     expect(store.read()).toEqual({ mm: false });
   });
 
+  it("toggles matchmat from a legacy rendered mm lane state", () => {
+    const { store, sidebarPath } = fixture();
+    writeFileSync(
+      sidebarPath,
+      'fleetLane("mm", 2, 0, true, 2, [\n',
+      "utf8",
+    );
+
+    expect(
+      runFleetSidebarCommand(["toggle", "matchmat"], {
+        store,
+        sidebarPath,
+      }),
+    ).toEqual({ ok: true, message: "mm lane expanded" });
+    expect(store.read()).toEqual({ mm: false });
+  });
+
   it("toggles from the currently rendered state when no preference exists", () => {
     const { store, sidebarPath } = fixture();
     writeFileSync(

--- a/tests/fleet-sidebar-cli.test.ts
+++ b/tests/fleet-sidebar-cli.test.ts
@@ -77,6 +77,29 @@ describe("fleet-sidebar CLI fallback", () => {
     expect(store.read()).toEqual({ mm: true });
   });
 
+  it("accepts matchmat as the canonical alias for the mm collapse key", () => {
+    const { store, sidebarPath } = fixture();
+
+    expect(
+      runFleetSidebarCommand(["expand", "matchmat"], { store, sidebarPath }),
+    ).toEqual({ ok: true, message: "mm lane expanded" });
+    expect(store.read()).toEqual({ mm: false });
+  });
+
+  it("toggles the mm key from the rendered matchmat lane state", () => {
+    const { store, sidebarPath } = fixture();
+    writeFileSync(
+      sidebarPath,
+      'fleetLane("matchmat", 2, 0, true, 2, [\n',
+      "utf8",
+    );
+
+    expect(
+      runFleetSidebarCommand(["toggle", "mm"], { store, sidebarPath }),
+    ).toEqual({ ok: true, message: "mm lane expanded" });
+    expect(store.read()).toEqual({ mm: false });
+  });
+
   it("toggles from the currently rendered state when no preference exists", () => {
     const { store, sidebarPath } = fixture();
     writeFileSync(

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -258,6 +258,44 @@ describe("fleet sidebar reconciled snapshot", () => {
     ]);
   });
 
+  it("attributes coachClaude to a dedicated coach lane", () => {
+    const snapshot = buildFleetSidebarSnapshot(
+      [
+        candidate({
+          agentId: "coach-lead",
+          surfaceTitle: "coachClaude",
+          repo: "coach",
+          launcherName: "coachClaude",
+          role: "orchestrator",
+        }),
+      ],
+      { liveSurfaceRefs: new Set(["surface:1"]) },
+    );
+
+    expect(snapshot.lanes).toEqual([
+      expect.objectContaining({ key: "coach", label: "coach" }),
+    ]);
+    expect(snapshot.lanes.map((lane) => lane.key)).not.toContain("other");
+  });
+
+  it("labels the compatibility mm lane with the canonical matchmat repo", () => {
+    const snapshot = buildFleetSidebarSnapshot(
+      [
+        candidate({
+          agentId: "matchmat-worker",
+          surfaceTitle: "mmCodex",
+          repo: "matchmat",
+          launcherName: "mmCodex",
+        }),
+      ],
+      { liveSurfaceRefs: new Set(["surface:1"]) },
+    );
+
+    expect(snapshot.lanes).toEqual([
+      expect.objectContaining({ key: "mm", label: "matchmat" }),
+    ]);
+  });
+
   it("sorts leads before workers and collapses only all-idle lanes", () => {
     const snapshot = buildFleetSidebarSnapshot(
       [


### PR DESCRIPTION
## Summary
- add a dedicated `coach` fleet lane so `coachClaude` no longer falls through to `other`
- preserve the v0.4.12 internal/collapse key `mm`, but expose the canonical repo label `matchmat`
- accept both `mm` and `matchmat` in the fleet-sidebar CLI and keep rendered-state toggling compatible with the new label
- recognize both launcher aliases and canonical matchmat repo/worktree identities

## Root cause
Fleet attribution used a fixed allow-list without `coach`, so named coach seats reached the `other` fallback. Separately, the compatibility key `mm` doubled as the display label, leaking the launcher prefix instead of the canonical `matchmat` repo identity.

## Counterfactual RED
Before implementation, focused tests failed with:
- `coachClaude` / repo `coach`: emitted lane key+label `other` instead of `coach`
- repo `matchmat` / launcher `mmCodex`: emitted label `mm` instead of `matchmat`
- `toggle mm` against rendered `fleetLane("matchmat", ..., collapsed=true)`: collapsed again instead of expanding, exposing a compatibility regression found during fallback review

## Verification
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 104 files, 2,132 tests passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `git diff --check` — passed

## Review disposition
- Local CodeRabbit: **SKIPPED — rate limit**; free OSS quota reported a 47-minute reset window and emitted no findings.
- Fallback blue/red self-review: completed; it found and fixed the rendered-label `mm` toggle compatibility edge.
- Visual verification: not performed against a deployed build; the lead should replay the round-11 sidebar scenario before merge.

## Scope boundary
This PR is based independently on current `origin/main` and changes only fleet lane attribution/CLI/tests. It does not touch `crash_recover`, respawn, or self-resurrection behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Classification and display-label changes in the fleet sidebar only; collapse state still uses the mm key and legacy rendered labels are handled in toggle.
> 
> **Overview**
> Adds a dedicated **`coach`** fleet lane so coach seats (e.g. `coachClaude`) are classified there instead of **`other`**, and keeps the internal collapse key **`mm`** while rendering the lane as **`matchmat`**.
> 
> **Matchmat** identity matching now treats `matchmat` repo/path/launcher prefixes like existing `mm` aliases. The fleet-sidebar CLI accepts **`matchmat`** as input for the **`mm`** key, and **toggle** reads collapsed state from rendered Swift using both the canonical label and the legacy **`mm`** string so older `fleet.swift` output still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afee540f89f679b9927ab6ec278180e9e72c5360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `coach` lane and rename `mm` lane label to `matchmat` in fleet sidebar
> - Adds `coach` as a new `FleetLaneKey`, ordered before `mm` in the sidebar, with `inferLane` routing `coach*` identities to it.
> - Renames the `mm` lane's display label from `"mm"` to `"matchmat"` and expands identity matching to recognize both `mm` and `matchmat` prefixes/paths.
> - Adds a `fleetLaneLabel` export to resolve canonical lane labels, used by both snapshot building and the CLI's rendered-state detection.
> - The CLI now accepts `"matchmat"` as an input alias for the `mm` lane and reads rendered state by matching either the canonical label or the raw key.
> - Behavioral Change: sidebars that previously rendered the `mm` lane as `"mm"` will now render it as `"matchmat"`; existing sidebar files using the old label are still detected via fallback matching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afee540.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->