### PR TITLE
fix(registry): preserve live seats during record repair

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -42,6 +42,25 @@ interface SurfaceAbsenceOptions {
   now?: number;
 }
 
+export interface LiveSeatDiscoveryProof {
+  observer_id: string;
+  observer_epoch: string;
+  seats: Array<{
+    surface_id: string;
+    surface_uuid: string | null;
+    seat_id: string;
+  }>;
+}
+
+interface SurfacelessEvictionOptions extends SurfaceAbsenceOptions {
+  /**
+   * Same-cycle, observer-pinned screen proof for role-classified live seats.
+   * Surface enumeration alone proves topology, not that the expected agent
+   * still owns the shell, so crash-recovery rows may only yield to this proof.
+   */
+  liveSeatProof?: LiveSeatDiscoveryProof | null;
+}
+
 export interface AgentRegistryOptions {
   /** Static identity for a client that never changes cmux socket topology. */
   observerId?: string | null;
@@ -323,16 +342,6 @@ function recordIdentityKeys(record: AgentRecord): string[] {
       ? `launcher:${pendingBaseAgentId(record.agent_id)}`
       : null,
   ].filter((key): key is string => Boolean(key));
-}
-
-function primaryRecordIdentityKey(record: AgentRecord): string | null {
-  if (record.seat_id) return `seat:${record.seat_id}`;
-  if (record.launcher_name) return `launcher:${record.launcher_name}`;
-  return null;
-}
-
-function canonicalIdentityName(record: AgentRecord): string | null {
-  return record.seat_id ?? record.launcher_name ?? null;
 }
 
 function repairCandidateIdentityKeys(
@@ -922,6 +931,10 @@ export class AgentRegistry {
       nonDestructive?: boolean;
     },
   ): Promise<MergedAgent[]> {
+    // Pin both scanned and caller-injected discovery to the observer that was
+    // current when this ingestion began. Reconciliation/purge awaits must not
+    // let an old snapshot cross a reconnect epoch and mutate the replacement.
+    const discoveryObserverSnapshot = this.captureObserverSnapshot();
     if (!opts?.nonDestructive) {
       const surfacelessConfirmation = {
         confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
@@ -931,7 +944,6 @@ export class AgentRegistry {
       await this.purgeTerminal(surfacelessConfirmation);
     }
 
-    const discoveryObserverSnapshot = this.captureObserverSnapshot();
     const discovered =
       opts?.discovered ?? (await discovery.scan(opts?.force ?? false));
     if (!this.isObserverSnapshotCurrent(discoveryObserverSnapshot)) {
@@ -1228,7 +1240,22 @@ export class AgentRegistry {
   ): void {
     if (candidates.length === 0) return;
 
-    const claimedSurfaceRefs = new Set<string>();
+    // Reserve every surface already bound to a managed record before attempting
+    // identity-based relocation. Otherwise filesystem/map iteration order lets
+    // an absent canonical ghost steal a live drifted record's surface.
+    const claimedSurfaceRefs = new Set(
+      candidates.flatMap((entry) => {
+        const occupied = [...this.agents.values()].some(
+          (record) =>
+            !isAutoAgentId(record.agent_id) &&
+            !isPendingAgentId(record.agent_id) &&
+            record.surface_id === entry.discovered.surface_id &&
+            !hasSurfaceUuidConflict(record, entry.discovered) &&
+            this.canUseObservedBinding(record, entry.discovered.surface_uuid),
+        );
+        return occupied ? [entry.discovered.surface_id] : [];
+      }),
+    );
     for (const record of [...this.agents.values()]) {
       if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
         continue;
@@ -1547,10 +1574,7 @@ export class AgentRegistry {
   }
 
   async evictSurfaceless(
-    opts: {
-      confirmationMs?: number;
-      now?: number;
-    } = {},
+    opts: SurfacelessEvictionOptions = {},
   ): Promise<string[]> {
     const observerSnapshot = this.captureObserverSnapshot();
     let surfaces: CmuxSurface[];
@@ -1593,7 +1617,15 @@ export class AgentRegistry {
       ) {
         continue;
       }
-      if (isCrashRecoveryEligible(agent)) {
+      if (
+        isCrashRecoveryEligible(agent) &&
+        !this.hasLiveManagedSeatSibling(
+          agent,
+          surfaces,
+          opts.liveSeatProof,
+          observerSnapshot,
+        )
+      ) {
         continue;
       }
 
@@ -1607,6 +1639,97 @@ export class AgentRegistry {
     }
 
     return evicted;
+  }
+
+  private hasLiveManagedSeatSibling(
+    agent: AgentRecord,
+    surfaces: readonly CmuxSurface[],
+    liveSeatProof: LiveSeatDiscoveryProof | null | undefined,
+    observerSnapshot: RegistryObserverSnapshot,
+  ): boolean {
+    const seatId = agent.seat_id?.trim();
+    if (!seatId) return false;
+    if (
+      !liveSeatProof ||
+      !observerSnapshot.ownerId ||
+      !observerSnapshot.epoch ||
+      liveSeatProof.observer_id !== observerSnapshot.ownerId ||
+      liveSeatProof.observer_epoch !== observerSnapshot.epoch
+    ) {
+      return false;
+    }
+
+    return [...this.agents.values()].some((candidate) => {
+      if (
+        candidate.agent_id === agent.agent_id ||
+        isAutoAgentId(candidate.agent_id) ||
+        isPendingAgentId(candidate.agent_id) ||
+        TERMINAL_STATES.has(candidate.state) ||
+        candidate.seat_id !== seatId
+      ) {
+        return false;
+      }
+      const liveSurface = this.matchingLiveSurface(candidate, surfaces);
+      return Boolean(
+        liveSurface &&
+          this.canUseObservedBinding(candidate, liveSurface.id) &&
+          liveSeatProof.seats.some(
+            (entry) =>
+              entry.seat_id === seatId &&
+              entry.surface_id === liveSurface.ref &&
+              surfaceUuidKey(entry.surface_uuid) ===
+                surfaceUuidKey(liveSurface.id),
+          ),
+      );
+    });
+  }
+
+  createLiveSeatDiscoveryProof(
+    discovered: readonly DiscoveredAgent[],
+    opts: {
+      seatRegistry?: SeatRegistry | null;
+      expectedObserverId: string | null;
+      expectedObserverEpoch: string | null;
+    },
+  ): LiveSeatDiscoveryProof | null {
+    const observerSnapshot = this.captureObserverSnapshot();
+    if (
+      !observerSnapshot.ownerId ||
+      !observerSnapshot.epoch ||
+      observerSnapshot.ownerId !== opts.expectedObserverId ||
+      observerSnapshot.epoch !== opts.expectedObserverEpoch ||
+      !this.isObserverSnapshotCurrent(observerSnapshot) ||
+      !hasBijectiveDiscoveryIdentity(discovered) ||
+      hasMixedDiscoveryIdentityCoverage(discovered)
+    ) {
+      return null;
+    }
+
+    const seats = discovered.flatMap((entry) => {
+      if (!entry.has_agent || entry.read_error) return [];
+      const candidate = repairCandidateForSurface(entry, opts.seatRegistry);
+      const seatId = candidate?.seat.seat_id?.trim();
+      if (
+        !seatId ||
+        candidate?.cli !== entry.cli ||
+        candidate.seat.seat_identity_status !== "ok"
+      ) {
+        return [];
+      }
+      return [
+        {
+          surface_id: entry.surface_id,
+          surface_uuid: entry.surface_uuid ?? null,
+          seat_id: seatId,
+        },
+      ];
+    });
+
+    return {
+      observer_id: observerSnapshot.ownerId,
+      observer_epoch: observerSnapshot.epoch,
+      seats,
+    };
   }
 
   private isSurfacelessConfirmed(
@@ -1690,9 +1813,7 @@ export class AgentRegistry {
     const evicted = new Set<string>();
     const skipped: RegistryRepairSkip[] = [];
     const liveSurfaceRefs = new Set(
-      discovered
-        .filter((entry) => !entry.read_error)
-        .map((entry) => entry.surface_id),
+      discovered.map((entry) => entry.surface_id),
     );
 
     for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
@@ -1729,10 +1850,6 @@ export class AgentRegistry {
           reason: error.message,
         });
       }
-    }
-
-    for (const removed of this.evictDuplicateManagedRegistrations(liveSurfaceRefs)) {
-      evicted.add(removed);
     }
 
     for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
@@ -1782,52 +1899,6 @@ export class AgentRegistry {
 
       if (!liveBackingSurface || supersededByRealRecord || supersededByManagedSeat) {
         const removedAgentId = this.evict(id);
-        if (removedAgentId) {
-          evicted.push(removedAgentId);
-        }
-      }
-    }
-
-    return evicted;
-  }
-
-  private evictDuplicateManagedRegistrations(
-    liveSurfaceRefs: ReadonlySet<string>,
-  ): string[] {
-    const byIdentity = new Map<string, AgentRecord[]>();
-    for (const record of this.agents.values()) {
-      if (isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id)) {
-        continue;
-      }
-      const key = primaryRecordIdentityKey(record);
-      if (!key) continue;
-      byIdentity.set(key, [...(byIdentity.get(key) ?? []), record]);
-    }
-
-    const evicted: string[] = [];
-    for (const records of byIdentity.values()) {
-      if (records.length <= 1) continue;
-      const sorted = [...records].sort((left, right) => {
-        const leftCanonical =
-          left.agent_id === canonicalIdentityName(left) ? 0 : 1;
-        const rightCanonical =
-          right.agent_id === canonicalIdentityName(right) ? 0 : 1;
-        if (leftCanonical !== rightCanonical) {
-          return leftCanonical - rightCanonical;
-        }
-        const leftLive = liveSurfaceRefs.has(left.surface_id) ? 0 : 1;
-        const rightLive = liveSurfaceRefs.has(right.surface_id) ? 0 : 1;
-        if (leftLive !== rightLive) {
-          return leftLive - rightLive;
-        }
-        return left.agent_id.localeCompare(right.agent_id);
-      });
-      const keep = sorted[0];
-      for (const duplicate of sorted.slice(1)) {
-        if (!this.canMutateForObservedAbsence(duplicate)) {
-          continue;
-        }
-        const removedAgentId = this.evict(duplicate.agent_id);
         if (removedAgentId) {
           evicted.push(removedAgentId);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9419,10 +9419,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             const repair = registry.repairFromDiscovery(discoveredBeforeRepair, {
               seatRegistry,
             });
+            const liveSeatProofObserverId = registry.getObserverId();
+            const liveSeatProofObserverEpoch = registry.getObserverEpoch();
             discovery.invalidate();
-            await registry.listMerged(discovery, { force: true });
+            const discoveredAfterRepair = await discovery.scan(true);
+            const liveSeatProof = registry.createLiveSeatDiscoveryProof(
+              discoveredAfterRepair,
+              {
+                seatRegistry,
+                expectedObserverId: liveSeatProofObserverId,
+                expectedObserverEpoch: liveSeatProofObserverEpoch,
+              },
+            );
+            await registry.listMerged(discovery, {
+              force: true,
+              discovered: discoveredAfterRepair,
+            });
             const surfacelessEvicted = await registry.evictSurfaceless(
-              surfaceAbsenceConfirmation,
+              {
+                ...surfaceAbsenceConfirmation,
+                liveSeatProof,
+              },
             );
             engine.evictDeadProcessAgents();
             discovery.invalidate();

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -67,6 +67,22 @@ function makeDiscovered(
 }
 
 const REPAIR_SEATS: SeatRegistry = {
+  coachClaude: {
+    repo: "coach",
+    launchers: {
+      claude: "coachClaude",
+    },
+    lane: "coach",
+    role: "lead",
+  },
+  golemsCodex: {
+    repo: "golems",
+    launchers: {
+      codex: "golemsCodex",
+    },
+    lane: "golems",
+    role: "worker",
+  },
   driverBuddy: {
     repo: "driverBuddy",
     launchers: {
@@ -1044,6 +1060,72 @@ describe("AgentRegistry", () => {
       expect(registry.get("list-worker-transient-gap")).toBeNull();
     });
 
+    it("rejects injected discovery when the observer epoch changes during listMerged preamble", async () => {
+      const ownerId = "cmux:/tmp/test.sock";
+      const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+      let observerEpoch = `${ownerId}@epoch-1`;
+      let changeEpochOnEnumeration = false;
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "epoch-pinned-managed-agent",
+          surface_id: "surface:old",
+          surface_uuid: surfaceUuid,
+          surface_observer_id: ownerId,
+          workspace_id: "workspace:old",
+          state: "working",
+        }),
+      );
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => {
+          if (changeEpochOnEnumeration) {
+            observerEpoch = `${ownerId}@epoch-2`;
+          }
+          const surfaceRef = changeEpochOnEnumeration
+            ? "surface:new"
+            : "surface:old";
+          const workspaceRef = changeEpochOnEnumeration
+            ? "workspace:new"
+            : "workspace:old";
+          return [
+            {
+              ...makeSurface(surfaceRef),
+              id: surfaceUuid,
+              workspace_ref: workspaceRef,
+            },
+          ];
+        },
+        {
+          observerIdProvider: () => ownerId,
+          observerEpochProvider: () => observerEpoch,
+        },
+      );
+      await registry.reconstitute();
+      changeEpochOnEnumeration = true;
+
+      await registry.listMerged(
+        { scan: vi.fn() } as any,
+        {
+          discovered: [
+            makeDiscovered({
+              surface_id: "surface:new",
+              surface_uuid: surfaceUuid,
+              workspace_id: "workspace:new",
+              surface_title: "brainlayerCodex",
+              cli: "codex",
+            }),
+          ],
+        },
+      );
+
+      expect(observerEpoch).toBe(`${ownerId}@epoch-2`);
+      expect(stateMgr.readState("epoch-pinned-managed-agent")).toMatchObject({
+        surface_id: "surface:old",
+        surface_uuid: surfaceUuid,
+        workspace_id: "workspace:old",
+      });
+    });
+
     it("does not evict an owned UUID-less booting row from mixed discovery identity coverage", async () => {
       const agentId = "mixed-discovery-legacy-booting";
       stateMgr.writeState(
@@ -1658,6 +1740,393 @@ describe("AgentRegistry", () => {
       );
     });
 
+    it("repairs a proven-live managed seat in place without losing session metadata", async () => {
+      const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+      const observerId = "cmux:/tmp/current.sock";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coach-drifted-record",
+          surface_id: "surface:coach",
+          surface_uuid: surfaceUuid,
+          surface_observer_id: observerId,
+          workspace_id: "workspace:old",
+          repo: "legacy-coach",
+          cli: "codex",
+          launcher_name: "legacyCoachCodex",
+          seat_id: "legacy-seat",
+          seat_lane: "legacy",
+          seat_role: "worker",
+          seat_identity_status: "mismatch",
+          seat_identity_error: "stale metadata",
+          role: "worker",
+          state: "working",
+          cli_session_id: "coach-session-id",
+          cli_session_path: "/tmp/coach-session.jsonl",
+          task_summary: "live coaching session",
+          pid: 4242,
+          surface_provenance: "unknown",
+        }),
+      );
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => [
+          {
+            ...makeSurface("surface:coach"),
+            id: surfaceUuid,
+          },
+        ],
+        { observerId },
+      );
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach",
+            surface_uuid: surfaceUuid,
+            surface_title: "coachClaude",
+            workspace_id: "workspace:coach",
+            cli: "claude",
+            model: "Opus 4.8",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result).toMatchObject({
+        repaired: [
+          {
+            agent_id: "coach-drifted-record",
+            surface_id: "surface:coach",
+            surface_uuid: surfaceUuid,
+            repo: "coach",
+            cli: "claude",
+            launcher_name: "coachClaude",
+            seat_id: "coachClaude",
+            action: "updated",
+          },
+        ],
+        evicted: [],
+        skipped: [],
+      });
+      expect(stateMgr.readState("coachClaude")).toBeNull();
+      expect(stateMgr.readState("coach-drifted-record")).toMatchObject({
+        agent_id: "coach-drifted-record",
+        surface_id: "surface:coach",
+        surface_uuid: surfaceUuid,
+        surface_observer_id: observerId,
+        workspace_id: "workspace:coach",
+        repo: "coach",
+        cli: "claude",
+        launcher_name: "coachClaude",
+        seat_id: "coachClaude",
+        seat_lane: "coach",
+        seat_role: "lead",
+        seat_identity_status: "ok",
+        seat_identity_error: null,
+        role: "orchestrator",
+        state: "working",
+        cli_session_id: "coach-session-id",
+        cli_session_path: "/tmp/coach-session.jsonl",
+        task_summary: "live coaching session",
+        pid: 4242,
+        surface_provenance: "unknown",
+      });
+      expect(registry.list().map((record) => record.agent_id)).toEqual([
+        "coach-drifted-record",
+      ]);
+    });
+
+    it("backfills missing optional seat metadata without renaming a healthy custom managed identity", async () => {
+      const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coach-legacy-record",
+          surface_id: "surface:coach",
+          surface_uuid: surfaceUuid,
+          repo: "coach",
+          cli: "claude",
+          launcher_name: null,
+          seat_id: null,
+          state: "working",
+          cli_session_id: "coach-session-id",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        { ...makeSurface("surface:coach"), id: surfaceUuid },
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach",
+            surface_uuid: surfaceUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          agent_id: "coach-legacy-record",
+          seat_id: "coachClaude",
+        }),
+      ]);
+      expect(result.evicted).toEqual([]);
+      expect(result.repaired[0]).not.toHaveProperty("previous_agent_id");
+      expect(stateMgr.readState("coachClaude")).toBeNull();
+      expect(stateMgr.readState("coach-legacy-record")).toMatchObject({
+        agent_id: "coach-legacy-record",
+        launcher_name: "coachClaude",
+        seat_id: "coachClaude",
+        state: "working",
+        cli_session_id: "coach-session-id",
+      });
+    });
+
+    it("skip-reports metadata repair when the drifted state disappears before update", async () => {
+      const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coach-drifted-record",
+          surface_id: "surface:coach",
+          surface_uuid: surfaceUuid,
+          repo: "legacy-coach",
+          cli: "codex",
+          launcher_name: "legacyCoachCodex",
+          seat_identity_status: "mismatch",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        { ...makeSurface("surface:coach"), id: surfaceUuid },
+      ]);
+      await registry.reconstitute();
+      vi.spyOn(stateMgr, "updateRecord").mockImplementation((agentId) => {
+        stateMgr.removeState(agentId);
+        throw new Error(`Agent not found: ${agentId}`);
+      });
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach",
+            surface_uuid: surfaceUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result).toEqual({
+        repaired: [],
+        evicted: [],
+        skipped: [
+          expect.objectContaining({
+            surface_id: "surface:coach",
+            surface_uuid: surfaceUuid,
+            agent_id: "coach-drifted-record",
+            seat_id: "coachClaude",
+            reason: "Agent not found: coach-drifted-record",
+          }),
+        ],
+      });
+    });
+
+    it("never evicts a live canonical duplicate when its screen read fails", async () => {
+      const observerId = "cmux:/tmp/current.sock";
+      const driftedUuid = "11111111-2222-4333-8444-555555555555";
+      const canonicalUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coach-drifted-record",
+          surface_id: "surface:coach-drifted",
+          surface_uuid: driftedUuid,
+          surface_observer_id: observerId,
+          repo: "legacy-coach",
+          cli: "codex",
+          launcher_name: "legacyCoachCodex",
+          role: "worker",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          surface_id: "surface:coach-canonical",
+          surface_uuid: canonicalUuid,
+          surface_observer_id: observerId,
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          seat_lane: "coach",
+          seat_role: "lead",
+          seat_identity_status: "ok",
+          role: "orchestrator",
+        }),
+      );
+      const surfaces = [
+        { ...makeSurface("surface:coach-drifted"), id: driftedUuid },
+        { ...makeSurface("surface:coach-canonical"), id: canonicalUuid },
+      ];
+      const registry = new AgentRegistry(stateMgr, async () => surfaces, {
+        observerId,
+      });
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach-drifted",
+            surface_uuid: driftedUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+          }),
+          makeDiscovered({
+            surface_id: "surface:coach-canonical",
+            surface_uuid: canonicalUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+            read_error: true,
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.evicted).toEqual([]);
+      expect(stateMgr.readState("coach-drifted-record")).not.toBeNull();
+      expect(stateMgr.readState("coachClaude")).not.toBeNull();
+      expect(registry.list().map((record) => record.agent_id).sort()).toEqual([
+        "coach-drifted-record",
+        "coachClaude",
+      ]);
+    });
+
+    it("does not evict an unobserved duplicate from a first partial discovery omission", async () => {
+      const firstUuid = "11111111-2222-4333-8444-555555555555";
+      const secondUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+      const makeCoachRecord = (
+        agentId: string,
+        surfaceId: string,
+        surfaceUuid: string,
+      ) =>
+        makeRecord({
+          agent_id: agentId,
+          surface_id: surfaceId,
+          surface_uuid: surfaceUuid,
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          seat_lane: "coach",
+          seat_role: "lead",
+          seat_identity_status: "ok",
+          role: "orchestrator",
+          state: "working",
+        });
+      stateMgr.writeState(
+        makeCoachRecord("coach-session-a", "surface:coach-a", firstUuid),
+      );
+      stateMgr.writeState(
+        makeCoachRecord("coach-session-b", "surface:coach-b", secondUuid),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        { ...makeSurface("surface:coach-a"), id: firstUuid },
+        { ...makeSurface("surface:coach-b"), id: secondUuid },
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach-a",
+            surface_uuid: firstUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.evicted).toEqual([]);
+      expect(stateMgr.readState("coach-session-a")).not.toBeNull();
+      expect(stateMgr.readState("coach-session-b")).not.toBeNull();
+    });
+
+    it("leaves an absent canonical duplicate for confirmation-based ghost eviction", async () => {
+      const observerId = "cmux:/tmp/current.sock";
+      const liveUuid = "11111111-2222-4333-8444-555555555555";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coach-session-record",
+          surface_id: "surface:coach-live",
+          surface_uuid: liveUuid,
+          surface_observer_id: observerId,
+          repo: "legacy-coach",
+          cli: "codex",
+          launcher_name: "legacyCoachCodex",
+          seat_identity_status: "mismatch",
+          state: "working",
+          cli_session_id: "coach-session-id",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          surface_id: "surface:coach-gone",
+          surface_uuid: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+          surface_observer_id: observerId,
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          seat_lane: "coach",
+          seat_role: "lead",
+          seat_identity_status: "ok",
+          state: "error",
+          error: "Surface surface:coach-gone disappeared",
+        }),
+      );
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => [
+          { ...makeSurface("surface:coach-live"), id: liveUuid },
+        ],
+        { observerId },
+      );
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach-live",
+            surface_uuid: liveUuid,
+            surface_title: "coachClaude",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          agent_id: "coach-session-record",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+        }),
+      ]);
+      expect(result.evicted).toEqual([]);
+      expect(stateMgr.readState("coach-session-record")).toMatchObject({
+        agent_id: "coach-session-record",
+        state: "working",
+        cli_session_id: "coach-session-id",
+      });
+      expect(stateMgr.readState("coachClaude")).not.toBeNull();
+    });
+
     it("repairs no-suffix auto-discovered panes from parsed cli and title repo evidence", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -2268,6 +2737,392 @@ describe("AgentRegistry", () => {
         registry.evictSurfaceless({ confirmationMs: 0 }),
       ).resolves.toEqual([]);
       expect(registry.get("uuid-agent-on-legacy-topology")).not.toBeNull();
+    });
+
+    it("keeps a recoverable seat ghost when only a terminal same-seat record has a surface", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "stale-coach-duplicate",
+          state: "done",
+          surface_id: "surface:shell",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:shell"),
+      ]);
+      await registry.reconstitute();
+
+      await expect(
+        registry.evictSurfaceless({ confirmationMs: 0 }),
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        state: "error",
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
+    });
+
+    it("keeps a recoverable seat ghost when a stale working same-seat record has only a shell surface", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "stale-coach-duplicate",
+          state: "working",
+          surface_id: "surface:shell",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          pid: null,
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        { ...makeSurface("surface:shell"), title: "plain shell" },
+      ], {
+        observerId: "cmux:/tmp/test.sock",
+        observerEpochProvider: () => "cmux:/tmp/test.sock@epoch-1",
+      });
+      await registry.reconstitute();
+
+      const proof = registry.createLiveSeatDiscoveryProof(
+        [
+          makeDiscovered({
+            surface_id: "surface:shell",
+            surface_title: "plain shell",
+            cli: "unknown",
+            parsed_status: null,
+            has_agent: false,
+            read_error: false,
+          }),
+        ],
+        {
+          seatRegistry: REPAIR_SEATS,
+          expectedObserverId: "cmux:/tmp/test.sock",
+          expectedObserverEpoch: "cmux:/tmp/test.sock@epoch-1",
+        },
+      );
+
+      await expect(
+        registry.evictSurfaceless({
+          confirmationMs: 0,
+          liveSeatProof: proof,
+        }),
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        state: "error",
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
+    });
+
+    it("evicts a confirmed recoverable ghost when discovery proves the live same-seat agent", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "live-coach-record",
+          state: "working",
+          surface_id: "surface:coach",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:coach"),
+      ], {
+        observerId: "cmux:/tmp/test.sock",
+        observerEpochProvider: () => "cmux:/tmp/test.sock@epoch-1",
+      });
+      await registry.reconstitute();
+
+      const proof = registry.createLiveSeatDiscoveryProof(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach",
+            surface_title: "coachClaude",
+            cli: "claude",
+            has_agent: true,
+            read_error: false,
+          }),
+        ],
+        {
+          seatRegistry: REPAIR_SEATS,
+          expectedObserverId: "cmux:/tmp/test.sock",
+          expectedObserverEpoch: "cmux:/tmp/test.sock@epoch-1",
+        },
+      );
+
+      await expect(
+        registry.evictSurfaceless({
+          confirmationMs: 0,
+          liveSeatProof: proof,
+        }),
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
+      expect(registry.get("live-coach-record")).not.toBeNull();
+    });
+
+    it("keeps a recoverable seat ghost when the live sibling surface resolves to another seat", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "stale-coach-row",
+          state: "working",
+          surface_id: "surface:other-agent",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:other-agent"),
+      ], {
+        observerId: "cmux:/tmp/test.sock",
+        observerEpochProvider: () => "cmux:/tmp/test.sock@epoch-1",
+      });
+      await registry.reconstitute();
+
+      const proof = registry.createLiveSeatDiscoveryProof(
+        [
+          makeDiscovered({
+            surface_id: "surface:other-agent",
+            surface_title: "golemsCodex",
+            cli: "codex",
+            has_agent: true,
+            read_error: false,
+          }),
+        ],
+        {
+          seatRegistry: REPAIR_SEATS,
+          expectedObserverId: "cmux:/tmp/test.sock",
+          expectedObserverEpoch: "cmux:/tmp/test.sock@epoch-1",
+        },
+      );
+
+      await expect(
+        registry.evictSurfaceless({
+          confirmationMs: 0,
+          liveSeatProof: proof,
+        }),
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
+    });
+
+    it("keeps a recoverable seat ghost when seat classification returns a mismatch", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "stale-coach-row",
+          state: "working",
+          surface_id: "surface:mismatch",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => [makeSurface("surface:mismatch")],
+        {
+          observerId: "cmux:/tmp/test.sock",
+          observerEpochProvider: () => "cmux:/tmp/test.sock@epoch-1",
+        },
+      );
+      await registry.reconstitute();
+
+      const proof = registry.createLiveSeatDiscoveryProof(
+        [
+          makeDiscovered({
+            surface_id: "surface:mismatch",
+            surface_title: "coachCodex",
+            cli: "codex",
+            has_agent: true,
+            read_error: false,
+          }),
+        ],
+        {
+          seatRegistry: REPAIR_SEATS,
+          expectedObserverId: "cmux:/tmp/test.sock",
+          expectedObserverEpoch: "cmux:/tmp/test.sock@epoch-1",
+        },
+      );
+
+      expect(proof?.seats).toEqual([]);
+      await expect(
+        registry.evictSurfaceless({
+          confirmationMs: 0,
+          liveSeatProof: proof,
+        }),
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
+    });
+
+    it("keeps a recoverable seat ghost when the observer epoch changes after proof", async () => {
+      let observerEpoch = "cmux:/tmp/test.sock@epoch-1";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "coachClaude",
+          state: "error",
+          surface_id: "surface:gone",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          crash_recover: true,
+          cli_session_id: "recover-me",
+          error: "Surface surface:gone disappeared",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "live-coach-record",
+          state: "working",
+          surface_id: "surface:coach",
+          repo: "coach",
+          cli: "claude",
+          launcher_name: "coachClaude",
+          seat_id: "coachClaude",
+          role: "orchestrator",
+          surface_observer_id: "cmux:/tmp/test.sock",
+        }),
+      );
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => [makeSurface("surface:coach")],
+        {
+          observerId: "cmux:/tmp/test.sock",
+          observerEpochProvider: () => observerEpoch,
+        },
+      );
+      await registry.reconstitute();
+      const proof = registry.createLiveSeatDiscoveryProof(
+        [
+          makeDiscovered({
+            surface_id: "surface:coach",
+            surface_title: "coachClaude",
+            cli: "claude",
+            has_agent: true,
+            read_error: false,
+          }),
+        ],
+        {
+          seatRegistry: REPAIR_SEATS,
+          expectedObserverId: "cmux:/tmp/test.sock",
+          expectedObserverEpoch: observerEpoch,
+        },
+      );
+
+      observerEpoch = "cmux:/tmp/test.sock@epoch-2";
+
+      await expect(
+        registry.evictSurfaceless({
+          confirmationMs: 0,
+          liveSeatProof: proof,
+        }),
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
     it("resets the absence window when the same surface is observed live", async () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -755,6 +755,22 @@ function makeEmptySurfaceExec(): ExecFn {
 }
 
 const REGISTRY_REPAIR_SEATS: SeatRegistry = {
+  coachClaude: {
+    repo: "coach",
+    launchers: {
+      claude: "coachClaude",
+    },
+    lane: "coach",
+    role: "lead",
+  },
+  golemsCodex: {
+    repo: "golems",
+    launchers: {
+      codex: "golemsCodex",
+    },
+    lane: "golems",
+    role: "worker",
+  },
   orcClaude: {
     repo: "orc",
     launchers: {
@@ -931,6 +947,125 @@ function makeRegistryRepairExec(
       stderr: "",
     };
   });
+}
+
+function makeSeatRecordRepairExec(): ExecFn & {
+  showCoachAgent(): void;
+  showCoachShell(): void;
+} {
+  let coachHasAgent = true;
+  const exec = vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Active",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:left",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:coach"],
+              selected_surface_ref: "surface:coach",
+              pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+            },
+            {
+              ref: "pane:right",
+              index: 1,
+              focused: false,
+              surface_count: 1,
+              surface_refs: ["surface:golems"],
+              selected_surface_ref: "surface:golems",
+              pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("list-pane-surfaces")) {
+      const pane = args.includes("--pane")
+        ? args[args.indexOf("--pane") + 1]
+        : "pane:left";
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: pane,
+          surfaces:
+            pane === "pane:left"
+              ? [
+                  {
+                    ref: "surface:coach",
+                    title: "coachClaude",
+                    type: "terminal",
+                    index: 0,
+                    selected: true,
+                  },
+                ]
+              : [
+                  {
+                    ref: "surface:golems",
+                    title: "golemsCodex",
+                    type: "terminal",
+                    index: 0,
+                    selected: true,
+                  },
+                ],
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args.includes("read-screen")) {
+      const surface = args[args.indexOf("--surface") + 1];
+      return {
+        stdout: JSON.stringify({
+          surface,
+          text:
+            surface === "surface:coach"
+              ? coachHasAgent
+                ? "Claude Code\n✻ Working…\n  Coaching session\n🤖 Opus 4.8 | 💰 $0.40 | ⏱️ 2m\n"
+                : "$ "
+              : "gpt-5.5 · 82% left · ~/Gits/golems\nWorking (1m 03s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+
+    return {
+      stdout: JSON.stringify({}),
+      stderr: "",
+    };
+  });
+  exec.showCoachAgent = () => {
+    coachHasAgent = true;
+  };
+  exec.showCoachShell = () => {
+    coachHasAgent = false;
+  };
+  return exec;
 }
 
 function makeLeftColumnWorkerExec(
@@ -3009,6 +3144,176 @@ describe("resync_agents tool", () => {
       launcher_name: "brainlayerClaude",
       seat_id: "brainClaude",
     });
+  });
+
+  it("resync_agents repairs live coach and golems records in place while evicting only a confirmed dead ghost", async () => {
+    const firstObservedAt = Date.parse("2026-07-15T10:00:00.000Z");
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstObservedAt);
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "coach-drifted-record",
+        surface_id: "surface:coach",
+        workspace_id: "workspace:1",
+        repo: "legacy-coach",
+        cli: "codex",
+        launcher_name: "legacyCoachCodex",
+        role: "worker",
+        state: "working",
+        cli_session_id: "coach-session-id",
+        task_summary: "live coaching session",
+        pid: 4242,
+        surface_provenance: "unknown",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "golems-drifted-record",
+        surface_id: "surface:golems",
+        workspace_id: "workspace:1",
+        repo: "legacy-golems",
+        cli: "claude",
+        launcher_name: "legacyGolemsClaude",
+        role: "orchestrator",
+        state: "working",
+        cli_session_id: "golems-session-id",
+        task_summary: "live golems work",
+        pid: 5252,
+        surface_provenance: "unknown",
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
+        agent_id: "coachClaude",
+        surface_id: "surface:gone",
+        workspace_id: "workspace:1",
+        repo: "coach",
+        cli: "claude",
+        launcher_name: "coachClaude",
+        seat_id: "coachClaude",
+        seat_lane: "coach",
+        seat_role: "lead",
+        seat_identity_status: "ok",
+        role: "orchestrator",
+        state: "error",
+        error: "Surface surface:gone disappeared",
+        cli_session_id: "coach-ghost-session-id",
+        crash_recover: true,
+        surface_provenance: "unknown",
+      }),
+    );
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    const exec = makeSeatRecordRepairExec();
+    const server = createServer({
+      exec,
+      stateDir: TEST_DIR,
+      seatRegistry: REGISTRY_REPAIR_SEATS,
+    });
+    const tool = (server as any)._registeredTools["resync_agents"];
+
+    const first = parseResult(await tool.handler({}, {} as any));
+    expect(first.ok).toBe(true);
+    expect(first.diff.repaired).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: "coach-drifted-record",
+          surface_id: "surface:coach",
+          seat_id: "coachClaude",
+        }),
+        expect.objectContaining({
+          agent_id: "golems-drifted-record",
+          surface_id: "surface:golems",
+          seat_id: "golemsCodex",
+        }),
+      ]),
+    );
+    expect(first.diff.evicted).not.toEqual(
+      expect.arrayContaining([
+        "coach-drifted-record",
+        "golems-drifted-record",
+      ]),
+    );
+    expect(first.diff.repair_skipped).toEqual([]);
+    expect(first.diff.mismatches).toEqual([]);
+    expect(first.diff.orphaned).toEqual([]);
+    expect(stateMgr.readState("coachClaude")).toMatchObject({
+      surface_id: "surface:gone",
+      state: "error",
+      crash_recover: true,
+    });
+    expect(stateMgr.readState("golemsCodex")).toBeNull();
+    expect(stateMgr.readState("coach-drifted-record")).toMatchObject({
+      agent_id: "coach-drifted-record",
+      surface_id: "surface:coach",
+      repo: "coach",
+      cli: "claude",
+      launcher_name: "coachClaude",
+      role: "orchestrator",
+      state: "working",
+      cli_session_id: "coach-session-id",
+      task_summary: "live coaching session",
+      pid: 4242,
+    });
+    expect(stateMgr.readState("golems-drifted-record")).toMatchObject({
+      agent_id: "golems-drifted-record",
+      surface_id: "surface:golems",
+      repo: "golems",
+      cli: "codex",
+      launcher_name: "golemsCodex",
+      role: "worker",
+      state: "working",
+      cli_session_id: "golems-session-id",
+      task_summary: "live golems work",
+      pid: 5252,
+    });
+    expect(first.diff.evicted).not.toContain("coachClaude");
+
+    const registry = (server as any)._registeredTools[
+      "interact"
+    ]._engine.getRegistry();
+    const originalRepair = registry.repairFromDiscovery.bind(registry);
+    let replaceAgentAfterRepair = true;
+    vi.spyOn(registry, "repairFromDiscovery").mockImplementation(
+      (...args: any[]) => {
+        const result = originalRepair(...args);
+        if (replaceAgentAfterRepair) {
+          replaceAgentAfterRepair = false;
+          exec.showCoachShell();
+        }
+        return result;
+      },
+    );
+    nowSpy.mockReturnValue(
+      firstObservedAt + SURFACE_EVICTION_CONFIRMATION_MS + 1,
+    );
+    const second = parseResult(await tool.handler({}, {} as any));
+
+    expect(second.ok).toBe(true);
+    expect(second.diff.evicted).not.toContain("coachClaude");
+    expect(stateMgr.readState("coachClaude")).toMatchObject({
+      cli_session_id: "coach-ghost-session-id",
+      crash_recover: true,
+    });
+
+    exec.showCoachAgent();
+    const third = parseResult(await tool.handler({}, {} as any));
+
+    expect(third.ok).toBe(true);
+    expect(third.diff.evicted).toContain("coachClaude");
+    expect(stateMgr.readState("coachClaude")).toBeNull();
+    const mutationCommands = new Set([
+      "new-split",
+      "move-surface",
+      "close-surface",
+      "send",
+      "send-key",
+      "paste-text",
+    ]);
+    const observedMutations = (exec as any).mock.calls.flatMap(
+      ([, args]: [unknown, string[]]) =>
+        args.filter((arg) => mutationCommands.has(arg)),
+    );
+    expect(observedMutations).toEqual([]);
   });
 
   it("resync_agents skips a missing-state seat and continues repairs and ghost eviction", async () => {


### PR DESCRIPTION
## Summary
- Repair drifted live managed seat metadata in place while preserving the agent ID, session transport, task, PID, and provenance.
- Reserve currently occupied managed surfaces before identity-based self-heal so ghost records cannot steal a live seat by iteration order.
- Keep recoverable ghosts until the normal absence window and a fresh, exact-seat positive discovery prove an active replacement.
- Pin discovery ingestion and destructive proof to the observer owner/epoch; read errors, shell-only rows, mismatched seats, stale lifecycle, and recycled identities fail closed.

## Safety
- Record-only registry repair; no pane/session mutation path was added or exercised.
- No live coach or agent session was read or touched.
- PR-3.5 cleanup intentionally excluded to keep scope isolated.
- Do not merge; lead review requested.

## Verification
- Full hermetic suite: 104 files, 2,200 tests passed.
- Focused registry/resync suite: 123 tests passed.
- Typecheck and build passed.
- Pre-PR harness: 61 tests passed.
- Push hook contract/regression/full-suite gates passed.

## Review
- Independent red-team review: CLEAN.
- Independent final code review: READY, no findings.
- Local CodeRabbit timed out after a partial finding; final automated retry was unavailable due the OSS rate limit, so the required manual fallback reviews were completed and all findings dispositioned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent registry reconciliation, eviction, and resync behavior; mistakes could drop live sessions or retain stale ghosts, though observer epoch pinning and fail-closed proof reduce cross-topology corruption.
> 
> **Overview**
> **Registry repair and eviction** now favor in-place metadata fixes and stricter proof before removing rows. Drifted managed seats are updated on the existing `agent_id` (sessions, PID, task text preserved) instead of aggressive duplicate eviction; **`evictDuplicateManagedRegistrations`** is removed.
> 
> **Self-heal** pre-reserves surfaces already bound to live managed records so iteration order cannot let a ghost steal a seat. **`listMerged`** pins the observer snapshot at the start of ingestion (including reconcile/purge) so stale discovery cannot mutate state after a reconnect epoch.
> 
> **Crash-recovery ghosts** skip surfaceless eviction unless a same-cycle **`LiveSeatDiscoveryProof`** (observer owner/epoch + screen-classified seat/surface pairs) proves an active same-seat replacement; **`resync_agents`** builds that proof after repair and passes it into **`evictSurfaceless`**.
> 
> **Repair path** treats all discovered surface refs as “live” for pending-ghost logic (read errors no longer hide refs) and drops duplicate managed eviction during **`repairFromDiscovery`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3302d1d1f3ec866be3af34bb8dda8241edc5d6ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix AgentRegistry to preserve live seats during record repair
> - Adds `createLiveSeatDiscoveryProof` to build an observer-epoch-pinned proof of live, role-classified seats, used to gate surfaceless eviction in `evictSurfaceless`.
> - Fixes `selfHealManagedRegistrationsFromDiscovery` so a live managed record's surface is no longer reassigned to a ghost canonical duplicate due to iteration order.
> - Crash-recoverable seat ghosts are now retained during eviction unless discovery proves a live same-seat sibling in the same observer epoch (via `hasLiveManagedSeatSibling`).
> - Removes the `evictDuplicateManagedRegistrations` pass that previously auto-evicted duplicate managed registrations by identity precedence.
> - `resync_agents` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/330/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now generates a live seat proof and passes the already-scanned discovery snapshot to `listMerged` to maintain epoch consistency.
> - Risk: removing duplicate-managed-record eviction changes repair behavior — duplicate records are no longer cleaned up automatically and must be resolved by other means.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3302d1d. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent recovery to avoid evicting seats that are still actively owned.
  * Strengthened reconciliation during observer changes and incomplete discovery results.
  * Preserved live agent registrations and session metadata during repair.
  * Deferred ghost-seat eviction until inactivity is confirmed.
  * Improved handling of duplicate, mismatched, or partially observed seat records.

* **Tests**
  * Added coverage for live-seat protection, repair behavior, observer changes, and end-to-end resynchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->