### PR TITLE
feat: surface Codex context fill from rollout files

### DIFF
--- a/src/codex-rollout-fill.ts
+++ b/src/codex-rollout-fill.ts
@@ -1,0 +1,422 @@
+import { open, stat } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import { parseCodexTokenUsageEvent } from "./harness-session.js";
+
+export const CODEX_CONTEXT_WINDOW = 400_000 as const;
+export const CODEX_ROLLOUT_READ_CHUNK_BYTES = 64 * 1024;
+export const CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES = 64 * 1024;
+export const CODEX_ROLLOUT_MAX_TAIL_BYTES = 512 * 1024;
+export const CODEX_ROLLOUT_REFRESH_INTERVAL_MS = 1_000;
+export const CODEX_ROLLOUT_CONTINUITY_BYTES = 64;
+export const CODEX_ROLLOUT_MAX_CACHE_ENTRIES = 1_024;
+
+export interface CodexRolloutFill {
+  token_count: number;
+  context_window: typeof CODEX_CONTEXT_WINDOW;
+  context_pct: number;
+  observed_model_context_window: number | null;
+}
+
+export interface CodexRolloutFileStat {
+  size: number;
+  mtimeMs: number;
+  dev: number;
+  ino: number;
+  isFile: boolean;
+}
+
+export interface CodexRolloutFillProviderOptions {
+  now?: () => number;
+  refreshIntervalMs?: number;
+  maxConcurrentReads?: number;
+  maxEntries?: number;
+  statFile?: (path: string) => Promise<CodexRolloutFileStat | null>;
+  readFileRange?: (
+    path: string,
+    start: number,
+    length: number,
+  ) => Promise<Uint8Array | null>;
+}
+
+export interface CodexRolloutFillProvider {
+  get(path: string): Promise<CodexRolloutFill | null>;
+}
+
+interface FillCacheEntry {
+  snapshot: CodexRolloutFill | null;
+  identity: string | null;
+  size: number;
+  mtimeMs: number;
+  cursor: number;
+  continuity: Buffer;
+  pending: Buffer;
+  discardingLine: boolean;
+  lastCheckedAt: number;
+  lastAccessAt: number;
+  inFlight: Promise<CodexRolloutFill | null> | null;
+}
+
+type ReadFileRange = NonNullable<
+  CodexRolloutFillProviderOptions["readFileRange"]
+>;
+
+async function readRangeFully(
+  readFileRange: ReadFileRange,
+  path: string,
+  start: number,
+  length: number,
+): Promise<Buffer | null> {
+  const chunks: Buffer[] = [];
+  let offset = 0;
+  while (offset < length) {
+    const requested = Math.min(
+      CODEX_ROLLOUT_READ_CHUNK_BYTES,
+      length - offset,
+    );
+    const bytes = await readFileRange(path, start + offset, requested);
+    if (!bytes || bytes.byteLength === 0) return null;
+    const chunk = Buffer.from(bytes);
+    chunks.push(chunk);
+    offset += chunk.length;
+  }
+  return Buffer.concat(chunks, offset);
+}
+
+async function defaultStatFile(
+  path: string,
+): Promise<CodexRolloutFileStat | null> {
+  try {
+    const value = await stat(path);
+    return {
+      size: value.size,
+      mtimeMs: value.mtimeMs,
+      dev: value.dev,
+      ino: value.ino,
+      isFile: value.isFile(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function defaultReadFileRange(
+  path: string,
+  start: number,
+  length: number,
+): Promise<Uint8Array | null> {
+  let file: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    file = await open(path, "r");
+    const buffer = Buffer.allocUnsafe(length);
+    const { bytesRead } = await file.read(buffer, 0, length, start);
+    return buffer.subarray(0, bytesRead);
+  } catch {
+    return null;
+  } finally {
+    await file?.close().catch(() => {});
+  }
+}
+
+export function makeCodexRolloutFillProvider(
+  options: CodexRolloutFillProviderOptions = {},
+): CodexRolloutFillProvider {
+  const statFile = options.statFile ?? defaultStatFile;
+  const readFileRange = options.readFileRange ?? defaultReadFileRange;
+  const now = options.now ?? Date.now;
+  const refreshIntervalMs = Math.max(
+    0,
+    options.refreshIntervalMs ?? CODEX_ROLLOUT_REFRESH_INTERVAL_MS,
+  );
+  const maxConcurrentReads = Math.max(
+    1,
+    Math.floor(options.maxConcurrentReads ?? 4),
+  );
+  const maxEntries = Math.max(
+    1,
+    Math.floor(options.maxEntries ?? CODEX_ROLLOUT_MAX_CACHE_ENTRIES),
+  );
+  let activeReads = 0;
+  const readWaiters: Array<() => void> = [];
+  const cache = new Map<string, FillCacheEntry>();
+
+  const evictOldestSettled = (): boolean => {
+    let oldestPath: string | null = null;
+    let oldestAccess = Number.POSITIVE_INFINITY;
+    for (const [candidatePath, candidate] of cache) {
+      if (candidate.inFlight || candidate.lastAccessAt >= oldestAccess) continue;
+      oldestPath = candidatePath;
+      oldestAccess = candidate.lastAccessAt;
+    }
+    return oldestPath === null ? false : cache.delete(oldestPath);
+  };
+
+  const trimCache = (): void => {
+    while (cache.size > maxEntries && evictOldestSettled()) {
+      // At most `maxEntries` settled paths survive. In-flight paths are retained
+      // until their callers finish, then the next completion trims them.
+    }
+  };
+
+  const withReadPermit = async <T>(operation: () => Promise<T>): Promise<T> => {
+    if (activeReads >= maxConcurrentReads) {
+      await new Promise<void>((resolve) => readWaiters.push(resolve));
+    }
+    activeReads += 1;
+    try {
+      return await operation();
+    } finally {
+      activeReads -= 1;
+      readWaiters.shift()?.();
+    }
+  };
+
+  const parseLine = (entry: FillCacheEntry, lineBytes: Buffer): void => {
+    const line = lineBytes.toString("utf8").trim();
+    if (!line) return;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!parsed || typeof parsed !== "object") return;
+      const latest = parseCodexTokenUsageEvent(
+        parsed as Record<string, unknown>,
+      );
+      if (!latest) return;
+      entry.snapshot = {
+        token_count: latest.total_tokens,
+        context_window: CODEX_CONTEXT_WINDOW,
+        context_pct: Math.min(
+          100,
+          Math.max(
+            0,
+            Math.round((latest.total_tokens / CODEX_CONTEXT_WINDOW) * 100),
+          ),
+        ),
+        observed_model_context_window: latest.model_context_window,
+      };
+    } catch {
+      // Malformed live rows are ignored; a complete later row can recover.
+    }
+  };
+
+  const ingest = (
+    entry: FillCacheEntry,
+    bytes: Buffer,
+    discardLeadingPartial: boolean,
+  ): void => {
+    let combined =
+      entry.pending.length > 0
+        ? Buffer.concat([entry.pending, bytes])
+        : bytes;
+    entry.pending = Buffer.alloc(0);
+    if (entry.discardingLine || discardLeadingPartial) {
+      const newline = combined.indexOf(0x0a);
+      if (newline < 0) {
+        entry.discardingLine = true;
+        return;
+      }
+      entry.discardingLine = false;
+      combined = combined.subarray(newline + 1);
+    }
+
+    let lineStart = 0;
+    while (lineStart < combined.length) {
+      const newline = combined.indexOf(0x0a, lineStart);
+      if (newline < 0) break;
+      if (newline - lineStart <= CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES) {
+        parseLine(entry, combined.subarray(lineStart, newline));
+      }
+      lineStart = newline + 1;
+    }
+    if (lineStart < combined.length) {
+      const pending = combined.subarray(lineStart);
+      if (pending.length <= CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES) {
+        entry.pending = Buffer.from(pending);
+      } else {
+        entry.discardingLine = true;
+      }
+    }
+  };
+
+  const resetReader = (entry: FillCacheEntry): void => {
+    entry.snapshot = null;
+    entry.identity = null;
+    entry.size = 0;
+    entry.mtimeMs = 0;
+    entry.cursor = 0;
+    entry.continuity = Buffer.alloc(0);
+    entry.pending = Buffer.alloc(0);
+    entry.discardingLine = false;
+  };
+
+  const cloneReader = (entry: FillCacheEntry): FillCacheEntry => ({
+    ...entry,
+    continuity: Buffer.from(entry.continuity),
+    pending: Buffer.from(entry.pending),
+  });
+
+  const commitReader = (
+    target: FillCacheEntry,
+    source: FillCacheEntry,
+  ): void => {
+    target.snapshot = source.snapshot;
+    target.identity = source.identity;
+    target.size = source.size;
+    target.mtimeMs = source.mtimeMs;
+    target.cursor = source.cursor;
+    target.continuity = source.continuity;
+    target.pending = source.pending;
+    target.discardingLine = source.discardingLine;
+  };
+
+  const bootstrap = async (
+    path: string,
+    entry: FillCacheEntry,
+    fileStat: CodexRolloutFileStat,
+  ): Promise<CodexRolloutFill | null> => {
+    const start = Math.max(
+      0,
+      fileStat.size - CODEX_ROLLOUT_MAX_TAIL_BYTES,
+    );
+    const bytes = await readRangeFully(
+      readFileRange,
+      path,
+      start,
+      fileStat.size - start,
+    );
+    if (!bytes) return entry.snapshot;
+
+    const draft = cloneReader(entry);
+    ingest(draft, bytes, start > 0);
+    draft.identity = `${fileStat.dev}:${fileStat.ino}`;
+    draft.size = fileStat.size;
+    draft.mtimeMs = fileStat.mtimeMs;
+    draft.cursor = fileStat.size;
+    draft.continuity = Buffer.from(
+      bytes.subarray(
+        Math.max(0, bytes.length - CODEX_ROLLOUT_CONTINUITY_BYTES),
+      ),
+    );
+    commitReader(entry, draft);
+    return entry.snapshot;
+  };
+
+  const refreshEntry = async (
+    path: string,
+    entry: FillCacheEntry,
+  ): Promise<CodexRolloutFill | null> => {
+    const fileStat = await statFile(path);
+    if (!fileStat) return entry.snapshot;
+    if (!fileStat.isFile || fileStat.size <= 0) {
+      resetReader(entry);
+      return null;
+    }
+    const identity = `${fileStat.dev}:${fileStat.ino}`;
+    const identityChanged =
+      entry.identity !== null && entry.identity !== identity;
+    const truncated = entry.identity === identity && fileStat.size < entry.cursor;
+    const sameSizeRewrite =
+      entry.identity === identity &&
+      fileStat.size === entry.cursor &&
+      fileStat.mtimeMs !== entry.mtimeMs;
+    if (
+      entry.identity === null ||
+      identityChanged ||
+      truncated ||
+      sameSizeRewrite
+    ) {
+      resetReader(entry);
+      return bootstrap(path, entry, fileStat);
+    }
+
+    if (fileStat.size === entry.cursor) return entry.snapshot;
+    if (entry.continuity.length > 0) {
+      const actual = await readRangeFully(
+        readFileRange,
+        path,
+        entry.cursor - entry.continuity.length,
+        entry.continuity.length,
+      );
+      if (!actual) return entry.snapshot;
+      if (!actual.equals(entry.continuity)) {
+        resetReader(entry);
+        return bootstrap(path, entry, fileStat);
+      }
+    }
+
+    const growth = fileStat.size - entry.cursor;
+    if (growth > CODEX_ROLLOUT_MAX_TAIL_BYTES) {
+      resetReader(entry);
+      return bootstrap(path, entry, fileStat);
+    }
+    const appended = await readRangeFully(
+      readFileRange,
+      path,
+      entry.cursor,
+      growth,
+    );
+    if (!appended) return entry.snapshot;
+    const draft = cloneReader(entry);
+    ingest(draft, appended, false);
+    draft.size = fileStat.size;
+    draft.mtimeMs = fileStat.mtimeMs;
+    draft.cursor = fileStat.size;
+    draft.continuity = Buffer.concat([
+      draft.continuity,
+      appended,
+    ]).subarray(-CODEX_ROLLOUT_CONTINUITY_BYTES);
+    commitReader(entry, draft);
+    return entry.snapshot;
+  };
+
+  return {
+    async get(path: string): Promise<CodexRolloutFill | null> {
+      if (!isAbsolute(path)) return null;
+      const checkedAt = now();
+      let entry = cache.get(path);
+      if (!entry) {
+        while (cache.size >= maxEntries && evictOldestSettled()) {
+          // Make room for this newly accessed path when a settled entry exists.
+        }
+        entry = {
+          snapshot: null,
+          identity: null,
+          size: 0,
+          mtimeMs: 0,
+          cursor: 0,
+          continuity: Buffer.alloc(0),
+          pending: Buffer.alloc(0),
+          discardingLine: false,
+          lastCheckedAt: Number.NEGATIVE_INFINITY,
+          lastAccessAt: checkedAt,
+          inFlight: null,
+        };
+        cache.set(path, entry);
+      }
+      entry.lastAccessAt = checkedAt;
+      if (checkedAt - entry.lastCheckedAt < refreshIntervalMs) {
+        return entry.snapshot;
+      }
+      if (!entry.inFlight) {
+        const refresh = withReadPermit(() => refreshEntry(path, entry!))
+          .then((snapshot) => {
+            entry!.snapshot = snapshot;
+            entry!.lastCheckedAt = now();
+            return snapshot;
+          })
+          .catch(() => {
+            entry!.lastCheckedAt = now();
+            return entry!.snapshot;
+          })
+          .finally(() => {
+            if (entry!.inFlight === refresh) entry!.inFlight = null;
+            trimCache();
+          });
+        entry.inFlight = refresh;
+      }
+      if (entry.snapshot) {
+        void entry.inFlight;
+        return entry.snapshot;
+      }
+      return entry.inFlight;
+    },
+  };
+}

--- a/src/codex-rollout-fill.ts
+++ b/src/codex-rollout-fill.ts
@@ -284,6 +284,17 @@ export function makeCodexRolloutFillProvider(
       0,
       fileStat.size - CODEX_ROLLOUT_MAX_TAIL_BYTES,
     );
+    let discardLeadingPartial = false;
+    if (start > 0) {
+      const preceding = await readRangeFully(
+        readFileRange,
+        path,
+        start - 1,
+        1,
+      );
+      if (!preceding) return entry.snapshot;
+      discardLeadingPartial = preceding[0] !== 0x0a;
+    }
     const bytes = await readRangeFully(
       readFileRange,
       path,
@@ -291,9 +302,18 @@ export function makeCodexRolloutFillProvider(
       fileStat.size - start,
     );
     if (!bytes) return entry.snapshot;
+    const confirmedStat = await statFile(path);
+    if (
+      !confirmedStat?.isFile ||
+      confirmedStat.dev !== fileStat.dev ||
+      confirmedStat.ino !== fileStat.ino ||
+      confirmedStat.size < fileStat.size
+    ) {
+      return entry.snapshot;
+    }
 
     const draft = cloneReader(entry);
-    ingest(draft, bytes, start > 0);
+    ingest(draft, bytes, discardLeadingPartial);
     draft.identity = `${fileStat.dev}:${fileStat.ino}`;
     draft.size = fileStat.size;
     draft.mtimeMs = fileStat.mtimeMs;

--- a/src/codex-rollout-fill.ts
+++ b/src/codex-rollout-fill.ts
@@ -30,6 +30,7 @@ export interface CodexRolloutFillProviderOptions {
   refreshIntervalMs?: number;
   maxConcurrentReads?: number;
   maxEntries?: number;
+  /** Return null only for confirmed absence; reject transient stat failures. */
   statFile?: (path: string) => Promise<CodexRolloutFileStat | null>;
   readFileRange?: (
     path: string,
@@ -94,8 +95,10 @@ async function defaultStatFile(
       ino: value.ino,
       isFile: value.isFile(),
     };
-  } catch {
-    return null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return null;
+    throw error;
   }
 }
 
@@ -309,7 +312,10 @@ export function makeCodexRolloutFillProvider(
     entry: FillCacheEntry,
   ): Promise<CodexRolloutFill | null> => {
     const fileStat = await statFile(path);
-    if (!fileStat) return entry.snapshot;
+    if (!fileStat) {
+      resetReader(entry);
+      return null;
+    }
     if (!fileStat.isFile || fileStat.size <= 0) {
       resetReader(entry);
       return null;
@@ -381,6 +387,7 @@ export function makeCodexRolloutFillProvider(
         while (cache.size >= maxEntries && evictOldestSettled()) {
           // Make room for this newly accessed path when a settled entry exists.
         }
+        if (cache.size >= maxEntries) return null;
         entry = {
           snapshot: null,
           identity: null,

--- a/src/codex-rollout-fill.ts
+++ b/src/codex-rollout-fill.ts
@@ -160,13 +160,18 @@ export function makeCodexRolloutFillProvider(
   const withReadPermit = async <T>(operation: () => Promise<T>): Promise<T> => {
     if (activeReads >= maxConcurrentReads) {
       await new Promise<void>((resolve) => readWaiters.push(resolve));
+    } else {
+      activeReads += 1;
     }
-    activeReads += 1;
     try {
       return await operation();
     } finally {
       activeReads -= 1;
-      readWaiters.shift()?.();
+      const next = readWaiters.shift();
+      if (next) {
+        activeReads += 1;
+        next();
+      }
     }
   };
 

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -263,6 +263,46 @@ function codexPayload(ev: Record<string, unknown>): {
   return { type, payload };
 }
 
+export interface CodexTokenUsageSample {
+  input_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_write_input_tokens: number | null;
+  output_tokens: number | null;
+  reasoning_output_tokens: number | null;
+  total_tokens: number;
+  model_context_window: number | null;
+}
+
+function asTokenCount(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+    ? value
+    : null;
+}
+
+/** Parse one upstream Codex `event_msg`/`token_count` rollout item. */
+export function parseCodexTokenUsageEvent(
+  ev: Record<string, unknown>,
+): CodexTokenUsageSample | null {
+  const { type, payload } = codexPayload(ev);
+  if (type !== "token_count") return null;
+  const info = asRecord(payload.info);
+  const last = asRecord(info?.last_token_usage);
+  const totalTokens = asTokenCount(last?.total_tokens);
+  if (totalTokens === null) return null;
+
+  return {
+    input_tokens: asTokenCount(last?.input_tokens),
+    cached_input_tokens: asTokenCount(last?.cached_input_tokens),
+    cache_write_input_tokens: asTokenCount(last?.cache_write_input_tokens),
+    output_tokens: asTokenCount(last?.output_tokens),
+    reasoning_output_tokens: asTokenCount(last?.reasoning_output_tokens),
+    total_tokens: totalTokens,
+    model_context_window: asTokenCount(info?.model_context_window),
+  };
+}
+
 function parseCodex(events: Record<string, unknown>[]): HarnessSessionState {
   let model: string | null = null;
   let tokensUsed: number | null = null;
@@ -278,13 +318,12 @@ function parseCodex(events: Record<string, unknown>[]): HarnessSessionState {
         break;
       }
       case "token_count": {
-        const info = asRecord(payload.info);
-        if (info) {
-          const last = asRecord(info.last_token_usage);
-          const total = asNumber(last?.total_tokens);
-          if (total !== null) tokensUsed = total;
-          const w = asNumber(info.model_context_window);
-          if (w !== null) window = w;
+        const usage = parseCodexTokenUsageEvent(ev);
+        if (usage) {
+          tokensUsed = usage.total_tokens;
+          if (usage.model_context_window !== null) {
+            window = usage.model_context_window;
+          }
         }
         break;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1839,6 +1839,7 @@ const JSONL_HARNESSES = new Set<Harness>(["claude", "codex", "cursor"]);
 function resolveHarnessStateForSurface(
   stateMgr: StateManager,
   surfaceRef: string,
+  authorizedRecord?: AgentRecord | null,
 ): ReturnType<typeof loadHarnessSession> {
   if (!harnessJsonlEnabled()) return null;
   const matches = stateMgr
@@ -1850,7 +1851,7 @@ function resolveHarnessStateForSurface(
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       );
     });
-  const record = matches[0];
+  const record = authorizedRecord ?? matches[0];
   const cli = record?.cli as Harness | undefined;
   const sessionId = record?.cli_session_id ?? null;
   // Codex fill is handled asynchronously from the exact self-registration
@@ -3348,7 +3349,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const readParsedSurface = async (
     surface: string,
     workspace?: string,
-    opts?: { throwOnSurfaceGone?: boolean },
+    opts?: { throwOnSurfaceGone?: boolean; agent?: AgentRecord },
   ): Promise<{ text: string; parsed: ParsedScreenResult } | null> => {
     try {
       const screen = await client.readScreen(surface, {
@@ -3362,7 +3363,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           text,
           pickLatestSurfaceModel(stateMgr, surface),
         ),
-        resolveHarnessStateForSurface(stateMgr, surface),
+        resolveHarnessStateForSurface(stateMgr, surface, opts?.agent),
       );
       return { text, parsed };
     } catch (error) {
@@ -4871,6 +4872,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     after: AgentRecord | null,
   ): AgentRecord | null => {
     if (!before || !after) return null;
+    if (before.cli !== "codex" || after.cli !== "codex") return null;
     if (before.agent_id !== after.agent_id) return null;
     if (
       before.surface_uuid?.trim().toLowerCase() !==
@@ -4879,6 +4881,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return null;
     }
     return before.cli_session_path === after.cli_session_path ? after : null;
+  };
+
+  const validateCodexRolloutFill = async (
+    agent: AgentRecord | null,
+    expectedSurfaceRef: string | null,
+    fill: CodexRolloutFill | null,
+  ): Promise<CodexRolloutFill | null> => {
+    if (!agent || !expectedSurfaceRef || !fill) return null;
+    const current = stateMgr.readState(agent.agent_id);
+    if (!sameCodexSessionBinding(agent, current)) return null;
+    const topology = await collectSurfaceTopology().catch(() => null);
+    const binding = current
+      ? resolveAuthorizedAgentSurfaceBinding(current, topology)
+      : null;
+    return binding?.surfaceRef === expectedSurfaceRef ? fill : null;
   };
 
   const applyCodexRolloutFill = (
@@ -4913,6 +4930,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       parsedSurface = await readParsedSurface(
         binding.surfaceRef,
         binding.workspaceId ?? undefined,
+        { agent },
       );
     }
     const surfaceOverrides = healthTopologyOverrides(
@@ -5062,6 +5080,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ? await readParsedSurface(
           binding.surfaceRef,
           binding.workspaceId ?? undefined,
+          { agent },
         )
       : null;
     const health = await evaluateServerAgentHealth(
@@ -6530,6 +6549,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const { column, column_count } =
           topology?.topologyBySurface.get(result.surface) ??
           EMPTY_SURFACE_TOPOLOGY;
+        const codexAgent = sameCodexSessionBinding(
+          codexAgentBeforeRead,
+          resolveCodexAgentForSurface(result.surface, topology),
+        );
+        const codexFill = await validateCodexRolloutFill(
+          codexAgent,
+          result.surface,
+          await readCodexRolloutFill(codexAgent),
+        );
         const parsed = applyCodexRolloutFill(
           applyHarnessState(
             enrichParsedScreen(
@@ -6537,14 +6565,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               result.text,
               pickLatestSurfaceModel(stateMgr, result.surface),
             ),
-            resolveHarnessStateForSurface(stateMgr, result.surface),
-          ),
-          await readCodexRolloutFill(
-            sameCodexSessionBinding(
-              codexAgentBeforeRead,
-              resolveCodexAgentForSurface(result.surface, topology),
+            resolveHarnessStateForSurface(
+              stateMgr,
+              result.surface,
+              codexAgent,
             ),
           ),
+          codexFill,
         );
 
         if (args.parsed_only) {
@@ -9240,7 +9267,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             state,
             topology,
           );
-          const [health, codexFill] = await Promise.all([
+          const [health, pendingCodexFill] = await Promise.all([
             evaluateServerAgentHealth(
               state,
               {
@@ -9251,6 +9278,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ),
             readCodexRolloutFill(authorizedBinding ? state : null),
           ]);
+          const codexFill = await validateCodexRolloutFill(
+            authorizedBinding ? state : null,
+            authorizedBinding?.surfaceRef ?? null,
+            pendingCodexFill,
+          );
           const formatted =
             formatAgentState(state) +
             `\nharvestability: ${
@@ -10936,7 +10968,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 liveSurfaceId = resolved.route.surface_id;
                 const screen = resolved.screen;
                 const fillWaitMs = Math.max(0, screenDeadline - Date.now());
-                const codexFill =
+                const pendingCodexFill =
                   fillWaitMs === 0
                     ? null
                     : await new Promise<CodexRolloutFill | null>((resolve) => {
@@ -10955,6 +10987,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           },
                         );
                       });
+                const codexFill = await validateCodexRolloutFill(
+                  agent,
+                  resolved.route.surface_id,
+                  pendingCodexFill,
+                );
                 screenData = applyCodexRolloutFill(
                   applyHarnessState(
                     enrichParsedScreen(
@@ -10962,7 +10999,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       screen.text,
                       pickLatestSurfaceModel(stateMgr, liveSurfaceId),
                     ),
-                    resolveHarnessStateForSurface(stateMgr, liveSurfaceId),
+                    resolveHarnessStateForSurface(
+                      stateMgr,
+                      liveSurfaceId,
+                      agent,
+                    ),
                   ),
                   codexFill,
                 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,6 +117,11 @@ import {
   loadHarnessSession,
   type Harness,
 } from "./harness-session.js";
+import {
+  makeCodexRolloutFillProvider,
+  type CodexRolloutFill,
+  type CodexRolloutFillProvider,
+} from "./codex-rollout-fill.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import {
   canInferAgentRole,
@@ -1848,6 +1853,9 @@ function resolveHarnessStateForSurface(
   const record = matches[0];
   const cli = record?.cli as Harness | undefined;
   const sessionId = record?.cli_session_id ?? null;
+  // Codex fill is handled asynchronously from the exact self-registration
+  // session path. Never fall back to the legacy synchronous sessions-dir scan.
+  if (cli === "codex") return null;
   if (!cli || !sessionId || !JSONL_HARNESSES.has(cli)) return null;
   // Honor CODEX_HOME (already used by app-server-bridge) and a test-only home override.
   const opts = {
@@ -1991,6 +1999,8 @@ export interface CreateServerOptions {
    * `makeSelfRegistrationSessionResolver()`; unset in tests keeps HOME I/O out.
    */
   selfRegistrationSessionResolver?: SessionIdentityResolver;
+  /** Async, throttled Codex rollout reader (primarily injectable for tests). */
+  codexRolloutFillProvider?: CodexRolloutFillProvider;
   /** Override git worktree execution/home for tests. */
   worktreeExec?: WorktreeExec;
   worktreeHomeDir?: string;
@@ -2079,6 +2089,7 @@ export interface CmuxServerContext {
   surfaceWriteLivenessCandidates: Set<string>;
   surfacePtyDeadSince: Map<string, number>;
   readScreenInflight: Map<string, Promise<ReadScreenSnapshot>>;
+  codexRolloutFillProvider: CodexRolloutFillProvider;
   surfaceWriteLiveness: SurfaceWriteLivenessTracker;
   enableClaudeChannels: boolean;
   skipAgentLifecycle: boolean;
@@ -2198,6 +2209,8 @@ export function createServerContext(
     surfaceWriteLivenessCandidates: new Set(),
     surfacePtyDeadSince: new Map(),
     readScreenInflight: new Map(),
+    codexRolloutFillProvider:
+      opts?.codexRolloutFillProvider ?? makeCodexRolloutFillProvider(),
     surfaceWriteLiveness:
       opts?.surfaceWriteLiveness ?? new SurfaceWriteLivenessTracker(),
     enableClaudeChannels:
@@ -4811,6 +4824,73 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       : null;
   };
 
+  const resolveCodexAgentForSurface = (
+    surfaceRef: string,
+    topology: SurfaceTopologySnapshot | null,
+  ): AgentRecord | null => {
+    const candidates = stateMgr
+      .listStates()
+      .filter(
+        (agent) =>
+          agent.cli === "codex" &&
+          Boolean(agent.surface_uuid?.trim()) &&
+          Boolean(agent.cli_session_path),
+      )
+      .sort((a, b) => {
+        if (b.version !== a.version) return b.version - a.version;
+        return (
+          new Date(b.updated_at).getTime() -
+          new Date(a.updated_at).getTime()
+        );
+      });
+
+    for (const candidate of candidates) {
+      const binding = resolveAuthorizedAgentSurfaceBinding(candidate, topology);
+      if (binding?.surfaceRef === surfaceRef) return candidate;
+    }
+    return null;
+  };
+
+  const readCodexRolloutFill = async (
+    agent: AgentRecord | null,
+  ): Promise<CodexRolloutFill | null> => {
+    const path = agent?.cli === "codex" ? agent.cli_session_path : null;
+    if (!path) return null;
+    try {
+      return await context.codexRolloutFillProvider.get(path);
+    } catch {
+      return null;
+    }
+  };
+
+  const sameCodexSessionBinding = (
+    before: AgentRecord | null,
+    after: AgentRecord | null,
+  ): AgentRecord | null => {
+    if (!before || !after) return null;
+    if (before.agent_id !== after.agent_id) return null;
+    if (
+      before.surface_uuid?.trim().toLowerCase() !==
+      after.surface_uuid?.trim().toLowerCase()
+    ) {
+      return null;
+    }
+    return before.cli_session_path === after.cli_session_path ? after : null;
+  };
+
+  const applyCodexRolloutFill = (
+    parsed: ParsedScreenResult,
+    fill: CodexRolloutFill | null,
+  ): ParsedScreenResult =>
+    fill
+      ? {
+          ...parsed,
+          token_count: fill.token_count,
+          context_window: fill.context_window,
+          context_pct: fill.context_pct,
+        }
+      : parsed;
+
   const evaluateServerAgentHealth = async (
     agent: AgentRecord,
     overrides?: AgentHealthInputOverrides,
@@ -6421,6 +6501,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.readOnly,
     async (args) => {
       try {
+        let codexAgentBeforeRead: AgentRecord | null = null;
+        const hasCodexRolloutCandidate = stateMgr.listStates().some(
+          (agent) =>
+            agent.cli === "codex" &&
+            Boolean(agent.surface_uuid?.trim()) &&
+            Boolean(agent.cli_session_path),
+        );
+        if (hasCodexRolloutCandidate) {
+          const topologyBeforeRead = await collectSurfaceTopology(
+            args.workspace,
+          ).catch(() => null);
+          codexAgentBeforeRead = resolveCodexAgentForSurface(
+            args.surface,
+            topologyBeforeRead,
+          );
+        }
         const { result, topology } = await readScreenSnapshot({
           surface: args.surface,
           workspace: args.workspace,
@@ -6431,13 +6527,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const { column, column_count } =
           topology?.topologyBySurface.get(result.surface) ??
           EMPTY_SURFACE_TOPOLOGY;
-        const parsed = applyHarnessState(
-          enrichParsedScreen(
-            parseScreen(result.text),
-            result.text,
-            pickLatestSurfaceModel(stateMgr, result.surface),
+        const parsed = applyCodexRolloutFill(
+          applyHarnessState(
+            enrichParsedScreen(
+              parseScreen(result.text),
+              result.text,
+              pickLatestSurfaceModel(stateMgr, result.surface),
+            ),
+            resolveHarnessStateForSurface(stateMgr, result.surface),
           ),
-          resolveHarnessStateForSurface(stateMgr, result.surface),
+          await readCodexRolloutFill(
+            sameCodexSessionBinding(
+              codexAgentBeforeRead,
+              resolveCodexAgentForSurface(result.surface, topology),
+            ),
+          ),
         );
 
         if (args.parsed_only) {
@@ -9129,14 +9233,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return err(new Error(`Agent not found: ${args.agent_id}`));
           const topology = await collectSurfaceTopology();
           const harvestability = engine.assessHarvestability(state);
-          const health = await evaluateServerAgentHealth(
+          const authorizedBinding = resolveAuthorizedAgentSurfaceBinding(
             state,
-            {
-              ...healthTopologyOverrides(state, topology),
-              harvestability,
-            },
             topology,
           );
+          const [health, codexFill] = await Promise.all([
+            evaluateServerAgentHealth(
+              state,
+              {
+                ...healthTopologyOverrides(state, topology),
+                harvestability,
+              },
+              topology,
+            ),
+            readCodexRolloutFill(authorizedBinding ? state : null),
+          ]);
           const formatted =
             formatAgentState(state) +
             `\nharvestability: ${
@@ -9144,11 +9255,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }` +
             `\nhealth: ${health.status}${
               health.issues.length > 0 ? ` (${health.issues.join("; ")})` : ""
-            }`;
+            }` +
+            `\ntoken_count: ${codexFill?.token_count ?? "unknown"}` +
+            `\ncontext_window: ${codexFill?.context_window ?? "unknown"}` +
+            `\ncontext_pct: ${codexFill?.context_pct ?? "unknown"}`;
           const payload = {
             ...toAgentStatePayload(state),
             harvestability,
             health,
+            token_count: codexFill?.token_count ?? null,
+            context_window: codexFill?.context_window ?? null,
+            context_pct: codexFill?.context_pct ?? null,
           };
           return okFormatted(
             formatted,
@@ -10798,11 +10915,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       surface_id: binding.surfaceRef,
                       workspace_id: binding.workspaceId,
                     };
-                    const screen = await client.readScreen(route.surface_id, {
-                      lines: 20,
-                      workspace: route.workspace_id ?? undefined,
-                    });
-                    return { route, screen };
+                    const [screen, codexFill] = await Promise.all([
+                      client.readScreen(route.surface_id, {
+                        lines: 20,
+                        workspace: route.workspace_id ?? undefined,
+                      }),
+                      readCodexRolloutFill(agent),
+                    ]);
+                    return { route, screen, codexFill };
                   })(),
                   new Promise<never>((_, reject) =>
                     setTimeout(
@@ -10813,13 +10933,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ]);
                 liveSurfaceId = resolved.route.surface_id;
                 const screen = resolved.screen;
-                screenData = applyHarnessState(
-                  enrichParsedScreen(
-                    parseScreen(screen.text),
-                    screen.text,
-                    pickLatestSurfaceModel(stateMgr, liveSurfaceId),
+                screenData = applyCodexRolloutFill(
+                  applyHarnessState(
+                    enrichParsedScreen(
+                      parseScreen(screen.text),
+                      screen.text,
+                      pickLatestSurfaceModel(stateMgr, liveSurfaceId),
+                    ),
+                    resolveHarnessStateForSurface(stateMgr, liveSurfaceId),
                   ),
-                  resolveHarnessStateForSurface(stateMgr, liveSurfaceId),
+                  resolved.codexFill,
                 );
               } catch (error) {
                 // Surface may be closed, unavailable, or timed out
@@ -10844,6 +10967,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ...(resumeCommand ? { resume_command: resumeCommand } : {}),
                 surface_id: liveSurfaceId,
                 token_count: screenData?.token_count ?? null,
+                context_window: screenData?.context_window ?? null,
                 context_pct: screenData?.context_pct ?? null,
                 cost: screenData?.cost ?? null,
                 task_summary: agent.task_summary,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4854,7 +4854,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const readCodexRolloutFill = async (
     agent: AgentRecord | null,
   ): Promise<CodexRolloutFill | null> => {
-    const path = agent?.cli === "codex" ? agent.cli_session_path : null;
+    const path =
+      agent?.cli === "codex" && Boolean(agent.surface_uuid?.trim())
+        ? agent.cli_session_path
+        : null;
     if (!path) return null;
     try {
       return await context.codexRolloutFillProvider.get(path);
@@ -10892,6 +10895,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const SCREEN_TIMEOUT = 3000;
           const enriched = await Promise.all(
             agents.map(async (agent) => {
+              const screenDeadline = Date.now() + SCREEN_TIMEOUT;
               let screenData: ParsedScreenResult | null = null;
               let liveSurfaceId: string | null = null;
               let screenFailure: {
@@ -10915,14 +10919,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       surface_id: binding.surfaceRef,
                       workspace_id: binding.workspaceId,
                     };
-                    const [screen, codexFill] = await Promise.all([
-                      client.readScreen(route.surface_id, {
-                        lines: 20,
-                        workspace: route.workspace_id ?? undefined,
-                      }),
-                      readCodexRolloutFill(agent),
-                    ]);
-                    return { route, screen, codexFill };
+                    const codexFillPromise = readCodexRolloutFill(agent);
+                    const screen = await client.readScreen(route.surface_id, {
+                      lines: 20,
+                      workspace: route.workspace_id ?? undefined,
+                    });
+                    return { route, screen, codexFillPromise };
                   })(),
                   new Promise<never>((_, reject) =>
                     setTimeout(
@@ -10933,6 +10935,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ]);
                 liveSurfaceId = resolved.route.surface_id;
                 const screen = resolved.screen;
+                const fillWaitMs = Math.max(0, screenDeadline - Date.now());
+                const codexFill =
+                  fillWaitMs === 0
+                    ? null
+                    : await new Promise<CodexRolloutFill | null>((resolve) => {
+                        const timeout = setTimeout(
+                          () => resolve(null),
+                          fillWaitMs,
+                        );
+                        resolved.codexFillPromise.then(
+                          (fill) => {
+                            clearTimeout(timeout);
+                            resolve(fill);
+                          },
+                          () => {
+                            clearTimeout(timeout);
+                            resolve(null);
+                          },
+                        );
+                      });
                 screenData = applyCodexRolloutFill(
                   applyHarnessState(
                     enrichParsedScreen(
@@ -10942,7 +10964,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     ),
                     resolveHarnessStateForSurface(stateMgr, liveSurfaceId),
                   ),
-                  resolved.codexFill,
+                  codexFill,
                 );
               } catch (error) {
                 // Surface may be closed, unavailable, or timed out

--- a/tests/codex-rollout-fill.test.ts
+++ b/tests/codex-rollout-fill.test.ts
@@ -174,6 +174,64 @@ describe("CodexRolloutFillProvider", () => {
     ).toBe(true);
   });
 
+  it("keeps a complete token row that starts exactly at the cold-tail boundary", async () => {
+    const path = "/tmp/rollout-tail-boundary.jsonl";
+    const token = Buffer.from(tokenCountLine(70_000));
+    const fillerLine = Buffer.from('{"type":"event_msg"}\n');
+    const tailParts = [token];
+    let tailLength = token.length;
+    while (
+      tailLength + fillerLine.length <=
+      CODEX_ROLLOUT_MAX_TAIL_BYTES
+    ) {
+      tailParts.push(fillerLine);
+      tailLength += fillerLine.length;
+    }
+    const remaining = CODEX_ROLLOUT_MAX_TAIL_BYTES - tailLength;
+    if (remaining > 0) {
+      tailParts.push(Buffer.from(`${" ".repeat(remaining - 1)}\n`));
+    }
+    const prefix = Buffer.from('{"type":"event_msg","prefix":true}\n');
+    const bytes = Buffer.concat([prefix, ...tailParts]);
+    const provider = makeCodexRolloutFillProvider({
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: 1,
+        dev: 2,
+        ino: 45,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 70_000,
+    });
+  });
+
+  it("discards cold bytes when the rollout identity rotates between stat and read", async () => {
+    const path = "/tmp/rollout-stat-read-rotation.jsonl";
+    const replacementBytes = Buffer.from(tokenCountLine(200_000));
+    let statCalls = 0;
+    const provider = makeCodexRolloutFillProvider({
+      statFile: async () => {
+        statCalls += 1;
+        return {
+          size: replacementBytes.length,
+          mtimeMs: statCalls,
+          dev: 2,
+          ino: statCalls === 1 ? 46 : 47,
+          isFile: true,
+        };
+      },
+      readFileRange: async (_requestedPath, start, length) =>
+        replacementBytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toBeNull();
+  });
+
   it("coalesces concurrent cold reads and serves warm data without more I/O", async () => {
     const path = "/tmp/rollout-coalesced.jsonl";
     const bytes = Buffer.from(tokenCountLine(40_000));
@@ -203,13 +261,13 @@ describe("CodexRolloutFillProvider", () => {
       Array.from({ length: 20 }, () => provider.get(path)),
     );
     expect(fills.every((fill) => fill?.token_count === 40_000)).toBe(true);
-    expect(statCalls).toBe(1);
+    expect(statCalls).toBe(2);
     expect(readCalls).toBe(1);
 
     await expect(provider.get(path)).resolves.toMatchObject({
       token_count: 40_000,
     });
-    expect(statCalls).toBe(1);
+    expect(statCalls).toBe(2);
     expect(readCalls).toBe(1);
   });
 
@@ -489,9 +547,9 @@ describe("CodexRolloutFillProvider", () => {
     now += 1;
     await provider.get(first);
 
-    expect(statCalls.get(first)).toBe(2);
-    expect(statCalls.get(second)).toBe(1);
-    expect(statCalls.get(third)).toBe(1);
+    expect(statCalls.get(first)).toBe(4);
+    expect(statCalls.get(second)).toBe(2);
+    expect(statCalls.get(third)).toBe(2);
   });
 
   it("rejects a cold admission while every cache slot is in flight", async () => {

--- a/tests/codex-rollout-fill.test.ts
+++ b/tests/codex-rollout-fill.test.ts
@@ -384,6 +384,55 @@ describe("CodexRolloutFillProvider", () => {
     expect(maxActiveStats).toBe(4);
   });
 
+  it("does not let a newcomer steal a permit reserved for a queued reader", async () => {
+    const firstPath = "/tmp/rollout-permit-first.jsonl";
+    let releaseFirst: (() => void) | null = null;
+    const firstMayFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let releaseFollowers: (() => void) | null = null;
+    const followersMayFinish = new Promise<void>((resolve) => {
+      releaseFollowers = resolve;
+    });
+    let activeStats = 0;
+    let maxActiveStats = 0;
+    const provider = makeCodexRolloutFillProvider({
+      maxConcurrentReads: 1,
+      statFile: async (path) => {
+        activeStats += 1;
+        maxActiveStats = Math.max(maxActiveStats, activeStats);
+        if (path === firstPath) await firstMayFinish;
+        else await followersMayFinish;
+        activeStats -= 1;
+        return null;
+      },
+    });
+
+    const first = provider.get(firstPath);
+    await flushAsyncWork();
+    const queued = provider.get("/tmp/rollout-permit-queued.jsonl");
+    await flushAsyncWork();
+
+    const intruders: Array<Promise<unknown>> = [];
+    let intruderIndex = 0;
+    const enqueueIntruder = (): void => {
+      queueMicrotask(() => {
+        intruders.push(
+          provider.get(`/tmp/rollout-permit-intruder-${intruderIndex++}.jsonl`),
+        );
+        if (intruderIndex < 50) enqueueIntruder();
+      });
+    };
+    enqueueIntruder();
+    releaseFirst?.();
+    for (let index = 0; index < 100; index += 1) await Promise.resolve();
+    const observedMax = maxActiveStats;
+
+    releaseFollowers?.();
+    await Promise.all([first, queued, ...intruders]);
+    expect(observedMax).toBe(1);
+  });
+
   it("evicts the least-recently-used settled path when the cache cap is reached", async () => {
     const bytes = Buffer.from(tokenCountLine(20_000));
     let now = 0;

--- a/tests/codex-rollout-fill.test.ts
+++ b/tests/codex-rollout-fill.test.ts
@@ -1,0 +1,603 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_ROLLOUT_MAX_TAIL_BYTES,
+  CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES,
+  CODEX_ROLLOUT_READ_CHUNK_BYTES,
+  makeCodexRolloutFillProvider,
+} from "../src/codex-rollout-fill.js";
+
+function tokenCountLine(
+  totalTokens: number,
+  modelContextWindow = 258_400,
+): string {
+  return `${JSON.stringify({
+    timestamp: "2026-07-18T02:45:55.000Z",
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: { total_tokens: 999_999 },
+        last_token_usage: {
+          input_tokens: totalTokens - 1_000,
+          cached_input_tokens: 50_000,
+          output_tokens: 1_000,
+          reasoning_output_tokens: 500,
+          total_tokens: totalTokens,
+        },
+        model_context_window: modelContextWindow,
+      },
+    },
+  })}\n`;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+describe("CodexRolloutFillProvider", () => {
+  it("cold-reads the exact rollout path and computes fill against 400K", async () => {
+    const path = "/tmp/rollout-session-a.jsonl";
+    const bytes = Buffer.from(tokenCountLine(100_000));
+    const provider = makeCodexRolloutFillProvider({
+      now: () => 1_000,
+      statFile: async (requestedPath) => {
+        expect(requestedPath).toBe(path);
+        return {
+          size: bytes.length,
+          mtimeMs: 1,
+          dev: 2,
+          ino: 3,
+          isFile: true,
+        };
+      },
+      readFileRange: async (requestedPath, start, length) => {
+        expect(requestedPath).toBe(path);
+        return bytes.subarray(start, start + length);
+      },
+    });
+
+    await expect(provider.get(path)).resolves.toEqual({
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+      observed_model_context_window: 258_400,
+    });
+  });
+
+  it("uses asynchronous production file operations when no reader is injected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-fill-"));
+    const path = join(dir, "rollout-session.jsonl");
+    writeFileSync(path, tokenCountLine(80_000));
+    try {
+      const provider = makeCodexRolloutFillProvider();
+      await expect(provider.get(path)).resolves.toMatchObject({
+        token_count: 80_000,
+        context_pct: 20,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("completes bounded range reads when the filesystem returns short chunks", async () => {
+    const path = "/tmp/rollout-short-reads.jsonl";
+    const bytes = Buffer.from(tokenCountLine(44_000));
+    const reads: Array<{ start: number; length: number }> = [];
+    const provider = makeCodexRolloutFillProvider({
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: 1,
+        dev: 2,
+        ino: 30,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) => {
+        reads.push({ start, length });
+        return bytes.subarray(start, start + Math.min(length, 7));
+      },
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 44_000,
+    });
+    expect(reads.length).toBeGreaterThan(1);
+    expect(reads.every(({ length }) => length <= 64 * 1024)).toBe(true);
+  });
+
+  it("cold-searches only the bounded tail in 64 KiB chunks and selects the newest event", async () => {
+    const path = "/tmp/rollout-large.jsonl";
+    const filler = `${JSON.stringify({
+      type: "event_msg",
+      payload: { type: "agent_message", message: "x".repeat(1_000) },
+    })}\n`;
+    const bytes = Buffer.from(
+      filler.repeat(700) +
+        tokenCountLine(50_000) +
+        filler.repeat(20) +
+        tokenCountLine(120_000),
+    );
+    const reads: Array<{ start: number; length: number }> = [];
+    const provider = makeCodexRolloutFillProvider({
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: 1,
+        dev: 2,
+        ino: 4,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) => {
+        reads.push({ start, length });
+        return bytes.subarray(start, start + length);
+      },
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 120_000,
+      context_pct: 30,
+    });
+    expect(reads.length).toBeGreaterThan(1);
+    expect(
+      reads.every(({ length }) => length <= CODEX_ROLLOUT_READ_CHUNK_BYTES),
+    ).toBe(true);
+    expect(
+      reads.some(
+        ({ start }) =>
+          start === Math.max(0, bytes.length - CODEX_ROLLOUT_MAX_TAIL_BYTES),
+      ),
+    ).toBe(true);
+  });
+
+  it("coalesces concurrent cold reads and serves warm data without more I/O", async () => {
+    const path = "/tmp/rollout-coalesced.jsonl";
+    const bytes = Buffer.from(tokenCountLine(40_000));
+    let statCalls = 0;
+    let readCalls = 0;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => 10_000,
+      statFile: async () => {
+        statCalls += 1;
+        await Promise.resolve();
+        return {
+          size: bytes.length,
+          mtimeMs: 1,
+          dev: 2,
+          ino: 5,
+          isFile: true,
+        };
+      },
+      readFileRange: async (_requestedPath, start, length) => {
+        readCalls += 1;
+        await Promise.resolve();
+        return bytes.subarray(start, start + length);
+      },
+    });
+
+    const fills = await Promise.all(
+      Array.from({ length: 20 }, () => provider.get(path)),
+    );
+    expect(fills.every((fill) => fill?.token_count === 40_000)).toBe(true);
+    expect(statCalls).toBe(1);
+    expect(readCalls).toBe(1);
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+    expect(statCalls).toBe(1);
+    expect(readCalls).toBe(1);
+  });
+
+  it("refreshes warm entries from the append cursor while returning the stale sample immediately", async () => {
+    const path = "/tmp/rollout-appended.jsonl";
+    let now = 0;
+    let bytes = Buffer.from(tokenCountLine(40_000));
+    let mtimeMs = 1;
+    const reads: Array<{ start: number; length: number }> = [];
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 6,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) => {
+        reads.push({ start, length });
+        return bytes.subarray(start, start + length);
+      },
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+    const previousSize = bytes.length;
+    reads.length = 0;
+    bytes = Buffer.concat([bytes, Buffer.from(tokenCountLine(80_000))]);
+    mtimeMs = 2;
+    now = 1_001;
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 80_000,
+    });
+    expect(reads.some(({ start }) => start === previousSize)).toBe(true);
+    expect(reads.every(({ length }) => length <= 64 * 1024)).toBe(true);
+  });
+
+  it("reboots from the bounded tail after a large append gap", async () => {
+    const path = "/tmp/rollout-large-gap.jsonl";
+    let now = 0;
+    let mtimeMs = 1;
+    let bytes = Buffer.from(tokenCountLine(40_000));
+    const reads: Array<{ start: number; length: number }> = [];
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 31,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) => {
+        reads.push({ start, length });
+        return bytes.subarray(start, start + length);
+      },
+    });
+
+    await provider.get(path);
+    reads.length = 0;
+    bytes = Buffer.concat([
+      bytes,
+      Buffer.from("x".repeat(CODEX_ROLLOUT_MAX_TAIL_BYTES + 100) + "\n"),
+      Buffer.from(tokenCountLine(140_000)),
+    ]);
+    mtimeMs = 2;
+    now = 1_001;
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 140_000,
+    });
+    expect(
+      reads.some(
+        ({ start }) =>
+          start === Math.max(0, bytes.length - CODEX_ROLLOUT_MAX_TAIL_BYTES),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips a complete token row that exceeds the 64 KiB line bound", async () => {
+    const path = "/tmp/rollout-oversized.jsonl";
+    const oversized = Buffer.from(
+      `${JSON.stringify({
+        timestamp: "2026-07-18T02:45:55.000Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          padding: "x".repeat(CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES),
+          info: { last_token_usage: { total_tokens: 123_000 } },
+        },
+      })}\n`,
+    );
+    const provider = makeCodexRolloutFillProvider({
+      statFile: async () => ({
+        size: oversized.length,
+        mtimeMs: 1,
+        dev: 2,
+        ino: 7,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        oversized.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toBeNull();
+  });
+
+  it("discards an oversized partial row through its newline before parsing later rows", async () => {
+    const path = "/tmp/rollout-oversized-partial.jsonl";
+    let now = 0;
+    let mtimeMs = 1;
+    let bytes = Buffer.from(
+      tokenCountLine(40_000) +
+        "x".repeat(CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES + 1),
+    );
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 8,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+    bytes = Buffer.concat([bytes, Buffer.from(tokenCountLine(200_000))]);
+    mtimeMs = 2;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 40_000,
+    });
+
+    bytes = Buffer.concat([bytes, Buffer.from(tokenCountLine(80_000))]);
+    mtimeMs = 3;
+    now = 2_002;
+    await provider.get(path);
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 80_000,
+    });
+  });
+
+  it("caps concurrent rollout refreshes across distinct paths", async () => {
+    const bytes = Buffer.from(tokenCountLine(20_000));
+    let releaseStats: (() => void) | null = null;
+    const statsMayFinish = new Promise<void>((resolve) => {
+      releaseStats = resolve;
+    });
+    let activeStats = 0;
+    let maxActiveStats = 0;
+    const provider = makeCodexRolloutFillProvider({
+      maxConcurrentReads: 4,
+      statFile: async () => {
+        activeStats += 1;
+        maxActiveStats = Math.max(maxActiveStats, activeStats);
+        await statsMayFinish;
+        activeStats -= 1;
+        return {
+          size: bytes.length,
+          mtimeMs: 1,
+          dev: 2,
+          ino: 9,
+          isFile: true,
+        };
+      },
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    const pending = Array.from({ length: 6 }, (_, index) =>
+      provider.get(`/tmp/rollout-concurrency-${index}.jsonl`),
+    );
+    await flushAsyncWork();
+    expect(maxActiveStats).toBe(4);
+    releaseStats?.();
+    await expect(Promise.all(pending)).resolves.toHaveLength(6);
+    expect(maxActiveStats).toBe(4);
+  });
+
+  it("evicts the least-recently-used settled path when the cache cap is reached", async () => {
+    const bytes = Buffer.from(tokenCountLine(20_000));
+    let now = 0;
+    const statCalls = new Map<string, number>();
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      maxEntries: 2,
+      statFile: async (path) => {
+        statCalls.set(path, (statCalls.get(path) ?? 0) + 1);
+        return {
+          size: bytes.length,
+          mtimeMs: 1,
+          dev: 2,
+          ino: path.charCodeAt(path.length - 1),
+          isFile: true,
+        };
+      },
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+    const first = "/tmp/rollout-cache-1";
+    const second = "/tmp/rollout-cache-2";
+    const third = "/tmp/rollout-cache-3";
+
+    await provider.get(first);
+    now += 1;
+    await provider.get(second);
+    now += 1;
+    await provider.get(third);
+    now += 1;
+    await provider.get(first);
+
+    expect(statCalls.get(first)).toBe(2);
+    expect(statCalls.get(second)).toBe(1);
+    expect(statCalls.get(third)).toBe(1);
+  });
+
+  it("waits for a partial token row to finish before publishing it", async () => {
+    const path = "/tmp/rollout-partial.jsonl";
+    let now = 0;
+    let mtimeMs = 1;
+    const line = Buffer.from(tokenCountLine(70_000));
+    const split = Math.floor(line.length / 2);
+    let bytes = line.subarray(0, split);
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 10,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toBeNull();
+    bytes = line;
+    mtimeMs = 2;
+    now = 1_001;
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 70_000,
+    });
+  });
+
+  it("clears a previous session snapshot when the path is replaced but unreadable", async () => {
+    const path = "/tmp/rollout-replaced.jsonl";
+    let now = 0;
+    let ino = 11;
+    let bytes = Buffer.from(tokenCountLine(90_000));
+    let failReads = false;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: now + 1,
+        dev: 2,
+        ino,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        failReads ? null : bytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 90_000,
+    });
+    ino = 12;
+    bytes = Buffer.from('{"type":"event_msg"}\n');
+    failReads = true;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toBeNull();
+  });
+
+  it("publishes only the replacement session after inode rotation", async () => {
+    const path = "/tmp/rollout-rotated.jsonl";
+    let now = 0;
+    let ino = 32;
+    let bytes = Buffer.from(tokenCountLine(90_000));
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: now + 1,
+        dev: 2,
+        ino,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await provider.get(path);
+    ino = 33;
+    bytes = Buffer.from(tokenCountLine(30_000));
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 30_000,
+    });
+  });
+
+  it("clears the old snapshot after truncate/rewrite has no valid token row", async () => {
+    const path = "/tmp/rollout-truncated.jsonl";
+    let now = 0;
+    let bytes = Buffer.from(tokenCountLine(90_000).repeat(3));
+    let mtimeMs = 1;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 34,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await provider.get(path);
+    bytes = Buffer.from('{"type":"event_msg"}\n');
+    mtimeMs = 2;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+
+    await expect(provider.get(path)).resolves.toBeNull();
+  });
+
+  it("resets on continuity mismatch before accepting an appended session sample", async () => {
+    const path = "/tmp/rollout-continuity.jsonl";
+    let now = 0;
+    let bytes = Buffer.from(tokenCountLine(90_000));
+    let mtimeMs = 1;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs,
+        dev: 2,
+        ino: 35,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await provider.get(path);
+    bytes = Buffer.concat([
+      Buffer.from(bytes.toString("utf8").replace("90000", "90001")),
+      Buffer.from(tokenCountLine(50_000)),
+    ]);
+    mtimeMs = 2;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 50_000,
+    });
+  });
+
+  it("keeps the last good same-file snapshot across a transient append read error", async () => {
+    const path = "/tmp/rollout-transient.jsonl";
+    let now = 0;
+    let bytes = Buffer.from(tokenCountLine(60_000));
+    let failReads = false;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => ({
+        size: bytes.length,
+        mtimeMs: now + 1,
+        dev: 2,
+        ino: 13,
+        isFile: true,
+      }),
+      readFileRange: async (_requestedPath, start, length) =>
+        failReads ? null : bytes.subarray(start, start + length),
+    });
+
+    await provider.get(path);
+    bytes = Buffer.concat([bytes, Buffer.from(tokenCountLine(100_000))]);
+    failReads = true;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 60_000,
+    });
+  });
+});

--- a/tests/codex-rollout-fill.test.ts
+++ b/tests/codex-rollout-fill.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -470,6 +470,51 @@ describe("CodexRolloutFillProvider", () => {
     expect(statCalls.get(third)).toBe(1);
   });
 
+  it("rejects a cold admission while every cache slot is in flight", async () => {
+    const firstPath = "/tmp/rollout-cache-inflight-1";
+    const secondPath = "/tmp/rollout-cache-inflight-2";
+    const bytes = Buffer.from(tokenCountLine(20_000));
+    let releaseFirst: (() => void) | null = null;
+    const firstMayFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const statFile = vi.fn(async (path: string) => {
+      if (path === firstPath) await firstMayFinish;
+      return {
+        size: bytes.length,
+        mtimeMs: 1,
+        dev: 2,
+        ino: path === firstPath ? 41 : 42,
+        isFile: true,
+      };
+    });
+    const provider = makeCodexRolloutFillProvider({
+      maxEntries: 1,
+      statFile,
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    const first = provider.get(firstPath);
+    await flushAsyncWork();
+    let secondSettled = false;
+    const second = provider.get(secondPath).then((value) => {
+      secondSettled = true;
+      return value;
+    });
+    await flushAsyncWork();
+
+    expect(secondSettled).toBe(true);
+    await expect(second).resolves.toBeNull();
+    expect(statFile).toHaveBeenCalledTimes(1);
+
+    releaseFirst?.();
+    await first;
+    await expect(provider.get(secondPath)).resolves.toMatchObject({
+      token_count: 20_000,
+    });
+  });
+
   it("waits for a partial token row to finish before publishing it", async () => {
     const path = "/tmp/rollout-partial.jsonl";
     let now = 0;
@@ -645,6 +690,70 @@ describe("CodexRolloutFillProvider", () => {
     now = 1_001;
     await provider.get(path);
     await flushAsyncWork();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 60_000,
+    });
+  });
+
+  it("clears the last snapshot after the rollout file is confirmed absent", async () => {
+    const path = "/tmp/rollout-deleted.jsonl";
+    const bytes = Buffer.from(tokenCountLine(60_000));
+    let now = 0;
+    let exists = true;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () =>
+        exists
+          ? {
+              size: bytes.length,
+              mtimeMs: 1,
+              dev: 2,
+              ino: 43,
+              isFile: true,
+            }
+          : null,
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 60_000,
+    });
+    exists = false;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+
+    await expect(provider.get(path)).resolves.toBeNull();
+  });
+
+  it("keeps the last snapshot across a transient stat failure", async () => {
+    const path = "/tmp/rollout-stat-transient.jsonl";
+    const bytes = Buffer.from(tokenCountLine(60_000));
+    let now = 0;
+    let failStat = false;
+    const provider = makeCodexRolloutFillProvider({
+      now: () => now,
+      statFile: async () => {
+        if (failStat) throw new Error("transient stat failure");
+        return {
+          size: bytes.length,
+          mtimeMs: 1,
+          dev: 2,
+          ino: 44,
+          isFile: true,
+        };
+      },
+      readFileRange: async (_requestedPath, start, length) =>
+        bytes.subarray(start, start + length),
+    });
+
+    await provider.get(path);
+    failStat = true;
+    now = 1_001;
+    await provider.get(path);
+    await flushAsyncWork();
+
     await expect(provider.get(path)).resolves.toMatchObject({
       token_count: 60_000,
     });

--- a/tests/codex-rollout-fill.test.ts
+++ b/tests/codex-rollout-fill.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { open, stat } from "node:fs/promises";
 import {
   CODEX_ROLLOUT_MAX_TAIL_BYTES,
   CODEX_ROLLOUT_MAX_PENDING_LINE_BYTES,
   CODEX_ROLLOUT_READ_CHUNK_BYTES,
   makeCodexRolloutFillProvider,
 } from "../src/codex-rollout-fill.js";
+
+vi.mock("node:fs/promises", () => ({
+  open: vi.fn(),
+  stat: vi.fn(),
+}));
 
 function tokenCountLine(
   totalTokens: number,
@@ -68,18 +71,39 @@ describe("CodexRolloutFillProvider", () => {
   });
 
   it("uses asynchronous production file operations when no reader is injected", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "codex-fill-"));
-    const path = join(dir, "rollout-session.jsonl");
-    writeFileSync(path, tokenCountLine(80_000));
-    try {
-      const provider = makeCodexRolloutFillProvider();
-      await expect(provider.get(path)).resolves.toMatchObject({
-        token_count: 80_000,
-        context_pct: 20,
-      });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    const path = "/tmp/rollout-session.jsonl";
+    const bytes = Buffer.from(tokenCountLine(80_000));
+    vi.mocked(stat).mockResolvedValue({
+      size: bytes.length,
+      mtimeMs: 1,
+      dev: 2,
+      ino: 3,
+      isFile: () => true,
+    } as Awaited<ReturnType<typeof stat>>);
+    const read = vi.fn(
+      async (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number,
+      ) => {
+        const chunk = bytes.subarray(position, position + length);
+        chunk.copy(buffer, offset);
+        return { bytesRead: chunk.length, buffer };
+      },
+    );
+    const close = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(open).mockResolvedValue({ read, close } as any);
+
+    const provider = makeCodexRolloutFillProvider();
+    await expect(provider.get(path)).resolves.toMatchObject({
+      token_count: 80_000,
+      context_pct: 20,
+    });
+    expect(stat).toHaveBeenCalledWith(path);
+    expect(open).toHaveBeenCalledWith(path, "r");
+    expect(read).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
   });
 
   it("completes bounded range reads when the filesystem returns short chunks", async () => {

--- a/tests/harness-jsonl-validation.test.ts
+++ b/tests/harness-jsonl-validation.test.ts
@@ -1,7 +1,7 @@
 // VALIDATION: Claude/Cursor keep the default-on synchronous harness behavior, while Codex
 // uses its exact self-registration path through the async provider and fixed 400K service
 // denominator. No harness may fall back to an inferred 1M Codex window.
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -56,24 +56,21 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
     "04",
     "rollout-2026-06-04T22-46-15-vsid-codex.jsonl",
   );
+  const codexRolloutFillProvider = {
+    get: vi.fn(async (requestedPath: string) => {
+      expect(requestedPath).toBe(codexPath);
+      return {
+        token_count: 108_569,
+        context_window: 400_000 as const,
+        context_pct: 27,
+        observed_model_context_window: 258_400,
+      };
+    }),
+  };
 
   beforeAll(() => {
-    // Place the verified fixtures where findHarnessSessionPath resolves them by sessionId.
-    mkdirSync(join(home, ".codex", "sessions", "2026", "06", "04"), {
-      recursive: true,
-    });
-    cpSync(
-      join(FIX, "codex.jsonl"),
-      join(
-        home,
-        ".codex",
-        "sessions",
-        "2026",
-        "06",
-        "04",
-        "rollout-2026-06-04T22-46-15-vsid-codex.jsonl",
-      ),
-    );
+    // Claude/Cursor retain their real JSONL validation fixtures. Codex uses an
+    // injected async provider so this test isolates exact-path server binding.
     mkdirSync(join(home, ".claude", "projects", "-x"), { recursive: true });
     cpSync(
       join(FIX, "claude.jsonl"),
@@ -205,6 +202,7 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
       stateDir,
       skipAgentLifecycle: true,
       surfaceObserverEpochProvider: () => "test:1",
+      codexRolloutFillProvider,
     });
     context.lifecycleRegistry = {
       canUseObservedBinding: () => true,
@@ -226,6 +224,7 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
     expect(p.context_window).not.toBe(1_000_000);
     expect(p.token_count).toBe(108569);
     expect(p.context_pct).toBe(27);
+    expect(codexRolloutFillProvider.get).toHaveBeenCalledWith(codexPath);
   });
 
   it("Claude: table window (opus-4-8 → 1M) from JSONL usage tail", async () => {

--- a/tests/harness-jsonl-validation.test.ts
+++ b/tests/harness-jsonl-validation.test.ts
@@ -1,11 +1,11 @@
-// VALIDATION (gates the default-on decision for #128): with CMUXLAYER_HARNESS_JSONL=1,
-// read_screen must report the REAL per-harness context window from the transcript JSONL —
-// Codex 258400 (NOT 1M), Claude the table window, Cursor cleanly falling back to its TUI strip.
+// VALIDATION: Claude/Cursor keep the default-on synchronous harness behavior, while Codex
+// uses its exact self-registration path through the async provider and fixed 400K service
+// denominator. No harness may fall back to an inferred 1M Codex window.
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer } from "../src/server.js";
+import { createServer, createServerContext } from "../src/server.js";
 import { StateManager } from "../src/state-manager.js";
 
 const FIX = join(__dirname, "fixtures", "harness");
@@ -44,6 +44,18 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
   const stateDir = mkdtempSync(join(tmpdir(), "cmux-validate-state-"));
   const prevFlag = process.env.CMUXLAYER_HARNESS_JSONL;
   const prevHome = process.env.CMUXLAYER_HARNESS_HOME;
+  const codexUuid = "11111111-1111-4111-8111-111111111111";
+  const claudeUuid = "22222222-2222-4222-8222-222222222222";
+  const cursorUuid = "33333333-3333-4333-8333-333333333333";
+  const codexPath = join(
+    home,
+    ".codex",
+    "sessions",
+    "2026",
+    "06",
+    "04",
+    "rollout-2026-06-04T22-46-15-vsid-codex.jsonl",
+  );
 
   beforeAll(() => {
     // Place the verified fixtures where findHarnessSessionPath resolves them by sessionId.
@@ -92,20 +104,28 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
     );
 
     const sm = new StateManager(stateDir);
+    sm.writeState({
+      ...record("a-codex", "surface:1", "codex", "vsid-codex", "gpt-5.5"),
+      surface_uuid: codexUuid,
+      cli_session_path: codexPath,
+    });
     sm.writeState(
-      record("a-codex", "surface:1", "codex", "vsid-codex", "gpt-5.5"),
+      {
+        ...record(
+          "a-claude",
+          "surface:2",
+          "claude",
+          "vsid-claude",
+          "claude-opus-4-8",
+        ),
+        surface_uuid: claudeUuid,
+      },
     );
     sm.writeState(
-      record(
-        "a-claude",
-        "surface:2",
-        "claude",
-        "vsid-claude",
-        "claude-opus-4-8",
-      ),
-    );
-    sm.writeState(
-      record("a-cursor", "surface:3", "cursor", "vsid-cursor", "cursor"),
+      {
+        ...record("a-cursor", "surface:3", "cursor", "vsid-cursor", "cursor"),
+        surface_uuid: cursorUuid,
+      },
     );
 
     process.env.CMUXLAYER_HARNESS_JSONL = "1";
@@ -142,24 +162,54 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
       listPanes: async () => ({
         workspace_ref: "workspace:1",
         window_ref: "window:1",
-        panes: [{ ref: "pane:1" }],
+        panes: [
+          {
+            ref: "pane:1",
+            surface_count: 3,
+            surface_refs: ["surface:1", "surface:2", "surface:3"],
+            surface_ids: [codexUuid, claudeUuid, cursorUuid],
+          },
+        ],
       }),
       listPaneSurfaces: async ({}: any) => ({
         workspace_ref: "workspace:1",
         window_ref: "window:1",
         pane_ref: "pane:1",
         surfaces: [
-          { ref: "surface:1", title: "codex", type: "terminal", index: 0 },
-          { ref: "surface:2", title: "claude", type: "terminal", index: 1 },
-          { ref: "surface:3", title: "cursor", type: "terminal", index: 2 },
+          {
+            ref: "surface:1",
+            id: codexUuid,
+            title: "codex",
+            type: "terminal",
+            index: 0,
+          },
+          {
+            ref: "surface:2",
+            id: claudeUuid,
+            title: "claude",
+            type: "terminal",
+            index: 1,
+          },
+          {
+            ref: "surface:3",
+            id: cursorUuid,
+            title: "cursor",
+            type: "terminal",
+            index: 2,
+          },
         ],
       }),
     } as any;
-    const server = createServer({
+    const context = createServerContext({
       client: mockClient,
       stateDir,
       skipAgentLifecycle: true,
+      surfaceObserverEpochProvider: () => "test:1",
     });
+    context.lifecycleRegistry = {
+      canUseObservedBinding: () => true,
+    } as any;
+    const server = createServer({ context });
     return (server as any)._registeredTools["read_screen"];
   }
 
@@ -169,13 +219,13 @@ describe("CMUXLAYER_HARNESS_JSONL=1 validation (real windows from JSONL)", () =>
     return (res.structuredContent ?? JSON.parse(res.content[0].text)).parsed;
   };
 
-  it("Codex: real in-JSONL window 258400 (NOT 1M)", async () => {
+  it("Codex: exact rollout path uses last usage against fixed 400K", async () => {
     const p = await callParsed("surface:1");
     expect(p.agent_type).toBe("codex");
-    expect(p.context_window).toBe(258400);
+    expect(p.context_window).toBe(400000);
     expect(p.context_window).not.toBe(1_000_000);
     expect(p.token_count).toBe(108569);
-    expect(p.context_pct).toBe(42);
+    expect(p.context_pct).toBe(27);
   });
 
   it("Claude: table window (opus-4-8 → 1M) from JSONL usage tail", async () => {

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -22,6 +22,7 @@ import {
   applyHarnessState,
   harnessJsonlEnabled,
   readHarnessSessionTextWindow,
+  parseCodexTokenUsageEvent,
 } from "../src/harness-session.js";
 
 const FIX = join(__dirname, "fixtures", "harness");
@@ -49,6 +50,67 @@ function codexContextJsonl(
     }),
   ].join("\n");
 }
+
+describe("parseCodexTokenUsageEvent", () => {
+  it("reads the latest usage sample instead of the cumulative session total", () => {
+    const usage = parseCodexTokenUsageEvent({
+      timestamp: "2026-07-18T02:45:55.000Z",
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: { total_tokens: 900_000 },
+          last_token_usage: {
+            input_tokens: 100_000,
+            cached_input_tokens: 60_000,
+            cache_write_input_tokens: 2_000,
+            output_tokens: 8_000,
+            reasoning_output_tokens: 4_000,
+            total_tokens: 108_569,
+          },
+          model_context_window: 258_400,
+        },
+      },
+    });
+
+    expect(usage).toEqual({
+      input_tokens: 100_000,
+      cached_input_tokens: 60_000,
+      cache_write_input_tokens: 2_000,
+      output_tokens: 8_000,
+      reasoning_output_tokens: 4_000,
+      total_tokens: 108_569,
+      model_context_window: 258_400,
+    });
+  });
+
+  it("returns null when only cumulative usage exists", () => {
+    expect(
+      parseCodexTokenUsageEvent({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: { total_token_usage: { total_tokens: 900_000 } },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 54])(
+    "rejects an invalid latest total token count: %s",
+    (totalTokens) => {
+      expect(
+        parseCodexTokenUsageEvent({
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: { last_token_usage: { total_tokens: totalTokens } },
+          },
+        }),
+      ).toBeNull();
+    },
+  );
+});
 
 describe("harnessJsonlEnabled (default-ON, opt-out with =0)", () => {
   const prev = process.env.CMUXLAYER_HARNESS_JSONL;

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -35,6 +35,7 @@ import {
   registerMonitor,
 } from "../src/monitor-registry.js";
 import { SurfaceWriteLivenessTracker } from "../src/surface-write-liveness.js";
+import { makeCodexRolloutFillProvider } from "../src/codex-rollout-fill.js";
 
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
@@ -602,6 +603,7 @@ function moveUuidRouteAfterNextSurfaceSnapshot(
 async function createUuidRouteServer(
   routeClient: ReturnType<typeof makeUuidRouteClient>,
   record: AgentRecord,
+  extraOptions: Record<string, unknown> = {},
 ) {
   const stateMgr = new StateManager(TEST_DIR);
   stateMgr.writeState(record);
@@ -610,6 +612,7 @@ async function createUuidRouteServer(
     stateDir: TEST_DIR,
     disableSpawnPreflight: true,
     sessionIdentityResolver: () => null,
+    ...extraOptions,
   });
   await serverContexts.at(-1)?.lifecycleStartPromise;
 
@@ -6992,6 +6995,554 @@ codex>
       };
       expect(reconcileAgentLiveState("error", shell)).toBe("error");
     });
+  });
+
+  it("read_screen binds a Codex fill by stable UUID and exact session path", async () => {
+    const stableUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const path = "/fixtures/codex/rollout-session-a.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:live",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-read-screen",
+      surface_id: "surface:live",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      state: "ready",
+      cli_session_id: "session-a",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+      observed_model_context_window: 258_400,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = await registeredTestTool(server, "read_screen").handler(
+      { surface: "surface:live", parsed_only: true },
+      {},
+    );
+    const parsed = parseToolResult(result);
+
+    expect(get).toHaveBeenCalledWith(path);
+    expect(parsed.parsed).toMatchObject({
+      agent_type: "codex",
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+    });
+  });
+
+  it("read_screen keeps an authorized Codex fill when the viewport lacks a Codex marker", async () => {
+    const stableUuid = "aaaabbbb-cccc-4ddd-8eee-ffff00001111";
+    const path = "/fixtures/codex/viewport-without-marker.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:markerless",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText("plain build output without a status bar");
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-markerless",
+      surface_id: "surface:markerless",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+      observed_model_context_window: null,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:markerless", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(result.parsed).toMatchObject({
+      agent_type: "unknown",
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+    });
+  });
+
+  it("read_screen never crosses Codex rollout paths between distinct stable UUIDs", async () => {
+    const firstUuid = "10000000-0000-4000-8000-000000000001";
+    const secondUuid = "20000000-0000-4000-8000-000000000002";
+    const firstPath = "/fixtures/codex/rollout-first.jsonl";
+    const secondPath = "/fixtures/codex/rollout-second.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:first",
+        id: firstUuid,
+        workspace_ref: "workspace:live",
+      },
+      {
+        ref: "surface:second",
+        id: secondUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 99% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const first = makeServerAgentRecord({
+      agent_id: "codex-fill-first",
+      surface_id: "surface:first",
+      surface_uuid: firstUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: firstPath,
+      launch_cwd: null,
+    });
+    const second = makeServerAgentRecord({
+      agent_id: "codex-fill-second",
+      surface_id: "surface:second",
+      surface_uuid: secondUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: secondPath,
+      launch_cwd: "/intentionally/mismatched",
+    });
+    const get = vi.fn(async (path: string) => ({
+      token_count: path === firstPath ? 40_000 : 120_000,
+      context_window: 400_000 as const,
+      context_pct: path === firstPath ? 10 : 30,
+      observed_model_context_window: null,
+    }));
+    const server = await createUuidRouteServer(routeClient, first, {
+      codexRolloutFillProvider: { get },
+    });
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(second);
+    engine.getRegistry().set(second.agent_id, second);
+
+    const firstResult = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:first", parsed_only: true },
+        {},
+      ),
+    );
+    const secondResult = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:second", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(firstResult.parsed.token_count).toBe(40_000);
+    expect(secondResult.parsed.token_count).toBe(120_000);
+    expect(get.mock.calls).toEqual([[firstPath], [secondPath]]);
+  });
+
+  it("read_screen preserves screen fallback and skips a recycled Codex surface ref", async () => {
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:recycled",
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-stale-ref",
+      surface_id: "surface:recycled",
+      surface_uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      workspace_id: "workspace:live",
+      cli_session_path: "/fixtures/codex/stale.jsonl",
+    });
+    const get = vi.fn();
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:recycled", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.parsed).toMatchObject({
+      token_count: null,
+      context_pct: 25,
+    });
+  });
+
+  it("read_screen refuses a Codex fill when the surface UUID changes during the read", async () => {
+    const oldUuid = "abab0000-0000-4000-8000-000000000001";
+    const newUuid = "abab0000-0000-4000-8000-000000000002";
+    const path = "/fixtures/codex/recycled-during-read.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:racing",
+        id: oldUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-racing-ref",
+      surface_id: "surface:racing",
+      surface_uuid: newUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 300_000,
+      context_window: 400_000,
+      context_pct: 75,
+      observed_model_context_window: null,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+    routeClient.client.readScreen.mockImplementationOnce(
+      async (surface: string) => {
+        routeClient.setLiveSurfaces([
+          {
+            ref: "surface:racing",
+            id: newUuid,
+            workspace_ref: "workspace:live",
+          },
+        ]);
+        return {
+          surface,
+          text: "gpt-5.4 high · 75% left · ~/Gits/old-seat\nWorking (2s • esc to interrupt)",
+          lines: 20,
+          scrollback_used: false,
+        };
+      },
+    );
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:racing", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.parsed).toMatchObject({
+      token_count: null,
+      context_pct: 25,
+    });
+  });
+
+  it("read_screen preserves the visible Codex percent when the bound rollout has no sample", async () => {
+    const stableUuid = "abababab-abab-4bab-8bab-abababababab";
+    const path = "/fixtures/codex/no-token-sample.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:no-sample",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-no-sample",
+      surface_id: "surface:no-sample",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue(null);
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:no-sample", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(get).toHaveBeenCalledWith(path);
+    expect(result.parsed).toMatchObject({
+      token_count: null,
+      context_window: 400_000,
+      context_pct: 25,
+    });
+  });
+
+  it("get_agent_state exposes Codex rollout fill without mutating AgentRecord", async () => {
+    const stableUuid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const path = "/fixtures/codex/get-agent-state.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:state",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-agent-state",
+      surface_id: "surface:state",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 80_000,
+      context_window: 400_000,
+      context_pct: 20,
+      observed_model_context_window: null,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "get_agent_state").handler(
+        { agent_id: record.agent_id },
+        {},
+      ),
+    );
+
+    expect(get).toHaveBeenCalledWith(path);
+    expect(result).toMatchObject({
+      token_count: 80_000,
+      context_window: 400_000,
+      context_pct: 20,
+    });
+    expect(testLifecycleEngine(server).getAgentState(record.agent_id)).not.toHaveProperty(
+      "token_count",
+    );
+  });
+
+  it("my_agents applies the authorized Codex rollout fill", async () => {
+    const stableUuid = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    const path = "/fixtures/codex/my-agents.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:child",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-my-agents",
+      surface_id: "surface:child",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      parent_agent_id: null,
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 160_000,
+      context_window: 400_000,
+      context_pct: 40,
+      observed_model_context_window: null,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "my_agents").handler({}, {}),
+    );
+
+    expect(get).toHaveBeenCalledWith(path);
+    expect(result.agents[0]).toMatchObject({
+      agent_id: record.agent_id,
+      token_count: 160_000,
+      context_window: 400_000,
+      context_pct: 40,
+    });
+  });
+
+  it("my_agents coalesces a shared Codex rollout across authorized records", async () => {
+    const firstUuid = "d1000000-0000-4000-8000-000000000001";
+    const secondUuid = "d2000000-0000-4000-8000-000000000002";
+    const path = "/fixtures/codex/shared-rollout.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:shared-first",
+        id: firstUuid,
+        workspace_ref: "workspace:live",
+      },
+      {
+        ref: "surface:shared-second",
+        id: secondUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 99% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const first = makeServerAgentRecord({
+      agent_id: "codex-shared-first",
+      surface_id: "surface:shared-first",
+      surface_uuid: firstUuid,
+      workspace_id: "workspace:live",
+      parent_agent_id: null,
+      cli_session_path: path,
+    });
+    const second = makeServerAgentRecord({
+      agent_id: "codex-shared-second",
+      surface_id: "surface:shared-second",
+      surface_uuid: secondUuid,
+      workspace_id: "workspace:live",
+      parent_agent_id: null,
+      cli_session_path: path,
+    });
+    const bytes = Buffer.from(
+      `${JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: { last_token_usage: { total_tokens: 200_000 } },
+        },
+      })}\n`,
+    );
+    const statFile = vi.fn().mockResolvedValue({
+      size: bytes.length,
+      mtimeMs: 1,
+      dev: 2,
+      ino: 50,
+      isFile: true,
+    });
+    const readFileRange = vi.fn(
+      async (_requestedPath: string, start: number, length: number) =>
+        bytes.subarray(start, start + length),
+    );
+    const server = await createUuidRouteServer(routeClient, first, {
+      codexRolloutFillProvider: makeCodexRolloutFillProvider({
+        statFile,
+        readFileRange,
+      }),
+    });
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(second);
+    engine.getRegistry().set(second.agent_id, second);
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "my_agents").handler({}, {}),
+    );
+
+    expect(result.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: first.agent_id,
+          token_count: 200_000,
+        }),
+        expect.objectContaining({
+          agent_id: second.agent_id,
+          token_count: 200_000,
+        }),
+      ]),
+    );
+    expect(statFile).toHaveBeenCalledTimes(1);
+    expect(readFileRange).toHaveBeenCalledTimes(1);
+  });
+
+  it("never invokes the Codex provider for a Claude read_screen", async () => {
+    const stableUuid = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:claude",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "Claude Code\n⏺ Completed successfully\nToken usage: total=12,345 input=10,000 output=2,345\n🤖 Sonnet 4.6 | 💰 $1.25 | ⏱️  2m 11s",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "claude-no-codex-fill",
+      surface_id: "surface:claude",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli: "claude",
+      model: "sonnet",
+      cli_session_path: "/fixtures/claude/session.jsonl",
+    });
+    const get = vi.fn();
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "read_screen").handler(
+        { surface: "surface:claude", parsed_only: true },
+        {},
+      ),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.parsed).toMatchObject({
+      agent_type: "claude",
+      token_count: 12_345,
+    });
+  });
+
+  it("keeps the Codex rollout reader off the delivery-safety path", async () => {
+    const stableUuid = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:delivery",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\ncodex> ",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-delivery-no-fill",
+      surface_id: "surface:delivery",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      state: "ready",
+      cli_session_path: "/fixtures/codex/delivery.jsonl",
+    });
+    const get = vi.fn();
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        agent_id: record.agent_id,
+        text: "delivery must stay scan-free",
+        press_enter: true,
+      },
+      {},
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(get).not.toHaveBeenCalled();
   });
 
   it("my_agents returns root agents when no parent_agent_id", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7756,7 +7756,7 @@ codex>
         }),
       ]),
     );
