### PR TITLE
fix(placement): keep seed cleanup summary consistent

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3636,6 +3636,9 @@ export class AgentEngine {
     const eligibleForTrigger = (agent: AgentRecord): boolean => {
       if (agent.surface_provenance !== "cmuxlayer_spawn") return false;
       if (trigger === "spawn") {
+        // Spawn reconciliation runs synchronously after registry persistence
+        // and before the launch command is sent, so membership is sufficient:
+        // this new agent cannot have entered a working state yet.
         return opts.agentIds?.has(agent.agent_id) ?? false;
       }
       if (trigger === "idle") return agent.state === "idle";
@@ -3824,10 +3827,6 @@ export class AgentEngine {
             beforeMutation: () =>
               assertFreshAgentBinding(sourceRef, "role placement move"),
           });
-          this.assertSurfaceObserverEpochCurrent(
-            observerEpoch,
-            "role placement",
-          );
           summary.moved.push({
             agent_id: agent.agent_id,
             surface_id: sourceRef,
@@ -3835,6 +3834,10 @@ export class AgentEngine {
             to_column: targetColumn,
             pane: targetPane,
           });
+          this.assertSurfaceObserverEpochCurrent(
+            observerEpoch,
+            "role placement",
+          );
         } finally {
           if (seed) {
             if (!seed.surface_id) {
@@ -3894,6 +3897,11 @@ export class AgentEngine {
           }
         }
       } catch (error) {
+        if (summary.moved.some((moved) => moved.agent_id === agent.agent_id)) {
+          // Seed cleanup is best-effort and must not overwrite a completed move
+          // by counting the same agent as skipped as well.
+          continue;
+        }
         summary.skipped.push({
           agent_id: agent.agent_id,
           surface_id: agent.surface_id,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -5596,6 +5596,86 @@ To continue this session, run codex resume ${sessionId}`,
       ]);
     });
 
+    it("does not count a successful move as skipped when seed cleanup lacks a stable UUID", async () => {
+      const record = makeRecord({
+        agent_id: "missing-seed-uuid-worker",
+        surface_id: "surface:missing-seed-uuid-worker",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        workspace_id: "ws:placement",
+        state: "idle",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      const leadRef = "surface:lead";
+      const leadUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+      liveSurfaces = [
+        {
+          ...makeSurface(leadRef),
+          id: leadUuid,
+          workspace_ref: "ws:placement",
+        },
+        {
+          ...makeSurface(record.surface_id),
+          id: record.surface_uuid ?? undefined,
+          workspace_ref: "ws:placement",
+        },
+      ];
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:placement",
+        window_ref: "window:placement",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 2,
+            surface_refs: [leadRef, record.surface_id],
+            surface_ids: [leadUuid, record.surface_uuid],
+            pixel_frame: leftFrame,
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        workspace_ref: "ws:placement",
+        window_ref: "window:placement",
+        pane_ref: "pane:left",
+        surfaces: liveSurfaces,
+      });
+      (mockClient.newSplit as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (_direction, opts) => {
+          await opts.beforeMutation?.();
+          return {
+            workspace: "ws:placement",
+            surface: "surface:worker-column-seed",
+            pane: "pane:right",
+            title: "",
+            type: "terminal",
+          };
+        },
+      );
+      (mockClient.moveSurface as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (opts) => {
+          await opts.beforeMutation?.();
+          return {
+            ok: true,
+            workspace: "ws:placement",
+            surface: opts.surface,
+            pane: "pane:right",
+          };
+        },
+      );
+
+      const summary = await engine.reconcileRolePlacements("idle");
+
+      expect(summary.moved).toHaveLength(1);
+      expect(summary.skipped).toEqual([]);
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    });
+
     it("serializes worker-column seed cleanup by the seed's stable UUID", async () => {
       const record = makeRecord({
         agent_id: "single-column-worker",


### PR DESCRIPTION
## Summary

- record a completed role-placement move before post-move validation or seed cleanup can fail
- keep seed-cleanup failures from counting the same agent as both moved and skipped
- document why spawn-trigger membership is sufficient before launch

## Scope

PR-3.5 follow-up from #329. No placement mutation, provenance, resync, or sidebar-render behavior changes.

## Verification

- RED: missing seed UUID regression initially produced both moved and skipped
- tests/agent-engine.test.ts: 265 passed
- hermetic full suite: 104 files / 2203 tests passed
- bun run typecheck
- bun run build
- local CodeRabbit rereview: 0 findings
- pre-push nightly contract runner and full hermetic suite passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix seed cleanup summary in `AgentEngine.reconcileRolePlacements` to suppress duplicate skipped entries
> When a seed cleanup or post-move assertion fails for an agent already recorded in `summary.moved`, the method was incorrectly adding that agent to `summary.skipped` as well. A guard now checks `summary.moved` before adding a skipped entry, keeping the move result intact. The epoch assertion is also reordered to run after the move is recorded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c86c45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->