### PR TITLE
fix(registry): preserve explicit spawn roles

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -76,6 +76,16 @@ export interface AgentRegistryOptions {
    * never persisted in agent state.
    */
   observerEpochProvider?: () => string | null | undefined;
+  /**
+   * Resolve caller-authoritative role metadata retained by the surface creator.
+   * Returning null/undefined leaves launcher/CLI inference as the fallback.
+   */
+  explicitRoleProvider?: (
+    discovered: Pick<
+      DiscoveredAgent,
+      "surface_id" | "surface_uuid" | "workspace_id"
+    >,
+  ) => AgentRole | null | undefined;
 }
 
 interface RegistryObserverSnapshot {
@@ -480,6 +490,9 @@ export class AgentRegistry {
   private observerId: string | null;
   private observerIdProvider: (() => string | null | undefined) | null;
   private observerEpochProvider: (() => string | null | undefined) | null;
+  private explicitRoleProvider: NonNullable<
+    AgentRegistryOptions["explicitRoleProvider"]
+  > | null;
   private enforceObserverOwnership: boolean;
 
   constructor(
@@ -492,6 +505,7 @@ export class AgentRegistry {
     this.observerId = opts?.observerId?.trim() || null;
     this.observerIdProvider = opts?.observerIdProvider ?? null;
     this.observerEpochProvider = opts?.observerEpochProvider ?? null;
+    this.explicitRoleProvider = opts?.explicitRoleProvider ?? null;
     // Omitted options retain the historical library/test behavior. Production
     // explicitly passes options (including null) so missing instance evidence
     // fails closed instead of treating one topology as globally authoritative.
@@ -521,6 +535,10 @@ export class AgentRegistry {
     } catch {
       return null;
     }
+  }
+
+  private explicitRoleFor(discovered: DiscoveredAgent): AgentRole | null {
+    return this.explicitRoleProvider?.(discovered) ?? null;
   }
 
   /** Capture persisted owner and transient epoch before an awaited scan. */
@@ -1096,6 +1114,7 @@ export class AgentRegistry {
         agentId,
         discoveredEntry,
         this.getObserverId(),
+        this.explicitRoleFor(discoveredEntry),
       );
       this.agents.set(agentId, record);
       if (!this.canUseObservedBinding(record, discoveredEntry.surface_uuid)) {
@@ -1222,7 +1241,7 @@ export class AgentRegistry {
       ) {
         return [];
       }
-      const candidate = repairCandidateForSurface(entry);
+      const candidate = this.repairCandidateForDiscovery(entry);
       if (!candidate) return [];
       return [
         {
@@ -1232,6 +1251,16 @@ export class AgentRegistry {
         },
       ];
     });
+  }
+
+  private repairCandidateForDiscovery(
+    discovered: DiscoveredAgent,
+    seatRegistry?: SeatRegistry | null,
+  ): RegistryRepairCandidate | null {
+    const candidate = repairCandidateForSurface(discovered, seatRegistry);
+    if (!candidate) return null;
+    const explicitRole = this.explicitRoleFor(discovered);
+    return explicitRole ? { ...candidate, role: explicitRole } : candidate;
   }
 
   private selfHealManagedRegistrationsFromDiscovery(
@@ -1376,6 +1405,7 @@ export class AgentRegistry {
     const desiredState = discoveredStatusToAgentState(
       discoveredEntry.parsed_status,
     );
+    const explicitRole = this.explicitRoleFor(discoveredEntry);
 
     const patch: Partial<AgentRecord> = {};
     if (repo !== record.repo) patch.repo = repo;
@@ -1385,6 +1415,9 @@ export class AgentRegistry {
     }
     if (surfaceUuid !== null && (record.surface_uuid ?? null) !== surfaceUuid) {
       patch.surface_uuid = surfaceUuid;
+    }
+    if (explicitRole && record.role !== explicitRole) {
+      patch.role = explicitRole;
     }
     const observerId = this.getObserverId();
     if (observerId && record.surface_observer_id !== observerId) {
@@ -1435,6 +1468,7 @@ export class AgentRegistry {
       return null;
     }
     const patch: Partial<AgentRecord> = {};
+    const explicitRole = this.explicitRoleFor(discoveredEntry);
     const persistedUuid = surfaceUuidKey(record.surface_uuid);
     const discoveredUuid = surfaceUuidKey(discoveredEntry.surface_uuid);
     if (
@@ -1457,6 +1491,9 @@ export class AgentRegistry {
       discoveredEntry.surface_uuid != null
     ) {
       patch.surface_uuid = discoveredEntry.surface_uuid;
+    }
+    if (explicitRole && record.role !== explicitRole) {
+      patch.role = explicitRole;
     }
     const observerId = this.getObserverId();
     if (observerId && record.surface_observer_id !== observerId) {
@@ -1822,7 +1859,10 @@ export class AgentRegistry {
 
     for (const entry of discovered) {
       if (entry.read_error) continue;
-      const candidate = repairCandidateForSurface(entry, opts?.seatRegistry);
+      const candidate = this.repairCandidateForDiscovery(
+        entry,
+        opts?.seatRegistry,
+      );
       if (!candidate) continue;
 
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2311,6 +2311,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const client = context.client;
   const stateMgr = context.stateMgr;
   const roleSurfaceOverrides = context.roleSurfaceOverrides;
+  const explicitRoleForDiscoveredSurface = (
+    discovered: Pick<
+      DiscoveredAgent,
+      "surface_id" | "surface_uuid" | "workspace_id"
+    >,
+  ): AgentRole | null => {
+    const uuid = discovered.surface_uuid?.trim().toLowerCase() || null;
+    const workspace = discovered.workspace_id ?? null;
+    const matchesBinding = (
+      override: {
+        role: AgentRole;
+        workspace: string | null;
+        surfaceUuid: string | null;
+      },
+    ): boolean => {
+      if (workspace && override.workspace && workspace !== override.workspace) {
+        return false;
+      }
+      const overrideUuid = override.surfaceUuid?.trim().toLowerCase() || null;
+      return uuid === null ? true : overrideUuid === uuid;
+    };
+    const direct = roleSurfaceOverrides.get(discovered.surface_id);
+    if (direct && matchesBinding(direct)) {
+      return direct.role;
+    }
+    if (!uuid) return null;
+    const stableMatches = [...roleSurfaceOverrides.values()].filter(
+      (override) =>
+        override.surfaceUuid?.trim().toLowerCase() === uuid &&
+        matchesBinding(override),
+    );
+    return stableMatches.length === 1 ? stableMatches[0]!.role : null;
+  };
   const eventLog = context.eventLog;
   const deliveries = context.deliveries;
   const latestDeliveryBySurface = context.latestDeliveryBySurface;
@@ -7297,6 +7330,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         {
           observerIdProvider: () => context.surfaceObserverId,
           observerEpochProvider: () => context.surfaceObserverEpoch,
+          explicitRoleProvider: explicitRoleForDiscoveredSurface,
         },
       );
     context.lifecycleRegistry = registry;

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -19,6 +19,7 @@ import { EventLog } from "./event-log.js";
 import {
   assertValidTransition,
   type AgentRecord,
+  type AgentRole,
   type AgentState,
   type StateTransition,
 } from "./agent-types.js";
@@ -536,6 +537,7 @@ export class StateManager {
     agentId: string,
     discovered: DiscoveredAgent,
     surfaceObserverId?: string | null,
+    explicitRole?: AgentRole | null,
   ): AgentRecord {
     const existing = this.readState(agentId);
     if (existing) {
@@ -565,11 +567,12 @@ export class StateManager {
       parent_agent_id: null,
       spawn_depth: 0,
       role:
-        discovered.cli === "claude"
+        explicitRole ??
+        (discovered.cli === "claude"
           ? "orchestrator"
           : discovered.cli === "unknown"
             ? "orchestrator"
-            : "worker",
+            : "worker"),
       auto_archive_on_done: false,
       deletion_intent: false,
       quality: "unknown",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -340,6 +340,39 @@ describe("AgentEngine", () => {
       );
     });
 
+    it.each([
+      {
+        label: "explicit Claude worker",
+        cli: "claude" as const,
+        role: "worker" as const,
+        expectedRole: "worker" as const,
+      },
+      {
+        label: "no-role Claude fallback",
+        cli: "claude" as const,
+        role: undefined,
+        expectedRole: "orchestrator" as const,
+      },
+      {
+        label: "explicit Codex orchestrator",
+        cli: "codex" as const,
+        role: "orchestrator" as const,
+        expectedRole: "orchestrator" as const,
+      },
+    ])(
+      "persists the $label role on managed spawn records",
+      async ({ cli, role, expectedRole }) => {
+        const result = await engine.spawnAgent({
+          repo: "brainlayer",
+          cli,
+          prompt: "Verify authoritative role",
+          ...(role ? { role } : {}),
+        });
+
+        expect(engine.getAgentState(result.agent_id)?.role).toBe(expectedRole);
+      },
+    );
+
     it("assigns each managed surface a launcher-preserving unique seat title", async () => {
       (
         mockClient.newSplit as ReturnType<typeof vi.fn>

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -15,6 +15,7 @@ import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { AgentEngine } from "../src/agent-engine.js";
 import { dispatch, writeHeartbeat } from "../src/inbox.js";
+import type { FleetSidebarPublication } from "../src/fleet-sidebar.js";
 
 type InputDeliveryTestModule = typeof import("../src/server.js") & {
   SEND_INPUT_PASTE_BATCH_MAX_BYTES: number;
@@ -6220,6 +6221,232 @@ describe("tool handler integration", () => {
     expect(secondParsed.placement).toBe("surface");
     expect(secondParsed.direction).toBeNull();
   });
+
+  it.each([
+    {
+      label: "an explicit Claude worker",
+      cli: "claude" as const,
+      title: "fableWeaverClaude",
+      role: "worker" as const,
+      reportsSurfaceUuid: true,
+      expectedSpawnRole: "worker" as const,
+      expectedRole: "worker" as const,
+      expectedSidebarRole: "worker" as const,
+    },
+    {
+      label: "a no-role Claude",
+      cli: "claude" as const,
+      title: "fableWeaverClaude",
+      role: undefined,
+      reportsSurfaceUuid: true,
+      expectedSpawnRole: "orchestrator" as const,
+      expectedRole: "orchestrator" as const,
+      expectedSidebarRole: "lead" as const,
+    },
+    {
+      label: "an explicit Codex orchestrator",
+      cli: "codex" as const,
+      title: "cmuxlayerCodex",
+      role: "orchestrator" as const,
+      reportsSurfaceUuid: true,
+      expectedSpawnRole: "orchestrator" as const,
+      expectedRole: "orchestrator" as const,
+      expectedSidebarRole: "lead" as const,
+    },
+    {
+      label: "a ref-only override after UUID identity appears",
+      cli: "claude" as const,
+      title: "fableWeaverClaude",
+      role: "worker" as const,
+      reportsSurfaceUuid: false,
+      expectedSpawnRole: "worker" as const,
+      expectedRole: "orchestrator" as const,
+      expectedSidebarRole: "lead" as const,
+    },
+  ])(
+    "persists the authoritative new_split role for $label through registry and sidebar",
+    async ({
+      cli,
+      title: initialTitle,
+      role,
+      reportsSurfaceUuid,
+      expectedSpawnRole,
+      expectedRole,
+      expectedSidebarRole,
+    }) => {
+      const stateDir = join(
+        CHANNEL_TEST_DIR,
+        `new-split-role-authority-${cli}-${role ?? "default"}-${reportsSurfaceUuid ? "uuid" : "ref"}`,
+      );
+      const surfaceUuid =
+        cli === "claude"
+          ? "11111111-2222-4333-8444-555555555555"
+          : "66666666-7777-4888-8999-aaaaaaaaaaaa";
+      let created = false;
+      let surfaceTitle = initialTitle;
+      const publications: FleetSidebarPublication[] = [];
+      rmSync(stateDir, { recursive: true, force: true });
+
+      const mockClient = {
+        listWorkspaces: vi.fn().mockResolvedValue({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "cmuxlayer",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        listPanes: vi.fn().mockImplementation(async () => ({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: created
+            ? [
+                {
+                  ref: "pane:agent",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:agent"],
+                  surface_ids: [surfaceUuid],
+                  pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+                },
+              ]
+            : [],
+        })),
+        listPaneSurfaces: vi.fn().mockImplementation(async () => ({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:agent",
+          surfaces: created
+            ? [
+                {
+                  ref: "surface:agent",
+                  id: surfaceUuid,
+                  title: surfaceTitle,
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [],
+        })),
+        readScreen: vi.fn().mockImplementation(async () => ({
+          surface: "surface:agent",
+          text:
+            cli === "claude"
+              ? [
+                  "0 tokens",
+                  "─────────────────────────────────────────────────────────────────────",
+                  "❯ ",
+                  "─────────────────────────────────────────────────────────────────────",
+                  "🤖 Opus 4.8 (1M context) | 💰 $0.00 | ⏱️  0m | 📚 88%",
+                ].join("\n")
+              : [
+                  "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer",
+                  "codex> ",
+                ].join("\n"),
+          lines: 30,
+          scrollback_used: false,
+        })),
+        newSplit: vi.fn().mockImplementation(async () => {
+          created = true;
+          return {
+            workspace: "workspace:1",
+            surface: "surface:agent",
+            ...(reportsSurfaceUuid ? { surface_id: surfaceUuid } : {}),
+            pane: "pane:agent",
+            title: "",
+            type: "terminal" as const,
+          };
+        }),
+        newSurface: vi.fn(),
+        renameTab: vi.fn().mockImplementation(async (_surface, nextTitle) => {
+          surfaceTitle = nextTitle;
+        }),
+        selectWorkspace: vi.fn(),
+        moveSurface: vi.fn(),
+        closeSurface: vi.fn(),
+        send: vi.fn(),
+        sendKey: vi.fn(),
+        log: vi.fn(),
+        setStatus: vi.fn(),
+        clearStatus: vi.fn(),
+        setProgress: vi.fn(),
+        clearProgress: vi.fn(),
+        notify: vi.fn(),
+      };
+      const context = createServerContext({
+        client: mockClient as any,
+        stateDir,
+        skipAgentLifecycle: true,
+        controlHealthIntervalMs: 0,
+      });
+      const splitServer = createServer({
+        context,
+        skipAgentLifecycle: true,
+      });
+      let lifecycleServer: ReturnType<typeof createServer> | null = null;
+
+      try {
+        const splitTool = (splitServer as any)._registeredTools["new_split"];
+        const splitResult = await splitTool.handler(
+          {
+            direction: "right",
+            workspace: "workspace:1",
+            title: initialTitle,
+            ...(role ? { role } : {}),
+          },
+          {} as any,
+        );
+        const parsedSplit =
+          splitResult.structuredContent ??
+          JSON.parse(splitResult.content[0].text);
+
+        expect(parsedSplit.ok).toBe(true);
+        expect(parsedSplit.role).toBe(expectedSpawnRole);
+        expect(context.roleSurfaceOverrides.get("surface:agent")?.role).toBe(
+          expectedSpawnRole,
+        );
+        if (role === "worker") {
+          expect(mockClient.newSplit).toHaveBeenCalledWith(
+            "right",
+            expect.objectContaining({ workspace: "workspace:1" }),
+          );
+        }
+
+        await splitServer.close();
+        lifecycleServer = createServer({
+          context,
+          skipAgentLifecycle: false,
+          fleetSidebarPublisher: {
+            publish: (publication) => publications.push(publication),
+            dispose: vi.fn(),
+          },
+        });
+        await context.lifecycleStartPromise;
+
+        const record = context.lifecycleRegistry
+          ?.list()
+          .find((candidate) => candidate.surface_id === "surface:agent");
+        expect(record).toMatchObject({ cli, role: expectedRole });
+
+        const populated = [...publications]
+          .reverse()
+          .find((publication) => publication.state === "populated");
+        const seat = populated?.snapshot.lanes
+          .flatMap((lane) => lane.seats)
+          .find((candidate) => candidate.surfaceRef === "surface:agent");
+        expect(seat).toMatchObject({ role: expectedSidebarRole });
+      } finally {
+        await lifecycleServer?.close();
+        context.dispose();
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("new_split follows a remembered role surface UUID instead of its recycled ref", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";


### PR DESCRIPTION
## Summary

- preserve an explicitly supplied `new_split.role` as authoritative when lifecycle discovery creates or repairs the registry record
- keep agent-type inference as the fallback only when no explicit role was supplied
- publish the persisted authoritative role through the Fleet sidebar while retaining role-based split placement from #329
- harden the surface binding so a recycled pane reference cannot inherit an override after discovery exposes a different stable UUID

## RED evidence

Before the implementation, the end-to-end `new_split` → registry → Fleet sidebar test produced 2 failures and 1 pass:

- Claude + explicit `role: worker`: recorded `orchestrator` instead of `worker`
- Codex + explicit `role: orchestrator`: recorded `worker` instead of `orchestrator`
- Claude + no role: correctly fell back to `orchestrator`

A subsequent recycled-ref safety test was also introduced RED before tightening UUID matching.

## Verification

- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 104 files, 2210 tests passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run pre-pr:harness` — 4 files, 63 tests passed
- `git diff --check` — passed
- focused role-authority tests — 4 server cases and 3 managed-spawn cases passed
- built MCP stdio smoke — 42 tools exposed; `spawn_agent`, `new_split`, and non-error `control_health` confirmed
- local CodeRabbit review — 0 findings after addressing its recycled-ref binding concern

## Scope

No renderer/layout implementation changed. Sidebar role content is verified through the published FleetSidebar snapshot in the end-to-end server test. This PR is intentionally left unmerged for lead review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent registry role assignment and UUID/ref binding for role overrides during discovery and repair; behavior is covered by new E2E tests but affects fleet metadata correctness.
> 
> **Overview**
> **Explicit `new_split.role` is now authoritative** when lifecycle discovery creates, repairs, or syncs registry records. CLI/title inference remains only when no explicit role was supplied at spawn.
> 
> The server wires **`explicitRoleProvider`** on `AgentRegistry` to resolve roles from **`roleSurfaceOverrides`**, matching by surface ref and (when present) stable UUID plus workspace so a **recycled pane ref cannot inherit the wrong override** after UUID identity appears.
> 
> **`ensureAutoRecord`** accepts an optional explicit role ahead of the Claude→orchestrator / other→worker defaults. Repair and sync paths apply the same override to managed and auto-discovered rows.
> 
> Tests cover **`new_split` → registry → Fleet sidebar** role persistence and managed spawn role cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8512049cd2b49b46aaaa5a3c3494c09bf99a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly assigning roles to discovered and newly created agents.
  * Role overrides can match surfaces by ID, UUID, and workspace.
  * Authoritative roles are preserved across agent registration, lifecycle updates, and sidebar publication.

* **Bug Fixes**
  * Prevented explicit agent roles from being replaced by automatic role inference.

* **Tests**
  * Added coverage for role persistence across agent creation, discovery, lifecycle updates, and sidebar results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve explicit spawn roles in agent registry during discovery and sync
> - Adds an `explicitRoleProvider` option to `AgentRegistry` — a caller-supplied function that returns an authoritative `AgentRole` for a discovered agent based on its surface identity.
> - Updates `StateManager.ensureAutoRecord` to accept an `explicitRole` parameter, seeding new records with the caller-specified role instead of inferring it from the CLI type.
> - Extends sync paths (`syncAutoRecord`, `syncManagedRecordSurfaceMetadata`) and the self-heal flow to update a managed record's role when it differs from the explicit role.
> - Wires the feature in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/333/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) by injecting an `explicitRoleForDiscoveredSurface` function derived from `roleSurfaceOverrides` into `AgentRegistry`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b85120.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->