### PR TITLE
fix(sidebar): isolate output by cmux instance

### DIFF
--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -71,6 +71,17 @@ cmux's socket. This is what stops a worker from opening in a *different* cmux ap
 (e.g. stable vs nightly). If it is unset and more than one cmux instance is live,
 the factory logs which socket it bound to and how to pin it.
 
+The fleet sidebar follows the same instance axis. Stable keeps its canonical
+`~/.config/cmux/sidebars/fleet.swift` output unchanged. A named socket or bundle
+instance writes `~/.config/cmux-<instance>/sidebars/fleet.swift`; for example,
+`/tmp/cmux-nightly.sock` writes under `~/.config/cmux-nightly/`. Its collapse
+state is isolated under `~/.local/state/cmuxlayer/<instance>/`. Set
+`CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH` to override the generated Swift path
+explicitly; the matching collapse state is stored beside that override. The
+canonical `/tmp/cmux-nightly.sock` and `/tmp/cmux-dev.sock` names stay readable;
+other instance keys include a short hash of the complete socket path or bundle
+ID so distinct identities cannot collide after filename sanitization.
+
 ## Cutting a release (versioning, on the go)
 
 One command does the whole pipeline:

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -764,6 +764,7 @@ function fleetSidebarInstanceKey(
   const bundleMatch = bundleId.match(/^com\.cmuxterm\.app\.(.+)$/i);
   if (!bundleMatch) return null;
   const label = normalizeFleetSidebarInstanceKey(bundleMatch[1]);
+  if (label === null) return null;
   if (label === "nightly" || label === "dev") return label;
   return hashedFleetSidebarInstanceKey(label, bundleId);
 }

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   mkdirSync,
   readFileSync,
