### PR TITLE
fix(lifecycle): preserve deferred session capture

### DIFF
--- a/docs/plans/2026-07-17-fix-333-resync-convergence-design.md
+++ b/docs/plans/2026-07-17-fix-333-resync-convergence-design.md
@@ -19,11 +19,12 @@ The fix still belongs in this batch because a user-sized sessions directory must
 
 ## Production boundary
 
-First-connect sidebar synchronization will skip only transcript-filesystem identity resolution. It will continue topology binding, screen-based boot capture, lifecycle reconciliation, and sidebar publication. The normal sweep and explicit `captureBootSessionId()` path retain transcript resolution, so session identity is deferred rather than removed.
+First-connect sidebar synchronization will skip only transcript-filesystem identity resolution. It will continue topology binding, screen-based boot capture, lifecycle reconciliation, and sidebar publication. Eligible sessionless rows remember that deferral so a same-pass transition to `done` or `error` cannot make transcript capture permanently ineligible or expose the row to the one-time stale-terminal purge. The normal sweep and explicit `captureBootSessionId()` path retain transcript resolution, so session identity is deferred rather than removed.
 
 This is narrower than making the synchronous resolver asynchronous or adding a cross-agent cache:
 
 - no startup await can enter the recursive sessions scan;
+- first-connect terminalization cannot discard a deferred identity lookup;
 - existing later-capture and resume semantics remain intact;
 - screen-derived session IDs can still be captured during the boot window;
 - the change is deterministic and directly testable with an injected resolver spy.
@@ -35,7 +36,7 @@ Production-server test helpers in `resync-tool.test.ts` and the sibling server s
 The lifecycle regression will assert both halves of the boundary:
 
 1. `initialize()` completes without invoking an eligible transcript resolver.
-2. A subsequent explicit sweep invokes that resolver, proving capture was deferred rather than disabled.
+2. A subsequent explicit sweep invokes that resolver, including when the row became terminal during first-connect, proving capture was deferred rather than disabled.
 
 The resync regression remains outcome-focused and deterministic under the hermetic helper.
 

--- a/docs/plans/2026-07-17-fix-333-resync-convergence.md
+++ b/docs/plans/2026-07-17-fix-333-resync-convergence.md
@@ -18,17 +18,17 @@
 
 **Step 1: Write the failing regression**
 
-Extend the idempotent-startup lifecycle test with an eligible discovered Codex record and a resolver spy. Assert `initialize()` does not call the spy, then call `runSweep()` and assert it does without increasing the approved 2,210-test suite count.
+Extend the idempotent-startup lifecycle test with an eligible discovered Codex record and a resolver spy. Assert `initialize()` does not call the spy, then call `runSweep()` and assert it does. Cover a record that reaches `done` during first-connect so terminalization cannot discard the deferred lookup, without increasing the approved 2,210-test suite count.
 
 **Step 2: Run the focused test to verify RED**
 
-Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/sidebar-sync.test.ts -t "discovers and publishes live seats exactly once during idempotent startup"`
+Run: `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET npx vitest run tests/sidebar-sync.test.ts -t "discovers live seats once and defers transcript capture beyond startup"`
 
 Expected: FAIL because first-connect `syncSidebar()` currently invokes the resolver.
 
 **Step 3: Implement the minimal boundary**
 
-Add an optional transcript-resolution flag to `maybeCaptureBootSessionId()`. Pass it as disabled only from `syncSidebar({ firstConnect: true })`; leave normal sweeps and explicit capture enabled.
+Add an optional transcript-resolution flag to `maybeCaptureBootSessionId()`. Pass it as disabled only from `syncSidebar({ firstConnect: true })`; retain eligible deferred rows across terminalization and the startup terminal purge, then clear the deferral after capture. Leave normal sweeps and explicit capture enabled.
 
 **Step 4: Run the focused test to verify GREEN**
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -806,6 +806,8 @@ export class AgentEngine {
   private deliveredLeadMonitorDeathAlerts = new Set<string>();
   /** agentId → consecutive ready-prompt matches */
   private readyPatternMatches = new Map<string, number>();
+  /** Sessionless rows whose first-connect transcript lookup was deferred. */
+  private deferredTranscriptSessionAgentIds = new Set<string>();
   /** Best-effort outbox drainer invoked each sweep (injectable for tests). */
   private outboxDrain: () => Promise<unknown>;
   /** Guards against overlapping outbox drains if a sweep runs long. */
@@ -2267,16 +2269,23 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
+      this.deferredTranscriptSessionAgentIds.delete(agent.agent_id);
       return agent;
     }
 
+    const transcriptEligible = this.canUseTranscriptSessionResolver(agent);
+    if (opts.resolveTranscript === false && transcriptEligible) {
+      this.deferredTranscriptSessionAgentIds.add(agent.agent_id);
+    }
     if (
       opts.resolveTranscript !== false &&
-      this.canUseTranscriptSessionResolver(agent)
+      (transcriptEligible ||
+        this.deferredTranscriptSessionAgentIds.has(agent.agent_id))
     ) {
       try {
         const transcriptSessionId = this.sessionIdentityResolver(agent);
         if (transcriptSessionId) {
+          this.deferredTranscriptSessionAgentIds.delete(agent.agent_id);
           return this.finalizeCapturedSession(agent, transcriptSessionId);
         }
       } catch {
@@ -2295,6 +2304,7 @@ export class AgentEngine {
         return agent;
       }
 
+      this.deferredTranscriptSessionAgentIds.delete(agent.agent_id);
       return this.finalizeCapturedSession(agent, {
         session_id: sessionId,
         path: null,
@@ -2874,6 +2884,9 @@ export class AgentEngine {
     }
     this.deliveredLeadMonitorDeathAlerts.delete(agentId);
     this.fleetScreenProgress.delete(agentId);
+    if (!this.registry.get(agentId) && !this.stateMgr.readState(agentId)) {
+      this.deferredTranscriptSessionAgentIds.delete(agentId);
+    }
   }
 
   private isLeadWatchBlind(
@@ -3970,8 +3983,12 @@ export class AgentEngine {
   private async purgeStartupTerminalAgents(): Promise<void> {
     if (!this.startupPurgePending) return;
     this.startupPurgePending = false;
+    const retainedAgentIds = new Set([
+      ...this.startupPurgeRetainedAgentIds,
+      ...this.deferredTranscriptSessionAgentIds,
+    ]);
     const purgedIds = this.registry.purgeAllTerminal({
-      retainAgentIds: this.startupPurgeRetainedAgentIds,
+      retainAgentIds: retainedAgentIds,
     });
     this.startupPurgeRetainedAgentIds.clear();
     try {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -659,7 +659,7 @@ describe("Sidebar Sync", () => {
     });
   });
 
-  it("discovers and publishes live seats exactly once during idempotent startup", async () => {
+  it("discovers live seats once and defers transcript capture beyond startup", async () => {
     const transcriptResolver = vi.fn(() => null);
     engine.dispose();
     const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
@@ -756,6 +756,86 @@ describe("Sidebar Sync", () => {
         cli: "codex",
       }),
     );
+
+    engine.dispose();
+    stateMgr.removeState("auto-codex-surface-42");
+    publishedFleetPublications.length = 0;
+    const capturedSessionId = "12345678-1234-4234-8234-123456789abc";
+    const deferredTranscriptResolver = vi.fn(() => ({
+      session_id: capturedSessionId,
+      path: "/tmp/codex-session.jsonl",
+    }));
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "cmuxlayerCodex-pending-startup",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerCodex",
+        task_done_candidate_at: "2026-03-14T03:40:00Z",
+      }),
+    );
+    const terminalRegistry = new AgentRegistry(
+      stateMgr,
+      async () => liveSurfaces,
+    );
+    engine = new AgentEngine(stateMgr, terminalRegistry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: deferredTranscriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: (publication) => {
+          if (!("snapshot" in publication)) {
+            throw new Error("engine must publish an explicit fleet state");
+          }
+          publishedFleetPublications.push(publication);
+        },
+        dispose: () => {},
+      },
+    });
+    mockClient.readScreen
+      .mockResolvedValueOnce({
+        surface: "surface:42",
+        text:
+          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
+        lines: 30,
+        scrollback_used: false,
+      })
+      .mockResolvedValue({
+        surface: "surface:42",
+        text:
+          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\nImplemented the fix.\nTASK_DONE",
+        lines: 30,
+        scrollback_used: false,
+      });
+    const terminalDiscovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(terminalDiscovery);
+
+    expect(deferredTranscriptResolver).not.toHaveBeenCalled();
+    expect(engine.getAgentState("cmuxlayerCodex-pending-startup")).toMatchObject(
+      { state: "done", cli_session_id: null },
+    );
+
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_id: "cmuxlayerCodex-pending-startup",
+        cli: "codex",
+        state: "done",
+      }),
+    );
+    expect(
+      engine.getAgentState(
+        generateAgentId("codex", "cmuxlayer", capturedSessionId),
+      ),
+    ).toMatchObject({
+      state: "done",
+      cli_session_id: capturedSessionId,
+      cli_session_path: "/tmp/codex-session.jsonl",
+    });
   });
 
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {


### PR DESCRIPTION
## Summary

- preserve transcript identity capture when an eligible sessionless row becomes `done` or `error` during first-connect lifecycle synchronization
- retain only those deferred rows across the one-time stale-terminal purge, then retry identity resolution on normal sweeps and clear the deferral after capture
- extend the existing idempotent-startup regression without increasing the approved 2,210-test suite count

## Context

Follow-up to #334 for the Codex P2 review finding: first-connect correctly skipped the host transcript scan, but a same-pass transition to a terminal state made the row ineligible for every later resolver attempt. The first normal sweep could also purge that newly terminal row before capture.

PR #334 was merged at `f92edde6` while this review fix was being verified. This PR contains the subsequent `8eb9fa7` fix only.

## Production boundary

The first-connect path still never invokes the transcript-filesystem resolver. Eligible sessionless rows record that the lookup was deferred. A normal sweep can then resolve the identity even if the row became terminal, and the one-time startup terminal purge retains the row until that sweep. Successful transcript or screen capture clears the deferral.

The regression drives a managed Codex row from `working` to `done` during first-connect, asserts that startup did not call the resolver, then proves the next sweep captures and persists the canonical session identity.

## Verification

Exact gate on `8eb9fa7`:

```text
$ bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test
$ tsc -p tsconfig.json --noEmit
Test Files  104 passed (104)
     Tests  2210 passed (2210)
