### PR TITLE
fix(lifecycle): persist deferred session capture

### DIFF
--- a/docs/plans/2026-07-17-persist-deferred-capture-design.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture-design.md
@@ -10,7 +10,7 @@ v0.4.15 keeps recursive transcript discovery out of first-connect startup and re
 
 ## Chosen design
 
-Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup and normal absence cleanup retain marked terminal rows. Before normal absence cleanup, a sweep retries every marked row without requiring a live surface binding, so a pane that closes during restart cannot strand the capture. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
+Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup and normal absence cleanup retain marked terminal rows. After the one-shot startup purge retains those marked rows, but before normal absence cleanup, a sweep retries every marker without requiring a live surface binding. This ordering prevents either a pane closing during restart or a successful first retry from discarding the captured identity. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
 
 Session identity persistence and marker clearing happen in the same atomic state-file replacement. If the identity write fails, the previous record remains sessionless and marked, so a later sweep retries. Once identity is persisted, the marker is false in that same record version.
 
@@ -43,5 +43,6 @@ Extend the existing first-connect lifecycle regression without adding a second o
 5. Remove the original pane and prove the first sweep still reaches the resolver, then leaves the row marked and sessionless.
 6. Prove a later sweep captures identity and clears the marker atomically.
 7. Prove normal surfaceless and terminal cleanup retain a marked row.
+8. Prove an immediate successful first-sweep capture survives the pending startup purge.
 
 Run the focused sidebar and resync suites, then the exact full gate from the approved brief.

--- a/docs/plans/2026-07-17-persist-deferred-capture-design.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture-design.md
@@ -10,15 +10,22 @@ v0.4.15 keeps recursive transcript discovery out of first-connect startup and re
 
 ## Chosen design
 
-Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup and normal absence cleanup retain marked terminal rows. After the one-shot startup purge retains those marked rows, but before normal absence cleanup, a sweep retries every marker without requiring a live surface binding. This ordering prevents either a pane closing during restart or a successful first retry from discarding the captured identity. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
+Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup and normal absence cleanup retain marked terminal rows. After the one-shot startup purge retains those marked rows, but before normal absence cleanup, a sweep retries structurally eligible markers without requiring a live surface binding; ineligible markers clear without a resolver call, and unsuccessful eligible retries stop after three calls. This ordering prevents either a pane closing during restart or a successful first retry from discarding the captured identity. Within that bounded window, a normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
 
 Session identity persistence and marker clearing happen in the same atomic state-file replacement. If the identity write fails, the previous record remains sessionless and marked, so a later sweep retries. Once identity is persisted, the marker is false in that same record version.
+
+### Bounded retry amendment (PR #336 review)
+
+Persist `transcript_session_capture_attempts` beside the marker and clear the marker after three failed resolver calls. Three normal sweeps preserve the useful post-boot window (roughly 15–45 seconds at the default active/idle sweep cadence), while placing a deterministic cap on recursive transcript scans that survives daemon restart. Resolver `null` results and throws consume the cap; a successful resolution whose identity write fails does not, preserving the transient-write P1 behavior.
+
+The marker also clears without invoking the resolver when the row no longer has structurally valid transcript context: a JSONL-backed CLI plus managed-launch/task context. Terminal lifecycle state alone is not treated as structurally ineligible, because retrying a just-terminalized Codex row is the purpose of the marker. Once either the cap or structural-ineligibility rule clears the marker, normal confirmed-absence cleanup can reap the row.
 
 ## Alternatives considered
 
 1. Add the memory-only deferred-ID set from the unmerged follow-up. This is minimal but loses intent across daemon restart and is the gap this batch closes.
 2. Set the marker through ordinary `StateManager.updateRecord()`. This is durable but increments `version`, refreshes `updated_at`, and can prevent age-based ghost retirement by making bookkeeping look like lifecycle progress.
 3. Persist through a dedicated age-neutral state mutation. This is selected because it provides restart durability without distorting retirement evidence.
+4. Expire by `created_at`. Rejected because an old restored row can receive a new marker; record creation time does not identify when deferred capture began. A persisted attempt cap bounds work without adding another clock field.
 
 ## Boundaries
 
@@ -26,6 +33,7 @@ Session identity persistence and marker clearing happen in the same atomic state
 - Screen-derived session capture remains available during the boot window.
 - Normal sweeps and explicit capture retain transcript resolution.
 - Only rows explicitly marked for deferred capture survive terminal cleanup; normal cleanup resumes after capture clears the marker.
+- Deferred resolver work is capped at three failed calls across restarts, and structurally ineligible markers clear without a resolver call.
 - The change stays behind the existing `maybeCaptureBootSessionId()` and `syncSidebar({ firstConnect: true })` seams.
 
 ## Failure handling
@@ -44,5 +52,7 @@ Extend the existing first-connect lifecycle regression without adding a second o
 6. Prove a later sweep captures identity and clears the marker atomically.
 7. Prove normal surfaceless and terminal cleanup retain a marked row.
 8. Prove an immediate successful first-sweep capture survives the pending startup purge.
+9. Prove a never-resolving terminal row stops at three resolver calls across restart and is reaped by normal confirmed-absence cleanup.
+10. Prove a structurally ineligible marked row clears without invoking the resolver.
 
 Run the focused sidebar and resync suites, then the exact full gate from the approved brief.

--- a/docs/plans/2026-07-17-persist-deferred-capture-design.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture-design.md
@@ -10,7 +10,7 @@ v0.4.15 keeps recursive transcript discovery out of first-connect startup and re
 
 ## Chosen design
 
-Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup purge retains marked terminal rows. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
+Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup and normal absence cleanup retain marked terminal rows. Before normal absence cleanup, a sweep retries every marked row without requiring a live surface binding, so a pane that closes during restart cannot strand the capture. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
 
 Session identity persistence and marker clearing happen in the same atomic state-file replacement. If the identity write fails, the previous record remains sessionless and marked, so a later sweep retries. Once identity is persisted, the marker is false in that same record version.
 
@@ -25,12 +25,12 @@ Session identity persistence and marker clearing happen in the same atomic state
 - First-connect must not call the transcript resolver or recursively inspect `~/.codex/sessions`.
 - Screen-derived session capture remains available during the boot window.
 - Normal sweeps and explicit capture retain transcript resolution.
-- Only rows explicitly marked for deferred capture survive the startup terminal purge.
+- Only rows explicitly marked for deferred capture survive terminal cleanup; normal cleanup resumes after capture clears the marker.
 - The change stays behind the existing `maybeCaptureBootSessionId()` and `syncSidebar({ firstConnect: true })` seams.
 
 ## Failure handling
 
-The initial marker write is best-effort so a state-filesystem failure cannot block daemon startup. A failed identity write leaves the durable marker unchanged. Canonical-row collisions and renames clear the marker wherever the captured identity is persisted.
+The initial marker write is best-effort so a state-filesystem failure cannot block daemon startup. A failed identity write leaves the durable marker unchanged and normal cleanup cannot evict it. Canonical-row collisions and renames clear the marker wherever the captured identity is persisted.
 
 ## Test contract
 
@@ -40,7 +40,8 @@ Extend the existing first-connect lifecycle regression without adding a second o
 2. Prove the durable marker is present after first-connect terminalization.
 3. Dispose and recreate the engine before the first normal sweep.
 4. Inject exactly one identity-state write failure.
