### PR TITLE
test: harden flaky timing coverage

### DIFF
--- a/docs/plans/2026-07-17-flaky-timing-hardening-design.md
+++ b/docs/plans/2026-07-17-flaky-timing-hardening-design.md
@@ -1,0 +1,81 @@
+# Flaky Timing Hardening Design
+
+## Root cause evidence
+
+The default-parallel full suite ran 20 fresh processes from v0.4.15. Eighteen
+passed. Run 10 failed `fleet-sidebar.test.ts` while its collapse-state change
+was still unpublished, and run 20 failed `proxy-version-bump.test.ts` because
+the asserted replacement connection had received only `initialize`; that run
+also emitted an `EPIPE` from the fake daemon writing to a socket closed by a
+later reconnect.
+
+The four originally reported tests and the additional proxy failure share one
+top-level mechanism: the harness lets scheduler progress determine when its
+assertion becomes true. The specific races differ:
+
+- `server-agent-tools.test.ts` drives the complete launch/submit path, including
+  real timer delays and registry filesystem work, even though the assertion is
+  only about the injected seat-manifest payload. Across the 20 full-suite runs,
+  this test took 1.167–4.090 seconds against Vitest's five-second default.
+- `agent-engine.test.ts` already uses fake time, but advances eight seconds in
+  one operation. That jump crosses async one-second polling, the five-second
+  done-evidence confirmation window, and the seven-second timeout. Under load,
+  the timeout callback can observe the clock before the earlier async poll has
+  persisted its candidate.
+- Both `fleet-sidebar.test.ts` cases depend on real `fs.watchFile` polling, a
+  real atomic state-file rename, the publisher's 500ms write throttle, and a
+  wall-clock polling deadline. The full-suite failure retained the expanded
+  source after the 1.2-second deadline, proving the watcher/publication signal
+  had not completed rather than a rendering assertion being wrong.
+- `proxy-version-bump.test.ts` makes `detectStaleBuild` return stale forever and
+  polls every 10ms. The mocked daemon spawn never changes the installed/running
+  versions, so another version-bump reconnect can destroy connection 2 while
+  its handshake replay is in flight. Concurrent targeted runs reproduced this
+  ordering failure twice in ten processes. The successful replay can occur on a
+  later connection, making the assertion against `messages[1]` racy.
+
+## Per-test classification
+
+| Test | Primary class | Deterministic correction |
+| --- | --- | --- |
+| Spawn manifest | Real-timer/FS work outside the assertion | Drive the existing launch path with controlled Vitest time and dispose every created lifecycle context. |
+| Non-Codex done confirmation | Async await-ordering race | Advance to the first poll, assert the persisted candidate, then advance the confirmation window. |
+| Fleet collapse republish | Real filesystem watcher and timer race | Inject the collapse-state watcher callback and trigger the same publication path directly. |
+| Fleet pending-decrease/collapse | Real filesystem watcher and timer race | Use the same watcher seam while retaining the pending-decrease invalidation assertions. |
+| Proxy reconnect replay | Repeated-trigger await-ordering race | Model one installed-version transition so only one reconnect is initiated. |
+
+## Chosen design
+
+Keep production timeouts, Vitest parallelism, Unix-socket integration, and every
+behavioral assertion. Add one production dependency-injection seam to
+`FleetSidebarPublisher`: a collapse-state watcher factory whose default adapter
+continues to use `watchFile`/`unwatchFile`. Tests inject a manual watcher, verify
+registration and disposal, update the real collapse store, then emit the
+dependency's change signal without racing libuv polling. Age the generated
+sidebar file before the signal when the 500ms write throttle is irrelevant to
+the behavior under test.
+
+The other corrections stay in test code: fake-time driving for both the
+manifest handler and its server lifecycle initialization before timer restore,
+staged fake-time advancement for `waitFor`, and a one-shot stale-build fixture
+for the proxy. This preserves launch behavior, evidence confirmation, collapse
+republishing, topology protection, handshake replay, and real Unix socket
+framing while removing scheduler-dependent gates.
+
+## Alternatives rejected
+
+- Raising per-test or global timeouts leaves the same races and only changes how
+  often they appear.
+- Serializing Vitest or adding retries hides cross-file contention and loses the
+  default-parallel coverage that exposed these failures.
+- Replacing the proxy socket test or the fleet publication assertions with
+  mocked return values would make the tests faster but would remove protocol or
+  behavior coverage.
+
+## Verification
+
+- Run each corrected test and each affected file in at least 20 fresh loops.
+- Run `bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test`
+  in at least three fresh processes.
+- Keep the full assertion bodies and report any newly surfaced flaky test rather
+  than narrowing the catalog silently.

--- a/docs/plans/2026-07-17-flaky-timing-hardening.md
+++ b/docs/plans/2026-07-17-flaky-timing-hardening.md
@@ -1,0 +1,111 @@
+# Flaky Timing Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make every cataloged timing-sensitive test deterministic without timeout increases, retries, serialization, or behavioral coverage loss.
+
+**Architecture:** Keep production timing policy intact. Repair harness ordering with controlled fake time and one-shot fixtures, and inject only the fleet collapse watcher boundary so tests can signal the same cached-publication path without real `fs.watchFile` scheduling.
+
+**Tech Stack:** TypeScript, Vitest 3, Bun, Node timers/filesystem/Unix sockets.
+
+---
+
+### Task 1: Make the fleet watcher boundary hermetic
+
+**Files:**
+- Modify: `src/fleet-sidebar.ts`
+- Modify: `tests/fleet-sidebar.test.ts`
+
+**Step 1: Write the watcher-seam tests**
+
+Update the two flaky tests to inject a watcher factory, capture its change
+listener, and invoke that listener after writing collapse state. Assert the
+factory receives the exact state path and its cleanup runs on dispose.
+
+**Step 2: Verify RED**
+
+Run the two named tests. Expected: type/test failure because
+`collapseStateWatcher` is not yet a publisher option.
+
+**Step 3: Implement the minimal watcher seam**
+
+Add the injectable watcher factory to `FleetSidebarPublisherOptions`; keep a
+default adapter that registers `watchFile` with the existing 100ms production
+interval and returns an `unwatchFile` cleanup closure.
+
+**Step 4: Verify GREEN**
+
+Run both tests and the complete fleet-sidebar file. Expected: all pass with the
+same render/topology assertions and no wall-clock polling loop.
+
+### Task 2: Control the manifest and waitFor clocks
+
+**Files:**
+- Modify: `tests/server-agent-tools.test.ts`
+- Modify: `tests/agent-engine.test.ts`
+
+**Step 1: Drive manifest launch time explicitly**
+
+Start the spawn handler and server lifecycle initialization, advance fake
+timers in small async slices until both settle, then assert the exact manifest.
+Restore real time in `finally` and add file-scope lifecycle-context cleanup so
+no test-owned sweep survives.
+
+**Step 2: Stage done-evidence confirmation**
+
+Pin fake system time, advance one polling tick, assert that trailing output
+created `task_done_candidate_at`, then advance the five-second confirmation
+window and await the original `waitFor` promise.
+
+**Step 3: Verify focused GREEN**
+
+Run both named tests and their complete files. Expected: existing behavioral
+assertions pass without real launch waits or a coarse timeout-crossing jump.
+
+### Task 3: Bound the proxy fixture to one version transition
+
+**Files:**
+- Modify: `tests/proxy-version-bump.test.ts`
+
+**Step 1: Preserve RED evidence**
+
+Use the recorded concurrent run where the current fixture failed twice in ten
+fresh processes and connection 2 contained only `initialize`.
+
+**Step 2: Make stale detection one-shot**
+
+After the fixture reports the intended installed-version bump once, have later
+checks report matched versions. Keep the real Unix socket, replay response, and
+exact `initialize` → `notifications/initialized` → `tools/list` assertion.
+
+**Step 3: Verify GREEN**
+
+Run the named test and complete proxy-version-bump file repeatedly.
+
+### Task 4: Prove determinism and publish
+
+**Files:**
+- Modify: PR body only
+
+**Step 1: Loop every fixed test and file**
+
+Run each named test and each affected file at least 20 times in fresh processes,
+starting a new process for every iteration and recording zero failures per
+target.
+
+**Step 2: Run the full gate three times**
+
+Run the exact brief command in three fresh processes and record file/test
+counts and failures.
+
+**Step 3: Review and publish**
+
+Run typecheck/diff checks, bounded local CodeRabbit review, commit, push
+`fix/flaky-timing-tests`, and open a ready PR with the catalog, classifications,
+and loop evidence. Invoke PR reviewers, resolve real findings, and do not merge.
+
+**Step 4: Report SETTLED**
+
+Re-enumerate cmux surfaces, send the PR URL/head/full evidence to cmuxLead-v2
+surface:143, verify the message in scrollback, and store WHAT + WHY in
+BrainLayer.