Duration  16.68s
```

Focused lifecycle/resync suites: 96/96 passed. Local CodeRabbit review of the two implementation/test files: 0 findings.

The first pre-push hook run hit four clustered existing stop-agent/temporary-directory race failures. All four passed in isolation, and an unmodified retry passed the full hook gate:

```text
Test Files  104 passed (104)
     Tests  2210 passed (2210)
run_tests.sh finished with exit status 0
```

## Merge ownership

Ready for review. cmuxLead-v2 owns merge; this worker will not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle, session identity rekeying, and startup terminal purge retention; scope is narrow with a focused regression test.
> 
> **Overview**
> Follow-up to the first-connect transcript deferral: eligible sessionless agents that skip the host transcript scan during `syncSidebar({ firstConnect: true })` are now **remembered** in `deferredTranscriptSessionAgentIds` so a same-pass transition to `done`/`error` does not permanently block later identity capture.
> 
> **`maybeCaptureBootSessionId`** records deferral when transcript resolution is disabled but the row would otherwise be eligible, retries the resolver on normal sweeps for deferred IDs even after terminalization, and clears the deferral once a session ID is captured (transcript or screen).
> 
> **Startup purge** keeps deferred rows alongside existing retained IDs so the one-time stale-terminal purge cannot remove them before the first post-startup sweep runs.
> 
> The sidebar-sync regression is renamed and extended to assert a managed Codex row can reach `done` during `initialize()` without calling the resolver, then capture and rekey to the canonical session identity on `runSweep()`. Plan docs describe the same boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb9fa759cc11da6ca254347596bb3491a3e98d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve deferred transcript session capture across first-connect terminalization and startup purge
> - Adds a `deferredTranscriptSessionAgentIds` set in `AgentEngine` to track agents whose transcript lookup was skipped during first-connect (when `resolveTranscript` is false).
> - Subsequent `runSweep` calls now perform the deferred lookup for those agents and clear the deferred marker on successful capture.
> - Agents with deferred transcript resolution are excluded from the startup terminal purge so they are not discarded before the lookup can occur.
> - Deferred markers are cleaned up when an agent is fully removed from both the registry and persisted state.
> - Risk: agents that reach a terminal state during first-connect now survive the startup purge until their transcript is resolved, which may briefly delay cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8eb9fa7. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->