-5. Prove the first sweep leaves the row marked and sessionless.
+5. Remove the original pane and prove the first sweep still reaches the resolver, then leaves the row marked and sessionless.
 6. Prove a later sweep captures identity and clears the marker atomically.
+7. Prove normal surfaceless and terminal cleanup retain a marked row.
 
 Run the focused sidebar and resync suites, then the exact full gate from the approved brief.

--- a/docs/plans/2026-07-17-persist-deferred-capture-design.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture-design.md
@@ -1,0 +1,46 @@
+# Persist Deferred Transcript Capture Design
+
+## Status
+
+Approved by Etan on 2026-07-17 as the top follow-up to v0.4.15.
+
+## Problem
+
+v0.4.15 keeps recursive transcript discovery out of first-connect startup and re-derives transcript eligibility during a normal sweep. It persists no retry intent. If first-connect terminalizes an eligible sessionless row, that row can be purged or become ineligible before capture; a daemon restart guarantees that no process-local context can help. The row can remain permanently non-resumable.
+
+## Chosen design
+
+Persist a `transcript_session_capture_deferred` marker on `AgentRecord`. First-connect sets the marker without changing the record's lifecycle age. Startup purge retains marked terminal rows. A normal sweep treats the marker as transcript-capture eligibility even after terminalization or restart.
+
+Session identity persistence and marker clearing happen in the same atomic state-file replacement. If the identity write fails, the previous record remains sessionless and marked, so a later sweep retries. Once identity is persisted, the marker is false in that same record version.
+
+## Alternatives considered
+
+1. Add the memory-only deferred-ID set from the unmerged follow-up. This is minimal but loses intent across daemon restart and is the gap this batch closes.
+2. Set the marker through ordinary `StateManager.updateRecord()`. This is durable but increments `version`, refreshes `updated_at`, and can prevent age-based ghost retirement by making bookkeeping look like lifecycle progress.
+3. Persist through a dedicated age-neutral state mutation. This is selected because it provides restart durability without distorting retirement evidence.
+
+## Boundaries
+
+- First-connect must not call the transcript resolver or recursively inspect `~/.codex/sessions`.
+- Screen-derived session capture remains available during the boot window.
+- Normal sweeps and explicit capture retain transcript resolution.
+- Only rows explicitly marked for deferred capture survive the startup terminal purge.
+- The change stays behind the existing `maybeCaptureBootSessionId()` and `syncSidebar({ firstConnect: true })` seams.
+
+## Failure handling
+
+The initial marker write is best-effort so a state-filesystem failure cannot block daemon startup. A failed identity write leaves the durable marker unchanged. Canonical-row collisions and renames clear the marker wherever the captured identity is persisted.
+
+## Test contract
+
+Extend the existing first-connect lifecycle regression without adding a second overlapping setup:
+
+1. Initialize an eligible sessionless Codex row and prove the transcript resolver is not called during startup.
+2. Prove the durable marker is present after first-connect terminalization.
+3. Dispose and recreate the engine before the first normal sweep.
+4. Inject exactly one identity-state write failure.
+5. Prove the first sweep leaves the row marked and sessionless.
+6. Prove a later sweep captures identity and clears the marker atomically.
+
+Run the focused sidebar and resync suites, then the exact full gate from the approved brief.

--- a/docs/plans/2026-07-17-persist-deferred-capture.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture.md
@@ -77,7 +77,7 @@ In `finalizeCapturedSession()`, include `transcript_session_capture_deferred: fa
 
 In `purgeStartupTerminalAgents()`, add marked registry rows to `retainAgentIds` before purging.
 
-Before normal absence cleanup, retry marked rows independently of live surface binding. Both `evictSurfaceless()` and `purgeTerminal()` retain marked rows and reset their absence confirmation evidence; ordinary cleanup resumes after the atomic capture clears the marker.
+After the pending one-shot startup purge has retained marked rows, but before normal absence cleanup, retry those rows independently of live surface binding. Both `evictSurfaceless()` and `purgeTerminal()` retain marked rows and reset their absence confirmation evidence; ordinary cleanup resumes after the atomic capture clears the marker. Add a regression proving an immediate successful first-sweep capture is not deleted by the pending startup purge.
 
 **Step 4: Verify GREEN**
 

--- a/docs/plans/2026-07-17-persist-deferred-capture.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture.md
@@ -4,7 +4,9 @@
 
 **Goal:** Preserve first-connect transcript capture intent across terminalization, daemon restart, startup purge, and a transient identity-write failure without scanning transcripts during startup.
 
-**Architecture:** Store an optional deferred-capture marker on `AgentRecord`. Use a dedicated atomic `StateManager` mutation to set the marker without changing `version` or `updated_at`; capture writes identity and clears the marker together through the normal atomic record update. Startup purge retains marked rows, and normal sweeps resolve transcripts for either ordinarily eligible or durably marked records.
+**Architecture:** Store an optional deferred-capture marker on `AgentRecord`. Use a dedicated atomic `StateManager` mutation to set the marker without changing `version` or `updated_at`; capture writes identity and clears the marker together through the normal atomic record update. Startup purge retains marked rows, while normal sweeps resolve structurally eligible markers for at most three failed calls and clear structurally ineligible markers without invoking the resolver.
+
+**Review amendment:** Persist a failed-resolver attempt count beside the marker. Clear after three failed calls across restarts, or immediately when JSONL/managed-launch transcript context is structurally ineligible, so normal confirmed-absence cleanup can reap the row. Identity-write failures do not consume the resolver cap.
 
 **Tech Stack:** TypeScript, Bun, Vitest, JSON state files with atomic temp-file rename.
 
@@ -13,6 +15,7 @@
 ### Task 1: Specify restart and retry behavior
 
 **Files:**
+- Modify: `tests/agent-registry.test.ts`
 - Modify: `tests/sidebar-sync.test.ts`
 
 **Step 1: Add a focused first-connect regression**
@@ -49,6 +52,8 @@ Expected: FAIL because v0.4.15 neither persists the marker nor retains/retries t
 - Modify: `src/agent-types.ts`
 - Modify: `src/state-manager.ts`
 - Modify: `src/agent-engine.ts`
+- Modify: `src/agent-registry.ts`
+- Modify: `tests/agent-registry.test.ts`
 
 **Step 1: Add the optional record field**
 
@@ -61,7 +66,7 @@ transcript_session_capture_deferred?: boolean;
 
 **Step 2: Add an age-neutral state mutation**
 
-Add `StateManager.setTranscriptSessionCaptureDeferred(agentId, deferred)`. It reads the current record, returns early if unchanged, replaces only the marker, writes `state.json.tmp`, atomically renames it to `state.json`, updates the surface-session index, and returns the record. It must not increment `version`, change `updated_at`, or append a lifecycle event.
+Add `StateManager.setTranscriptSessionCaptureDeferred(agentId, deferred, attempts)`. It reads the current record, returns early if both values are unchanged, atomically replaces the marker and persisted attempt count through `state.json.tmp` plus rename, updates the surface-session index, and returns the record. The mutation supports increment, reset, and clear without incrementing `version`, changing `updated_at`, or appending a lifecycle event.
 
 **Step 3: Route capture through the marker**
 
@@ -70,8 +75,9 @@ In `maybeCaptureBootSessionId()`:
 - Clear a stale marker age-neutrally when a record already has `cli_session_id`.
 - On first-connect (`resolveTranscript: false`), set the marker for transcript-eligible sessionless records.
 - On normal sweeps, resolve when ordinary eligibility is true or the durable marker is true.
-- Never clear the marker before `finalizeCapturedSession()` succeeds.
-- Preserve the marked record when resolver or identity persistence throws.
+- Successful capture clears the marker and attempt count only inside `finalizeCapturedSession()`.
+- Structural ineligibility and the terminal three-failure budget clear both fields through the age-neutral atomic mutation.
+- Preserve the marker when resolver or identity persistence throws before either terminal condition; identity-write failures do not consume the resolver budget.
 
 In `finalizeCapturedSession()`, include `transcript_session_capture_deferred: false` in the same `updateRecord()` patch as `cli_session_id` and `cli_session_path`, including the existing-canonical-row path.
 
@@ -126,7 +132,7 @@ git commit -m "fix(lifecycle): persist deferred session capture"
 bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test
 ```
 
