### PR TITLE
fix: keep transcript scans off lifecycle startup

### DIFF
--- a/docs/plans/2026-07-17-fix-333-resync-convergence-design.md
+++ b/docs/plans/2026-07-17-fix-333-resync-convergence-design.md
@@ -1,0 +1,59 @@
+# Fix #333 Resync Convergence Design
+
+## Status
+
+Approved for implementation by the 2026-07-17 design ruling, with Etan's 400,000-token gpt-5.6 app-tier ruling folded into the same batch.
+
+## Root cause and #333 causality audit
+
+The timeout is caused by startup synchronously resolving transcript identity while `AgentEngine.initializeOnce()` awaits first-connect sidebar synchronization. A persisted JSONL-harness record with no `cli_session_id` and managed-launch metadata is eligible for `maybeCaptureBootSessionId()`. The production Codex resolver then recursively scans `~/.codex/sessions` and reads candidate JSONL files. That unbounded real-filesystem work delays lifecycle readiness and every tool handler that awaits it.
+
+The accepted timeout is real, but the premise that #333 introduced the eligibility path is not supported by the source or runtime evidence:
+
+- `v0.4.14` and #333 contain identical transcript-eligibility, capture, first-connect sidebar, and initialization code in `src/agent-engine.ts`.
+- #333 added an explicit-role provider backed by `roleSurfaceOverrides`; the map is populated only by a successful managed spawn.
+- In the isolated regression, a controlled runtime probe observed an empty override map while the resolver was called for `stale-left-worker` as a working Codex record with launcher `cmuxlayerCodex`.
+- Repeated runs at the same #333 merge commit varied from roughly 1.5 seconds to 16.7 seconds, including both pass and timeout. A two-run version comparison was therefore timing-correlated with filesystem/cache state rather than a causal #333 state transition.
+
+The fix still belongs in this batch because a user-sized sessions directory must not determine MCP startup/tool readiness.
+
+## Production boundary
+
+First-connect sidebar synchronization will skip only transcript-filesystem identity resolution. It will continue topology binding, screen-based boot capture, lifecycle reconciliation, and sidebar publication. The normal sweep and explicit `captureBootSessionId()` path retain transcript resolution, so session identity is deferred rather than removed.
+
+This is narrower than making the synchronous resolver asynchronous or adding a cross-agent cache:
+
+- no startup await can enter the recursive sessions scan;
+- existing later-capture and resume semantics remain intact;
+- screen-derived session IDs can still be captured during the boot window;
+- the change is deterministic and directly testable with an injected resolver spy.
+
+## Test hermeticity
+
+Production-server test helpers in `resync-tool.test.ts` and the sibling server suites will inject `sessionIdentityResolver: () => null` unless a test explicitly supplies a resolver. This prevents fixtures from consulting a developer's real `~/.codex/sessions`, while preserving focused resolver tests via explicit override.
+
+The lifecycle regression will assert both halves of the boundary:
+
+1. `initialize()` completes without invoking an eligible transcript resolver.
+2. A subsequent explicit sweep invokes that resolver, proving capture was deferred rather than disabled.
+
+The resync regression remains outcome-focused and deterministic under the hermetic helper.
+
+## gpt-5.6 window ruling
+
+Keep an explicit gpt-5.6 rule at 400,000 with `jsonlFloor: true` in `MODEL_WINDOW_RULES`, and mirror 400,000 in the screen-parser fallback table. Although this now equals the generic gpt-5 fallback, the explicit rule preserves two important semantics:
+
+- it documents the model-specific app-tier ruling and its provenance;
+- it retains the verified JSONL floor when a lagging client reports a smaller window.
+
+Comments will retain the prior 2026-07-11 Etan web-verification/fleet-rules attribution and add the 2026-07-15 app-tier ruling that supersedes the older 1,050,000 value for the app tier.
+
+## Verification and delivery
+
+Use TDD for the startup boundary and window expectations. Run focused suites first, then the required full gate:
+
+```bash
+bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test
+```
+
+The full result must be 2,210/2,210 before the ready-for-review PR is opened. The worker endpoint is PR plus review responses; cmuxLead-v2 owns merge.