--- a/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic-design.md
+++ b/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic-design.md
@@ -1,0 +1,67 @@
+# PR #337 Spawn-Manifest Hermeticity Design
+
+## Evidence and corrected proof condition
+
+The independently observed failure is a real 5,000 ms Vitest wall-clock
+timeout under concurrent load, not the fake-clock ordering race addressed by
+the first #337 commit. Running the four flaky files together produced a 6.499 s
+manifest-test timeout for the reviewer. A local ten-run repetition did not fail,
+but the same tests reached 4.530 s and 3.245 s, leaving no safe wall-clock
+margin. Isolated test/file loops are therefore supplementary evidence only;
+the acceptance topology must run all four files together.
+
+The current manifest tests construct a complete server lifecycle. Before the
+manifest assertion can finish, that path creates a filesystem-backed
+`StateManager`, reconstitutes and discovers the lifecycle registry, performs
+managed-metadata refreshes, persists a spawn record and event log, and tears
+the lifecycle down. Fake timers do not remove this CPU/filesystem work, and
+Vitest's five-second watchdog remains real.
+
+## Considered approaches
+
+1. **Inject lifecycle persistence, registry, and initialization (selected).**
+   Add optional `CreateServerOptions` seams for a `StateManager`, an
+   `AgentRegistry`, and the lifecycle initializer. Production defaults remain
+   the current filesystem manager, registry construction, and
+   `engine.initialize(discovery)`. The two manifest tests inject an in-memory
+   state manager, a registry backed by it, and a resolved initializer. This
+   keeps the real `spawn_agent` handler, `AgentEngine.spawnAgent`, client
+   protocol, and manifest publisher while removing external lifecycle I/O.
+2. **Inject an entire fake `AgentEngine`.** This would eliminate more code but
+   requires a broad, incomplete engine double for every lifecycle tool closure
+   and risks testing mock behavior rather than the real spawn path.
+3. **Extract and unit-test a pure record-to-manifest mapper.** This is fast but
+   weakens coverage: it no longer proves that `spawn_agent` publishes the
+   expected-state manifest, so it violates the brief.
+
+## Selected design
+
+`createServerContext` accepts an optional state manager and registry instead of
+unconditionally creating filesystem-backed lifecycle state. The context also
+retains an optional zero-argument lifecycle initializer. `createServer` calls
+that initializer when supplied; otherwise it executes the unchanged production
+`engine.initialize(discovery)` path.
+
+The test-only in-memory state manager preserves the real record semantics used
+by spawn: write, read, list, update, transition, reset, rename, and remove. The
+real `AgentRegistry` and `AgentEngine` operate over those records. Both
+manifest tests assert that their deliberately nonexistent state directory stays
+absent, proving no fallback filesystem state was created, and that the injected
+initializer ran exactly once. The exact full manifest assertion and launcher
+name assertion remain unchanged.
+
+The earlier fake-time driver is removed from the manifest test because the
+hermetic handler has no awaited lifecycle timer. Scheduled post-spawn liveness
+is still owned and canceled by context disposal.
+
+## Verification
+
+- Watch the hermeticity test fail before the seams exist because the forbidden
+  state directory is created by the real `StateManager`.
+- Run both manifest tests and the complete server-tools file.
+- Run all four flaky files together in at least 20 fresh Vitest processes with
+  zero failures.
+- Run the full suite in at least five fresh processes with typecheck and zero
+  failures.
+- Do not raise timeouts, add retries/serialization, modify the other three test
+  files, or weaken assertions.

--- a/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic.md
+++ b/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Prove the manifest tests still touch lifecycle storage
+## Task 1: Prove the manifest tests still touch lifecycle storage
 
 **Files:**
 - Modify: `tests/server-agent-tools.test.ts`
@@ -34,7 +34,7 @@ directory was never created.
 Run both named manifest tests. Expected: FAIL because the current server ignores
 the injected lifecycle state and creates the state directory.
 
-### Task 2: Add the minimal production dependency seams
+## Task 2: Add the minimal production dependency seams
 
 **Files:**
 - Modify: `src/server.ts`
@@ -63,7 +63,7 @@ Delete the fake-time helper if it has no remaining callers.
 Run both manifest tests, typecheck, and the complete server-tools file. Expected:
 all pass; the exact manifest and launcher-name assertions are unchanged.
 
-### Task 3: Prove the corrected load contract and publish
+## Task 3: Prove the corrected load contract and publish
 
 **Files:**
 - Modify: PR #337 body/comment only