-Expected: typecheck exits zero and all 2,211 tests pass. Record the actual summary, not the expectation.
+Expected: typecheck and the full suite exit zero. Record the actual file and test counts reported by the gate output.
 
 **Step 2: Run bounded local review**
 
@@ -143,3 +149,24 @@ Wait at least 120 seconds before the first review check. Read all PR comments an
 **Step 5: Report**
 
 Re-enumerate cmux surfaces, deliver the final PR URL and test count to cmuxLead-v2 on `surface:143`, store the WHAT+WHY milestone in BrainLayer, and stop with `TASK_DONE`.
+
+### Task 5: Bound never-resolving markers (independent review RED)
+
+**Files:**
+- Modify: `src/agent-types.ts`
+- Modify: `src/state-manager.ts`
+- Modify: `src/agent-engine.ts`
+- Modify: `tests/state-manager.test.ts`
+- Modify: `tests/sidebar-sync.test.ts`
+
+**Step 1: Verify RED**
+
+Add a persisted terminal marked row whose resolver always returns `null`. Run sweeps across an engine restart and assert the resolver is called at most three times and the row is subsequently reaped. Add a structurally ineligible marked row and assert it clears without a resolver call. Add a state-manager assertion that the attempt count persists without changing lifecycle age or emitting an event.
+
+**Step 2: Implement the bounded marker**
+
+Persist `transcript_session_capture_attempts` in the age-neutral marker mutation. Count resolver `null`/throw outcomes, clear atomically at three, reset on successful capture, and leave the count unchanged when identity persistence fails. Split lifecycle eligibility from structural transcript context so a terminal JSONL row can use its bounded marker override while unsupported/malformed context clears immediately.
+
+**Step 3: Verify GREEN and run the full gate**
+
+Run the focused state-manager/sidebar regressions, then the exact full typecheck and test gate. Push to the existing PR branch, request re-review, process CI/review findings, and do not merge.