@@ -695,20 +696,118 @@ ${content}
 `;
 }
 
-export function defaultFleetSidebarPath(home = homedir()): string {
-  return join(home, ".config", "cmux", "sidebars", "fleet.swift");
+function normalizeFleetSidebarInstanceKey(value: string): string | null {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (
+    normalized === "" ||
+    normalized === "stable" ||
+    normalized === "prod" ||
+    normalized === "production"
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function hashedFleetSidebarInstanceKey(
+  label: string | null,
+  identity: string,
+): string {
+  const digest = createHash("sha256")
+    .update(identity)
+    .digest("hex")
+    .slice(0, 12);
+  return `${label ?? "instance"}-${digest}`;
+}
+
+function fleetSidebarInstanceKey(
+  home: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  const upstreamSocket = env.CMUX_SOCKET_PATH?.trim();
+  if (upstreamSocket) {
+    const socketName = basename(upstreamSocket);
+    const productionStateSocket =
+      dirname(upstreamSocket) === join(home, ".local", "state", "cmux") &&
+      /^cmux-\d+\.sock$/i.test(socketName);
+    const productionTmpSocket =
+      dirname(upstreamSocket) === "/tmp" &&
+      /^(?:cmux|cmux-\d+)\.sock$/i.test(socketName);
+    const productionApplicationSupportSocket =
+      upstreamSocket ===
+      join(home, "Library", "Application Support", "cmux", "cmux.sock");
+    if (
+      productionStateSocket ||
+      productionTmpSocket ||
+      productionApplicationSupportSocket
+    ) {
+      return null;
+    }
+    if (upstreamSocket === "/tmp/cmux-nightly.sock") return "nightly";
+    if (upstreamSocket === "/tmp/cmux-dev.sock") return "dev";
+    const socketStem = socketName
+      .replace(/\.sock$/i, "")
+      .replace(/^cmux(?:[-_.]+)?/i, "");
+    return hashedFleetSidebarInstanceKey(
+      normalizeFleetSidebarInstanceKey(socketStem),
+      upstreamSocket,
+    );
+  }
+
+  const bundleId = env.CMUX_BUNDLE_ID?.trim() ?? "";
+  if (/^com\.cmuxterm\.app$/i.test(bundleId)) {
+    return null;
+  }
+  const bundleMatch = bundleId.match(/^com\.cmuxterm\.app\.(.+)$/i);
+  if (!bundleMatch) return null;
+  const label = normalizeFleetSidebarInstanceKey(bundleMatch[1]);
+  if (label === "nightly" || label === "dev") return label;
+  return hashedFleetSidebarInstanceKey(label, bundleId);
+}
+
+/**
+ * Stable keeps the legacy `~/.config/cmux/sidebars/fleet.swift` contract.
+ * Named socket or bundle instances use `~/.config/cmux-<instance>/sidebars`
+ * so Nightly and development publishers cannot overwrite Stable's source.
+ * Non-canonical identities include a short hash of their complete identity to
+ * prevent distinct socket paths from collapsing onto the same directory.
+ */
+export function defaultFleetSidebarPath(
+  home = homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH?.trim();
+  if (override) return override;
+  const instanceKey = fleetSidebarInstanceKey(home, env);
+  return join(
+    home,
+    ".config",
+    instanceKey ? `cmux-${instanceKey}` : "cmux",
+    "sidebars",
+    "fleet.swift",
+  );
 }
 
 export function defaultFleetSidebarDevPath(home = homedir()): string {
   return join(home, ".config", "cmux", "sidebars", "fleet-dev.swift");
 }
 
-export function defaultFleetSidebarCollapseStatePath(home = homedir()): string {
+export function defaultFleetSidebarCollapseStatePath(
+  home = homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH?.trim();
+  if (override) return `${override}.collapse.json`;
+  const instanceKey = fleetSidebarInstanceKey(home, env);
   return join(
     home,
     ".local",
     "state",
     "cmuxlayer",
+    ...(instanceKey ? [instanceKey] : []),
     "fleet-sidebar-collapse.json",
   );
 }
@@ -898,10 +997,7 @@ export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
 
   constructor(opts: FleetSidebarPublisherOptions = {}) {
     const canonicalOutputPath = defaultFleetSidebarPath();
-    this.outputPath =
-      opts.outputPath ??
-      process.env.CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH ??
-      canonicalOutputPath;
+    this.outputPath = opts.outputPath ?? canonicalOutputPath;
     if (process.env.VITEST === "true" && opts.outputPath === undefined) {
       throw new Error(
         "FleetSidebarPublisher tests must inject an explicit outputPath",
@@ -919,7 +1015,7 @@ export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
       opts.collapseStore ??
       new FleetSidebarCollapseStore(
         this.outputPath === canonicalOutputPath
-          ? {}
+          ? { statePath: defaultFleetSidebarCollapseStatePath() }
           : { statePath: `${this.outputPath}.collapse.json` },
       );
     this.minWriteIntervalMs = Math.max(

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -732,7 +732,7 @@ function fleetSidebarInstanceKey(
     const socketName = basename(upstreamSocket);
     const productionStateSocket =
       dirname(upstreamSocket) === join(home, ".local", "state", "cmux") &&
-      /^cmux-\d+\.sock$/i.test(socketName);
+      /^cmux(?:-\d+)?\.sock$/i.test(socketName);
     const productionTmpSocket =
       dirname(upstreamSocket) === "/tmp" &&
       /^(?:cmux|cmux-\d+)\.sock$/i.test(socketName);

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -1289,6 +1289,15 @@ describe("fleet sidebar atomic publisher", () => {
     ).toBe("/tmp/example-home/.config/cmux/sidebars/fleet.swift");
   });
 
+  it("keeps the non-UID Stable state socket on the legacy sidebar path", () => {
+    expect(
+      defaultFleetSidebarPath("/tmp/example-home", {
+        CMUX_SOCKET_PATH:
+          "/tmp/example-home/.local/state/cmux/cmux.sock",
+      }),
+    ).toBe("/tmp/example-home/.config/cmux/sidebars/fleet.swift");
+  });
+
   it("uses the bundle id when no socket pin identifies the instance", () => {
     expect(
       defaultFleetSidebarPath("/tmp/example-home", {

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -1232,10 +1232,80 @@ describe("fleet sidebar atomic publisher", () => {
     };
   }
 
-  it("uses the canonical home-relative output path", () => {
-    expect(defaultFleetSidebarPath("/tmp/example-home")).toBe(
+  it("keeps the canonical stable output path unchanged", () => {
+    expect(defaultFleetSidebarPath("/tmp/example-home", {})).toBe(
       "/tmp/example-home/.config/cmux/sidebars/fleet.swift",
     );
+  });
+
+  it("uses an isolated output path for the Nightly socket", () => {
+    const stablePath = defaultFleetSidebarPath("/tmp/example-home", {});
+    const nightlyPath = defaultFleetSidebarPath("/tmp/example-home", {
+      CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+    });
+
+    expect(nightlyPath).toBe(
+      "/tmp/example-home/.config/cmux-nightly/sidebars/fleet.swift",
+    );
+    expect(nightlyPath).not.toBe(stablePath);
+  });
+
+  it("derives a separate instance directory from a development socket", () => {
+    expect(
+      defaultFleetSidebarPath("/tmp/example-home", {
+        CMUX_SOCKET_PATH: "/tmp/cmux-dev.sock",
+      }),
+    ).toBe("/tmp/example-home/.config/cmux-dev/sidebars/fleet.swift");
+  });
+
+  it("does not collapse distinct full socket paths with the same basename", () => {
+    const first = defaultFleetSidebarPath("/tmp/example-home", {
+      CMUX_SOCKET_PATH: "/tmp/instance-a/cmux-dev.sock",
+    });
+    const second = defaultFleetSidebarPath("/tmp/example-home", {
+      CMUX_SOCKET_PATH: "/var/run/instance-b/cmux-dev.sock",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("does not collapse distinct socket names during sanitization", () => {
+    const dotted = defaultFleetSidebarPath("/tmp/example-home", {
+      CMUX_SOCKET_PATH: "/tmp/cmux-nightly.v2.sock",
+    });
+    const dashed = defaultFleetSidebarPath("/tmp/example-home", {
+      CMUX_SOCKET_PATH: "/tmp/cmux-nightly-v2.sock",
+    });
+
+    expect(dotted).not.toBe(dashed);
+  });
+
+  it("keeps a production socket stable even when the bundle id says Nightly", () => {
+    expect(
+      defaultFleetSidebarPath("/tmp/example-home", {
+        CMUX_SOCKET_PATH: "/tmp/cmux-501.sock",
+        CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly",
+      }),
+    ).toBe("/tmp/example-home/.config/cmux/sidebars/fleet.swift");
+  });
+
+  it("uses the bundle id when no socket pin identifies the instance", () => {
+    expect(
+      defaultFleetSidebarPath("/tmp/example-home", {
+        CMUX_BUNDLE_ID: "com.cmuxterm.app.nightly",
+      }),
+    ).toBe(
+      "/tmp/example-home/.config/cmux-nightly/sidebars/fleet.swift",
+    );
+  });
+
+  it("lets the explicit sidebar output override win", () => {
+    expect(
+      defaultFleetSidebarPath("/tmp/example-home", {
+        CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+        CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH: "/custom/fleet.swift",
+      }),
+    ).toBe("/custom/fleet.swift");
   });
 
   it("uses a separate discoverable fleet-dev path for development previews", () => {
@@ -1253,9 +1323,93 @@ describe("fleet sidebar atomic publisher", () => {
   });
 
   it("keeps collapse preferences outside cmux's discoverable sidebars directory", () => {
-    expect(defaultFleetSidebarCollapseStatePath("/tmp/example-home")).toBe(
+    expect(
+      defaultFleetSidebarCollapseStatePath("/tmp/example-home", {}),
+    ).toBe(
       "/tmp/example-home/.local/state/cmuxlayer/fleet-sidebar-collapse.json",
     );
+  });
+
+  it("isolates Nightly collapse preferences from stable", () => {
+    const stablePath = defaultFleetSidebarCollapseStatePath(
+      "/tmp/example-home",
+      {},
+    );
+    const nightlyPath = defaultFleetSidebarCollapseStatePath(
+      "/tmp/example-home",
+      { CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock" },
+    );
+
+    expect(nightlyPath).toBe(
+      "/tmp/example-home/.local/state/cmuxlayer/nightly/fleet-sidebar-collapse.json",
+    );
+    expect(nightlyPath).not.toBe(stablePath);
+  });
+
+  it("keeps an overridden sidebar's collapse state beside that output", () => {
+    expect(
+      defaultFleetSidebarCollapseStatePath("/tmp/example-home", {
+        CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH: "/custom/fleet.swift",
+      }),
+    ).toBe("/custom/fleet.swift.collapse.json");
+  });
+
+  it("keeps publishers on stable and Nightly output files isolated", () => {
+    const home = mkdtempSync(join(tmpdir(), "cmuxlayer-fleet-instances-"));
+    tempDirs.push(home);
+    const stableOutputPath = defaultFleetSidebarPath(home, {});
+    const nightlyOutputPath = defaultFleetSidebarPath(home, {
+      CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+    });
+    const stablePublisher = new FleetSidebarPublisher({
+      outputPath: stableOutputPath,
+    });
+    const nightlyPublisher = new FleetSidebarPublisher({
+      outputPath: nightlyOutputPath,
+    });
+
+    stablePublisher.publish(snapshotWithStatus("stable-owner"));
+    nightlyPublisher.publish(snapshotWithStatus("nightly-owner"));
+
+    expect(stableOutputPath).not.toBe(nightlyOutputPath);
+    expect(readFileSync(stableOutputPath, "utf8")).toContain(
+      '"status": "stable-owner"',
+    );
+    expect(readFileSync(nightlyOutputPath, "utf8")).toContain(
+      '"status": "nightly-owner"',
+    );
+    stablePublisher.dispose();
+    nightlyPublisher.dispose();
+  });
+
+  it("keeps publishers with same-named sockets in different directories isolated", () => {
+    const home = mkdtempSync(join(tmpdir(), "cmuxlayer-fleet-collisions-"));
+    tempDirs.push(home);
+    const firstOutputPath = defaultFleetSidebarPath(home, {
+      CMUX_SOCKET_PATH: "/tmp/instance-a/cmux-dev.sock",
+    });
+    const secondOutputPath = defaultFleetSidebarPath(home, {
+      CMUX_SOCKET_PATH: "/var/run/instance-b/cmux-dev.sock",
+    });
+    const firstPublisher = new FleetSidebarPublisher({
+      outputPath: firstOutputPath,
+    });
+    const secondPublisher = new FleetSidebarPublisher({
+      outputPath: secondOutputPath,
+    });
+
+    firstPublisher.publish(snapshotWithStatus("instance-a"));
+    secondPublisher.publish(snapshotWithStatus("instance-b"));
+
+    expect(firstOutputPath).not.toBe(secondOutputPath);
+    expect(readFileSync(firstOutputPath, "utf8")).toContain(
+      '"status": "instance-a"',
+    );
+    expect(readFileSync(secondOutputPath, "utf8")).toContain(
+      '"status": "instance-b"',
+    );
+    firstPublisher.dispose();
+    secondPublisher.dispose();
   });
 
   it("isolates implicit collapse state beside a custom output path", () => {

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -1308,6 +1308,20 @@ describe("fleet sidebar atomic publisher", () => {
     );
   });
 
+  it("keeps Stable bundle aliases on the legacy sidebar path", () => {
+    for (const bundleId of [
+      "com.cmuxterm.app.stable",
+      "com.cmuxterm.app.prod",
+      "com.cmuxterm.app.production",
+    ]) {
+      expect(
+        defaultFleetSidebarPath("/tmp/example-home", {
+          CMUX_BUNDLE_ID: bundleId,
+        }),
+      ).toBe("/tmp/example-home/.config/cmux/sidebars/fleet.swift");
+    }
+  });
+
   it("lets the explicit sidebar output override win", () => {
     expect(
       defaultFleetSidebarPath("/tmp/example-home", {


### PR DESCRIPTION
## Summary

- preserve Stable's exact `~/.config/cmux/sidebars/fleet.swift` output contract
- derive isolated Nightly/dev sidebar and collapse-state paths from `CMUX_SOCKET_PATH` or `CMUX_BUNDLE_ID`
- honor `CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH`, and hash non-canonical full identities so distinct sockets cannot collide after sanitization
- add hermetic TDD coverage for Stable, Nightly, dev, overrides, collapse state, publisher isolation, and collision resistance

## Test plan

- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 104 files / 2,159 tests passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run typecheck` — passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run build` — passed
- pre-push `scripts/run_tests.sh` — exit 0

## Review disposition

Status: CodeRabbit local review SKIPPED — timed out after the bounded three-minute window while still reviewing; stopped with exit 130.

- HIGH: Stable's non-UID `~/.local/state/cmux/cmux.sock` was treated as a named instance — FIXED in `f94fa8d` with a RED/GREEN regression test
- HIGH: Stable bundle aliases (`stable`, `prod`, `production`) were hashed instead of preserving the legacy path — FIXED in `0fae9f4` with a RED/GREEN regression test
- MEDIUM: distinct full socket identities could collide after basename/sanitization — FIXED with a short SHA-256 suffix and RED/GREEN regression tests
- Red-team re-review: prior finding resolved; zero remaining issues
- Independent code review and blue-team review: zero findings

## Scope

MCP-side path-keying enabler only. No app-side Nightly activation, render changes, or single-writer-authority changes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate Fleet sidebar output and collapse state paths by cmux instance
> - Adds `fleetSidebarInstanceKey` to derive a per-instance key from `CMUX_SOCKET_PATH` or `CMUX_BUNDLE_ID`, returning `null` for stable/production and canonical or hashed keys for Nightly, Dev, and other instances.
> - Updates `defaultFleetSidebarPath` and `defaultFleetSidebarCollapseStatePath` to write under `~/.config/cmux-<instance>/` and `~/.local/state/cmuxlayer/<instance>/` for non-stable instances; stable remains at the legacy paths.
> - `CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH` overrides both paths; the collapse state is colocated as `<override>.collapse.json`.
> - `FleetSidebarPublisher` now derives its output and collapse paths via the updated helpers instead of reading env vars directly.
> - Behavioral Change: existing non-stable instances will write to new per-instance paths rather than the shared stable path, so any previously written sidebar files will not be read from the new location.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fae9f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->