--- a/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic.md
+++ b/docs/plans/2026-07-18-pr337-spawn-manifest-hermetic.md
@@ -1,0 +1,91 @@
+# PR #337 Spawn-Manifest Hermeticity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the two spawn-manifest tests independent of filesystem-backed registry and lifecycle initialization work so they remain below Vitest's real watchdog under concurrent load.
+
+**Architecture:** Add optional server-construction dependencies for state persistence, registry, and lifecycle initialization, with unchanged production defaults. Exercise the real spawn handler and manifest publisher over in-memory lifecycle state in the two tests.
+
+**Tech Stack:** TypeScript, Vitest 3, Bun/Node, cmuxlayer `StateManager`, `AgentRegistry`, and `AgentEngine`.
+
+---
+
+### Task 1: Prove the manifest tests still touch lifecycle storage
+
+**Files:**
+- Modify: `tests/server-agent-tools.test.ts`
+
+**Step 1: Add an in-memory lifecycle fixture contract**
+
+Create an in-memory `StateManager` double with real record semantics, a real
+`AgentRegistry` backed by it, a no-op lifecycle initializer, and a unique
+nonexistent state path. Pass those dependencies through the server options via
+a temporary structural cast so the test compiles before production accepts the
+new fields.
+
+**Step 2: Add hermeticity assertions**
+
+In both manifest tests, keep the existing manifest assertions and additionally
+assert that the lifecycle initializer was called once and the nonexistent state
+directory was never created.
+
+**Step 3: Verify RED**
+
+Run both named manifest tests. Expected: FAIL because the current server ignores
+the injected lifecycle state and creates the state directory.
+
+### Task 2: Add the minimal production dependency seams
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+**Step 1: Accept injected lifecycle dependencies**
+
+Add optional `stateManager`, `lifecycleRegistry`, and `lifecycleInitializer`
+fields to `CreateServerOptions` and the initializer field to
+`CmuxServerContext`. Use injected state/registry values in
+`createServerContext`; preserve all existing defaults.
+
+**Step 2: Route startup through the initializer**
+
+Resolve the initializer from options/context and call it instead of
+`engine.initialize(discovery)` only when supplied. Keep error capture,
+`lifecycleStarted`, and sweep startup unchanged.
+
+**Step 3: Remove obsolete fake-time driving**
+
+Await the real hermetic spawn handler directly in the first manifest test.
+Delete the fake-time helper if it has no remaining callers.
+
+**Step 4: Verify GREEN**
+
+Run both manifest tests, typecheck, and the complete server-tools file. Expected:
+all pass; the exact manifest and launcher-name assertions are unchanged.
+
+### Task 3: Prove the corrected load contract and publish
+
+**Files:**
+- Modify: PR #337 body/comment only
+
+**Step 1: Run the concurrent four-file proof**
+
+Start a fresh Vitest process for every iteration and run
+`fleet-sidebar`, `agent-engine`, `server-agent-tools`, and
+`proxy-version-bump` together at least 20 times. Record 20/20 and zero failures.
+
+**Step 2: Run the full gate five times**
+
+Run typecheck plus the full suite in five fresh processes. Record file/test
+counts and zero failures for every run.
+
+**Step 3: Review and update PR #337**
+
+Run diff checks and bounded local review, commit only the follow-up scope, push
+the same branch, invoke PR reviewers, and resolve real findings. Do not merge.
+
+**Step 4: Report corrected SETTLED**
+
+Paste the concurrent-load and five-suite evidence on PR #337, re-enumerate cmux
+surface:143, send the new head and evidence to cmuxLead-v2, verify delivery, and
+store WHAT + WHY.

--- a/src/fleet-sidebar.ts
+++ b/src/fleet-sidebar.ts
@@ -978,6 +978,18 @@ export interface FleetSidebarPublisherOptions {
   outputPath?: string;
   minWriteIntervalMs?: number;
   collapseStore?: FleetSidebarCollapseStore;
+  collapseStateWatcher?: (
+    statePath: string,
+    onChange: () => void,
+  ) => () => void;
+}
+
+function watchFleetSidebarCollapseState(
+  statePath: string,
+  onChange: () => void,
+): () => void {
+  watchFile(statePath, { persistent: false, interval: 100 }, onChange);
+  return () => unwatchFile(statePath, onChange);
 }
 
 export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
@@ -989,6 +1001,7 @@ export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
   private pendingBaselineSource: string | null = null;
   private lastPublishedPublication: FleetSidebarPublication | null = null;
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly stopCollapseStateWatcher: () => void;
   private disposed = false;
   private readonly collapseStateListener = () => {
     const publication =
@@ -1023,9 +1036,10 @@ export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
       500,
       opts.minWriteIntervalMs ?? 500,
     );
-    watchFile(
+    this.stopCollapseStateWatcher = (
+      opts.collapseStateWatcher ?? watchFleetSidebarCollapseState
+    )(
       this.collapseStore.getStatePath(),
-      { persistent: false, interval: 100 },
       this.collapseStateListener,
     );
   }