-    expect(statFile).toHaveBeenCalledTimes(1);
+    expect(statFile).toHaveBeenCalledTimes(2);
     expect(readFileRange).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../src/monitor-registry.js";
 import { SurfaceWriteLivenessTracker } from "../src/surface-write-liveness.js";
 import { makeCodexRolloutFillProvider } from "../src/codex-rollout-fill.js";
+import type { CodexRolloutFill } from "../src/codex-rollout-fill.js";
 
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
@@ -851,6 +852,14 @@ function parseToolResult(result: TestToolResult): Record<string, unknown> {
     result.structuredContent ??
     (JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>)
   );
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }
 
 /** Read the durable close/kill telemetry the handlers append to events.jsonl. */
@@ -7087,6 +7096,82 @@ codex>
     });
   });
 
+  it("read_screen never overlays a stale ref-selected harness onto an authorized Codex UUID", async () => {
+    const stableUuid = "aaaacccc-eeee-4ddd-8bbb-ffff00002222";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:harness-collision",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const codex = makeServerAgentRecord({
+      agent_id: "codex-fill-harness-collision",
+      surface_id: "surface:harness-collision",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: "/fixtures/codex/harness-collision.jsonl",
+    });
+    const server = await createUuidRouteServer(routeClient, codex, {
+      codexRolloutFillProvider: { get: vi.fn().mockResolvedValue(null) },
+    });
+    const staleClaude = makeServerAgentRecord({
+      agent_id: "claude-stale-harness-collision",
+      surface_id: "surface:harness-collision",
+      surface_uuid: "ffffcccc-eeee-4ddd-8bbb-aaaa00003333",
+      workspace_id: "workspace:live",
+      cli: "claude",
+      model: "claude-opus-4-8",
+      cli_session_id: "stale-claude-session",
+      cli_session_path: null,
+      version: codex.version + 10,
+      updated_at: "2026-07-18T04:30:00.000Z",
+    });
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(staleClaude);
+    engine.getRegistry().set(staleClaude.agent_id, staleClaude);
+    const harnessHome = join(TEST_DIR, "harness-collision-home");
+    const claudeProject = join(harnessHome, ".claude", "projects", "-x");
+    mkdirSync(claudeProject, { recursive: true });
+    writeFileSync(
+      join(claudeProject, "stale-claude-session.jsonl"),
+      `${JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "stale reply" }],
+          usage: { input_tokens: 80_000, output_tokens: 2_000 },
+        },
+      })}\n`,
+    );
+    const previousFlag = process.env.CMUXLAYER_HARNESS_JSONL;
+    const previousHome = process.env.CMUXLAYER_HARNESS_HOME;
+    process.env.CMUXLAYER_HARNESS_JSONL = "1";
+    process.env.CMUXLAYER_HARNESS_HOME = harnessHome;
+    try {
+      const result = parseToolResult(
+        await registeredTestTool(server, "read_screen").handler(
+          { surface: "surface:harness-collision", parsed_only: true },
+          {},
+        ),
+      );
+
+      expect(result.parsed).toMatchObject({
+        agent_type: "codex",
+        token_count: null,
+        context_pct: 25,
+      });
+    } finally {
+      if (previousFlag === undefined) delete process.env.CMUXLAYER_HARNESS_JSONL;
+      else process.env.CMUXLAYER_HARNESS_JSONL = previousFlag;
+      if (previousHome === undefined) delete process.env.CMUXLAYER_HARNESS_HOME;
+      else process.env.CMUXLAYER_HARNESS_HOME = previousHome;
+    }
+  });
+
   it("read_screen never crosses Codex rollout paths between distinct stable UUIDs", async () => {
     const firstUuid = "10000000-0000-4000-8000-000000000001";
     const secondUuid = "20000000-0000-4000-8000-000000000002";
@@ -7205,7 +7290,7 @@ codex>
     const record = makeServerAgentRecord({
       agent_id: "codex-fill-racing-ref",
       surface_id: "surface:racing",
-      surface_uuid: newUuid,
+      surface_uuid: oldUuid,
       workspace_id: "workspace:live",
       cli_session_path: path,
     });
@@ -7286,6 +7371,62 @@ codex>
     expect(result.parsed).toMatchObject({
       token_count: null,
       context_window: 400_000,
+      context_pct: 25,
+    });
+  });
+
+  it("read_screen discards a Codex fill when the exact session path changes during rollout I/O", async () => {
+    const stableUuid = "acac0000-0000-4000-8000-000000000001";
+    const oldPath = "/fixtures/codex/session-before-read.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:path-race",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-path-race",
+      surface_id: "surface:path-race",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: oldPath,
+    });
+    const fill = deferred<CodexRolloutFill | null>();
+    const get = vi.fn(() => fill.promise);
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const pending = registeredTestTool(server, "read_screen").handler(
+      { surface: "surface:path-race", parsed_only: true },
+      {},
+    );
+    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+      await Promise.resolve();
+    }
+    expect(get).toHaveBeenCalledWith(oldPath);
+    const updated = {
+      ...record,
+      cli_session_path: "/fixtures/codex/session-after-read.jsonl",
+      version: record.version + 1,
+    };
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(updated);
+    engine.getRegistry().set(updated.agent_id, updated);
+    fill.resolve({
+      token_count: 300_000,
+      context_window: 400_000,
+      context_pct: 75,
+      observed_model_context_window: null,
+    });
+
+    const result = parseToolResult(await pending);
+    expect(result.parsed).toMatchObject({
+      token_count: null,
       context_pct: 25,
     });
   });