--- a/docs/plans/2026-07-17-fix-333-resync-convergence.md
+++ b/docs/plans/2026-07-17-fix-333-resync-convergence.md
@@ -1,0 +1,132 @@
+# Fix #333 Resync Convergence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove real-filesystem transcript scans from lifecycle startup, make production-server tests hermetic, and apply Etan's 400,000-token gpt-5.6 app-tier ruling.
+
+**Architecture:** Treat transcript identity discovery as deferred sweep work. First-connect sidebar sync keeps topology and screen-based work but does not call the transcript resolver. Test server factories inject a no-op resolver by default. The explicit gpt-5.6 rule stays model-specific at 400,000 with its JSONL-floor behavior.
+
+**Tech Stack:** TypeScript, Bun, Vitest, MCP server lifecycle tests.
+
+---
+
+### Task 1: Specify the startup boundary
+
+**Files:**
+- Modify: `tests/sidebar-sync.test.ts`
+- Modify: `src/agent-engine.ts`
+
+**Step 1: Write the failing regression**
+
+Extend the idempotent-startup lifecycle test with an eligible discovered Codex record and a resolver spy. Assert `initialize()` does not call the spy, then call `runSweep()` and assert it does without increasing the approved 2,210-test suite count.
+
+**Step 2: Run the focused test to verify RED**
+
+Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/sidebar-sync.test.ts -t "discovers and publishes live seats exactly once during idempotent startup"`
+
+Expected: FAIL because first-connect `syncSidebar()` currently invokes the resolver.
+
+**Step 3: Implement the minimal boundary**
+
+Add an optional transcript-resolution flag to `maybeCaptureBootSessionId()`. Pass it as disabled only from `syncSidebar({ firstConnect: true })`; leave normal sweeps and explicit capture enabled.
+
+**Step 4: Run the focused test to verify GREEN**
+
+Run the same command and expect one passing test.
+
+### Task 2: Make real-server tests structurally hermetic
+
+**Files:**
+- Modify: `tests/resync-tool.test.ts`
+- Modify: `tests/server.test.ts`
+- Modify: `tests/server-agent-tools.test.ts`
+
+**Step 1: Add no-op defaults in test factories**
+
+Set `sessionIdentityResolver` to the caller's explicit resolver or `() => null` in each production-server helper before either context or server construction.
+
+**Step 2: Preserve explicit resolver coverage**
+
+Use nullish-coalescing defaults so tests that intentionally inject a resolver continue exercising it.
+
+**Step 3: Run the affected suites**
+
+Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/resync-tool.test.ts tests/server-agent-tools.test.ts tests/server.test.ts`
+
+Expected: all tests pass without reading the host transcript tree.
+
+### Task 3: Apply the 400,000-token gpt-5.6 ruling
+
+**Files:**
+- Modify: `tests/harness-session.test.ts`
+- Modify: `tests/screen-parser.test.ts`
+- Modify: `src/harness-session.ts`
+- Modify: `src/screen-parser.ts`
+
+**Step 1: Change expectations first**
+
+Update gpt-5.6 expectations from 1,050,000 to 400,000, including percentage expectations for the stale-JSONL-floor case. Add wording that distinguishes the app-tier ruling from the superseded value.
+
+**Step 2: Run focused window tests to verify RED**
+
+Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/harness-session.test.ts tests/screen-parser.test.ts`
+
+Expected: gpt-5.6 assertions fail against the old production constants.
+
+**Step 3: Update production rules and provenance**
+
+Keep the explicit gpt-5.6 `jsonlFloor: true` rule, set it to 400,000, update the screen fallback, and retain/add both dated attribution sources in comments.
+
+**Step 4: Re-run focused window tests to verify GREEN**
+
+Run the same command and expect both files to pass.
+
+### Task 4: Verify the full approved batch
+
+**Files:**
+- Review all changed files and `git diff`
+
+**Step 1: Run targeted regression suites**
+
+Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/sidebar-sync.test.ts tests/resync-tool.test.ts tests/harness-session.test.ts tests/screen-parser.test.ts`
+
+**Step 2: Run the exact full gate**
+
+Run: `bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test`
+
+Expected: typecheck exits zero and the suite reports 2,210/2,210 tests passing.
+
+**Step 3: Inspect the final diff**
+
+Run: `git diff --check && git status --short && git diff --stat && git diff`
+
+Confirm no diagnostics or unrelated files remain.
+
+### Task 5: Complete the worker PR loop
+
+**Files:**
+- Commit all approved source, test, and plan files.
+
+**Step 1: Run bounded pre-commit review**
+
+Run `coderabbit review --agent` with a bounded wait. Address substantive findings or record tool unavailability.
+
+**Step 2: Commit and push**
+
+Create intentional commits on `fix/333-resync-convergence`, then push the branch without merging.
+
+**Step 3: Open a ready PR**
+
+Include the exact #333 causality audit, production boundary rationale, hermeticity audit, gpt-5.6 dual attribution, and the real 2,210/2,210 gate summary.
+
+**Step 4: Invoke and process reviewers**
+
+Request available bot reviews, wait the required interval, inspect every response, and fix or explicitly reply to actionable high-severity findings.
+
+**Step 5: Report to cmuxLead-v2 and BrainLayer**
+
+Re-enumerate cmux agents before reporting the ready PR URL and test count to cmuxLead-v2. Store the implementation decision and milestone in BrainLayer; if storage remains unavailable, update the local fallback honestly.
+
+**Step 6: Stop without merging**
+
+Return the PR URL, verification evidence, review status, and a clear `TASK_DONE` signal. cmuxLead-v2 owns merge.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2264,12 +2264,16 @@ export class AgentEngine {
   private async maybeCaptureBootSessionId(
     agent: AgentRecord,
     ctx: SweepAgentContext,
+    opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
       return agent;
     }
 
-    if (this.canUseTranscriptSessionResolver(agent)) {
+    if (
+      opts.resolveTranscript !== false &&
+      this.canUseTranscriptSessionResolver(agent)
+    ) {
       try {
         const transcriptSessionId = this.sessionIdentityResolver(agent);
         if (transcriptSessionId) {
@@ -3195,9 +3199,12 @@ export class AgentEngine {
         this.registry.set(originalAgent.agent_id, originalAgent);
       }
       const sweepCtx: SweepAgentContext = {};
+      // MCP readiness must not depend on a synchronous scan of the host's
+      // transcript tree. Normal sweeps retry transcript capture after startup.
       const capturedAgent = await this.maybeCaptureBootSessionId(
         originalAgent,
         sweepCtx,
+        { resolveTranscript: opts.firstConnect !== true },
       );
       const readyAgent = await this.maybeMarkBootReady(capturedAgent, sweepCtx);
       const taskDoneResult = await this.maybeMarkTaskDone(readyAgent, sweepCtx);

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -32,7 +32,8 @@ export interface HarnessSessionState {
 }
 
 // AIDEV-NOTE: Verified per-model context windows (researcher, BrainLayer brainbar-8a3da79c-159,
-// 2026-06-04; gpt-5.6: Etan web-verify + fleet rules doc §10, 2026-07-11). Used as the
+// 2026-06-04; gpt-5.6: Etan web-verify + fleet rules doc §10, 2026-07-11, superseded
+// for the app tier by Etan's 400K ruling, 2026-07-15). Used as the
 // Claude denominator (Claude JSONL has no window), the no-JSONL fallback, and a floor only
 // for explicitly versioned Codex rules when a lagging CLI reports a smaller session window.
 // Rules are checked in order, so specific versions must precede generic family matches.
@@ -46,8 +47,8 @@ const MODEL_WINDOW_RULES: Array<
   [/fable/, 1_000_000],
   // Claude — 200K tier (Haiku, and 4.0–4.5 generation incl. opus-4-1)
   [/haiku|(sonnet-4(?!-6))|(opus-4(?!-?[678]))|(opus-4-1)/, 200_000],
-  // OpenAI GPT-5.6 / Codex family — whole family is 1.05M.
-  [/gpt-5[.-]6(?:$|[^0-9])/, 1_050_000, true],
+  // OpenAI GPT-5.6 / Codex app tier — 400K, with an explicit stale-JSONL floor.
+  [/gpt-5[.-]6(?:$|[^0-9])/, 400_000, true],
   // OpenAI generic GPT-5 / Codex family — 400K total window (272K input + 128K output)
   [/gpt-5/, 400_000],
   // OpenAI GPT-4 family

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -12,7 +12,8 @@ import { modelContextWindow } from "./harness-session.js";
 
 // AIDEV-NOTE: DEFAULT context window sizes per model family. Verified numbers (researcher,
 // BrainLayer brainbar-8a3da79c-159, 2026-06-04; gpt-5.6: Etan web-verify + fleet rules doc §10,
-// 2026-07-11) — do NOT guess/round. This is the SCREEN-PARSER FALLBACK only: harness JSONL
+// 2026-07-11, superseded for the app tier by Etan's 400K ruling, 2026-07-15) — do NOT
+// guess/round. This is the SCREEN-PARSER FALLBACK only: harness JSONL
 // normally carries the real per-session window, but an explicitly versioned verified rule can
 // floor a stale smaller CLI value — see harness-session.ts + docs/harness-jsonl-field-map.md.
 // All Claude models default to 200K; the 1M tier is detected
@@ -25,8 +26,8 @@ export const MODEL_MAX_TOKENS: Record<string, number> = {
   opus: 200_000,
   sonnet: 200_000,
   haiku: 200_000,
-  // OpenAI GPT-5.6 / Codex family — whole family is 1.05M.
-  "gpt-5.6": 1_050_000,
+  // OpenAI GPT-5.6 / Codex app tier — 400K total window.
+  "gpt-5.6": 400_000,
   // OpenAI generic GPT-5 / Codex family — 400K TOTAL window (272K input + 128K output).
   "gpt-5": 400_000,
   // OpenAI GPT-4 family (gpt-4o, gpt-4-turbo)

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -95,14 +95,14 @@ describe("parseHarnessSession", () => {
     expect(s.last_tool).toBe("exec_command");
   });
 
-  it("Codex: gpt-5.6 family uses the larger verified window over stale JSONL", () => {
+  it("Codex: gpt-5.6 uses the verified 400K app-tier floor over stale JSONL", () => {
     const s = parseHarnessSession(
       "codex",
       codexContextJsonl("gpt-5.6-sol", 105_000, 353_400),
     );
 
-    expect(s.context_window).toBe(1_050_000);
-    expect(s.context_pct).toBe(10);
+    expect(s.context_window).toBe(400_000);
+    expect(s.context_pct).toBe(26);
   });
 
   it("Codex: unknown models keep their JSONL window as the only signal", () => {
@@ -274,9 +274,9 @@ describe("modelContextWindow (Claude denominator + no-JSONL fallback)", () => {
     expect(modelContextWindow("claude-opus-4-1")).toBe(200_000);
   });
 
-  it("GPT-5.6 family = 1.05M verified window", () => {
-    expect(modelContextWindow("gpt-5.6")).toBe(1_050_000);
-    expect(modelContextWindow("gpt-5.6-sol")).toBe(1_050_000);
+  it("GPT-5.6 family = 400K verified app-tier window", () => {
+    expect(modelContextWindow("gpt-5.6")).toBe(400_000);
+    expect(modelContextWindow("gpt-5.6-sol")).toBe(400_000);
   });
 
   it("plain GPT-5/Codex family stays at 400K", () => {

--- a/tests/resync-tool.test.ts
+++ b/tests/resync-tool.test.ts
@@ -21,6 +21,7 @@ function withTestObserver<T extends Omit<CreateServerOptions, "context">>(
 ): T & Omit<CreateServerOptions, "context"> {
   return {
     ...opts,
+    sessionIdentityResolver: opts.sessionIdentityResolver ?? (() => null),
     surfaceObserverOwnerIdProvider:
       opts.surfaceObserverOwnerIdProvider ?? (() => TEST_OBSERVER_OWNER),
     surfaceObserverEpochProvider:

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1345,15 +1345,15 @@ Working (1m 12s • esc to interrupt)
       expect(parsed.context_pct).toBe(40); // 100 - 60 = 40% used
     });
 
-    it("reports 1.05M for the gpt-5.6 family fallback", () => {
+    it("reports the 400K app-tier window for the gpt-5.6 family fallback", () => {
       const parsed = parseScreen(`
 gpt-5.6-sol xhigh · 90% left · ~/Gits/cmuxlayer
 Working (1m 12s • esc to interrupt)
 `);
 
-      expect(MODEL_MAX_TOKENS["gpt-5.6"]).toBe(1_050_000);
-      expect(resolveModelMax("gpt-5.6-sol")).toBe(1_050_000);
-      expect(parsed.context_window).toBe(1_050_000);
+      expect(MODEL_MAX_TOKENS["gpt-5.6"]).toBe(400_000);
+      expect(resolveModelMax("gpt-5.6-sol")).toBe(400_000);
+      expect(parsed.context_window).toBe(400_000);
       expect(parsed.context_pct).toBe(10);
     });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -222,6 +222,7 @@ function createTrackedServer(opts: Omit<CreateServerOptions, "context">) {
   };
   const normalizedOpts: Omit<CreateServerOptions, "context"> = {
     ...opts,
+    sessionIdentityResolver: opts.sessionIdentityResolver ?? (() => null),
     surfaceObserverOwnerIdProvider:
       opts.surfaceObserverOwnerIdProvider ?? testObserverOwnerId,
     surfaceObserverEpochProvider:

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -41,6 +41,7 @@ function withTestObserver(opts: CreateServerOptions = {}): CreateServerOptions {
   if (opts.context) return opts;
   return {
     ...opts,
+    sessionIdentityResolver: opts.sessionIdentityResolver ?? (() => null),
     surfaceObserverOwnerIdProvider:
       opts.surfaceObserverOwnerIdProvider ?? (() => TEST_OBSERVER_OWNER),
     surfaceObserverEpochProvider:

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -660,6 +660,23 @@ describe("Sidebar Sync", () => {
   });
 
   it("discovers and publishes live seats exactly once during idempotent startup", async () => {
+    const transcriptResolver = vi.fn(() => null);
+    engine.dispose();
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: transcriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: (publication) => {
+          if (!("snapshot" in publication)) {
+            throw new Error("engine must publish an explicit fleet state");
+          }
+          publishedFleetPublications.push(publication);
+        },
+        dispose: () => {},
+      },
+    });
     liveSurfaces = [
       {
         ...makeSurface("surface:42"),
@@ -706,6 +723,7 @@ describe("Sidebar Sync", () => {
     await engine.initialize(discovery);
 
     expect(scan).toHaveBeenCalledTimes(1);
+    expect(transcriptResolver).not.toHaveBeenCalled();
     expect(publishedFleetPublications).toHaveLength(2);
     expect(publishedFleetPublications[0]).toMatchObject({
       state: "discovering",
@@ -729,6 +747,15 @@ describe("Sidebar Sync", () => {
         ],
       },
     });
+
+    await engine.runSweep();
+
+    expect(transcriptResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_id: "auto-codex-surface-42",
+        cli: "codex",
+      }),
+    );
   });
 
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {


### PR DESCRIPTION
## Summary
- keep synchronous transcript-filesystem discovery out of first-connect lifecycle startup, while retaining screen capture and deferring transcript capture to normal sweeps
- make the resync and sibling production-server test factories hermetic with an injected no-op `sessionIdentityResolver`
- apply Etan's 2026-07-15 gpt-5.6 app-tier ruling: 400,000 tokens in both JSONL and screen paths, retaining the explicit `jsonlFloor: true` rule and the prior 2026-07-11 attribution

## Root cause and exact #333 mechanism
The timeout comes from `initializeOnce()` awaiting first-connect `syncSidebar()`, which previously called `maybeCaptureBootSessionId()` with transcript resolution enabled. A working Codex record with no session id and `launcher_name=cmuxlayerCodex` passes `canUseTranscriptSessionResolver()` (`src/agent-engine.ts:1877-1888`), and the default resolver synchronously walks `~/.codex/sessions` before lifecycle/tool readiness.

There is **no #333 line that newly makes this stale record eligible**:

- `git diff v0.4.14..b02c2bf -- src/agent-engine.ts tests/resync-tool.test.ts` is empty. Eligibility, capture, first-connect sidebar sync, and the test fixture are identical across the two revisions.
- #333 added `explicitRoleForDiscoveredSurface()` (`src/server.ts:2314-2346`) and passes it into `AgentRegistry` (`src/server.ts:7325-7334`).
- The provider reads only `roleSurfaceOverrides`, which is populated after a managed `new_split` creates a surface (`src/server.ts:5718-5723`).
- The registry wrapper changes a repair candidate only when that provider returns a role (`src/agent-registry.ts:1244`, `src/agent-registry.ts:1256-1263`).
- This isolated test performs no managed split. A controlled runtime probe showed `roleSurfaceOverrides=[]` while the resolver was invoked for `stale-left-worker` as `{cli:"codex", launcher_name:"cmuxlayerCodex", role:"worker", state:"working"}`.

Therefore the earlier 2x revision comparison was timing-correlated, not causal: repeated runs at the same #333 merge commit ranged from about 1.5s to 16.7s and produced both passes and timeouts. The unbounded host-filesystem scan is the actual defect.

## Production boundary
`maybeCaptureBootSessionId()` now accepts a narrow `resolveTranscript` option (`src/agent-engine.ts:2264-2285`). First-connect sidebar sync disables that option (`src/agent-engine.ts:3201-3208`), so MCP readiness cannot await the recursive host transcript scan. Normal sweeps and explicit capture keep the default-enabled behavior, so session capture is deferred rather than removed; screen-derived capture for booting agents also remains available during startup.

The lifecycle regression proves both sides at `tests/sidebar-sync.test.ts:662-758`: two idempotent `initialize()` calls do not invoke the resolver, then `runSweep()` does.

## Hermeticity audit
The production-server factories in these suites now inject `sessionIdentityResolver: () => null` unless a test explicitly supplies one:

- `tests/resync-tool.test.ts`
- `tests/server.test.ts`
- `tests/server-agent-tools.test.ts`

This preserves focused resolver tests through explicit override while preventing fixtures from reading a developer's real transcript tree.

## gpt-5.6 window ruling
The explicit gpt-5.6 rule remains ahead of generic gpt-5 and keeps `jsonlFloor: true`, but is now 400,000 (`src/harness-session.ts:34-53`). Keeping the explicit rule documents the model-specific app-tier ruling and floors stale 353,400-token CLI reports. The screen fallback matches at `src/screen-parser.ts:13-32`. Both comments retain the prior Etan web-verify/fleet-rules §10 attribution (2026-07-11) and add the superseding app-tier ruling (2026-07-15).

## Verification
Exact approved gate:

```text
$ bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test
$ tsc -p tsconfig.json --noEmit
Test Files  104 passed (104)
     Tests  2210 passed (2210)
Duration  17.19s
```

Focused suites:

```text
sidebar-sync + resync-tool + harness-session + screen-parser: 270 passed
server + server-agent-tools: 334 passed
```

Pre-commit CodeRabbit reviewed all 11 changed files with 0 findings.

The first pre-push hook run encountered one transient existing 5s timeout in `spawn_agent publishes the exact expected-state manifest` (2,209 passed, 1 timed out). The isolated reproduction passed in 3.02s, and the second unmodified pre-push hook run passed:

```text
Test Files  104 passed (104)
     Tests  2210 passed (2210)
run_tests.sh finished with exit status 0
```

## Merge ownership
Ready for review. cmuxLead-v2 owns merge; this worker will not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP lifecycle startup and session-ID capture timing; behavior change is intentional and regression-tested, but transcript IDs may appear slightly later than before.
> 
> **Overview**
> Fixes MCP startup timeouts by **not** running synchronous `~/.codex/sessions` transcript resolution during first-connect sidebar sync. `maybeCaptureBootSessionId()` gains a `resolveTranscript` flag; `syncSidebar({ firstConnect: true })` disables it so `initialize()` can finish without a host filesystem walk, while normal sweeps and explicit capture still resolve transcripts (screen-based boot capture unchanged).
> 
> Production-server test helpers in `resync-tool`, `server`, and `server-agent-tools` default `sessionIdentityResolver` to `() => null` so suites stay hermetic unless a test injects a resolver. `sidebar-sync` asserts initialize never calls the resolver and a later `runSweep()` does.
> 
> **gpt-5.6** context window moves from 1.05M to **400K** app-tier in `MODEL_WINDOW_RULES` (keeps `jsonlFloor: true`) and the screen-parser fallback, with updated harness/screen-parser tests and design/implementation plan docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92edde6fd52a29d8188f310dfa7241890d19bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer transcript scans during lifecycle startup in `AgentEngine`
> - `AgentEngine.maybeCaptureBootSessionId` now accepts `{ resolveTranscript?: boolean }` and skips filesystem transcript scans when called from the first-connect path in `syncSidebar`, deferring resolution to a later sweep instead.
> - Updates the `gpt-5.6` context window from 1,050,000 to 400,000 in both [`harness-session.ts`](https://github.com/EtanHey/cmuxlayer/pull/334/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) and [`screen-parser.ts`](https://github.com/EtanHey/cmuxlayer/pull/334/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) to match the app-tier ruling.
> - Makes tests hermetic by defaulting `sessionIdentityResolver` to a no-op in test helpers across `resync-tool`, `server-agent-tools`, and `server` test suites.
> - Adds a `sidebar-sync` lifecycle test asserting the transcript resolver is not called during `initialize()` but is called during `runSweep()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f92edde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup synchronization so initial sidebar loading no longer waits for transcript identity scans.
  * Transcript identity is resolved during a later synchronization pass when needed.
  * Made test environments deterministic by avoiding filesystem-based identity resolution during setup.
  * Corrected GPT-5.6 context-window handling to use a 400,000-token application limit, including JSONL-derived values.

* **Documentation**
  * Added design and implementation plans for the resynchronization convergence fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->