### PR TITLE
feat(session): resolve self-registered sessions by surface UUID

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1891,6 +1891,15 @@ export class AgentEngine {
     return agent.state === "booting";
   }
 
+  private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
+    return Boolean(
+      this.selfRegistrationSessionResolver &&
+      TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state) &&
+      JSONL_HARNESSES.has(agent.cli) &&
+      agent.surface_uuid?.trim(),
+    );
+  }
+
   private canUseTranscriptSessionResolver(agent: AgentRecord): boolean {
     if (!TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state)) return false;
     if (!JSONL_HARNESSES.has(agent.cli)) return false;
@@ -2049,10 +2058,13 @@ export class AgentEngine {
   private resolveSessionIdentityWithSelfRegistration(
     agent: AgentRecord,
   ): CapturedSessionIdentity | null {
-    const selfRegistered = this.selfRegistrationSessionResolver?.(agent);
-    if (selfRegistered) {
-      return this.normalizeCapturedSessionIdentity(selfRegistered);
+    if (this.canUseSelfRegistrationSessionResolver(agent)) {
+      const selfRegistered = this.selfRegistrationSessionResolver?.(agent);
+      if (selfRegistered) {
+        return this.normalizeCapturedSessionIdentity(selfRegistered);
+      }
     }
+    if (!this.canUseTranscriptSessionResolver(agent)) return null;
     return this.findTranscriptSessionIdentity(agent);
   }
 
@@ -2314,14 +2326,22 @@ export class AgentEngine {
       return agent;
     }
 
-    if (
+    const canUseSelfRegistration =
+      this.canUseSelfRegistrationSessionResolver(agent);
+    const canUseTranscript =
       opts.resolveTranscript !== false &&
-      this.canUseTranscriptSessionResolver(agent)
-    ) {
+      this.canUseTranscriptSessionResolver(agent);
+    if (canUseSelfRegistration || canUseTranscript) {
       try {
-        const transcriptSessionId = this.sessionIdentityResolver(agent);
-        if (transcriptSessionId) {
-          return this.finalizeCapturedSession(agent, transcriptSessionId);
+        const resolvedSession =
+          opts.resolveTranscript === false
+            ? this.selfRegistrationSessionResolver?.(agent)
+            : this.sessionIdentityResolver(agent);
+        if (resolvedSession) {
+          return this.finalizeCapturedSession(
+            agent,
+            this.normalizeCapturedSessionIdentity(resolvedSession),
+          );
         }
       } catch {
         return agent;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -279,6 +279,10 @@ export interface AgentEngineOptions {
   spawnGuard?: SpawnGuard;
   postSpawnLivenessMs?: number;
   stopPostConditionTimeoutMs?: number;
+  /**
+   * Optional fallback override after self-registration misses. When supplied,
+   * it replaces the filesystem transcript scan (primarily for hermetic tests).
+   */
   sessionIdentityResolver?: SessionIdentityResolver;
   /**
    * PRIMARY session-identity resolver: the self-registration READ side. When
@@ -855,9 +859,12 @@ export class AgentEngine {
     // app-server-runtime).
     this.selfRegistrationSessionResolver =
       opts?.selfRegistrationSessionResolver ?? null;
-    this.sessionIdentityResolver =
-      opts?.sessionIdentityResolver ??
-      ((agent) => this.resolveSessionIdentityWithSelfRegistration(agent));
+    const fallbackSessionIdentityResolver = opts?.sessionIdentityResolver;
+    this.sessionIdentityResolver = (agent) =>
+      this.resolveSessionIdentityWithSelfRegistration(
+        agent,
+        fallbackSessionIdentityResolver,
+      );
     // Default no-op: constructing an engine (tests, libraries) must never touch
     // the real outbox or network. Production entrypoints inject the real
     // drainOutbox (see server.ts createServer / app-server-runtime).
@@ -2052,18 +2059,21 @@ export class AgentEngine {
    * boot, so we read it instead of scanning `~/.claude`/`~/.codex` and inferring
    * by cwd+recency (which breaks with raw spawns + worktrees + many agents per
    * repo). The scan is only reached when self-registration returns null (unset in
-   * bare construction, or a hook-less agent with no registry entry); #336's
-   * bounded deferred-capture marker still guards that fallback.
+   * bare construction, or a hook-less agent with no registry entry) and no
+   * injected fallback override is present; #336's bounded deferred-capture marker
+   * still guards that fallback.
    */
   private resolveSessionIdentityWithSelfRegistration(
     agent: AgentRecord,
-  ): CapturedSessionIdentity | null {
+    fallbackResolver?: SessionIdentityResolver,
+  ): CapturedSessionIdentity | string | null {
     if (this.canUseSelfRegistrationSessionResolver(agent)) {
       const selfRegistered = this.selfRegistrationSessionResolver?.(agent);
       if (selfRegistered) {
         return this.normalizeCapturedSessionIdentity(selfRegistered);
       }
     }
+    if (fallbackResolver) return fallbackResolver(agent);
     if (!this.canUseTranscriptSessionResolver(agent)) return null;
     return this.findTranscriptSessionIdentity(agent);
   }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -280,6 +280,15 @@ export interface AgentEngineOptions {
   postSpawnLivenessMs?: number;
   stopPostConditionTimeoutMs?: number;
   sessionIdentityResolver?: SessionIdentityResolver;
+  /**
+   * PRIMARY session-identity resolver: the self-registration READ side. When
+   * provided (production entrypoints inject
+   * `makeSelfRegistrationSessionResolver()`), it is tried BEFORE the deprecated
+   * transcript scan and only falls through to the scan when it returns null.
+   * Default (bare/test construction): unset, so the engine touches no real
+   * registry file — hermetic like `outboxDrain`/`closeForensicsRunner`.
+   */
+  selfRegistrationSessionResolver?: SessionIdentityResolver;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -326,9 +335,9 @@ export interface AgentEngineOptions {
    * construction never reads the real cmux file; production entrypoints inject
    * the runner. Pass an explicit runner in tests.
    */
-  closeForensicsRunner?: (() =>
-    | CloseForensicsSweepResult
-    | Promise<CloseForensicsSweepResult>) | null;
+  closeForensicsRunner?:
+    | (() => CloseForensicsSweepResult | Promise<CloseForensicsSweepResult>)
+    | null;
   /**
    * Receives the reconciled registry, topology, health, and screen evidence.
    * Defaults to a NO-OP so bare engines never write operator configuration.
@@ -338,10 +347,7 @@ export interface AgentEngineOptions {
   fleetWorkingNoProgressTimeoutMs?: number;
 }
 
-export type RolePlacementReconcileTrigger =
-  | "spawn"
-  | "idle"
-  | "boot";
+export type RolePlacementReconcileTrigger = "spawn" | "idle" | "boot";
 
 export interface RolePlacementReconcileSummary {
   moved: Array<{
@@ -785,6 +791,7 @@ export class AgentEngine {
   private inboxOpts?: InboxOpts;
   private sessionIdentityResolver: SessionIdentityResolver;
   private hasCustomSessionIdentityResolver: boolean;
+  private selfRegistrationSessionResolver: SessionIdentityResolver | null;
   private seatRegistry: SeatRegistry | null;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
   private fleetSidebarWakeRepublishTimer: ReturnType<typeof setTimeout> | null =
@@ -815,9 +822,9 @@ export class AgentEngine {
   private monitorRegistryNotify: MonitorDeadmanNotify;
   private monitorRegistrySweepInFlight = false;
   /** Best-effort close-forensics ingest; null when disabled. */
-  private closeForensicsRunner: (() =>
-    | CloseForensicsSweepResult
-    | Promise<CloseForensicsSweepResult>) | null;
+  private closeForensicsRunner:
+    | (() => CloseForensicsSweepResult | Promise<CloseForensicsSweepResult>)
+    | null;
   private closeForensicsSweepInFlight = false;
   private fleetSidebarPublisher: FleetSidebarPublisherLike;
   private fleetWorkingNoProgressTimeoutMs: number;
@@ -842,22 +849,31 @@ export class AgentEngine {
         : this.loadSeatRegistry(opts?.seatRegistryPath);
     this.hasCustomSessionIdentityResolver =
       opts?.sessionIdentityResolver !== undefined;
+    // Default DISABLED (null): bare construction (tests, libraries) must never
+    // read the real `~/.cmuxlayer/session-registry.jsonl`. Production entrypoints
+    // inject `makeSelfRegistrationSessionResolver()` (see entry.ts / daemon.ts /
+    // app-server-runtime).
+    this.selfRegistrationSessionResolver =
+      opts?.selfRegistrationSessionResolver ?? null;
     this.sessionIdentityResolver =
       opts?.sessionIdentityResolver ??
-      ((agent) => this.findTranscriptSessionIdentity(agent));
+      ((agent) => this.resolveSessionIdentityWithSelfRegistration(agent));
     // Default no-op: constructing an engine (tests, libraries) must never touch
     // the real outbox or network. Production entrypoints inject the real
     // drainOutbox (see server.ts createServer / app-server-runtime).
     this.outboxDrain = opts?.outboxDrain ?? (async () => {});
     this.monitorRegistryPath = opts?.monitorRegistryPath;
     this.monitorRegistryNow = opts?.monitorRegistryNow;
-    this.monitorRegistryNotify = opts?.monitorRegistryNotify ?? (async () => {});
+    this.monitorRegistryNotify =
+      opts?.monitorRegistryNotify ?? (async () => {});
     // Default DISABLED: bare construction (tests, libraries) must never read the
     // real `~/.cmuxterm/events.jsonl`. Production entrypoints inject the real
     // runner (see app-server-runtime / server.ts createServer). `null` keeps it
     // off; an explicit runner (tests) drives it deterministically.
     this.closeForensicsRunner =
-      opts?.closeForensicsRunner !== undefined ? opts.closeForensicsRunner : null;
+      opts?.closeForensicsRunner !== undefined
+        ? opts.closeForensicsRunner
+        : null;
     this.fleetSidebarPublisher = opts?.fleetSidebarPublisher ?? {
       publish: () => {},
       dispose: () => {},
@@ -907,7 +923,9 @@ export class AgentEngine {
       });
   }
 
-  private loadSeatRegistry(configPath: string | undefined): SeatRegistry | null {
+  private loadSeatRegistry(
+    configPath: string | undefined,
+  ): SeatRegistry | null {
     try {
       return loadSeatRegistryFromConfig(configPath);
     } catch {
@@ -973,7 +991,9 @@ export class AgentEngine {
       reportText !== null &&
       reportFresh === true &&
       reportFinalLine === goal.doneMarker;
-    const keptOpen = reportText ? this.extractKeptOpenContract(reportText) : null;
+    const keptOpen = reportText
+      ? this.extractKeptOpenContract(reportText)
+      : null;
     const prLoopRequired = this.isPrLoopRequired(
       agent,
       goal.goalText,
@@ -1141,9 +1161,8 @@ export class AgentEngine {
         const reportContext =
           /\breport(?:[_ -]?path)?\b/i.test(context) ||
           /\bwrite\s+(?:the\s+)?report\b/i.test(context);
-        const basenameIncludesReport = /(?:^|[/\\])[^/\\]*report[^/\\]*\.md$/i.test(
-          rawPath,
-        );
+        const basenameIncludesReport =
+          /(?:^|[/\\])[^/\\]*report[^/\\]*\.md$/i.test(rawPath);
         candidates.push({
           rawPath,
           score:
@@ -1164,8 +1183,7 @@ export class AgentEngine {
 
   private isMarkdownContractPath(rawPath: string): boolean {
     return (
-      /\.md$/i.test(rawPath) ||
-      /(?:^|[/\\])reports[/\\].+\.md$/i.test(rawPath)
+      /\.md$/i.test(rawPath) || /(?:^|[/\\])reports[/\\].+\.md$/i.test(rawPath)
     );
   }
 
@@ -1183,7 +1201,9 @@ export class AgentEngine {
     }
     candidates.push(resolve(process.cwd(), stripped));
 
-    return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+    return (
+      candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
+    );
   }
 
   private extractDoneMarker(goalText: string): string | null {
@@ -1315,7 +1335,8 @@ export class AgentEngine {
     const reviewOrMergeComplete =
       /\b(?:merged|review(?:ed)?\s+(?:complete|passed|done)|review\/merge loop complete)\b/i.test(
         reportText,
-      ) || /\bPR\s+(?:status|state)\s*:\s*(?:merged|closed)\b/i.test(reportText);
+      ) ||
+      /\bPR\s+(?:status|state)\s*:\s*(?:merged|closed)\b/i.test(reportText);
     return hasPrReference && reviewOrMergeComplete;
   }
 
@@ -1405,10 +1426,7 @@ export class AgentEngine {
     return Date.now() - session.mtime_ms >= DONE_QUIESCENCE_MS;
   }
 
-  private screenContradictsTranscriptDone(
-    cli: CliType,
-    text: string,
-  ): boolean {
+  private screenContradictsTranscriptDone(cli: CliType, text: string): boolean {
     const parsed = parseScreen(text);
     return screenHasActiveAgentMarker(cli, text, parsed);
   }
@@ -1518,8 +1536,7 @@ export class AgentEngine {
         return { agent };
       }
 
-      const count =
-        (waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
+      const count = (waitForReadyPatternMatches.get(agent.agent_id) ?? 0) + 1;
       waitForReadyPatternMatches.set(agent.agent_id, count);
       if (count < Math.max(1, evidence.consecutive)) {
         return { agent };
@@ -1532,10 +1549,9 @@ export class AgentEngine {
             })
           : agent;
       if (targetState === "ready" && transitionAgent.boot_prompt_pending) {
-        transitionAgent = this.stateMgr.updateRecord(
-          transitionAgent.agent_id,
-          { boot_prompt_pending: false },
-        );
+        transitionAgent = this.stateMgr.updateRecord(transitionAgent.agent_id, {
+          boot_prompt_pending: false,
+        });
         this.registry.set(transitionAgent.agent_id, transitionAgent);
       }
       let updated = this.stateMgr.transition(
@@ -1707,12 +1723,13 @@ export class AgentEngine {
         : null;
       const parentDefinitelyElsewhere = Boolean(
         parentAgent?.workspace_id &&
-          workspace &&
-          parentAgent.workspace_id !== workspace,
+        workspace &&
+        parentAgent.workspace_id !== workspace,
       );
-      const parentSurfaceId = parentAgent && !parentDefinitelyElsewhere
-        ? resolveObservedAgentSurfaceRef(parentAgent, surfaceObservation)
-        : null;
+      const parentSurfaceId =
+        parentAgent && !parentDefinitelyElsewhere
+          ? resolveObservedAgentSurfaceRef(parentAgent, surfaceObservation)
+          : null;
       if (
         parentAgent?.surface_uuid &&
         !parentSurfaceId &&
@@ -1879,8 +1896,8 @@ export class AgentEngine {
     if (!JSONL_HARNESSES.has(agent.cli)) return false;
     const hasManagedLaunchContext = Boolean(
       agent.launcher_name ||
-        agent.launch_cwd?.trim() ||
-        agent.worktree_path?.trim(),
+      agent.launch_cwd?.trim() ||
+      agent.worktree_path?.trim(),
     );
     if (agent.task_summary.trim().length === 0 && !hasManagedLaunchContext) {
       return false;
@@ -1904,9 +1921,7 @@ export class AgentEngine {
       .map((line) => line.trim())
       .filter(Boolean);
     const promptTailSource = promptLines.at(-1) ?? prompt;
-    const tail = promptTailSource.slice(
-      -Math.min(80, promptTailSource.length),
-    );
+    const tail = promptTailSource.slice(-Math.min(80, promptTailSource.length));
     return this.screenInputRegionContainsPromptTail(
       agent.cli,
       screenText,
@@ -2021,6 +2036,33 @@ export class AgentEngine {
     return join(homedir(), "Gits", agent.repo);
   }
 
+  /**
+   * Default session-identity resolution: self-registration READ (PRIMARY) then
+   * the deprecated transcript scan (last-resort fallback). Self-registration is
+   * the P0 root fix — agents append their real session id to the registry at
+   * boot, so we read it instead of scanning `~/.claude`/`~/.codex` and inferring
+   * by cwd+recency (which breaks with raw spawns + worktrees + many agents per
+   * repo). The scan is only reached when self-registration returns null (unset in
+   * bare construction, or a hook-less agent with no registry entry); #336's
+   * bounded deferred-capture marker still guards that fallback.
+   */
+  private resolveSessionIdentityWithSelfRegistration(
+    agent: AgentRecord,
+  ): CapturedSessionIdentity | null {
+    const selfRegistered = this.selfRegistrationSessionResolver?.(agent);
+    if (selfRegistered) {
+      return this.normalizeCapturedSessionIdentity(selfRegistered);
+    }
+    return this.findTranscriptSessionIdentity(agent);
+  }
+
+  /**
+   * @deprecated Last-resort fallback only. Scans `~/.claude`/`~/.codex`
+   * transcript dirs and infers identity by cwd+recency — fragile with raw
+   * spawns, worktrees, and many-agents-per-repo. Prefer the self-registration
+   * READ side (`makeSelfRegistrationSessionResolver`), which
+   * `resolveSessionIdentityWithSelfRegistration` tries first.
+   */
   private findTranscriptSessionIdentity(
     agent: AgentRecord,
   ): CapturedSessionIdentity | null {
@@ -2039,7 +2081,9 @@ export class AgentEngine {
         ...(process.env.CMUXLAYER_HARNESS_HOME
           ? { home: process.env.CMUXLAYER_HARNESS_HOME }
           : {}),
-        ...(process.env.CODEX_HOME ? { codexHome: process.env.CODEX_HOME } : {}),
+        ...(process.env.CODEX_HOME
+          ? { codexHome: process.env.CODEX_HOME }
+          : {}),
       },
     );
     return identity
@@ -2305,7 +2349,8 @@ export class AgentEngine {
   }
 
   async captureBootSessionId(agentId: string): Promise<AgentRecord | null> {
-    const agent = this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    const agent =
+      this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
     if (!agent) {
       return null;
     }
@@ -2638,7 +2683,9 @@ export class AgentEngine {
     );
   }
 
-  private async logUnboundSurfaceCleanupWarning(message: string): Promise<void> {
+  private async logUnboundSurfaceCleanupWarning(
+    message: string,
+  ): Promise<void> {
     try {
       await this.client.log(message, {
         level: "warning",
@@ -2696,8 +2743,7 @@ export class AgentEngine {
           surface.observerEpoch,
           "crash recovery",
         );
-        const resumeWorkspace =
-          surface.actual_workspace ?? surface.workspace;
+        const resumeWorkspace = surface.actual_workspace ?? surface.workspace;
         await this.beforeCrashRecoveryMutation?.({
           phase: "resume",
           agent_id: agent.agent_id,
@@ -2769,9 +2815,7 @@ export class AgentEngine {
   }
 
   private compactSidebarValue(value: string | null | undefined): string {
-    const normalized = (value ?? "")
-      .replace(/\s+/g, " ")
-      .trim();
+    const normalized = (value ?? "").replace(/\s+/g, " ").trim();
     if (!normalized) return "-";
     return normalized.length > 160
       ? `${normalized.slice(0, 157).trimEnd()}...`
@@ -3086,7 +3130,9 @@ export class AgentEngine {
    * Sync sidebar: diff agents against snapshot, push only changes.
    * Logs lifecycle events (spawned, done, error) once each.
    */
-  private async syncSidebar(opts: { firstConnect?: boolean } = {}): Promise<void> {
+  private async syncSidebar(
+    opts: { firstConnect?: boolean } = {},
+  ): Promise<void> {
     const agents = this.registry.list();
     const total = agents.length;
     const done = agents.filter((a) => a.state === "done").length;
@@ -3154,10 +3200,7 @@ export class AgentEngine {
       const observedSurfaceUuid =
         surfaceTopology?.surfaceIdByRef.get(surfaceBinding.surfaceRef) ?? null;
       if (
-        !this.registry.canUseObservedBinding(
-          registryAgent,
-          observedSurfaceUuid,
-        )
+        !this.registry.canUseObservedBinding(registryAgent, observedSurfaceUuid)
       ) {
         // A live ref without compatible provenance cannot publish, read, or
         // mutate this row. Preserve it for its owning observer.
@@ -3185,10 +3228,7 @@ export class AgentEngine {
         bindingPatch.workspace_id = surfaceBinding.workspaceId;
       }
       const observerId = this.registry.getObserverId();
-      if (
-        observerId &&
-        originalAgent.surface_observer_id !== observerId
-      ) {
+      if (observerId && originalAgent.surface_observer_id !== observerId) {
         bindingPatch.surface_observer_id = observerId;
       }
       if (Object.keys(bindingPatch).length > 0) {
@@ -3277,8 +3317,8 @@ export class AgentEngine {
             const owners = new Set(ownerSeats);
             return readMonitorRegistry({
               registryPath: this.monitorRegistryPath,
-            }).monitors
-              .filter(
+            })
+              .monitors.filter(
                 (monitor) =>
                   monitor.state === "collapsed" &&
                   owners.has(monitor.owner_seat),
@@ -3496,25 +3536,15 @@ export class AgentEngine {
             if (agent.spawn_depth === 0) {
               // Root agent: send /compact
               const compactRoute = await this.resolveAgentIoRoute(agentId);
-              await this.client.send(
-                compactRoute.surface_id,
-                "/compact",
-                {
-                  workspace: compactRoute.workspace_id ?? undefined,
-                  ...this.stableSurfaceWriteOptions(
-                    compactRoute.surface_uuid,
-                  ),
-                },
-              );
+              await this.client.send(compactRoute.surface_id, "/compact", {
+                workspace: compactRoute.workspace_id ?? undefined,
+                ...this.stableSurfaceWriteOptions(compactRoute.surface_uuid),
+              });
               const returnRoute = await this.resolveAgentIoRoute(agentId);
-              await this.client.sendKey(
-                returnRoute.surface_id,
-                "return",
-                {
-                  workspace: returnRoute.workspace_id ?? undefined,
-                  ...this.stableSurfaceWriteOptions(returnRoute.surface_uuid),
-                },
-              );
+              await this.client.sendKey(returnRoute.surface_id, "return", {
+                workspace: returnRoute.workspace_id ?? undefined,
+                ...this.stableSurfaceWriteOptions(returnRoute.surface_uuid),
+              });
             } else {
               await this.client.log(
                 `context-limit: depth ${agent.spawn_depth} agent ${agent.repo} degraded; leaving pane running for orchestrator decision`,
@@ -3593,16 +3623,15 @@ export class AgentEngine {
         : {}),
       workingNoProgressTimeoutMs: this.fleetWorkingNoProgressTimeoutMs,
     });
-    const publicationState =
-      !topologyIsAuthoritative
-        ? "unknown"
-        : snapshot.seatCount > 0
-          ? "populated"
-          : fleetCandidates.length > 0
+    const publicationState = !topologyIsAuthoritative
+      ? "unknown"
+      : snapshot.seatCount > 0
+        ? "populated"
+        : fleetCandidates.length > 0
+          ? "unknown"
+          : opts.firstConnect
             ? "unknown"
-            : opts.firstConnect
-              ? "unknown"
-              : "empty";
+            : "empty";
     try {
       this.fleetSidebarPublisher.publish({
         state: publicationState,
@@ -4084,9 +4113,7 @@ export class AgentEngine {
     }
   }
 
-  private markIntentionalSurfaceCloses(
-    events: CloseForensicsEvent[],
-  ): void {
+  private markIntentionalSurfaceCloses(events: CloseForensicsEvent[]): void {
     const closedSurfaceUuids = new Set(
       events
         .filter(
@@ -4946,7 +4973,9 @@ export class AgentEngine {
             ...(workspaceId ? { workspace: workspaceId } : {}),
             pane: pane.ref,
           });
-          if (paneSurfaces.surfaces.some((surface) => surface.ref === surfaceId)) {
+          if (
+            paneSurfaces.surfaces.some((surface) => surface.ref === surfaceId)
+          ) {
             return paneSurfaces.pane_ref || pane.ref;
           }
         } catch {
@@ -5000,9 +5029,7 @@ export class AgentEngine {
       if (!this.isSurfaceObserverEpochCurrent(observerEpoch)) {
         return failClosedPolicy;
       }
-      const paneSurfaceRefs = panes.panes.flatMap(
-        (pane) => pane.surface_refs,
-      );
+      const paneSurfaceRefs = panes.panes.flatMap((pane) => pane.surface_refs);
       const paneSurfaceRefSet = new Set(paneSurfaceRefs);
       const observationIsComplete =
         (surfaceObservation.coverage === "ref" ||
@@ -5074,9 +5101,9 @@ export class AgentEngine {
     );
   }
 
-  private stableSurfaceWriteOptions(
-    surfaceUuid: string | null | undefined,
-  ): { stableSurfaceIdentity?: string } {
+  private stableSurfaceWriteOptions(surfaceUuid: string | null | undefined): {
+    stableSurfaceIdentity?: string;
+  } {
     return this.registry.isObserverOwnershipEnforced() && surfaceUuid
       ? { stableSurfaceIdentity: surfaceUuid }
       : {};
@@ -5153,10 +5180,7 @@ export class AgentEngine {
         agent.pid !== null &&
         agent.pid !== undefined &&
         this.processLiveness(agent.pid) === "gone";
-      if (
-        !this.isTerminalDeadRegistryGhost(agent) &&
-        !processGone
-      ) {
+      if (!this.isTerminalDeadRegistryGhost(agent) && !processGone) {
         continue;
       }
 
@@ -5422,7 +5446,8 @@ export class AgentEngine {
         closeRoute.surface_id,
         closeRoute.workspace_id,
       );
-      let confirmedCloseRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+      let confirmedCloseRoute =
+        await this.resolveAgentIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(closeRoute, confirmedCloseRoute)) {
         closeRoute = confirmedCloseRoute;
         stopClosePolicy = await this.resolveStopSurfaceClosePolicy(
@@ -5545,11 +5570,7 @@ export class AgentEngine {
     const route = await this.resolveAgentIoRoute(agentId);
     const workspace = route.workspace_id ?? undefined;
     const assertSurfaceBindingCurrent = async (): Promise<void> => {
-      await this.resolveUnchangedAgentIoRoute(
-        agentId,
-        route,
-        "agent send",
-      );
+      await this.resolveUnchangedAgentIoRoute(agentId, route, "agent send");
     };
     await this.client.send(route.surface_id, sanitizeTerminalInput(text), {
       workspace,
@@ -5558,11 +5579,7 @@ export class AgentEngine {
     });
     if (pressEnter) {
       try {
-        await this.resolveUnchangedAgentIoRoute(
-          agentId,
-          route,
-          "Return",
-        );
+        await this.resolveUnchangedAgentIoRoute(agentId, route, "Return");
       } catch (error) {
         throw new Error(
           `Agent "${agentId}" surface route changed before Return; refusing ` +

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
+import { makeSelfRegistrationSessionResolver } from "./self-registration.js";
 import type { AgentRoute } from "./agent-types.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
@@ -227,10 +228,14 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
               this.client.listPaneSurfaces({ workspace: ref, pane: pane.ref }),
             ),
           );
-          const groups = partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
-            workspace_ref: panes.workspace_ref ?? ref,
-            window_ref: panes.window_ref,
-          });
+          const groups = partitionPaneSurfacesByMembership(
+            panes.panes,
+            rawGroups,
+            {
+              workspace_ref: panes.workspace_ref ?? ref,
+              window_ref: panes.window_ref,
+            },
+          );
           assertCompletePaneSurfaceEnumeration(panes.panes, groups, ref);
           return groups;
         }),
@@ -283,11 +288,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         setProgress: async () => {},
         clearProgress: async () => {},
         newSplit: (direction, splitOpts) => {
-          const {
-            beforeMutation,
-            stableSurfaceIdentity,
-            ...clientOpts
-          } = splitOpts ?? {};
+          const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+            splitOpts ?? {};
           return this.runWorkspaceMutation(
             "new_split",
             splitOpts?.workspace,
@@ -323,11 +325,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         listPaneSurfaces: (surfaceOpts) =>
           this.client.listPaneSurfaces(surfaceOpts),
         closeSurface: (surface, closeOpts) => {
-          const {
-            beforeMutation,
-            stableSurfaceIdentity,
-            ...clientOpts
-          } = closeOpts ?? {};
+          const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+            closeOpts ?? {};
           return this.runWorkspaceMutation(
             "close_surface",
             closeOpts?.workspace,
@@ -344,11 +343,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
           );
         },
         moveSurface: (moveOpts) => {
-          const {
-            beforeMutation,
-            stableSurfaceIdentity,
-            ...clientOpts
-          } = moveOpts;
+          const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+            moveOpts;
           return this.runWorkspaceMutation(
             "move_surface",
             moveOpts.workspace,
@@ -381,6 +377,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
         monitorRegistryPath: defaultMonitorRegistryPath(),
         monitorRegistryNotify: httpNotifyMonitorDeadman,
+        selfRegistrationSessionResolver: makeSelfRegistrationSessionResolver(),
         closeForensicsRunner: createDefaultCloseForensicsRunner({
           stateMgr: this.stateMgr,
           listSurfacesForRefMap: surfaceProvider,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -521,6 +521,7 @@ export class CmuxLayerDaemon {
           spawnPreflight: this.opts.spawnPreflight,
           disableSpawnPreflight: this.opts.disableSpawnPreflight,
           selfRegistrationSessionResolver:
+            this.opts.selfRegistrationSessionResolver ??
             makeSelfRegistrationSessionResolver(),
           surfaceObserverOwnerIdProvider:
             this.opts.surfaceObserverOwnerIdProvider,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18,6 +18,7 @@ import {
   type CreateCmuxClientOptions,
 } from "./cmux-client-factory.js";
 import { createServer, createServerContext } from "./server.js";
+import { makeSelfRegistrationSessionResolver } from "./self-registration.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
 import {
   defaultMonitorRegistryPath,
@@ -519,10 +520,11 @@ export class CmuxLayerDaemon {
           enableClaudeChannels: this.opts.enableClaudeChannels,
           spawnPreflight: this.opts.spawnPreflight,
           disableSpawnPreflight: this.opts.disableSpawnPreflight,
+          selfRegistrationSessionResolver:
+            makeSelfRegistrationSessionResolver(),
           surfaceObserverOwnerIdProvider:
             this.opts.surfaceObserverOwnerIdProvider,
-          surfaceObserverEpochProvider:
-            this.opts.surfaceObserverEpochProvider,
+          surfaceObserverEpochProvider: this.opts.surfaceObserverEpochProvider,
         });
         return this.context;
       })();

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -8,10 +8,7 @@ import {
   type CmuxLayerProxyOptions,
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
-import {
-  spawnDaemonProcess,
-  type SpawnDaemonOptions,
-} from "./daemon-spawn.js";
+import { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
@@ -138,6 +135,7 @@ export async function startInProcessRuntime(
     { defaultMonitorRegistryPath, httpNotifyMonitorDeadman },
     { ensureNodeMaxOldSpaceEnv, installHeapGuard },
     { FleetSidebarPublisher },
+    { makeSelfRegistrationSessionResolver },
   ] = await Promise.all([
     import("@modelcontextprotocol/sdk/server/stdio.js"),
     import("./stdio-lifecycle.js"),
@@ -147,6 +145,7 @@ export async function startInProcessRuntime(
     import("./monitor-registry.js"),
     import("./heap-guard.js"),
     import("./fleet-sidebar.js"),
+    import("./self-registration.js"),
   ]);
 
   ensureNodeMaxOldSpaceEnv();
@@ -158,6 +157,7 @@ export async function startInProcessRuntime(
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,
     enableCloseForensics: true,
+    selfRegistrationSessionResolver: makeSelfRegistrationSessionResolver(),
     fleetSidebarPublisher: new FleetSidebarPublisher(),
     defaultPalette: opts.env?.CMUXLAYER_DEFAULT_PALETTE,
     ...(opts.fallbackWarnings

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -105,6 +105,10 @@ function surfaceUuidKey(value: string | null | undefined): string | null {
   return value?.trim().toLowerCase() || null;
 }
 
+function cliKey(value: string | null | undefined): string | null {
+  return value?.trim().toLowerCase() || null;
+}
+
 /**
  * Parse JSONL registry text into entries. Malformed lines and records missing
  * the required `session_id`/`surface_uuid` are skipped; unknown fields are
@@ -328,8 +332,10 @@ function makeIncrementalEntryIndexReader(
  * repaired records deliberately skip that lower bound because their
  * `created_at` is discovery time, not launch time. All candidates are bounded
  * against the reader clock so a row from before a backward clock correction
- * cannot dominate. AgentRecord pid is deliberately ignored because production
- * does not populate it with the CLI process pid. Returns
+ * cannot dominate. A row with explicit `cli` metadata must match the agent;
+ * missing CLI remains compatible with older writers. AgentRecord pid is
+ * deliberately ignored because production does not populate it with the CLI
+ * process pid. Returns
  * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
  * missing/unreadable/empty registry, an agent without a stable surface UUID, or
  * no UUID match all return `null` (the caller then falls back to the scan).
@@ -365,6 +371,7 @@ export function makeSelfRegistrationSessionResolver(
   return (agent: AgentRecord): CapturedSessionIdentity | null => {
     const agentSurfaceUuid = surfaceUuidKey(agent.surface_uuid);
     if (!agentSurfaceUuid) return null;
+    const agentCli = cliKey(agent.cli);
     const launchCwd = agent.launch_cwd?.trim() || null;
     const createdAt = Date.parse(agent.created_at);
     if (Number.isNaN(createdAt)) return null;
@@ -379,6 +386,7 @@ export function makeSelfRegistrationSessionResolver(
 
     const candidates = (readCandidates(agentSurfaceUuid) ?? []).filter(
       (entry) =>
+        (entry.cli === null || cliKey(entry.cli) === agentCli) &&
         entry.ts !== null &&
         entry.ts >= earliestCurrentLaunchTs &&
         entry.ts <= latestPlausibleTs,

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -252,6 +252,11 @@ function chooseCandidate(
 
 type SurfaceEntryIndex = Map<string, SelfRegistrationEntry[]>;
 
+/** Exclude rows that can never resolve before they consume bounded index state. */
+function isIndexableRegistrationEntry(entry: SelfRegistrationEntry): boolean {
+  return entry.ts !== null;
+}
+
 /**
  * Index one registration while bounding both history dimensions. Map insertion
  * order tracks the most recently appended row for each surface, so exceeding
@@ -422,6 +427,7 @@ function makeIncrementalEntryIndexReader(
           SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
         pendingLine = boundPendingRegistrationLine(trailingLine);
         for (const entry of parseSelfRegistrationBufferLines(completeLines)) {
+          if (!isIndexableRegistrationEntry(entry)) continue;
           const key = surfaceUuidKey(entry.surface_uuid);
           if (!key) continue;
           indexSurfaceCandidate(entriesBySurface, key, entry);

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -33,6 +33,8 @@ import type {
 
 const SESSION_REGISTRATION_TIMESTAMP_SKEW_MS = 5_000;
 const SESSION_REGISTRATION_CONTINUITY_BYTES = 64;
+export const SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES = 64 * 1024;
+export const SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE = 64;
 
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
@@ -117,9 +119,30 @@ export function copyBufferTail(
   const boundedMaxBytes =
     Number.isSafeInteger(maxBytes) && maxBytes > 0 ? maxBytes : 0;
   const length = Math.min(source.byteLength, boundedMaxBytes);
-  const copy = Buffer.allocUnsafe(length);
+  const copy = Buffer.allocUnsafeSlow(length);
   source.copy(copy, 0, source.byteLength - length);
   return copy;
+}
+
+/** Retain a partial JSONL row only while it remains within the record cap. */
+export function boundPendingRegistrationLine(
+  source: Buffer,
+): Buffer<ArrayBuffer> {
+  if (source.byteLength > SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES) {
+    return Buffer.alloc(0);
+  }
+  return copyBufferTail(source, source.byteLength);
+}
+
+/** Keep only the recent per-surface history needed for bounded selection. */
+export function appendBoundedSurfaceCandidate(
+  candidates: SelfRegistrationEntry[],
+  entry: SelfRegistrationEntry,
+): void {
+  candidates.push(entry);
+  const excess =
+    candidates.length - SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE;
+  if (excess > 0) candidates.splice(0, excess);
 }
 
 /**
@@ -314,18 +337,20 @@ function makeIncrementalEntryIndexReader(
       const finalNewline = combined.lastIndexOf(0x0a);
       if (finalNewline >= 0) {
         const completeLines = combined.subarray(0, finalNewline + 1);
-        pendingLine = Buffer.from(combined.subarray(finalNewline + 1));
+        pendingLine = boundPendingRegistrationLine(
+          combined.subarray(finalNewline + 1),
+        );
         for (const entry of parseSelfRegistrationLines(
           completeLines.toString("utf8"),
         )) {
           const key = surfaceUuidKey(entry.surface_uuid);
           if (!key) continue;
           const existing = entriesBySurface.get(key);
-          if (existing) existing.push(entry);
+          if (existing) appendBoundedSurfaceCandidate(existing, entry);
           else entriesBySurface.set(key, [entry]);
         }
       } else {
-        pendingLine = combined;
+        pendingLine = boundPendingRegistrationLine(combined);
       }
     }
     observedMtimeMs = fileStat.mtimeMs;

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -35,6 +35,7 @@ const SESSION_REGISTRATION_TIMESTAMP_SKEW_MS = 5_000;
 const SESSION_REGISTRATION_CONTINUITY_BYTES = 64;
 export const SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES = 64 * 1024;
 export const SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE = 64;
+export const SESSION_REGISTRATION_MAX_INDEXED_SURFACES = 1_024;
 
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
@@ -217,6 +218,35 @@ function chooseCandidate(
 type SurfaceEntryIndex = Map<string, SelfRegistrationEntry[]>;
 
 /**
+ * Index one registration while bounding both history dimensions. Map insertion
+ * order tracks the most recently appended row for each surface, so exceeding
+ * the key cap evicts the least-recent historical surface rather than a surface
+ * that has just re-registered.
+ */
+function indexSurfaceCandidate(
+  entriesBySurface: SurfaceEntryIndex,
+  key: string,
+  entry: SelfRegistrationEntry,
+): void {
+  const existing = entriesBySurface.get(key);
+  if (existing) {
+    appendBoundedSurfaceCandidate(existing, entry);
+    entriesBySurface.delete(key);
+    entriesBySurface.set(key, existing);
+  } else {
+    entriesBySurface.set(key, [entry]);
+  }
+
+  while (
+    entriesBySurface.size > SESSION_REGISTRATION_MAX_INDEXED_SURFACES
+  ) {
+    const leastRecentKey = entriesBySurface.keys().next().value;
+    if (leastRecentKey === undefined) break;
+    entriesBySurface.delete(leastRecentKey);
+  }
+}
+
+/**
  * Build an append-aware registry index for production lookups.
  *
  * Each call stats the file, but unchanged files perform no read or parse. New
@@ -361,9 +391,7 @@ function makeIncrementalEntryIndexReader(
         )) {
           const key = surfaceUuidKey(entry.surface_uuid);
           if (!key) continue;
-          const existing = entriesBySurface.get(key);
-          if (existing) appendBoundedSurfaceCandidate(existing, entry);
-          else entriesBySurface.set(key, [entry]);
+          indexSurfaceCandidate(entriesBySurface, key, entry);
         }
       } else {
         discardingOversizedLine =

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -31,7 +31,7 @@ import type {
   SessionIdentityResolver,
 } from "./agent-engine.js";
 
-const SESSION_REGISTRATION_CREATION_SKEW_MS = 5_000;
+const SESSION_REGISTRATION_TIMESTAMP_SKEW_MS = 5_000;
 
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
@@ -62,6 +62,8 @@ export interface SelfRegistrationResolverOptions {
    * Injected in tests so no real HOME I/O is touched.
    */
   readFile?: (path: string) => string | null;
+  /** Injectable wall clock for future-timestamp rejection (default Date.now). */
+  now?: () => number;
 }
 
 /** Resolve the registry path from env, defaulting under `$HOME/.cmuxlayer`. */
@@ -161,12 +163,13 @@ function chooseCandidate(
  *
  * Match is stable-surface UUID PRIMARY
  * (`entry.surface_uuid === agent.surface_uuid`). Exact launch_cwd is only an
- * optional secondary validator, then newest `ts` decides. Candidates must also
- * be timestamped within the current agent-creation window, preventing an
- * append-only record from a previous process on the same surface from being
- * finalized during the short interval before the new hook appends. AgentRecord
- * pid is deliberately ignored because production does not populate it with the
- * CLI process pid. Returns
+ * optional secondary validator, then newest `ts` decides. Candidates must be
+ * newer than the current agent-creation window and no farther in the future
+ * than the allowed reader-clock skew. Those bounds prevent an append-only row
+ * from a previous process (or from before a backward clock correction) from
+ * being finalized before the new hook appends. AgentRecord pid is deliberately
+ * ignored because production does not populate it with the CLI process pid.
+ * Returns
  * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
  * missing/unreadable/empty registry, an agent without a stable surface UUID, or
  * no UUID match all return `null` (the caller then falls back to the scan).
@@ -176,6 +179,7 @@ export function makeSelfRegistrationSessionResolver(
 ): SessionIdentityResolver {
   const registryPath = options.registryPath ?? resolveSessionRegistryPath();
   const readFile = options.readFile ?? defaultReadFile;
+  const now = options.now ?? Date.now;
 
   return (agent: AgentRecord): CapturedSessionIdentity | null => {
     const agentSurfaceUuid = surfaceUuidKey(agent.surface_uuid);
@@ -184,7 +188,11 @@ export function makeSelfRegistrationSessionResolver(
     const createdAt = Date.parse(agent.created_at);
     if (Number.isNaN(createdAt)) return null;
     const earliestCurrentLaunchTs =
-      createdAt - SESSION_REGISTRATION_CREATION_SKEW_MS;
+      createdAt - SESSION_REGISTRATION_TIMESTAMP_SKEW_MS;
+    const resolvedAt = now();
+    if (!Number.isSafeInteger(resolvedAt)) return null;
+    const latestPlausibleTs =
+      resolvedAt + SESSION_REGISTRATION_TIMESTAMP_SKEW_MS;
 
     let text: string | null;
     try {
@@ -198,7 +206,8 @@ export function makeSelfRegistrationSessionResolver(
       (entry) =>
         surfaceUuidKey(entry.surface_uuid) === agentSurfaceUuid &&
         entry.ts !== null &&
-        entry.ts >= earliestCurrentLaunchTs,
+        entry.ts >= earliestCurrentLaunchTs &&
+        entry.ts <= latestPlausibleTs,
     );
     const chosen = chooseCandidate(candidates, launchCwd);
     if (!chosen) return null;

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -109,6 +109,19 @@ function cliKey(value: string | null | undefined): string | null {
   return value?.trim().toLowerCase() || null;
 }
 
+/** Copy a bounded tail without retaining the source Buffer's backing store. */
+export function copyBufferTail(
+  source: Buffer,
+  maxBytes: number,
+): Buffer<ArrayBuffer> {
+  const boundedMaxBytes =
+    Number.isSafeInteger(maxBytes) && maxBytes > 0 ? maxBytes : 0;
+  const length = Math.min(source.byteLength, boundedMaxBytes);
+  const copy = Buffer.allocUnsafe(length);
+  source.copy(copy, 0, source.byteLength - length);
+  return copy;
+}
+
 /**
  * Parse JSONL registry text into entries. Malformed lines and records missing
  * the required `session_id`/`surface_uuid` are skipped; unknown fields are
@@ -293,17 +306,15 @@ function makeIncrementalEntryIndexReader(
 
       consumedBytes = fileStat.size;
       const continuitySource = Buffer.concat([continuityTail, appended]);
-      continuityTail = continuitySource.subarray(
-        Math.max(
-          0,
-          continuitySource.byteLength - SESSION_REGISTRATION_CONTINUITY_BYTES,
-        ),
+      continuityTail = copyBufferTail(
+        continuitySource,
+        SESSION_REGISTRATION_CONTINUITY_BYTES,
       );
       const combined = Buffer.concat([pendingLine, appended]);
       const finalNewline = combined.lastIndexOf(0x0a);
       if (finalNewline >= 0) {
         const completeLines = combined.subarray(0, finalNewline + 1);
-        pendingLine = combined.subarray(finalNewline + 1);
+        pendingLine = Buffer.from(combined.subarray(finalNewline + 1));
         for (const entry of parseSelfRegistrationLines(
           completeLines.toString("utf8"),
         )) {

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -156,6 +156,12 @@ export function parseSelfRegistrationLines(
 ): SelfRegistrationEntry[] {
   const entries: SelfRegistrationEntry[] = [];
   for (const rawLine of text.split("\n")) {
+    if (
+      Buffer.byteLength(rawLine, "utf8") >
+      SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES
+    ) {
+      continue;
+    }
     const line = rawLine.trim();
     if (!line) continue;
     let parsed: unknown;
@@ -185,6 +191,35 @@ export function parseSelfRegistrationLines(
       session_path: toStringOrNull(rec.session_path),
       ts: toIntegerOrNull(rec.ts),
     });
+  }
+  return entries;
+}
+
+/**
+ * Parse complete JSONL rows without decoding a row that exceeds the byte cap.
+ * The production incremental reader calls this only with newline-complete
+ * bytes; handling a final unterminated slice keeps the helper safe in isolation.
+ */
+function parseSelfRegistrationBufferLines(
+  source: Buffer,
+): SelfRegistrationEntry[] {
+  const entries: SelfRegistrationEntry[] = [];
+  let lineStart = 0;
+  while (lineStart < source.byteLength) {
+    const newline = source.indexOf(0x0a, lineStart);
+    const lineEnd = newline >= 0 ? newline : source.byteLength;
+    if (
+      lineEnd - lineStart <=
+      SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES
+    ) {
+      entries.push(
+        ...parseSelfRegistrationLines(
+          source.subarray(lineStart, lineEnd).toString("utf8"),
+        ),
+      );
+    }
+    if (newline < 0) break;
+    lineStart = newline + 1;
   }
   return entries;
 }
@@ -386,9 +421,7 @@ function makeIncrementalEntryIndexReader(
           trailingLine.byteLength >
           SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
         pendingLine = boundPendingRegistrationLine(trailingLine);
-        for (const entry of parseSelfRegistrationLines(
-          completeLines.toString("utf8"),
-        )) {
+        for (const entry of parseSelfRegistrationBufferLines(completeLines)) {
           const key = surfaceUuidKey(entry.surface_uuid);
           if (!key) continue;
           indexSurfaceCandidate(entriesBySurface, key, entry);

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -239,6 +239,7 @@ function makeIncrementalEntryIndexReader(
   let consumedBytes = 0;
   let observedMtimeMs = Number.NEGATIVE_INFINITY;
   let pendingLine = Buffer.alloc(0);
+  let discardingOversizedLine = false;
   let continuityTail = Buffer.alloc(0);
   let entriesBySurface: SurfaceEntryIndex = new Map();
 
@@ -246,6 +247,7 @@ function makeIncrementalEntryIndexReader(
     consumedBytes = 0;
     observedMtimeMs = Number.NEGATIVE_INFINITY;
     pendingLine = Buffer.alloc(0);
+    discardingOversizedLine = false;
     continuityTail = Buffer.alloc(0);
     entriesBySurface = new Map();
   };
@@ -333,13 +335,27 @@ function makeIncrementalEntryIndexReader(
         continuitySource,
         SESSION_REGISTRATION_CONTINUITY_BYTES,
       );
-      const combined = Buffer.concat([pendingLine, appended]);
+      let parseableAppended = appended;
+      if (discardingOversizedLine) {
+        const discardedLineEnd = parseableAppended.indexOf(0x0a);
+        if (discardedLineEnd < 0) {
+          parseableAppended = Buffer.alloc(0);
+        } else {
+          discardingOversizedLine = false;
+          parseableAppended = parseableAppended.subarray(
+            discardedLineEnd + 1,
+          );
+        }
+      }
+      const combined = Buffer.concat([pendingLine, parseableAppended]);
       const finalNewline = combined.lastIndexOf(0x0a);
       if (finalNewline >= 0) {
         const completeLines = combined.subarray(0, finalNewline + 1);
-        pendingLine = boundPendingRegistrationLine(
-          combined.subarray(finalNewline + 1),
-        );
+        const trailingLine = combined.subarray(finalNewline + 1);
+        discardingOversizedLine =
+          trailingLine.byteLength >
+          SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
+        pendingLine = boundPendingRegistrationLine(trailingLine);
         for (const entry of parseSelfRegistrationLines(
           completeLines.toString("utf8"),
         )) {
@@ -350,6 +366,9 @@ function makeIncrementalEntryIndexReader(
           else entriesBySurface.set(key, [entry]);
         }
       } else {
+        discardingOversizedLine =
+          discardingOversizedLine ||
+          combined.byteLength > SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
         pendingLine = boundPendingRegistrationLine(combined);
       }
     }

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -1,0 +1,188 @@
+/**
+ * Session-ID self-registration — cmuxlayer READ side (P0 root fix).
+ *
+ * Agents SELF-REGISTER their real session id at boot: a Claude SessionStart hook
+ * (or a Codex launcher wrapper) appends one JSON object per line to an
+ * append-only registry file. cmuxlayer READS that file instead of scanning
+ * `~/.claude`/`~/.codex` transcript dirs and inferring identity by cwd+recency —
+ * the fragile mechanism that breaks with raw spawns, worktrees, and
+ * many-agents-per-repo (25/25 agents `session_id:null`).
+ *
+ * The resolver here is the PRIMARY `SessionIdentityResolver`; the old transcript
+ * scan (`findLatestHarnessSessionIdentity`) is kept only as a deprecated
+ * last-resort fallback for hook-less agents, reached when this returns null.
+ *
+ * Registry contract (written by the boot hook / launcher wrapper; verified live):
+ *   {"session_id":"<id>","cwd":"<abs worktree cwd>","pid":<agent pid,int>,
+ *    "cli":"claude|codex","launcher":"<e.g. cmuxlayerCodex>",
+ *    "session_path":"<optional rollout path>","ts":<epoch MILLISECONDS,int>}
+ * Path: ${CMUXLAYER_SESSION_REGISTRY:-$HOME/.cmuxlayer/session-registry.jsonl}.
+ * Tolerant reader: skip malformed lines, ignore unknown extra fields, require
+ * only session_id + cwd to bind, never fabricate an id.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentRecord } from "./agent-types.js";
+import type {
+  CapturedSessionIdentity,
+  SessionIdentityResolver,
+} from "./agent-engine.js";
+
+/** A single self-registration record, after tolerant parsing. */
+export interface SelfRegistrationEntry {
+  session_id: string;
+  cwd: string;
+  /** Agent CLI process pid (getppid past the shell wrapper). May be absent. */
+  pid: number | null;
+  cli: string | null;
+  launcher: string | null;
+  /** Optional rollout/transcript path; returned as the resolved `path`. */
+  session_path: string | null;
+  /** Epoch MILLISECONDS. Sorted descending; missing sorts oldest. */
+  ts: number | null;
+}
+
+export interface SelfRegistrationResolverOptions {
+  /**
+   * Registry file path. Defaults to
+   * `${CMUXLAYER_SESSION_REGISTRY:-$HOME/.cmuxlayer/session-registry.jsonl}`.
+   */
+  registryPath?: string;
+  /**
+   * Injectable reader (default `fs.readFileSync` utf8). Returns the file body,
+   * `null` for a missing/unreadable file, or throws (also treated as null).
+   * Injected in tests so no real HOME I/O is touched.
+   */
+  readFile?: (path: string) => string | null;
+}
+
+/** Resolve the registry path from env, defaulting under `$HOME/.cmuxlayer`. */
+export function resolveSessionRegistryPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_SESSION_REGISTRY?.trim();
+  if (override) return override;
+  return join(homedir(), ".cmuxlayer", "session-registry.jsonl");
+}
+
+function toFiniteInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Parse JSONL registry text into entries. Malformed lines and records missing
+ * the required `session_id`/`cwd` are skipped; unknown fields are ignored.
+ */
+export function parseSelfRegistrationLines(
+  text: string,
+): SelfRegistrationEntry[] {
+  const entries: SelfRegistrationEntry[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue; // malformed line — skip
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      continue;
+    }
+    const rec = parsed as Record<string, unknown>;
+    const session_id =
+      typeof rec.session_id === "string" ? rec.session_id.trim() : "";
+    const cwd = typeof rec.cwd === "string" ? rec.cwd : "";
+    if (!session_id || !cwd) continue; // require session_id + cwd to bind
+    entries.push({
+      session_id,
+      cwd,
+      pid: toFiniteInt(rec.pid),
+      cli: toStringOrNull(rec.cli),
+      launcher: toStringOrNull(rec.launcher),
+      session_path: toStringOrNull(rec.session_path),
+      ts: toFiniteInt(rec.ts),
+    });
+  }
+  return entries;
+}
+
+/**
+ * Choose the winning entry among same-cwd candidates.
+ *
+ * pid is a SECONDARY tiebreaker: if the agent's pid is known AND some candidate
+ * shares it, restrict to those; otherwise the whole cwd-matched pool competes.
+ * The winner is the newest `ts` (epoch ms); on an exact tie the later (appended
+ * last) record wins. Note: cmuxlayer's AgentRecord.pid is currently never
+ * populated in production (always null), so in practice this reduces to
+ * newest-ts-among-same-cwd — cwd-exact already carries the worktree case.
+ */
+function chooseCandidate(
+  candidates: SelfRegistrationEntry[],
+  agentPid: number | null | undefined,
+): SelfRegistrationEntry | null {
+  if (candidates.length === 0) return null;
+  let pool = candidates;
+  if (agentPid != null) {
+    const pidMatches = candidates.filter((e) => e.pid === agentPid);
+    if (pidMatches.length > 0) pool = pidMatches;
+  }
+  return pool.reduce((best, entry) => {
+    const bestTs = best.ts ?? Number.NEGATIVE_INFINITY;
+    const entryTs = entry.ts ?? Number.NEGATIVE_INFINITY;
+    return entryTs >= bestTs ? entry : best;
+  });
+}
+
+/**
+ * Build the self-registration `SessionIdentityResolver`.
+ *
+ * Match is cwd-exact PRIMARY (`entry.cwd === agent.launch_cwd`, worktree-precise)
+ * with pid as a secondary tiebreaker and newest `ts` deciding. Returns
+ * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
+ * missing/unreadable/empty registry, an agent without a launch_cwd, or no
+ * cwd match all return `null` (the caller then falls back to the scan).
+ */
+export function makeSelfRegistrationSessionResolver(
+  options: SelfRegistrationResolverOptions = {},
+): SessionIdentityResolver {
+  const registryPath = options.registryPath ?? resolveSessionRegistryPath();
+  const readFile = options.readFile ?? defaultReadFile;
+
+  return (agent: AgentRecord): CapturedSessionIdentity | null => {
+    const launchCwd = agent.launch_cwd?.trim();
+    if (!launchCwd) return null; // no cwd key → cannot bind
+
+    let text: string | null;
+    try {
+      text = readFile(registryPath);
+    } catch {
+      return null; // missing/unreadable → fall back to scan
+    }
+    if (!text) return null;
+
+    const candidates = parseSelfRegistrationLines(text).filter(
+      (entry) => entry.cwd === launchCwd,
+    );
+    const chosen = chooseCandidate(candidates, agent.pid);
+    if (!chosen) return null;
+    return {
+      session_id: chosen.session_id,
+      path: chosen.session_path ?? null,
+    };
+  };
+}
+
+function defaultReadFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -32,6 +32,7 @@ import type {
 } from "./agent-engine.js";
 
 const SESSION_REGISTRATION_TIMESTAMP_SKEW_MS = 5_000;
+const SESSION_REGISTRATION_CONTINUITY_BYTES = 64;
 
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
@@ -180,9 +181,10 @@ type SurfaceEntryIndex = Map<string, SelfRegistrationEntry[]>;
  *
  * Each call stats the file, but unchanged files perform no read or parse. New
  * bytes are read exactly once and indexed by surface UUID, so a sweep across N
- * uncaptured agents is O(file delta + N), not O(N * registry size). A partial
- * final JSONL row is retained until its newline arrives. Compaction, truncation,
- * or rotation resets the index before the replacement file is consumed.
+ * uncaptured agents is O(bounded continuity check + file delta + N), not
+ * O(N * registry size). A partial final JSONL row is retained until its newline
+ * arrives. Compaction, truncation, rotation, or a failed append-continuity check
+ * resets the index before the replacement file is consumed.
  */
 function makeIncrementalEntryIndexReader(
   registryPath: string,
@@ -197,12 +199,14 @@ function makeIncrementalEntryIndexReader(
   let consumedBytes = 0;
   let observedMtimeMs = Number.NEGATIVE_INFINITY;
   let pendingLine = Buffer.alloc(0);
+  let continuityTail = Buffer.alloc(0);
   let entriesBySurface: SurfaceEntryIndex = new Map();
 
   const reset = () => {
     consumedBytes = 0;
     observedMtimeMs = Number.NEGATIVE_INFINITY;
     pendingLine = Buffer.alloc(0);
+    continuityTail = Buffer.alloc(0);
     entriesBySurface = new Map();
   };
 
@@ -231,6 +235,12 @@ function makeIncrementalEntryIndexReader(
       fileIdentity !== null &&
       fileStat.size === consumedBytes &&
       fileStat.mtimeMs !== observedMtimeMs;
+    const sameFileGrowth =
+      fileIdentity !== null &&
+      !replaced &&
+      fileStat.size > consumedBytes &&
+      consumedBytes > 0 &&
+      continuityTail.byteLength > 0;
     if (
       fileIdentity === null ||
       replaced ||
@@ -242,17 +252,49 @@ function makeIncrementalEntryIndexReader(
     fileIdentity = nextIdentity;
 
     if (fileStat.size > consumedBytes) {
-      const offset = consumedBytes;
+      const continuityLength = sameFileGrowth
+        ? Math.min(continuityTail.byteLength, consumedBytes)
+        : 0;
+      const offset = consumedBytes - continuityLength;
       const length = fileStat.size - offset;
-      let appended: Buffer | null;
+      let readBuffer: Buffer | null;
       try {
-        appended = readFileRange(registryPath, offset, length);
+        readBuffer = readFileRange(registryPath, offset, length);
       } catch {
-        appended = null;
+        readBuffer = null;
       }
-      if (!appended || appended.byteLength !== length) return null;
+      if (!readBuffer || readBuffer.byteLength !== length) return null;
+
+      let appended = readBuffer;
+      if (continuityLength > 0) {
+        const expectedBoundary = continuityTail.subarray(
+          continuityTail.byteLength - continuityLength,
+        );
+        const observedBoundary = readBuffer.subarray(0, continuityLength);
+        if (!observedBoundary.equals(expectedBoundary)) {
+          reset();
+          try {
+            readBuffer = readFileRange(registryPath, 0, fileStat.size);
+          } catch {
+            readBuffer = null;
+          }
+          if (!readBuffer || readBuffer.byteLength !== fileStat.size) {
+            return null;
+          }
+          appended = readBuffer;
+        } else {
+          appended = readBuffer.subarray(continuityLength);
+        }
+      }
 
       consumedBytes = fileStat.size;
+      const continuitySource = Buffer.concat([continuityTail, appended]);
+      continuityTail = continuitySource.subarray(
+        Math.max(
+          0,
+          continuitySource.byteLength - SESSION_REGISTRATION_CONTINUITY_BYTES,
+        ),
+      );
       const combined = Buffer.concat([pendingLine, appended]);
       const finalNewline = combined.lastIndexOf(0x0a);
       if (finalNewline >= 0) {

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -12,13 +12,14 @@
  * scan (`findLatestHarnessSessionIdentity`) is kept only as a deprecated
  * last-resort fallback for hook-less agents, reached when this returns null.
  *
- * Registry contract (written by the boot hook / launcher wrapper; verified live):
- *   {"session_id":"<id>","cwd":"<abs worktree cwd>","pid":<agent pid,int>,
+ * Registry contract (written by the boot hook / launcher wrapper):
+ *   {"session_id":"<id>","surface_uuid":"<CMUX_SURFACE_ID>",
+ *    "cwd":"<abs worktree cwd>","pid":<agent pid,int>,
  *    "cli":"claude|codex","launcher":"<e.g. cmuxlayerCodex>",
  *    "session_path":"<optional rollout path>","ts":<epoch MILLISECONDS,int>}
  * Path: ${CMUXLAYER_SESSION_REGISTRY:-$HOME/.cmuxlayer/session-registry.jsonl}.
  * Tolerant reader: skip malformed lines, ignore unknown extra fields, require
- * only session_id + cwd to bind, never fabricate an id.
+ * session_id + surface_uuid to bind, never fabricate an id.
  */
 
 import { readFileSync } from "node:fs";
@@ -33,7 +34,10 @@ import type {
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
   session_id: string;
-  cwd: string;
+  /** Stable cmux UUID from the pane's injected CMUX_SURFACE_ID. */
+  surface_uuid: string;
+  /** Optional validator for duplicate records from the same surface. */
+  cwd: string | null;
   /** Agent CLI process pid (getppid past the shell wrapper). May be absent. */
   pid: number | null;
   cli: string | null;
@@ -67,17 +71,24 @@ export function resolveSessionRegistryPath(
   return join(homedir(), ".cmuxlayer", "session-registry.jsonl");
 }
 
-function toFiniteInt(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+function toIntegerOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value)
+    ? value
+    : null;
 }
 
 function toStringOrNull(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function surfaceUuidKey(value: string | null | undefined): string | null {
+  return value?.trim().toLowerCase() || null;
+}
+
 /**
  * Parse JSONL registry text into entries. Malformed lines and records missing
- * the required `session_id`/`cwd` are skipped; unknown fields are ignored.
+ * the required `session_id`/`surface_uuid` are skipped; unknown fields are
+ * ignored. `cwd` is optional because raw-seat records do not reliably carry it.
  */
 export function parseSelfRegistrationLines(
   text: string,
@@ -98,41 +109,44 @@ export function parseSelfRegistrationLines(
     const rec = parsed as Record<string, unknown>;
     const session_id =
       typeof rec.session_id === "string" ? rec.session_id.trim() : "";
-    const cwd = typeof rec.cwd === "string" ? rec.cwd : "";
-    if (!session_id || !cwd) continue; // require session_id + cwd to bind
+    const surface_uuid =
+      typeof rec.surface_uuid === "string" ? rec.surface_uuid.trim() : "";
+    const cwd =
+      typeof rec.cwd === "string" && rec.cwd.length > 0 ? rec.cwd : null;
+    if (!session_id || !surface_uuid) continue;
     entries.push({
       session_id,
+      surface_uuid,
       cwd,
-      pid: toFiniteInt(rec.pid),
+      pid: toIntegerOrNull(rec.pid),
       cli: toStringOrNull(rec.cli),
       launcher: toStringOrNull(rec.launcher),
       session_path: toStringOrNull(rec.session_path),
-      ts: toFiniteInt(rec.ts),
+      ts: toIntegerOrNull(rec.ts),
     });
   }
   return entries;
 }
 
 /**
- * Choose the winning entry among same-cwd candidates.
+ * Choose the winning entry among records for one stable surface UUID.
  *
- * pid is a SECONDARY tiebreaker: if the agent's pid is known AND some candidate
- * shares it, restrict to those; otherwise the whole cwd-matched pool competes.
- * The winner is the newest `ts` (epoch ms); on an exact tie the later (appended
- * last) record wins. Note: cmuxlayer's AgentRecord.pid is currently never
- * populated in production (always null), so in practice this reduces to
- * newest-ts-among-same-cwd — cwd-exact already carries the worktree case.
+ * AgentRecord.pid is not a CLI process pid: production record creation,
+ * recovery, repair, and auto-discovery paths all leave it null. It therefore
+ * cannot soundly participate in identity selection. When launch_cwd is known
+ * and at least one candidate matches it exactly, that subset is preferred as
+ * an optional validator. The winner is then the newest `ts` (epoch ms); on an
+ * exact tie the later (last-appended) record wins.
  */
 function chooseCandidate(
   candidates: SelfRegistrationEntry[],
-  agentPid: number | null | undefined,
+  launchCwd: string | null,
 ): SelfRegistrationEntry | null {
   if (candidates.length === 0) return null;
-  let pool = candidates;
-  if (agentPid != null) {
-    const pidMatches = candidates.filter((e) => e.pid === agentPid);
-    if (pidMatches.length > 0) pool = pidMatches;
-  }
+  const cwdMatches = launchCwd
+    ? candidates.filter((entry) => entry.cwd === launchCwd)
+    : [];
+  const pool = cwdMatches.length > 0 ? cwdMatches : candidates;
   return pool.reduce((best, entry) => {
     const bestTs = best.ts ?? Number.NEGATIVE_INFINITY;
     const entryTs = entry.ts ?? Number.NEGATIVE_INFINITY;
@@ -143,11 +157,14 @@ function chooseCandidate(
 /**
  * Build the self-registration `SessionIdentityResolver`.
  *
- * Match is cwd-exact PRIMARY (`entry.cwd === agent.launch_cwd`, worktree-precise)
- * with pid as a secondary tiebreaker and newest `ts` deciding. Returns
+ * Match is stable-surface UUID PRIMARY
+ * (`entry.surface_uuid === agent.surface_uuid`). Exact launch_cwd is only an
+ * optional secondary validator, then newest `ts` decides. AgentRecord.pid is
+ * deliberately ignored because production does not populate it with the CLI
+ * process pid. Returns
  * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
- * missing/unreadable/empty registry, an agent without a launch_cwd, or no
- * cwd match all return `null` (the caller then falls back to the scan).
+ * missing/unreadable/empty registry, an agent without a stable surface UUID, or
+ * no UUID match all return `null` (the caller then falls back to the scan).
  */
 export function makeSelfRegistrationSessionResolver(
   options: SelfRegistrationResolverOptions = {},
@@ -156,8 +173,9 @@ export function makeSelfRegistrationSessionResolver(
   const readFile = options.readFile ?? defaultReadFile;
 
   return (agent: AgentRecord): CapturedSessionIdentity | null => {
-    const launchCwd = agent.launch_cwd?.trim();
-    if (!launchCwd) return null; // no cwd key → cannot bind
+    const agentSurfaceUuid = surfaceUuidKey(agent.surface_uuid);
+    if (!agentSurfaceUuid) return null;
+    const launchCwd = agent.launch_cwd?.trim() || null;
 
     let text: string | null;
     try {
@@ -168,9 +186,9 @@ export function makeSelfRegistrationSessionResolver(
     if (!text) return null;
 
     const candidates = parseSelfRegistrationLines(text).filter(
-      (entry) => entry.cwd === launchCwd,
+      (entry) => surfaceUuidKey(entry.surface_uuid) === agentSurfaceUuid,
     );
-    const chosen = chooseCandidate(candidates, agent.pid);
+    const chosen = chooseCandidate(candidates, launchCwd);
     if (!chosen) return null;
     return {
       session_id: chosen.session_id,

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -31,6 +31,8 @@ import type {
   SessionIdentityResolver,
 } from "./agent-engine.js";
 
+const SESSION_REGISTRATION_CREATION_SKEW_MS = 5_000;
+
 /** A single self-registration record, after tolerant parsing. */
 export interface SelfRegistrationEntry {
   session_id: string;
@@ -44,7 +46,7 @@ export interface SelfRegistrationEntry {
   launcher: string | null;
   /** Optional rollout/transcript path; returned as the resolved `path`. */
   session_path: string | null;
-  /** Epoch MILLISECONDS. Sorted descending; missing sorts oldest. */
+  /** Epoch MILLISECONDS. Required for current-launch freshness checks. */
   ts: number | null;
 }
 
@@ -159,9 +161,12 @@ function chooseCandidate(
  *
  * Match is stable-surface UUID PRIMARY
  * (`entry.surface_uuid === agent.surface_uuid`). Exact launch_cwd is only an
- * optional secondary validator, then newest `ts` decides. AgentRecord.pid is
- * deliberately ignored because production does not populate it with the CLI
- * process pid. Returns
+ * optional secondary validator, then newest `ts` decides. Candidates must also
+ * be timestamped within the current agent-creation window, preventing an
+ * append-only record from a previous process on the same surface from being
+ * finalized during the short interval before the new hook appends. AgentRecord
+ * pid is deliberately ignored because production does not populate it with the
+ * CLI process pid. Returns
  * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
  * missing/unreadable/empty registry, an agent without a stable surface UUID, or
  * no UUID match all return `null` (the caller then falls back to the scan).
@@ -176,6 +181,10 @@ export function makeSelfRegistrationSessionResolver(
     const agentSurfaceUuid = surfaceUuidKey(agent.surface_uuid);
     if (!agentSurfaceUuid) return null;
     const launchCwd = agent.launch_cwd?.trim() || null;
+    const createdAt = Date.parse(agent.created_at);
+    if (Number.isNaN(createdAt)) return null;
+    const earliestCurrentLaunchTs =
+      createdAt - SESSION_REGISTRATION_CREATION_SKEW_MS;
 
     let text: string | null;
     try {
@@ -186,7 +195,10 @@ export function makeSelfRegistrationSessionResolver(
     if (!text) return null;
 
     const candidates = parseSelfRegistrationLines(text).filter(
-      (entry) => surfaceUuidKey(entry.surface_uuid) === agentSurfaceUuid,
+      (entry) =>
+        surfaceUuidKey(entry.surface_uuid) === agentSurfaceUuid &&
+        entry.ts !== null &&
+        entry.ts >= earliestCurrentLaunchTs,
     );
     const chosen = chooseCandidate(candidates, launchCwd);
     if (!chosen) return null;

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -33,6 +33,7 @@ import type {
 
 const SESSION_REGISTRATION_TIMESTAMP_SKEW_MS = 5_000;
 const SESSION_REGISTRATION_CONTINUITY_BYTES = 64;
+export const SESSION_REGISTRATION_READ_CHUNK_BYTES = 64 * 1024;
 export const SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES = 64 * 1024;
 export const SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE = 64;
 export const SESSION_REGISTRATION_MAX_INDEXED_SURFACES = 1_024;
@@ -322,6 +323,55 @@ function makeIncrementalEntryIndexReader(
     entriesBySurface = new Map();
   };
 
+  const readExactRange = (offset: number, length: number): Buffer | null => {
+    let readBuffer: Buffer | null;
+    try {
+      readBuffer = readFileRange(registryPath, offset, length);
+    } catch {
+      readBuffer = null;
+    }
+    return readBuffer?.byteLength === length ? readBuffer : null;
+  };
+
+  const consumeAppendedBytes = (appended: Buffer): void => {
+    const continuitySource = Buffer.concat([continuityTail, appended]);
+    continuityTail = copyBufferTail(
+      continuitySource,
+      SESSION_REGISTRATION_CONTINUITY_BYTES,
+    );
+    let parseableAppended = appended;
+    if (discardingOversizedLine) {
+      const discardedLineEnd = parseableAppended.indexOf(0x0a);
+      if (discardedLineEnd < 0) {
+        parseableAppended = Buffer.alloc(0);
+      } else {
+        discardingOversizedLine = false;
+        parseableAppended = parseableAppended.subarray(discardedLineEnd + 1);
+      }
+    }
+    const combined = Buffer.concat([pendingLine, parseableAppended]);
+    const finalNewline = combined.lastIndexOf(0x0a);
+    if (finalNewline >= 0) {
+      const completeLines = combined.subarray(0, finalNewline + 1);
+      const trailingLine = combined.subarray(finalNewline + 1);
+      discardingOversizedLine =
+        trailingLine.byteLength >
+        SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
+      pendingLine = boundPendingRegistrationLine(trailingLine);
+      for (const entry of parseSelfRegistrationBufferLines(completeLines)) {
+        if (!isIndexableRegistrationEntry(entry)) continue;
+        const key = surfaceUuidKey(entry.surface_uuid);
+        if (!key) continue;
+        indexSurfaceCandidate(entriesBySurface, key, entry);
+      }
+    } else {
+      discardingOversizedLine =
+        discardingOversizedLine ||
+        combined.byteLength > SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
+      pendingLine = boundPendingRegistrationLine(combined);
+    }
+  };
+
   return () => {
     let fileStat: SelfRegistrationFileStat | null;
     try {
@@ -347,97 +397,44 @@ function makeIncrementalEntryIndexReader(
       fileIdentity !== null &&
       fileStat.size === consumedBytes &&
       fileStat.mtimeMs !== observedMtimeMs;
-    const sameFileGrowth =
-      fileIdentity !== null &&
-      !replaced &&
-      fileStat.size > consumedBytes &&
-      consumedBytes > 0 &&
-      continuityTail.byteLength > 0;
-    if (
+    const resetsIndex =
       fileIdentity === null ||
       replaced ||
       fileStat.size < consumedBytes ||
-      rewrittenAtSameSize
-    ) {
-      reset();
-    }
+      rewrittenAtSameSize;
+    const sameFileGrowth =
+      !resetsIndex &&
+      fileStat.size > consumedBytes &&
+      consumedBytes > 0 &&
+      continuityTail.byteLength > 0;
+    if (resetsIndex) reset();
     fileIdentity = nextIdentity;
 
-    if (fileStat.size > consumedBytes) {
-      const continuityLength = sameFileGrowth
-        ? Math.min(continuityTail.byteLength, consumedBytes)
-        : 0;
-      const offset = consumedBytes - continuityLength;
-      const length = fileStat.size - offset;
-      let readBuffer: Buffer | null;
-      try {
-        readBuffer = readFileRange(registryPath, offset, length);
-      } catch {
-        readBuffer = null;
-      }
-      if (!readBuffer || readBuffer.byteLength !== length) return null;
-
-      let appended = readBuffer;
-      if (continuityLength > 0) {
-        const expectedBoundary = continuityTail.subarray(
-          continuityTail.byteLength - continuityLength,
-        );
-        const observedBoundary = readBuffer.subarray(0, continuityLength);
-        if (!observedBoundary.equals(expectedBoundary)) {
-          reset();
-          try {
-            readBuffer = readFileRange(registryPath, 0, fileStat.size);
-          } catch {
-            readBuffer = null;
-          }
-          if (!readBuffer || readBuffer.byteLength !== fileStat.size) {
-            return null;
-          }
-          appended = readBuffer;
-        } else {
-          appended = readBuffer.subarray(continuityLength);
-        }
-      }
-
-      consumedBytes = fileStat.size;
-      const continuitySource = Buffer.concat([continuityTail, appended]);
-      continuityTail = copyBufferTail(
-        continuitySource,
-        SESSION_REGISTRATION_CONTINUITY_BYTES,
+    if (sameFileGrowth) {
+      const continuityLength = Math.min(
+        continuityTail.byteLength,
+        consumedBytes,
       );
-      let parseableAppended = appended;
-      if (discardingOversizedLine) {
-        const discardedLineEnd = parseableAppended.indexOf(0x0a);
-        if (discardedLineEnd < 0) {
-          parseableAppended = Buffer.alloc(0);
-        } else {
-          discardingOversizedLine = false;
-          parseableAppended = parseableAppended.subarray(
-            discardedLineEnd + 1,
-          );
-        }
-      }
-      const combined = Buffer.concat([pendingLine, parseableAppended]);
-      const finalNewline = combined.lastIndexOf(0x0a);
-      if (finalNewline >= 0) {
-        const completeLines = combined.subarray(0, finalNewline + 1);
-        const trailingLine = combined.subarray(finalNewline + 1);
-        discardingOversizedLine =
-          trailingLine.byteLength >
-          SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
-        pendingLine = boundPendingRegistrationLine(trailingLine);
-        for (const entry of parseSelfRegistrationBufferLines(completeLines)) {
-          if (!isIndexableRegistrationEntry(entry)) continue;
-          const key = surfaceUuidKey(entry.surface_uuid);
-          if (!key) continue;
-          indexSurfaceCandidate(entriesBySurface, key, entry);
-        }
-      } else {
-        discardingOversizedLine =
-          discardingOversizedLine ||
-          combined.byteLength > SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES;
-        pendingLine = boundPendingRegistrationLine(combined);
-      }
+      const observedBoundary = readExactRange(
+        consumedBytes - continuityLength,
+        continuityLength,
+      );
+      if (!observedBoundary) return null;
+      const expectedBoundary = continuityTail.subarray(
+        continuityTail.byteLength - continuityLength,
+      );
+      if (!observedBoundary.equals(expectedBoundary)) reset();
+    }
+
+    while (consumedBytes < fileStat.size) {
+      const readLength = Math.min(
+        SESSION_REGISTRATION_READ_CHUNK_BYTES,
+        fileStat.size - consumedBytes,
+      );
+      const readBuffer = readExactRange(consumedBytes, readLength);
+      if (!readBuffer) return null;
+      consumeAppendedBytes(readBuffer);
+      consumedBytes += readLength;
     }
     observedMtimeMs = fileStat.mtimeMs;
     return entriesBySurface;

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -163,13 +163,13 @@ function chooseCandidate(
  *
  * Match is stable-surface UUID PRIMARY
  * (`entry.surface_uuid === agent.surface_uuid`). Exact launch_cwd is only an
- * optional secondary validator, then newest `ts` decides. Candidates must be
- * newer than the current agent-creation window and no farther in the future
- * than the allowed reader-clock skew. Those bounds prevent an append-only row
- * from a previous process (or from before a backward clock correction) from
- * being finalized before the new hook appends. AgentRecord pid is deliberately
- * ignored because production does not populate it with the CLI process pid.
- * Returns
+ * optional secondary validator, then newest `ts` decides. For cmuxlayer-owned
+ * launches, candidates must be newer than the agent-creation window; raw and
+ * repaired records deliberately skip that lower bound because their
+ * `created_at` is discovery time, not launch time. All candidates are bounded
+ * against the reader clock so a row from before a backward clock correction
+ * cannot dominate. AgentRecord pid is deliberately ignored because production
+ * does not populate it with the CLI process pid. Returns
  * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
  * missing/unreadable/empty registry, an agent without a stable surface UUID, or
  * no UUID match all return `null` (the caller then falls back to the scan).
@@ -188,7 +188,9 @@ export function makeSelfRegistrationSessionResolver(
     const createdAt = Date.parse(agent.created_at);
     if (Number.isNaN(createdAt)) return null;
     const earliestCurrentLaunchTs =
-      createdAt - SESSION_REGISTRATION_TIMESTAMP_SKEW_MS;
+      agent.surface_provenance === "cmuxlayer_spawn"
+        ? createdAt - SESSION_REGISTRATION_TIMESTAMP_SKEW_MS
+        : Number.NEGATIVE_INFINITY;
     const resolvedAt = now();
     if (!Number.isSafeInteger(resolvedAt)) return null;
     const latestPlausibleTs =

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -22,7 +22,7 @@
  * session_id + surface_uuid to bind, never fabricate an id.
  */
 
-import { readFileSync } from "node:fs";
+import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentRecord } from "./agent-types.js";
@@ -62,8 +62,23 @@ export interface SelfRegistrationResolverOptions {
    * Injected in tests so no real HOME I/O is touched.
    */
   readFile?: (path: string) => string | null;
+  /** Injectable file metadata reader for the production incremental index. */
+  statFile?: (path: string) => SelfRegistrationFileStat | null;
+  /** Injectable byte-range reader for the production incremental index. */
+  readFileRange?: (
+    path: string,
+    offset: number,
+    length: number,
+  ) => Buffer | null;
   /** Injectable wall clock for future-timestamp rejection (default Date.now). */
   now?: () => number;
+}
+
+export interface SelfRegistrationFileStat {
+  size: number;
+  mtimeMs: number;
+  dev: number;
+  ino: number;
 }
 
 /** Resolve the registry path from env, defaulting under `$HOME/.cmuxlayer`. */
@@ -158,6 +173,109 @@ function chooseCandidate(
   });
 }
 
+type SurfaceEntryIndex = Map<string, SelfRegistrationEntry[]>;
+
+/**
+ * Build an append-aware registry index for production lookups.
+ *
+ * Each call stats the file, but unchanged files perform no read or parse. New
+ * bytes are read exactly once and indexed by surface UUID, so a sweep across N
+ * uncaptured agents is O(file delta + N), not O(N * registry size). A partial
+ * final JSONL row is retained until its newline arrives. Compaction, truncation,
+ * or rotation resets the index before the replacement file is consumed.
+ */
+function makeIncrementalEntryIndexReader(
+  registryPath: string,
+  statFile: (path: string) => SelfRegistrationFileStat | null,
+  readFileRange: (
+    path: string,
+    offset: number,
+    length: number,
+  ) => Buffer | null,
+): () => SurfaceEntryIndex | null {
+  let fileIdentity: string | null = null;
+  let consumedBytes = 0;
+  let observedMtimeMs = Number.NEGATIVE_INFINITY;
+  let pendingLine = Buffer.alloc(0);
+  let entriesBySurface: SurfaceEntryIndex = new Map();
+
+  const reset = () => {
+    consumedBytes = 0;
+    observedMtimeMs = Number.NEGATIVE_INFINITY;
+    pendingLine = Buffer.alloc(0);
+    entriesBySurface = new Map();
+  };
+
+  return () => {
+    let fileStat: SelfRegistrationFileStat | null;
+    try {
+      fileStat = statFile(registryPath);
+    } catch {
+      fileStat = null;
+    }
+    if (
+      !fileStat ||
+      !Number.isSafeInteger(fileStat.size) ||
+      fileStat.size < 0 ||
+      !Number.isFinite(fileStat.mtimeMs)
+    ) {
+      fileIdentity = null;
+      reset();
+      return null;
+    }
+
+    const nextIdentity = `${fileStat.dev}:${fileStat.ino}`;
+    const replaced =
+      fileIdentity !== null && nextIdentity !== fileIdentity;
+    const rewrittenAtSameSize =
+      fileIdentity !== null &&
+      fileStat.size === consumedBytes &&
+      fileStat.mtimeMs !== observedMtimeMs;
+    if (
+      fileIdentity === null ||
+      replaced ||
+      fileStat.size < consumedBytes ||
+      rewrittenAtSameSize
+    ) {
+      reset();
+    }
+    fileIdentity = nextIdentity;
+
+    if (fileStat.size > consumedBytes) {
+      const offset = consumedBytes;
+      const length = fileStat.size - offset;
+      let appended: Buffer | null;
+      try {
+        appended = readFileRange(registryPath, offset, length);
+      } catch {
+        appended = null;
+      }
+      if (!appended || appended.byteLength !== length) return null;
+
+      consumedBytes = fileStat.size;
+      const combined = Buffer.concat([pendingLine, appended]);
+      const finalNewline = combined.lastIndexOf(0x0a);
+      if (finalNewline >= 0) {
+        const completeLines = combined.subarray(0, finalNewline + 1);
+        pendingLine = combined.subarray(finalNewline + 1);
+        for (const entry of parseSelfRegistrationLines(
+          completeLines.toString("utf8"),
+        )) {
+          const key = surfaceUuidKey(entry.surface_uuid);
+          if (!key) continue;
+          const existing = entriesBySurface.get(key);
+          if (existing) existing.push(entry);
+          else entriesBySurface.set(key, [entry]);
+        }
+      } else {
+        pendingLine = combined;
+      }
+    }
+    observedMtimeMs = fileStat.mtimeMs;
+    return entriesBySurface;
+  };
+}
+
 /**
  * Build the self-registration `SessionIdentityResolver`.
  *
@@ -178,8 +296,29 @@ export function makeSelfRegistrationSessionResolver(
   options: SelfRegistrationResolverOptions = {},
 ): SessionIdentityResolver {
   const registryPath = options.registryPath ?? resolveSessionRegistryPath();
-  const readFile = options.readFile ?? defaultReadFile;
   const now = options.now ?? Date.now;
+  const readCandidates = options.readFile
+    ? (surfaceKey: string): SelfRegistrationEntry[] | null => {
+        let text: string | null;
+        try {
+          text = options.readFile?.(registryPath) ?? null;
+        } catch {
+          return null;
+        }
+        if (!text) return null;
+        return parseSelfRegistrationLines(text).filter(
+          (entry) => surfaceUuidKey(entry.surface_uuid) === surfaceKey,
+        );
+      }
+    : (() => {
+        const readIndex = makeIncrementalEntryIndexReader(
+          registryPath,
+          options.statFile ?? defaultStatFile,
+          options.readFileRange ?? defaultReadFileRange,
+        );
+        return (surfaceKey: string): SelfRegistrationEntry[] | null =>
+          readIndex()?.get(surfaceKey) ?? null;
+      })();
 
   return (agent: AgentRecord): CapturedSessionIdentity | null => {
     const agentSurfaceUuid = surfaceUuidKey(agent.surface_uuid);
@@ -196,17 +335,8 @@ export function makeSelfRegistrationSessionResolver(
     const latestPlausibleTs =
       resolvedAt + SESSION_REGISTRATION_TIMESTAMP_SKEW_MS;
 
-    let text: string | null;
-    try {
-      text = readFile(registryPath);
-    } catch {
-      return null; // missing/unreadable → fall back to scan
-    }
-    if (!text) return null;
-
-    const candidates = parseSelfRegistrationLines(text).filter(
+    const candidates = (readCandidates(agentSurfaceUuid) ?? []).filter(
       (entry) =>
-        surfaceUuidKey(entry.surface_uuid) === agentSurfaceUuid &&
         entry.ts !== null &&
         entry.ts >= earliestCurrentLaunchTs &&
         entry.ts <= latestPlausibleTs,
@@ -220,10 +350,45 @@ export function makeSelfRegistrationSessionResolver(
   };
 }
 
-function defaultReadFile(path: string): string | null {
+function defaultStatFile(path: string): SelfRegistrationFileStat | null {
   try {
-    return readFileSync(path, "utf8");
+    const stat = statSync(path);
+    return {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      dev: stat.dev,
+      ino: stat.ino,
+    };
   } catch {
     return null;
+  }
+}
+
+function defaultReadFileRange(
+  path: string,
+  offset: number,
+  length: number,
+): Buffer | null {
+  let fileDescriptor: number | null = null;
+  try {
+    fileDescriptor = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(length);
+    let totalRead = 0;
+    while (totalRead < length) {
+      const bytesRead = readSync(
+        fileDescriptor,
+        buffer,
+        totalRead,
+        length - totalRead,
+        offset + totalRead,
+      );
+      if (bytesRead === 0) return null;
+      totalRead += bytesRead;
+    }
+    return buffer;
+  } catch {
+    return null;
+  } finally {
+    if (fileDescriptor !== null) closeSync(fileDescriptor);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,10 +22,7 @@ import {
 import { assertMutationAllowed, parseReservedModeKey } from "./mode-policy.js";
 import { extractPrefix, replaceTaskSuffix } from "./naming.js";
 import { createStaleBuildWarner, RUNNING_VERSION } from "./version.js";
-import {
-  buildSpawnToolReturn,
-  shapeSpawnResponse,
-} from "./spawn-response.js";
+import { buildSpawnToolReturn, shapeSpawnResponse } from "./spawn-response.js";
 import { StateManager } from "./state-manager.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import {
@@ -153,7 +150,10 @@ import {
   screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
-import { reposEquivalent, resolveWorkspaceRefForRepo } from "./repo-workspace.js";
+import {
+  reposEquivalent,
+  resolveWorkspaceRefForRepo,
+} from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
   buildSurfaceBindingObservation,
@@ -210,10 +210,7 @@ class SurfaceEnumerationError extends Error {
   }
 }
 
-function requireSurfaceEnumerationArray<T>(
-  value: unknown,
-  label: string,
-): T[] {
+function requireSurfaceEnumerationArray<T>(value: unknown, label: string): T[] {
   if (Array.isArray(value)) return value as T[];
   throw new SurfaceEnumerationError(
     `Malformed cmux surface enumeration: ${label} is not an array`,
@@ -365,8 +362,7 @@ const BOOT_PROMPT_TIMEOUT_MS = 60_000;
 const BOOT_PROMPT_READY_POLL_MS = 250;
 const BOOT_PROMPT_UPDATE_MAX_MS = 120_000;
 const BOOT_PROMPT_UPDATE_RELAUNCH_MAX = 2;
-const BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS =
-  BOOT_PROMPT_READY_POLL_MS * 3;
+const BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS = BOOT_PROMPT_READY_POLL_MS * 3;
 const BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS = BOOT_PROMPT_READY_POLL_MS * 3;
 
 function bootPromptUpdateMaxMs(): number {
@@ -379,8 +375,7 @@ const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 /** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
-const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS =
-  AGENT_HEALTH_MONITOR_MAX_AGE_MS;
+const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = AGENT_HEALTH_MONITOR_MAX_AGE_MS;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
 /** Agent states that are safe to close without `force`: the task is over. */
 const TERMINAL_AGENT_STATES = new Set<AgentState>(["done", "error"]);
@@ -513,8 +508,7 @@ class DeliverySafetyGateError extends Error {
 
   constructor(
     readonly error_code:
-      | "blocked_by_interactive_prompt"
-      | "blocked_by_permission_prompt",
+      "blocked_by_interactive_prompt" | "blocked_by_permission_prompt",
     readonly screen: ParsedScreenResult,
   ) {
     super(
@@ -629,7 +623,10 @@ function controlModeFromStatusEntries(entries: unknown): ControlMode {
 }
 
 function screenUnavailableMessage(error: unknown): string {
-  return readErrorText(error).replace(/^Error\ncmux read-screen failed:\s*/i, "");
+  return readErrorText(error).replace(
+    /^Error\ncmux read-screen failed:\s*/i,
+    "",
+  );
 }
 
 function isSurfaceGoneReadFailure(error: unknown, surface: string): boolean {
@@ -768,10 +765,7 @@ function requireValue(
 }
 
 type ListSurfacesRemoteState =
-  | "local"
-  | "connected"
-  | "disconnected"
-  | "unavailable";
+  "local" | "connected" | "disconnected" | "unavailable";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -1244,11 +1238,7 @@ function hasInlinePrompt(value: string | undefined): value is string {
 
 function assertInlineInputAllowed(opts: {
   tool:
-    | "send_input"
-    | "send_command"
-    | "spawn_agent"
-    | "send_to"
-    | "send_to_agent";
+    "send_input" | "send_command" | "spawn_agent" | "send_to" | "send_to_agent";
   arg: "text" | "command" | "prompt";
   value: string | undefined;
   allowLongInline?: boolean;
@@ -1297,7 +1287,8 @@ function inferBroadcastRecordRole(agent: AgentRecord): AgentRole | null {
     return inferAgentRole({
       role: agent.role,
       cli: agent.cli,
-      launcherName: agent.launcher_name ?? launcherNameForCli(agent.repo, agent.cli),
+      launcherName:
+        agent.launcher_name ?? launcherNameForCli(agent.repo, agent.cli),
       title: agent.task_summary,
     });
   } catch (error) {
@@ -1418,7 +1409,9 @@ function shouldHandleCodexUpdateMenu(
   cli: CliType | undefined,
   text: string,
 ): boolean {
-  return (cli === undefined || cli === "codex") && isCodexUpdateMenuScreen(text);
+  return (
+    (cli === undefined || cli === "codex") && isCodexUpdateMenuScreen(text)
+  );
 }
 
 function readyPatternCandidates(cli?: CliType): CliType[] {
@@ -1547,8 +1540,7 @@ function lineIsCurrentComposerRegionAnchor(
       return /Claude Code|What can I help you with\?/i.test(trimmed);
     case "codex":
       return (
-        /\bOpenAI\s+Codex\b/i.test(trimmed) ||
-        /\bModel:\s*gpt-/i.test(trimmed)
+        /\bOpenAI\s+Codex\b/i.test(trimmed) || /\bModel:\s*gpt-/i.test(trimmed)
       );
     case "cursor":
       return /^Cursor Agent$/i.test(trimmed) || /^cursor>\s*$/i.test(trimmed);
@@ -1740,8 +1732,7 @@ export function screenShowsPendingShellInput(
     .join("")
     .trimEnd();
   return (
-    pending === trimmed ||
-    pending.replace(/\s+/g, "") === compactSubmitted
+    pending === trimmed || pending.replace(/\s+/g, "") === compactSubmitted
   );
 }
 
@@ -1993,6 +1984,13 @@ export interface CreateServerOptions {
   inboxBaseDir?: string;
   /** Override session identity lookup (primarily for mocked tests). */
   sessionIdentityResolver?: SessionIdentityResolver;
+  /**
+   * PRIMARY session-identity resolver — the self-registration READ side. Threaded
+   * to the lifecycle engine as its primary resolver (self-registration first,
+   * transcript scan only as fallback). Production entrypoints inject
+   * `makeSelfRegistrationSessionResolver()`; unset in tests keeps HOME I/O out.
+   */
+  selfRegistrationSessionResolver?: SessionIdentityResolver;
   /** Override git worktree execution/home for tests. */
   worktreeExec?: WorktreeExec;
   worktreeHomeDir?: string;
@@ -2087,6 +2085,7 @@ export interface CmuxServerContext {
   spawnPreflight?: (params: SpawnAgentParams) => Promise<void>;
   disableSpawnPreflight?: boolean;
   sessionIdentityResolver?: SessionIdentityResolver;
+  selfRegistrationSessionResolver?: SessionIdentityResolver;
   lifecycleRegistry: AgentRegistry | null;
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
@@ -2208,6 +2207,7 @@ export function createServerContext(
     spawnPreflight: opts?.spawnPreflight,
     disableSpawnPreflight: opts?.disableSpawnPreflight,
     sessionIdentityResolver: opts?.sessionIdentityResolver,
+    selfRegistrationSessionResolver: opts?.selfRegistrationSessionResolver,
     lifecycleRegistry: null,
     lifecycleStarted: false,
     lifecycleStartPromise: null,
@@ -2319,13 +2319,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): AgentRole | null => {
     const uuid = discovered.surface_uuid?.trim().toLowerCase() || null;
     const workspace = discovered.workspace_id ?? null;
-    const matchesBinding = (
-      override: {
-        role: AgentRole;
-        workspace: string | null;
-        surfaceUuid: string | null;
-      },
-    ): boolean => {
+    const matchesBinding = (override: {
+      role: AgentRole;
+      workspace: string | null;
+      surfaceUuid: string | null;
+    }): boolean => {
       if (workspace && override.workspace && workspace !== override.workspace) {
         return false;
       }
@@ -2352,8 +2350,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const originalLaunchCommandsBySurface =
     context.originalLaunchCommandsBySurface;
   const surfaceWriteLiveness = context.surfaceWriteLiveness;
-  const surfaceWriteLivenessCandidates =
-    context.surfaceWriteLivenessCandidates;
+  const surfaceWriteLivenessCandidates = context.surfaceWriteLivenessCandidates;
   const surfacePtyDeadSince = context.surfacePtyDeadSince;
   const seatManifestWriter: SeatManifestWriter =
     opts?.seatManifestWriter ??
@@ -2421,8 +2418,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   }) => Promise<void> = async () => {};
   let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
   let lifecycleRefreshManagedMetadata:
-    | ((agentId?: string) => Promise<void>)
-    | null = null;
+    ((agentId?: string) => Promise<void>) | null = null;
   let lifecycleHealthEngine: AgentEngine | null = null;
   const refreshManagedMetadataBestEffort = async (
     agentId?: string,
@@ -2464,7 +2460,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return { control: "autonomous" };
     }
     try {
-      const entries = await statusClient.listStatus({ workspace: modeWorkspace });
+      const entries = await statusClient.listStatus({
+        workspace: modeWorkspace,
+      });
       return {
         control: controlModeFromStatusEntries(entries),
         workspace: modeWorkspace,
@@ -2523,7 +2521,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   const monitorRegistryOptions = (): MonitorRegistryOptions => ({
-    ...(opts?.monitorRegistryPath ? { registryPath: opts.monitorRegistryPath } : {}),
+    ...(opts?.monitorRegistryPath
+      ? { registryPath: opts.monitorRegistryPath }
+      : {}),
     ...(opts?.monitorRegistryNow ? { now: opts.monitorRegistryNow } : {}),
   });
   const monitorRegistryError = (
@@ -2544,10 +2544,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
     const ownerSeat = nonEmptyString(args.owner_seat);
     if (!ownerSeat || /^(?:unknown|none|null|n\/a)$/i.test(ownerSeat)) {
-      return monitorRegistryError(
-        "missing-or-unknown-owner-seat",
-        monitorId,
-      );
+      return monitorRegistryError("missing-or-unknown-owner-seat", monitorId);
     }
     const watchTargets = Array.isArray(args.watch_targets)
       ? args.watch_targets.map(nonEmptyString)
@@ -2600,10 +2597,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           target !== "~" && !target.startsWith("~/") && !isAbsolute(target),
       )
     ) {
-      return monitorRegistryError(
-        "rearm-watch-target-not-absolute",
-        monitorId,
-      );
+      return monitorRegistryError("rearm-watch-target-not-absolute", monitorId);
     }
 
     return {
@@ -2630,7 +2624,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     claimed_monitor_ids?: string[];
   }): string[] => {
     const ids = [
-      ...(nonEmptyString(args.monitor_id) ? [nonEmptyString(args.monitor_id)!] : []),
+      ...(nonEmptyString(args.monitor_id)
+        ? [nonEmptyString(args.monitor_id)!]
+        : []),
       ...(Array.isArray(args.monitor_ids) ? args.monitor_ids : []),
       ...(Array.isArray(args.claimed_monitor_ids)
         ? args.claimed_monitor_ids
@@ -2696,11 +2692,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ...(claimedMonitorIds.length > 0 ? { claimedMonitorIds } : {}),
     });
     const requestedIds = new Set(claimedMonitorIds);
-    const monitors = filterMonitorRegistryRecords(
-      query.monitors,
-      args,
-      true,
-    );
+    const monitors = filterMonitorRegistryRecords(query.monitors, args, true);
     const monitorById = new Map(
       query.monitors.map((monitor) => [monitor.monitor_id, monitor]),
     );
@@ -2737,17 +2729,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const rawTool = server.tool.bind(server) as (...args: unknown[]) => unknown;
   const toolHandlersByName = new Map<
     string,
-    (
-      args: Record<string, unknown>,
-      extra: unknown,
-    ) => Promise<ToolReturn>
+    (args: Record<string, unknown>, extra: unknown) => Promise<ToolReturn>
   >();
   const palette = createDefaultToolPalette(
     opts?.defaultPalette ?? process.env[CMUXLAYER_DEFAULT_PALETTE_ENV],
   );
-  (
-    server as unknown as { tool: (...args: unknown[]) => unknown }
-  ).tool = (...args: unknown[]): unknown => {
+  (server as unknown as { tool: (...args: unknown[]) => unknown }).tool = (
+    ...args: unknown[]
+  ): unknown => {
     const toolName = args[0];
     const handlerIndex = args.length - 1;
     const handler = args[handlerIndex];
@@ -2864,8 +2853,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (
             workspace &&
             override.workspace === workspace &&
-            (observation.coverage === "uuid" ||
-              observation.coverage === "ref")
+            (observation.coverage === "uuid" || observation.coverage === "ref")
           ) {
             roleSurfaceOverrides.delete(surfaceId);
           }
@@ -3016,7 +3004,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     } = {},
   ): Promise<T> => {
     if (opts.toolName) {
-      await assertSurfaceMutationAllowed(opts.toolName, surface, opts.workspace);
+      await assertSurfaceMutationAllowed(
+        opts.toolName,
+        surface,
+        opts.workspace,
+      );
     }
     const owner = opts.owner ?? `surface-write:${randomUUID()}`;
     // Capture the ref-only provenance before the async write. A reconnect or
@@ -3189,7 +3181,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               SEND_INPUT_SAFE_RETRY_OBSERVE_MS -
               (Date.now() - observationStartedAt);
             if (remainingMs <= 0) break;
-            await delay(Math.min(SEND_INPUT_SUBMIT_VERIFY_POLL_MS, remainingMs));
+            await delay(
+              Math.min(SEND_INPUT_SUBMIT_VERIFY_POLL_MS, remainingMs),
+            );
           }
 
           const message =
@@ -3359,7 +3353,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       return { text, parsed };
     } catch (error) {
-      if (opts?.throwOnSurfaceGone && isSurfaceGoneReadFailure(error, surface)) {
+      if (
+        opts?.throwOnSurfaceGone &&
+        isSurfaceGoneReadFailure(error, surface)
+      ) {
         throw new SurfaceGoneError(surface, error);
       }
       return null;
@@ -3561,11 +3558,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ? true
           : opts.require_working_status
             ? false
-          : lastHasPendingInput
-            ? false
-          : lastRetryEligiblePendingInput
-            ? false
-            : null,
+            : lastHasPendingInput
+              ? false
+              : lastRetryEligiblePendingInput
+                ? false
+                : null,
       retry_count: retryCount,
     };
   };
@@ -3763,8 +3760,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   const current = await opts.resolveRoute!();
                   if (
                     current.surface !== target.surface ||
-                    (current.workspace ?? null) !==
-                      (target.workspace ?? null)
+                    (current.workspace ?? null) !== (target.workspace ?? null)
                   ) {
                     throw new Error(
                       `Boot prompt route changed before update-menu Return; ` +
@@ -3806,7 +3802,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         if (updateStartedAt !== null) {
-          const updateDuration = Math.max(now - updateStartedAt, updateElapsedMs);
+          const updateDuration = Math.max(
+            now - updateStartedAt,
+            updateElapsedMs,
+          );
           deadline = Math.max(
             deadline + updateDuration,
             now + postUpdateReadyBudgetMs(),
@@ -3824,8 +3823,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           updateWasSeen &&
           opts.onUpdateShellRelaunch &&
           matchesShellPrompt(screen.text) &&
-          !candidates.some((candidate) =>
-            matchReadyPattern(candidate, screen.text).matched,
+          !candidates.some(
+            (candidate) => matchReadyPattern(candidate, screen.text).matched,
           )
         ) {
           if (updateShellRelaunches >= BOOT_PROMPT_UPDATE_RELAUNCH_MAX) {
@@ -3913,7 +3912,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         const composerInput = extractComposerInputRegion(snapshot.text);
-        const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
+        const hasPendingInput = screenShowsPendingInput(
+          snapshot.text,
+          opts.text,
+        );
         if (
           composerInput !== null &&
           !hasPendingInput &&
@@ -4163,124 +4165,129 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       });
     }
     await opts.assertSurfaceBindingCurrent?.();
-    await withSurfaceWrite(opts.surface, async () => {
-      const submitPendingLauncherCommand = async (): Promise<boolean> => {
-        const readLauncherScreen = () =>
-          client.readScreen(opts.surface, {
-            workspace: opts.workspace,
-            lines: 80,
-            scrollback: false,
-          });
+    await withSurfaceWrite(
+      opts.surface,
+      async () => {
+        const submitPendingLauncherCommand = async (): Promise<boolean> => {
+          const readLauncherScreen = () =>
+            client.readScreen(opts.surface, {
+              workspace: opts.workspace,
+              lines: 80,
+              scrollback: false,
+            });
 
-        let screen;
-        try {
-          screen = await readLauncherScreen();
-        } catch (error) {
-          if (isSurfaceGoneReadFailure(error, opts.surface)) {
-            throw new SurfaceGoneError(opts.surface, error);
-          }
-          return false;
-        }
-        if (!screenShowsPendingShellInput(screen.text, sanitizedCommand)) {
-          return false;
-        }
-
-        try {
-          // Return is a mutation: retrying after a lost acknowledgement can
-          // submit into the newly started CLI. Probe before any fallback.
-          await opts.assertSurfaceBindingCurrent?.();
-          await client.sendKey(opts.surface, "return", {
-            workspace: opts.workspace,
-          });
-          return true;
-        } catch (error) {
-          if (isSurfaceGoneReadFailure(error, opts.surface)) {
-            throw new SurfaceGoneError(opts.surface, error);
-          }
+          let screen;
           try {
-            const confirmation = await readLauncherScreen();
-            return !screenShowsPendingShellInput(
-              confirmation.text,
-              sanitizedCommand,
-            );
-          } catch (confirmationError) {
-            if (isSurfaceGoneReadFailure(confirmationError, opts.surface)) {
-              throw new SurfaceGoneError(opts.surface, confirmationError);
+            screen = await readLauncherScreen();
+          } catch (error) {
+            if (isSurfaceGoneReadFailure(error, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, error);
             }
-            throw error;
+            return false;
           }
-        }
-      };
-      const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {
-        await opts.assertSurfaceBindingCurrent?.();
-        await sendKeyWithRetry(opts.surface, "ctrl-c", opts.workspace);
-        await waitForLaunchShellReady({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          require_fresh_shell_prompt: true,
-        });
-      };
-      if (opts.relaunch) {
-        if (await submitPendingLauncherCommand()) {
-          return;
-        }
-        await clearAndVerifyFreshShellPrompt();
-      }
-      const relaunchOriginalCommand = async (): Promise<void> => {
-        await clearAndVerifyFreshShellPrompt();
-        await deliverInputChunks({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          chunks,
-          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-          press_enter: true,
-          source_event: "spawn_agent",
-          verify_submit: false,
-          beforeMutation: opts.assertSurfaceBindingCurrent,
-        });
-      };
-      try {
-        const delivery = await deliverInputChunks({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          chunks,
-          chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-          chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-          press_enter: true,
-          source_event: "spawn_agent",
-          verify_submit: true,
-          submit_verify_timeout_ms: SEND_INPUT_RECOVERY_ENTER_DELAY_MS,
-          beforeMutation: opts.assertSurfaceBindingCurrent,
-        });
-        if (delivery.submit_verified !== true) {
-          // The command can clear from the shell without proving the launcher
-          // accepted it. Probe once to consume transient ready evidence, then
-          // let boot-prompt readiness own update/relaunch monitoring.
-          await probeAgentLaunchReadyOnce({
+          if (!screenShowsPendingShellInput(screen.text, sanitizedCommand)) {
+            return false;
+          }
+
+          try {
+            // Return is a mutation: retrying after a lost acknowledgement can
+            // submit into the newly started CLI. Probe before any fallback.
+            await opts.assertSurfaceBindingCurrent?.();
+            await client.sendKey(opts.surface, "return", {
+              workspace: opts.workspace,
+            });
+            return true;
+          } catch (error) {
+            if (isSurfaceGoneReadFailure(error, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, error);
+            }
+            try {
+              const confirmation = await readLauncherScreen();
+              return !screenShowsPendingShellInput(
+                confirmation.text,
+                sanitizedCommand,
+              );
+            } catch (confirmationError) {
+              if (isSurfaceGoneReadFailure(confirmationError, opts.surface)) {
+                throw new SurfaceGoneError(opts.surface, confirmationError);
+              }
+              throw error;
+            }
+          }
+        };
+        const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {
+          await opts.assertSurfaceBindingCurrent?.();
+          await sendKeyWithRetry(opts.surface, "ctrl-c", opts.workspace);
+          await waitForLaunchShellReady({
             surface: opts.surface,
             workspace: opts.workspace,
+            require_fresh_shell_prompt: true,
+          });
+        };
+        if (opts.relaunch) {
+          if (await submitPendingLauncherCommand()) {
+            return;
+          }
+          await clearAndVerifyFreshShellPrompt();
+        }
+        const relaunchOriginalCommand = async (): Promise<void> => {
+          await clearAndVerifyFreshShellPrompt();
+          await deliverInputChunks({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: true,
+            source_event: "spawn_agent",
+            verify_submit: false,
+            beforeMutation: opts.assertSurfaceBindingCurrent,
+          });
+        };
+        try {
+          const delivery = await deliverInputChunks({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: true,
+            source_event: "spawn_agent",
+            verify_submit: true,
+            submit_verify_timeout_ms: SEND_INPUT_RECOVERY_ENTER_DELAY_MS,
+            beforeMutation: opts.assertSurfaceBindingCurrent,
+          });
+          if (delivery.submit_verified !== true) {
+            // The command can clear from the shell without proving the launcher
+            // accepted it. Probe once to consume transient ready evidence, then
+            // let boot-prompt readiness own update/relaunch monitoring.
+            await probeAgentLaunchReadyOnce({
+              surface: opts.surface,
+              workspace: opts.workspace,
+            });
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (!/Enter submit could not be verified/.test(message)) {
+            throw error;
+          }
+          // The command can remain visible in shell history while the launcher is
+          // already booting. Readiness detection is the authoritative launch check.
+          await waitForAgentLaunchReady({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            onUpdateShellRelaunch: relaunchOriginalCommand,
           });
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!/Enter submit could not be verified/.test(message)) {
-          throw error;
-        }
-        // The command can remain visible in shell history while the launcher is
-        // already booting. Readiness detection is the authoritative launch check.
-        await waitForAgentLaunchReady({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          onUpdateShellRelaunch: relaunchOriginalCommand,
-        });
-      }
-    }, {
-      toolName: "send_command",
-      workspace: opts.workspace,
-      observePtyWrite: true,
-      stableSurfaceIdentity: opts.stableSurfaceIdentity,
-    });
+      },
+      {
+        toolName: "send_command",
+        workspace: opts.workspace,
+        observePtyWrite: true,
+        stableSurfaceIdentity: opts.stableSurfaceIdentity,
+      },
+    );
   };
 
   const deliverBootPrompt = async (opts: {
@@ -4362,7 +4369,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       : undefined;
     const useFilePointer =
       Boolean(bootPromptPath) &&
-      (/[\r\n]/.test(rawPrompt) || rawPrompt.length > SEND_INPUT_MAX_INLINE_CHARS);
+      (/[\r\n]/.test(rawPrompt) ||
+        rawPrompt.length > SEND_INPUT_MAX_INLINE_CHARS);
     const promptWarning =
       bootPromptPath &&
       rawPrompt.length > BOOT_PROMPT_PATH_WARNING_CHARS &&
@@ -4560,9 +4568,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const explicitWorkspace = opts.explicitWorkspace
       ? await canonicalWorkspaceRef(opts.explicitWorkspace)
       : undefined;
-    if (explicitWorkspace) return { workspace: explicitWorkspace, warnings: [] };
+    if (explicitWorkspace)
+      return { workspace: explicitWorkspace, warnings: [] };
 
-    const callerWorkspace = opts.callerWorkspace ?? (await callerWorkspaceStrict());
+    const callerWorkspace =
+      opts.callerWorkspace ?? (await callerWorkspaceStrict());
     if (callerWorkspace) return { workspace: callerWorkspace, warnings: [] };
 
     const repoWorkspace = await resolveWorkspaceForRepo(opts.repo);
@@ -4697,8 +4707,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   const surfaceObserverEpochProvider =
-    (): SurfaceObserverIdProvider | undefined =>
-      () => context.surfaceObserverEpoch;
+    (): SurfaceObserverIdProvider | undefined => () =>
+      context.surfaceObserverEpoch;
 
   const assertSurfaceObserverEpochCurrent = (
     observerEpoch: SurfaceObserverEpoch,
@@ -4781,7 +4791,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const resolveSurfaceWorkspace = async (
     surfaceRef: string,
   ): Promise<string | null> =>
-    (await collectSurfaceTopology())?.workspaceBySurface.get(surfaceRef) ?? null;
+    (await collectSurfaceTopology())?.workspaceBySurface.get(surfaceRef) ??
+    null;
 
   const resolveAuthorizedAgentSurfaceBinding = (
     agent: AgentRecord,
@@ -4856,11 +4867,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         resolveCollapsedMonitors: (ownerSeats) => {
           if (!opts?.monitorRegistryPath) return [];
           const owners = new Set(ownerSeats);
-          return readMonitorRegistry(monitorRegistryOptions()).monitors
-            .filter(
+          return readMonitorRegistry(monitorRegistryOptions())
+            .monitors.filter(
               (monitor) =>
-                monitor.state === "collapsed" &&
-                owners.has(monitor.owner_seat),
+                monitor.state === "collapsed" && owners.has(monitor.owner_seat),
             )
             .map((monitor) => ({
               monitor_id: monitor.monitor_id,
@@ -4929,7 +4939,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     const issueSeverities = Object.fromEntries(
-      issueCodes.map((code) => [code, DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code]]),
+      issueCodes.map((code) => [
+        code,
+        DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code],
+      ]),
     );
     const hasBlockingIssue = issueCodes.some(
       (code) => DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY[code] === "blocking",
@@ -5041,7 +5054,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspaceCwdByRef.set(workspace.ref, cwd);
           }
         }
-        const paneByWorkspaceAndRef = new Map<string, Record<string, unknown>>();
+        const paneByWorkspaceAndRef = new Map<
+          string,
+          Record<string, unknown>
+        >();
         for (const { workspaceRef, panes } of panesByWorkspace) {
           for (const pane of panes.panes) {
             paneByWorkspaceAndRef.set(
@@ -5233,7 +5249,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         if (isToolReturn(inputOrError)) {
           return inputOrError;
         }
-        const existing = readMonitorRegistry(monitorRegistryOptions()).monitors.find(
+        const existing = readMonitorRegistry(
+          monitorRegistryOptions(),
+        ).monitors.find(
           (record) => record.monitor_id === inputOrError.monitor_id,
         );
         if (existing?.state === "deadman-fired") {
@@ -5446,10 +5464,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const callerWorkspace = await currentCallerWorkspace();
         const deletingCallerWorkspace = callerWorkspace === targetWorkspace;
 
-        if (
-          !args.force &&
-          (deletingCallerWorkspace || liveAgents.length > 0)
-        ) {
+        if (!args.force && (deletingCallerWorkspace || liveAgents.length > 0)) {
           const reasons = [
             ...(deletingCallerWorkspace ? ["it is the caller workspace"] : []),
             ...(liveAgents.length > 0
@@ -5472,10 +5487,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         await client.deleteWorkspace(targetWorkspace);
-        const removedWorkspace =
-          workspaces.find((workspace) => workspace.ref === targetWorkspace) ?? {
-            ref: targetWorkspace,
-          };
+        const removedWorkspace = workspaces.find(
+          (workspace) => workspace.ref === targetWorkspace,
+        ) ?? {
+          ref: targetWorkspace,
+        };
         const data = {
           workspace: targetWorkspace,
           force: args.force ?? false,
@@ -5723,8 +5739,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
         }
         let bootPromptDelivery:
-          | Awaited<ReturnType<typeof deliverBootPrompt>>
-          | undefined;
+          Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
         if (bootPromptPath) {
           const launcher = inferLauncherFromTitle(args.title ?? result.title);
           bootPromptDelivery = await deliverBootPrompt({
@@ -5764,12 +5779,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data.role = inferredRole;
         }
         if (bootPromptDelivery) {
-          data.boot_prompt_delivered = isBootPromptDelivered(
-            bootPromptDelivery,
-          );
+          data.boot_prompt_delivered =
+            isBootPromptDelivered(bootPromptDelivery);
           data.boot_prompt_bytes = bootPromptDelivery.bytes;
-          data.boot_prompt_submit_verified =
-            bootPromptDelivery.submit_verified;
+          data.boot_prompt_submit_verified = bootPromptDelivery.submit_verified;
         }
         return okFormatted(
           formatOk("new_split", {
@@ -5868,8 +5881,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           result.title = args.title;
         }
         let bootPromptDelivery:
-          | Awaited<ReturnType<typeof deliverBootPrompt>>
-          | undefined;
+          Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
         if (bootPromptPath) {
           const launcher = inferLauncherFromTitle(args.title ?? result.title);
           bootPromptDelivery = await deliverBootPrompt({
@@ -5896,12 +5908,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         const data: Record<string, unknown> = { ...result };
         if (bootPromptDelivery) {
-          data.boot_prompt_delivered = isBootPromptDelivered(
-            bootPromptDelivery,
-          );
+          data.boot_prompt_delivered =
+            isBootPromptDelivered(bootPromptDelivery);
           data.boot_prompt_bytes = bootPromptDelivery.bytes;
-          data.boot_prompt_submit_verified =
-            bootPromptDelivery.submit_verified;
+          data.boot_prompt_submit_verified = bootPromptDelivery.submit_verified;
         }
         return okFormatted(
           formatOk("new_surface", {
@@ -6110,23 +6120,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
 
-        const delivery = await withSurfaceWrite(args.surface, async () => {
-          return deliverInputChunks({
-            surface: args.surface,
+        const delivery = await withSurfaceWrite(
+          args.surface,
+          async () => {
+            return deliverInputChunks({
+              surface: args.surface,
+              workspace: args.workspace,
+              chunks,
+              chunk_size: effectiveChunkSize,
+              chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+              press_enter: args.press_enter,
+              rename_to_task: args.rename_to_task,
+              source_event: "send_input",
+              verify_submit: shouldVerifySubmit,
+            });
+          },
+          {
+            toolName: "send_input",
             workspace: args.workspace,
-            chunks,
-            chunk_size: effectiveChunkSize,
-            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-            press_enter: args.press_enter,
-            rename_to_task: args.rename_to_task,
-            source_event: "send_input",
-            verify_submit: shouldVerifySubmit,
-          });
-        }, {
-          toolName: "send_input",
-          workspace: args.workspace,
-          observePtyWrite: true,
-        });
+            observePtyWrite: true,
+          },
+        );
 
         const identity = resolveTargetIdentity(stateMgr, args.surface);
         const data = {
@@ -6236,26 +6250,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const shouldVerifySubmit =
           !!targetRecord && INTERACTIVE_AGENT_STATES.has(targetRecord.state);
 
-        const delivery = await withSurfaceWrite(args.surface, async () => {
-          return deliverInputChunks({
-            surface: args.surface,
+        const delivery = await withSurfaceWrite(
+          args.surface,
+          async () => {
+            return deliverInputChunks({
+              surface: args.surface,
+              workspace: args.workspace,
+              chunks,
+              chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+              chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+              press_enter: true,
+              source_event: "send_command",
+              verify_submit: bootPromptPath ? false : shouldVerifySubmit,
+            });
+          },
+          {
+            toolName: "send_command",
             workspace: args.workspace,
-            chunks,
-            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-            press_enter: true,
-            source_event: "send_command",
-            verify_submit: bootPromptPath ? false : shouldVerifySubmit,
-          });
-        }, {
-          toolName: "send_command",
-          workspace: args.workspace,
-          observePtyWrite: true,
-        });
+            observePtyWrite: true,
+          },
+        );
 
         let bootPromptDelivery:
-          | Awaited<ReturnType<typeof deliverBootPrompt>>
-          | undefined;
+          Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
         if (bootPromptPath && launcherCli) {
           bootPromptDelivery = await deliverBootPrompt({
             surface: args.surface,
@@ -6282,7 +6299,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           submit_verified: delivery.submit_verified,
           boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           boot_prompt_bytes: bootPromptDelivery?.bytes,
-          boot_prompt_submit_verified: bootPromptDelivery?.submit_verified ?? null,
+          boot_prompt_submit_verified:
+            bootPromptDelivery?.submit_verified ?? null,
           boot_prompt_warning: bootPromptDelivery?.prompt_warning ?? null,
         };
         return okFormatted(
@@ -6346,13 +6364,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         const key = normalizeKeyName(args.key);
-        await withSurfaceWrite(args.surface, async () => {
-          await sendKeyWithRetry(args.surface, key, args.workspace);
-        }, {
-          toolName: "send_key",
-          workspace: args.workspace,
-          observePtyWrite: true,
-        });
+        await withSurfaceWrite(
+          args.surface,
+          async () => {
+            await sendKeyWithRetry(args.surface, key, args.workspace);
+          },
+          {
+            toolName: "send_key",
+            workspace: args.workspace,
+            observePtyWrite: true,
+          },
+        );
         const data = { surface: args.surface, key };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
@@ -6524,11 +6546,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const currentTitle = surface?.title ?? "";
           finalTitle = replaceTaskSuffix(currentTitle, args.title);
         }
-        await withSurfaceWrite(args.surface, async () => {
-          await client.renameTab(args.surface, finalTitle, {
-            workspace: args.workspace,
-          });
-        }, { toolName: "rename_tab", workspace: args.workspace });
+        await withSurfaceWrite(
+          args.surface,
+          async () => {
+            await client.renameTab(args.surface, finalTitle, {
+              workspace: args.workspace,
+            });
+          },
+          { toolName: "rename_tab", workspace: args.workspace },
+        );
         await lifecycleSeatManifestPublisher({
           surfaceId: args.surface,
           tabName: finalTitle,
@@ -6669,7 +6695,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           args.workspace,
         );
         let staleRegistryDoneConsolidated:
-          | { agent_id: string; previous_state: AgentState; done_signal: string }
+          | {
+              agent_id: string;
+              previous_state: AgentState;
+              done_signal: string;
+            }
           | undefined;
         // Liveness guard: never destroy a pane whose agent is still live unless
         // the caller explicitly forces it. This is the safety net for the
@@ -6810,8 +6840,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         let closePolicy:
-          | ReturnType<typeof chooseSurfaceClosePolicy>
-          | undefined;
+          ReturnType<typeof chooseSurfaceClosePolicy> | undefined;
 
         try {
           const identified = args.workspace
@@ -7256,10 +7285,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               client.listPaneSurfaces({ workspace: ref, pane: p.ref }),
             ),
           );
-          const groups = partitionPaneSurfacesByMembership(paneList, rawGroups, {
-            workspace_ref: panes.workspace_ref ?? ref,
-            window_ref: panes.window_ref,
-          });
+          const groups = partitionPaneSurfacesByMembership(
+            paneList,
+            rawGroups,
+            {
+              workspace_ref: panes.workspace_ref ?? ref,
+              window_ref: panes.window_ref,
+            },
+          );
           if (!isPaneSurfaceEnumerationComplete(paneList, groups)) {
             throw new SurfaceEnumerationError(
               `Incomplete cmux surface enumeration for ${ref}`,
@@ -7275,8 +7308,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const observerEpoch = context.surfaceObserverEpoch;
       if (
         lastLifecycleSurfaces &&
-        (!observerEpoch ||
-          lastLifecycleSurfaceObserverEpoch !== observerEpoch)
+        (!observerEpoch || lastLifecycleSurfaceObserverEpoch !== observerEpoch)
       ) {
         lastLifecycleSurfaces = null;
         lastLifecycleSurfaceObserverEpoch = null;
@@ -7324,15 +7356,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     };
     registry =
       context.lifecycleRegistry ??
-      new AgentRegistry(
-        stateMgr,
-        surfaceProvider,
-        {
-          observerIdProvider: () => context.surfaceObserverId,
-          observerEpochProvider: () => context.surfaceObserverEpoch,
-          explicitRoleProvider: explicitRoleForDiscoveredSurface,
-        },
-      );
+      new AgentRegistry(stateMgr, surfaceProvider, {
+        observerIdProvider: () => context.surfaceObserverId,
+        observerEpochProvider: () => context.surfaceObserverEpoch,
+        explicitRoleProvider: explicitRoleForDiscoveredSurface,
+      });
     context.lifecycleRegistry = registry;
     const discovery = new AgentDiscovery({
       observerIdProvider: () => context.surfaceObserverEpoch,
@@ -7391,11 +7419,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           readScreen: (surface, readOpts) =>
             client.readScreen(surface, readOpts),
           send: (surface, text, sendOpts) => {
-            const {
-              beforeMutation,
-              stableSurfaceIdentity,
-              ...clientOpts
-            } = sendOpts ?? {};
+            const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+              sendOpts ?? {};
             return withSurfaceWrite(
               surface,
               async () => {
@@ -7411,11 +7436,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           },
           sendKey: (surface, key, keyOpts) => {
-            const {
-              beforeMutation,
-              stableSurfaceIdentity,
-              ...clientOpts
-            } = keyOpts ?? {};
+            const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+              keyOpts ?? {};
             return withSurfaceWrite(
               surface,
               async () => {
@@ -7434,11 +7456,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             client.setProgress(value, progressOpts),
           clearProgress: (progressOpts) => client.clearProgress(progressOpts),
           newSplit: async (direction, splitOpts) => {
-            const {
-              beforeMutation,
-              stableSurfaceIdentity,
-              ...clientOpts
-            } = splitOpts ?? {};
+            const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+              splitOpts ?? {};
             await assertWorkspaceMutationAllowed(
               "agent_engine",
               splitOpts?.workspace,
@@ -7481,11 +7500,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           listPaneSurfaces: (surfaceOpts) =>
             client.listPaneSurfaces(surfaceOpts),
           closeSurface: (surface, closeOpts) => {
-            const {
-              beforeMutation,
-              stableSurfaceIdentity,
-              ...clientOpts
-            } = closeOpts ?? {};
+            const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+              closeOpts ?? {};
             return withSurfaceWrite(
               surface,
               async () => {
@@ -7509,11 +7525,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           },
           moveSurface: async (moveOpts) => {
-            const {
-              beforeMutation,
-              stableSurfaceIdentity,
-              ...clientOpts
-            } = moveOpts;
+            const { beforeMutation, stableSurfaceIdentity, ...clientOpts } =
+              moveOpts;
             await assertWorkspaceMutationAllowed(
               "move_surface",
               moveOpts.workspace,
@@ -7540,6 +7553,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             spawnPreflight ??
             (disableSpawnPreflight ? async () => {} : undefined),
           sessionIdentityResolver: context.sessionIdentityResolver,
+          selfRegistrationSessionResolver:
+            context.selfRegistrationSessionResolver,
           roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
           inboxOpts,
           launchCommandSender: async ({
@@ -7569,10 +7584,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace,
           }) => {
             if (phase === "placement") {
-              await assertWorkspaceMutationAllowed(
-                "agent_engine",
-                workspace,
-              );
+              await assertWorkspaceMutationAllowed("agent_engine", workspace);
               return;
             }
             if (!surface) {
@@ -7605,9 +7617,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       try {
         const existing = input.agentId
           ? engine.getAgentState(input.agentId)
-          : registry.list().find(
-              (record) => record.surface_id === input.surfaceId,
-            ) ?? null;
+          : (registry
+              .list()
+              .find((record) => record.surface_id === input.surfaceId) ?? null);
         if (!existing) return;
 
         const updated =
@@ -7637,8 +7649,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           model: updated.model,
           permission_mode:
             updated.cli === "kiro" ? "default" : "skip-permissions",
-          cwd:
-            updated.launch_cwd ?? join(homedir(), "Gits", updated.repo),
+          cwd: updated.launch_cwd ?? join(homedir(), "Gits", updated.repo),
           repo: updated.repo,
           cli: updated.cli,
           updated_at: seatManifestNow(),
@@ -8053,7 +8064,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         model: z
           .string()
           .optional()
-          .describe("OPTIONAL — leave UNSET so the launcher pins the top-tier model. Only set this if you have a specific reason NOT to use the top model (e.g. a deliberately cheaper 'sonnet' pass, or a non-claude engine variant like 'codex'). Never pass 'opus' for claude — the top Claude model is already the default."),
+          .describe(
+            "OPTIONAL — leave UNSET so the launcher pins the top-tier model. Only set this if you have a specific reason NOT to use the top model (e.g. a deliberately cheaper 'sonnet' pass, or a non-claude engine variant like 'codex'). Never pass 'opus' for claude — the top Claude model is already the default.",
+          ),
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])
           .describe("CLI tool to launch"),
@@ -8188,7 +8201,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
           const spawnWorkspace = targetResolution.workspace;
           const comparisonWorkspace = spawnWorkspace ?? parentWorkspace;
-          await assertWorkspaceMutationAllowed("spawn_agent", comparisonWorkspace);
+          await assertWorkspaceMutationAllowed(
+            "spawn_agent",
+            comparisonWorkspace,
+          );
           const worktree = await prepareSpawnWorktree(
             args.repo,
             args.worktree,
@@ -8272,8 +8288,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           let bootPromptDelivery:
-            | Awaited<ReturnType<typeof deliverBootPrompt>>
-            | undefined;
+            Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
           try {
             if (hasInlinePrompt(args.prompt) || bootPromptPath) {
               const deliveryWorkspace = spawnDeliveryWorkspace(
@@ -8326,7 +8341,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           } catch (e) {
             const message = e instanceof Error ? e.message : String(e);
             const clearBootPromptPending = () => {
-              const record = resolveSpawnRecord(result.agent_id, result.surface_id);
+              const record = resolveSpawnRecord(
+                result.agent_id,
+                result.surface_id,
+              );
               const agentId = record?.agent_id ?? result.agent_id;
               const updated = stateMgr.updateRecord(agentId, {
                 boot_prompt_pending: false,
@@ -8408,35 +8426,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : undefined;
 
           const formattedData = {
-              agent_id: result.agent_id,
-              repo: args.repo,
-              model: result.model ?? args.model,
-              requested_model: result.requested_model,
-              warning:
-                result.warnings && result.warnings.length > 0
-                  ? result.warnings.join(" | ")
-                  : undefined,
-              surface: result.surface_id,
-              role,
-              health,
-              duplicate_spawn_warning: duplicateSpawnWarning,
-              monitor_boot: monitorBoot,
-              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
-            };
+            agent_id: result.agent_id,
+            repo: args.repo,
+            model: result.model ?? args.model,
+            requested_model: result.requested_model,
+            warning:
+              result.warnings && result.warnings.length > 0
+                ? result.warnings.join(" | ")
+                : undefined,
+            surface: result.surface_id,
+            role,
+            health,
+            duplicate_spawn_warning: duplicateSpawnWarning,
+            monitor_boot: monitorBoot,
+            boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
+          };
           const responseData = {
-              ...result,
-              worktree: worktree.prepared,
-              mcp_profile: worktree.mcpProfileLabel,
-              role,
-              health,
-              duplicate_spawn_warning: duplicateSpawnWarning,
-              existing_same_lane_agents: existingSameLaneAgents,
-              monitor_boot: monitorBoot,
-              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
-              boot_prompt_bytes: bootPromptDelivery?.bytes,
-              boot_prompt_submit_verified:
-                bootPromptDelivery?.submit_verified ?? null,
-            };
+            ...result,
+            worktree: worktree.prepared,
+            mcp_profile: worktree.mcpProfileLabel,
+            role,
+            health,
+            duplicate_spawn_warning: duplicateSpawnWarning,
+            existing_same_lane_agents: existingSameLaneAgents,
+            monitor_boot: monitorBoot,
+            boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
+            boot_prompt_bytes: bootPromptDelivery?.bytes,
+            boot_prompt_submit_verified:
+              bootPromptDelivery?.submit_verified ?? null,
+          };
           return buildSpawnToolReturn(
             {
               retry_count: currentTransportRetryCount(),
@@ -8552,8 +8570,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           let bootPromptDelivery:
-            | Awaited<ReturnType<typeof deliverBootPrompt>>
-            | undefined;
+            Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
           if (hasPrompt) {
             const deliveryWorkspace = spawnDeliveryWorkspace(
               result,
@@ -8606,23 +8623,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : undefined;
 
           const formattedData = {
-              agent_id: result.agent_id,
-              surface: result.surface_id,
-              worktree: worktree.prepared?.path ?? "",
-              mcp_profile: worktree.mcpProfileLabel ?? "inherit",
-              health,
-            };
+            agent_id: result.agent_id,
+            surface: result.surface_id,
+            worktree: worktree.prepared?.path ?? "",
+            mcp_profile: worktree.mcpProfileLabel ?? "inherit",
+            health,
+          };
           const responseData = {
-              ...result,
-              role: "worker",
-              health,
-              worktree: worktree.prepared,
-              mcp_profile: worktree.mcpProfileLabel ?? "inherit",
-              boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
-              boot_prompt_bytes: bootPromptDelivery?.bytes,
-              boot_prompt_submit_verified:
-                bootPromptDelivery?.submit_verified ?? null,
-            };
+            ...result,
+            role: "worker",
+            health,
+            worktree: worktree.prepared,
+            mcp_profile: worktree.mcpProfileLabel ?? "inherit",
+            boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
+            boot_prompt_bytes: bootPromptDelivery?.bytes,
+            boot_prompt_submit_verified:
+              bootPromptDelivery?.submit_verified ?? null,
+          };
           return buildSpawnToolReturn(
             {
               retry_count: currentTransportRetryCount(),
@@ -8735,8 +8752,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             originalLaunchCommandsBySurface.delete(result.surface_id);
             appendStaleBuildWarning(result);
             let bootPromptDelivery:
-              | Awaited<ReturnType<typeof deliverBootPrompt>>
-              | undefined;
+              Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
 
             if (hasPrompt) {
               const deliveryWorkspace = spawnDeliveryWorkspace(
@@ -8793,7 +8809,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role === "orchestrator"
                 ? ensureMonitorBoot(result.agent_id)
                 : undefined;
-            const topology = currentAgent ? await collectSurfaceTopology() : null;
+            const topology = currentAgent
+              ? await collectSurfaceTopology()
+              : null;
             const health = currentAgent
               ? await evaluateServerAgentHealth(
                   agentForSpawnHealth(currentAgent, result),
@@ -8846,18 +8864,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const workspaceWarnings = staleWarning ? [staleWarning] : [];
 
           const formattedData = {
-              workspace,
-              agents: spawnedAgents.length,
-              ...(staleWarning ? { warning: staleWarning } : {}),
-            };
+            workspace,
+            agents: spawnedAgents.length,
+            ...(staleWarning ? { warning: staleWarning } : {}),
+          };
           const responseData = {
-              workspace,
-              title: workspaceResult.title,
-              agents: spawnedAgents,
-              ...(workspaceWarnings.length > 0
-                ? { warnings: workspaceWarnings }
-                : {}),
-            };
+            workspace,
+            title: workspaceResult.title,
+            agents: spawnedAgents,
+            ...(workspaceWarnings.length > 0
+              ? { warnings: workspaceWarnings }
+              : {}),
+          };
           return buildSpawnToolReturn(
             {
               retry_count: currentTransportRetryCount(),
@@ -8898,7 +8916,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       "wait_for",
       "Block until one agent_id or every agent in ids reaches a target registry state and return health. Defaults to waiting for completion (`done`).",
       {
-        agent_id: z.string().optional().describe("Single agent ID from spawn_agent"),
+        agent_id: z
+          .string()
+          .optional()
+          .describe("Single agent ID from spawn_agent"),
         ids: z
           .array(z.string())
           .min(1)
@@ -9122,9 +9143,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               harvestability.closeable ? "closeable" : "not closeable"
             }` +
             `\nhealth: ${health.status}${
-              health.issues.length > 0
-                ? ` (${health.issues.join("; ")})`
-                : ""
+              health.issues.length > 0 ? ` (${health.issues.join("; ")})` : ""
             }`;
           const payload = {
             ...toAgentStatePayload(state),
@@ -9226,7 +9245,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       add(process.env.CMUX_TAB_ID);
       add(process.env.CMUX_SURFACE_ID);
 
-      for (const surface of [process.env.CMUX_SURFACE_ID, process.env.CMUX_TAB_ID]) {
+      for (const surface of [
+        process.env.CMUX_SURFACE_ID,
+        process.env.CMUX_TAB_ID,
+      ]) {
         if (!surface?.trim()) continue;
         try {
           const identified = await client.identify(surface.trim());
@@ -9243,10 +9265,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       agent: AgentRecord,
     ): Promise<string | null> => {
       if (agent.state === "error") {
-        let livenessTarget: Pick<
-          AgentRecord,
-          "surface_id" | "surface_uuid"
-        > = agent;
+        let livenessTarget: Pick<AgentRecord, "surface_id" | "surface_uuid"> =
+          agent;
         try {
           livenessTarget = await engine.resolveAgentIoRoute(agent.agent_id);
         } catch {
@@ -9276,9 +9296,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     };
 
     const agentSeatLabel = (agent: AgentRecord): string =>
-      agent.seat_id?.trim() ||
-      agent.surface_id ||
-      agent.agent_id;
+      agent.seat_id?.trim() || agent.surface_id || agent.agent_id;
 
     server.tool(
       "broadcast",
@@ -9307,7 +9325,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const parsedArgs = BroadcastArgsSchema.safeParse(rawArgs);
           if (!parsedArgs.success) {
             return err(
-              new Error(formatToolValidationError("broadcast", parsedArgs.error)),
+              new Error(
+                formatToolValidationError("broadcast", parsedArgs.error),
+              ),
             );
           }
           const args = parsedArgs.data;
@@ -9330,7 +9350,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   return await registry.listMerged(discovery);
                 } catch (error) {
                   if (
-                    !(error instanceof SurfaceBindingChangedDuringDiscoveryError)
+                    !(
+                      error instanceof SurfaceBindingChangedDuringDiscoveryError
+                    )
                   ) {
                     throw error;
                   }
@@ -9355,7 +9377,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
           const targets = (await collectTargets()).filter(
             (agent) =>
-              broadcastRoleMatches(args.role, inferBroadcastRecordRole(agent)) &&
+              broadcastRoleMatches(
+                args.role,
+                inferBroadcastRecordRole(agent),
+              ) &&
               workspaceMatches(agent) &&
               !excludedAgentIds.has(agent.agent_id) &&
               !isCaller(agent),
@@ -9450,9 +9475,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
             discovery.invalidate();
             const discoveredBeforeRepair = await discovery.scan(true);
-            const repair = registry.repairFromDiscovery(discoveredBeforeRepair, {
-              seatRegistry,
-            });
+            const repair = registry.repairFromDiscovery(
+              discoveredBeforeRepair,
+              {
+                seatRegistry,
+              },
+            );
             const liveSeatProofObserverId = registry.getObserverId();
             const liveSeatProofObserverEpoch = registry.getObserverEpoch();
             discovery.invalidate();
@@ -9469,12 +9497,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               force: true,
               discovered: discoveredAfterRepair,
             });
-            const surfacelessEvicted = await registry.evictSurfaceless(
-              {
-                ...surfaceAbsenceConfirmation,
-                liveSeatProof,
-              },
-            );
+            const surfacelessEvicted = await registry.evictSurfaceless({
+              ...surfaceAbsenceConfirmation,
+              liveSeatProof,
+            });
             engine.evictDeadProcessAgents();
             discovery.invalidate();
             let after = await registry.listMerged(discovery, { force: true });
@@ -9493,9 +9519,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 (uuidCount === 0 || uuidCount === surfaceCount)
               );
             };
-            const topologyBeforeReflowIsCoherent = topologyIsCoherent(
-              topologyBeforeReflow,
-            );
+            const topologyBeforeReflowIsCoherent =
+              topologyIsCoherent(topologyBeforeReflow);
             const reflowed: Array<{
               agent_id: string;
               surface_id: string;
@@ -9504,10 +9529,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               pane: string;
             }> = [];
             type ReflowOperation =
-              | "new_split"
-              | "move_surface"
-              | "verify_reflow"
-              | "close_surface";
+              "new_split" | "move_surface" | "verify_reflow" | "close_surface";
             const reflowSkipped: Array<{
               agent_id: string;
               surface_id: string;
@@ -9562,11 +9584,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               expectedWorkspace: string,
               operation: ReflowOperation,
             ) => {
-              assertCurrentReflowAuthority(
-                agent,
-                expectedWorkspace,
-                operation,
-              );
+              assertCurrentReflowAuthority(agent, expectedWorkspace, operation);
               assertSurfaceObserverEpochCurrent(
                 reflowObserverEpoch,
                 `resync_agents ${operation}`,
@@ -9597,9 +9615,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               const observedUuid =
                 topology.surfaceIdByRef.get(binding.surfaceRef) ?? null;
-              if (
-                !registry.canUseObservedBinding(currentAgent, observedUuid)
-              ) {
+              if (!registry.canUseObservedBinding(currentAgent, observedUuid)) {
                 throw new Error(
                   `Fresh binding ${binding.surfaceRef} is not owned by the current observer before ${operation}; refusing reflow mutation.`,
                 );
@@ -9617,7 +9633,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     `${binding.surfaceRef}@${workspace ?? "unknown"}); refusing to mutate a recycled ref.`,
                 );
               }
-              const current = topology.topologyBySurface.get(binding.surfaceRef);
+              const current = topology.topologyBySurface.get(
+                binding.surfaceRef,
+              );
               if (current?.column !== 0) {
                 throw new Error(
                   `Stable surface UUID ${agent.surface_uuid ?? "unavailable"} no longer needs left-column reflow before ${operation}.`,
@@ -9653,9 +9671,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   continue;
                 }
                 const liveSurfaceRef = binding.surfaceRef;
-                const current = topologyBeforeReflow.topologyBySurface.get(
-                  liveSurfaceRef,
-                );
+                const current =
+                  topologyBeforeReflow.topologyBySurface.get(liveSurfaceRef);
                 if (current?.column !== 0) continue;
 
                 let seededSurface: string | null = null;
@@ -9669,7 +9686,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   workspace =
                     topologyBeforeReflow.workspaceBySurface.get(
                       liveSurfaceRef,
-                    ) ?? agent.workspace_id ?? null;
+                    ) ??
+                    agent.workspace_id ??
+                    null;
                   if (!workspace) continue;
 
                   let targetPane: string | null = null;
@@ -9740,10 +9759,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       reflowObserverEpoch,
                       "resync_agents move_surface pane selection",
                     );
-                    targetPane = topPaneInRoleColumn(
-                      panes.panes,
-                      "worker",
-                    )?.ref ?? null;
+                    targetPane =
+                      topPaneInRoleColumn(panes.panes, "worker")?.ref ?? null;
                   }
                   if (!targetPane) continue;
 
@@ -9798,7 +9815,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   panesByWorkspace.delete(workspace);
 
                   attemptedOperation = "verify_reflow";
-                  const topologyAfterMove = await collectSurfaceTopology(workspace);
+                  const topologyAfterMove =
+                    await collectSurfaceTopology(workspace);
                   assertSurfaceObserverEpochCurrent(
                     reflowObserverEpoch,
                     "resync_agents verify_reflow",
@@ -9845,7 +9863,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 } finally {
                   if (seededSurface) {
                     try {
-                      const cleanupSeedUuid = seededSurfaceUuid as string | null;
+                      const cleanupSeedUuid = seededSurfaceUuid as
+                        string | null;
                       assertSurfaceObserverEpochCurrent(
                         reflowObserverEpoch,
                         "resync_agents close_surface",
@@ -9866,10 +9885,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         );
                       }
                       const seedUuidKey = cleanupSeedUuid.toLowerCase();
-                      const freshSeedRef = [...cleanupTopology.surfaceRefById]
-                        .find(([surfaceUuid]) =>
+                      const freshSeedRef = [
+                        ...cleanupTopology.surfaceRefById,
+                      ].find(
+                        ([surfaceUuid]) =>
                           surfaceUuid.toLowerCase() === seedUuidKey,
-                        )?.[1];
+                      )?.[1];
                       if (!freshSeedRef) {
                         throw new Error(
                           `Seed UUID ${cleanupSeedUuid} is no longer uniquely bound; refusing close_surface.`,
@@ -9895,8 +9916,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           }
                           const immediateSeedRef = [
                             ...immediateTopology.surfaceRefById,
-                          ].find(([surfaceUuid]) =>
-                            surfaceUuid.toLowerCase() === seedUuidKey,
+                          ].find(
+                            ([surfaceUuid]) =>
+                              surfaceUuid.toLowerCase() === seedUuidKey,
                           )?.[1];
                           if (immediateSeedRef !== freshSeedRef) {
                             throw new Error(
@@ -9964,7 +9986,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 !surface.read_error &&
                 !managedSurfaceIds.has(surface.surface_id),
             );
-            const orphanedHealth = orphanedSurfaces.map(buildOrphanSurfaceHealth);
+            const orphanedHealth = orphanedSurfaces.map(
+              buildOrphanSurfaceHealth,
+            );
             const evicted = [
               ...new Set([
                 ...repair.evicted,
@@ -10109,7 +10133,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (mode === "command") {
               const command = args.command ?? args.text;
               if (command === undefined) {
-                throw new Error("send_to mode=command requires command or text");
+                throw new Error(
+                  "send_to mode=command requires command or text",
+                );
               }
               return legacyHandler("send_command")(
                 {
@@ -10751,13 +10777,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             agents.map(async (agent) => {
               let screenData: ParsedScreenResult | null = null;
               let liveSurfaceId: string | null = null;
-              let screenFailure:
-                | {
-                    screen_unavailable: true;
-                    error_code: "screen_unavailable";
-                    screen_error: string;
-                  }
-                | null = null;
+              let screenFailure: {
+                screen_unavailable: true;
+                error_code: "screen_unavailable";
+                screen_error: string;
+              } | null = null;
               try {
                 const resolved = await Promise.race([
                   (async () => {
@@ -10923,10 +10947,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
         ...(replacement
           ? {
-              callback: async (
-                args: Record<string, unknown>,
-                extra: unknown,
-              ) =>
+              callback: async (args: Record<string, unknown>, extra: unknown) =>
                 withDeprecationWarning(
                   await originalHandler(args, extra),
                   name,

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -538,6 +538,29 @@ describe("CmuxLayerDaemon", () => {
     context.dispose();
   });
 
+  it("forwards a custom self-registration resolver into its lazy context", async () => {
+    const selfRegistrationSessionResolver = vi.fn(() => null);
+    const daemon = new CmuxLayerDaemon({
+      exec: createListSurfacesExec(),
+      stateDir: stateDir("custom-self-registration-resolver-state"),
+      skipAgentLifecycle: true,
+      selfRegistrationSessionResolver,
+    });
+
+    const context = await (
+      daemon as unknown as {
+        getContext(): Promise<
+          ReturnType<typeof createProductionServerContext>
+        >;
+      }
+    ).getContext();
+
+    expect(context.selfRegistrationSessionResolver).toBe(
+      selfRegistrationSessionResolver,
+    );
+    context.dispose();
+  });
+
   it("retires exactly once when the installed build becomes stale", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("stale-retire");

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -13,6 +13,7 @@ import {
   SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE,
   SESSION_REGISTRATION_MAX_INDEXED_SURFACES,
   SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES,
+  SESSION_REGISTRATION_READ_CHUNK_BYTES,
 } from "../src/self-registration.js";
 import type { SelfRegistrationEntry } from "../src/self-registration.js";
 import type { AgentRecord } from "../src/agent-types.js";
@@ -280,9 +281,60 @@ describe("makeSelfRegistrationSessionResolver", () => {
       { offset: 0, length: previousLength },
       {
         offset: previousLength - 64,
-        length: body.byteLength - previousLength + 64,
+        length: 64,
       },
+      { offset: previousLength, length: body.byteLength - previousLength },
     ]);
+  });
+
+  it("bounds every cold-start range read for a large registry", () => {
+    const body = Buffer.from(
+      jsonl(
+        {
+          session_id: "sid-oversized-cold-row",
+          surface_uuid: SURFACE_UUID_A,
+          padding: "x".repeat(SESSION_REGISTRATION_READ_CHUNK_BYTES * 3),
+          ts: 1000,
+        },
+        {
+          session_id: "sid-after-large-cold-row",
+          surface_uuid: SURFACE_UUID_B,
+          ts: 2000,
+        },
+      ),
+    );
+    const reads: Array<{ offset: number; length: number }> = [];
+    let shortSecondChunk = true;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs: 1,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) => {
+        reads.push({ offset, length });
+        if (
+          shortSecondChunk &&
+          offset === SESSION_REGISTRATION_READ_CHUNK_BYTES
+        ) {
+          shortSecondChunk = false;
+          return body.subarray(offset, offset + length - 1);
+        }
+        return body.subarray(offset, offset + length);
+      },
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toBeNull();
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toEqual({
+      session_id: "sid-after-large-cold-row",
+      path: null,
+    });
+    expect(reads.length).toBeGreaterThan(1);
+    expect(Math.max(...reads.map((read) => read.length))).toBeLessThanOrEqual(
+      SESSION_REGISTRATION_READ_CHUNK_BYTES,
+    );
   });
 
   it("evicts least-recent surface keys after the global index cap", () => {
@@ -637,9 +689,10 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ surface_uuid: SURFACE_UUID_D }))?.session_id).toBe(
       "sid-D",
     );
-    expect(reads.slice(-2).map((read) => read.offset)).toEqual([
+    expect(reads.slice(-3).map((read) => read.offset)).toEqual([
       previousLength - 64,
       previousLength - 64,
+      previousLength,
     ]);
   });
 

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -491,6 +491,39 @@ describe("makeSelfRegistrationSessionResolver", () => {
     ).toBe("sid-B");
   });
 
+  it("rejects an explicit registry CLI mismatch for the same surface UUID", () => {
+    const resolve = resolverFor(
+      jsonl({
+        session_id: "sid-claude",
+        surface_uuid: SURFACE_UUID_A,
+        cli: "claude",
+        cwd: null,
+        ts: 2000,
+      }),
+    );
+
+    expect(
+      resolve(agent({ surface_uuid: SURFACE_UUID_A, cli: "codex" })),
+    ).toBeNull();
+  });
+
+  it("keeps older writer rows without CLI metadata backward-compatible", () => {
+    const resolve = resolverFor(
+      jsonl({
+        session_id: "sid-legacy",
+        surface_uuid: SURFACE_UUID_A,
+        cli: null,
+        cwd: null,
+        ts: 2000,
+      }),
+    );
+
+    expect(
+      resolve(agent({ surface_uuid: SURFACE_UUID_A, cli: "codex" }))
+        ?.session_id,
+    ).toBe("sid-legacy");
+  });
+
   it("same-cwd, pid unknown (production reality): newest ts wins", () => {
     const resolve = resolverFor(
       jsonl(

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -4,11 +4,16 @@ import { homedir } from "node:os";
 import { rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
+  appendBoundedSurfaceCandidate,
+  boundPendingRegistrationLine,
   copyBufferTail,
   makeSelfRegistrationSessionResolver,
   parseSelfRegistrationLines,
   resolveSessionRegistryPath,
+  SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE,
+  SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES,
 } from "../src/self-registration.js";
+import type { SelfRegistrationEntry } from "../src/self-registration.js";
 import type { AgentRecord } from "../src/agent-types.js";
 import { AgentEngine } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
@@ -81,8 +86,44 @@ describe("copyBufferTail", () => {
 
     expect(tail).toEqual(Buffer.alloc(64, 0x62));
     expect(tail.buffer).not.toBe(source.buffer);
+    expect(tail.buffer.byteLength).toBe(tail.byteLength);
     source.fill(0x63);
     expect(tail).toEqual(Buffer.alloc(64, 0x62));
+  });
+});
+
+describe("bounded incremental registry state", () => {
+  it("drops an oversized unterminated row instead of retaining it", () => {
+    const oversized = Buffer.alloc(
+      SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES + 1,
+      0x61,
+    );
+
+    expect(boundPendingRegistrationLine(oversized)).toEqual(Buffer.alloc(0));
+  });
+
+  it("retains only the newest bounded candidates for one surface", () => {
+    const candidates: SelfRegistrationEntry[] = [];
+    const total = SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE + 5;
+
+    for (let index = 0; index < total; index += 1) {
+      appendBoundedSurfaceCandidate(candidates, {
+        session_id: `sid-${index}`,
+        surface_uuid: SURFACE_UUID_A,
+        cwd: `/worktree/${index}`,
+        pid: null,
+        cli: "claude",
+        launcher: null,
+        session_path: null,
+        ts: index,
+      });
+    }
+
+    expect(candidates).toHaveLength(
+      SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE,
+    );
+    expect(candidates[0]?.session_id).toBe("sid-5");
+    expect(candidates.at(-1)?.session_id).toBe(`sid-${total - 1}`);
   });
 });
 
@@ -783,6 +824,9 @@ describe("AgentEngine self-registration wiring", () => {
   function makeEngineHarness(
     selfRegistrationSessionResolver:
       ReturnType<typeof makeSelfRegistrationSessionResolver> | (() => null),
+    sessionIdentityResolver?: (agent: AgentRecord) =>
+      | { session_id: string; path: string | null }
+      | null,
   ): {
     engine: AgentEngine;
     stateMgr: StateManager;
@@ -800,6 +844,7 @@ describe("AgentEngine self-registration wiring", () => {
       engine: new AgentEngine(stateMgr, registry, client, {
         spawnPreflight: async () => {},
         selfRegistrationSessionResolver,
+        sessionIdentityResolver,
       }),
       stateMgr,
       registry,
@@ -860,6 +905,85 @@ describe("AgentEngine self-registration wiring", () => {
 
     expect(result).toEqual({ session_id: "sid-scan", path: null });
     expect(scanSpy).toHaveBeenCalledTimes(1);
+    engine.dispose();
+  });
+
+  it("keeps self-registration primary when a custom fallback is also supplied", () => {
+    const selfRegistrationSessionResolver = vi.fn(() => ({
+      session_id: "sid-self-reg",
+      path: null,
+    }));
+    const customFallback = vi.fn(() => ({
+      session_id: "sid-custom",
+      path: null,
+    }));
+    const { engine } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+      customFallback,
+    );
+    const resolver = (
+      engine as unknown as {
+        sessionIdentityResolver: (a: AgentRecord) => unknown;
+      }
+    ).sessionIdentityResolver;
+
+    expect(resolver(agent({ launch_cwd: "/w" }))).toEqual({
+      session_id: "sid-self-reg",
+      path: null,
+    });
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    expect(customFallback).not.toHaveBeenCalled();
+    engine.dispose();
+  });
+
+  it("uses the custom resolver after a self-registration miss", () => {
+    const selfRegistrationSessionResolver = vi.fn(() => null);
+    const customFallback = vi.fn(() => ({
+      session_id: "sid-custom",
+      path: null,
+    }));
+    const { engine } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+      customFallback,
+    );
+    const resolver = (
+      engine as unknown as {
+        sessionIdentityResolver: (a: AgentRecord) => unknown;
+      }
+    ).sessionIdentityResolver;
+
+    expect(resolver(agent({ launch_cwd: "/w" }))).toEqual({
+      session_id: "sid-custom",
+      path: null,
+    });
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    expect(customFallback).toHaveBeenCalledTimes(1);
+    engine.dispose();
+  });
+
+  it("lets an injected null fallback suppress real transcript I/O", () => {
+    const selfRegistrationSessionResolver = vi.fn(() => null);
+    const customFallback = vi.fn(() => null);
+    const { engine } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+      customFallback,
+    );
+    const scanSpy = vi.spyOn(
+      engine as unknown as {
+        findTranscriptSessionIdentity: (a: AgentRecord) => unknown;
+      },
+      "findTranscriptSessionIdentity",
+    );
+    const resolver = (
+      engine as unknown as {
+        sessionIdentityResolver: (a: AgentRecord) => unknown;
+      }
+    ).sessionIdentityResolver;
+
+    expect(resolver(agent({ launch_cwd: "/w" }))).toBeNull();
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    expect(customFallback).toHaveBeenCalledTimes(1);
+    expect(scanSpy).not.toHaveBeenCalled();
     engine.dispose();
   });
 

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
+  copyBufferTail,
   makeSelfRegistrationSessionResolver,
   parseSelfRegistrationLines,
   resolveSessionRegistryPath,
@@ -70,6 +71,20 @@ function resolverFor(text: string) {
     readFile: () => text,
   });
 }
+
+describe("copyBufferTail", () => {
+  it("copies only the bounded tail without retaining the source backing buffer", () => {
+    const source = Buffer.alloc(1024, 0x61);
+    source.fill(0x62, source.byteLength - 64);
+
+    const tail = copyBufferTail(source, 64);
+
+    expect(tail).toEqual(Buffer.alloc(64, 0x62));
+    expect(tail.buffer).not.toBe(source.buffer);
+    source.fill(0x63);
+    expect(tail).toEqual(Buffer.alloc(64, 0x62));
+  });
+});
 
 describe("resolveSessionRegistryPath", () => {
   it("prefers CMUXLAYER_SESSION_REGISTRY when set", () => {

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -333,6 +333,40 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ surface_uuid: "surface-1" }))).toBeNull();
   });
 
+  it("does not let universally unusable rows consume surface slots", () => {
+    const records: Array<Record<string, unknown>> = [
+      {
+        session_id: "sid-valid-older-surface",
+        surface_uuid: SURFACE_UUID_A,
+        ts: 1,
+      },
+      ...Array.from(
+        { length: SESSION_REGISTRATION_MAX_INDEXED_SURFACES },
+        (_, index) => ({
+          session_id: `sid-unusable-${index}`,
+          surface_uuid: `unusable-surface-${index}`,
+          ts: null,
+        }),
+      ),
+    ];
+    const body = Buffer.from(jsonl(...records));
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs: 1,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-valid-older-surface",
+    );
+  });
+
   it("holds an incomplete UTF-8 append until its JSONL newline arrives", () => {
     const firstLine = Buffer.from(
       jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -11,6 +11,7 @@ import {
   parseSelfRegistrationLines,
   resolveSessionRegistryPath,
   SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE,
+  SESSION_REGISTRATION_MAX_INDEXED_SURFACES,
   SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES,
 } from "../src/self-registration.js";
 import type { SelfRegistrationEntry } from "../src/self-registration.js";
@@ -282,6 +283,54 @@ describe("makeSelfRegistrationSessionResolver", () => {
         length: body.byteLength - previousLength + 64,
       },
     ]);
+  });
+
+  it("evicts least-recent surface keys after the global index cap", () => {
+    const records: Array<Record<string, unknown>> = Array.from(
+      { length: SESSION_REGISTRATION_MAX_INDEXED_SURFACES },
+      (_, index) => ({
+        session_id: `sid-${index}`,
+        surface_uuid: `surface-${index}`,
+        ts: index,
+      }),
+    );
+    records.push(
+      {
+        session_id: "sid-0-refreshed",
+        surface_uuid: "surface-0",
+        ts: SESSION_REGISTRATION_MAX_INDEXED_SURFACES,
+      },
+      {
+        session_id: `sid-${SESSION_REGISTRATION_MAX_INDEXED_SURFACES}`,
+        surface_uuid: `surface-${SESSION_REGISTRATION_MAX_INDEXED_SURFACES}`,
+        ts: SESSION_REGISTRATION_MAX_INDEXED_SURFACES + 1,
+      },
+    );
+    const body = Buffer.from(jsonl(...records));
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs: 1,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+      now: () => SESSION_REGISTRATION_MAX_INDEXED_SURFACES + 1,
+    });
+
+    expect(resolve(agent({ surface_uuid: "surface-0" }))?.session_id).toBe(
+      "sid-0-refreshed",
+    );
+    expect(
+      resolve(
+        agent({
+          surface_uuid: `surface-${SESSION_REGISTRATION_MAX_INDEXED_SURFACES}`,
+        }),
+      )?.session_id,
+    ).toBe(`sid-${SESSION_REGISTRATION_MAX_INDEXED_SURFACES}`);
+    expect(resolve(agent({ surface_uuid: "surface-1" }))).toBeNull();
   });
 
   it("holds an incomplete UTF-8 append until its JSONL newline arrives", () => {

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -327,6 +327,57 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
   });
 
+  it("ignores a future-dated row instead of letting it dominate the current registration", () => {
+    const now = Date.parse("2026-07-18T00:01:00.000Z");
+    const createdAt = now - 30_000;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      readFile: () =>
+        jsonl(
+          { session_id: "sid-current", cwd: "/w", ts: now },
+          {
+            session_id: "sid-future-stale",
+            cwd: "/w",
+            ts: now + 5_001,
+          },
+        ),
+      now: () => now,
+    });
+
+    expect(
+      resolve(
+        agent({
+          launch_cwd: "/w",
+          created_at: new Date(createdAt).toISOString(),
+        }),
+      )?.session_id,
+    ).toBe("sid-current");
+  });
+
+  it("accepts a timestamp at the reader-clock skew boundary", () => {
+    const now = Date.parse("2026-07-18T00:01:00.000Z");
+    const createdAt = now - 30_000;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      readFile: () =>
+        jsonl({
+          session_id: "sid-skew-boundary",
+          cwd: "/w",
+          ts: now + 5_000,
+        }),
+      now: () => now,
+    });
+
+    expect(
+      resolve(
+        agent({
+          launch_cwd: "/w",
+          created_at: new Date(createdAt).toISOString(),
+        }),
+      )?.session_id,
+    ).toBe("sid-skew-boundary");
+  });
+
   it("skips malformed lines but still binds a valid same-surface entry", () => {
     const resolve = resolverFor(
       jsonl("corrupt line not json", {

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi } from "vitest";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  makeSelfRegistrationSessionResolver,
+  parseSelfRegistrationLines,
+  resolveSessionRegistryPath,
+} from "../src/self-registration.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import { AgentEngine } from "../src/agent-engine.js";
+import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-self-registration-test");
+
+/**
+ * Minimal AgentRecord for resolver tests — the resolver only reads
+ * `launch_cwd` and `pid`; the composed-default tests additionally need
+ * `cli`/`repo`/`state`/`created_at`/`task_summary` for the scan guard.
+ */
+function agent(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    agent_id: "cmuxlayerClaude-pending",
+    surface_id: "surface:1",
+    state: "booting",
+    repo: "cmuxlayer",
+    model: "opus",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "do the thing",
+    pid: null,
+    version: 1,
+    created_at: "2026-07-18T00:00:00.000Z",
+    updated_at: "2026-07-18T00:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    launch_cwd: "/Users/e/Gits/cmuxlayer",
+    ...overrides,
+  } as AgentRecord;
+}
+
+/** Build a JSONL registry body from record objects (append-only, one/line). */
+function jsonl(...records: Array<Record<string, unknown> | string>): string {
+  return (
+    records
+      .map((r) => (typeof r === "string" ? r : JSON.stringify(r)))
+      .join("\n") + "\n"
+  );
+}
+
+function resolverFor(text: string) {
+  return makeSelfRegistrationSessionResolver({
+    registryPath: "/fake/registry.jsonl",
+    readFile: () => text,
+  });
+}
+
+describe("resolveSessionRegistryPath", () => {
+  it("prefers CMUXLAYER_SESSION_REGISTRY when set", () => {
+    expect(
+      resolveSessionRegistryPath({
+        CMUXLAYER_SESSION_REGISTRY: "/custom/reg.jsonl",
+      }),
+    ).toBe("/custom/reg.jsonl");
+  });
+
+  it("defaults to ~/.cmuxlayer/session-registry.jsonl", () => {
+    expect(resolveSessionRegistryPath({})).toBe(
+      join(homedir(), ".cmuxlayer", "session-registry.jsonl"),
+    );
+  });
+});
+
+describe("parseSelfRegistrationLines", () => {
+  it("ignores malformed lines and keeps valid records", () => {
+    const text = jsonl(
+      { session_id: "sid-1", cwd: "/w", pid: 10, ts: 1000 },
+      "this is not json {{{",
+      "",
+      { session_id: "sid-2", cwd: "/w", pid: 20, ts: 2000 },
+    );
+    const entries = parseSelfRegistrationLines(text);
+    expect(entries.map((e) => e.session_id)).toEqual(["sid-1", "sid-2"]);
+  });
+
+  it("requires session_id AND cwd; drops records missing either", () => {
+    const text = jsonl(
+      { session_id: "sid-1", cwd: "/w" },
+      { session_id: "no-cwd" },
+      { cwd: "/no-session" },
+      { session_id: "", cwd: "/w" },
+    );
+    const entries = parseSelfRegistrationLines(text);
+    expect(entries.map((e) => e.session_id)).toEqual(["sid-1"]);
+  });
+
+  it("tolerates unknown extra fields and preserves session_path", () => {
+    const entries = parseSelfRegistrationLines(
+      jsonl({
+        session_id: "sid-1",
+        cwd: "/w",
+        pid: 10,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: "/rollout/abc.jsonl",
+        ts: 1234,
+        somethingNew: "future-field",
+      }),
+    );
+    expect(entries[0]).toMatchObject({
+      session_id: "sid-1",
+      cwd: "/w",
+      pid: 10,
+      cli: "codex",
+      session_path: "/rollout/abc.jsonl",
+      ts: 1234,
+    });
+  });
+});
+
+describe("makeSelfRegistrationSessionResolver", () => {
+  it("returns the registered session_id on a cwd-exact match", () => {
+    const resolve = resolverFor(
+      jsonl({
+        session_id: "sid-exact",
+        cwd: "/Users/e/Gits/cmuxlayer",
+        pid: 111,
+        session_path: "/rollout/exact.jsonl",
+        ts: 5000,
+      }),
+    );
+    expect(resolve(agent({ launch_cwd: "/Users/e/Gits/cmuxlayer" }))).toEqual({
+      session_id: "sid-exact",
+      path: "/rollout/exact.jsonl",
+    });
+  });
+
+  it("returns path:null when the entry has no session_path", () => {
+    const resolve = resolverFor(
+      jsonl({ session_id: "sid-1", cwd: "/w", pid: 1, ts: 1 }),
+    );
+    expect(resolve(agent({ launch_cwd: "/w" }))).toEqual({
+      session_id: "sid-1",
+      path: null,
+    });
+  });
+
+  it("disambiguates 3 worktrees by cwd — each agent binds ONLY its own (no cross-binding)", () => {
+    const cwdA = "/Users/e/Gits/repo.wt/alpha";
+    const cwdB = "/Users/e/Gits/repo.wt/beta";
+    const cwdC = "/Users/e/Gits/repo";
+    const resolve = resolverFor(
+      jsonl(
+        { session_id: "sid-A", cwd: cwdA, pid: 1, ts: 1000 },
+        { session_id: "sid-B", cwd: cwdB, pid: 2, ts: 1001 },
+        { session_id: "sid-C", cwd: cwdC, pid: 3, ts: 1002 },
+      ),
+    );
+    expect(resolve(agent({ launch_cwd: cwdA, pid: null }))?.session_id).toBe(
+      "sid-A",
+    );
+    expect(resolve(agent({ launch_cwd: cwdB, pid: null }))?.session_id).toBe(
+      "sid-B",
+    );
+    expect(resolve(agent({ launch_cwd: cwdC, pid: null }))?.session_id).toBe(
+      "sid-C",
+    );
+  });
+
+  it("same-cwd, pid unknown (production reality): newest ts wins", () => {
+    const resolve = resolverFor(
+      jsonl(
+        { session_id: "sid-old", cwd: "/w", pid: 100, ts: 1000 },
+        { session_id: "sid-new", cwd: "/w", pid: 200, ts: 2000 },
+      ),
+    );
+    expect(resolve(agent({ launch_cwd: "/w", pid: null }))?.session_id).toBe(
+      "sid-new",
+    );
+  });
+
+  it("same-cwd, pid known and matching: pid wins even against a newer-ts entry", () => {
+    const resolve = resolverFor(
+      jsonl(
+        { session_id: "sid-old", cwd: "/w", pid: 100, ts: 1000 },
+        { session_id: "sid-new", cwd: "/w", pid: 200, ts: 2000 },
+      ),
+    );
+    expect(resolve(agent({ launch_cwd: "/w", pid: 100 }))?.session_id).toBe(
+      "sid-old",
+    );
+  });
+
+  it("same-cwd, pid known but no entry matches: falls back to newest ts", () => {
+    const resolve = resolverFor(
+      jsonl(
+        { session_id: "sid-old", cwd: "/w", pid: 100, ts: 1000 },
+        { session_id: "sid-new", cwd: "/w", pid: 200, ts: 2000 },
+      ),
+    );
+    expect(resolve(agent({ launch_cwd: "/w", pid: 999 }))?.session_id).toBe(
+      "sid-new",
+    );
+  });
+
+  it("no cwd match returns null (never fabricates)", () => {
+    const resolve = resolverFor(
+      jsonl({ session_id: "sid-1", cwd: "/other", pid: 1, ts: 1 }),
+    );
+    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+  });
+
+  it("returns null when the agent has no launch_cwd", () => {
+    const resolve = resolverFor(
+      jsonl({ session_id: "sid-1", cwd: "/w", pid: 1, ts: 1 }),
+    );
+    expect(resolve(agent({ launch_cwd: null }))).toBeNull();
+  });
+
+  it("skips malformed lines but still binds a valid same-cwd entry", () => {
+    const resolve = resolverFor(
+      jsonl("corrupt line not json", {
+        session_id: "sid-good",
+        cwd: "/w",
+        pid: 1,
+        ts: 1,
+      }),
+    );
+    expect(resolve(agent({ launch_cwd: "/w" }))?.session_id).toBe("sid-good");
+  });
+
+  it("empty file returns null (no throw)", () => {
+    const resolve = resolverFor("");
+    expect(() => resolve(agent({ launch_cwd: "/w" }))).not.toThrow();
+    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+  });
+
+  it("missing/unreadable file (readFile throws) returns null (no throw)", () => {
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/does/not/exist.jsonl",
+      readFile: () => {
+        const err = new Error("ENOENT") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      },
+    });
+    expect(() => resolve(agent({ launch_cwd: "/w" }))).not.toThrow();
+    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+  });
+
+  it("readFile returning null returns null (no throw)", () => {
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/does/not/exist.jsonl",
+      readFile: () => null,
+    });
+    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+  });
+});
+
+/**
+ * Engine-composition tests: self-registration is the PRIMARY resolver; the
+ * transcript scan (findTranscriptSessionIdentity → findLatestHarnessSessionIdentity)
+ * is only a deprecated last-resort fallback reached when self-registration
+ * returns null. Exercised via the engine's composed default resolver directly so
+ * the assertion is hermetic (no real HOME I/O).
+ */
+describe("AgentEngine self-registration wiring", () => {
+  function makeEngine(
+    selfRegistrationSessionResolver:
+      ReturnType<typeof makeSelfRegistrationSessionResolver> | (() => null),
+  ): AgentEngine {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const stateMgr = new StateManager(TEST_DIR);
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    const client = {
+      readScreen: vi.fn(),
+      log: vi.fn(),
+    } as unknown as CmuxClient;
+    return new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      selfRegistrationSessionResolver,
+    });
+  }
+
+  it("uses the self-registration hit and does NOT call the transcript scan", () => {
+    const engine = makeEngine(() => ({
+      session_id: "sid-self-reg",
+      path: "/rollout/x.jsonl",
+    }));
+    const scanSpy = vi.spyOn(
+      engine as unknown as {
+        findTranscriptSessionIdentity: (a: AgentRecord) => unknown;
+      },
+      "findTranscriptSessionIdentity",
+    );
+    const resolver = (
+      engine as unknown as {
+        sessionIdentityResolver: (a: AgentRecord) => unknown;
+      }
+    ).sessionIdentityResolver;
+
+    const result = resolver(agent({ launch_cwd: "/w" }));
+
+    expect(result).toEqual({
+      session_id: "sid-self-reg",
+      path: "/rollout/x.jsonl",
+    });
+    expect(scanSpy).not.toHaveBeenCalled();
+    engine.dispose();
+  });
+
+  it("falls back to the transcript scan when self-registration returns null", () => {
+    const engine = makeEngine(() => null);
+    const scanSpy = vi
+      .spyOn(
+        engine as unknown as {
+          findTranscriptSessionIdentity: (a: AgentRecord) => unknown;
+        },
+        "findTranscriptSessionIdentity",
+      )
+      .mockReturnValue({ session_id: "sid-scan", path: null });
+    const resolver = (
+      engine as unknown as {
+        sessionIdentityResolver: (a: AgentRecord) => unknown;
+      }
+    ).sessionIdentityResolver;
+
+    const result = resolver(agent({ launch_cwd: "/w" }));
+
+    expect(result).toEqual({ session_id: "sid-scan", path: null });
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+    engine.dispose();
+  });
+});

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -15,16 +15,19 @@ import { AgentRegistry } from "../src/agent-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-self-registration-test");
+const SURFACE_UUID_A = "11111111-2222-4333-8444-555555555555";
+const SURFACE_UUID_B = "66666666-7777-4888-8999-aaaaaaaaaaaa";
 
 /**
  * Minimal AgentRecord for resolver tests — the resolver only reads
- * `launch_cwd` and `pid`; the composed-default tests additionally need
+ * `surface_uuid` and optionally `launch_cwd`; the composed-default tests need
  * `cli`/`repo`/`state`/`created_at`/`task_summary` for the scan guard.
  */
 function agent(overrides: Partial<AgentRecord>): AgentRecord {
   return {
     agent_id: "cmuxlayerClaude-pending",
     surface_id: "surface:1",
+    surface_uuid: SURFACE_UUID_A,
     state: "booting",
     repo: "cmuxlayer",
     model: "opus",
@@ -50,7 +53,11 @@ function agent(overrides: Partial<AgentRecord>): AgentRecord {
 function jsonl(...records: Array<Record<string, unknown> | string>): string {
   return (
     records
-      .map((r) => (typeof r === "string" ? r : JSON.stringify(r)))
+      .map((r) =>
+        typeof r === "string"
+          ? r
+          : JSON.stringify({ surface_uuid: SURFACE_UUID_A, ...r }),
+      )
       .join("\n") + "\n"
   );
 }
@@ -90,15 +97,19 @@ describe("parseSelfRegistrationLines", () => {
     expect(entries.map((e) => e.session_id)).toEqual(["sid-1", "sid-2"]);
   });
 
-  it("requires session_id AND cwd; drops records missing either", () => {
+  it("requires session_id and surface_uuid while allowing cwd to be absent", () => {
     const text = jsonl(
       { session_id: "sid-1", cwd: "/w" },
-      { session_id: "no-cwd" },
+      { session_id: "sid-no-cwd", cwd: null },
+      { session_id: "no-surface", surface_uuid: null, cwd: "/w" },
       { cwd: "/no-session" },
       { session_id: "", cwd: "/w" },
     );
     const entries = parseSelfRegistrationLines(text);
-    expect(entries.map((e) => e.session_id)).toEqual(["sid-1"]);
+    expect(entries.map((e) => e.session_id)).toEqual([
+      "sid-1",
+      "sid-no-cwd",
+    ]);
   });
 
   it("tolerates unknown extra fields and preserves session_path", () => {
@@ -116,6 +127,7 @@ describe("parseSelfRegistrationLines", () => {
     );
     expect(entries[0]).toMatchObject({
       session_id: "sid-1",
+      surface_uuid: SURFACE_UUID_A,
       cwd: "/w",
       pid: 10,
       cli: "codex",
@@ -123,10 +135,28 @@ describe("parseSelfRegistrationLines", () => {
       ts: 1234,
     });
   });
+
+  it("does not use fractional pid or timestamp values as integer identity metadata", () => {
+    const entries = parseSelfRegistrationLines(
+      jsonl({
+        session_id: "sid-1",
+        cwd: "/w",
+        pid: 10.5,
+        ts: 1234.5,
+      }),
+    );
+
+    expect(entries[0]).toMatchObject({
+      session_id: "sid-1",
+      cwd: "/w",
+      pid: null,
+      ts: null,
+    });
+  });
 });
 
 describe("makeSelfRegistrationSessionResolver", () => {
-  it("returns the registered session_id on a cwd-exact match", () => {
+  it("returns the registered session_id on a surface_uuid-exact match", () => {
     const resolve = resolverFor(
       jsonl({
         session_id: "sid-exact",
@@ -152,7 +182,7 @@ describe("makeSelfRegistrationSessionResolver", () => {
     });
   });
 
-  it("disambiguates 3 worktrees by cwd — each agent binds ONLY its own (no cross-binding)", () => {
+  it("uses exact cwd as an optional secondary among records for one surface", () => {
     const cwdA = "/Users/e/Gits/repo.wt/alpha";
     const cwdB = "/Users/e/Gits/repo.wt/beta";
     const cwdC = "/Users/e/Gits/repo";
@@ -174,6 +204,36 @@ describe("makeSelfRegistrationSessionResolver", () => {
     );
   });
 
+  it("binds distinct surface UUIDs without cwd and never cross-binds them", () => {
+    const resolve = resolverFor(
+      jsonl(
+        {
+          session_id: "sid-A",
+          surface_uuid: SURFACE_UUID_A,
+          cwd: null,
+          ts: 2000,
+        },
+        {
+          session_id: "sid-B",
+          surface_uuid: SURFACE_UUID_B,
+          cwd: "/wrong/cwd",
+          ts: 3000,
+        },
+      ),
+    );
+
+    expect(
+      resolve(
+        agent({ surface_uuid: SURFACE_UUID_A, launch_cwd: "/agent/a" }),
+      )?.session_id,
+    ).toBe("sid-A");
+    expect(
+      resolve(
+        agent({ surface_uuid: SURFACE_UUID_B, launch_cwd: "/agent/b" }),
+      )?.session_id,
+    ).toBe("sid-B");
+  });
+
   it("same-cwd, pid unknown (production reality): newest ts wins", () => {
     const resolve = resolverFor(
       jsonl(
@@ -186,7 +246,7 @@ describe("makeSelfRegistrationSessionResolver", () => {
     );
   });
 
-  it("same-cwd, pid known and matching: pid wins even against a newer-ts entry", () => {
+  it("ignores AgentRecord.pid because production does not populate the CLI pid", () => {
     const resolve = resolverFor(
       jsonl(
         { session_id: "sid-old", cwd: "/w", pid: 100, ts: 1000 },
@@ -194,37 +254,32 @@ describe("makeSelfRegistrationSessionResolver", () => {
       ),
     );
     expect(resolve(agent({ launch_cwd: "/w", pid: 100 }))?.session_id).toBe(
-      "sid-old",
-    );
-  });
-
-  it("same-cwd, pid known but no entry matches: falls back to newest ts", () => {
-    const resolve = resolverFor(
-      jsonl(
-        { session_id: "sid-old", cwd: "/w", pid: 100, ts: 1000 },
-        { session_id: "sid-new", cwd: "/w", pid: 200, ts: 2000 },
-      ),
-    );
-    expect(resolve(agent({ launch_cwd: "/w", pid: 999 }))?.session_id).toBe(
       "sid-new",
     );
   });
 
-  it("no cwd match returns null (never fabricates)", () => {
+  it("uses the UUID match when cwd is mismatched", () => {
     const resolve = resolverFor(
       jsonl({ session_id: "sid-1", cwd: "/other", pid: 1, ts: 1 }),
     );
-    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+    expect(resolve(agent({ launch_cwd: "/w" }))?.session_id).toBe("sid-1");
   });
 
-  it("returns null when the agent has no launch_cwd", () => {
+  it("uses the UUID match when the agent has no launch_cwd", () => {
     const resolve = resolverFor(
       jsonl({ session_id: "sid-1", cwd: "/w", pid: 1, ts: 1 }),
     );
-    expect(resolve(agent({ launch_cwd: null }))).toBeNull();
+    expect(resolve(agent({ launch_cwd: null }))?.session_id).toBe("sid-1");
   });
 
-  it("skips malformed lines but still binds a valid same-cwd entry", () => {
+  it("returns null when the agent has no surface_uuid", () => {
+    const resolve = resolverFor(
+      jsonl({ session_id: "sid-1", cwd: "/w", pid: 1, ts: 1 }),
+    );
+    expect(resolve(agent({ surface_uuid: null, launch_cwd: "/w" }))).toBeNull();
+  });
+
+  it("skips malformed lines but still binds a valid same-surface entry", () => {
     const resolve = resolverFor(
       jsonl("corrupt line not json", {
         session_id: "sid-good",

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -426,6 +426,47 @@ describe("makeSelfRegistrationSessionResolver", () => {
     });
   });
 
+  it("skips a complete newline-terminated row over the byte cap", () => {
+    const oversizedLine = Buffer.from(
+      jsonl({
+        session_id: "sid-must-be-skipped",
+        surface_uuid: SURFACE_UUID_A,
+        padding: "x".repeat(SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES),
+        ts: 1000,
+      }),
+    );
+    expect(oversizedLine.byteLength).toBeGreaterThan(
+      SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES,
+    );
+    const body = Buffer.concat([
+      oversizedLine,
+      Buffer.from(
+        jsonl({
+          session_id: "sid-after-oversized-row",
+          surface_uuid: SURFACE_UUID_B,
+          ts: 2000,
+        }),
+      ),
+    ]);
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs: 1,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))).toBeNull();
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toEqual({
+      session_id: "sid-after-oversized-row",
+      path: null,
+    });
+  });
+
   it("drops cached candidates on same-size rewrite and inode rotation", () => {
     let body = Buffer.from(
       jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -327,6 +327,56 @@ describe("makeSelfRegistrationSessionResolver", () => {
     });
   });
 
+  it("discards every suffix of an oversized row until its newline", () => {
+    let body = Buffer.alloc(
+      SESSION_REGISTRATION_MAX_PENDING_LINE_BYTES + 1,
+      0x78,
+    );
+    let mtimeMs = 1;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))).toBeNull();
+
+    body = Buffer.concat([
+      body,
+      Buffer.from(
+        jsonl({
+          session_id: "sid-must-be-discarded",
+          surface_uuid: SURFACE_UUID_A,
+          ts: 1000,
+        }),
+      ),
+    ]);
+    mtimeMs += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))).toBeNull();
+
+    body = Buffer.concat([
+      body,
+      Buffer.from(
+        jsonl({
+          session_id: "sid-after-newline",
+          surface_uuid: SURFACE_UUID_B,
+          ts: 2000,
+        }),
+      ),
+    ]);
+    mtimeMs += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toEqual({
+      session_id: "sid-after-newline",
+      path: null,
+    });
+  });
+
   it("drops cached candidates on same-size rewrite and inode rotation", () => {
     let body = Buffer.from(
       jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -36,8 +36,8 @@ function agent(overrides: Partial<AgentRecord>): AgentRecord {
     task_summary: "do the thing",
     pid: null,
     version: 1,
-    created_at: "2026-07-18T00:00:00.000Z",
-    updated_at: "2026-07-18T00:00:00.000Z",
+    created_at: new Date(0).toISOString(),
+    updated_at: new Date(0).toISOString(),
     error: null,
     parent_agent_id: null,
     spawn_depth: 0,
@@ -279,6 +279,54 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ surface_uuid: null, launch_cwd: "/w" }))).toBeNull();
   });
 
+  it("rejects a same-surface record older than the current launch window", () => {
+    const createdAt = Date.parse("2026-07-18T00:00:10.000Z");
+    const resolve = resolverFor(
+      jsonl({
+        session_id: "sid-stale",
+        cwd: "/w",
+        ts: createdAt - 5_001,
+      }),
+    );
+
+    expect(
+      resolve(
+        agent({
+          launch_cwd: "/w",
+          created_at: new Date(createdAt).toISOString(),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts a hook record within the five-second launch tolerance", () => {
+    const createdAt = Date.parse("2026-07-18T00:00:10.000Z");
+    const resolve = resolverFor(
+      jsonl({
+        session_id: "sid-current",
+        cwd: "/w",
+        ts: createdAt - 5_000,
+      }),
+    );
+
+    expect(
+      resolve(
+        agent({
+          launch_cwd: "/w",
+          created_at: new Date(createdAt).toISOString(),
+        }),
+      )?.session_id,
+    ).toBe("sid-current");
+  });
+
+  it("rejects a same-surface record without an epoch timestamp", () => {
+    const resolve = resolverFor(
+      jsonl({ session_id: "sid-undated", cwd: "/w" }),
+    );
+
+    expect(resolve(agent({ launch_cwd: "/w" }))).toBeNull();
+  });
+
   it("skips malformed lines but still binds a valid same-surface entry", () => {
     const resolve = resolverFor(
       jsonl("corrupt line not json", {
@@ -327,10 +375,14 @@ describe("makeSelfRegistrationSessionResolver", () => {
  * the assertion is hermetic (no real HOME I/O).
  */
 describe("AgentEngine self-registration wiring", () => {
-  function makeEngine(
+  function makeEngineHarness(
     selfRegistrationSessionResolver:
       ReturnType<typeof makeSelfRegistrationSessionResolver> | (() => null),
-  ): AgentEngine {
+  ): {
+    engine: AgentEngine;
+    stateMgr: StateManager;
+    registry: AgentRegistry;
+  } {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });
     const stateMgr = new StateManager(TEST_DIR);
@@ -339,10 +391,21 @@ describe("AgentEngine self-registration wiring", () => {
       readScreen: vi.fn(),
       log: vi.fn(),
     } as unknown as CmuxClient;
-    return new AgentEngine(stateMgr, registry, client, {
-      spawnPreflight: async () => {},
-      selfRegistrationSessionResolver,
-    });
+    return {
+      engine: new AgentEngine(stateMgr, registry, client, {
+        spawnPreflight: async () => {},
+        selfRegistrationSessionResolver,
+      }),
+      stateMgr,
+      registry,
+    };
+  }
+
+  function makeEngine(
+    selfRegistrationSessionResolver:
+      ReturnType<typeof makeSelfRegistrationSessionResolver> | (() => null),
+  ): AgentEngine {
+    return makeEngineHarness(selfRegistrationSessionResolver).engine;
   }
 
   it("uses the self-registration hit and does NOT call the transcript scan", () => {
@@ -392,6 +455,76 @@ describe("AgentEngine self-registration wiring", () => {
 
     expect(result).toEqual({ session_id: "sid-scan", path: null });
     expect(scanSpy).toHaveBeenCalledTimes(1);
+    engine.dispose();
+  });
+
+  it("captures a raw auto-discovered agent using only its stable surface UUID", async () => {
+    const selfRegistrationSessionResolver = vi.fn(() => ({
+      session_id: "sid-raw",
+      path: "/rollout/raw.jsonl",
+    }));
+    const { engine, stateMgr, registry } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+    );
+    const rawAgent = agent({
+      agent_id: "auto-claude-surface-live",
+      state: "working",
+      launcher_name: null,
+      launch_cwd: null,
+      worktree_path: null,
+      task_summary: "(auto-discovered)",
+    });
+    stateMgr.writeState(rawAgent);
+    registry.set(rawAgent.agent_id, rawAgent);
+
+    const captured = await engine.captureBootSessionId(rawAgent.agent_id);
+
+    expect(captured).toMatchObject({
+      cli_session_id: "sid-raw",
+      cli_session_path: "/rollout/raw.jsonl",
+    });
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    engine.dispose();
+  });
+
+  it("captures self-registration on first connect without invoking the scan", async () => {
+    const selfRegistrationSessionResolver = vi.fn(() => ({
+      session_id: "sid-first-connect",
+      path: null,
+    }));
+    const { engine, stateMgr, registry } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+    );
+    const rawAgent = agent({
+      agent_id: "auto-claude-surface-first-connect",
+      state: "ready",
+      launcher_name: null,
+      launch_cwd: null,
+      worktree_path: null,
+      task_summary: "(auto-discovered)",
+    });
+    stateMgr.writeState(rawAgent);
+    registry.set(rawAgent.agent_id, rawAgent);
+    const scanSpy = vi.spyOn(
+      engine as unknown as {
+        findTranscriptSessionIdentity: (a: AgentRecord) => unknown;
+      },
+      "findTranscriptSessionIdentity",
+    );
+
+    const captured = await (
+      engine as unknown as {
+        maybeCaptureBootSessionId(
+          a: AgentRecord,
+          ctx: Record<string, never>,
+          opts: { resolveTranscript: boolean },
+        ): Promise<AgentRecord>;
+      }
+    ).maybeCaptureBootSessionId(rawAgent, {}, { resolveTranscript: false });
+
+    expect(captured.cli_session_id).toBe("sid-first-connect");
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    expect(scanSpy).not.toHaveBeenCalled();
     engine.dispose();
   });
 });

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -17,6 +17,8 @@ import type { CmuxClient } from "../src/cmux-client.js";
 const TEST_DIR = join(tmpdir(), "cmux-self-registration-test");
 const SURFACE_UUID_A = "11111111-2222-4333-8444-555555555555";
 const SURFACE_UUID_B = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+const SURFACE_UUID_C = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+const SURFACE_UUID_D = "12345678-90ab-4cde-8f01-234567890abc";
 
 /**
  * Minimal AgentRecord for resolver tests — the resolver only reads
@@ -156,6 +158,216 @@ describe("parseSelfRegistrationLines", () => {
 });
 
 describe("makeSelfRegistrationSessionResolver", () => {
+  it("indexes the registry once and reads only newly appended bytes", () => {
+    let body = Buffer.from(
+      jsonl(
+        {
+          session_id: "sid-A",
+          surface_uuid: SURFACE_UUID_A,
+          cwd: null,
+          ts: 1000,
+        },
+        {
+          session_id: "sid-B",
+          surface_uuid: SURFACE_UUID_B,
+          cwd: null,
+          ts: 2000,
+        },
+      ),
+    );
+    let mtimeMs = 1;
+    const reads: Array<{ offset: number; length: number }> = [];
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) => {
+        reads.push({ offset, length });
+        return body.subarray(offset, offset + length);
+      },
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-A",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))?.session_id).toBe(
+      "sid-B",
+    );
+    expect(reads).toEqual([{ offset: 0, length: body.byteLength }]);
+
+    const previousLength = body.byteLength;
+    body = Buffer.concat([
+      body,
+      Buffer.from(
+        jsonl({
+          session_id: "sid-C",
+          surface_uuid: SURFACE_UUID_C,
+          cwd: null,
+          ts: 3000,
+        }),
+      ),
+    ]);
+    mtimeMs += 1;
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_C }))?.session_id).toBe(
+      "sid-C",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-A",
+    );
+    expect(reads).toEqual([
+      { offset: 0, length: previousLength },
+      { offset: previousLength, length: body.byteLength - previousLength },
+    ]);
+  });
+
+  it("holds an incomplete UTF-8 append until its JSONL newline arrives", () => {
+    const firstLine = Buffer.from(
+      jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),
+    );
+    const secondLine = Buffer.from(
+      jsonl({
+        session_id: "sid-B",
+        surface_uuid: SURFACE_UUID_B,
+        session_path: "/tmp/🧪.jsonl",
+        ts: 2000,
+      }),
+    );
+    const multibyteMarker = Buffer.from("🧪");
+    const markerOffset = secondLine.indexOf(multibyteMarker);
+    expect(markerOffset).toBeGreaterThan(0);
+    const splitAt = markerOffset + 2;
+    let body = Buffer.concat([firstLine, secondLine.subarray(0, splitAt)]);
+    let mtimeMs = 1;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-A",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toBeNull();
+
+    body = Buffer.concat([body, secondLine.subarray(splitAt)]);
+    mtimeMs += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toEqual({
+      session_id: "sid-B",
+      path: "/tmp/🧪.jsonl",
+    });
+  });
+
+  it("drops cached candidates on same-size rewrite and inode rotation", () => {
+    let body = Buffer.from(
+      jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),
+    );
+    let mtimeMs = 1;
+    let ino = 1;
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({ size: body.byteLength, mtimeMs, dev: 1, ino }),
+      readFileRange: (_path, offset, length) =>
+        body.subarray(offset, offset + length),
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-A",
+    );
+
+    body = Buffer.from(
+      jsonl({ session_id: "sid-B", surface_uuid: SURFACE_UUID_B, ts: 2000 }),
+    );
+    mtimeMs += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))?.session_id).toBe(
+      "sid-B",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))).toBeNull();
+
+    body = Buffer.from(
+      jsonl({ session_id: "sid-C", surface_uuid: SURFACE_UUID_C, ts: 3000 }),
+    );
+    ino += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_C }))?.session_id).toBe(
+      "sid-C",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toBeNull();
+  });
+
+  it("resets after truncation and retries a short appended-byte read", () => {
+    let body = Buffer.from(
+      jsonl(
+        { session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 },
+        { session_id: "sid-B", surface_uuid: SURFACE_UUID_B, ts: 2000 },
+      ),
+    );
+    let mtimeMs = 1;
+    let shortNextRead = false;
+    const reads: Array<{ offset: number; length: number }> = [];
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) => {
+        reads.push({ offset, length });
+        if (shortNextRead) {
+          shortNextRead = false;
+          return body.subarray(offset, offset + length - 1);
+        }
+        return body.subarray(offset, offset + length);
+      },
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))?.session_id).toBe(
+      "sid-B",
+    );
+
+    body = Buffer.from(
+      jsonl({ session_id: "sid-C", surface_uuid: SURFACE_UUID_C, ts: 3000 }),
+    );
+    mtimeMs += 1;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_C }))?.session_id).toBe(
+      "sid-C",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toBeNull();
+
+    const previousLength = body.byteLength;
+    body = Buffer.concat([
+      body,
+      Buffer.from(
+        jsonl({
+          session_id: "sid-D",
+          surface_uuid: SURFACE_UUID_D,
+          ts: 4000,
+        }),
+      ),
+    ]);
+    mtimeMs += 1;
+    shortNextRead = true;
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_D }))).toBeNull();
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_D }))?.session_id).toBe(
+      "sid-D",
+    );
+    expect(reads.slice(-2).map((read) => read.offset)).toEqual([
+      previousLength,
+      previousLength,
+    ]);
+  });
+
   it("returns the registered session_id on a surface_uuid-exact match", () => {
     const resolve = resolverFor(
       jsonl({

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -158,7 +158,7 @@ describe("parseSelfRegistrationLines", () => {
 });
 
 describe("makeSelfRegistrationSessionResolver", () => {
-  it("indexes the registry once and reads only newly appended bytes", () => {
+  it("indexes once and reads only a bounded continuity tail plus new bytes", () => {
     let body = Buffer.from(
       jsonl(
         {
@@ -221,7 +221,10 @@ describe("makeSelfRegistrationSessionResolver", () => {
     );
     expect(reads).toEqual([
       { offset: 0, length: previousLength },
-      { offset: previousLength, length: body.byteLength - previousLength },
+      {
+        offset: previousLength - 64,
+        length: body.byteLength - previousLength + 64,
+      },
     ]);
   });
 
@@ -304,6 +307,48 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))).toBeNull();
   });
 
+  it("reindexes an in-place rewrite that grows instead of treating it as an append", () => {
+    let body = Buffer.from(
+      jsonl({ session_id: "sid-A", surface_uuid: SURFACE_UUID_A, ts: 1000 }),
+    );
+    let mtimeMs = 1;
+    const reads: Array<{ offset: number; length: number }> = [];
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      statFile: () => ({
+        size: body.byteLength,
+        mtimeMs,
+        dev: 1,
+        ino: 1,
+      }),
+      readFileRange: (_path, offset, length) => {
+        reads.push({ offset, length });
+        return body.subarray(offset, offset + length);
+      },
+    });
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))?.session_id).toBe(
+      "sid-A",
+    );
+
+    body = Buffer.from(
+      jsonl(
+        { session_id: "sid-B", surface_uuid: SURFACE_UUID_B, ts: 2000 },
+        { session_id: "sid-C", surface_uuid: SURFACE_UUID_C, ts: 3000 },
+      ),
+    );
+    mtimeMs += 1;
+
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_B }))?.session_id).toBe(
+      "sid-B",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_C }))?.session_id).toBe(
+      "sid-C",
+    );
+    expect(resolve(agent({ surface_uuid: SURFACE_UUID_A }))).toBeNull();
+    expect(reads.at(-1)?.offset).toBe(0);
+  });
+
   it("resets after truncation and retries a short appended-byte read", () => {
     let body = Buffer.from(
       jsonl(
@@ -363,8 +408,8 @@ describe("makeSelfRegistrationSessionResolver", () => {
       "sid-D",
     );
     expect(reads.slice(-2).map((read) => read.offset)).toEqual([
-      previousLength,
-      previousLength,
+      previousLength - 64,
+      previousLength - 64,
     ]);
   });
 

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -293,6 +293,7 @@ describe("makeSelfRegistrationSessionResolver", () => {
       resolve(
         agent({
           launch_cwd: "/w",
+          surface_provenance: "cmuxlayer_spawn",
           created_at: new Date(createdAt).toISOString(),
         }),
       ),
@@ -313,6 +314,7 @@ describe("makeSelfRegistrationSessionResolver", () => {
       resolve(
         agent({
           launch_cwd: "/w",
+          surface_provenance: "cmuxlayer_spawn",
           created_at: new Date(createdAt).toISOString(),
         }),
       )?.session_id,
@@ -353,6 +355,53 @@ describe("makeSelfRegistrationSessionResolver", () => {
       )?.session_id,
     ).toBe("sid-current");
   });
+
+  it.each([
+    {
+      label: "auto-discovered",
+      overrides: {
+        surface_provenance: "unknown" as const,
+        task_summary: "(auto-discovered)",
+        launcher_name: null,
+        launch_cwd: null,
+        worktree_path: null,
+      },
+    },
+    {
+      label: "resync-repaired",
+      overrides: {
+        surface_provenance: undefined,
+        task_summary: "(resync-repaired)",
+        launch_cwd: null,
+        worktree_path: null,
+      },
+    },
+  ])(
+    "accepts a valid $label registration older than its discovery record",
+    ({ overrides }) => {
+      const now = Date.parse("2026-07-18T00:10:00.000Z");
+      const discoveredAt = now - 10_000;
+      const resolve = makeSelfRegistrationSessionResolver({
+        registryPath: "/fake/registry.jsonl",
+        readFile: () =>
+          jsonl({
+            session_id: "sid-already-running",
+            cwd: "/actual/agent/cwd",
+            ts: discoveredAt - 60_000,
+          }),
+        now: () => now,
+      });
+
+      expect(
+        resolve(
+          agent({
+            ...overrides,
+            created_at: new Date(discoveredAt).toISOString(),
+          }),
+        )?.session_id,
+      ).toBe("sid-already-running");
+    },
+  );
 
   it("accepts a timestamp at the reader-clock skew boundary", () => {
     const now = Date.parse("2026-07-18T00:01:00.000Z");


### PR DESCRIPTION
## Summary

- Add the self-registration read side for `${CMUXLAYER_SESSION_REGISTRY:-$HOME/.cmuxlayer/session-registry.jsonl}` and wire it ahead of the deprecated transcript-directory scan in stdio, daemon, and app-server production entrypoints.
- Join records by the hook-provided `surface_uuid` (`CMUX_SURFACE_ID`) to `AgentRecord.surface_uuid`. Exact `launch_cwd` is only an optional secondary validator; newest epoch-ms wins remaining ties.
- Ignore `AgentRecord.pid` during selection. Production spawn, recovery, repair, and auto-discovery paths populate it as `null`; no production caller supplies the CLI PID through the generic transition seam.
- Require `session_id` + `surface_uuid`, tolerate missing/mismatched cwd and unknown fields, preserve `session_path`, reject non-integer PID/timestamp metadata, and fall back without throwing on malformed/missing registry data.

## Binding-key blocker resolved

The initial pid/cwd contract was unsound for RAW seats: live repaired/auto records had both `pid:null` and `launch_cwd:null`, while terminal metadata exposed the shell cwd rather than the agent worktree cwd. The design ruling is now `CMUX_SURFACE_ID -> AgentRecord.surface_uuid`, which is the same stable UUID space already used by registry reconciliation. Tests cover two records with absent/mismatched cwd and distinct UUIDs, proving each agent binds only its own session.

Records from an older writer that lack `surface_uuid` intentionally return null and use the bounded last-resort scan; layerSpec is adding `surface_uuid` to the writer record.

## Verification

- TDD: UUID-primary tests failed against cwd-first selection, then passed after the resolver/parser change.
- `bun run test tests/self-registration.test.ts` — 21/21 passed.
- `bun run typecheck && env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` — 105/105 files, 2231/2231 tests passed on committed head.
- The push hook independently finished green (`run_tests.sh finished with exit status 0`; 2231/2231 Vitest tests plus contract/regression checks).

One declared spawn-manifest flake initially timed out because its static generated temp directory had accumulated 3,180 files / 148 MB. Moving that exact fixture directory to Trash made the unchanged focused test pass in 116 ms; two subsequent full gates were green. No timeout or coverage workaround was used.

Local CodeRabbit was attempted but its free OSS quota was exhausted; GitHub CI/review findings will be processed on this PR.

Base: `origin/main` / v0.4.15. Do not merge; held for the cleared Claude review and Etan's merge/release decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent lifecycle session binding used during boot and sweeps; incorrect matching or fallback behavior could leave agents without `cli_session_id`, though transcript scan remains as last resort and tests default stays hermetic.
> 
> **Overview**
> Introduces **self-registration as the primary way** to bind managed agents to harness `session_id` values at boot, instead of inferring from `~/.claude` / `~/.codex` transcript scans.
> 
> A new **`self-registration.ts`** module reads append-only **`session-registry.jsonl`** (or `CMUXLAYER_SESSION_REGISTRY`), parses tolerant JSONL rows, and matches **`surface_uuid`** on the agent to hook-written records—optionally preferring exact **`launch_cwd`**, then newest **`ts`**. Production uses an **incremental index** (dev/inode, byte continuity, bounded per-surface history) so sweeps do not re-read the whole file.
> 
> **`AgentEngine`** gains **`selfRegistrationSessionResolver`** (off by default for hermetic tests). Resolution order is: self-registration → injected **`sessionIdentityResolver`** (test override) → deprecated **`findTranscriptSessionIdentity`**. Boot capture paths (`maybeCaptureBootSessionId`) honor the same ordering.
> 
> **Stdio, daemon, and app-server** entrypoints inject **`makeSelfRegistrationSessionResolver()`** through **`createServer`** / daemon context options; daemon tests assert custom resolver forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6397ba5e50327b541c39e0ac38a8e2b96a7bbffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve self-registered sessions by surface UUID from a JSONL registry file
> - Adds `makeSelfRegistrationSessionResolver` in [self-registration.ts](https://github.com/EtanHey/cmuxlayer/pull/338/files#diff-cf32477d60bc1f3ca2d584c32ddbd325f3ec591ab42b5daf4d9b5ffebc76beea), which reads a JSONL registry file (default `~/.cmuxlayer/session-registry.jsonl`, overridable via `CMUXLAYER_SESSION_REGISTRY`) and returns a matching `session_id` and path keyed by `surface_uuid`.
> - The resolver uses an incremental, append-aware reader that detects file rotation/truncation and re-indexes only new bytes, avoiding full re-reads on each invocation.
> - `AgentEngine` now tries the self-registration resolver first, then an optional injected fallback, and only falls back to the legacy transcript scan as a last resort.
> - The resolver is wired into all three server entry points: `CmuxLayerDaemon`, `CmuxAppServerRuntime`, and `startInProcessRuntime`, with an escape hatch to inject a custom resolver via options.
> - Risk: the legacy transcript scan is now bypassed whenever self-registration succeeds, which changes session capture behavior for agents with a non-empty `surface_uuid` in a JSONL-backed harness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6397ba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-registration–based session identity resolution as the primary matching path.
  * Exposed an optional custom session resolver across server and daemon setups, including in-process runtime.
  * Improved session registry handling for incremental updates, truncation, and safe candidate selection.

* **Bug Fixes**
  * Strengthened fallback behavior when self-registration can’t determine a session.
  * Refined boot prompt detection, readiness matching, and session capture/command status reporting.

* **Tests**
  * Added extensive unit and integration tests covering resolver behavior, registry edge cases, and engine integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->