@@ -7375,6 +7516,114 @@ codex>
     );
 
     expect(get).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      token_count: null,
+      context_window: null,
+      context_pct: null,
+    });
+  });
+
+  it("get_agent_state discards a Codex fill when the session path changes during rollout I/O", async () => {
+    const stableUuid = "cdcd0000-0000-4000-8000-000000000001";
+    const oldPath = "/fixtures/codex/state-session-before.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:state-path-race",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-state-path-race",
+      surface_id: "surface:state-path-race",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: oldPath,
+    });
+    const fill = deferred<CodexRolloutFill | null>();
+    const get = vi.fn(() => fill.promise);
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const pending = registeredTestTool(server, "get_agent_state").handler(
+      { agent_id: record.agent_id },
+      {},
+    );
+    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+      await Promise.resolve();
+    }
+    expect(get).toHaveBeenCalledWith(oldPath);
+    const updated = {
+      ...record,
+      cli_session_path: "/fixtures/codex/state-session-after.jsonl",
+      version: record.version + 1,
+    };
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(updated);
+    engine.getRegistry().set(updated.agent_id, updated);
+    fill.resolve({
+      token_count: 300_000,
+      context_window: 400_000,
+      context_pct: 75,
+      observed_model_context_window: null,
+    });
+
+    const result = parseToolResult(await pending);
+    expect(result).toMatchObject({
+      token_count: null,
+      context_window: null,
+      context_pct: null,
+    });
+  });
+
+  it("get_agent_state discards a Codex fill when the record changes to another CLI during rollout I/O", async () => {
+    const stableUuid = "cece0000-0000-4000-8000-000000000001";
+    const path = "/fixtures/codex/state-cli-before.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:state-cli-race",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-state-cli-race",
+      surface_id: "surface:state-cli-race",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const fill = deferred<CodexRolloutFill | null>();
+    const get = vi.fn(() => fill.promise);
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const pending = registeredTestTool(server, "get_agent_state").handler(
+      { agent_id: record.agent_id },
+      {},
+    );
+    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+      await Promise.resolve();
+    }
+    expect(get).toHaveBeenCalledWith(path);
+    const updated = {
+      ...record,
+      cli: "claude" as const,
+      version: record.version + 1,
+    };
+    const engine = testLifecycleEngine(server);
+    engine.stateMgr.writeState(updated);
+    engine.getRegistry().set(updated.agent_id, updated);
+    fill.resolve({
+      token_count: 300_000,
+      context_window: 400_000,
+      context_pct: 75,
+      observed_model_context_window: null,
+    });
+
+    const result = parseToolResult(await pending);
     expect(result).toMatchObject({
       token_count: null,
       context_window: null,
@@ -7556,6 +7805,61 @@ codex>
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("my_agents discards a Codex fill when the stable surface is recycled during rollout I/O", async () => {
+    const oldUuid = "d4000000-0000-4000-8000-000000000004";
+    const newUuid = "d5000000-0000-4000-8000-000000000005";
+    const path = "/fixtures/codex/my-agents-recycled.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:my-agents-race",
+        id: oldUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-my-agents-race",
+      surface_id: "surface:my-agents-race",
+      surface_uuid: oldUuid,
+      workspace_id: "workspace:live",
+      parent_agent_id: null,
+      cli_session_path: path,
+    });
+    const fill = deferred<CodexRolloutFill | null>();
+    const get = vi.fn(() => fill.promise);
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const pending = registeredTestTool(server, "my_agents").handler({}, {});
+    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+      await Promise.resolve();
+    }
+    expect(get).toHaveBeenCalledWith(path);
+    routeClient.setLiveSurfaces([
+      {
+        ref: "surface:my-agents-race",
+        id: newUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    fill.resolve({
+      token_count: 300_000,
+      context_window: 400_000,
+      context_pct: 75,
+      observed_model_context_window: null,
+    });
+
+    const result = parseToolResult(await pending);
+    expect(result.agents[0]).toMatchObject({
+      agent_id: record.agent_id,
+      token_count: null,
+      context_pct: 25,
+    });
   });
 
   it("never invokes the Codex provider for a Claude read_screen", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7338,6 +7338,50 @@ codex>
     );
   });
 
+  it("get_agent_state never reads a Codex rollout for a UUID-less record", async () => {
+    const path = "/fixtures/codex/uuidless-agent-state.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:uuidless-state",
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-fill-uuidless-state",
+      surface_id: "surface:uuidless-state",
+      surface_uuid: null,
+      surface_observer_id: "cmux:/tmp/current.sock",
+      workspace_id: "workspace:live",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 80_000,
+      context_window: 400_000,
+      context_pct: 20,
+      observed_model_context_window: null,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "get_agent_state").handler(
+        { agent_id: record.agent_id },
+        {},
+      ),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      token_count: null,
+      context_window: null,
+      context_pct: null,
+    });
+  });
+
   it("my_agents applies the authorized Codex rollout fill", async () => {
     const stableUuid = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
     const path = "/fixtures/codex/my-agents.jsonl";
@@ -7465,6 +7509,53 @@ codex>
     );
     expect(statFile).toHaveBeenCalledTimes(1);
     expect(readFileRange).toHaveBeenCalledTimes(1);
+  });
+
+  it("my_agents preserves screen data when an optional Codex fill never resolves", async () => {
+    const stableUuid = "d3000000-0000-4000-8000-000000000003";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:slow-fill",
+        id: stableUuid,
+        workspace_ref: "workspace:live",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-slow-optional-fill",
+      surface_id: "surface:slow-fill",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:live",
+      parent_agent_id: null,
+      cli_session_path: "/fixtures/codex/slow-fill.jsonl",
+    });
+    const get = vi.fn(() => new Promise<never>(() => {}));
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+
+    vi.useFakeTimers();
+    try {
+      const pending = registeredTestTool(server, "my_agents").handler({}, {});
+      for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+        await Promise.resolve();
+      }
+      expect(get).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(3_000);
+      const result = parseToolResult(await pending);
+
+      expect(result.agents[0]).toMatchObject({
+        agent_id: record.agent_id,
+        surface_id: "surface:slow-fill",
+        token_count: null,
+        context_pct: 25,
+      });
+      expect(result.agents[0]).not.toHaveProperty("screen_unavailable");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("never invokes the Codex provider for a Claude read_screen", async () => {


### PR DESCRIPTION
## Summary

- parse Codex rollout `token_count` events through the existing pure Codex reducer and use `last_token_usage.total_tokens`
- add an async exact-path rollout reader with a fixed 400K denominator, 1s stale-while-refresh throttle, resumable bounded reads, per-path coalescing, global concurrency 4, and a 1,024-entry LRU
- surface ephemeral fill in `read_screen`, `get_agent_state`, and `my_agents` only after stable UUID authorization; keep Codex off the synchronous harness scan and lifecycle/delivery paths
- clear snapshots across confirmed deletion, inode replacement, truncation, rewrite, or continuity mismatch; preserve proven same-file values across transient errors

## Binding and safety

- read-side lookup uses only #338 `cli_session_path`; there is no resolver or sessions-directory fallback
- all three APIs revalidate the durable agent ID, Codex CLI, stable surface UUID, exact session path, and live surface after asynchronous rollout I/O
- recycled refs, incomplete topology, path/CLI transitions, malformed rows, and provider failures preserve null/screen fallback without leaking another session
- cache admission and concurrent reads are globally bounded; cold tailing handles exact line boundaries and confirms file identity again after I/O
- optional fill cannot make an otherwise available screen result unavailable
- Claude and Cursor behavior stays unchanged

## Launcher dependency

Non-null Codex fills require the Codex launcher-wrapper write side to populate `session_path` for Codex seats. That is a separate launcher-scope dependency; this provider correctly returns null until it lands.

## Verification

- `bun run typecheck`
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test`
- 106 test files passed; 2,306 tests passed
- push-hook full gate passed
- CodeRabbit: six findings resolved
- GitHub Codex: two findings resolved
- Macroscope: semaphore fairness, stat/read rotation, and exact-tail-boundary findings resolved; final check passed
- Cursor Bugbot could not run because its usage limit was reached
- final local confirmation review was limited by the free OSS quota

Stacked on #338 / `feat/session-self-registration`. Do not merge; v0.4.16 batch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Codex context fill from rollout JSONL files in `read_screen`, `get_agent_state`, and `list_agents`
> - Adds [`src/codex-rollout-fill.ts`](https://github.com/EtanHey/cmuxlayer/pull/339/files#diff-f3a97e55ec81dc76bdb63a329b47e86e499a7e2fa92da7bd07a2bf11f35f4002) implementing an async, throttled, LRU-cached tail-reader (`makeCodexRolloutFillProvider`) that parses Codex rollout JSONL files to extract `token_count`, `context_window`, and `context_pct`.
> - Integrates the provider into `read_screen`, `agent_status`, and `list_agents` RPC handlers in [`src/server.ts`](https://github.com/EtanHey/cmuxlayer/pull/339/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), replacing the legacy synchronous harness JSONL path for Codex agents.
> - Validates rollout fill against agent surface UUID and `cli_session_path` at read time and discards stale results when either changes mid-flight.
> - Extracts `parseCodexTokenUsageEvent` into [`src/harness-session.ts`](https://github.com/EtanHey/cmuxlayer/pull/339/files#diff-1b8e3afe8fbd75629b966063900f0471c94dc16101301788c36f4653bf692b36) as a reusable, validated parser including `model_context_window`.
> - Behavioral Change: Codex surfaces no longer go through the legacy synchronous sessions-dir harness scan; token usage now comes exclusively from the rollout file reader.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 426aa85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->