### PR TITLE
fix(release): hermeticize v0.4.14 release verification

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,7 +7,7 @@ set -uo pipefail
 
 [ ! -f scripts/run_tests.sh ] && { echo "⚠️  no scripts/run_tests.sh"; exit 0; }
 
-bash scripts/run_tests.sh
+env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bash scripts/run_tests.sh
 exit_status=$?
 
 if [ "$exit_status" -ne 0 ]; then

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -92,11 +92,20 @@ One command does the whole pipeline:
 
 It will: verify a clean tree + green build/tests, bump `package.json`, commit,
 push `main`, tag `vX.Y.Z`, then update the Homebrew formula's `url` + `sha256`
-in `~/Gits/homebrew-layers` and push the tap. Afterwards:
+in `~/Gits/homebrew-layers` and push the tap. Afterwards, run the verification
+helper with the released version:
 
 ```bash
-brew update && brew upgrade etanhey/layers/cmuxlayer
+~/Gits/cmuxlayer/scripts/release-verify.sh 0.3.0
 ```
+
+The helper fetches and hard-resets the tap clone Homebrew actually reads at
+`$(brew --repository)/Library/Taps/etanhey/homebrew-layers` to `origin/main`,
+runs `brew upgrade etanhey/layers/cmuxlayer`, and fails unless
+`brew list --versions cmuxlayer` prints exactly the released version. This
+explicit sync is required because that tap's `origin` can be the local
+`~/Gits/homebrew-layers` checkout while its `main` has no upstream tracking, so
+`brew update` alone does not guarantee a fast-forward.
 
 Manual equivalent, if you prefer:
 
@@ -107,7 +116,10 @@ Manual equivalent, if you prefer:
 5. In `~/Gits/homebrew-layers/Formula/cmuxlayer.rb` set `url` to the new tag and
    `sha256` to the value from step 4; `brew audit etanhey/layers/cmuxlayer`;
    commit + push.
-6. `brew upgrade etanhey/layers/cmuxlayer`.
+6. Sync the tap Homebrew reads:
+   `git -C "$(brew --repository)/Library/Taps/etanhey/homebrew-layers" fetch origin && git -C "$(brew --repository)/Library/Taps/etanhey/homebrew-layers" reset --hard origin/main`.
+7. `brew upgrade etanhey/layers/cmuxlayer`.
+8. Assert `brew list --versions cmuxlayer` is exactly `cmuxlayer X.Y.Z`.
 
 The formula also carries a `head` block, so `--HEAD` installs always track
 `main` with **no** sha/tag bump — that is the on-the-go dogfood path.
@@ -197,3 +209,4 @@ explicit `workspace` only when you deliberately want a different one.
 | `~/.golems/bin/cmuxlayer-mcp` | launcher: brew (default) vs live source (`CMUXLAYER_DEV=1`) |
 | `EtanHey/homebrew-layers` → `Formula/cmuxlayer.rb` | the brew formula (stable tag + `head`) |
 | `scripts/release.sh` | one-command release: bump → tag → formula bump → push |
+| `scripts/release-verify.sh` | sync Homebrew's tap clone → upgrade → assert installed version |

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Sync the tap clone Homebrew actually reads, upgrade cmuxlayer, and verify it.
+set -euo pipefail
+
+die() { echo "release-verify: $*" >&2; exit 1; }
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || die "usage: release-verify.sh <X.Y.Z>"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver X.Y.Z, got '$VERSION'"
+command -v brew >/dev/null 2>&1 || die "brew is not installed"
+
+BREW_TAP_DIR="$(brew --repository)/Library/Taps/etanhey/homebrew-layers"
+[ -d "$BREW_TAP_DIR/.git" ] || die "Homebrew tap clone not found at $BREW_TAP_DIR"
+
+git -C "$BREW_TAP_DIR" fetch origin
+git -C "$BREW_TAP_DIR" reset --hard origin/main
+brew upgrade etanhey/layers/cmuxlayer
+
+INSTALLED="$(brew list --versions cmuxlayer)"
+[ "$INSTALLED" = "cmuxlayer $VERSION" ] || die "expected cmuxlayer $VERSION, got '${INSTALLED:-not installed}'"
+
+echo "release-verify: cmuxlayer $VERSION is installed from the synced tap"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@
 #
 # Steps: clean-tree + green build/tests gate → bump package.json → commit +
 # push main → tag vX.Y.Z + push tag → update formula url+sha256 in the
-# homebrew-layers tap → push tap → tell you to `brew upgrade`.
+# homebrew-layers tap → push tap → tell you to run release verification.
 #
 # See docs/releases-and-brew.md.
 set -euo pipefail
@@ -50,7 +50,7 @@ fi
 
 echo "release: gating on typecheck + tests…"
 run "bun run typecheck"
-run "bun run test"
+run "env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test"
 echo "release: gating on real-cmux contracts (warn-only skip when no live CMUX_SOCKET_PATH is reachable)…"
 run "bun run test:contract"
 
@@ -98,7 +98,7 @@ cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
 Next:
-  brew update && brew upgrade etanhey/layers/cmuxlayer
+  $REPO_DIR/scripts/release-verify.sh "$VERSION"
 
 # Outbox-semantics releases only (see docs/releases-and-brew.md "Pre-deploy hygiene"):
 #   if this release changes outbox dedup-id derivation or the delivery gate,