--- a/docs/plans/2026-07-17-persist-deferred-capture.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture.md
@@ -29,7 +29,9 @@ const deferredTranscriptResolver = vi.fn(() => ({
 
 After `initialize()`, assert the resolver was not called and the terminal record is sessionless with `transcript_session_capture_deferred: true`. Dispose the engine, recreate it from the same `StateManager`, and initialize again before any normal sweep.
 
-Spy on `stateMgr.updateRecord` and throw exactly once when the patch contains the captured session ID. Run one sweep and assert the resolver was called but the record remains sessionless and marked. Restore the spy, run a later sweep, then assert the canonical record has the captured ID/path and `transcript_session_capture_deferred: false`.
+Spy on `stateMgr.updateRecord` and throw exactly once when the patch contains the captured session ID. Remove the original pane while leaving an unrelated live surface as authoritative absence evidence. Run one sweep and assert the resolver was called without a live binding but the record remains sessionless and marked. Restore the spy, run a later sweep, then assert the canonical record has the captured ID/path and `transcript_session_capture_deferred: false`.
+
+Add a registry regression proving both normal surfaceless eviction and terminal purge retain a marked row.
 
 **Step 2: Verify RED on release main**
 
@@ -74,6 +76,8 @@ In `maybeCaptureBootSessionId()`:
 In `finalizeCapturedSession()`, include `transcript_session_capture_deferred: false` in the same `updateRecord()` patch as `cli_session_id` and `cli_session_path`, including the existing-canonical-row path.
 
 In `purgeStartupTerminalAgents()`, add marked registry rows to `retainAgentIds` before purging.
+
+Before normal absence cleanup, retry marked rows independently of live surface binding. Both `evictSurfaceless()` and `purgeTerminal()` retain marked rows and reset their absence confirmation evidence; ordinary cleanup resumes after the atomic capture clears the marker.
 
 **Step 4: Verify GREEN**
 

--- a/docs/plans/2026-07-17-persist-deferred-capture.md
+++ b/docs/plans/2026-07-17-persist-deferred-capture.md
@@ -1,0 +1,141 @@
+# Persist Deferred Transcript Capture Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve first-connect transcript capture intent across terminalization, daemon restart, startup purge, and a transient identity-write failure without scanning transcripts during startup.
+
+**Architecture:** Store an optional deferred-capture marker on `AgentRecord`. Use a dedicated atomic `StateManager` mutation to set the marker without changing `version` or `updated_at`; capture writes identity and clears the marker together through the normal atomic record update. Startup purge retains marked rows, and normal sweeps resolve transcripts for either ordinarily eligible or durably marked records.
+
+**Tech Stack:** TypeScript, Bun, Vitest, JSON state files with atomic temp-file rename.
+
+---
+
+### Task 1: Specify restart and retry behavior
+
+**Files:**
+- Modify: `tests/sidebar-sync.test.ts`
+
+**Step 1: Add a focused first-connect regression**
+
+Add `persists deferred transcript capture across restart and identity-write failure`. Create a managed sessionless record that terminalizes during first-connect. Use a resolver returning a complete captured identity:
+
+```ts
+const capturedSessionId = "12345678-1234-4234-8234-123456789abc";
+const deferredTranscriptResolver = vi.fn(() => ({
+  session_id: capturedSessionId,
+  path: "/tmp/codex-session.jsonl",
+}));
+```
+
+After `initialize()`, assert the resolver was not called and the terminal record is sessionless with `transcript_session_capture_deferred: true`. Dispose the engine, recreate it from the same `StateManager`, and initialize again before any normal sweep.
+
+Spy on `stateMgr.updateRecord` and throw exactly once when the patch contains the captured session ID. Run one sweep and assert the resolver was called but the record remains sessionless and marked. Restore the spy, run a later sweep, then assert the canonical record has the captured ID/path and `transcript_session_capture_deferred: false`.
+
+**Step 2: Verify RED on release main**
+
+Run:
+
+```bash
+env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run tests/sidebar-sync.test.ts -t "persists deferred transcript capture across restart and identity-write failure"
+```
+
+Expected: FAIL because v0.4.15 neither persists the marker nor retains/retries the terminal record after restart.
+
+### Task 2: Implement the durable marker
+
+**Files:**
+- Modify: `src/agent-types.ts`
+- Modify: `src/state-manager.ts`
+- Modify: `src/agent-engine.ts`
+
+**Step 1: Add the optional record field**
+
+Add to `AgentRecord`:
+
+```ts
+/** First-connect skipped transcript identity resolution; retry on sweeps. */
+transcript_session_capture_deferred?: boolean;
+```
+
+**Step 2: Add an age-neutral state mutation**
+
+Add `StateManager.setTranscriptSessionCaptureDeferred(agentId, deferred)`. It reads the current record, returns early if unchanged, replaces only the marker, writes `state.json.tmp`, atomically renames it to `state.json`, updates the surface-session index, and returns the record. It must not increment `version`, change `updated_at`, or append a lifecycle event.
+
+**Step 3: Route capture through the marker**
+
+In `maybeCaptureBootSessionId()`:
+
+- Clear a stale marker age-neutrally when a record already has `cli_session_id`.
+- On first-connect (`resolveTranscript: false`), set the marker for transcript-eligible sessionless records.
+- On normal sweeps, resolve when ordinary eligibility is true or the durable marker is true.
+- Never clear the marker before `finalizeCapturedSession()` succeeds.
+- Preserve the marked record when resolver or identity persistence throws.
+
+In `finalizeCapturedSession()`, include `transcript_session_capture_deferred: false` in the same `updateRecord()` patch as `cli_session_id` and `cli_session_path`, including the existing-canonical-row path.
+
+In `purgeStartupTerminalAgents()`, add marked registry rows to `retainAgentIds` before purging.
+
+**Step 4: Verify GREEN**
+
+Run the focused command from Task 1. Expected: one passing test.
+
+### Task 3: Prove lifecycle-age and resync compatibility
+
+**Files:**
+- Verify: `tests/sidebar-sync.test.ts`
+- Verify: `tests/resync-tool.test.ts`
+
+**Step 1: Run both affected suites**
+
+```bash
+env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run tests/sidebar-sync.test.ts tests/resync-tool.test.ts
+```
+
+Expected: all tests pass. The existing booting-ghost eviction regression proves that marker persistence did not refresh lifecycle age.
+
+**Step 2: Inspect the implementation diff**
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+git diff
+```
+
+Confirm no startup resolver call was added, no timeout changed, and no unrelated file was modified.
+
+**Step 3: Commit the implementation**
+
+```bash
+git add docs/plans/2026-07-17-persist-deferred-capture.md src/agent-types.ts src/state-manager.ts src/agent-engine.ts tests/sidebar-sync.test.ts
+git commit -m "fix(lifecycle): persist deferred session capture"
+```
+
+### Task 4: Run the full gate and worker PR loop
+
+**Files:**
+- Review all branch changes against `origin/main`.
+
+**Step 1: Run the exact full gate**
+
+```bash
+bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test
+```
+
+Expected: typecheck exits zero and all 2,211 tests pass. Record the actual summary, not the expectation.
+
+**Step 2: Run bounded local review**
+
+Run `coderabbit review --agent` with a three-minute bound. Address substantive findings. If the OSS limit blocks review, record that limitation and rely on fresh test evidence plus PR-level reviewers.
+
+**Step 3: Push and open a ready PR**
+
+Push `feat/persist-deferred-capture`, create a non-draft PR against `main`, include the actual gate summary and the baseline `doctor.test.ts` flake/retry evidence, then invoke CodeRabbit, Codex, and Cursor/Bugbot.
+
+**Step 4: Process reviews and CI**
+
+Wait at least 120 seconds before the first review check. Read all PR comments and inline findings, fix real issues with focused tests, push, and request re-review. Do not merge.
+
+**Step 5: Report**
+
+Re-enumerate cmux surfaces, deliver the final PR URL and test count to cmuxLead-v2 on `surface:143`, store the WHAT+WHY milestone in BrainLayer, and stop with `TASK_DONE`.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4163,15 +4163,15 @@ export class AgentEngine {
       now: Date.now(),
     };
     await this.registry.reconcile(surfacelessConfirmation);
-    // Deferred transcript identity does not require a live surface binding.
-    // Retry it before absence cleanup so a closed pane cannot strand or evict
-    // the durable capture intent before the resolver gets a chance to run.
-    await this.retryDeferredTranscriptCaptures();
     await this.registry.evictSurfaceless(surfacelessConfirmation);
     await this.recoverCrashedAgents();
 
     await this.purgeStartupTerminalAgents();
 
+    // Deferred transcript identity does not require a live surface binding.
+    // Retry after the one-shot startup purge has retained marked rows, but
+    // before normal terminal cleanup can act on a closed pane.
+    await this.retryDeferredTranscriptCaptures();
     await this.registry.purgeTerminal(surfacelessConfirmation);
     await this.sweepMonitorRegistryBestEffort();
     await this.reconcileRolePlacements("idle");

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2427,6 +2427,13 @@ export class AgentEngine {
     return this.maybeCaptureBootSessionId(agent, {});
   }
 
+  private async retryDeferredTranscriptCaptures(): Promise<void> {
+    for (const agent of this.registry.list()) {
+      if (agent.transcript_session_capture_deferred !== true) continue;
+      await this.maybeCaptureBootSessionId(agent, {});
+    }
+  }
+
   private async maybeMarkBootReady(
     agent: AgentRecord,
     ctx: SweepAgentContext,
@@ -4156,6 +4163,10 @@ export class AgentEngine {
       now: Date.now(),
     };
     await this.registry.reconcile(surfacelessConfirmation);
+    // Deferred transcript identity does not require a live surface binding.
+    // Retry it before absence cleanup so a closed pane cannot strand or evict
+    // the durable capture intent before the resolver gets a chance to run.
+    await this.retryDeferredTranscriptCaptures();
     await this.registry.evictSurfaceless(surfacelessConfirmation);
     await this.recoverCrashedAgents();
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2074,7 +2074,12 @@ export class AgentEngine {
       }
     }
     if (fallbackResolver) return fallbackResolver(agent);
-    if (!this.canUseTranscriptSessionResolver(agent)) return null;
+    if (
+      !this.canUseTranscriptSessionResolver(agent) &&
+      agent.transcript_session_capture_deferred !== true
+    ) {
+      return null;
+    }
     return this.findTranscriptSessionIdentity(agent);
   }
 
@@ -2199,6 +2204,7 @@ export class AgentEngine {
     let updated = this.stateMgr.updateRecord(agent.agent_id, {
       cli_session_id: identity.session_id,
       cli_session_path: identity.path,
+      transcript_session_capture_deferred: false,
     });
     this.registry.set(agent.agent_id, updated);
 
@@ -2235,11 +2241,13 @@ export class AgentEngine {
         identity.path ?? existingFinal.cli_session_path ?? null;
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
-        existingFinal.cli_session_path === sessionPath
+        existingFinal.cli_session_path === sessionPath &&
+        existingFinal.transcript_session_capture_deferred !== true
           ? existingFinal
           : this.stateMgr.updateRecord(finalAgentId, {
               cli_session_id: identity.session_id,
               cli_session_path: sessionPath,
+              transcript_session_capture_deferred: false,
             });
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);
@@ -2333,48 +2341,80 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
+      if (agent.transcript_session_capture_deferred === true) {
+        try {
+          const updated = this.stateMgr.setTranscriptSessionCaptureDeferred(
+            agent.agent_id,
+            false,
+          );
+          this.registry.set(agent.agent_id, updated);
+          return updated;
+        } catch {
+          return agent;
+        }
+      }
       return agent;
     }
 
+    let captureAgent = agent;
+    const transcriptEligible = this.canUseTranscriptSessionResolver(agent);
+    if (
+      opts.resolveTranscript === false &&
+      transcriptEligible &&
+      agent.transcript_session_capture_deferred !== true
+    ) {
+      try {
+        captureAgent = this.stateMgr.setTranscriptSessionCaptureDeferred(
+          agent.agent_id,
+          true,
+        );
+        this.registry.set(agent.agent_id, captureAgent);
+      } catch {
+        // Startup remains available even if the best-effort retry marker fails.
+      }
+    }
+
     const canUseSelfRegistration =
-      this.canUseSelfRegistrationSessionResolver(agent);
-    const canUseTranscript =
-      opts.resolveTranscript !== false &&
-      this.canUseTranscriptSessionResolver(agent);
-    if (canUseSelfRegistration || canUseTranscript) {
+      this.canUseSelfRegistrationSessionResolver(captureAgent);
+    const shouldResolveIdentity =
+      canUseSelfRegistration ||
+      (opts.resolveTranscript !== false &&
+        (transcriptEligible ||
+          captureAgent.transcript_session_capture_deferred === true));
+    if (shouldResolveIdentity) {
       try {
         const resolvedSession =
           opts.resolveTranscript === false
-            ? this.selfRegistrationSessionResolver?.(agent)
-            : this.sessionIdentityResolver(agent);
+            ? this.selfRegistrationSessionResolver?.(captureAgent)
+            : this.sessionIdentityResolver(captureAgent);
         if (resolvedSession) {
           return this.finalizeCapturedSession(
-            agent,
+            captureAgent,
             this.normalizeCapturedSessionIdentity(resolvedSession),
           );
         }
       } catch {
-        return agent;
+        return captureAgent;
       }
     }
 
-    if (!this.isBootCaptureWindowOpen(agent)) {
-      return agent;
+    if (!this.isBootCaptureWindowOpen(captureAgent)) {
+      return captureAgent;
     }
 
     try {
-      const screen = await this.readSweepScreen(agent, ctx);
+      const screen = await this.readSweepScreen(captureAgent, ctx);
       const sessionId = extractSessionId(screen.text);
       if (!sessionId) {
-        return agent;
+        return captureAgent;
       }
 
-      return this.finalizeCapturedSession(agent, {
+      return this.finalizeCapturedSession(captureAgent, {
         session_id: sessionId,
         path: null,
       });
     } catch {
-      return agent;
+      return captureAgent;
     }
   }
 
@@ -4029,8 +4069,14 @@ export class AgentEngine {
   private async purgeStartupTerminalAgents(): Promise<void> {
     if (!this.startupPurgePending) return;
     this.startupPurgePending = false;
+    const retainedAgentIds = new Set(this.startupPurgeRetainedAgentIds);
+    for (const agent of this.registry.list()) {
+      if (agent.transcript_session_capture_deferred === true) {
+        retainedAgentIds.add(agent.agent_id);
+      }
+    }
     const purgedIds = this.registry.purgeAllTerminal({
-      retainAgentIds: this.startupPurgeRetainedAgentIds,
+      retainAgentIds: retainedAgentIds,
     });
     this.startupPurgeRetainedAgentIds.clear();
     try {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -381,6 +381,7 @@ const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
 const STOP_POST_CONDITION_POLL_MS = 50;
 const BOOT_SESSION_CAPTURE_LINES = 80;
+const MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS = 3;
 const BOOT_PROMPT_PENDING_STALE_MS = 5 * 60_000;
 const TASK_DONE_CONFIRMATION_MS = 5_000;
 const DONE_QUIESCENCE_MS = 1_500;
@@ -1909,6 +1910,10 @@ export class AgentEngine {
 
   private canUseTranscriptSessionResolver(agent: AgentRecord): boolean {
     if (!TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state)) return false;
+    return this.hasTranscriptSessionResolverContext(agent);
+  }
+
+  private hasTranscriptSessionResolverContext(agent: AgentRecord): boolean {
     if (!JSONL_HARNESSES.has(agent.cli)) return false;
     const hasManagedLaunchContext = Boolean(
       agent.launcher_name ||
@@ -2205,6 +2210,7 @@ export class AgentEngine {
       cli_session_id: identity.session_id,
       cli_session_path: identity.path,
       transcript_session_capture_deferred: false,
+      transcript_session_capture_attempts: 0,
     });
     this.registry.set(agent.agent_id, updated);
 
@@ -2242,12 +2248,14 @@ export class AgentEngine {
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
         existingFinal.cli_session_path === sessionPath &&
-        existingFinal.transcript_session_capture_deferred !== true
+        existingFinal.transcript_session_capture_deferred !== true &&
+        (existingFinal.transcript_session_capture_attempts ?? 0) === 0
           ? existingFinal
           : this.stateMgr.updateRecord(finalAgentId, {
               cli_session_id: identity.session_id,
               cli_session_path: sessionPath,
               transcript_session_capture_deferred: false,
+              transcript_session_capture_attempts: 0,
             });
       const index = this.stateMgr.getSurfaceSessionIndex();
       index.removeAgent(updated.agent_id);
@@ -2341,11 +2349,15 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
-      if (agent.transcript_session_capture_deferred === true) {
+      if (
+        agent.transcript_session_capture_deferred === true ||
+        (agent.transcript_session_capture_attempts ?? 0) > 0
+      ) {
         try {
           const updated = this.stateMgr.setTranscriptSessionCaptureDeferred(
             agent.agent_id,
             false,
+            0,
           );
           this.registry.set(agent.agent_id, updated);
           return updated;
@@ -2357,44 +2369,77 @@ export class AgentEngine {
     }
 
     let captureAgent = agent;
+    const hasTranscriptContext =
+      this.hasTranscriptSessionResolverContext(agent);
     const transcriptEligible = this.canUseTranscriptSessionResolver(agent);
+    if (
+      agent.transcript_session_capture_deferred === true &&
+      !hasTranscriptContext
+    ) {
+      try {
+        captureAgent = this.stateMgr.setTranscriptSessionCaptureDeferred(
+          agent.agent_id,
+          false,
+          0,
+        );
+        this.registry.set(agent.agent_id, captureAgent);
+      } catch {
+        return agent;
+      }
+    }
     if (
       opts.resolveTranscript === false &&
       transcriptEligible &&
-      agent.transcript_session_capture_deferred !== true
+      captureAgent.transcript_session_capture_deferred !== true
     ) {
       try {
         captureAgent = this.stateMgr.setTranscriptSessionCaptureDeferred(
           agent.agent_id,
           true,
+          0,
         );
         this.registry.set(agent.agent_id, captureAgent);
       } catch {
         // Startup remains available even if the best-effort retry marker fails.
       }
     }
-
     const canUseSelfRegistration =
       this.canUseSelfRegistrationSessionResolver(captureAgent);
+    const resolvingFirstConnect = opts.resolveTranscript === false;
     const shouldResolveIdentity =
       canUseSelfRegistration ||
-      (opts.resolveTranscript !== false &&
+      (!resolvingFirstConnect &&
         (transcriptEligible ||
           captureAgent.transcript_session_capture_deferred === true));
     if (shouldResolveIdentity) {
+      let resolvedSession: CapturedSessionIdentity | string | null;
       try {
-        const resolvedSession =
-          opts.resolveTranscript === false
-            ? this.selfRegistrationSessionResolver?.(captureAgent)
-            : this.sessionIdentityResolver(captureAgent);
-        if (resolvedSession) {
+        resolvedSession = resolvingFirstConnect
+          ? (this.selfRegistrationSessionResolver?.(captureAgent) ?? null)
+          : this.sessionIdentityResolver(captureAgent);
+      } catch {
+        return !resolvingFirstConnect &&
+          captureAgent.transcript_session_capture_deferred === true
+          ? this.recordDeferredTranscriptCaptureFailure(captureAgent)
+          : captureAgent;
+      }
+      if (resolvedSession) {
+        try {
           return this.finalizeCapturedSession(
             captureAgent,
-            this.normalizeCapturedSessionIdentity(resolvedSession),
+            resolvedSession,
           );
+        } catch {
+          return captureAgent;
         }
-      } catch {
-        return captureAgent;
+      }
+      if (
+        !resolvingFirstConnect &&
+        captureAgent.transcript_session_capture_deferred === true
+      ) {
+        captureAgent = this.recordDeferredTranscriptCaptureFailure(
+          captureAgent,
+        );
       }
     }
 
@@ -2415,6 +2460,34 @@ export class AgentEngine {
       });
     } catch {
       return captureAgent;
+    }
+  }
+
+  private recordDeferredTranscriptCaptureFailure(
+    agent: AgentRecord,
+  ): AgentRecord {
+    const previousAttempts = Number.isFinite(
+      agent.transcript_session_capture_attempts,
+    )
+      ? Math.max(
+          0,
+          Math.trunc(agent.transcript_session_capture_attempts ?? 0),
+        )
+      : 0;
+    const attempts = Math.min(
+      MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS,
+      previousAttempts + 1,
+    );
+    try {
+      const updated = this.stateMgr.setTranscriptSessionCaptureDeferred(
+        agent.agent_id,
+        attempts < MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS,
+        attempts,
+      );
+      this.registry.set(agent.agent_id, updated);
+      return updated;
+    } catch {
+      return agent;
     }
   }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -1636,6 +1636,10 @@ export class AgentRegistry {
     const evicted: string[] = [];
 
     for (const [id, agent] of [...this.agents.entries()]) {
+      if (agent.transcript_session_capture_deferred === true) {
+        this.surfacelessObservations.delete(agent.agent_id);
+        continue;
+      }
       if (this.matchingLiveSurface(agent, surfaces)) {
         this.surfacelessObservations.delete(agent.agent_id);
         continue;
@@ -2270,6 +2274,10 @@ export class AgentRegistry {
     let purged = 0;
 
     for (const [id, agent] of this.agents) {
+      if (agent.transcript_session_capture_deferred === true) {
+        this.surfacelessObservations.delete(agent.agent_id);
+        continue;
+      }
       if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -60,6 +60,8 @@ export interface AgentRecord {
   auto_archive_on_done?: boolean;
   task_done_candidate_at?: string | null;
   task_done_detected_at?: string | null;
+  /** First-connect skipped transcript identity resolution; retry on sweeps. */
+  transcript_session_capture_deferred?: boolean;
   deletion_intent: boolean;
   // Quality fields (Task 19)
   quality: AgentQuality;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -60,8 +60,10 @@ export interface AgentRecord {
   auto_archive_on_done?: boolean;
   task_done_candidate_at?: string | null;
   task_done_detected_at?: string | null;
-  /** First-connect skipped transcript identity resolution; retry on sweeps. */
+  /** First-connect skipped transcript identity resolution; retry on bounded sweeps. */
   transcript_session_capture_deferred?: boolean;
+  /** Failed deferred transcript resolver calls, persisted across restarts. */
+  transcript_session_capture_attempts?: number;
   deletion_intent: boolean;
   // Quality fields (Task 19)
   quality: AgentQuality;

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -399,25 +399,33 @@ export class StateManager {
   }
 
   /**
-   * Persist the startup transcript-capture retry marker without refreshing
-   * lifecycle age. The marker is bookkeeping, not agent progress.
+   * Persist startup transcript-capture retry bookkeeping without refreshing
+   * lifecycle age. Marker/attempt changes are not agent progress.
    */
   setTranscriptSessionCaptureDeferred(
     agentId: string,
     deferred: boolean,
+    attempts = 0,
   ): AgentRecord {
     const dirName = this.resolveStateDir(agentId);
     const current = dirName ? this.readStateFromDir(dirName) : null;
     if (!current) {
       throw new Error(`Agent not found: ${agentId}`);
     }
-    if (current.transcript_session_capture_deferred === deferred) {
+    const normalizedAttempts = Number.isFinite(attempts)
+      ? Math.max(0, Math.trunc(attempts))
+      : 0;
+    if (
+      current.transcript_session_capture_deferred === deferred &&
+      (current.transcript_session_capture_attempts ?? 0) === normalizedAttempts
+    ) {
       return current;
     }
 
     const updated: AgentRecord = {
       ...current,
       transcript_session_capture_deferred: deferred,
+      transcript_session_capture_attempts: normalizedAttempts,
     };
     const agentDir = join(this.baseDir, dirName!);
     const stateFile = this.stateFilePath(dirName!);

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -399,6 +399,36 @@ export class StateManager {
   }
 
   /**
+   * Persist the startup transcript-capture retry marker without refreshing
+   * lifecycle age. The marker is bookkeeping, not agent progress.
+   */
+  setTranscriptSessionCaptureDeferred(
+    agentId: string,
+    deferred: boolean,
+  ): AgentRecord {
+    const dirName = this.resolveStateDir(agentId);
+    const current = dirName ? this.readStateFromDir(dirName) : null;
+    if (!current) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    if (current.transcript_session_capture_deferred === deferred) {
+      return current;
+    }
+
+    const updated: AgentRecord = {
+      ...current,
+      transcript_session_capture_deferred: deferred,
+    };
+    const agentDir = join(this.baseDir, dirName!);
+    const stateFile = this.stateFilePath(dirName!);
+    const tmpFile = join(agentDir, "state.json.tmp");
+    writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
+    renameSync(tmpFile, stateFile);
+    this.surfaceSessionIndex.persistRecord(updated);
+    return updated;
+  }
+
+  /**
    * Explicitly reset an agent's lifecycle state after an operation that has
    * already established new ground truth outside the normal state machine.
    * This bypass is intentionally separate from transition().

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -2718,6 +2718,33 @@ describe("AgentRegistry", () => {
   });
 
   describe("evictSurfaceless confirmation", () => {
+    it("retains deferred transcript captures through normal absence cleanup", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "deferred-terminal-worker",
+          state: "done",
+          surface_id: "surface:missing",
+          role: "worker",
+          transcript_session_capture_deferred: true,
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:witness"),
+      ]);
+      await registry.reconstitute();
+
+      await expect(
+        registry.evictSurfaceless({ confirmationMs: 0 }),
+      ).resolves.toEqual([]);
+      await expect(
+        registry.purgeTerminal({ confirmationMs: 0 }),
+      ).resolves.toBe(0);
+      expect(registry.get("deferred-terminal-worker")).toMatchObject({
+        cli_session_id: null,
+        transcript_session_capture_deferred: true,
+      });
+    });
+
     it("does not evict a UUID-backed record when a legacy topology confirms its ref live", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -758,6 +758,142 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("persists deferred transcript capture across restart and identity-write failure", async () => {
+    const capturedSessionId = "12345678-1234-4234-8234-123456789abc";
+    const deferredTranscriptResolver = vi.fn(() => ({
+      session_id: capturedSessionId,
+      path: "/tmp/codex-session.jsonl",
+    }));
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "cmuxlayerCodex-pending-startup",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerCodex",
+        task_done_candidate_at: "2026-03-14T03:40:00Z",
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:42"),
+        title: "cmuxlayerCodex [surface:42]",
+        workspace_ref: "workspace:cmuxlayer",
+      },
+    ];
+    engine.dispose();
+    const terminalRegistry = new AgentRegistry(
+      stateMgr,
+      async () => liveSurfaces,
+    );
+    engine = new AgentEngine(stateMgr, terminalRegistry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: deferredTranscriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    mockClient.readScreen
+      .mockResolvedValueOnce({
+        surface: "surface:42",
+        text:
+          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
+        lines: 30,
+        scrollback_used: false,
+      })
+      .mockResolvedValue({
+        surface: "surface:42",
+        text:
+          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\nImplemented the fix.\nTASK_DONE",
+        lines: 30,
+        scrollback_used: false,
+      });
+    const terminalDiscovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(terminalDiscovery);
+
+    expect(deferredTranscriptResolver).not.toHaveBeenCalled();
+    expect(engine.getAgentState("cmuxlayerCodex-pending-startup")).toMatchObject(
+      {
+        state: "done",
+        cli_session_id: null,
+        transcript_session_capture_deferred: true,
+      },
+    );
+
+    engine.dispose();
+    const restartedRegistry = new AgentRegistry(
+      stateMgr,
+      async () => liveSurfaces,
+    );
+    engine = new AgentEngine(stateMgr, restartedRegistry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: deferredTranscriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    const restartedDiscovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(restartedDiscovery);
+
+    expect(deferredTranscriptResolver).not.toHaveBeenCalled();
+    const updateRecord = stateMgr.updateRecord.bind(stateMgr);
+    let rejectCapturedSessionWrite = true;
+    const updateRecordSpy = vi
+      .spyOn(stateMgr, "updateRecord")
+      .mockImplementation((agentId, patch) => {
+        if (
+          rejectCapturedSessionWrite &&
+          patch.cli_session_id === capturedSessionId
+        ) {
+          rejectCapturedSessionWrite = false;
+          throw new Error("transient state write failure");
+        }
+        return updateRecord(agentId, patch);
+      });
+
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_id: "cmuxlayerCodex-pending-startup",
+        cli: "codex",
+        state: "done",
+      }),
+    );
+    expect(engine.getAgentState("cmuxlayerCodex-pending-startup")).toMatchObject(
+      {
+        state: "done",
+        cli_session_id: null,
+        transcript_session_capture_deferred: true,
+      },
+    );
+
+    updateRecordSpy.mockRestore();
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledTimes(2);
+    expect(
+      engine.getAgentState(
+        generateAgentId("codex", "cmuxlayer", capturedSessionId),
+      ),
+    ).toMatchObject({
+      state: "done",
+      cli_session_id: capturedSessionId,
+      cli_session_path: "/tmp/codex-session.jsonl",
+      transcript_session_capture_deferred: false,
+    });
+  });
+
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {
     const discovery = new AgentDiscovery({
       listSurfaces: async () => [],

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -902,6 +902,66 @@ describe("Sidebar Sync", () => {
     });
   });
 
+  it("retains a successful deferred capture through the pending startup purge", async () => {
+    const capturedSessionId = "87654321-4321-4321-8321-cba987654321";
+    const deferredTranscriptResolver = vi.fn(() => ({
+      session_id: capturedSessionId,
+      path: "/tmp/codex-startup-purge-session.jsonl",
+    }));
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "cmuxlayerCodex-deferred-startup-purge",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerCodex",
+        state: "done",
+        transcript_session_capture_deferred: true,
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:42"),
+        title: "cmuxlayerCodex [surface:42]",
+        workspace_ref: "workspace:cmuxlayer",
+      },
+    ];
+    engine.dispose();
+    const restartedRegistry = new AgentRegistry(
+      stateMgr,
+      async () => liveSurfaces,
+    );
+    engine = new AgentEngine(stateMgr, restartedRegistry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: deferredTranscriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(discovery);
+
+    expect(deferredTranscriptResolver).not.toHaveBeenCalled();
+
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledTimes(1);
+    expect(
+      engine.getAgentState(
+        generateAgentId("codex", "cmuxlayer", capturedSessionId),
+      ),
+    ).toMatchObject({
+      state: "done",
+      cli_session_id: capturedSessionId,
+      cli_session_path: "/tmp/codex-startup-purge-session.jsonl",
+      transcript_session_capture_deferred: false,
+    });
+  });
+
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {
     const discovery = new AgentDiscovery({
       listSurfaces: async () => [],

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -962,6 +962,131 @@ describe("Sidebar Sync", () => {
     });
   });
 
+  it("bounds unresolved deferred capture across restart and reaps the terminal row", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-17T20:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    const deferredTranscriptResolver = vi.fn(() => null);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "cmuxlayerCodex-stuck-deferred-capture",
+        repo: "cmuxlayer",
+        launcher_name: "cmuxlayerCodex",
+        role: "worker",
+        state: "done",
+        surface_id: "surface:missing",
+        transcript_session_capture_deferred: true,
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:witness"),
+        title: "unrelated live surface",
+        workspace_ref: "workspace:other",
+      },
+    ];
+    const makeDeferredEngine = () => {
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      return new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: deferredTranscriptResolver,
+        inboxOpts,
+        fleetSidebarPublisher: {
+          publish: () => {},
+          dispose: () => {},
+        },
+      });
+    };
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    engine.dispose();
+    engine = makeDeferredEngine();
+    await engine.initialize(discovery);
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledTimes(1);
+    expect(
+      engine.getAgentState("cmuxlayerCodex-stuck-deferred-capture"),
+    ).toMatchObject({
+      cli_session_id: null,
+      transcript_session_capture_deferred: true,
+    });
+
+    engine.dispose();
+    engine = makeDeferredEngine();
+    await engine.initialize(discovery);
+    expect(deferredTranscriptResolver).toHaveBeenCalledTimes(1);
+
+    for (let sweep = 1; sweep <= 3; sweep += 1) {
+      vi.setSystemTime(startedAt.getTime() + sweep * 6_000);
+      await engine.runSweep();
+    }
+
+    expect(deferredTranscriptResolver).toHaveBeenCalledTimes(3);
+    expect(
+      engine.getAgentState("cmuxlayerCodex-stuck-deferred-capture"),
+    ).toBeNull();
+  });
+
+  it("clears an ineligible deferred marker without invoking the resolver", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-17T20:30:00.000Z");
+    vi.setSystemTime(startedAt);
+    const deferredTranscriptResolver = vi.fn(() => null);
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "gemini-stale-deferred-capture",
+        cli: "gemini",
+        model: "gemini",
+        launcher_name: "geminiWorker",
+        role: "worker",
+        state: "done",
+        surface_id: "surface:missing",
+        transcript_session_capture_deferred: true,
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:witness"),
+        title: "unrelated live surface",
+        workspace_ref: "workspace:other",
+      },
+    ];
+    engine.dispose();
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: deferredTranscriptResolver,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(discovery);
+    await engine.runSweep();
+
+    expect(deferredTranscriptResolver).not.toHaveBeenCalled();
+    expect(
+      engine.getAgentState("gemini-stale-deferred-capture"),
+    ).toMatchObject({ transcript_session_capture_deferred: false });
+
+    vi.setSystemTime(startedAt.getTime() + 6_000);
+    await engine.runSweep();
+
+    expect(
+      engine.getAgentState("gemini-stale-deferred-capture"),
+    ).toBeNull();
+  });
+
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {
     const discovery = new AgentDiscovery({
       listSurfaces: async () => [],

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -861,6 +861,14 @@ describe("Sidebar Sync", () => {
         return updateRecord(agentId, patch);
       });
 
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:witness"),
+        title: "unrelated live surface",
+        workspace_ref: "workspace:other",
+      },
+    ];
+
     await engine.runSweep();
 
     expect(deferredTranscriptResolver).toHaveBeenCalledWith(

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -164,6 +164,33 @@ describe("StateManager", () => {
     });
   });
 
+  describe("setTranscriptSessionCaptureDeferred", () => {
+    it("persists the failed-attempt count without refreshing lifecycle age", () => {
+      const mgr = new StateManager(TEST_DIR);
+      const record = makeRecord({
+        version: 7,
+        updated_at: "2026-03-14T03:40:00Z",
+      });
+      mgr.writeState(record);
+      const eventCount = mgr.getEventLog().readAll().length;
+
+      const updated = mgr.setTranscriptSessionCaptureDeferred(
+        record.agent_id,
+        true,
+        2,
+      );
+
+      expect(updated).toMatchObject({
+        transcript_session_capture_deferred: true,
+        transcript_session_capture_attempts: 2,
+        version: 7,
+        updated_at: "2026-03-14T03:40:00Z",
+      });
+      expect(mgr.getEventLog().readAll()).toHaveLength(eventCount);
+      expect(mgr.readState(record.agent_id)).toEqual(updated);
+    });
+  });
+
   describe("listStates", () => {
     it("returns all agent records", () => {
       const mgr = new StateManager(TEST_DIR);


### PR DESCRIPTION
## Summary

- persist first-connect transcript-capture intent on `AgentRecord` without refreshing lifecycle age
- retain marked terminal rows across startup purge, daemon restart, and normal absence cleanup
- cap failed deferred resolver calls at three across restarts; clear structurally ineligible markers without scanning
- clear marker/attempt bookkeeping atomically with captured identity so transient identity-write failures remain retryable
- add regressions proving a never-resolving row stops scanning and is reaped, while early-success P1 paths remain intact

## Design

This follows shipped v0.4.15 / #334. The deferred marker now carries an age-neutral failed-attempt count. Resolver `null` results and throws consume the three-call cap; successful resolution followed by an identity-write failure does not. Terminal lifecycle state remains eligible through the bounded marker override, while unsupported JSONL/managed-launch context clears immediately. After marker clear, normal confirmed-absence cleanup reaps the row.

## Test plan

- RED: stuck-marker regression expected 3 resolver calls but current head made 4
- RED: structurally ineligible marker expected 0 resolver calls but current head made 1
- RED: age-neutral state regression showed the attempt count was not persisted
- focused GREEN: 3/3 new regressions
- affected lifecycle suites: 467/467 across agent engine, sidebar sync, registry, state manager, and resync
- exact final-head gate: typecheck passed; 104/104 files and 2,216/2,216 tests passed
- final pre-push hook: contract runners passed; 104/104 files and 2,216/2,216 tests passed

## Flake evidence

The first full-gate run hit the brief-named spawn-manifest timeout: 2,215/2,216 passed. That single test passed focused (1/1), then the unchanged exact full gate passed 2,216/2,216. No timeout or unrelated test code changed.

## Review disposition

- Independent reviewer TOP RISK: fixed by persisted three-call cap, structural-ineligibility clear, and eventual-reap regression.
- Local CodeRabbit: two stale documentation summaries fixed.
- Local CodeRabbit `purgeAllTerminal()` suggestion: waived as redundant. Its sole production caller already passes every marked ID through `retainAgentIds`, and the startup-purge regression exercises that path. Adding a second unconditional retention policy would not improve the bounded-marker invariant.
- Cursor/Bugbot auto-run on this head was skipped at the repository usage limit; no Bugbot findings were produced.

Do not merge from this worker lane; cmuxLead-v2 and Etan own merge/release gating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle, state persistence, and sweep ordering; mistakes could retain stale rows or skip capture, but behavior is bounded (three attempts) and heavily regression-tested.
> 
> **Overview**
> **Persists first-connect transcript capture intent** so sessionless agents that terminalize during startup are not permanently lost after purge or daemon restart.
> 
> `AgentRecord` gains `transcript_session_capture_deferred` and `transcript_session_capture_attempts`. First-connect sets the marker without calling the transcript resolver; `StateManager.setTranscriptSessionCaptureDeferred` updates those fields atomically **without** bumping `version` or `updated_at`. Successful capture clears marker and attempts in the same `updateRecord` patch as `cli_session_id` / `cli_session_path`.
> 
> **Sweep and cleanup behavior changes:** marked rows are retained through startup terminal purge, `evictSurfaceless`, and `purgeTerminal`; `retryDeferredTranscriptCaptures` runs after startup purge and before normal terminal cleanup. Deferred rows can still hit the resolver without a live surface. Failed resolver `null`/throws increment attempts up to three (persisted across restarts); structurally ineligible markers clear without a resolver call; identity-write failures do not consume the attempt budget.
> 
> Design and implementation plan docs plus sidebar-sync, registry, and state-manager regressions cover restart, transient write failure, startup-purge retention, cap-and-reap, and ineligible-marker clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087e8229c9b0fc6108f778e0064949accddba390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist deferred session transcript capture with bounded retries across restarts
> - Agents that are eligible for transcript capture but lack a session ID at first connect are now marked with `transcript_session_capture_deferred` instead of being skipped. Subsequent sweeps retry resolution using this marker.
> - Adds `retryDeferredTranscriptCaptures` to the sweep loop, which runs after startup purge and before terminal cleanup to process marked agents.
> - Failed deferred resolutions increment a persisted `transcript_session_capture_attempts` counter (capped at 3 via `MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS`); at the cap, the deferred marker is cleared.
> - Marked agents are exempt from surfaceless eviction, terminal purge, and startup purge until capture succeeds or the attempt cap is reached.
> - `StateManager.setTranscriptSessionCaptureDeferred` persists the marker and attempt count atomically without bumping `version`/`updated_at` or emitting state events.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 087e822. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deferred transcript capture now persists across restarts and is retried during background sweeps.
  * Captured transcript identity is retained and finalized when it becomes available.
* **Bug Fixes**
  * Agents awaiting transcript capture are no longer removed during terminal cleanup or absence-based eviction.
  * Temporary identity-write failures are retried automatically.
* **Documentation**
  * Added implementation plans documenting deferred transcript capture behavior, safeguards, alternatives, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
