### PR TITLE
feat: enforce provenance-gated role placement

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -22,6 +22,7 @@ import {
 import type { AgentDiscovery } from "./agent-discovery.js";
 import { toPublicAgent } from "./agent-facade.js";
 import type {
+  CmuxMoveSurfaceResult,
   CmuxPane,
   CmuxPaneSurfaces,
   CmuxNewSplitResult,
@@ -51,14 +52,17 @@ import {
 import type { CloseForensicsSweepResult } from "./close-forensics.js";
 import { cleanScreenText, parseScreen } from "./screen-parser.js";
 import {
+  canonicalRoleColumn,
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
   collectRoleSurfaceIds,
+  deriveRoleColumnIndex,
   inferAgentRole,
   inferRecordRole,
   inferRecordRoleOrNull,
   isAgentRoleInferenceError,
   launcherNameForCli,
+  topPaneInRoleColumn,
   type RoleSurfaceIds,
 } from "./layout-policy.js";
 import {
@@ -334,6 +338,26 @@ export interface AgentEngineOptions {
   fleetWorkingNoProgressTimeoutMs?: number;
 }
 
+export type RolePlacementReconcileTrigger =
+  | "spawn"
+  | "idle"
+  | "boot";
+
+export interface RolePlacementReconcileSummary {
+  moved: Array<{
+    agent_id: string;
+    surface_id: string;
+    from_column: number;
+    to_column: number;
+    pane: string;
+  }>;
+  skipped: Array<{
+    agent_id: string;
+    surface_id: string;
+    reason: string;
+  }>;
+}
+
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
 
 const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
@@ -573,6 +597,8 @@ interface AgentEngineClient {
       url?: string;
       title?: string;
       focus?: boolean;
+      beforeMutation?: () => Promise<void>;
+      stableSurfaceIdentity?: string | null;
     },
   ): Promise<CmuxNewSplitResult>;
   newSurface(opts: {
@@ -603,8 +629,20 @@ interface AgentEngineClient {
       workspace?: string;
       collapsePane?: boolean;
       beforeMutation?: () => Promise<void>;
+      stableSurfaceIdentity?: string | null;
     },
   ): Promise<void>;
+  moveSurface(opts: {
+    surface: string;
+    pane?: string;
+    workspace?: string;
+    before?: string;
+    after?: string;
+    index?: number;
+    focus?: boolean;
+    beforeMutation?: () => Promise<void>;
+    stableSurfaceIdentity?: string | null;
+  }): Promise<CmuxMoveSurfaceResult>;
   notify?(opts?: {
     title?: string;
     subtitle?: string;
@@ -1521,6 +1559,11 @@ export class AgentEngine {
         });
       }
       this.registry.set(transitionAgent.agent_id, updated);
+      if (targetState === "idle") {
+        await this.reconcileRolePlacements("idle", {
+          agentIds: new Set([updated.agent_id]),
+        });
+      }
       waitForReadyPatternMatches.delete(agent.agent_id);
       waitForReadyPatternMatches.delete(transitionAgent.agent_id);
       return { agent: updated, source: "screen" };
@@ -1719,7 +1762,8 @@ export class AgentEngine {
       if (
         isAgentRoleInferenceError(error) ||
         error instanceof PlacementSurfaceBindingError ||
-        Boolean(context?.parentAgent?.surface_uuid)
+        Boolean(context?.parentAgent?.surface_uuid) ||
+        canonicalRoleColumn(context?.role ?? "worker") !== null
       ) {
         throw error;
       }
@@ -2671,6 +2715,7 @@ export class AgentEngine {
           surface_id: surface.surface,
           surface_uuid: surface.surface_id ?? null,
           surface_observer_id: surface.observerId,
+          surface_provenance: "cmuxlayer_spawn",
           workspace_id: resumeWorkspace,
           crash_recover: true,
           respawn_attempts: nextRespawnAttempt,
@@ -2915,12 +2960,16 @@ export class AgentEngine {
     }
 
     const spec = LIFECYCLE_LOGS[event];
-    await this.client.log(`${spec.message}: ${agent.repo}`, {
-      level: spec.level,
-      source: "cmuxlayer",
-    });
-
-    this.loggedEvents.add(eventKey);
+    try {
+      await this.client.log(`${spec.message}: ${agent.repo}`, {
+        level: spec.level,
+        source: "cmuxlayer",
+      });
+      this.loggedEvents.add(eventKey);
+    } catch {
+      // Lifecycle logging is auxiliary publication, not boot topology truth.
+      // Retry on the next sweep without failing the daemon's ingestion gate.
+    }
   }
 
   private async notifyLifecycleEvent(
@@ -3575,6 +3624,288 @@ export class AgentEngine {
   }
 
   /**
+   * Restore the two-column role contract without ever taking authority over an
+   * operator-created surface. Provenance authorizes the source mutation;
+   * stable UUID + observer evidence authorizes the current binding.
+   */
+  async reconcileRolePlacements(
+    trigger: RolePlacementReconcileTrigger,
+    opts: { agentIds?: ReadonlySet<string> } = {},
+  ): Promise<RolePlacementReconcileSummary> {
+    const summary: RolePlacementReconcileSummary = { moved: [], skipped: [] };
+    const eligibleForTrigger = (agent: AgentRecord): boolean => {
+      if (agent.surface_provenance !== "cmuxlayer_spawn") return false;
+      if (trigger === "spawn") {
+        return opts.agentIds?.has(agent.agent_id) ?? false;
+      }
+      if (trigger === "idle") return agent.state === "idle";
+      return agent.state === "idle" || TERMINAL_STATES.has(agent.state);
+    };
+    const candidates = this.registry.list().filter((agent) => {
+      if (opts.agentIds && !opts.agentIds.has(agent.agent_id)) return false;
+      if (!eligibleForTrigger(agent)) return false;
+      if (canonicalRoleColumn(inferRecordRoleOrNull(agent) ?? "ic") === null) {
+        return false;
+      }
+      return true;
+    });
+
+    for (const agent of candidates) {
+      const role = inferRecordRoleOrNull(agent);
+      if (!role) continue;
+      const targetColumn = canonicalRoleColumn(role);
+      if (targetColumn === null) continue;
+      if (!agent.surface_uuid || !agent.workspace_id) {
+        summary.skipped.push({
+          agent_id: agent.agent_id,
+          surface_id: agent.surface_id,
+          reason: "stable surface UUID and workspace are required",
+        });
+        continue;
+      }
+
+      const observerEpoch = this.captureSurfaceObserverEpoch();
+      try {
+        const assertFreshAgentBinding = async (
+          expectedSurfaceRef: string,
+          operation: string,
+        ): Promise<void> => {
+          this.assertSurfaceObserverEpochCurrent(observerEpoch, operation);
+          const current =
+            this.registry.get(agent.agent_id) ??
+            this.stateMgr.readState(agent.agent_id);
+          if (
+            !current ||
+            !eligibleForTrigger(current) ||
+            current.surface_uuid?.trim().toLowerCase() !==
+              agent.surface_uuid?.trim().toLowerCase() ||
+            (current.workspace_id ?? null) !== (agent.workspace_id ?? null)
+          ) {
+            throw new Error(
+              "agent provenance, state, or stable binding changed before mutation",
+            );
+          }
+          const topology = await this.collectObservedSurfaceTopology();
+          this.assertSurfaceObserverEpochCurrent(observerEpoch, operation);
+          if (!topology?.complete) {
+            throw new Error("fresh stable UUID topology is incomplete");
+          }
+          const binding = resolveAgentSurfaceBinding(current, topology);
+          const workspace = binding
+            ? (topology.workspaceBySurface.get(binding.surfaceRef) ??
+              binding.workspaceId)
+            : null;
+          const observedUuid = binding
+            ? (topology.surfaceIdByRef.get(binding.surfaceRef) ?? null)
+            : null;
+          if (
+            !binding ||
+            binding.provenance !== "uuid" ||
+            binding.surfaceRef !== expectedSurfaceRef ||
+            workspace !== agent.workspace_id ||
+            !this.registry.canUseObservedBinding(current, observedUuid)
+          ) {
+            throw new Error(
+              "spawned surface UUID is no longer uniquely bound before mutation",
+            );
+          }
+          const latest =
+            this.registry.get(agent.agent_id) ??
+            this.stateMgr.readState(agent.agent_id);
+          if (!latest || !eligibleForTrigger(latest)) {
+            throw new Error("agent became busy before role placement mutation");
+          }
+        };
+
+        this.assertSurfaceObserverEpochCurrent(observerEpoch, "role placement");
+        const panes = await this.client.listPanes({
+          workspace: agent.workspace_id,
+        });
+        const rawPaneSurfaces = await Promise.all(
+          panes.panes.map(async (pane) => {
+            const observed = await this.client.listPaneSurfaces({
+              workspace: agent.workspace_id ?? undefined,
+              pane: pane.ref,
+            });
+            return observed.pane_ref
+              ? observed
+              : { ...observed, pane_ref: pane.ref };
+          }),
+        );
+        this.assertSurfaceObserverEpochCurrent(observerEpoch, "role placement");
+        const paneSurfaces = partitionPaneSurfacesByMembership(
+          panes.panes,
+          rawPaneSurfaces,
+          {
+            workspace_ref: panes.workspace_ref ?? agent.workspace_id,
+            window_ref: panes.window_ref,
+          },
+        );
+        if (!isPaneSurfaceEnumerationComplete(panes.panes, paneSurfaces)) {
+          throw new Error("pane surface enumeration is incomplete");
+        }
+        const observation = buildSurfaceBindingObservation(
+          panes.panes,
+          paneSurfaces,
+        );
+        if (observation.coverage !== "uuid") {
+          throw new Error(
+            "stable UUID topology is incomplete or contradictory",
+          );
+        }
+        const sourceRef = resolveObservedAgentSurfaceRef(agent, observation);
+        const observedUuid = sourceRef
+          ? observation.surfaceUuidByRef.get(sourceRef)
+          : null;
+        if (
+          !sourceRef ||
+          !this.registry.canUseObservedBinding(agent, observedUuid)
+        ) {
+          throw new Error("spawned surface is not uniquely bound");
+        }
+        const sourcePane = paneSurfaces.find((pane) =>
+          pane.surfaces.some((surface) => surface.ref === sourceRef),
+        )?.pane_ref;
+        const columnByPane = deriveRoleColumnIndex(panes.panes);
+        const fromColumn = sourcePane
+          ? columnByPane.get(sourcePane)
+          : undefined;
+        if (fromColumn === undefined) {
+          throw new Error("spawned surface pane is not observable");
+        }
+        if (fromColumn === targetColumn) continue;
+
+        let targetPane = topPaneInRoleColumn(panes.panes, role)?.ref ?? null;
+        let seed: CmuxNewSplitResult | null = null;
+        if (!targetPane && role === "worker") {
+          const leadPane = topPaneInRoleColumn(panes.panes, "orchestrator");
+          if (!leadPane) {
+            throw new Error("column 0 anchor is unavailable");
+          }
+          const createdSeed = await this.client.newSplit("right", {
+            pane: leadPane.ref,
+            surface: sourceRef,
+            workspace: agent.workspace_id,
+            type: "terminal",
+            stableSurfaceIdentity: agent.surface_uuid,
+            beforeMutation: () =>
+              assertFreshAgentBinding(sourceRef, "worker-column seed"),
+          });
+          this.assertSurfaceObserverEpochCurrent(
+            observerEpoch,
+            "role placement",
+          );
+          if (
+            createdSeed.surface === sourceRef ||
+            (createdSeed.surface_id ?? null) === agent.surface_uuid
+          ) {
+            throw new Error(
+              "worker-column seed collided with the spawned surface binding",
+            );
+          }
+          seed = createdSeed;
+          targetPane = seed.pane;
+        }
+        if (!targetPane) {
+          throw new Error(`canonical column ${targetColumn} is unavailable`);
+        }
+
+        try {
+          this.assertSurfaceObserverEpochCurrent(
+            observerEpoch,
+            "role placement",
+          );
+          await this.client.moveSurface({
+            surface: sourceRef,
+            pane: targetPane,
+            workspace: agent.workspace_id,
+            focus: false,
+            stableSurfaceIdentity: agent.surface_uuid,
+            beforeMutation: () =>
+              assertFreshAgentBinding(sourceRef, "role placement move"),
+          });
+          this.assertSurfaceObserverEpochCurrent(
+            observerEpoch,
+            "role placement",
+          );
+          summary.moved.push({
+            agent_id: agent.agent_id,
+            surface_id: sourceRef,
+            from_column: fromColumn,
+            to_column: targetColumn,
+            pane: targetPane,
+          });
+        } finally {
+          if (seed) {
+            if (!seed.surface_id) {
+              throw new Error(
+                "worker-column seed has no stable UUID; refusing cleanup by mutable ref",
+              );
+            }
+            const seedTopology = await this.collectObservedSurfaceTopology();
+            const seedBinding = seedTopology?.complete
+              ? resolveAgentSurfaceBinding(
+                  {
+                    surface_id: seed.surface,
+                    surface_uuid: seed.surface_id,
+                  },
+                  seedTopology,
+                )
+              : null;
+            if (!seedBinding || seedBinding.provenance !== "uuid") {
+              throw new Error(
+                `worker-column seed UUID ${seed.surface_id} is no longer uniquely bound; refusing cleanup`,
+              );
+            }
+            await this.client.closeSurface(seedBinding.surfaceRef, {
+              workspace: seedBinding.workspaceId ?? seed.workspace,
+              stableSurfaceIdentity: seed.surface_id,
+              beforeMutation: async () => {
+                this.assertSurfaceObserverEpochCurrent(
+                  observerEpoch,
+                  "role placement seed cleanup",
+                );
+                const freshSeedTopology =
+                  await this.collectObservedSurfaceTopology();
+                this.assertSurfaceObserverEpochCurrent(
+                  observerEpoch,
+                  "role placement seed cleanup",
+                );
+                const freshSeedBinding = freshSeedTopology?.complete
+                  ? resolveAgentSurfaceBinding(
+                      {
+                        surface_id: seed.surface,
+                        surface_uuid: seed.surface_id,
+                      },
+                      freshSeedTopology,
+                    )
+                  : null;
+                if (
+                  !freshSeedBinding ||
+                  freshSeedBinding.provenance !== "uuid" ||
+                  freshSeedBinding.surfaceRef !== seedBinding.surfaceRef
+                ) {
+                  throw new Error(
+                    "worker-column seed binding changed before cleanup",
+                  );
+                }
+              },
+            });
+          }
+        }
+      } catch (error) {
+        summary.skipped.push({
+          agent_id: agent.agent_id,
+          surface_id: agent.surface_id,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return summary;
+  }
+
+  /**
    * Initialize lifecycle state exactly once for a fresh runtime connection.
    * Reconstitution and one additive discovery complete before the immediate
    * sidebar sync, so a fresh process cannot publish an empty first paint.
@@ -3603,21 +3934,22 @@ export class AgentEngine {
       now: Date.now(),
     });
     this.enableStartupPurge({ retainAgentIds: newlySurfacelessAgentIds });
-    let discovered: Awaited<ReturnType<AgentDiscovery["scan"]>> | null = null;
+    const discovered = await discovery.scan(true);
+    await this.registry.listMerged(discovery, {
+      force: true,
+      discovered,
+      nonDestructive: true,
+    });
+    // Missing legacy provenance is intentionally equivalent to "unknown".
+    // Do not rewrite those records at boot: changing updated_at would distort
+    // lifecycle age and ghost-eviction evidence.
+    await this.reconcileRolePlacements("boot");
     try {
-      discovered = await discovery.scan(true);
+      await this.syncSidebar({ firstConnect: true });
     } catch {
-      // Startup discovery is a monotonic hint, not an availability gate. Keep
-      // the reconstituted registry and publish unknown until a sweep recovers.
+      // Sidebar/status publication is auxiliary. Boot placement may go live
+      // once registry ingestion and the provenance-gated sweep have completed.
     }
-    if (discovered !== null) {
-      await this.registry.listMerged(discovery, {
-        force: true,
-        discovered,
-        nonDestructive: true,
-      });
-    }
-    await this.syncSidebar({ firstConnect: true });
   }
 
   private async purgeStartupTerminalAgents(): Promise<void> {
@@ -3711,6 +4043,7 @@ export class AgentEngine {
 
     await this.registry.purgeTerminal(surfacelessConfirmation);
     await this.sweepMonitorRegistryBestEffort();
+    await this.reconcileRolePlacements("idle");
     await this.syncSidebar();
     await this.drainOutboxBestEffort();
   }
@@ -4064,6 +4397,7 @@ export class AgentEngine {
       surface_id: surface.surface,
       surface_uuid: surface.surface_id ?? null,
       surface_observer_id: surface.observerId,
+      surface_provenance: "cmuxlayer_spawn",
       workspace_id: surface.workspace,
       state: "booting",
       repo: spawnParams.repo,
@@ -4153,6 +4487,9 @@ export class AgentEngine {
       throw error;
     }
     this.registry.set(agentId, record);
+    await this.reconcileRolePlacements("spawn", {
+      agentIds: new Set([record.agent_id]),
+    });
 
     // 3. Send launch command
     const launchCmd = buildLaunchCommand(
@@ -4418,6 +4755,18 @@ export class AgentEngine {
    */
   getAgentState(agentId: string): AgentRecord | null {
     return this.registry.get(agentId);
+  }
+
+  /** Reserve an idle agent from placement before releasing its surface lock. */
+  markAgentWorking(agentId: string): AgentRecord | null {
+    const current =
+      this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    if (!current || current.state !== "idle") {
+      return current;
+    }
+    const working = this.stateMgr.transition(agentId, "working");
+    this.registry.set(agentId, working);
+    return working;
   }
 
   getPublicAgent(agentId: string): PublicAgent | null {
@@ -5212,7 +5561,8 @@ export class AgentEngine {
         beforeMutation: assertSurfaceBindingCurrent,
       });
     }
-    const refreshed = this.stateMgr.updateRecord(agent.agent_id, {});
-    this.registry.set(agent.agent_id, refreshed);
+    if (pressEnter) {
+      this.markAgentWorking(agent.agent_id);
+    }
   }
 }

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -16,6 +16,7 @@ export type CliType = "claude" | "codex" | "gemini" | "kiro" | "cursor";
 
 export type AgentQuality = "unknown" | "verified" | "suspect" | "degraded";
 export type AgentRole = "orchestrator" | "ic" | "worker";
+export type SurfaceProvenance = "cmuxlayer_spawn" | "unknown";
 export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
 
 export const MAX_SPAWN_DEPTH = 2;
@@ -29,6 +30,8 @@ export interface AgentRecord {
   surface_uuid?: string | null;
   /** cmux app/socket instance that is authoritative for surface absence. */
   surface_observer_id?: string | null;
+  /** Durable authority for automated role-placement mutations. */
+  surface_provenance?: SurfaceProvenance;
   workspace_id?: string | null;
   state: AgentState;
   repo: string;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -282,10 +282,31 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
           ),
         setProgress: async () => {},
         clearProgress: async () => {},
-        newSplit: (direction, splitOpts) =>
-          this.runWorkspaceMutation("new_split", splitOpts?.workspace, () =>
-            this.client.newSplit(direction, splitOpts),
-          ),
+        newSplit: (direction, splitOpts) => {
+          const {
+            beforeMutation,
+            stableSurfaceIdentity,
+            ...clientOpts
+          } = splitOpts ?? {};
+          return this.runWorkspaceMutation(
+            "new_split",
+            splitOpts?.workspace,
+            () => {
+              const mutate = async () => {
+                await beforeMutation?.();
+                return this.client.newSplit(direction, clientOpts);
+              };
+              return splitOpts?.surface
+                ? this.withSurfaceWrite(
+                    stableSurfaceIdentity
+                      ? `uuid:${stableSurfaceIdentity.toLowerCase()}`
+                      : splitOpts.surface,
+                    mutate,
+                  )
+                : mutate();
+            },
+          );
+        },
         newSurface: (surfaceOpts) =>
           this.runWorkspaceMutation("new_surface", surfaceOpts?.workspace, () =>
             this.client.newSurface(surfaceOpts),
@@ -301,12 +322,48 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         listPanes: (paneOpts) => this.client.listPanes(paneOpts),
         listPaneSurfaces: (surfaceOpts) =>
           this.client.listPaneSurfaces(surfaceOpts),
-        closeSurface: (surface, closeOpts) =>
-          this.runWorkspaceMutation("close_surface", closeOpts?.workspace, () =>
-            this.withSurfaceWrite(surface, () =>
-              this.client.closeSurface(surface, closeOpts),
-            ),
-          ),
+        closeSurface: (surface, closeOpts) => {
+          const {
+            beforeMutation,
+            stableSurfaceIdentity,
+            ...clientOpts
+          } = closeOpts ?? {};
+          return this.runWorkspaceMutation(
+            "close_surface",
+            closeOpts?.workspace,
+            () =>
+              this.withSurfaceWrite(
+                stableSurfaceIdentity
+                  ? `uuid:${stableSurfaceIdentity.toLowerCase()}`
+                  : surface,
+                async () => {
+                  await beforeMutation?.();
+                  return this.client.closeSurface(surface, clientOpts);
+                },
+              ),
+          );
+        },
+        moveSurface: (moveOpts) => {
+          const {
+            beforeMutation,
+            stableSurfaceIdentity,
+            ...clientOpts
+          } = moveOpts;
+          return this.runWorkspaceMutation(
+            "move_surface",
+            moveOpts.workspace,
+            () =>
+              this.withSurfaceWrite(
+                stableSurfaceIdentity
+                  ? `uuid:${stableSurfaceIdentity.toLowerCase()}`
+                  : moveOpts.surface,
+                async () => {
+                  await beforeMutation?.();
+                  return this.client.moveSurface(clientOpts);
+                },
+              ),
+          );
+        },
         notify: (notifyOpts) => this.client.notify(notifyOpts),
         notifyLifecycleEvent: async () => {},
       },
@@ -409,12 +466,34 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       SEND_INPUT_CHUNK_THRESHOLD,
     );
 
-    await this.withSurfaceWrite(`agent:${agentId}`, async () => {
-      for (const [index, chunk] of chunks.entries()) {
-        const route = await this.resolveFreshMutationRoute(
-          agentId,
-          "send_command",
+    const lockedRoute = await this.resolveFreshMutationRoute(
+      agentId,
+      "send_command",
+    );
+    const resolveLockedRoute = async (toolName: string) => {
+      const route = await this.resolveFreshMutationRoute(agentId, toolName);
+      const lockedUuid = lockedRoute.surface_uuid?.toLowerCase() ?? null;
+      const routeUuid = route.surface_uuid?.toLowerCase() ?? null;
+      const bindingChanged = lockedUuid
+        ? routeUuid !== lockedUuid
+        : route.surface_id !== lockedRoute.surface_id ||
+          (route.workspace_id ?? null) !== (lockedRoute.workspace_id ?? null);
+      if (bindingChanged) {
+        throw new Error(
+          `Agent ${agentId} changed surface binding during ${toolName}; ` +
+            "refusing to continue outside the locked surface.",
         );
+      }
+      return route;
+    };
+
+    const lockKey = lockedRoute.surface_uuid
+      ? `uuid:${lockedRoute.surface_uuid.toLowerCase()}`
+      : lockedRoute.surface_id;
+    await this.withSurfaceWrite(lockKey, async () => {
+      await resolveLockedRoute("send_command");
+      for (const [index, chunk] of chunks.entries()) {
+        const route = await resolveLockedRoute("send_command");
         await this.client.send(route.surface_id, chunk, {
           workspace: route.workspace_id ?? undefined,
         });
@@ -423,16 +502,32 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         }
       }
       await delay(50);
-      const route = await this.resolveFreshMutationRoute(agentId, "send_key");
+      const route = await resolveLockedRoute("send_key");
       await this.client.sendKey(route.surface_id, "return", {
         workspace: route.workspace_id ?? undefined,
       });
+      this.engine.markAgentWorking(agentId);
     });
   }
 
   async interruptTurn(threadId: string): Promise<void> {
-    await this.withSurfaceWrite(`agent:${threadId}`, async () => {
+    const lockedRoute = await this.resolveFreshMutationRoute(
+      threadId,
+      "send_key",
+    );
+    const lockKey = lockedRoute.surface_uuid
+      ? `uuid:${lockedRoute.surface_uuid.toLowerCase()}`
+      : lockedRoute.surface_id;
+    await this.withSurfaceWrite(lockKey, async () => {
       const route = await this.resolveFreshMutationRoute(threadId, "send_key");
+      if (
+        route.surface_id !== lockedRoute.surface_id ||
+        (route.surface_uuid ?? null) !== (lockedRoute.surface_uuid ?? null)
+      ) {
+        throw new Error(
+          `Agent ${threadId} changed surface binding during interrupt; refusing stale surface I/O.`,
+        );
+      }
       await this.client.sendKey(route.surface_id, "c-c", {
         workspace: route.workspace_id ?? undefined,
       });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -387,6 +387,7 @@ export class CmuxLayerDaemon {
   private readonly drainTimeoutMs: number;
   private readonly activeTransports = new Set<SocketJsonRpcTransport>();
   private readonly activeServers = new Set<McpServer>();
+  private readonly pendingBootSockets = new Set<net.Socket>();
   private readonly drainWaiters = new Set<() => void>();
   private inFlightRequests = 0;
   private draining = false;
@@ -535,16 +536,27 @@ export class CmuxLayerDaemon {
       return;
     }
     socket.pause();
+    this.pendingBootSockets.add(socket);
+    const clearPendingSocket = () => {
+      this.pendingBootSockets.delete(socket);
+      socket.off("close", clearPendingSocket);
+      socket.off("error", onPendingSocketError);
+    };
+    const onPendingSocketError = () => {
+      // The connection is not live yet; cleanup is completed after the gate.
+    };
+    socket.once("close", clearPendingSocket);
+    socket.on("error", onPendingSocketError);
 
     let context: CmuxServerContext;
     try {
       context = await this.getContext();
-    } catch (error) {
-      socket.destroy(error instanceof Error ? error : undefined);
+    } catch {
+      clearPendingSocket();
+      socket.destroy();
       return;
     }
 
-    const transport = new SocketJsonRpcTransport(socket);
     const mcpServer = createServer({
       context,
       outboxDrain: this.opts.outboxDrain,
@@ -553,6 +565,25 @@ export class CmuxLayerDaemon {
       monitorRegistryNotify: this.opts.monitorRegistryNotify,
       fleetSidebarPublisher: this.opts.fleetSidebarPublisher,
     });
+    try {
+      await (context.lifecycleStartPromise ?? Promise.resolve());
+      if (context.lifecycleStartError) {
+        throw context.lifecycleStartError;
+      }
+    } catch {
+      clearPendingSocket();
+      socket.destroy();
+      await mcpServer.close().catch(() => {});
+      return;
+    }
+    if (this.draining || socket.destroyed || !socket.readable) {
+      clearPendingSocket();
+      socket.destroy();
+      await mcpServer.close().catch(() => {});
+      return;
+    }
+    clearPendingSocket();
+    const transport = new SocketJsonRpcTransport(socket);
     const pendingRequestIds = new Set<RequestId>();
     this.activeTransports.add(transport);
     this.activeServers.add(mcpServer);
@@ -607,6 +638,10 @@ export class CmuxLayerDaemon {
     reason: DaemonShutdownReason,
   ): Promise<DaemonShutdownResult> {
     this.draining = true;
+    for (const socket of this.pendingBootSockets) {
+      socket.destroy();
+    }
+    this.pendingBootSockets.clear();
     this.pauseActiveTransports();
     const listenerClosed = this.closeListener();
 

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -148,12 +148,51 @@ export function deriveColumnIndex(panes: CmuxPane[]): Map<string, number> {
   );
 }
 
-function isDedicatedOrchestratorPane(layout: PaneLayout): boolean {
+/**
+ * Role columns ignore zero-area phantom panes when cmux also reports rendered
+ * panes. If every pane is backgrounded (all frames are zero-area), preserve
+ * deterministic pane-index ordering so the two logical columns do not collapse.
+ */
+export function deriveRoleColumnIndex(
+  panes: CmuxPane[],
+): Map<string, number> {
+  const hasCompleteGeometry = panes.every((pane) => pane.pixel_frame);
+  const renderedPanes = hasCompleteGeometry
+    ? panes.filter(
+        (pane) =>
+          pane.pixel_frame!.width > 0 && pane.pixel_frame!.height > 0,
+      )
+    : panes;
+  return deriveColumnIndex(renderedPanes.length > 0 ? renderedPanes : panes);
+}
+
+export function canonicalRoleColumn(role: AgentRole): number | null {
+  if (role === "orchestrator") return 0;
+  if (role === "worker") return 1;
+  return null;
+}
+
+/**
+ * Return the current top pane in a role's canonical column. Geometry is the
+ * authority when cmux provides it; pane index is the deterministic fallback.
+ * Pane contents deliberately do not participate in this choice.
+ */
+export function topPaneInRoleColumn(
+  panes: CmuxPane[],
+  role: AgentRole,
+): CmuxPane | null {
+  const targetColumn = canonicalRoleColumn(role);
+  if (targetColumn === null) return null;
+  const columnByPane = deriveRoleColumnIndex(panes);
   return (
-    layout.orchestratorCount > 0 &&
-    layout.icCount === 0 &&
-    layout.workerCount === 0 &&
-    layout.nonRoleCount === 0
+    [...panes]
+      .filter((pane) => columnByPane.get(pane.ref) === targetColumn)
+      .sort((a, b) => {
+        const aY = a.pixel_frame?.y ?? a.index;
+        const bY = b.pixel_frame?.y ?? b.index;
+        return aY - bY || a.index - b.index;
+      })
+      .at(0) ?? null
   );
 }
 
@@ -172,84 +211,6 @@ function isDedicatedWorkerPane(layout: PaneLayout): boolean {
     layout.orchestratorCount === 0 &&
     layout.icCount === 0 &&
     layout.nonRoleCount === 0
-  );
-}
-
-/**
- * A pane workers own for docking. Stricter than "has a worker": it must hold no
- * orchestrators/ICs and workers must be the strict majority of its surfaces, so
- * a real workers pane that also carries a stray non-role tab (a setup shell, a
- * dashboard) still docks new workers as tabs instead of spawning a third pane.
- * A pure dedicated worker pane (nonRoleCount === 0) trivially satisfies this.
- * A lone worker tied with a non-role surface does NOT (1 is not > 1), so an
- * accidental worker in someone's shell pane still splits out to a clean pane.
- */
-function isWorkerDockPane(layout: PaneLayout): boolean {
-  return (
-    layout.orchestratorCount === 0 &&
-    layout.icCount === 0 &&
-    layout.workerCount > 0 &&
-    layout.workerCount > layout.nonRoleCount
-  );
-}
-
-function isWorkerMajorityPane(layout: PaneLayout): boolean {
-  const nonWorkerCount = layout.surfaces.length - layout.workerCount;
-  return layout.workerCount > 0 && layout.workerCount > nonWorkerCount;
-}
-
-function isLeadMajorityPane(layout: PaneLayout): boolean {
-  const leadCount = layout.orchestratorCount + layout.icCount;
-  const nonLeadCount = layout.surfaces.length - leadCount;
-  return leadCount > 0 && leadCount > nonLeadCount;
-}
-
-function isNonLeadWorkerZonePane(
-  layout: PaneLayout,
-  leftPane: PaneLayout | undefined,
-): boolean {
-  const workerZoneCount = layout.workerCount + layout.unknownCount;
-  const nonWorkerZoneCount =
-    layout.surfaces.length -
-    layout.orchestratorCount -
-    layout.icCount -
-    workerZoneCount;
-
-  return (
-    layout.pane.ref !== leftPane?.pane.ref &&
-    layout.orchestratorCount === 0 &&
-    layout.icCount === 0 &&
-    workerZoneCount > 0 &&
-    workerZoneCount > nonWorkerZoneCount
-  );
-}
-
-function isSparseWorkerZoneSeedPane(layout: PaneLayout): boolean {
-  return (
-    layout.orchestratorCount === 0 &&
-    layout.icCount === 0 &&
-    layout.workerCount === 0 &&
-    layout.unknownCount === 0
-  );
-}
-
-function paneContainingSurface(
-  layouts: PaneLayout[],
-  surfaceId?: string | null,
-): PaneLayout | undefined {
-  if (!surfaceId) return undefined;
-  return layouts.find((layout) =>
-    layout.surfaces.some((surface) => surface.ref === surfaceId),
-  );
-}
-
-function paneContainingAnySurface(
-  layouts: PaneLayout[],
-  surfaceIds: ReadonlySet<string>,
-): PaneLayout | undefined {
-  if (surfaceIds.size === 0) return undefined;
-  return layouts.find((layout) =>
-    layout.surfaces.some((surface) => surfaceIds.has(surface.ref)),
   );
 }
 
@@ -412,14 +373,11 @@ export function collectRoleSurfaceIds(
 }
 
 /**
- * Deterministic worker placement:
- * - in a single-column layout, the first worker creates the right split
- * - once at least two columns exist, workers become tabs in the rightmost
- *   non-lead-owned pane; worker-dock and worker-zone predicates only order
- *   which right-column pane wins
- * - if every right-column pane is lead-owned, split within that column instead
- *   of creating another column
- * - single-column layouts may still split right to seed the worker column
+ * Role-deterministic placement:
+ * - orchestrators dock at the current top of column 0
+ * - workers dock at the current top of column 1, independent of pane fill
+ * - a missing worker column is seeded to the right of the top lead pane
+ * - IC placement retains its existing hierarchy-aware policy
  */
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
@@ -436,50 +394,31 @@ export function chooseAgentSpawnPlacement(
     const bColumn = columnByPane.get(b.pane.ref) ?? b.pane.index;
     return aColumn - bColumn || a.pane.index - b.pane.index;
   };
-  const leftmostByColumn = (candidates: PaneLayout[]) =>
-    [...candidates].sort(byColumnThenIndex).at(0);
   const rightmostByColumn = (candidates: PaneLayout[]) =>
     [...candidates].sort(byColumnThenIndex).at(-1);
-  const leftPane = leftmostByColumn(layouts);
 
   if (layouts.length === 0) {
     return { kind: "split", direction: "right" };
   }
 
-  const columnValues = [...new Set(columnByPane.values())];
-  const columnCount = columnValues.length;
-  const rightmostColumn = Math.max(...columnValues);
-  const rightmostColumnPanes = layouts.filter(
-    (layout) => columnByPane.get(layout.pane.ref) === rightmostColumn,
-  );
-
   if (role === "orchestrator") {
-    const leftLeadPane =
-      leftPane && !isWorkerMajorityPane(leftPane) ? leftPane : undefined;
-    const orchestratorPane =
-      leftLeadPane ??
-      leftmostByColumn(layouts.filter(isDedicatedOrchestratorPane));
+    const orchestratorPane = topPaneInRoleColumn(panes, role);
     return orchestratorPane
-      ? { kind: "surface", pane: orchestratorPane.pane.ref }
+      ? { kind: "surface", pane: orchestratorPane.ref }
       : { kind: "split", direction: "left" };
   }
 
-  // Column 0 is reserved for leads. A worker in any single-column workspace
-  // must seed the right worker column, even when the existing pane is already
-  // worker-owned or role classification is sparse. Docking into that pane would
-  // make the bad placement fill-dependent and permanent.
-  if (role === "worker" && columnCount < 2) {
-    const hasLeadColumn =
-      layouts.some(isLeadMajorityPane) ||
-      context.parentRole === "orchestrator" ||
-      context.parentRole === "ic";
-    return hasLeadColumn
-      ? { kind: "split", direction: "right" }
-      : {
-          kind: "split",
-          direction: "right",
-          pane: rightmostByColumn(layouts)?.pane.ref,
-        };
+  if (role === "worker") {
+    const workerPane = topPaneInRoleColumn(panes, role);
+    if (workerPane) {
+      return { kind: "surface", pane: workerPane.ref };
+    }
+    const leadPane = topPaneInRoleColumn(panes, "orchestrator");
+    return {
+      kind: "split",
+      direction: "right",
+      ...(leadPane ? { pane: leadPane.ref } : {}),
+    };
   }
 
   const workerPanes = layouts.filter(isDedicatedWorkerPane);
@@ -501,132 +440,7 @@ export function chooseAgentSpawnPlacement(
     return { kind: "split", direction: "right" };
   }
 
-  if (columnCount >= 2) {
-    const nonLeadRightColumnPanes = rightmostColumnPanes.filter(
-      (layout) => !isLeadMajorityPane(layout),
-    );
-    const structuralWorkerPane =
-      rightmostByColumn(nonLeadRightColumnPanes.filter(isWorkerDockPane)) ??
-      rightmostByColumn(
-        nonLeadRightColumnPanes.filter((layout) =>
-          isNonLeadWorkerZonePane(layout, leftPane),
-        ),
-      ) ??
-      rightmostByColumn(
-        nonLeadRightColumnPanes.filter(isSparseWorkerZoneSeedPane),
-      ) ??
-      rightmostByColumn(nonLeadRightColumnPanes);
-
-    if (structuralWorkerPane) {
-      return { kind: "surface", pane: structuralWorkerPane.pane.ref };
-    }
-
-    const leadOwnedRightPane = rightmostByColumn(rightmostColumnPanes);
-    if (leadOwnedRightPane) {
-      return {
-        kind: "split",
-        direction: "down",
-        pane: leadOwnedRightPane.pane.ref,
-      };
-    }
-  }
-
-  if (context.parentRole === "ic") {
-    const childPane = paneContainingAnySurface(
-      layouts,
-      context.childWorkerSurfaceIds ?? new Set(),
-    );
-    if (childPane && isDedicatedWorkerPane(childPane)) {
-      return { kind: "surface", pane: childPane.pane.ref };
-    }
-
-    const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
-    if (parentPane) {
-      return {
-        kind: "split",
-        direction: "down",
-        pane: parentPane.pane.ref,
-      };
-    }
-  }
-
-  if (context.parentRole === "orchestrator") {
-    const childPane = paneContainingAnySurface(
-      layouts,
-      context.childWorkerSurfaceIds ?? new Set(),
-    );
-    if (childPane && isWorkerDockPane(childPane)) {
-      return { kind: "surface", pane: childPane.pane.ref };
-    }
-
-    const parentPane = paneContainingSurface(layouts, context.parentSurfaceId);
-    if (parentPane) {
-      return {
-        kind: "split",
-        direction: "right",
-        pane: parentPane.pane.ref,
-      };
-    }
-  }
-
-  // Dock into the rightmost pane workers already own — including one that
-  // carries a stray non-role tab — so a populated workers pane never gets a
-  // redundant third pane split off beside it.
-  const rightmostWorkerPane = rightmostByColumn(
-    layouts.filter(isWorkerDockPane),
-  );
-  if (rightmostWorkerPane) {
-    return { kind: "surface", pane: rightmostWorkerPane.pane.ref };
-  }
-
-  const hasLiveWorkerOrUnknownSurface = layouts.some(
-    (layout) => layout.workerCount > 0 || layout.unknownCount > 0,
-  );
-  if (!hasLiveWorkerOrUnknownSurface) {
-    const sparseWorkerZonePane = rightmostByColumn(
-      layouts.filter(
-        (layout) =>
-          layout.pane.ref !== leftPane?.pane.ref &&
-          isSparseWorkerZoneSeedPane(layout),
-      ),
-    );
-    if (sparseWorkerZonePane) {
-      return { kind: "surface", pane: sparseWorkerZonePane.pane.ref };
-    }
-  }
-
-  const mixedWorkerPane = rightmostByColumn(
-    layouts.filter(
-      (layout) =>
-        (layout.workerCount > 0 || layout.unknownCount > 0) &&
-        !isWorkerDockPane(layout),
-    ),
-  );
-  if (mixedWorkerPane) {
-    if (isNonLeadWorkerZonePane(mixedWorkerPane, leftPane)) {
-      return { kind: "surface", pane: mixedWorkerPane.pane.ref };
-    }
-
-    return {
-      kind: "split",
-      direction: "right",
-      pane: mixedWorkerPane.pane.ref,
-    };
-  }
-
-  const rightmostIcPane = rightmostByColumn(icPanes);
-  if (rightmostIcPane) {
-    return {
-      kind: "split",
-      direction: "down",
-      pane: rightmostIcPane.pane.ref,
-    };
-  }
-
-  const rightmostPane = rightmostByColumn(layouts);
-  return rightmostPane
-    ? { kind: "split", direction: "right", pane: rightmostPane.pane.ref }
-    : { kind: "split", direction: "right" };
+  return { kind: "split", direction: "right" };
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,7 @@ import {
   deriveColumnIndex,
   inferAgentRole,
   inferRecordRoleOrNull,
+  topPaneInRoleColumn,
   isAgentRoleInferenceError,
   launcherNameForCli,
 } from "./layout-policy.js";
@@ -2089,6 +2090,7 @@ export interface CmuxServerContext {
   lifecycleRegistry: AgentRegistry | null;
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
+  lifecycleStartError: Error | null;
   lifecycleSweepEngine: AgentEngine | null;
   lifecycleAgentInputDeliverer: LifecycleAgentInputDeliverer | null;
   lifecycleAgentInputDelivererReadyListeners: Set<() => void>;
@@ -2209,6 +2211,7 @@ export function createServerContext(
     lifecycleRegistry: null,
     lifecycleStarted: false,
     lifecycleStartPromise: null,
+    lifecycleStartError: null,
     lifecycleSweepEngine: null,
     lifecycleAgentInputDeliverer: null,
     lifecycleAgentInputDelivererReadyListeners: new Set(),
@@ -2240,6 +2243,7 @@ export function createServerContext(
       context.originalLaunchCommandsBySurface.clear();
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
+      context.lifecycleStartError = null;
       if (autoVitestStateDir) {
         removeAutoVitestStateDir(autoVitestStateDir);
       }
@@ -2975,6 +2979,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       owner?: string;
       observePtyWrite?: boolean;
       stableSurfaceIdentity?: string | null;
+      lockKey?: string;
     } = {},
   ): Promise<T> => {
     if (opts.toolName) {
@@ -2984,7 +2989,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // Capture the ref-only provenance before the async write. A reconnect or
     // socket replacement after the attempt must not relabel its liveness.
     const surfaceObserverIdentity = context.surfaceObserverId;
-    acquireSurfaceWrite(surface, owner);
+    const lockKey =
+      opts.lockKey ??
+      (opts.stableSurfaceIdentity
+        ? `uuid:${opts.stableSurfaceIdentity.toLowerCase()}`
+        : surface);
+    acquireSurfaceWrite(lockKey, owner);
     try {
       const result = await fn();
       if (opts.observePtyWrite) {
@@ -3006,7 +3016,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       throw error;
     } finally {
-      releaseSurfaceWrite(surface, owner);
+      releaseSurfaceWrite(lockKey, owner);
     }
   };
 
@@ -7299,6 +7309,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       if (context.lifecycleStartPromise) {
         await context.lifecycleStartPromise;
       }
+      if (context.lifecycleStartError) {
+        throw context.lifecycleStartError;
+      }
     };
     const notifyLifecycleEvent = async (
       event: AgentLifecycleEvent,
@@ -7387,11 +7400,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             client.setProgress(value, progressOpts),
           clearProgress: (progressOpts) => client.clearProgress(progressOpts),
           newSplit: async (direction, splitOpts) => {
+            const {
+              beforeMutation,
+              stableSurfaceIdentity,
+              ...clientOpts
+            } = splitOpts ?? {};
             await assertWorkspaceMutationAllowed(
               "agent_engine",
               splitOpts?.workspace,
             );
-            return client.newSplit(direction, splitOpts);
+            const mutate = async () => {
+              await beforeMutation?.();
+              return client.newSplit(direction, clientOpts);
+            };
+            return splitOpts?.surface
+              ? withSurfaceWrite(splitOpts.surface, mutate, {
+                  toolName: "new_split",
+                  lockKey: stableSurfaceIdentity
+                    ? `uuid:${stableSurfaceIdentity.toLowerCase()}`
+                    : splitOpts.surface,
+                })
+              : mutate();
           },
           newSurface: async (surfaceOpts) => {
             await assertWorkspaceMutationAllowed(
@@ -7418,7 +7447,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           listPaneSurfaces: (surfaceOpts) =>
             client.listPaneSurfaces(surfaceOpts),
           closeSurface: (surface, closeOpts) => {
-            const { beforeMutation, ...clientOpts } = closeOpts ?? {};
+            const {
+              beforeMutation,
+              stableSurfaceIdentity,
+              ...clientOpts
+            } = closeOpts ?? {};
             return withSurfaceWrite(
               surface,
               async () => {
@@ -7434,7 +7467,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 });
                 return result;
               },
-              { toolName: "close_surface", workspace: closeOpts?.workspace },
+              {
+                toolName: "close_surface",
+                workspace: closeOpts?.workspace,
+                stableSurfaceIdentity,
+              },
+            );
+          },
+          moveSurface: async (moveOpts) => {
+            const {
+              beforeMutation,
+              stableSurfaceIdentity,
+              ...clientOpts
+            } = moveOpts;
+            await assertWorkspaceMutationAllowed(
+              "move_surface",
+              moveOpts.workspace,
+            );
+            return withSurfaceWrite(
+              moveOpts.surface,
+              async () => {
+                await beforeMutation?.();
+                return client.moveSurface(clientOpts);
+              },
+              {
+                toolName: "move_surface",
+                lockKey: stableSurfaceIdentity
+                  ? `uuid:${stableSurfaceIdentity.toLowerCase()}`
+                  : moveOpts.surface,
+              },
             );
           },
           notify: (notifyOpts) => client.notify(notifyOpts),
@@ -7869,7 +7930,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return withSurfaceWrite(
         deliveryRoute.surface_id,
         async () => {
-          return deliverInputChunks({
+          await assertDeliveryRouteCurrent();
+          const delivery = await deliverInputChunks({
             surface: deliveryRoute.surface_id,
             workspace: deliveryRoute.workspace_id ?? undefined,
             chunks,
@@ -7890,6 +7952,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             allow_recovery_enter_retry: !args.allow_busy,
             beforeMutation: assertDeliveryRouteCurrent,
           });
+          if (args.press_enter) {
+            engine.markAgentWorking(args.agent_id);
+          }
+          return delivery;
         },
         {
           toolName: args.source_event,
@@ -7908,13 +7974,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // context and may construct more than one MCP server over its lifetime.
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
+      context.lifecycleStartError = null;
       context.lifecycleStartPromise = engine
         .initialize(discovery)
-        .catch((e) =>
-          console.error("[cmuxlayer] lifecycle initialization failed:", e),
-        )
+        .catch((error) => {
+          context.lifecycleStartError =
+            error instanceof Error ? error : new Error(String(error));
+          console.error(
+            "[cmuxlayer] lifecycle initialization failed:",
+            context.lifecycleStartError,
+          );
+        })
         .then(() => {
           if (
+            !context.lifecycleStartError &&
             context.lifecycleStarted &&
             context.lifecycleSweepEngine === engine
           ) {
@@ -7926,7 +7999,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // it only after persisted lifecycle state has been reconstituted so route
     // resolution is ready, then wake any boot-time recovery claim.
     void (context.lifecycleStartPromise ?? Promise.resolve()).then(() => {
-      if (context.lifecycleStarted && context.lifecycleSweepEngine === engine) {
+      if (
+        !context.lifecycleStartError &&
+        context.lifecycleStarted &&
+        context.lifecycleSweepEngine === engine
+      ) {
         context.setLifecycleAgentInputDeliverer(deliverAgentInput);
       }
     });
@@ -9399,12 +9476,46 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 reason: error instanceof Error ? error.message : String(error),
               });
             };
+            const assertCurrentReflowAuthority = (
+              agent: AgentRecord,
+              expectedWorkspace: string,
+              operation: ReflowOperation,
+            ): AgentRecord => {
+              const currentAgent =
+                registry.get(agent.agent_id) ??
+                stateMgr.readState(agent.agent_id);
+              const expectedUuid = agent.surface_uuid?.trim().toLowerCase();
+              const currentUuid = currentAgent?.surface_uuid
+                ?.trim()
+                .toLowerCase();
+              if (
+                !currentAgent ||
+                currentAgent.surface_provenance !== "cmuxlayer_spawn" ||
+                inferRecordRoleOrNull(currentAgent) !== "worker" ||
+                (currentAgent.state !== "idle" &&
+                  !TERMINAL_AGENT_STATES.has(currentAgent.state)) ||
+                !expectedUuid ||
+                currentUuid !== expectedUuid ||
+                (currentAgent.workspace_id ?? null) !== expectedWorkspace
+              ) {
+                throw new Error(
+                  `Agent ${agent.agent_id} provenance, role, state, or stable ` +
+                    `binding changed before ${operation}; refusing to move a busy or unowned pane.`,
+                );
+              }
+              return currentAgent;
+            };
             const resolveFreshReflowBinding = async (
               agent: AgentRecord,
               expectedSurfaceRef: string,
               expectedWorkspace: string,
               operation: ReflowOperation,
             ) => {
+              assertCurrentReflowAuthority(
+                agent,
+                expectedWorkspace,
+                operation,
+              );
               assertSurfaceObserverEpochCurrent(
                 reflowObserverEpoch,
                 `resync_agents ${operation}`,
@@ -9419,7 +9530,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   `Fresh topology is incomplete before ${operation}; refusing reflow mutation.`,
                 );
               }
-              const binding = resolveAgentSurfaceBinding(agent, topology);
+              const currentAgent = assertCurrentReflowAuthority(
+                agent,
+                expectedWorkspace,
+                operation,
+              );
+              const binding = resolveAgentSurfaceBinding(
+                currentAgent,
+                topology,
+              );
               if (!binding) {
                 throw new Error(
                   `Stable surface UUID ${agent.surface_uuid ?? "unavailable"} is not uniquely bound before ${operation}; refusing reflow mutation.`,
@@ -9427,7 +9546,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               const observedUuid =
                 topology.surfaceIdByRef.get(binding.surfaceRef) ?? null;
-              if (!registry.canUseObservedBinding(agent, observedUuid)) {
+              if (
+                !registry.canUseObservedBinding(currentAgent, observedUuid)
+              ) {
                 throw new Error(
                   `Fresh binding ${binding.surfaceRef} is not owned by the current observer before ${operation}; refusing reflow mutation.`,
                 );
@@ -9462,6 +9583,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
               for (const agent of after) {
                 if (inferRecordRoleOrNull(agent) !== "worker") continue;
+                if (agent.surface_provenance !== "cmuxlayer_spawn") continue;
+                if (
+                  agent.state !== "idle" &&
+                  !TERMINAL_AGENT_STATES.has(agent.state)
+                ) {
+                  continue;
+                }
                 const binding = resolveAgentSurfaceBinding(
                   agent,
                   topologyBeforeReflow,
@@ -9523,6 +9651,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           reflowObserverEpoch,
                           "resync_agents new_split",
                         );
+                        assertCurrentReflowAuthority(
+                          agent,
+                          immediate.workspace ?? workspace!,
+                          attemptedOperation,
+                        );
                         const seed = await client.newSplit("right", {
                           workspace: immediate.workspace,
                           surface: immediate.binding.surfaceRef,
@@ -9538,6 +9671,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       },
                       {
                         owner: `resync-reflow:new_split:${agent.agent_id}`,
+                        stableSurfaceIdentity: agent.surface_uuid,
                       },
                     );
                     panesByWorkspace.delete(workspace);
@@ -9555,16 +9689,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       reflowObserverEpoch,
                       "resync_agents move_surface pane selection",
                     );
-                    const columns = deriveColumnIndex(panes.panes);
-                    targetPane = [...panes.panes]
-                      .filter((pane) => (columns.get(pane.ref) ?? 0) > 0)
-                      .sort((a, b) => {
-                        const columnDelta =
-                          (columns.get(a.ref) ?? 0) -
-                          (columns.get(b.ref) ?? 0);
-                        return columnDelta || a.index - b.index;
-                      })
-                      .at(-1)?.ref ?? null;
+                    targetPane = topPaneInRoleColumn(
+                      panes.panes,
+                      "worker",
+                    )?.ref ?? null;
                   }
                   if (!targetPane) continue;
 
@@ -9593,6 +9721,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         reflowObserverEpoch,
                         "resync_agents move_surface",
                       );
+                      assertCurrentReflowAuthority(
+                        agent,
+                        immediate.workspace ?? workspace!,
+                        attemptedOperation,
+                      );
                       await client.moveSurface({
                         surface: immediate.binding.surfaceRef,
                         pane: targetPane!,
@@ -9608,6 +9741,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       toolName: "move_surface",
                       workspace: freshBeforeMove.workspace ?? workspace,
                       owner: `resync-reflow:move_surface:${agent.agent_id}`,
+                      stableSurfaceIdentity: agent.surface_uuid,
                     },
                   );
                   panesByWorkspace.delete(workspace);
@@ -9635,9 +9769,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   const actual = topologyAfterMove.topologyBySurface.get(
                     bindingAfterMove.surfaceRef,
                   );
-                  if (actual?.column == null || actual.column === 0) {
+                  if (actual?.column !== 1) {
                     throw new Error(
-                      "Post-move topology still places the worker in column 0.",
+                      "Post-move topology does not place the worker in canonical column 1.",
                     );
                   }
 
@@ -9745,6 +9879,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           toolName: "close_surface",
                           workspace: cleanupWorkspace,
                           owner: `resync-reflow:close_surface:${agent.agent_id}`,
+                          stableSurfaceIdentity: cleanupSeedUuid,
                         },
                       );
                     } catch (error) {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -548,6 +548,7 @@ export class StateManager {
       surface_id: discovered.surface_id,
       surface_uuid: discovered.surface_uuid ?? null,
       surface_observer_id: surfaceObserverId?.trim() || null,
+      surface_provenance: "unknown",
       workspace_id: discovered.workspace_id ?? null,
       state: discoveredStatusToAgentState(discovered.parsed_status),
       repo: inferRepoFromTitle(discovered.surface_title),

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -1,7 +1,7 @@
 import type { AgentRecord } from "./agent-types.js";
 import type { AgentTopologyHealthInput } from "./agent-health.js";
 import type { AgentHealthInputOverrides } from "./agent-health-input.js";
-import { deriveColumnIndex } from "./layout-policy.js";
+import { deriveRoleColumnIndex } from "./layout-policy.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import type {
   CmuxPane,
@@ -310,7 +310,7 @@ export async function collectSurfaceTopology(
       const panes = await client.listPanes({ workspace: workspaceRef });
       if (!panes.panes || panes.panes.length === 0) continue;
 
-      const columnIndex = deriveColumnIndex(panes.panes);
+      const columnIndex = deriveRoleColumnIndex(panes.panes);
       const columnCount = new Set(columnIndex.values()).size;
       for (const pane of panes.panes) {
         for (const [index, surfaceRef] of pane.surface_refs.entries()) {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -733,6 +733,7 @@ describe("AgentEngine", () => {
     });
 
     it("writes initial state file", async () => {
+      const reconcileSpy = vi.spyOn(engine, "reconcileRolePlacements");
       const result = await engine.spawnAgent({
         repo: "brainlayer",
         model: "sonnet",
@@ -745,6 +746,10 @@ describe("AgentEngine", () => {
       expect(state!.state).toBe("booting");
       expect(state!.repo).toBe("brainlayer");
       expect(state!.task_summary).toBe("Fix gap F");
+      expect(state!.surface_provenance).toBe("cmuxlayer_spawn");
+      expect(reconcileSpy).toHaveBeenCalledWith("spawn", {
+        agentIds: new Set([result.agent_id]),
+      });
     });
 
     it("cleans the created surface when initial state persistence fails before commit", async () => {
@@ -1114,6 +1119,7 @@ describe("AgentEngine", () => {
         "workspace:parent",
       );
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        pane: "pane:parent",
         workspace: "workspace:parent",
         type: "terminal",
       });
@@ -1251,7 +1257,7 @@ describe("AgentEngine", () => {
       });
 
       expect(result.workspace_id).toBe("workspace:new");
-      expect(mockClient.newSplit).toHaveBeenCalledWith("down", {
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
         pane: "pane:new-parent",
         workspace: "workspace:new",
         type: "terminal",
@@ -1399,7 +1405,7 @@ describe("AgentEngine", () => {
       expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
 
-    it("seeds a worktree worker to the right without anchoring to the left lead pane", async () => {
+    it("seeds a worktree worker beside the current top left lead pane", async () => {
       const parent = makeRecord({
         agent_id: "parent-claude",
         surface_id: "surface:parent",
@@ -1454,6 +1460,7 @@ describe("AgentEngine", () => {
       });
 
       expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
+        pane: "pane:parent",
         workspace: "workspace:parent",
         type: "terminal",
       });
@@ -2160,7 +2167,7 @@ describe("AgentEngine", () => {
       expect(stateMgr.listStates()).toHaveLength(0);
     });
 
-    it("cleans a fallback split when its post-create epoch assertion fails", async () => {
+    it("refuses an enforced-role spawn when placement topology is unavailable", async () => {
       engine.dispose();
       const ownerId = "cmux:/tmp/cmux.sock#socket=1:2:3:4";
       let observerEpoch = `${ownerId}@socket:1`;
@@ -2187,67 +2194,23 @@ describe("AgentEngine", () => {
           },
         ],
       });
-      (mockClient.listPanes as ReturnType<typeof vi.fn>)
-        .mockRejectedValueOnce(new Error("placement listing failed"))
-        .mockResolvedValue({
-          workspace_ref: "ws:1",
-          window_ref: "window:1",
-          panes: [
-            {
-              ref: "pane:fallback",
-              index: 0,
-              focused: true,
-              surface_count: 1,
-              surface_refs: ["surface:fallback-created"],
-              surface_ids: [SPAWN_SURFACE_UUID],
-            },
-          ],
-        });
-      (
-        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({
-        workspace_ref: "ws:1",
-        window_ref: "window:1",
-        pane_ref: "pane:fallback",
-        surfaces: [
-          {
-            ...makeSurface("surface:fallback-created"),
-            id: SPAWN_SURFACE_UUID,
-          },
-        ],
-      });
-      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockImplementation(
-        async () => {
-          observerEpoch = `${ownerId}@socket:2`;
-          return {
-            workspace: "ws:1",
-            surface: "surface:fallback-created",
-            surface_id: SPAWN_SURFACE_UUID,
-            pane: "pane:fallback",
-            title: "",
-            type: "terminal",
-          };
-        },
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("placement listing failed"),
       );
 
       await expect(
         engine.spawnAgent({
           repo: "brainlayer",
           cli: "codex",
-          prompt: "Clean a fallback split across reconnect",
+          prompt: "Refuse a blind fallback split",
           workspace: "ws:1",
         }),
-      ).rejects.toThrow(/surface observer changed.*placement/i);
+      ).rejects.toThrow(/placement listing failed/i);
 
-      expect(mockClient.newSplit).toHaveBeenCalledTimes(1);
-      expect(mockClient.closeSurface).toHaveBeenCalledWith(
-        "surface:fallback-created",
-        expect.objectContaining({
-          workspace: "ws:1",
-          collapsePane: false,
-          beforeMutation: expect.any(Function),
-        }),
-      );
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
       expect(stateMgr.listStates()).toHaveLength(0);
     });
 
@@ -2630,7 +2593,7 @@ describe("AgentEngine", () => {
       warnSpy.mockRestore();
     });
 
-    it("splits a child worker under its parent IC pane", async () => {
+    it("docks a child worker into canonical column 1 without a row split", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "ic-1",
@@ -2682,7 +2645,7 @@ describe("AgentEngine", () => {
         parent_agent_id: "ic-1",
       });
 
-      expect(mockClient.newSplit).toHaveBeenCalledWith("down", {
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
         pane: "pane:ic",
         workspace: "ws:1",
         type: "terminal",
@@ -3778,6 +3741,7 @@ describe("AgentEngine", () => {
         state: "booting",
         surface_id: "surface:new",
         surface_observer_id: createdObserverId,
+        surface_provenance: "cmuxlayer_spawn",
       });
       expect(engine.getAgentState(record.agent_id)).toMatchObject({
         state: "booting",
@@ -5315,6 +5279,577 @@ To continue this session, run codex resume ${sessionId}`,
       expect(engine.getAgentState("contradictory-topology-agent")?.state).toBe(
         "ready",
       );
+    });
+  });
+
+  describe("role placement reconciliation", () => {
+    const leftFrame = { x: 0, y: 0, width: 500, height: 900 };
+    const rightFrame = { x: 500, y: 0, width: 500, height: 900 };
+
+    function installTwoColumnTopology(source: AgentRecord): void {
+      const targetUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      liveSurfaces = [
+        {
+          ...makeSurface(source.surface_id),
+          id: source.surface_uuid ?? undefined,
+          workspace_ref: "ws:placement",
+        },
+        {
+          ...makeSurface("surface:right-target"),
+          id: targetUuid,
+          workspace_ref: "ws:placement",
+        },
+      ];
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:placement",
+        window_ref: "window:placement",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: [source.surface_id],
+            surface_ids: [source.surface_uuid],
+            selected_surface_ref: source.surface_id,
+            pixel_frame: leftFrame,
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:right-target"],
+            surface_ids: [targetUuid],
+            selected_surface_ref: "surface:right-target",
+            pixel_frame: rightFrame,
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:placement",
+        window_ref: "window:placement",
+        pane_ref: pane ?? "pane:left",
+        surfaces:
+          pane === "pane:right"
+            ? [
+                {
+                  ...makeSurface("surface:right-target"),
+                  id: targetUuid,
+                  workspace_ref: "ws:placement",
+                },
+              ]
+            : [
+                {
+                  ...makeSurface(source.surface_id),
+                  id: source.surface_uuid ?? undefined,
+                  workspace_ref: "ws:placement",
+                },
+              ],
+      }));
+    }
+
+    it("never moves an unknown-provenance operator pane", async () => {
+      const record = makeRecord({
+        agent_id: "operator-worker",
+        surface_id: "surface:operator-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "unknown",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+
+      await engine.runSweep();
+
+      expect(mockClient.moveSurface).not.toHaveBeenCalled();
+    });
+
+    it("moves an idle programmatic worker from column 0 to column 1", async () => {
+      const record = makeRecord({
+        agent_id: "idle-worker",
+        surface_id: "surface:idle-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+
+      await engine.runSweep();
+
+      expect(mockClient.moveSurface).toHaveBeenCalledWith(expect.objectContaining({
+        surface: record.surface_id,
+        pane: "pane:right",
+        workspace: "ws:placement",
+        focus: false,
+      }));
+    });
+
+    it("corrects the just-created programmatic surface at the spawn trigger", async () => {
+      const record = makeRecord({
+        agent_id: "booting-spawn-worker",
+        surface_id: "surface:booting-spawn-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "booting",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+
+      await engine.reconcileRolePlacements("spawn", {
+        agentIds: new Set([record.agent_id]),
+      });
+
+      expect(mockClient.moveSurface).toHaveBeenCalledWith(expect.objectContaining({
+        surface: record.surface_id,
+        pane: "pane:right",
+        workspace: "ws:placement",
+        focus: false,
+      }));
+    });
+
+    it("leaves an unknown-provenance leftover untouched during boot sweep", async () => {
+      const record = makeRecord({
+        agent_id: "boot-operator-worker",
+        surface_id: "surface:boot-operator-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "unknown",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+
+      await engine.reconcileRolePlacements("boot");
+
+      expect(mockClient.moveSurface).not.toHaveBeenCalled();
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    });
+
+    it("never moves a mid-work programmatic pane", async () => {
+      const record = makeRecord({
+        agent_id: "working-worker",
+        surface_id: "surface:working-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "working",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+
+      await engine.runSweep();
+
+      expect(mockClient.moveSurface).not.toHaveBeenCalled();
+    });
+
+    it("aborts an idle placement when the agent starts working before mutation", async () => {
+      const record = makeRecord({
+        agent_id: "idle-to-working-worker",
+        surface_id: "surface:idle-to-working-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+      let mutated = false;
+      (mockClient.moveSurface as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (opts) => {
+          const working = stateMgr.transition(record.agent_id, "working");
+          engine.getRegistry().set(record.agent_id, working);
+          await opts.beforeMutation?.();
+          mutated = true;
+          return {
+            ok: true,
+            workspace: opts.workspace ?? "ws:placement",
+            surface: opts.surface,
+            pane: opts.pane ?? "pane:right",
+          };
+        },
+      );
+
+      const summary = await engine.reconcileRolePlacements("idle");
+
+      expect(mutated).toBe(false);
+      expect(summary.moved).toEqual([]);
+      expect(summary.skipped).toEqual([
+        expect.objectContaining({
+          agent_id: record.agent_id,
+          reason: expect.stringMatching(/state|busy/i),
+        }),
+      ]);
+    });
+
+    it("aborts placement when the cached ref is recycled before mutation", async () => {
+      const record = makeRecord({
+        agent_id: "recycled-placement-worker",
+        surface_id: "surface:recycled",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      const foreignUuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+      const targetUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      installTwoColumnTopology(record);
+      let mutated = false;
+      (mockClient.moveSurface as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (opts) => {
+          liveSurfaces = [
+            {
+              ...makeSurface(record.surface_id),
+              id: foreignUuid,
+              workspace_ref: "ws:placement",
+            },
+            {
+              ...makeSurface("surface:moved-stable-worker"),
+              id: record.surface_uuid ?? undefined,
+              workspace_ref: "ws:placement",
+            },
+            {
+              ...makeSurface("surface:right-target"),
+              id: targetUuid,
+              workspace_ref: "ws:placement",
+            },
+          ];
+          (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+            workspace_ref: "ws:placement",
+            window_ref: "window:placement",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: [record.surface_id],
+                surface_ids: [foreignUuid],
+                pixel_frame: leftFrame,
+              },
+              {
+                ref: "pane:right",
+                index: 1,
+                focused: false,
+                surface_count: 2,
+                surface_refs: [
+                  "surface:moved-stable-worker",
+                  "surface:right-target",
+                ],
+                surface_ids: [record.surface_uuid, targetUuid],
+                pixel_frame: rightFrame,
+              },
+            ],
+          });
+          (
+            mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+          ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+            workspace_ref: "ws:placement",
+            window_ref: "window:placement",
+            pane_ref: pane,
+            surfaces:
+              pane === "pane:left"
+                ? [liveSurfaces[0]]
+                : [liveSurfaces[1], liveSurfaces[2]],
+          }));
+          await opts.beforeMutation?.();
+          mutated = true;
+          return {
+            ok: true,
+            workspace: opts.workspace ?? "ws:placement",
+            surface: opts.surface,
+            pane: opts.pane ?? "pane:right",
+          };
+        },
+      );
+
+      const summary = await engine.reconcileRolePlacements("idle");
+
+      expect(mutated).toBe(false);
+      expect(summary.moved).toEqual([]);
+      expect(summary.skipped).toEqual([
+        expect.objectContaining({
+          agent_id: record.agent_id,
+          reason: expect.stringMatching(/uniquely bound/i),
+        }),
+      ]);
+    });
+
+    it("serializes worker-column seed cleanup by the seed's stable UUID", async () => {
+      const record = makeRecord({
+        agent_id: "single-column-worker",
+        surface_id: "surface:single-column-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      const leadRef = "surface:lead";
+      const leadUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      const seedRef = "surface:worker-column-seed";
+      const seedUuid = "33333333-4444-4555-8666-777777777777";
+      let workerPane: "pane:left" | "pane:right" = "pane:left";
+      let seedOpen = false;
+      const refreshLiveSurfaces = () => {
+        liveSurfaces = [
+          {
+            ...makeSurface(leadRef),
+            id: leadUuid,
+            workspace_ref: "ws:placement",
+          },
+          {
+            ...makeSurface(record.surface_id),
+            id: record.surface_uuid ?? undefined,
+            workspace_ref: "ws:placement",
+          },
+          ...(seedOpen
+            ? [
+                {
+                  ...makeSurface(seedRef),
+                  id: seedUuid,
+                  workspace_ref: "ws:placement",
+                },
+              ]
+            : []),
+        ];
+      };
+      refreshLiveSurfaces();
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          const leftRefs = [
+            leadRef,
+            ...(workerPane === "pane:left" ? [record.surface_id] : []),
+          ];
+          const leftIds = [
+            leadUuid,
+            ...(workerPane === "pane:left" ? [record.surface_uuid] : []),
+          ];
+          const rightRefs = [
+            ...(seedOpen ? [seedRef] : []),
+            ...(workerPane === "pane:right" ? [record.surface_id] : []),
+          ];
+          const rightIds = [
+            ...(seedOpen ? [seedUuid] : []),
+            ...(workerPane === "pane:right" ? [record.surface_uuid] : []),
+          ];
+          return {
+            workspace_ref: "ws:placement",
+            window_ref: "window:placement",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: true,
+                surface_count: leftRefs.length,
+                surface_refs: leftRefs,
+                surface_ids: leftIds,
+                pixel_frame: leftFrame,
+              },
+              ...(rightRefs.length > 0
+                ? [
+                    {
+                      ref: "pane:right",
+                      index: 1,
+                      focused: false,
+                      surface_count: rightRefs.length,
+                      surface_refs: rightRefs,
+                      surface_ids: rightIds,
+                      pixel_frame: rightFrame,
+                    },
+                  ]
+                : []),
+            ],
+          };
+        },
+      );
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:placement",
+        window_ref: "window:placement",
+        pane_ref: pane,
+        surfaces:
+          pane === "pane:right"
+            ? [
+                ...(seedOpen
+                  ? [
+                      {
+                        ...makeSurface(seedRef),
+                        id: seedUuid,
+                        workspace_ref: "ws:placement",
+                      },
+                    ]
+                  : []),
+                ...(workerPane === "pane:right"
+                  ? [
+                      {
+                        ...makeSurface(record.surface_id),
+                        id: record.surface_uuid ?? undefined,
+                        workspace_ref: "ws:placement",
+                      },
+                    ]
+                  : []),
+              ]
+            : [
+                {
+                  ...makeSurface(leadRef),
+                  id: leadUuid,
+                  workspace_ref: "ws:placement",
+                },
+                ...(workerPane === "pane:left"
+                  ? [
+                      {
+                        ...makeSurface(record.surface_id),
+                        id: record.surface_uuid ?? undefined,
+                        workspace_ref: "ws:placement",
+                      },
+                    ]
+                  : []),
+              ],
+      }));
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (_direction, opts) => {
+          await opts.beforeMutation?.();
+          seedOpen = true;
+          refreshLiveSurfaces();
+          return {
+            workspace: "ws:placement",
+            surface: seedRef,
+            surface_id: seedUuid,
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          };
+        },
+      );
+      (mockClient.moveSurface as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (opts) => {
+          await opts.beforeMutation?.();
+          workerPane = "pane:right";
+          return {
+            ok: true,
+            workspace: "ws:placement",
+            surface: opts.surface,
+            pane: "pane:right",
+          };
+        },
+      );
+      (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (_surface, opts) => {
+          await opts.beforeMutation?.();
+          seedOpen = false;
+          refreshLiveSurfaces();
+        },
+      );
+
+      const summary = await engine.reconcileRolePlacements("idle");
+
+      expect(summary.moved).toHaveLength(1);
+      expect(mockClient.closeSurface).toHaveBeenCalledWith(
+        seedRef,
+        expect.objectContaining({
+          workspace: "ws:placement",
+          stableSurfaceIdentity: seedUuid,
+          beforeMutation: expect.any(Function),
+        }),
+      );
+    });
+
+    it("orders boot ingestion before provable-leftover sweep and publication", async () => {
+      const events: string[] = [];
+      const record = makeRecord({
+        agent_id: "boot-leftover-worker",
+        surface_id: "surface:boot-leftover-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "done",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      stateMgr.writeState(record);
+      installTwoColumnTopology(record);
+      (mockClient.moveSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async (opts) => {
+          events.push("sweep");
+          return {
+            ok: true,
+            workspace: opts.workspace ?? "ws:placement",
+            surface: opts.surface,
+            pane: opts.pane ?? "pane:right",
+          };
+        },
+      );
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        fleetSidebarPublisher: {
+          publish: ({ state }) => {
+            if (state !== "discovering") events.push("placement-live");
+          },
+          dispose: () => {},
+        },
+      });
+      const discovery = {
+        scan: vi.fn(async () => {
+          events.push("ingest");
+          return [];
+        }),
+      };
+      (mockClient.newSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ pane, workspace }) => {
+          events.push("spawn");
+          return {
+            workspace: workspace ?? "ws:placement",
+            surface: "surface:post-boot-worker",
+            surface_id: "99999999-2222-4333-8444-555555555555",
+            pane,
+            title: "",
+            type: "terminal" as const,
+          };
+        },
+      );
+
+      await engine.initialize(discovery as any);
+      await engine.spawnAgent({
+        repo: "cmuxlayer",
+        cli: "codex",
+        prompt: "spawn immediately after boot",
+        workspace: "ws:placement",
+        role: "worker",
+      });
+
+      expect(events).toEqual(["ingest", "sweep", "placement-live", "spawn"]);
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right",
+        type: "terminal",
+        workspace: "ws:placement",
+      });
     });
   });
 
@@ -9409,15 +9944,16 @@ To continue this session, run codex resume ${sessionId}`,
       expect(mockClient.sendKey).not.toHaveBeenCalled();
     });
 
-    it("works for agents in idle state", async () => {
+    it("keeps an idle agent idle when text is staged without Return", async () => {
       vi.useFakeTimers();
       const sentAt = new Date("2026-05-25T13:00:00.000Z");
+      const originalUpdatedAt = "2026-05-25T12:00:00.000Z";
       stateMgr.writeState(
         makeRecord({
           agent_id: "agent-idle",
           state: "idle",
           surface_id: "surface:42",
-          updated_at: "2026-05-25T12:00:00.000Z",
+          updated_at: originalUpdatedAt,
         }),
       );
       liveSurfaces = [makeSurface("surface:42")];
@@ -9428,12 +9964,59 @@ To continue this session, run codex resume ${sessionId}`,
         await engine.sendToAgent("agent-idle", "continue");
 
         expect(mockClient.send).toHaveBeenCalled();
-        expect(engine.getAgentState("agent-idle")?.updated_at).toBe(
-          sentAt.toISOString(),
-        );
+        expect(engine.getAgentState("agent-idle")).toMatchObject({
+          state: "idle",
+          updated_at: originalUpdatedAt,
+        });
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("marks an idle agent working only after Return is delivered", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-idle-submit",
+          state: "idle",
+          surface_id: "surface:42",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.sendToAgent("agent-idle-submit", "continue", true);
+
+      expect(mockClient.sendKey).toHaveBeenCalledWith(
+        "surface:42",
+        "return",
+        expect.anything(),
+      );
+      expect(engine.getAgentState("agent-idle-submit")?.state).toBe(
+        "working",
+      );
+    });
+
+    it("leaves an idle agent idle when submitted delivery fails", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-idle-send-failure",
+          state: "idle",
+          surface_id: "surface:42",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:42")];
+      await engine.getRegistry().reconstitute();
+      (mockClient.sendKey as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Return delivery failed"),
+      );
+
+      await expect(
+        engine.sendToAgent("agent-idle-send-failure", "continue", true),
+      ).rejects.toThrow(/Return delivery failed/);
+
+      expect(engine.getAgentState("agent-idle-send-failure")?.state).toBe(
+        "idle",
+      );
     });
 
     it("rejects sending to agents in non-interactive states", async () => {

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -589,6 +589,7 @@ describe("CmuxAppServerRuntime", () => {
     });
     const record = {
       ...makeRecord(),
+      state: "idle" as const,
       surface_observer_id: (runtime as any).registry.getObserverId(),
     };
     (runtime as any).stateMgr.writeState(record);
@@ -611,6 +612,9 @@ describe("CmuxAppServerRuntime", () => {
       workspace: "workspace:app",
       lines: 40,
     });
+    expect((runtime as any).engine.getAgentState("agent-1")?.state).toBe(
+      "working",
+    );
 
     runtime.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
@@ -665,6 +669,57 @@ describe("CmuxAppServerRuntime", () => {
       ).rejects.toThrow(/manual mode/i);
       expect(client.send).not.toHaveBeenCalled();
       expect(client.sendKey).not.toHaveBeenCalled();
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves an idle bridge agent idle when Return delivery fails", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [{ ref: "workspace:app" }],
+    });
+    client.listPanes.mockResolvedValue({
+      workspace_ref: "workspace:app",
+      panes: [
+        {
+          ref: "pane:1",
+          surface_count: 1,
+          surface_refs: ["surface:1"],
+        },
+      ],
+    });
+    client.listPaneSurfaces.mockResolvedValue({
+      workspace_ref: "workspace:app",
+      pane_ref: "pane:1",
+      surfaces: [
+        {
+          ref: "surface:1",
+          title: "agent",
+          type: "terminal",
+        },
+      ],
+    });
+    client.sendKey.mockRejectedValueOnce(new Error("Return delivery failed"));
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const record = {
+      ...makeRecord(),
+      state: "idle" as const,
+      surface_observer_id: (runtime as any).registry.getObserverId(),
+    };
+    (runtime as any).stateMgr.writeState(record);
+    (runtime as any).registry.set(record.agent_id, record);
+
+    try {
+      await expect(
+        runtime.sendTurn({ threadId: record.agent_id, text: "continue" }),
+      ).rejects.toThrow(/Return delivery failed/);
+      expect((runtime as any).engine.getAgentState(record.agent_id)?.state).toBe(
+        "idle",
+      );
     } finally {
       runtime.dispose();
       rmSync(TEST_DIR, { recursive: true, force: true });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -18,6 +18,7 @@ import {
   type CreateServerOptions,
 } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
+import { AgentDiscovery } from "../src/agent-discovery.js";
 import {
   readMonitorRegistry,
   registerMonitor,
@@ -1711,6 +1712,133 @@ describe("CmuxLayerDaemon", () => {
     });
 
     await daemon.shutdown();
+  });
+
+  it("keeps the first connection paused until boot topology ingestion and sweep finish", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("boot-topology-gate");
+    const bootReady = deferred<void>();
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("boot-topology-gate"),
+      disableSpawnPreflight: true,
+    });
+    context.lifecycleStarted = true;
+    context.lifecycleStartPromise = bootReady.promise;
+    const daemon = new CmuxLayerDaemon({ socketPath: path, context });
+
+    await daemon.start();
+    const socket = net.createConnection(path);
+    await once(socket, "connect");
+    await delay(20);
+
+    expect(daemon.activeConnectionCount()).toBe(0);
+
+    bootReady.resolve();
+    await waitUntil(() => daemon.activeConnectionCount() === 1);
+
+    socket.destroy();
+    await daemon.shutdown();
+  });
+
+  it("does not register a client that disconnects while boot ingestion is pending", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("boot-topology-disconnect");
+    const bootReady = deferred<void>();
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("boot-topology-disconnect"),
+      disableSpawnPreflight: true,
+    });
+    context.lifecycleStarted = true;
+    context.lifecycleStartPromise = bootReady.promise;
+    const daemon = new CmuxLayerDaemon({ socketPath: path, context });
+
+    await daemon.start();
+    const socket = net.createConnection(path);
+    await once(socket, "connect");
+    socket.destroy();
+    await once(socket, "close");
+
+    bootReady.resolve();
+    await delay(20);
+
+    expect(daemon.activeConnectionCount()).toBe(0);
+    await daemon.shutdown();
+  });
+
+  it("keeps the gate closed when production lifecycle initialization failed", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("boot-topology-failed");
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("boot-topology-failed"),
+      disableSpawnPreflight: true,
+    });
+    context.lifecycleStarted = true;
+    context.lifecycleStartPromise = Promise.resolve();
+    context.lifecycleStartError = new Error("boot topology ingest failed");
+    const daemon = new CmuxLayerDaemon({ socketPath: path, context });
+
+    await daemon.start();
+    const socket = net.createConnection(path);
+    await once(socket, "connect");
+    await once(socket, "close");
+
+    expect(daemon.activeConnectionCount()).toBe(0);
+    await daemon.shutdown();
+  });
+
+  it("keeps the gate closed when boot pane discovery rejects", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("boot-topology-discovery-rejects");
+    const scan = vi
+      .spyOn(AgentDiscovery.prototype, "scan")
+      .mockRejectedValueOnce(new Error("boot pane discovery failed"));
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("boot-topology-discovery-rejects"),
+      disableSpawnPreflight: true,
+    });
+    const daemon = new CmuxLayerDaemon({ socketPath: path, context });
+
+    try {
+      await daemon.start();
+      const socket = net.createConnection(path);
+      await once(socket, "connect");
+      await once(socket, "close");
+      await context.lifecycleStartPromise;
+
+      expect(context.lifecycleStartError).toMatchObject({
+        message: "boot pane discovery failed",
+      });
+      expect(daemon.activeConnectionCount()).toBe(0);
+    } finally {
+      scan.mockRestore();
+      await daemon.shutdown();
+    }
+  });
+
+  it("shutdown destroys clients still waiting for boot ingestion", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("boot-topology-shutdown");
+    const bootReady = deferred<void>();
+    const context = createServerContext({
+      exec: createLifecycleExec(),
+      stateDir: stateDir("boot-topology-shutdown"),
+      disableSpawnPreflight: true,
+    });
+    context.lifecycleStarted = true;
+    context.lifecycleStartPromise = bootReady.promise;
+    const daemon = new CmuxLayerDaemon({ socketPath: path, context });
+
+    await daemon.start();
+    const socket = net.createConnection(path);
+    await once(socket, "connect");
+
+    await expect(daemon.shutdown()).resolves.toMatchObject({ forced: false });
+    expect(socket.destroyed).toBe(true);
+    bootReady.resolve();
   });
 
   it("closes the per-connection MCP server when a client disconnects", async () => {

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -201,6 +201,46 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
+  it("ignores a zero-area phantom between rendered role columns", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+      makePane("pane:phantom", 1, [], {
+        x: 250,
+        y: 0,
+        width: 0,
+        height: 0,
+      }),
+      makePane("pane:right", 2, ["surface:worker"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      [
+        makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+        makePaneSurfaces("pane:phantom", []),
+        makePaneSurfaces("pane:right", ["surface:worker"]),
+      ],
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker"]),
+      },
+      { role: "worker" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
   it("infers default role from repoGolem launcher names", () => {
     expect(inferAgentRole({ launcherName: "orcClaude" })).toBe("orchestrator");
     expect(inferAgentRole({ launcherName: "cmuxlayerCodex" })).toBe("worker");
@@ -486,7 +526,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
   });
 
-  it("splits orchestrators left when the leftmost pane is worker-majority despite a stale IC record", () => {
+  it("docks orchestrators in column 0 even when that pane is worker-majority", () => {
     const panes = [
       makePane(
         "pane:left-workers",
@@ -549,7 +589,10 @@ describe("layout policy", () => {
       { role: "orchestrator" },
     );
 
-    expect(placement).toEqual({ kind: "split", direction: "left" });
+    expect(placement).toEqual({
+      kind: "surface",
+      pane: "pane:left-workers",
+    });
   });
 
   it("keeps a worker spawn out of column 0 when the only pane is worker-owned", () => {
@@ -618,7 +661,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("places the first worker under its parent IC", () => {
+  it("docks the first worker in column 1 without inventing a row rule", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -644,14 +687,10 @@ describe("layout policy", () => {
       },
     );
 
-    expect(placement).toEqual({
-      kind: "split",
-      direction: "down",
-      pane: "pane:ic",
-    });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
-  it("docks a parent IC's first child into the rightmost worker column when one exists", () => {
+  it("ignores a third worker column for a parent IC's first child", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -679,13 +718,10 @@ describe("layout policy", () => {
       },
     );
 
-    expect(placement).toEqual({
-      kind: "surface",
-      pane: "pane:other-workers",
-    });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
-  it("reuses an existing worker pane under the parent IC for sibling workers", () => {
+  it("keeps sibling workers in canonical column 1 instead of a child row", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -713,10 +749,7 @@ describe("layout policy", () => {
       },
     );
 
-    expect(placement).toEqual({
-      kind: "surface",
-      pane: "pane:children",
-    });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
   it("docks the first child worker into an existing right-column non-lead pane", () => {
@@ -1182,7 +1215,7 @@ describe("layout policy", () => {
     expect(placement).not.toEqual({ kind: "split", direction: "right" });
   });
 
-  it("prefers sparse worker docking over the IC fallback for parentless workers", () => {
+  it("uses column 1 instead of a sparse third column for parentless workers", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -1205,10 +1238,10 @@ describe("layout policy", () => {
       { role: "worker" },
     );
 
-    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
-  it("preserves the IC fallback when no sparse worker seed pane exists", () => {
+  it("uses the existing column-1 pane without imposing a worker row", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -1229,11 +1262,7 @@ describe("layout policy", () => {
       { role: "worker" },
     );
 
-    expect(placement).toEqual({
-      kind: "split",
-      direction: "down",
-      pane: "pane:ic",
-    });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
   it("treats worker role ids missing from the live layout as sparse", () => {
@@ -1260,7 +1289,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 
-  it("seeds a parentless managed worker without anchoring to the lead pane", () => {
+  it("seeds a parentless managed worker beside the current top lead pane", () => {
     const panes = [makePane("pane:lead", 0, ["surface:orchestrator"])];
     const paneSurfaces = [
       makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
@@ -1280,10 +1309,11 @@ describe("layout policy", () => {
     expect(placement).toEqual({
       kind: "split",
       direction: "right",
+      pane: "pane:lead",
     });
   });
 
-  it("seeds a worktree worker column without anchoring to the left lead pane", () => {
+  it("seeds a worktree worker column beside the current top lead pane", () => {
     const panes = [makePane("pane:lead", 0, ["surface:orchestrator"])];
     const paneSurfaces = [
       makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
@@ -1308,6 +1338,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({
       kind: "split",
       direction: "right",
+      pane: "pane:lead",
     });
   });
 
@@ -1336,6 +1367,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({
       kind: "split",
       direction: "right",
+      pane: "pane:lead",
     });
   });
 
@@ -1456,7 +1488,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("reuses the rightmost dedicated worker pane when multiple worker panes exist", () => {
+  it("uses canonical column 1 when multiple worker columns exist", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive"]),
       makePane("pane:right", 1, ["surface:worker-1"]),
@@ -1474,7 +1506,7 @@ describe("layout policy", () => {
       new Set(["surface:worker-1", "surface:worker-2"]),
     );
 
-    expect(placement).toEqual({ kind: "surface", pane: "pane:rightmost" });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
   });
 });
 
@@ -1518,7 +1550,11 @@ describe("worktree worker placement — always right, never left", () => {
       },
     );
 
-    expect(placement).toEqual({ kind: "split", direction: "right" });
+    expect(placement).toEqual({
+      kind: "split",
+      direction: "right",
+      pane: "pane:lead",
+    });
     assertNeverLeft(placement);
   });
 
@@ -1551,7 +1587,11 @@ describe("worktree worker placement — always right, never left", () => {
         },
       );
 
-      expect(placement).toEqual({ kind: "split", direction: "right" });
+      expect(placement).toEqual({
+        kind: "split",
+        direction: "right",
+        pane: "pane:lead",
+      });
       assertNeverLeft(placement);
     },
   );
@@ -1589,7 +1629,7 @@ describe("worktree worker placement — always right, never left", () => {
     assertNeverLeft(placement);
   });
 
-  it("(b2) picks the rightmost worker column when several worker panes exist", () => {
+  it("(b2) ignores a stray third column and docks in the canonical right column", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
       makePane("pane:right", 1, ["surface:worker-1"], rightColumn),
@@ -1622,8 +1662,119 @@ describe("worktree worker placement — always right, never left", () => {
       },
     );
 
-    expect(placement).toEqual({ kind: "surface", pane: "pane:rightmost" });
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
     assertNeverLeft(placement);
+  });
+
+  it("docks at the current top of the right column regardless of pane fill", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:right-bottom", 1, ["surface:worker"], {
+        x: 500,
+        y: 450,
+        width: 500,
+        height: 450,
+      }),
+      makePane("pane:right-top", 2, ["surface:operator"], {
+        x: 500,
+        y: 0,
+        width: 500,
+        height: 450,
+      }),
+    ];
+    const paneSurfaces = [
+      makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+      makePaneSurfaces("pane:right-bottom", ["surface:worker"]),
+      makePaneSurfaces("pane:right-top", ["surface:operator"]),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      paneSurfaces,
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:worker"]),
+      },
+      { role: "worker", worktree: true },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:right-top" });
+  });
+
+  it("keeps N worker spawns in the same canonical right-column top pane", () => {
+    const panes = [
+      makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
+      makePane("pane:right", 1, ["surface:worker-0"], rightColumn),
+      makePane("pane:leftover", 2, ["surface:worker-leftover"], {
+        x: 1000,
+        y: 0,
+        width: 500,
+        height: 900,
+      }),
+    ];
+    const workerSurfaceIds = new Set([
+      "surface:worker-0",
+      "surface:worker-leftover",
+    ]);
+    const rightSurfaces = ["surface:worker-0"];
+
+    for (let index = 1; index <= 5; index += 1) {
+      const placement = chooseAgentSpawnPlacement(
+        panes,
+        [
+          makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
+          makePaneSurfaces("pane:right", rightSurfaces),
+          makePaneSurfaces("pane:leftover", ["surface:worker-leftover"]),
+        ],
+        {
+          orchestrator: new Set(["surface:orchestrator"]),
+          ic: new Set(),
+          worker: workerSurfaceIds,
+        },
+        { role: "worker", worktree: true },
+      );
+
+      expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+      const spawned = `surface:worker-${index}`;
+      rightSurfaces.push(spawned);
+      workerSurfaceIds.add(spawned);
+    }
+  });
+
+  it("docks a lead in the top of column 0 even when that pane is worker-filled", () => {
+    const panes = [
+      makePane("pane:left-bottom", 0, ["surface:orchestrator"], {
+        x: 0,
+        y: 450,
+        width: 500,
+        height: 450,
+      }),
+      makePane("pane:left-top", 1, ["surface:stray-worker"], {
+        x: 0,
+        y: 0,
+        width: 500,
+        height: 450,
+      }),
+      makePane("pane:right", 2, ["surface:worker"], rightColumn),
+    ];
+
+    const placement = chooseAgentSpawnPlacement(
+      panes,
+      [
+        makePaneSurfaces("pane:left-bottom", ["surface:orchestrator"]),
+        makePaneSurfaces("pane:left-top", ["surface:stray-worker"]),
+        makePaneSurfaces("pane:right", ["surface:worker"]),
+      ],
+      {
+        orchestrator: new Set(["surface:orchestrator"]),
+        ic: new Set(),
+        worker: new Set(["surface:stray-worker", "surface:worker"]),
+      },
+      { role: "orchestrator" },
+    );
+
+    expect(placement).toEqual({ kind: "surface", pane: "pane:left-top" });
   });
 
   it("(c) nth worker while a prior worker is stuck in the LEFT column: docks into the RIGHT column, never the left worker", () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -74,6 +74,30 @@ function makeAgentRecord(overrides: Partial<AgentRecord>): AgentRecord {
   };
 }
 
+function writeProgrammaticLeftWorker(
+  overrides: Partial<AgentRecord> = {},
+): void {
+  new StateManager(TEST_DIR).writeState(
+    makeAgentRecord({
+      agent_id: "programmatic-left-worker",
+      surface_id: "surface:worker-left",
+      surface_uuid: "11111111-2222-4333-8444-555555555555",
+      workspace_id: "workspace:1",
+      state: "working",
+      role: "worker",
+      cli: "codex",
+      surface_provenance: "cmuxlayer_spawn",
+      ...overrides,
+    }),
+  );
+}
+
+function markProgrammaticLeftWorkerIdle(
+  agentId = "programmatic-left-worker",
+): void {
+  new StateManager(TEST_DIR).transition(agentId, "idle");
+}
+
 function makeDiscoveryExec(): ExecFn {
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("list-workspaces")) {
@@ -916,6 +940,7 @@ function makeLeftColumnWorkerExec(
     stableIds?: boolean;
     workerScreen?: string;
     workerTitle?: string;
+    zeroAreaPhantom?: boolean;
   } = {},
 ): ExecFn & { recycleSeedSurfaceRef(): void } {
   let workerPane = "pane:left";
@@ -998,9 +1023,23 @@ function makeLeftColumnWorkerExec(
           workspace_ref: "workspace:1",
           window_ref: "window:1",
           panes: [
+            ...(opts.zeroAreaPhantom
+              ? [
+                  {
+                    ref: "pane:phantom",
+                    index: 0,
+                    focused: false,
+                    surface_count: 1,
+                    surface_refs: ["surface:phantom"],
+                    surface_ids: ["55555555-6666-4777-8888-999999999999"],
+                    selected_surface_ref: "surface:phantom",
+                    pixel_frame: { x: -500, y: 0, width: 0, height: 0 },
+                  },
+                ]
+              : []),
             {
               ref: "pane:left",
-              index: 0,
+              index: opts.zeroAreaPhantom ? 1 : 0,
               focused: true,
               surface_count: workerPane === "pane:left" ? 2 : 1,
               surface_refs:
@@ -1022,7 +1061,7 @@ function makeLeftColumnWorkerExec(
               ? [
                   {
                     ref: "pane:right",
-                    index: 1,
+                    index: opts.zeroAreaPhantom ? 2 : 1,
                     focused: false,
                     surface_count:
                       (seedSurfaceOpen
@@ -1086,7 +1125,18 @@ function makeLeftColumnWorkerExec(
     if (args.includes("list-pane-surfaces")) {
       const pane = String(args[args.indexOf("--pane") + 1]);
       const base =
-        pane === "pane:left"
+        pane === "pane:phantom"
+          ? [
+              {
+                ref: "surface:phantom",
+                id: "55555555-6666-4777-8888-999999999999",
+                title: "operator phantom",
+                type: "terminal" as const,
+                index: 0,
+                selected: true,
+              },
+            ]
+          : pane === "pane:left"
           ? [
               {
                 ref: "surface:lead",
@@ -1485,7 +1535,7 @@ describe("resync_agents tool", () => {
     expect(parsed.count).toBe(1);
   });
 
-  it("resync_agents moves an auto-discovered worker out of the leftmost lead column", async () => {
+  it("resync_agents never moves an auto-discovered unknown-provenance worker", async () => {
     const exec = makeLeftColumnWorkerExec();
     const server = createServer({ exec, stateDir: TEST_DIR });
 
@@ -1495,7 +1545,7 @@ describe("resync_agents tool", () => {
     );
     const parsed = parseResult(result);
 
-    expect(exec).toHaveBeenCalledWith(
+    expect(exec).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
         "move-surface",
@@ -1505,13 +1555,7 @@ describe("resync_agents tool", () => {
         "pane:right",
       ]),
     );
-    expect(parsed.diff.reflowed).toEqual([
-      expect.objectContaining({
-        surface_id: "surface:worker-left",
-        from_column: 0,
-        to_column: 1,
-      }),
-    ]);
+    expect(parsed.diff.reflowed).toEqual([]);
   });
 
   it("resync_agents never reflows a UUID-less worker owned by another observer", async () => {
@@ -1614,6 +1658,9 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents refuses a seed split when the observer changes after its topology snapshot", async () => {
+    writeProgrammaticLeftWorker({
+      surface_observer_id: "cmux:/tmp/cmux-primary.sock",
+    });
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -1628,6 +1675,7 @@ describe("resync_agents tool", () => {
     });
     const server = createServer({ context });
     await context.lifecycleStartPromise;
+    markProgrammaticLeftWorkerIdle();
     const registry = (server as any)._registeredTools["interact"]._engine.getRegistry() as any;
     let switchOnNextBindingAuthorization = false;
     const originalCanUseObservedBinding =
@@ -1686,6 +1734,8 @@ describe("resync_agents tool", () => {
         workspace_id: "workspace:1",
         role: "worker",
         cli: "codex",
+        state: "working",
+        surface_provenance: "cmuxlayer_spawn",
       }),
     );
     const route = makeMovedUuidReflowExec();
@@ -1701,6 +1751,7 @@ describe("resync_agents tool", () => {
     });
     const server = createServer({ context });
     await context.lifecycleStartPromise;
+    stateMgr.transition("uuid-reflow-worker-after-snapshot", "idle");
     const registry = (server as any)._registeredTools["interact"]._engine.getRegistry();
     armAfterSecondResyncMerge(registry, snapshot.arm);
 
@@ -1730,7 +1781,67 @@ describe("resync_agents tool", () => {
     }
   });
 
+  it("resync_agents never moves an idle worker that starts working before mutation", async () => {
+    const stateMgr = new StateManager(TEST_DIR);
+    const agentId = "idle-worker-starts-working";
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: agentId,
+        surface_id: "surface:worker-left",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "workspace:1",
+        state: "working",
+        role: "worker",
+        cli: "codex",
+        surface_provenance: "cmuxlayer_spawn",
+      }),
+    );
+    const base = makeLeftColumnWorkerExec({ stableIds: true });
+    let registry: any;
+    const snapshot = afterNextPaneSnapshot(base, "pane:right", () => {
+      const working = stateMgr.transition(agentId, "working");
+      registry.set(agentId, working);
+    });
+    const context = createServerContext({
+      exec: snapshot.exec,
+      stateDir: TEST_DIR,
+      controlHealthIntervalMs: 0,
+    });
+    const server = createServer({ context });
+    await context.lifecycleStartPromise;
+    const idle = stateMgr.transition(agentId, "idle");
+    registry = (server as any)._registeredTools["interact"]._engine.getRegistry();
+    registry.set(agentId, idle);
+    armAfterSecondResyncMerge(registry, snapshot.arm);
+
+    try {
+      const result = await (server as any)._registeredTools["resync_agents"].handler(
+        {},
+        {} as any,
+      );
+      const parsed = parseResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(snapshot.exec).not.toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["move-surface"]),
+      );
+      expect(parsed.diff.reflowed).toEqual([]);
+      expect(parsed.diff.reflow_skipped).toEqual([
+        expect.objectContaining({
+          agent_id: agentId,
+          operation: "move_surface",
+          reason: expect.stringMatching(/state|busy/i),
+        }),
+      ]);
+    } finally {
+      await server.close();
+      context.dispose();
+    }
+  });
+
   it("resync_agents fresh-resolves a seeded surface UUID before cleanup instead of closing a recycled ref", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -1751,6 +1862,7 @@ describe("resync_agents tool", () => {
       return result;
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1779,6 +1891,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents reports and skips a seed split in a manual workspace", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -1793,6 +1906,7 @@ describe("resync_agents tool", () => {
       return base(cmd, args);
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1818,6 +1932,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents reports and skips moving a manual surface", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({ stableIds: true });
     const exec: ExecFn = vi.fn().mockImplementation(async (cmd, args) => {
       if (args.includes("list-status")) {
@@ -1829,6 +1944,7 @@ describe("resync_agents tool", () => {
       return base(cmd, args);
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1850,6 +1966,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents reports and skips seed cleanup when the seed becomes manual", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -1871,6 +1988,7 @@ describe("resync_agents tool", () => {
       return result;
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1893,6 +2011,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents rechecks workspace mode after its final seed topology read", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -1922,6 +2041,7 @@ describe("resync_agents tool", () => {
       return result;
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1943,6 +2063,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents rechecks surface mode after its final move topology read", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({ stableIds: true });
     let armModeFlip = false;
     let manual = false;
@@ -1969,6 +2090,7 @@ describe("resync_agents tool", () => {
       return result;
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -1990,6 +2112,7 @@ describe("resync_agents tool", () => {
   });
 
   it("resync_agents rechecks seed mode after its final cleanup topology read", async () => {
+    writeProgrammaticLeftWorker();
     const base = makeLeftColumnWorkerExec({
       singleColumn: true,
       stableIds: true,
@@ -2020,6 +2143,7 @@ describe("resync_agents tool", () => {
       return result;
     });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -2041,9 +2165,14 @@ describe("resync_agents tool", () => {
     ]);
   });
 
-  it("resync_agents seeds a right column for a single-column auto-discovered worker", async () => {
-    const exec = makeLeftColumnWorkerExec({ singleColumn: true });
+  it("resync_agents seeds a right column for a single-column programmatic worker", async () => {
+    writeProgrammaticLeftWorker();
+    const exec = makeLeftColumnWorkerExec({
+      singleColumn: true,
+      stableIds: true,
+    });
     const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
 
     const result = await (server as any)._registeredTools["resync_agents"].handler(
       {},
@@ -2074,6 +2203,40 @@ describe("resync_agents tool", () => {
     expect(parsed.diff.reflowed).toEqual([
       expect.objectContaining({
         surface_id: "surface:worker-left",
+        from_column: 0,
+        to_column: 1,
+      }),
+    ]);
+  });
+
+  it("resync_agents ignores a zero-area phantom before the two rendered role columns", async () => {
+    writeProgrammaticLeftWorker();
+    const exec = makeLeftColumnWorkerExec({
+      stableIds: true,
+      zeroAreaPhantom: true,
+    });
+    const server = createServer({ exec, stateDir: TEST_DIR });
+    markProgrammaticLeftWorkerIdle();
+
+    const result = await (server as any)._registeredTools["resync_agents"].handler(
+      {},
+      {} as any,
+    );
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "move-surface",
+        "--surface",
+        "surface:worker-left",
+        "--pane",
+        "pane:right",
+      ]),
+    );
+    expect(parsed.diff.reflowed).toEqual([
+      expect.objectContaining({
         from_column: 0,
         to_column: 1,
       }),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5306,6 +5306,44 @@ codex>
     expect(result.content[0].text).toMatch(/not in an interactive state/);
   });
 
+  it("send_to_agent leaves an idle agent idle when submitted delivery fails", async () => {
+    let failReturn = false;
+    const base = makeLifecycleExec({
+      surfaceUuid: "11111111-2222-4333-8444-555555555555",
+    });
+    const exec: ExecFn = vi.fn().mockImplementation(async (cmd, args) => {
+      if (failReturn && args.includes("send-key") && args.includes("return")) {
+        throw new Error("Return delivery failed");
+      }
+      return base(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to_agent"];
+    const spawnResult = await spawn.handler(
+      { repo: "test", model: "sonnet", cli: "claude" },
+      {} as any,
+    );
+    const agentId = parseToolResult(spawnResult).agent_id as string;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const idle = engine.stateMgr.resetState(
+      agentId,
+      "idle",
+      {},
+      "test delivery precondition",
+    );
+    engine.getRegistry().set(agentId, idle);
+    failReturn = true;
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: "continue", press_enter: true },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(engine.getAgentState(agentId)?.state).toBe("idle");
+  });
+
   it.each(["send_to", "send_to_agent"] as const)(
     "RC3: %s delivers to an error-state agent whose surface is alive",
     async (toolName) => {
@@ -5875,7 +5913,7 @@ codex>
     expect(parsed.agent_id).toBe(agentId);
   });
 
-  it("send_to returns post-delivery screen evidence and health disagreement", async () => {
+  it("send_to reserves an idle agent as working before health evidence", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const sendTo = (server as any)._registeredTools["send_to"];
@@ -5894,8 +5932,13 @@ codex>
 
     const engine = (server as any)._registeredTools["interact"]._engine;
     const registry = engine.getRegistry();
-    const agent = registry.get(agentId);
-    registry.set(agentId, { ...agent, state: "ready" });
+    const idle = engine.stateMgr.resetState(
+      agentId,
+      "idle",
+      {},
+      "test delivery precondition",
+    );
+    registry.set(agentId, idle);
 
     const result = await sendTo.handler(
       { agent_id: agentId, text: "begin work", press_enter: true },
@@ -5906,13 +5949,15 @@ codex>
 
     expect(result.isError).toBeFalsy();
     expect(parsed.ok).toBe(true);
-    expect(parsed.registry_state).toBe("ready");
+    expect(parsed.registry_state).toBe("working");
     expect(parsed.screen).toMatchObject({
       agent_type: "claude",
       status: "working",
     });
-    expect(parsed.state_conflict).toBe(true);
-    expect(parsed.health.issue_codes).toContain("registry_screen_disagreement");
+    expect(parsed.state_conflict).toBe(false);
+    expect(parsed.health.issue_codes).not.toContain(
+      "registry_screen_disagreement",
+    );
   });
 
   it("send_to omits post-delivery evidence when the stable UUID disappears", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -748,7 +748,7 @@ describe("Sidebar Sync", () => {
     ]);
   });
 
-  it("degrades a transient first-connect discovery failure to unknown", async () => {
+  it("keeps placement unavailable when first-connect discovery fails", async () => {
     mockClient.listWorkspaces.mockRejectedValue(
       new Error("cmux socket unavailable"),
     );
@@ -759,14 +759,12 @@ describe("Sidebar Sync", () => {
       readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
     });
 
-    await expect(engine.initialize(discovery)).resolves.toBeUndefined();
+    await expect(engine.initialize(discovery)).rejects.toThrow(
+      /cmux socket unavailable/,
+    );
 
     expect(publishedFleetPublications).toEqual([
       expect.objectContaining({ state: "discovering" }),
-      expect.objectContaining({
-        state: "unknown",
-        observedLiveSurfaceRefs: null,
-      }),
     ]);
   });
 

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -317,6 +317,7 @@ describe("StateManager", () => {
 
       expect(record.role).toBe("worker");
       expect(record.auto_archive_on_done).toBe(false);
+      expect(record.surface_provenance).toBe("unknown");
       expect(record.surface_uuid).toBe(
         "11111111-2222-4333-8444-555555555555",
       );


### PR DESCRIPTION
## Summary

- enforce deterministic role columns: orchestrators in column 0 and workers in column 1, always docking at the current top of the role column
- persist cmuxlayer-spawn provenance and gate every sweep/reflow mutation on provable provenance plus idle/terminal state
- ingest and re-register existing topology before the boot sweep and before placement becomes live
- serialize delivery and placement mutations by stable surface UUID, with just-in-time authority rechecks
- keep unknown/operator surfaces untouched and fail closed when boot topology cannot be ingested

## Contract

Boot order is: reconstitute registry -> ingest/re-register existing panes -> sweep provable idle leftovers -> placement live.

Reconciliation runs at spawn and idle only. It never yanks a working pane. Unknown provenance is operator-owned and is never moved or closed.

## TDD evidence

Counterfactual RED coverage includes:
- immediate post-boot spawn docks against ingested current topology
- unknown provenance is never moved or closed
- working panes are not reconciled
- idle-to-working races abort before mutation
- stale refs and recycled UUIDs cannot authorize placement
- zero-area phantom panes do not redefine role columns
- failed boot ingestion keeps the daemon gate closed
- repeated role spawns remain at the current top of the canonical role column

## Verification

- bun run test: 104 files, 2186 tests passed
- bun run typecheck
- bun run build
- hermetic pre-PR harness: 61 tests passed
- git diff --check
- manual red-team, blue-team, and code-review follow-ups: no findings

CodeRabbit rerun was unavailable due the free OSS rate limit; the required manual red/blue fallback completed cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to cmux topology mutations, boot gating, and automated surface moves; mistakes could relocate operator panes or block daemon clients until boot succeeds.
> 
> **Overview**
> Introduces a **two-column role contract** (orchestrators column 0, workers column 1) backed by **`surface_provenance`**: only `cmuxlayer_spawn` surfaces are auto-moved; discovered/operator panes stay `unknown` and untouched.
> 
> **`reconcileRolePlacements`** runs at spawn, when agents become idle, on boot, and each sweep. It uses stable UUID topology, observer epochs, and `beforeMutation` checks so working agents, recycled refs, and idle→working races never get yanked. Worker column seeding can split beside the lead pane and then close the seed by UUID.
> 
> **Spawn placement** is simplified to dock at the **top of the canonical role column** (`topPaneInRoleColumn` / `deriveRoleColumnIndex`), ignoring zero-area phantom panes instead of fill-based heuristics.
> 
> **Boot** is stricter: registry reconstitute → forced discovery merge → boot reconcile → sidebar; discovery failure rejects init. The **daemon** holds new sockets until lifecycle startup succeeds and records **`lifecycleStartError`** when it does not.
> 
> **Surface I/O** locks and mutations key off **stable UUIDs**; `moveSurface` is wired through server, app-server runtime, and reflow. **`markAgentWorking`** runs only after successful Return on submit paths, not on staging-only sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8064485c47129e505ae3d760d33a733db798de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce provenance-gated role placement for spawned agent terminals
> - Introduces `surface_provenance` on `AgentRecord` (`'cmuxlayer_spawn'` | `'unknown'`) so the engine can distinguish programmatically created terminals from auto-discovered ones.
> - Adds `AgentEngine.reconcileRolePlacements` which enforces a two-column layout: orchestrators dock into canonical column 0, workers into column 1, using stable UUID-based write locks and pre-mutation guards to avoid stale-ref races.
> - Reconciliation runs at spawn, on idle transition, on each sweep, and at boot (before first sidebar sync); auto-discovered (`unknown`-provenance) agents are never moved.
> - Rewrites `chooseAgentSpawnPlacement` in [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/329/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed) to use `topPaneInRoleColumn` and canonical column indices, removing majority/heuristic predicates; zero-area phantom panes are filtered from column derivation.
> - Incoming daemon connections are now gated on `lifecycleStartPromise`; failures are recorded in `lifecycleStartError` and surfaced to callers rather than silently proceeding.
> - `markAgentWorking` transitions an idle agent to working immediately when a command is dispatched (Enter key sent), reserving its placement slot.
> - Risk: `initialize` now rejects on first-connect discovery failure instead of degrading to an `'unknown'` placement state, which is a behavioral change for callers that previously handled the degraded state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8e80644. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic two-column role placement for orchestrators and workers.
  * Added automatic reconciliation to restore misplaced agent surfaces.
  * Added provenance tracking for agent surfaces.
  * Agents now transition to “working” after successful Return-key delivery.

* **Bug Fixes**
  * Prevented commands from routing to surfaces that change during delivery.
  * Improved connection startup and shutdown handling.
  * Unknown or unverified surfaces are no longer moved automatically.
  * Zero-area phantom panes are ignored during placement decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->