### PR TITLE
fix: enforce dense inline routing policy

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -327,8 +327,17 @@ const CLAUDE_CHANNEL_NOTIFICATION = "notifications/claude/channel";
 const CLAUDE_CHANNEL_INSTRUCTIONS =
   "When loaded with Claude Code --channels, this server may emit notifications/claude/channel for cmuxlayer agent lifecycle events. These arrive as <channel> status updates and are one-way only.";
 export const SEND_INPUT_CHUNK_THRESHOLD = 500;
+export const DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS =
+  3 * SEND_INPUT_CHUNK_THRESHOLD;
 const BOOT_PROMPT_PATH_WARNING_CHARS = 500;
 export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
+const DENSE_INLINE_ROUTING_GUIDANCE =
+  `Routing policy: inline payloads over the ${DEFAULT_SEND_INPUT_MAX_INLINE_CHARS}-character default cap, ` +
+  `or dense payloads with an unbroken line over ${DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS} characters, ` +
+  'belong in a file; send only "Read and follow <path>" inline. Use allow_long_inline:true only for ' +
+  "a deliberate raw-send override where the tool supports it.";
+const ZSH_BANG_INLINE_WARNING =
+  'WARNING — a `!` in an inline brief may be consumed by zsh history expansion before it reaches the worker, leaving the worker idle with no task; file-backed payloads avoid that shell interpretation.';
 export const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
@@ -1266,16 +1275,50 @@ function assertInlineInputAllowed(opts: {
   );
 }
 