@@ -1082,10 +1096,7 @@ export class FleetSidebarPublisher implements FleetSidebarPublisherLike {
     this.disposed = true;
     this.clearPending();
     this.lastPublishedPublication = null;
-    unwatchFile(
-      this.collapseStore.getStatePath(),
-      this.collapseStateListener,
-    );
+    this.stopCollapseStateWatcher();
     this.clearTimer();
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2386,6 +2386,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     opts?.enableClaudeChannels ?? context.enableClaudeChannels;
   const skipAgentLifecycle =
     opts?.skipAgentLifecycle ?? context.skipAgentLifecycle;
+  const lifecycleInitializer =
+    opts?.lifecycleInitializer ?? context.lifecycleInitializer;
   const spawnPreflight = opts?.spawnPreflight ?? context.spawnPreflight;
   const disableSpawnPreflight =
     opts?.disableSpawnPreflight ?? context.disableSpawnPreflight;
@@ -8163,8 +8165,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
       context.lifecycleStartError = null;
-      const lifecycleInitialization = context.lifecycleInitializer
-        ? Promise.resolve().then(() => context.lifecycleInitializer!())
+      const lifecycleInitialization = lifecycleInitializer
+        ? Promise.resolve().then(() => lifecycleInitializer())
         : engine.initialize(discovery);
       context.lifecycleStartPromise = lifecycleInitialization
         .catch((error) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1979,6 +1979,12 @@ export interface CreateServerOptions {
   context?: CmuxServerContext;
   /** Base directory for agent state files. Defaults to ~/.local/state/cmux-agents */
   stateDir?: string;
+  /** Override lifecycle persistence (primarily for hermetic tests). */
+  stateManager?: StateManager;
+  /** Override the lifecycle registry paired with stateManager (primarily for tests). */
+  lifecycleRegistry?: AgentRegistry;
+  /** Override persisted-state reconstitution at lifecycle startup (primarily for tests). */
+  lifecycleInitializer?: () => Promise<void>;
   /** Skip agent lifecycle initialization (for testing low-level tools only) */
   skipAgentLifecycle?: boolean;
   /** Override the per-session resident-tool palette (primarily for entry wiring/tests). */
@@ -2099,6 +2105,7 @@ export interface CmuxServerContext {
   sessionIdentityResolver?: SessionIdentityResolver;
   selfRegistrationSessionResolver?: SessionIdentityResolver;
   lifecycleRegistry: AgentRegistry | null;
+  lifecycleInitializer: (() => Promise<void>) | null;
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
   lifecycleStartError: Error | null;
@@ -2164,17 +2171,18 @@ export function createServerContext(
       bin: opts?.bin ?? (opts?.exec ? "cmux" : undefined),
     });
   const autoVitestStateDir =
-    !opts?.stateDir && process.env.VITEST === "true"
+    !opts?.stateDir && !opts?.stateManager && process.env.VITEST === "true"
       ? mkdtempSync(join(tmpdir(), "cmuxlayer-vitest-state-"))
       : null;
   const stateDir =
+    opts?.stateManager?.getBaseDir() ??
     opts?.stateDir ??
     autoVitestStateDir ??
     join(homedir(), ".local", "state", "cmux-agents");
   if (autoVitestStateDir) {
     registerAutoVitestStateDir(autoVitestStateDir);
   }
-  const stateMgr = new StateManager(stateDir);
+  const stateMgr = opts?.stateManager ?? new StateManager(stateDir);
   const readObserverProvider = (
     provider: () => string | null | undefined,
   ): string | null => {
@@ -2222,7 +2230,8 @@ export function createServerContext(
     disableSpawnPreflight: opts?.disableSpawnPreflight,
     sessionIdentityResolver: opts?.sessionIdentityResolver,
     selfRegistrationSessionResolver: opts?.selfRegistrationSessionResolver,
-    lifecycleRegistry: null,
+    lifecycleRegistry: opts?.lifecycleRegistry ?? null,
+    lifecycleInitializer: opts?.lifecycleInitializer ?? null,
     lifecycleStarted: false,
     lifecycleStartPromise: null,
     lifecycleStartError: null,
@@ -8154,8 +8163,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
       context.lifecycleStartError = null;
-      context.lifecycleStartPromise = engine
-        .initialize(discovery)
+      const lifecycleInitialization = context.lifecycleInitializer
+        ? Promise.resolve().then(() => context.lifecycleInitializer!())
+        : engine.initialize(discovery);
+      context.lifecycleStartPromise = lifecycleInitialization
         .catch((error) => {
           context.lifecycleStartError =
             error instanceof Error ? error : new Error(String(error));

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -6974,7 +6974,7 @@ To continue this session, run codex resume ${sessionId}`,
     });
 
     it("resolves done for a non-Codex worker after trailing done output evidence is confirmed", async () => {
-      vi.useFakeTimers();
+      vi.useFakeTimers({ now: new Date("2026-07-17T12:00:00.000Z") });
       try {
         stateMgr.writeState(
           makeRecord({
@@ -6995,7 +6995,11 @@ To continue this session, run codex resume ${sessionId}`,
         await engine.getRegistry().reconstitute();
 
         const pending = engine.waitFor("claude-output-done", "done", 7_000);
-        await vi.advanceTimersByTimeAsync(8_000);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(
+          engine.getAgentState("claude-output-done")?.task_done_candidate_at,
+        ).toEqual(expect.any(String));
+        await vi.advanceTimersByTimeAsync(5_000);
         const result = await pending;
 
         expect(result.matched).toBe(true);

--- a/tests/fleet-sidebar.test.ts
+++ b/tests/fleet-sidebar.test.ts
@@ -32,6 +32,35 @@ import {
 
 const tempDirs: string[] = [];
 
+function manualCollapseStateWatcher() {
+  let listener: (() => void) | null = null;
+  let watchedPath: string | null = null;
+  let disposed = false;
+  return {
+    watch: (path: string, onChange: () => void) => {
+      watchedPath = path;
+      listener = onChange;
+      return () => {
+        disposed = true;
+        listener = null;
+      };
+    },
+    emit: () => {
+      if (!listener) return false;
+      listener();
+      return true;
+    },
+    watchedPath: () => watchedPath,
+    connected: () => listener !== null,
+    disposed: () => disposed,
+  };
+}
+
+function agePublishedSidebar(path: string): void {
+  const oldEnoughToBypassThrottle = new Date(Date.now() - 1_000);
+  utimesSync(path, oldEnoughToBypassThrottle, oldEnoughToBypassThrottle);
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
@@ -1614,41 +1643,41 @@ writeFileSync(process.argv[3], "released");`,
     publisher.dispose();
   });
 
-  it("republishes the cached snapshot promptly when CLI state changes", async () => {
+  it("republishes the cached snapshot promptly when CLI state changes", () => {
     const outputPath = tempOutputPath();
     const statePath = join(outputPath, "..", "fleet-collapse.json");
     const store = new FleetSidebarCollapseStore({ statePath });
+    const watcher = manualCollapseStateWatcher();
     const publisher = new FleetSidebarPublisher({
       outputPath,
       collapseStore: store,
+      collapseStateWatcher: watcher.watch,
     });
 
+    let source = "";
     try {
       publisher.publish(snapshotWithStatus("collapse without waiting for sweep"));
       expect(readFileSync(outputPath, "utf8")).toContain(
         '"surfaceRef": "surface:1"',
       );
+      agePublishedSidebar(outputPath);
 
       new FleetSidebarCollapseStore({ statePath }).setLaneCollapsed(
         "cmuxlayer",
         true,
       );
-      const deadline = Date.now() + 1_200;
-      while (
-        Date.now() < deadline &&
-        readFileSync(outputPath, "utf8").includes(
-          '"surfaceRef": "surface:1"',
-        )
-      ) {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      }
+      expect(watcher.emit()).toBe(true);
 
-      const source = readFileSync(outputPath, "utf8");
+      source = readFileSync(outputPath, "utf8");
       expect(source).toContain('fleetLane("cmuxlayer", 1, 1, true, 1, [');
       expect(source).not.toContain('"surfaceRef": "surface:1"');
+      expect(watcher.watchedPath()).toBe(statePath);
     } finally {
       publisher.dispose();
     }
+    expect(watcher.connected()).toBe(false);
+    expect(watcher.disposed()).toBe(true);
+    expect(watcher.emit()).toBe(false);
   });
 
   it("creates the target atomically and leaves no temporary file", () => {
@@ -1816,13 +1845,15 @@ writeFileSync(process.argv[3], "released");`,
     publisher.dispose();
   });
 
-  it("keeps the last authoritative topology when collapse changes after a pending decrease is canceled", async () => {
+  it("keeps the last authoritative topology when collapse changes after a pending decrease is canceled", () => {
     const outputPath = tempOutputPath();
     const statePath = join(outputPath, "..", "fleet-collapse.json");
     const store = new FleetSidebarCollapseStore({ statePath });
+    const watcher = manualCollapseStateWatcher();
     const publisher = new FleetSidebarPublisher({
       outputPath,
       collapseStore: store,
+      collapseStateWatcher: watcher.watch,
     });
     publisher.publish(
       publication(
@@ -1842,15 +1873,10 @@ writeFileSync(process.argv[3], "released");`,
         ["surface:1", "surface:2"],
       ),
     );
+    agePublishedSidebar(outputPath);
     store.setLaneCollapsed("cmuxlayer", true);
+    expect(watcher.emit()).toBe(true);
     const collapsedLane = 'fleetLane("cmuxlayer", 2, 2, true, 2, [';
-    const deadline = Date.now() + 2_000;
-    while (
-      Date.now() < deadline &&
-      !readFileSync(outputPath, "utf8").includes(collapsedLane)
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
 
     const source = readFileSync(outputPath, "utf8");
     expect(source).toContain(
@@ -1859,6 +1885,9 @@ writeFileSync(process.argv[3], "released");`,
     expect(source).toContain(collapsedLane);
     expect(source).not.toContain("rendered=1");
     publisher.dispose();
+    expect(watcher.connected()).toBe(false);
+    expect(watcher.disposed()).toBe(true);
+    expect(watcher.emit()).toBe(false);
   });
 
   it("accepts a populated decrease after omitted seat surfaces disappear", async () => {

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -235,7 +235,8 @@ describe("proxy version-bump auto-reconnect", () => {
     daemons.push(daemon);
     await daemon.start();
 
-    let stale = false;
+    let runningVersion = "0.3.33";
+    let installedVersion = "0.3.33";
     const input = new PassThrough();
     const output = new PassThrough();
     const collector = createCollector(output);
@@ -249,10 +250,20 @@ describe("proxy version-bump auto-reconnect", () => {
       requestTimeoutMs: 500,
       staleRecheckIntervalMs: 10,
       detectStaleBuild: () =>
-        stale
-          ? { stale: true, running: "0.3.33", installed: "0.3.34" }
-          : { stale: false, running: "0.3.33", installed: "0.3.33" },
-      spawnDaemonForVersionBump: vi.fn().mockResolvedValue(undefined),
+        runningVersion === installedVersion
+          ? {
+              stale: false,
+              running: runningVersion,
+              installed: installedVersion,
+            }
+          : {
+              stale: true,
+              running: runningVersion,
+              installed: installedVersion,
+            },
+      spawnDaemonForVersionBump: vi.fn().mockImplementation(async () => {
+        runningVersion = installedVersion;
+      }),
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
       logger: { error: vi.fn() },
     });
@@ -283,7 +294,7 @@ describe("proxy version-bump auto-reconnect", () => {
       ),
     );
 
-    stale = true;
+    installedVersion = "0.3.34";
 
     await waitFor(() => daemon.connections.length >= 2, 1_000);
     await waitFor(

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -423,6 +423,35 @@ describe("lifecycle dependency seams", () => {
     }
   });
 
+  it("prefers a per-server lifecycle initializer for a shared context", async () => {
+    const stateManager = createInMemoryStateManager();
+    const lifecycleSurfaceProvider = vi.fn(async () => {
+      throw new Error("Shared-context seam attempted lifecycle surface I/O");
+    });
+    const lifecycleRegistry = new AgentRegistry(
+      stateManager,
+      lifecycleSurfaceProvider,
+    );
+    const contextInitializer = vi.fn(async () => {});
+    const serverInitializer = vi.fn(async () => {});
+    const context = createServerContext({
+      exec: makeLifecycleExec(),
+      stateManager,
+      lifecycleRegistry,
+      lifecycleInitializer: contextInitializer,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    serverContexts.push(context);
+
+    createServer({ context, lifecycleInitializer: serverInitializer });
+    await context.lifecycleStartPromise;
+
+    expect(serverInitializer).toHaveBeenCalledTimes(1);
+    expect(contextInitializer).not.toHaveBeenCalled();
+    expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
+  });
+
   it("captures synchronous injected lifecycle initializer failures", async () => {
     const stateManager = createInMemoryStateManager();
     const lifecycleRegistry = new AgentRegistry(stateManager, async () => []);

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -41,6 +41,17 @@ import type { CodexRolloutFill } from "../src/codex-rollout-fill.js";
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
 
+afterEach(async () => {
+  await Promise.allSettled(
+    serverContexts.map(
+      (context) => context.lifecycleStartPromise ?? Promise.resolve(),
+    ),
+  );
+  for (const context of serverContexts.splice(0)) {
+    context.dispose();
+  }
+});
+
 const AGENT_TOOLS = [
   "spawn_agent",
   "new_worktree_split",
@@ -254,8 +265,32 @@ function createLifecycleServer(exec: ExecFn) {
   });
 }
 
+async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  const resultPromise = run();
+  let settled = false;
+  void resultPromise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  for (let elapsed = 0; elapsed < 5_000 && !settled; elapsed += 50) {
+    for (let flush = 0; flush < 8; flush += 1) {
+      await Promise.resolve();
+    }
+    await vi.advanceTimersByTimeAsync(50);
+  }
+  if (!settled) {
+    throw new Error("Operation did not settle within 5,000 ms of fake time");
+  }
+  return resultPromise;
+}
+
 describe("lean spawn tool responses", () => {
   it("spawn_agent publishes the exact expected-state manifest through the injected writer", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-17T12:00:00.000Z") });
     const manifests: SeatManifest[] = [];
     const surfaceUuid = "11111111-2222-4333-8444-555555555555";
     const server = createTrackedServer({
@@ -268,31 +303,43 @@ describe("lean spawn tool responses", () => {
       },
       seatManifestNow: () => "2026-07-12T12:00:00.000Z",
     });
+    const context = serverContexts.at(-1)!;
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
-    const result = await spawn.handler(
-      { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
-      {} as any,
-    );
-    const parsed =
-      result.structuredContent ?? JSON.parse(result.content[0].text);
+    try {
+      const result = await runWithFakeTimers(async () => {
+        const [spawnResult] = await Promise.all([
+          spawn.handler(
+            { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
+            {} as any,
+          ),
+          context.lifecycleStartPromise ?? Promise.resolve(),
+        ]);
+        return spawnResult;
+      });
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
-    expect(manifests).toEqual([
-      {
-        surface_id: "surface:new",
-        surface_uuid: surfaceUuid,
-        agent_id: parsed.agent_id,
-        tab_name: "cmuxlayerClaude [surface:new]",
-        session_name: null,
-        model: "fable-5",
-        permission_mode: "skip-permissions",
-        cwd: join(homedir(), "Gits", "cmuxlayer"),
-        repo: "cmuxlayer",
-        cli: "claude",
-        updated_at: "2026-07-12T12:00:00.000Z",
-      },
-    ]);
+      expect(parsed.ok).toBe(true);
+      expect(manifests).toEqual([
+        {
+          surface_id: "surface:new",
+          surface_uuid: surfaceUuid,
+          agent_id: parsed.agent_id,
+          tab_name: "cmuxlayerClaude [surface:new]",
+          session_name: null,
+          model: "fable-5",
+          permission_mode: "skip-permissions",
+          cwd: join(homedir(), "Gits", "cmuxlayer"),
+          repo: "cmuxlayer",
+          cli: "claude",
+          updated_at: "2026-07-12T12:00:00.000Z",
+        },
+      ]);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("spawn_agent manifest uses the launcher name resolved by preflight", async () => {
@@ -924,15 +971,7 @@ describe("agent lifecycle tool handlers", () => {
     mockExec = makeLifecycleExec();
   });
 
-  afterEach(async () => {
-    await Promise.allSettled(
-      serverContexts.map(
-        (context) => context.lifecycleStartPromise ?? Promise.resolve(),
-      ),
-    );
-    for (const context of serverContexts.splice(0)) {
-      context.dispose();
-    }
+  afterEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -56,6 +56,7 @@ afterEach(async () => {
   for (const stateDir of hermeticSpawnStateDirs.splice(0)) {
     rmSync(stateDir, { recursive: true, force: true });
   }
+  rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 const AGENT_TOOLS = [
@@ -1145,10 +1146,6 @@ describe("agent lifecycle tool handlers", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
     mockExec = makeLifecycleExec();
-  });
-
-  afterEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
   it("does not adopt cached lifecycle UUID evidence after an observer reconnect", async () => {
@@ -8588,10 +8585,6 @@ describe("auto-focus discipline (focus target before split, restore after render
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
   });
-  afterEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
-  });
-
   // Builds an exec mock that records every call, reports `selectedWorkspace` as
   // the focused one, and returns a non-ready screen for the first `notReadyFor`
   // read-screen polls before reporting ready.

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -271,7 +271,9 @@ function createLifecycleServer(exec: ExecFn) {
   });
 }
 
-function createInMemoryStateManager(): StateManager {
+function createInMemoryStateManager(
+  baseDir = "/in-memory/spawn-manifest",
+): StateManager {
   const records = new Map<string, AgentRecord>();
   const eventLog = {
     append: vi.fn(),
@@ -317,7 +319,7 @@ function createInMemoryStateManager(): StateManager {
   };
 
   return {
-    getBaseDir: () => "/in-memory/spawn-manifest",
+    getBaseDir: () => baseDir,
     getEventLog: () => eventLog,
     getSurfaceSessionIndex: () => surfaceSessionIndex,
     writeState: (record) => {
@@ -372,7 +374,7 @@ function createHermeticSpawnServer(
   rmSync(stateDir, { recursive: true, force: true });
   hermeticSpawnStateDirs.push(stateDir);
 
-  const stateManager = createInMemoryStateManager();
+  const stateManager = createInMemoryStateManager(stateDir);
   const lifecycleSurfaceProvider = vi.fn(async () => {
     throw new Error("Hermetic spawn fixture attempted registry surface I/O");
   });
@@ -394,9 +396,11 @@ function createHermeticSpawnServer(
     lifecycleRegistry,
     lifecycleInitializer,
   } as Omit<CreateServerOptions, "context">;
+  const server = createTrackedServer(serverOptions);
 
   return {
-    server: createTrackedServer(serverOptions),
+    server,
+    context: serverContexts.at(-1)!,
     stateDir,
     lifecycleInitializer,
     lifecycleSurfaceProvider,
@@ -468,6 +472,7 @@ describe("lean spawn tool responses", () => {
     });
     const {
       server,
+      context,
       stateDir,
       lifecycleInitializer,
       lifecycleSurfaceProvider,
@@ -499,6 +504,7 @@ describe("lean spawn tool responses", () => {
     ]);
     expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
     expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
+    expect(context.stateDir).toBe(stateDir);
     expect(existsSync(stateDir)).toBe(false);
   });
 
@@ -513,6 +519,7 @@ describe("lean spawn tool responses", () => {
     });
     const {
       server,
+      context,
       stateDir,
       lifecycleInitializer,
       lifecycleSurfaceProvider,
@@ -529,6 +536,7 @@ describe("lean spawn tool responses", () => {
     );
     expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
     expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
+    expect(context.stateDir).toBe(stateDir);
     expect(existsSync(stateDir)).toBe(false);
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -29,6 +29,7 @@ import type { ExecFn } from "../src/cmux-client.js";
 import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { ParsedScreenResult } from "../src/types.js";
 import type { SeatManifest } from "../src/seat-manifest.js";
+import { AgentRegistry } from "../src/agent-registry.js";
 import { StateManager } from "../src/state-manager.js";
 import {
   reconcileMonitorRegistry,
@@ -40,6 +41,8 @@ import type { CodexRolloutFill } from "../src/codex-rollout-fill.js";
 
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
+const hermeticSpawnStateDirs: string[] = [];
+let hermeticSpawnFixtureSequence = 0;
 
 afterEach(async () => {
   await Promise.allSettled(
@@ -49,6 +52,9 @@ afterEach(async () => {
   );
   for (const context of serverContexts.splice(0)) {
     context.dispose();
+  }
+  for (const stateDir of hermeticSpawnStateDirs.splice(0)) {
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 
@@ -265,37 +271,194 @@ function createLifecycleServer(exec: ExecFn) {
   });
 }
 
-async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
-  const resultPromise = run();
-  let settled = false;
-  void resultPromise.then(
-    () => {
-      settled = true;
+function createInMemoryStateManager(): StateManager {
+  const records = new Map<string, AgentRecord>();
+  const eventLog = {
+    append: vi.fn(),
+    appendDelivery: vi.fn(),
+    appendControlHealth: vi.fn(),
+    appendClose: vi.fn(),
+    appendCloseForensics: vi.fn(),
+    readAll: vi.fn(() => []),
+    readEntries: vi.fn(() => []),
+    readForAgent: vi.fn(() => []),
+    readCloseEvents: vi.fn(() => []),
+  } as unknown as ReturnType<StateManager["getEventLog"]>;
+  const surfaceSessionIndex = {
+    persist: vi.fn(),
+    persistRecord: vi.fn(() => null),
+    removeAgent: vi.fn(),
+    lookup: vi.fn(() => null),
+  } as unknown as ReturnType<StateManager["getSurfaceSessionIndex"]>;
+  const readRecord = (agentId: string): AgentRecord | null => {
+    const record = records.get(agentId);
+    return record ? { ...record } : null;
+  };
+  const requireRecord = (agentId: string): AgentRecord => {
+    const record = readRecord(agentId);
+    if (!record) throw new Error(`Agent not found: ${agentId}`);
+    return record;
+  };
+  const updateRecord = (
+    agentId: string,
+    fields: Partial<AgentRecord>,
+  ): AgentRecord => {
+    const current = requireRecord(agentId);
+    const updated: AgentRecord = {
+      ...current,
+      ...fields,
+      agent_id: current.agent_id,
+      created_at: current.created_at,
+      version: current.version + 1,
+      updated_at: new Date().toISOString(),
+    };
+    records.set(agentId, updated);
+    return { ...updated };
+  };
+
+  return {
+    getBaseDir: () => "/in-memory/spawn-manifest",
+    getEventLog: () => eventLog,
+    getSurfaceSessionIndex: () => surfaceSessionIndex,
+    writeState: (record) => {
+      records.set(record.agent_id, { ...record });
     },
-    () => {
-      settled = true;
+    readState: readRecord,
+    hasStateFile: (agentId) => records.has(agentId),
+    transition: (agentId, toState, extra) =>
+      updateRecord(agentId, { state: toState, ...extra }),
+    updateRecord,
+    resetState: (agentId, toState, fields) =>
+      updateRecord(agentId, { ...fields, state: toState }),
+    renameState: (agentId, newAgentId) => {
+      const current = requireRecord(agentId);
+      if (agentId !== newAgentId && records.has(newAgentId)) {
+        throw new Error(`Agent already exists: ${newAgentId}`);
+      }
+      records.delete(agentId);
+      const renamed: AgentRecord = {
+        ...current,
+        agent_id: newAgentId,
+        version: current.version + 1,
+        updated_at: new Date().toISOString(),
+      };
+      records.set(newAgentId, renamed);
+      for (const child of records.values()) {
+        if (child.parent_agent_id === agentId) {
+          records.set(child.agent_id, {
+            ...child,
+            parent_agent_id: newAgentId,
+            version: child.version + 1,
+            updated_at: new Date().toISOString(),
+          });
+        }
+      }
+      return { ...renamed };
     },
-  );
-  for (let elapsed = 0; elapsed < 5_000 && !settled; elapsed += 50) {
-    for (let flush = 0; flush < 8; flush += 1) {
-      await Promise.resolve();
-    }
-    await vi.advanceTimersByTimeAsync(50);
-  }
-  if (!settled) {
-    throw new Error("Operation did not settle within 5,000 ms of fake time");
-  }
-  return resultPromise;
+    listStates: () => [...records.values()].map((record) => ({ ...record })),
+    removeState: (agentId) => {
+      records.delete(agentId);
+    },
+  } as unknown as StateManager;
 }
+
+function createHermeticSpawnServer(
+  opts: Omit<CreateServerOptions, "context" | "stateDir">,
+) {
+  const stateDir = join(
+    tmpdir(),
+    `cmuxlayer-spawn-hermetic-${process.pid}-${hermeticSpawnFixtureSequence++}`,
+  );
+  rmSync(stateDir, { recursive: true, force: true });
+  hermeticSpawnStateDirs.push(stateDir);
+
+  const stateManager = createInMemoryStateManager();
+  const lifecycleSurfaceProvider = vi.fn(async () => {
+    throw new Error("Hermetic spawn fixture attempted registry surface I/O");
+  });
+  const lifecycleRegistry = new AgentRegistry(
+    stateManager,
+    lifecycleSurfaceProvider,
+  );
+  vi.spyOn(
+    lifecycleRegistry,
+    "refreshManagedSurfaceMetadata",
+  ).mockImplementation(async (_discovery, refreshOpts) =>
+    refreshOpts?.agentId ? lifecycleRegistry.get(refreshOpts.agentId) : null,
+  );
+  const lifecycleInitializer = vi.fn(async () => {});
+  const serverOptions = {
+    ...opts,
+    stateDir,
+    stateManager,
+    lifecycleRegistry,
+    lifecycleInitializer,
+  } as Omit<CreateServerOptions, "context">;
+
+  return {
+    server: createTrackedServer(serverOptions),
+    stateDir,
+    lifecycleInitializer,
+    lifecycleSurfaceProvider,
+  };
+}
+
+describe("lifecycle dependency seams", () => {
+  it("uses the injected state manager as the state directory authority", () => {
+    const stateManager = createInMemoryStateManager();
+    const context = createServerContext({
+      stateDir: "/conflicting/spawn-manifest-state",
+      stateManager,
+    });
+
+    try {
+      expect(context.stateDir).toBe(stateManager.getBaseDir());
+    } finally {
+      context.dispose();
+    }
+  });
+
+  it("captures synchronous injected lifecycle initializer failures", async () => {
+    const stateManager = createInMemoryStateManager();
+    const lifecycleRegistry = new AgentRegistry(stateManager, async () => []);
+    const initializationError = new Error("synchronous lifecycle failure");
+    const lifecycleInitializer = vi.fn((): Promise<void> => {
+      throw initializationError;
+    });
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(() =>
+        createTrackedServer({
+          exec: makeLifecycleExec(),
+          stateManager,
+          lifecycleRegistry,
+          lifecycleInitializer,
+          disableSpawnPreflight: true,
+          sessionIdentityResolver: () => null,
+        }),
+      ).not.toThrow();
+
+      const context = serverContexts.at(-1)!;
+      await context.lifecycleStartPromise;
+      expect(context.lifecycleStartError).toBe(initializationError);
+      expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
+      expect(errorLog).toHaveBeenCalledWith(
+        "[cmuxlayer] lifecycle initialization failed:",
+        initializationError,
+      );
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+});
 
 describe("lean spawn tool responses", () => {
   it("spawn_agent publishes the exact expected-state manifest through the injected writer", async () => {
-    vi.useFakeTimers({ now: new Date("2026-07-17T12:00:00.000Z") });
     const manifests: SeatManifest[] = [];
     const surfaceUuid = "11111111-2222-4333-8444-555555555555";
-    const server = createTrackedServer({
+    const fixture = createHermeticSpawnServer({
       exec: makeLifecycleExec({ surfaceUuid }),
-      stateDir: TEST_DIR,
       disableSpawnPreflight: true,
       sessionIdentityResolver: () => null,
       seatManifestWriter: async (manifest) => {
@@ -303,55 +466,57 @@ describe("lean spawn tool responses", () => {
       },
       seatManifestNow: () => "2026-07-12T12:00:00.000Z",
     });
-    const context = serverContexts.at(-1)!;
+    const {
+      server,
+      stateDir,
+      lifecycleInitializer,
+      lifecycleSurfaceProvider,
+    } = fixture;
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
-    try {
-      const result = await runWithFakeTimers(async () => {
-        const [spawnResult] = await Promise.all([
-          spawn.handler(
-            { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
-            {} as any,
-          ),
-          context.lifecycleStartPromise ?? Promise.resolve(),
-        ]);
-        return spawnResult;
-      });
-      const parsed =
-        result.structuredContent ?? JSON.parse(result.content[0].text);
+    const result = await spawn.handler(
+      { repo: "cmuxlayer", model: "fable-5", cli: "claude" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
 
-      expect(parsed.ok).toBe(true);
-      expect(manifests).toEqual([
-        {
-          surface_id: "surface:new",
-          surface_uuid: surfaceUuid,
-          agent_id: parsed.agent_id,
-          tab_name: "cmuxlayerClaude [surface:new]",
-          session_name: null,
-          model: "fable-5",
-          permission_mode: "skip-permissions",
-          cwd: join(homedir(), "Gits", "cmuxlayer"),
-          repo: "cmuxlayer",
-          cli: "claude",
-          updated_at: "2026-07-12T12:00:00.000Z",
-        },
-      ]);
-    } finally {
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
+    expect(parsed.ok).toBe(true);
+    expect(manifests).toEqual([
+      {
+        surface_id: "surface:new",
+        surface_uuid: surfaceUuid,
+        agent_id: parsed.agent_id,
+        tab_name: "cmuxlayerClaude [surface:new]",
+        session_name: null,
+        model: "fable-5",
+        permission_mode: "skip-permissions",
+        cwd: join(homedir(), "Gits", "cmuxlayer"),
+        repo: "cmuxlayer",
+        cli: "claude",
+        updated_at: "2026-07-12T12:00:00.000Z",
+      },
+    ]);
+    expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
+    expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
+    expect(existsSync(stateDir)).toBe(false);
   });
 
   it("spawn_agent manifest uses the launcher name resolved by preflight", async () => {
     const manifests: SeatManifest[] = [];
-    const server = createTrackedServer({
+    const fixture = createHermeticSpawnServer({
       exec: makeLifecycleExec(),
-      stateDir: TEST_DIR,
       spawnPreflight: async () => ({ launcherName: "registeredClaude" }),
       sessionIdentityResolver: () => null,
       seatManifestWriter: async (manifest) => manifests.push(manifest),
       seatManifestNow: () => "2026-07-12T12:00:00.000Z",
     });
+    const {
+      server,
+      stateDir,
+      lifecycleInitializer,
+      lifecycleSurfaceProvider,
+    } = fixture;
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
     await spawn.handler(
@@ -362,6 +527,9 @@ describe("lean spawn tool responses", () => {
     expect(manifests[0]?.tab_name).toBe(
       "registeredClaude [surface:new]",
     );
+    expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
+    expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
+    expect(existsSync(stateDir)).toBe(false);
   });
 
   it("spawn_agent defaults to the lean payload in text and structured content", async () => {


### PR DESCRIPTION
## Summary

- Makes the two spawn-manifest tests hermetic by injecting an in-memory state manager, lifecycle registry, and no-op lifecycle initializer.
- Keeps the exact manifest, launcher-name, lifecycle-start, and no-filesystem-I/O assertions.
- Retains the earlier deterministic fixes for agent-engine waitFor, fleet-sidebar collapse watching, and proxy version-bump replay.
- Adds optional production seams whose defaults and production behavior are unchanged.
- Centralizes server-tools teardown so lifecycle startup settles and contexts dispose before TEST_DIR is removed.
- Honors a per-server lifecycle initializer when createServer uses a pre-built shared context.

## Root cause

The spawn-manifest tests only validate tool output, but they were starting the complete registry and lifecycle stack. Under concurrent load this performed registry reads, managed-metadata refreshes, state/event-log I/O, and lifecycle discovery inside the Vitest default wall-clock timeout. Fake timers did not remove that CPU and filesystem work, which is why isolated-file loops passed while the four-file concurrent loop still failed.

The corrected fixture supplies the registry/lifecycle boundary in memory, stubs managed metadata and initialization, asserts the effective context state directory is the unique nonexistent test path, and verifies the lifecycle surface provider is never reached.

## TDD and review evidence

- Removing the lifecycle-initializer seam made both manifest tests fail because the injected initializer was never called.
- A conflicting injected StateManager base directory failed the context.stateDir authority regression.
- A synchronous injected initializer throw failed the lifecycle error-capture regression.
- The effective-state-path review regression failed until the in-memory manager and context used the same unique path.
- Codex found nested TEST_DIR cleanup could run before file-level lifecycle disposal. Head 8a01c93 removed both nested deletions and performs deletion only after lifecycle promise settlement and context disposal.
- Codex found per-server lifecycleInitializer was ignored with a shared context. The new regression failed at 0 calls before head 8b53c90 made the per-server option override the context fallback.

## Final deterministic proof

Four flaky files together in fresh processes after the final shared-context fix:

- 20/20 runs passed
- 4/4 files and 519/519 tests passed in every run
- 0 failed runs and 0 failed tests

Full suite in fresh processes after the final shared-context fix:

- 5/5 runs passed
- 104/104 files and 2213/2213 tests passed in every run
- 0 failed runs and 0 failed tests

Exact final gate:

    bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test

Result: typecheck green; 104/104 files and 2213/2213 tests green.

The final push hook independently passed 104/104 files and 2213/2213 tests with hooks enabled.

## Coverage guardrails

- no timeout increase
- no retry or test serialization
- no assertion weakening
- no Vitest configuration change
- production lifecycle defaults remain unchanged
- exact manifest and launcher assertions remain
- filesystem purity is checked against the effective injected context path

## Review status

- GitHub CI test and build-site: green on head 8b53c90
- CodeRabbit: green on head; local CLI retry was rate-limited after earlier zero-finding review
- All four inline review threads: fixed and resolved
- Macroscope: passed the implementation head; skipped cleanup-only incremental heads
- Codex: both findings fixed; final review on 8b53c9078d found no major issues
- Cursor Bugbot: unavailable because its account review limit is exhausted; not counted as green

Do not merge; hold for lead review and the v0.4.16 release decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production paths keep prior defaults; changes are primarily test harnesses plus small, opt-in injection points on server lifecycle startup and fleet collapse watching.
> 
> **Overview**
> Hardens previously flaky Vitest coverage by removing scheduler-dependent waits while keeping behavioral assertions and production timing defaults.
> 
> **Production (optional seams, unchanged defaults):** `FleetSidebarPublisher` accepts an injectable `collapseStateWatcher` (default still `watchFile`/`unwatchFile`). `createServer` / `createServerContext` accept optional `stateManager`, `lifecycleRegistry`, and `lifecycleInitializer`; when an initializer is supplied it replaces `engine.initialize(discovery)` for lifecycle startup, and injected `stateManager` drives `stateDir` authority.
> 
> **Tests:** Fleet sidebar collapse cases use a manual watcher and direct change signals instead of wall-clock polling; sidebar mtime is aged to bypass the write throttle where irrelevant. Agent-engine `waitFor` done confirmation advances fake time in stages (poll tick, assert candidate, then confirmation window). Proxy version-bump models a single installed-version transition and updates running version on mock spawn. Spawn-manifest tests use an in-memory `StateManager`, stubbed registry metadata/initializer, and assert no filesystem state dir and one initializer call; file-level teardown waits on lifecycle promises before disposing contexts and removing temp dirs. New regressions cover state-dir authority, per-server initializer override on shared context, and synchronous initializer error capture.
> 
> **Docs:** Adds design and implementation plans for flaky-timing hardening and spawn-manifest hermeticity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8aa751df85a2d1aa829a2463ec98f00d8d753a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->