### PR TITLE
fix(resync): skip and report missing registry seats

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -104,9 +104,19 @@ export interface RegistryRepairEntry {
   action: "created" | "updated";
 }
 
+export interface RegistryRepairSkip {
+  surface_id: string;
+  surface_uuid?: string | null;
+  surface_title: string;
+  agent_id: string;
+  seat_id: string | null;
+  reason: string;
+}
+
 export interface RegistryRepairSummary {
   repaired: RegistryRepairEntry[];
   evicted: string[];
+  skipped: RegistryRepairSkip[];
 }
 
 interface RegistryRepairCandidate {
@@ -1674,10 +1684,11 @@ export class AgentRegistry {
       hasMixedDiscoveryIdentityCoverage(discovered)
     ) {
       this.surfacelessObservations.clear();
-      return { repaired: [], evicted: [] };
+      return { repaired: [], evicted: [], skipped: [] };
     }
     const repaired: RegistryRepairEntry[] = [];
     const evicted = new Set<string>();
+    const skipped: RegistryRepairSkip[] = [];
     const liveSurfaceRefs = new Set(
       discovered
         .filter((entry) => !entry.read_error)
@@ -1693,14 +1704,30 @@ export class AgentRegistry {
       const candidate = repairCandidateForSurface(entry, opts?.seatRegistry);
       if (!candidate) continue;
 
-      const repair = this.repairDiscoveredSurface(
-        entry,
-        candidate,
-        evicted,
-        liveSurfaceRefs,
-      );
-      if (repair) {
-        repaired.push(repair);
+      try {
+        const repair = this.repairDiscoveredSurface(
+          entry,
+          candidate,
+          evicted,
+          liveSurfaceRefs,
+        );
+        if (repair) {
+          repaired.push(repair);
+        }
+      } catch (error) {
+        if (!(error instanceof AgentNotFoundError)) {
+          throw error;
+        }
+        skipped.push({
+          surface_id: entry.surface_id,
+          ...(entry.surface_uuid != null
+            ? { surface_uuid: entry.surface_uuid }
+            : {}),
+          surface_title: entry.surface_title,
+          agent_id: error.agentId,
+          seat_id: candidate.seat.seat_id,
+          reason: error.message,
+        });
       }
     }
 
@@ -1712,7 +1739,7 @@ export class AgentRegistry {
       evicted.add(removed);
     }
 
-    return { repaired, evicted: [...evicted] };
+    return { repaired, evicted: [...evicted], skipped };
   }
 
   private evictPendingGhostRegistrations(
@@ -1908,7 +1935,16 @@ export class AgentRegistry {
       return null;
     }
 
-    const updated = this.stateMgr.updateRecord(record.agent_id, patch);
+    let updated: AgentRecord;
+    try {
+      updated = this.stateMgr.updateRecord(record.agent_id, patch);
+    } catch (error) {
+      const missingState = this.getMissingStateSentinel(record.agent_id);
+      if (missingState) {
+        throw missingState;
+      }
+      throw error;
+    }
     this.agents.delete(record.agent_id);
     this.agents.set(updated.agent_id, updated);
     return updated;
@@ -1993,7 +2029,7 @@ export class AgentRegistry {
   }
 
   private getMissingStateSentinel(agentId: string): AgentNotFoundError | null {
-    if (this.stateMgr.readState(agentId) !== null) {
+    if (this.stateMgr.hasStateFile(agentId)) {
       return null;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9790,6 +9790,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               added: [...afterIds].filter((id) => !beforeIds.has(id)),
               evicted,
               repaired: repair.repaired,
+              repair_skipped: repair.skipped,
               reflowed,
               reflow_skipped: reflowSkipped,
               mismatches: after

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -12,6 +12,7 @@ import {
   readdirSync,
   rmSync,
   existsSync,
+  type Dirent,
 } from "node:fs";
 import { join } from "node:path";
 import { EventLog } from "./event-log.js";
@@ -258,6 +259,52 @@ export class StateManager {
   readState(agentId: string): AgentRecord | null {
     const dirName = this.resolveStateDir(agentId);
     return dirName ? this.readStateFromDir(dirName) : null;
+  }
+
+  hasStateFile(agentId: string): boolean {
+    const readStrict = (dirName: string): string | null => {
+      try {
+        return readFileSync(this.stateFilePath(dirName), "utf-8");
+      } catch (error) {
+        const code =
+          error && typeof error === "object" && "code" in error
+            ? (error as { code?: unknown }).code
+            : null;
+        if (code === "ENOENT" || code === "ENOTDIR") {
+          return null;
+        }
+        throw error;
+      }
+    };
+
+    if (readStrict(agentId) !== null) {
+      return true;
+    }
+
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(this.baseDir, { withFileTypes: true });
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? (error as { code?: unknown }).code
+          : null;
+      if (code === "ENOENT" || code === "ENOTDIR") {
+        return false;
+      }
+      throw error;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === agentId) continue;
+      const raw = readStrict(entry.name);
+      if (raw === null) continue;
+      const record = JSON.parse(raw) as AgentRecord;
+      if (record.agent_id === agentId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   transition(

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1603,6 +1603,7 @@ describe("AgentRegistry", () => {
       expect(registry.repairFromDiscovery(discovered)).toEqual({
         repaired: [],
         evicted: [],
+        skipped: [],
       });
       expect(stateMgr.listStates()).toEqual([
         expect.objectContaining({

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -2846,6 +2846,186 @@ describe("resync_agents tool", () => {
       launcher_name: "brainlayerClaude",
       seat_id: "brainClaude",
     });
+  });
+
+  it("resync_agents skips a missing-state seat and continues repairs and ghost eviction", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "brainlayerClaude-pending-1710000000-live",
+        surface_id: "surface:27",
+        workspace_id: "workspace:1",
+        repo: "brainlayer",
+        cli: "claude",
+        role: "orchestrator",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "cmuxlayerCodex-pending-1710000000-dead",
+        surface_id: "surface:missing",
+        workspace_id: "workspace:1",
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+      }),
+    );
+
+    const context = createServerContext({
+      exec: makeRegistryRepairExec(),
+      stateDir: TEST_DIR,
+      controlHealthIntervalMs: 0,
+    });
+    const server = createServer({
+      context,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    try {
+      await context.lifecycleStartPromise;
+      const registry = (server as any)._registeredTools[
+        "interact"
+      ]._engine.getRegistry();
+      registry.set(
+        "orcClaude",
+        makeAgentRecord({
+          agent_id: "orcClaude",
+          surface_id: "surface:4",
+          workspace_id: "workspace:1",
+          repo: "stale-orc-metadata",
+          cli: "claude",
+          launcher_name: "staleOrcClaude",
+          role: "worker",
+        }),
+      );
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.diff.repair_skipped).toEqual([
+        {
+          surface_id: "surface:4",
+          surface_title: "🎯 orc-driver",
+          agent_id: "orcClaude",
+          seat_id: "orcClaude",
+          reason: "Agent not found: orcClaude",
+        },
+      ]);
+      expect(parsed.diff.repaired).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            surface_id: "surface:27",
+            agent_id: "brainClaude",
+            seat_id: "brainClaude",
+          }),
+        ]),
+      );
+      expect(parsed.diff.evicted).toContain(
+        "cmuxlayerCodex-pending-1710000000-dead",
+      );
+      expect(stateMgr.readState("brainClaude")).toMatchObject({
+        agent_id: "brainClaude",
+        surface_id: "surface:27",
+      });
+    } finally {
+      await server.close();
+      context.dispose();
+    }
+  });
+
+  it("resync_agents aborts on a same-text repair failure when state exists", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const staleRecord = makeAgentRecord({
+      agent_id: "orcClaude",
+      surface_id: "surface:4",
+      workspace_id: "workspace:1",
+      repo: "stale-orc-metadata",
+      cli: "claude",
+      launcher_name: "staleOrcClaude",
+      role: "worker",
+    });
+    stateMgr.writeState(staleRecord);
+
+    const context = createServerContext({
+      exec: makeRegistryRepairExec(),
+      stateDir: TEST_DIR,
+      controlHealthIntervalMs: 0,
+    });
+    const server = createServer({
+      context,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    try {
+      await context.lifecycleStartPromise;
+      const registry = (server as any)._registeredTools[
+        "interact"
+      ]._engine.getRegistry();
+      registry.set("orcClaude", staleRecord);
+      vi.spyOn(context.stateMgr, "updateRecord").mockImplementation(() => {
+        throw new Error("Agent not found: orcClaude");
+      });
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed).toMatchObject({
+        ok: false,
+        error: "Agent not found: orcClaude",
+      });
+      expect(parsed.diff).toBeUndefined();
+    } finally {
+      await server.close();
+      context.dispose();
+    }
+  });
+
+  it("resync_agents aborts when state presence cannot be resolved", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const staleRecord = makeAgentRecord({
+      agent_id: "orcClaude",
+      surface_id: "surface:4",
+      workspace_id: "workspace:1",
+      repo: "stale-orc-metadata",
+      cli: "claude",
+      launcher_name: "staleOrcClaude",
+      role: "worker",
+    });
+    stateMgr.writeState(staleRecord);
+
+    const context = createServerContext({
+      exec: makeRegistryRepairExec(),
+      stateDir: TEST_DIR,
+      controlHealthIntervalMs: 0,
+    });
+    const server = createServer({
+      context,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+
+    try {
+      await context.lifecycleStartPromise;
+      const statePath = join(TEST_DIR, "orcClaude", "state.json");
+      rmSync(statePath);
+      symlinkSync("state.json", statePath);
+
+      const result = await (server as any)._registeredTools[
+        "resync_agents"
+      ].handler({}, {} as any);
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("ELOOP");
+      expect(parsed.diff).toBeUndefined();
+    } finally {
+      await server.close();
+      context.dispose();
+    }
   });
 
   it("RC4: resync_agents keeps a live pending sibling registered and addressable", async () => {


### PR DESCRIPTION
## Summary

- isolate per-seat missing-state repair failures during `resync_agents`
- continue healthy seat repair and real ghost eviction after a skipped seat
- report skipped seats structurally in `diff.repair_skipped`
- preserve fail-closed behavior for same-text generic errors, corrupt state, and filesystem faults

## TDD evidence

- RED: a missing in-memory seat state aborted the whole resync before healthy repair/ghost eviction
- RED: a persisted seat throwing the same generic `Agent not found` text was incorrectly accepted by the initial message-based boundary
- RED: an `ELOOP` state path was incorrectly classified as absent by `existsSync`
- GREEN: only a typed, strictly proven absent-state sentinel is skipped; every ambiguous/non-absence error aborts with no diff

## Verification

- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 104 files, 2,162 tests passed
- affected suites — 128 tests passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run typecheck`
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run build`
- `git diff --check`
- red-team, blue-team, and implementation reviews: zero remaining findings
- local CodeRabbit CLI: skipped after its bounded three-minute review window; disposition lint passed

No sidebar render or placement code changed. All tests were hermetic; no live cmux/agent session was accessed or mutated.

Do not merge; `@cmuxlayerRethink-lead` owns review and merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent registry repair and resync diff behavior during discovery repair; incorrect skip vs abort logic could leave stale seats or block healthy resyncs, though tests enforce fail-closed on non-absence errors.
> 
> **Overview**
> **`resync_agents` no longer aborts the whole run when one seat’s on-disk state is missing** while the in-memory registry still references it. Per-surface repair failures are isolated: only a typed **`AgentNotFoundError`** (proven absent state) is recorded in **`diff.repair_skipped`** with surface, agent, seat, and reason; other seats continue to repair and ghost eviction proceeds.
> 
> **Missing-state detection is tightened** so “no state file” is not inferred from unreadable paths. **`StateManager.hasStateFile`** reads the state file strictly (ENOENT/ENOTDIR → absent) and can resolve aliased state dirs; **`getMissingStateSentinel`** uses that instead of **`readState`**, so filesystem faults (e.g. **`ELOOP`**) still **fail closed** and abort resync with no diff. **`updateManagedSurfaceRegistration`** maps update failures to the same sentinel only when absence is strictly proven; generic “Agent not found” text when state still exists still aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18216c00988d2b2c5c778be2a8651973c562cfe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip and report missing registry seats during `resync_agents` repair
> - `AgentRegistry.repairFromDiscovery` now catches `AgentNotFoundError` per seat, records a skip entry, and continues processing rather than aborting the entire repair. The repair summary gains a `skipped` array alongside `repaired` and `evicted`.
> - `AgentRegistry.repairExistingRecord` wraps `stateMgr.updateRecord` failures and reclassifies them as `AgentNotFoundError` when no state file exists, allowing upstream logic to skip gracefully.
> - `StateManager.hasStateFile` is added to check agent state existence by scanning state directories, used to distinguish truly missing agents from transient read errors.
> - The `resync_agents` tool response now includes a `repair_skipped` field populated from the skipped entries.
> - Risk: missing-state detection now uses file existence rather than a successful `readState`, so agents with unreadable state files may now be classified as missing and skipped instead of surfacing an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18216c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->