-function assertBroadcastInlineInputAllowed(text: string): void {
-  if (text.length <= SEND_INPUT_MAX_INLINE_CHARS) {
+function assertDenseInlineInputAllowed(opts: {
+  tool:
+    | "send_input"
+    | "send_command"
+    | "spawn_agent"
+    | "send_to"
+    | "send_to_agent"
+    | "broadcast";
+  arg: "text" | "command" | "prompt";
+  value: string | undefined;
+  allowLongInline?: boolean;
+}): void {
+  if (opts.allowLongInline || opts.value === undefined) {
     return;
   }
 
+  const longestUnbrokenRun = opts.value
+    .split("\n")
+    .reduce((longest, line) => Math.max(longest, line.length), 0);
+  if (longestUnbrokenRun <= DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS) {
+    return;
+  }
+
+  const argName = `${opts.tool}.${opts.arg}`;
+  const overrideGuidance =
+    opts.tool === "broadcast"
+      ? ""
+      : " To deliberately send raw inline text, pass allow_long_inline:true.";
   throw new Error(
-    `broadcast.text is ${text.length} characters, above CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}. ` +
-      `Broadcasts are capped to one-line pointers: write the payload to a file and broadcast "Read and follow <path>" instead. ` +
-      `CMUXLAYER_MAX_INLINE_CHARS may be set to a positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}.`,
+    `${argName} is ${opts.value.length} characters and its longest unbroken run is ${longestUnbrokenRun}, above the dense inline routing policy threshold ${DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS}. Long dense payloads belong in a file: write the payload to a file and send one line: "Read and follow <path>".` +
+      overrideGuidance,
   );
+}
+
+function assertBroadcastInlineInputAllowed(text: string): void {
+  if (text.length > SEND_INPUT_MAX_INLINE_CHARS) {
+    throw new Error(
+      `broadcast.text is ${text.length} characters, above CMUXLAYER_MAX_INLINE_CHARS=${SEND_INPUT_MAX_INLINE_CHARS}. ` +
+        `Broadcasts are capped to one-line pointers: write the payload to a file and broadcast "Read and follow <path>" instead. ` +
+        `CMUXLAYER_MAX_INLINE_CHARS may be set to a positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}.`,
+    );
+  }
+
+  assertDenseInlineInputAllowed({ tool: "broadcast", arg: "text", value: text });
 }
 
 function broadcastRoleMatches(
@@ -6114,7 +6157,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 5. send_input
   server.tool(
     "send_input",
-    `Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxlayer resolves the current backing surface. WARNING — DO NOT include a bare \`@word\` (e.g. \`@narration-lead\`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats \`@\` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (\`narration-lead:\`) for pane-to-pane addressing; reserve \`@<name>\` for collab-file posts where monitors match it. If a literal \`@\` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); tracked Codex/Claude/Cursor/Gemini agents also refuse multi-paragraph inline text by default. Write the payload to a file and send one line: "Read and follow <path>". Pass allow_long_inline:true only for deliberate raw sends. Text over ${SEND_INPUT_CHUNK_THRESHOLD} characters that is allowed is automatically chunked into line-aligned batches before delivery, and each chunk waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Paste failure returns an error without pressing Return. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically.`,
+    `Low-level surface tool: send text input to a terminal surface. For tracked agents, prefer send_to(agent_id) so cmuxlayer resolves the current backing surface. WARNING — DO NOT include a bare \`@word\` (e.g. \`@narration-lead\`) in text destined for an interactive agent composer (Claude Code / Codex / Cursor TUIs): the receiving composer treats \`@\` as its file-reference trigger and pops a file-picker overlay, swallowing the rest of your message — silent delivery corruption that the ok:true result will NOT report. Use the bare name (\`narration-lead:\`) for pane-to-pane addressing; reserve \`@<name>\` for collab-file posts where monitors match it. If a literal \`@\` is unavoidable, deliver via a file the agent cat-reads, not live keystrokes. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); tracked Codex/Claude/Cursor/Gemini agents also refuse multi-paragraph inline text by default. Write the payload to a file and send one line: "Read and follow <path>". Pass allow_long_inline:true only for deliberate raw sends. Text over ${SEND_INPUT_CHUNK_THRESHOLD} characters that is allowed is split into line-aligned logical chunks and coalesced into bounded paste batches; each physical paste waits for cmux acknowledgment before the next is sent. Chunked or multiline text is pasted into the composer so embedded newlines do not submit partial messages; press_enter=true presses return once after the final chunk. Paste failure returns an error without pressing Return. Set background=true to return immediately with a delivery_id while chunking continues in the background. For full commands, prefer send_command so text and return land on the same surface atomically. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
     {
       surface: z.string().describe("Target surface ref"),
       text: z
@@ -6158,6 +6201,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         assertInlineInputAllowed({
+          tool: "send_input",
+          arg: "text",
+          value: args.text,
+          allowLongInline: args.allow_long_inline,
+        });
+        assertDenseInlineInputAllowed({
           tool: "send_input",
           arg: "text",
           value: args.text,
@@ -6298,7 +6347,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 7. send_command
   server.tool(
     "send_command",
-    `Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command only when it fits the ${SEND_INPUT_MAX_INLINE_CHARS}-character inline cap. WARNING — never include a bare \`@word\` in text destined for an interactive agent composer: it fires the receiver's file-reference picker and corrupts delivery (use the bare name; \`@<name>\` belongs in collab files, not pane keystrokes). For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path is checked before launch and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness; use it instead of embedding a multi-paragraph boot prompt in pane keystrokes. Passing boot_prompt_path for plain shell commands is rejected. Pass allow_long_inline:true only for deliberate raw long commands.`,
+    `Atomically send a command and press return on the same raw surface. Prefer this over separate send_input + send_key calls when launching or resuming agents. If the user provided an exact command, send exactly that command only when it fits the ${SEND_INPUT_MAX_INLINE_CHARS}-character inline cap. WARNING — never include a bare \`@word\` in text destined for an interactive agent composer: it fires the receiver's file-reference picker and corrupts delivery (use the bare name; \`@<name>\` belongs in collab files, not pane keystrokes). For known agent launchers with -s (for example brainlayerCodex -s), boot_prompt_path is checked before launch and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness; use it instead of embedding a multi-paragraph boot prompt in pane keystrokes. Passing boot_prompt_path for plain shell commands is rejected. Pass allow_long_inline:true only for deliberate raw long commands. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
     {
       surface: z.string().describe("Target surface ref"),
       command: z
@@ -6333,6 +6382,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         assertInlineInputAllowed({
+          tool: "send_command",
+          arg: "command",
+          value: args.command,
+          allowLongInline: args.allow_long_inline,
+        });
+        assertDenseInlineInputAllowed({
           tool: "send_command",
           arg: "command",
           value: args.command,
@@ -8203,7 +8258,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      `Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately.`,
+      `Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
       {
         repo: z
           .string()
@@ -8318,6 +8373,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
           assertBootPromptMode(args.prompt, bootPromptPath);
           assertInlineInputAllowed({
+            tool: "spawn_agent",
+            arg: "prompt",
+            value: args.prompt,
+            allowLongInline: args.allow_long_inline,
+          });
+          assertDenseInlineInputAllowed({
             tool: "spawn_agent",
             arg: "prompt",
             value: args.prompt,
@@ -9465,7 +9526,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "broadcast",
-      `Fan out a short pointer-style message to registered agents by role using the same guarded delivery path as send_to. Defaults to role=leads (orchestrator + ic). Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters; for larger payloads write a file and broadcast "Read and follow <path>". Returns per-agent receipts so one failed target never hides the rest.`,
+      `Fan out a short pointer-style message to registered agents by role using the same guarded delivery path as send_to. Defaults to role=leads (orchestrator + ic). Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters; for larger payloads write a file and broadcast "Read and follow <path>". Returns per-agent receipts so one failed target never hides the rest. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
       {
         text: BroadcastArgsSchema.shape.text.describe(
           `Message to broadcast. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters; write larger payloads to a file and broadcast "Read and follow <path>".`,
@@ -10235,7 +10296,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      `Unified send path. mode=agent (default) routes by agent_id without exposing surface details; mode=surface writes text to a raw surface; mode=command atomically sends a command and Return; mode=key sends one normalized key. Raw-surface modes accept target or surface directly and deliberately do not require a healthy agent registry, preserving the fleet recovery escape hatch. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default; use file-backed boot_prompt_path for launcher prompts or allow_long_inline:true only for deliberate raw sends.`,
+      `Unified send path. mode=agent (default) routes by agent_id without exposing surface details; mode=surface writes text to a raw surface; mode=command atomically sends a command and Return; mode=key sends one normalized key. Raw-surface modes accept target or surface directly and deliberately do not require a healthy agent registry, preserving the fleet recovery escape hatch. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default; use file-backed boot_prompt_path for launcher prompts or allow_long_inline:true only for deliberate raw sends. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(
@@ -10336,6 +10397,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             value: args.text,
             allowLongInline: args.allow_long_inline,
           });
+          assertDenseInlineInputAllowed({
+            tool: "send_to",
+            arg: "text",
+            value: args.text,
+            allowLongInline: args.allow_long_inline,
+          });
           const targetAgent =
             engine.getAgentState(agentId) ?? registry.get(agentId);
           assertInteractiveMultilineInputAllowed({
@@ -10381,7 +10448,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 18. send_to_agent
     server.tool(
       "send_to_agent",
-      `Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); write large payloads to a file and send one line: "Read and follow <path>". For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path through spawn_agent/send_command instead of routing raw long text through the agent composer. Pass allow_long_inline:true only for deliberate raw sends. Returns the same post-delivery registry/screen health evidence as send_to.`,
+      `Deprecated for client integrations: use send_to instead. Internal/advanced path for sending text input to an agent in ready or idle state. Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters by default (CMUXLAYER_MAX_INLINE_CHARS, positive integer >= ${SEND_INPUT_CHUNK_THRESHOLD}); write large payloads to a file and send one line: "Read and follow <path>". For launcher boot prompts, put the full prompt in a file and pass boot_prompt_path through spawn_agent/send_command instead of routing raw long text through the agent composer. Pass allow_long_inline:true only for deliberate raw sends. Returns the same post-delivery registry/screen health evidence as send_to. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(
@@ -10415,6 +10482,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             throw new Error("send_to_agent requires agent_id and text");
           }
           assertInlineInputAllowed({
+            tool: "send_to_agent",
+            arg: "text",
+            value: args.text,
+            allowLongInline: args.allow_long_inline,
+          });
+          assertDenseInlineInputAllowed({
             tool: "send_to_agent",
             arg: "text",
             value: args.text,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1291,9 +1291,13 @@ function assertDenseInlineInputAllowed(opts: {
     return;
   }
 
+  const inputCharacterCount = Array.from(opts.value).length;
   const longestUnbrokenRun = opts.value
-    .split("\n")
-    .reduce((longest, line) => Math.max(longest, line.length), 0);
+    .split(/\r?\n/)
+    .reduce(
+      (longest, line) => Math.max(longest, Array.from(line).length),
+      0,
+    );
   if (longestUnbrokenRun <= DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS) {
     return;
   }
@@ -1304,7 +1308,7 @@ function assertDenseInlineInputAllowed(opts: {
       ? ""
       : " To deliberately send raw inline text, pass allow_long_inline:true.";
   throw new Error(
-    `${argName} is ${opts.value.length} characters and its longest unbroken run is ${longestUnbrokenRun}, above the dense inline routing policy threshold ${DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS}. Long dense payloads belong in a file: write the payload to a file and send one line: "Read and follow <path>".` +
+    `${argName} is ${inputCharacterCount} characters and its longest unbroken run is ${longestUnbrokenRun}, above the dense inline routing policy threshold ${DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS}. Long dense payloads belong in a file: write the payload to a file and send one line: "Read and follow <path>".` +
       overrideGuidance,
   );
 }

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -385,6 +385,37 @@ describe("pane input pointer discipline", () => {
     expect(parseToolResult(result).ok).toBe(true);
   });
 
+  it("counts astral symbols as Unicode characters for the dense threshold", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+    const text = "😀".repeat(751);
+
+    const result = await tool.handler(
+      { surface: "surface:1", text },
+      {} as any,
+    );
+
+    expect(text).toHaveLength(1_502);
+    expect(Array.from(text)).toHaveLength(751);
+    expect(parseToolResult(result).ok).toBe(true);
+  });
+
+  it("does not count CR in CRLF as line content at the dense boundary", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: `${"x".repeat(1_500)}\r\nok` },
+      {} as any,
+    );
+
+    expect(parseToolResult(result).ok).toBe(true);
+  });
+
   it("send_input refuses while a Claude AskUserQuestion overlay is active", async () => {
     const overlayText = readPainpointFixture("claude-ask-user-question-overlay.txt");
     const { createServer } = await loadServerModule();

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -13,6 +13,9 @@ import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
 
 const previousMaxInlineChars = process.env.CMUXLAYER_MAX_INLINE_CHARS;
 let testDir = "";
+const denseIncidentPayload = "x".repeat(1_734);
+const lineBrokenIncidentPayload =
+  `${"x".repeat(79)}\n`.repeat(21) + "x".repeat(54);
 
 async function loadServerModule() {
   vi.resetModules();
@@ -289,7 +292,10 @@ describe("pane input pointer discipline", () => {
     tool = (server as any)._registeredTools["send_input"];
 
     result = await tool.handler(
-      { surface: "surface:1", text: "x".repeat(1_700) },
+      {
+        surface: "surface:1",
+        text: `${"x".repeat(850)}\n${"x".repeat(849)}`,
+      },
       {} as any,
     );
 
@@ -316,6 +322,67 @@ describe("pane input pointer discipline", () => {
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1"]),
     );
+  });
+
+  it("send_input refuses the 1,734-character dense incident as routing policy", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: denseIncidentPayload },
+      {} as any,
+    );
+
+    expect(denseIncidentPayload).toHaveLength(1_734);
+    expect(denseIncidentPayload).not.toContain("\n");
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("send_input.text");
+    expect(parsed.error).toContain("1734 characters");
+    expect(parsed.error).toContain("longest unbroken run is 1734");
+    expect(parsed.error).toContain("routing policy threshold 1500");
+    expect(parsed.error).toContain("Read and follow <path>");
+    expect(parsed.error).toContain("allow_long_inline");
+    expect(parsed.error).not.toContain("mid-token");
+    expect(parsed.error).not.toContain("break panes");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("keeps a line-broken 1,734-character send_input payload allowed", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: lineBrokenIncidentPayload },
+      {} as any,
+    );
+
+    expect(lineBrokenIncidentPayload).toHaveLength(1_734);
+    expect(
+      Math.max(
+        ...lineBrokenIncidentPayload.split("\n").map((line) => line.length),
+      ),
+    ).toBe(79);
+    expect(parseToolResult(result).ok).toBe(true);
+  });
+
+  it("keeps a 1,500-character unbroken send_input payload allowed", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_input"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", text: "x".repeat(1_500) },
+      {} as any,
+    );
+
+    expect(parseToolResult(result).ok).toBe(true);
   });
 
   it("send_input refuses while a Claude AskUserQuestion overlay is active", async () => {
@@ -534,6 +601,24 @@ describe("pane input pointer discipline", () => {
     ).toBe(1);
   });
 
+  it("send_command refuses the dense incident below the general inline cap", async () => {
+    const { createServer } = await loadServerModule();
+    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["send_command"];
+
+    const result = await tool.handler(
+      { surface: "surface:1", command: denseIncidentPayload },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("send_command.command");
+    expect(parsed.error).toContain("routing policy threshold 1500");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it("spawn_agent refuses an over-threshold inline prompt and points to boot_prompt_path", async () => {
     process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
     const { createServer, createServerContext } = await loadServerModule();
@@ -564,6 +649,37 @@ describe("pane input pointer discipline", () => {
     expect(parsed.error).toContain("spawn_agent.prompt");
     expect(parsed.error).toContain("boot_prompt_path");
     expect(parsed.error).toContain("allow_long_inline");
+    expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it("spawn_agent refuses the dense incident below the general inline cap", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+    mockExec.mockClear();
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: denseIncidentPayload,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("spawn_agent.prompt");
+    expect(parsed.error).toContain("routing policy threshold 1500");
     expect(mockExec).not.toHaveBeenCalled();
     context.dispose();
   });
@@ -667,6 +783,73 @@ describe("pane input pointer discipline", () => {
     expect(mockExec).not.toHaveBeenCalled();
     context.dispose();
   });
+
+  it("send_to mode=agent refuses the dense incident below the general inline cap", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendTo = (server as any)._registeredTools["send_to"];
+    mockExec.mockClear();
+
+    const result = await sendTo.handler(
+      { agent_id: agentId, text: denseIncidentPayload, press_enter: true },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("send_to.text");
+    expect(parsed.error).toContain("routing policy threshold 1500");
+    expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it.each([
+    ["surface", { text: denseIncidentPayload }],
+    ["command", { command: denseIncidentPayload }],
+  ] as const)(
+    "send_to mode=%s refuses the dense incident below the general inline cap",
+    async (mode, payload) => {
+      const { createServer, createServerContext } = await loadServerModule();
+      const mockExec = makeLifecycleExec();
+      const context = createServerContext({
+        exec: mockExec,
+        stateDir: testDir,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      });
+      const server = createServer({ context });
+      const sendTo = (server as any)._registeredTools["send_to"];
+      mockExec.mockClear();
+
+      const result = await sendTo.handler(
+        { mode, target: "surface:new", ...payload },
+        {} as any,
+      );
+
+      const parsed = parseToolResult(result);
+      expect(result.isError).toBe(true);
+      expect(parsed.error).toContain(
+        mode === "surface" ? "send_input.text" : "send_command.command",
+      );
+      expect(parsed.error).toContain("routing policy threshold 1500");
+      expect(
+        mockExec.mock.calls.some(([, args]) =>
+          args.some((arg: string) =>
+            ["send", "set-buffer", "paste-buffer", "send-key"].includes(arg),
+          ),
+        ),
+      ).toBe(false);
+      context.dispose();
+    },
+  );
 
   it("send_to allow_long_inline bypasses the inline text cap", async () => {
     process.env.CMUXLAYER_MAX_INLINE_CHARS = "600";
@@ -829,6 +1012,66 @@ describe("pane input pointer discipline", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("CMUXLAYER_MAX_INLINE_CHARS=700");
     expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it("send_to_agent refuses the dense incident below the general inline cap", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    const mockExec = makeLifecycleExec();
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    const sendToAgent = (server as any)._registeredTools["send_to_agent"];
+    mockExec.mockClear();
+
+    const result = await sendToAgent.handler(
+      { agent_id: agentId, text: denseIncidentPayload, press_enter: true },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("send_to_agent.text");
+    expect(parsed.error).toContain("routing policy threshold 1500");
+    expect(mockExec).not.toHaveBeenCalled();
+    context.dispose();
+  });
+
+  it("send-class tool descriptions teach the dense payload routing policy", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    const context = createServerContext({
+      exec: makeLifecycleExec(),
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context }) as any;
+
+    for (const toolName of [
+      "send_input",
+      "send_command",
+      "spawn_agent",
+      "broadcast",
+      "send_to",
+      "send_to_agent",
+    ]) {
+      const description = server._registeredTools[toolName].description;
+      expect(description, toolName).toContain("1500");
+      expect(description, toolName).toMatch(/dense/i);
+      expect(description, toolName).toMatch(/routing policy/i);
+      expect(description, toolName).toContain("Read and follow <path>");
+      expect(description, toolName).toMatch(/zsh history expansion/i);
+      expect(description, toolName).toContain("!");
+      expect(description, toolName).not.toMatch(
+        /mid-token|break panes|pane break/i,
+      );
+    }
+
     context.dispose();
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -4059,7 +4059,8 @@ describe("agent lifecycle tool handlers", () => {
         role: "ic",
       }),
     ];
-    const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(records);
+    const { server, sendCalls, sendKeyCalls } =
+      await createBroadcastServer(records);
     const broadcast = (server as any)._registeredTools["broadcast"];
 
     const result = await broadcast.handler(
@@ -4076,6 +4077,35 @@ describe("agent lifecycle tool handlers", () => {
     expect(sendCalls).toHaveLength(0);
     expect(sendKeyCalls).toHaveLength(0);
     expect(readOutboxMtimeMs(outboxPath)).toBe(outboxMtimeBefore);
+  });
+
+  it("broadcast refuses the dense incident below the general inline cap", async () => {
+    const records = [
+      makeServerAgentRecord({
+        agent_id: "ic-target",
+        surface_id: "surface:ic",
+        state: "ready",
+        role: "ic",
+      }),
+    ];
+    const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(records);
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = await broadcast.handler(
+      { text: "x".repeat(1_734) },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toContain("broadcast.text");
+    expect(parsed.error).toContain("1734 characters");
+    expect(parsed.error).toContain("longest unbroken run is 1734");
+    expect(parsed.error).toContain("routing policy threshold 1500");
+    expect(parsed.error).toContain("Read and follow <path>");
+    expect(parsed.error).not.toContain("allow_long_inline");
+    expect(sendCalls).toHaveLength(0);
+    expect(sendKeyCalls).toHaveLength(0);
   });
 
   it("broadcast fails closed when live surface enumeration is malformed", async () => {


### PR DESCRIPTION
## Summary

- Refuse dense inline payloads whose longest unbroken line exceeds 1,500 characters, derived as 3 × the existing 500-character chunk threshold.
- Apply the routing policy uniformly to send_input, send_command, every inline send_to mode, send_to_agent, broadcast, and spawn_agent prompt delivery. dispatch_to_agent remains unchanged because its task payload is appended to an inbox file and only a generated one-line pointer reaches the terminal.
- Teach callers to put large or dense payloads in a file and send only Read and follow <path>, including the existing zsh history-expansion warning without claiming pane breakage or mid-token fragmentation.

## Incident and measured impact

- Regression fixture: 1,734 characters, one line, previously accepted; now refused with actual length, longest unbroken run, threshold, and pointer guidance.
- Same-length content broken into roughly 80-character lines remains allowed.
- Frozen historical sample: 871 send-class calls.
- Dense policy alone would refuse 19/871 calls (2.2%).
- Newly refused versus current guards: 16/871 calls (1.8%): 15 send_to calls and 1 send_command call.
- Existing guards plus this policy would refuse 61/871 calls (7.0%).

## Verification

- TDD: recorded acceptance on current code, flipped to a failing refusal assertion, then implemented the guard.
- bun run typecheck
- bun run build
- bun run test — 106 files, 2,326 tests passed with no exclusions
- mandatory pre-push regression harness — passed, including 2,326 tests
- local CodeRabbit rerun was rate-limited for 21 minutes after reviewing prerequisite PR #341; PR-level reviewers are requested below.

## Dependency

This is a stacked PR based on fix/current-opus-parity / #341. That prerequisite only aligns cmuxlayer's current top-Opus pin so the mandatory pre-push parity gate can pass. Merge #341 before retargeting this PR to main.

## No merge authority

This PR is ready for review but must not be merged by this worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation on all terminal input paths; long single-line payloads that previously passed the character cap will now fail unless callers use files or allow_long_inline.
> 
> **Overview**
> Adds a **dense inline routing policy** that blocks payloads whose **longest unbroken line** exceeds `DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS` (3× the 500-character send chunk threshold), even when total length stays under `CMUXLAYER_MAX_INLINE_CHARS`. The new `assertDenseInlineInputAllowed` runs alongside existing inline caps on `send_input`, `send_command`, `spawn_agent`, `send_to`, `send_to_agent`, and `broadcast` (via `assertBroadcastInlineInputAllowed`).
> 
> Errors report character count, longest run, threshold, and **Read and follow &lt;path&gt;** guidance; non-broadcast tools can still opt out with `allow_long_inline:true`. Line breaks reset the run (CRLF-safe); astral symbols count as Unicode code points.
> 
> Tool descriptions now embed shared **dense routing** and **zsh `!` history-expansion** warnings; `send_input` docs clarify line-aligned chunks coalesced into paste batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49bda98ae5efee04d9bf343d68fadd45e575a2c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce dense inline routing policy across all input tools
> - Adds `assertDenseInlineInputAllowed` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/342/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) that rejects inline payloads where any single unbroken line exceeds `DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS` (1500 chars), with an error message directing callers to use a file-based pointer instead.
> - Applies this check to `send_input`, `send_command`, `spawn_agent`, `send_to`, `send_to_agent`, and `broadcast`; all tools except `broadcast` accept an `allow_long_inline: true` override.
> - Appends dense inline routing guidance and a zsh `!` history-expansion warning to all affected tool descriptions.
> - Behavioral Change: any existing call passing a long single-line payload inline will now fail unless `allow_long_inline` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49bda98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->