--- a/tests/pre-pr-scripts.test.ts
+++ b/tests/pre-pr-scripts.test.ts
@@ -46,11 +46,41 @@ describe("pre-PR script ladder", () => {
 
   it("runs the opt-in contract lane from the release preflight", () => {
     const release = readFileSync(join(repoRoot, "scripts", "release.sh"), "utf8");
-    const hermeticGate = release.indexOf('run "bun run test"');
+    const hermeticGate = release.indexOf(
+      'run "env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test"',
+    );
     const contractGate = release.indexOf('run "bun run test:contract"');
 
     expect(hermeticGate).toBeGreaterThan(-1);
     expect(contractGate).toBeGreaterThan(hermeticGate);
+  });
+
+  it("removes ambient cmux socket pins from the pre-push regression gate", () => {
+    const hook = readFileSync(
+      join(repoRoot, ".githooks", "pre-push"),
+      "utf8",
+    );
+
+    expect(hook).toContain(
+      "env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bash scripts/run_tests.sh",
+    );
+  });
+
+  it("syncs the brew tap clone and verifies the installed release version", () => {
+    const verify = readFileSync(
+      join(repoRoot, "scripts", "release-verify.sh"),
+      "utf8",
+    );
+    const release = readFileSync(join(repoRoot, "scripts", "release.sh"), "utf8");
+
+    expect(verify).toContain(
+      'BREW_TAP_DIR="$(brew --repository)/Library/Taps/etanhey/homebrew-layers"',
+    );
+    expect(verify).toContain('git -C "$BREW_TAP_DIR" fetch origin');
+    expect(verify).toContain('git -C "$BREW_TAP_DIR" reset --hard origin/main');
+    expect(verify).toContain("brew upgrade etanhey/layers/cmuxlayer");
+    expect(verify).toContain("brew list --versions cmuxlayer");
+    expect(release).toContain('scripts/release-verify.sh "$VERSION"');
   });
 
   it("refuses the live harness unless CMUX_LIVE_HARNESS=1 is set", () => {


### PR DESCRIPTION
## Summary
- remove ambient cmux socket pins from deterministic release and pre-push test gates while preserving the opt-in live contract lane
- add a release verification helper that syncs Homebrew's actual tap clone, upgrades cmuxlayer, and asserts the installed version
- document the post-release verification flow

## Test plan
- counterfactual RED: pre-PR script contract had 3 expected failures before implementation
- focused contract: 10 passed, 0 failed
- hermetic suite: 104 files, 2202 tests passed
- bun run typecheck
- bun run build
- bash syntax checks and release dry-run

## Review notes
- local CodeRabbit reviewed all 5 changed files; its findings misread the final here-document as executing release-verify instead of printing the documented follow-up command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release/docs/scripts and test harness env hygiene; no runtime product logic.
> 
> **Overview**
> **Release and pre-push gates** now run the default test suite with `CMUX_SOCKET_PATH` and `CMUX_DAEMON_SOCKET` unset so local cmux pins cannot make CI-like gates non-deterministic. The opt-in `test:contract` lane in `release.sh` is unchanged and still runs after the hermetic gate.
> 
> **Post-release verification** adds `scripts/release-verify.sh`, which hard-resets Homebrew's tap clone at `Library/Taps/etanhey/homebrew-layers` to `origin/main`, runs `brew upgrade`, and fails unless `brew list --versions` matches the released semver. `release.sh` and `docs/releases-and-brew.md` point operators at this helper instead of relying on `brew update` alone when the tap's `origin` is a local checkout without upstream tracking.
> 
> **Tests** extend `pre-pr-scripts.test.ts` to lock in the env-unset hooks, hermetic release gate, and release-verify wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf38a17015d858e05f9c7304148a2319c215da42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hermetic release verification script for v0.4.14 and unset CMUX env vars in test gates
> - Adds [`scripts/release-verify.sh`](https://github.com/EtanHey/cmuxlayer/pull/331/files#diff-0361eb8bb3c02e45c57619eeac55e5f0388deb60ff9c6e3bb7e9a318cd39d124) that syncs the Homebrew tap clone via `git fetch`/`git reset --hard origin/main`, runs `brew upgrade etanhey/layers/cmuxlayer`, and exits non-zero if the installed version doesn't exactly match the specified semver argument.
> - Updates [`scripts/release.sh`](https://github.com/EtanHey/cmuxlayer/pull/331/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389) and [`.githooks/pre-push`](https://github.com/EtanHey/cmuxlayer/pull/331/files#diff-d98b367aa518731b4158dd028ca94d051dfe32fefe54c4affde19f591ebc5fb6) to unset `CMUX_SOCKET_PATH` and `CMUX_DAEMON_SOCKET` before running tests, preventing ambient socket state from affecting test results.
> - Updates [`docs/releases-and-brew.md`](https://github.com/EtanHey/cmuxlayer/pull/331/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) to include the new verification script in the release workflow.
> - Adds tests in [`tests/pre-pr-scripts.test.ts`](https://github.com/EtanHey/cmuxlayer/pull/331/files#diff-85e90b49d31bf726c30302c0bea5dee1da315806081b12f76b3bd05caacfeabf) covering the hermetic env-unset invocations and the release verification script's tap sync and version assertion logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cf38a17. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->