### PR TITLE
fix(relay): reject false submit receipts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Raw terminal captures preserve right-padding spaces from the rendered pane.
+tests/fixtures/cursor-pr343-v2-immediate-working-response.txt whitespace=-blank-at-eol
+tests/fixtures/painpoints/codex-pr343-live-queued-followup.txt whitespace=-blank-at-eol

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Raw terminal captures preserve right-padding spaces from the rendered pane.
-tests/fixtures/cursor-pr343-v2-immediate-working-response.txt whitespace=-blank-at-eol
-tests/fixtures/painpoints/codex-pr343-live-queued-followup.txt whitespace=-blank-at-eol
+# They also keep LF endings so exact-substring assertions are cross-platform.
+tests/fixtures/**/*.txt text eol=lf whitespace=-blank-at-eol

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -259,6 +259,7 @@ const CURSOR_CWD_FOOTER_RE =
 const CURSOR_MODE_BAR_RE =
   /\/ commands · @ files · ! shell · ctrl\+r to review edits/i;
 const CURSOR_HEX_RUNNING_RE = /⬡\s+Running\.\.\./i;
+const CURSOR_BRAILLE_WORKING_RE = /^\s*[\u2800-\u28ff]+\s+Working\b/im;
 const CURSOR_HEX_IDLE_RE = /⬡\s+Idle\b/i;
 const CURSOR_TOKEN_LINE_RE =
   /⬡\s+(?:Running\.\.\.|Idle)\s+([0-9][0-9,]*(?:\.[0-9]+)?)\s*([km])?\s*tokens\b/i;
@@ -1174,7 +1175,10 @@ function inferStatus(
   }
 
   if (agentType === "cursor") {
-    if (CURSOR_HEX_RUNNING_RE.test(text)) {
+    if (
+      CURSOR_HEX_RUNNING_RE.test(text) ||
+      CURSOR_BRAILLE_WORKING_RE.test(text)
+    ) {
       return "working";
     }
     if (CURSOR_FOLLOWUP_RE.test(text) || CURSOR_HEX_IDLE_RE.test(text)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4013,7 +4013,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const screenCli = inferComposerCli(snapshot.text, snapshot.parsed);
       const cursorShowsSubmittedResponse =
         screenCli === "cursor" &&
-        hasPendingInput &&
         screenShowsFreshCursorResponseAfterSubmittedInput(
           snapshot.text,
           opts.text,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1816,6 +1816,7 @@ function matchLegacyClaudePromptLine(
 function normalizeKnownPlaceholderComposerInput(
   cli: CliType | null,
   input: string,
+  submittedText?: string,
 ): string {
   const withoutCursorBorders = input
     .split("\n")
@@ -1827,12 +1828,18 @@ function normalizeKnownPlaceholderComposerInput(
     (cli === "cursor" &&
       withoutCursorBorders === "Plan, search, build anything")
   ) {
+    if (withoutCursorBorders === submittedText?.trim()) {
+      return input;
+    }
     return "";
   }
   return input;
 }
 
-function extractComposerInputRegion(screenText: string): string | null {
+function extractComposerInputRegion(
+  screenText: string,
+  submittedText?: string,
+): string | null {
   const lines = normalizeTerminalText(screenText).split("\n");
   const cli = inferComposerCli(screenText);
   const start = currentComposerRegionStart(cli, lines);
@@ -1858,6 +1865,7 @@ function extractComposerInputRegion(screenText: string): string | null {
     return normalizeKnownPlaceholderComposerInput(
       cli,
       inputLines.join("\n").trimEnd(),
+      submittedText,
     );
   }
 
@@ -1878,6 +1886,7 @@ function extractComposerInputRegion(screenText: string): string | null {
     return normalizeKnownPlaceholderComposerInput(
       cli,
       inputLines.join("\n").trimEnd(),
+      submittedText,
     );
   }
 
@@ -1900,7 +1909,7 @@ function screenShowsPendingInput(
 
   const tail = trimmed.slice(-Math.min(80, trimmed.length));
   const compactTail = tail.replace(/\s+/g, "");
-  const composerInput = extractComposerInputRegion(screenText);
+  const composerInput = extractComposerInputRegion(screenText, submittedText);
   return (
     composerInput !== null &&
     (composerInput.includes(tail) ||
@@ -9414,7 +9423,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : undefined,
             beforeMutation: assertDeliveryRouteCurrent,
           });
-          if (args.press_enter) {
+          if (args.press_enter && delivery.submit_verified === true) {
             engine.markAgentWorking(args.agent_id);
           }
           return delivery;
@@ -12187,6 +12196,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               });
             }
             throw e;
+          }
+          if (delivery.submit_verified !== true) {
+            const error = new SubmitVerificationError(
+              `Supersede submission could not be verified for ${args.agent_id}`,
+              delivery.retry_count,
+              "submit_evidence_absent",
+            );
+            return err(error, {
+              error_code: "supersede_submit_unverified",
+              ...submitVerificationFailurePayload(error),
+              registry_updated: false,
+              goal_delivery_state: "unverified_pane_side_effect",
+              recovery:
+                "Do not retry automatically; inspect the target composer/queue and reconcile the pane before attempting another supersede.",
+            });
           }
           const canonicalAgentId = current.agent_id;
           const supersedePatch = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1880,6 +1880,21 @@ function screenShowsPendingInput(
   );
 }
 
+function screenShowsQueuedAgentInput(screenText: string): boolean {
+  const normalized = normalizeTerminalText(screenText);
+  const heading =
+    /(?:^|\n)[ \t]*Messages to be submitted after next tool call[ \t]*(?=\n|$)/i.exec(
+      normalized,
+    );
+  if (!heading) {
+    return false;
+  }
+
+  return /(?:^|\n)[ \t]*↳(?:[ \t]|$)/.test(
+    normalized.slice(heading.index + heading[0].length),
+  );
+}
+
 export function screenShowsPendingShellInput(
   screenText: string,
   submittedText: string,
@@ -3726,7 +3741,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let retryCount = 0;
     let sawClearedComposerEvidence = false;
     let sawAllowedClearedComposerEvidence = false;
-    let lastHasPendingInput = false;
+    let lastHasPendingSubmitEvidence = false;
     let lastRetryEligiblePendingInput = false;
     let retryEligiblePendingSince: number | null = null;
     let retriedAt: number | null = null;
@@ -3758,21 +3773,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       sawReadableScreen = true;
 
-      if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
+      const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
+      const hasQueuedAgentInput = screenShowsQueuedAgentInput(snapshot.text);
+      const hasPendingSubmitEvidence =
+        hasPendingInput || hasQueuedAgentInput;
+      lastHasPendingSubmitEvidence = hasPendingSubmitEvidence;
+      const composerInput = extractComposerInputRegion(snapshot.text);
+      if (
+        !hasPendingSubmitEvidence &&
+        isSubmitVerifiedStatus(snapshot.parsed.status)
+      ) {
         return {
           submit_verified: true,
           submit_verification_reason: null,
           retry_count: retryCount,
         };
       }
-
-      const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
-      lastHasPendingInput = hasPendingInput;
-      const composerInput = extractComposerInputRegion(snapshot.text);
       const hasClearedAgentComposer =
         composerInput !== null &&
         composerInput.trim() === "" &&
-        !hasPendingInput &&
+        !hasPendingSubmitEvidence &&
         screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed);
       if (hasClearedAgentComposer) {
         sawClearedComposerEvidence = true;
@@ -3867,7 +3887,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const submitVerified =
       opts.require_working_status ||
-      lastHasPendingInput ||
+      lastHasPendingSubmitEvidence ||
       lastRetryEligiblePendingInput ||
       !sawReadableScreen
         ? false
@@ -3875,7 +3895,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const failureReason: SubmitVerificationFailureReason | null =
       submitVerified !== false
         ? null
-        : lastHasPendingInput || lastRetryEligiblePendingInput
+        : lastHasPendingSubmitEvidence || lastRetryEligiblePendingInput
           ? "input_still_pending"
           : !sawReadableScreen
             ? sawBlankScreen
@@ -9108,15 +9128,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             stableSurfaceIdentity: deliveryRoute.surface_uuid,
             source_event: args.source_event,
             source_agent: args.agent_id,
-            // Verify every relay to an interactive agent — not just long ones.
-            // A short relay (the common agent-to-agent case) to a frozen
-            // terminal must be caught, never reported as ok. allow_busy sends
-            // are deliberate queue/interjection writes and stay unverified to
-            // avoid false-failing accepted queued input.
+            // Verify every submitted agent relay — not just long ones. A short
+            // relay (the common agent-to-agent case) to a frozen terminal must
+            // be caught, never reported as ok. Busy sends do not retry Return:
+            // accepted queued input can repaint slowly, but text still proven
+            // inside the active composer must not receive a success receipt.
             verify_submit:
               args.press_enter &&
-              !args.allow_busy &&
-              INTERACTIVE_AGENT_STATES.has(deliveryRoute.state),
+              (args.allow_busy ||
+                INTERACTIVE_AGENT_STATES.has(deliveryRoute.state)),
             allow_recovery_enter_retry: !args.allow_busy,
             beforeMutation: assertDeliveryRouteCurrent,
           });

--- a/src/server.ts
+++ b/src/server.ts
@@ -377,6 +377,10 @@ export const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
   DEFAULT_SEND_INPUT_MAX_INLINE_CHARS,
 );
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
+// Busy relays are interjections into an already-running UI. Observe several
+// repaint frames, but fail quickly when the submitted text remains queued or
+// in the composer so fleet fan-out does not inherit the general 5s timeout.
+const BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS = 500;
 const SEND_INPUT_SAFE_RETRY_OBSERVE_MS = 2500;
 const SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS = 300;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
@@ -1809,6 +1813,25 @@ function matchLegacyClaudePromptLine(
   return match ? { input: match[1] ?? "" } : null;
 }
 
+function normalizeKnownPlaceholderComposerInput(
+  cli: CliType | null,
+  input: string,
+): string {
+  const withoutCursorBorders = input
+    .split("\n")
+    .filter((line) => !/^\s*[▄▀]{8,}\s*$/.test(line))
+    .join("\n")
+    .trim();
+  if (
+    (cli === "codex" && withoutCursorBorders === "Implement {feature}") ||
+    (cli === "cursor" &&
+      withoutCursorBorders === "Plan, search, build anything")
+  ) {
+    return "";
+  }
+  return input;
+}
+
 function extractComposerInputRegion(screenText: string): string | null {
   const lines = normalizeTerminalText(screenText).split("\n");
   const cli = inferComposerCli(screenText);
@@ -1832,7 +1855,10 @@ function extractComposerInputRegion(screenText: string): string | null {
       inputLines.push(line);
     }
 
-    return inputLines.join("\n").trimEnd();
+    return normalizeKnownPlaceholderComposerInput(
+      cli,
+      inputLines.join("\n").trimEnd(),
+    );
   }
 
   for (let index = end - 1; index >= start; index -= 1) {
@@ -1849,7 +1875,10 @@ function extractComposerInputRegion(screenText: string): string | null {
       inputLines.push(line);
     }
 
-    return inputLines.join("\n").trimEnd();
+    return normalizeKnownPlaceholderComposerInput(
+      cli,
+      inputLines.join("\n").trimEnd(),
+    );
   }
 
   const lastActiveLine = lines[end - 1] ?? "";
@@ -1880,19 +1909,212 @@ function screenShowsPendingInput(
   );
 }
 
-function screenShowsQueuedAgentInput(screenText: string): boolean {
-  const normalized = normalizeTerminalText(screenText);
-  const heading =
-    /(?:^|\n)[ \t]*Messages to be submitted after next tool call[ \t]*(?=\n|$)/i.exec(
-      normalized,
+function stripCodexQueueGutter(line: string): string {
+  return line.replace(/^\s*[│┃║┆┊]\s?/, "").trimEnd();
+}
+
+function compactQueueCorrelationText(text: string): string {
+  return normalizeTerminalText(text).replace(/\s+/g, "");
+}
+
+function cursorSubmittedResponseEvidenceSignatures(
+  screenText: string,
+  submittedText: string,
+): string[] {
+  const trimmed = submittedText.trim();
+  if (!trimmed || inferComposerCli(screenText) !== "cursor") {
+    return [];
+  }
+
+  const lines = normalizeTerminalText(screenText).split("\n");
+  let composerIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (matchComposerPromptLine(lines[index] ?? "")) {
+      composerIndex = index;
+      break;
+    }
+  }
+  if (composerIndex < 0) {
+    return [];
+  }
+
+  const correlationTail = compactQueueCorrelationText(
+    trimmed.slice(-Math.min(80, trimmed.length)),
+  );
+  let regionStart = 0;
+  for (let index = composerIndex - 1; index >= 0; index -= 1) {
+    if (lineIsCurrentComposerRegionAnchor("cursor", lines[index] ?? "")) {
+      regionStart = index + 1;
+      break;
+    }
+  }
+  const evidence: string[] = [];
+  for (let index = composerIndex - 1; index >= regionStart; index -= 1) {
+    const submittedTranscriptWindow = compactQueueCorrelationText(
+      lines.slice(Math.max(regionStart, index - 16), index).join("\n"),
     );
-  if (!heading) {
+    if (!submittedTranscriptWindow.includes(correlationTail)) {
+      continue;
+    }
+
+    const activityMatch = (lines[index] ?? "").match(
+      /^\s*(?:[\u2800-\u28ff]+\s*)?(Working|Thinking|Running)\b/i,
+    );
+    if (activityMatch?.[1]) {
+      evidence.push(`activity:${activityMatch[1].toLowerCase()}`);
+      continue;
+    }
+
+    if (
+      !/^\s*[│┃║]\s*(?:…|\.\.\.)?\s*Thought for \d+(?:\.\d+)?(?:ms|s|m)\b/i.test(
+        lines[index] ?? "",
+      )
+    ) {
+      continue;
+    }
+
+    const responseRows: string[] = [];
+    for (
+      let rowIndex = index + 1;
+      rowIndex < Math.min(composerIndex, index + 17);
+      rowIndex += 1
+    ) {
+      const row = lines[rowIndex] ?? "";
+      if (/^\s*[└╰].*[┘╯]\s*$/.test(row)) {
+        break;
+      }
+      const content = row.replace(/^\s*[│┃║]\s?/, "").trim();
+      if (content && !/^[─━┌┐└┘╭╮╰╯]+$/.test(content)) {
+        responseRows.push(content);
+      }
+    }
+    if (responseRows.length > 0) {
+      evidence.push(
+        `thought:${responseRows.join(" ").replace(/\s+/g, " ").trim()}`,
+      );
+    }
+  }
+
+  return evidence;
+}
+
+function screenShowsFreshCursorResponseAfterSubmittedInput(
+  screenText: string,
+  submittedText: string,
+  baselineEvidence: readonly string[] | null,
+): boolean {
+  if (baselineEvidence === null) {
     return false;
   }
 
-  return /(?:^|\n)[ \t]*↳(?:[ \t]|$)/.test(
-    normalized.slice(heading.index + heading[0].length),
+  const baselineCounts = new Map<string, number>();
+  for (const signature of baselineEvidence) {
+    baselineCounts.set(signature, (baselineCounts.get(signature) ?? 0) + 1);
+  }
+  for (const signature of cursorSubmittedResponseEvidenceSignatures(
+    screenText,
+    submittedText,
+  )) {
+    const remaining = baselineCounts.get(signature) ?? 0;
+    if (remaining === 0) {
+      return true;
+    }
+    baselineCounts.set(signature, remaining - 1);
+  }
+
+  return false;
+}
+
+function screenShowsQueuedAgentInput(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  const lines = normalizeTerminalText(screenText).split("\n");
+  if (inferComposerCli(screenText) !== "codex") {
+    return false;
+  }
+
+  let composerIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (matchComposerPromptLine(stripCodexQueueGutter(lines[index] ?? ""))) {
+      composerIndex = index;
+      break;
+    }
+  }
+  if (composerIndex < 0) {
+    return false;
+  }
+
+  let index = composerIndex - 1;
+  while (
+    index >= 0 &&
+    (!stripCodexQueueGutter(lines[index] ?? "").trim() ||
+      /^[•✻✢✳✶]?\s*(?:Working|Thinking)\b/i.test(
+        stripCodexQueueGutter(lines[index] ?? ""),
+      ))
+  ) {
+    index -= 1;
+  }
+
+  const queuedItemRows: string[] = [];
+  let foundQueuedItem = false;
+  while (index >= 0) {
+    const rawLine = lines[index] ?? "";
+    const activeLine = stripCodexQueueGutter(rawLine).trim();
+    const itemMatch = /^↳(?:\s+(.*)|\s*$)/.exec(activeLine);
+    if (itemMatch) {
+      queuedItemRows.unshift(itemMatch[1] ?? "");
+      foundQueuedItem = true;
+      index -= 1;
+      break;
+    }
+    const isWrappedItemRow =
+      /^\s*[│┃║┆┊]/.test(rawLine) || /^\s{2,}\S/.test(rawLine);
+    if (!activeLine || !isWrappedItemRow) {
+      return false;
+    }
+    queuedItemRows.unshift(activeLine);
+    index -= 1;
+  }
+  if (!foundQueuedItem) {
+    return false;
+  }
+
+  while (
+    index >= 0 &&
+    !stripCodexQueueGutter(lines[index] ?? "").trim()
+  ) {
+    index -= 1;
+  }
+  const queueHeadingPattern =
+    /^messages to be submitted after next tool call(?: \(press esc to interrupt and send immediately\))?$/i;
+  let wrappedHeading = "";
+  let foundHeading = false;
+  for (let headingRows = 0; index >= 0 && headingRows < 4; headingRows += 1) {
+    const headingRow = stripCodexQueueGutter(lines[index] ?? "")
+      .trim()
+      .replace(/^•\s*/, "");
+    if (!headingRow) {
+      break;
+    }
+    wrappedHeading = `${headingRow} ${wrappedHeading}`
+      .replace(/\s+/g, " ")
+      .trim();
+    if (queueHeadingPattern.test(wrappedHeading)) {
+      foundHeading = true;
+      break;
+    }
+    index -= 1;
+  }
+  if (!foundHeading) {
+    return false;
+  }
+
+  const visiblePrefix = compactQueueCorrelationText(
+    queuedItemRows.join(" ").replace(/(?:…|\.\.\.)+\s*$/, ""),
   );
+  const submitted = compactQueueCorrelationText(submittedText.trim());
+  return visiblePrefix.length > 0 && submitted.startsWith(visiblePrefix);
 }
 
 export function screenShowsPendingShellInput(
@@ -3650,12 +3872,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     surface: string,
     workspace?: string,
     cli?: CliType,
-  ): Promise<void> => {
+  ): Promise<{ text: string; parsed: ParsedScreenResult } | null> => {
     const snapshot = await readParsedSurface(surface, workspace, {
       throwOnSurfaceGone: true,
     });
     if (!snapshot) {
-      return;
+      return null;
     }
 
     if (snapshot.parsed.control_state === "permission_prompt") {
@@ -3671,6 +3893,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         snapshot.parsed,
       );
     }
+
+    return snapshot;
   };
 
   const maybeRenameTask = async (opts: {
@@ -3714,6 +3938,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     require_working_status?: boolean;
     allow_recovery_enter_retry?: boolean;
     timeout_ms?: number;
+    cursor_response_baseline: readonly string[] | null;
     beforeMutation?: () => Promise<void>;
   }): Promise<{
     submit_verified: boolean | null;
@@ -3774,14 +3999,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       sawReadableScreen = true;
 
       const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
-      const hasQueuedAgentInput = screenShowsQueuedAgentInput(snapshot.text);
+      const hasQueuedAgentInput = screenShowsQueuedAgentInput(
+        snapshot.text,
+        opts.text,
+      );
+      if (hasQueuedAgentInput) {
+        return {
+          submit_verified: false,
+          submit_verification_reason: "input_still_pending",
+          retry_count: retryCount,
+        };
+      }
+      const screenCli = inferComposerCli(snapshot.text, snapshot.parsed);
+      const cursorShowsSubmittedResponse =
+        screenCli === "cursor" &&
+        hasPendingInput &&
+        screenShowsFreshCursorResponseAfterSubmittedInput(
+          snapshot.text,
+          opts.text,
+          opts.cursor_response_baseline,
+        );
       const hasPendingSubmitEvidence =
-        hasPendingInput || hasQueuedAgentInput;
+        hasPendingInput && !cursorShowsSubmittedResponse;
       lastHasPendingSubmitEvidence = hasPendingSubmitEvidence;
       const composerInput = extractComposerInputRegion(snapshot.text);
       if (
         !hasPendingSubmitEvidence &&
-        isSubmitVerifiedStatus(snapshot.parsed.status)
+        (isSubmitVerifiedStatus(snapshot.parsed.status) ||
+          cursorShowsSubmittedResponse)
       ) {
         return {
           submit_verified: true,
@@ -3933,7 +4178,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verified: boolean | null;
   }> => {
     await opts.beforeMutation?.();
-    await assertDeliveryTargetIsSafe(opts.surface, opts.workspace);
+    const deliverySafetySnapshot = await assertDeliveryTargetIsSafe(
+      opts.surface,
+      opts.workspace,
+    );
     const deliveryBatches = buildInputDeliveryBatches(opts.chunks);
     const shouldPaste = shouldPasteInputDelivery(
       opts.chunks,
@@ -3964,12 +4212,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       (sum, chunk) => sum + Buffer.byteLength(chunk, "utf-8"),
       0,
     );
+    const submittedText = opts.chunks.join("");
     let submit_verified: boolean | null = null;
     let submit_verification_reason: SubmitVerificationFailureReason | null =
       null;
     let retry_count = 0;
 
     if (opts.press_enter) {
+      let cursorResponseBaseline: readonly string[] | null = null;
+      if (
+        opts.verify_submit &&
+        deliverySafetySnapshot &&
+        inferComposerCli(
+          deliverySafetySnapshot.text,
+          deliverySafetySnapshot.parsed,
+        ) === "cursor"
+      ) {
+        await opts.beforeMutation?.();
+        const preReturnSnapshot = await readParsedSurface(
+          opts.surface,
+          opts.workspace,
+          { throwOnSurfaceGone: true },
+        );
+        cursorResponseBaseline = preReturnSnapshot
+          ? cursorSubmittedResponseEvidenceSignatures(
+              preReturnSnapshot.text,
+              submittedText,
+            )
+          : null;
+      }
       await delay(computeEnterDelayMs(bytes, opts.chunks.length));
       await sendKeyWithRetry(
         opts.surface,
@@ -3990,13 +4261,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const verification = await verifySubmitAfterEnter({
         surface: opts.surface,
         workspace: opts.workspace,
-        text: opts.chunks.join(""),
+        text: submittedText,
         bytes,
         source_event: opts.source_event ?? "send_command",
         source_agent: opts.source_agent,
         verify_submit: opts.verify_submit ?? false,
         allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
         timeout_ms: opts.submit_verify_timeout_ms,
+        cursor_response_baseline: cursorResponseBaseline,
         require_working_status: opts.source_event === "boot_prompt",
         beforeMutation: opts.beforeMutation,
       });
@@ -9138,6 +9410,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               (args.allow_busy ||
                 INTERACTIVE_AGENT_STATES.has(deliveryRoute.state)),
             allow_recovery_enter_retry: !args.allow_busy,
+            submit_verify_timeout_ms: args.allow_busy
+              ? BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS
+              : undefined,
             beforeMutation: assertDeliveryRouteCurrent,
           });
           if (args.press_enter) {
@@ -11632,7 +11907,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
-          "If true, bypass the lifecycle-state gate so a working agent can receive an interjection. Picker/menu and permission-prompt safety gates still refuse text; use mode=key for deliberate menu driving.",
+          "If true, bypass the lifecycle-state gate so a working agent can receive an interjection. Queued-but-unsubmitted input returns an error and must not be retried blindly. Picker/menu and permission-prompt safety gates still refuse text; use mode=key for deliberate menu driving.",
         ),
         allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
@@ -11781,7 +12056,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
-          "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state (matches send_input behavior).",
+          "If true, bypass the interactive-state gate and deliver raw keystrokes regardless of agent state. Queued-but-unsubmitted input returns an error and must not be retried blindly.",
         ),
         allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
@@ -11860,7 +12135,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "supersede_agent_goal",
-      "Replace an existing managed agent's active mission with a file-backed /goal contract. Updates registry task_summary/goal_file, sends `/goal Read and execute this goal file until complete: <path>` through the guarded agent relay, and returns delivery evidence plus health. Use this to reuse an existing pane instead of spawning a duplicate lane.",
+      "Replace an existing managed agent's active mission with a file-backed /goal contract. Sends `/goal Read and execute this goal file until complete: <path>` through the guarded agent relay, then applies the supersede registry patch only after verified submission. An unverified submission does not apply that patch but may have mutated the target pane, so it is not safe to retry blindly. Use this to reuse an existing pane instead of spawning a duplicate lane.",
       {
         agent_id: z.string().describe("Managed agent_id to supersede"),
         goal_file: z
@@ -11877,7 +12152,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default(true)
           .describe(
-            "If true, supersede even while the agent is working. Defaults true because supersession intentionally replaces the active mission.",
+            "If true, supersede even while the agent is working. Defaults true because supersession intentionally replaces the active mission. Queued-but-unsubmitted input returns an error and may require manual pane reconciliation before retrying.",
           ),
       },
       ANNOTATIONS.mutating,
@@ -11890,13 +12165,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           await preflightBootPromptFile(args.goal_file);
           const taskSummary = args.summary?.trim() || args.goal_file;
-          const delivery = await deliverAgentInput({
-            agent_id: args.agent_id,
-            text: `/goal Read and execute this goal file until complete: ${args.goal_file}`,
-            press_enter: true,
-            allow_busy: args.allow_busy ?? true,
-            source_event: "supersede_agent_goal",
-          });
+          let delivery: Awaited<ReturnType<typeof deliverAgentInput>>;
+          try {
+            delivery = await deliverAgentInput({
+              agent_id: args.agent_id,
+              text: `/goal Read and execute this goal file until complete: ${args.goal_file}`,
+              press_enter: true,
+              allow_busy: args.allow_busy ?? true,
+              source_event: "supersede_agent_goal",
+            });
+          } catch (e) {
+            if (e instanceof SubmitVerificationError) {
+              return err(e, {
+                error_code: "supersede_submit_unverified",
+                submit_verified: false,
+                retry_count: e.retry_count,
+                registry_updated: false,
+                goal_delivery_state: "unverified_pane_side_effect",
+                retry_safe: false,
+                recovery:
+                  "Do not retry automatically; inspect the target composer/queue and reconcile the pane before attempting another supersede.",
+              });
+            }
+            throw e;
+          }
           const canonicalAgentId = current.agent_id;
           const supersedePatch = {
             task_summary: taskSummary,

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1601,6 +1601,29 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      cli: "codex" as const,
+      screen: CODEX_PLACEHOLDER_SCREEN,
+      submittedText: "Implement {feature}",
+    },
+    {
+      cli: "cursor" as const,
+      screen: CURSOR_BOOT_READY_SCREEN,
+      submittedText: "Plan, search, build anything",
+    },
+  ])(
+    "keeps a literal submitted $cli placeholder pending when Return is missed",
+    ({ screen, submittedText }) => {
+      expect(
+        __submitEvidenceTestHooks.screenShowsPendingInput(
+          screen,
+          submittedText,
+        ),
+      ).toBe(true);
+    },
+  );
+
   it("does not verify send_input to an uncached shell from prompt clearing", async () => {
     const client = new FakeShellSurfaceClient();
     server = createReliabilityServer(client as any);

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1477,6 +1477,47 @@ describe("enter reliability", () => {
     );
   }, 10_000);
 
+  it("accepts the live v3 Cursor Working transition when the retained composer truncates the submitted token", async () => {
+    const submittedText = "CURSOR_WORKING_PROBE_V3_1785621661796_Q7";
+    const postReturnScreen =
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN.replace(
+        "\n ⠀⠞ Working\n",
+        `\n  ${submittedText}\n\n ⠰⠰ Working\n`,
+      );
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.preReturnScreenText = CURSOR_PR343_V2_PRE_RETURN_SCREEN;
+    client.postReturnScreenText = postReturnScreen;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "cursor" });
+
+    expect(postReturnScreen).toContain(submittedText);
+    expect(postReturnScreen).toContain("⠰⠰ Working");
+    expect(
+      __submitEvidenceTestHooks.screenShowsPendingInput(
+        postReturnScreen,
+        submittedText,
+      ),
+    ).toBe(false);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: submittedText,
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
   it("does not accept parsed Cursor working status without post-submit response evidence", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -219,13 +219,13 @@ class FakeClaudeSurfaceClient {
     }
 
     this.returnCount += 1;
+    this.queuedCodexReadsRemaining = this.queuedCodexReadsAfterReturn;
     if (this.returnCount >= this.requiredReturns) {
       this.pendingText = "";
       this.mode = this.completionMode;
       return;
     }
 
-    this.queuedCodexReadsRemaining = this.queuedCodexReadsAfterReturn;
     this.mode = this.keepWorkingStatusWhilePending ? "working" : "idle";
   }
 
@@ -277,7 +277,11 @@ class FakeClaudeSurfaceClient {
     if (this.returnCount === 0 && this.preReturnScreenText !== null) {
       return this.preReturnScreenText;
     }
-    if (this.pendingText && this.postReturnPendingScreenText !== null) {
+    if (
+      this.returnCount > 0 &&
+      this.pendingText &&
+      this.postReturnPendingScreenText !== null
+    ) {
       return this.postReturnPendingScreenText;
     }
     if (!this.pendingText && this.postReturnScreenText !== null) {
@@ -285,7 +289,10 @@ class FakeClaudeSurfaceClient {
     }
     if (this.cli === "codex") {
       const status = this.mode === "working" ? "Working (11s)" : "";
-      if (this.pendingText && this.queuedCodexReadsRemaining > 0) {
+      if (
+        (this.pendingText || this.queuedCodexVisibleText !== null) &&
+        this.queuedCodexReadsRemaining > 0
+      ) {
         this.queuedCodexReadsRemaining -= 1;
         const queueText = this.queuedCodexVisibleText ?? this.pendingText;
         const truncated = `${queueText.slice(0, 42)}…`;
@@ -1269,7 +1276,7 @@ describe("enter reliability", () => {
 
   it("ignores adjacent Codex queue chrome for another sender's visible prefix", async () => {
     const client = new FakeClaudeSurfaceClient();
-    client.requiredReturns = 99;
+    client.requiredReturns = 1;
     client.cli = "codex";
     client.keepWorkingStatusWhilePending = true;
     client.queuedCodexReadsAfterReturn = 1;
@@ -1312,6 +1319,10 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe(
+      "surface_read_unavailable",
+    );
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
@@ -1467,7 +1478,7 @@ describe("enter reliability", () => {
 
     expect(CURSOR_PR343_V2_PRE_RETURN_SCREEN).not.toContain("⠀⠞ Working");
     expect(client.screenReads.at(-1)).toContain("⠀⠞ Working");
-    expect(parsed.screen?.status).toBe("idle");
+    expect(parsed.screen?.status).toBe("working");
     expect(result.isError).not.toBe(true);
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -26,6 +26,22 @@ async function callTool(
   return resultPromise;
 }
 
+async function callToolInTimerSteps(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  const resultPromise = tool.handler(args, {} as any);
+  for (let elapsed = 0; elapsed < 10_000; elapsed += 100) {
+    await vi.advanceTimersByTimeAsync(100);
+  }
+  return resultPromise;
+}
+
 function readEventLog(): Array<Record<string, unknown>> {
   const filePath = join(TEST_DIR, "events.jsonl");
   if (!existsSync(filePath)) {
@@ -50,11 +66,17 @@ class FakeClaudeSurfaceClient {
   readonly title = "brainlayerClaude";
   readonly sendCalls: string[] = [];
   readonly sendKeyCalls: string[] = [];
+  readonly screenReads: string[] = [];
   readonly renameTabCalls: string[] = [];
   requiredReturns = 2;
   completionMode: "idle" | "working" = "working";
+  cli: "claude" | "codex" = "claude";
+  keepWorkingStatusWhilePending = false;
+  queuedCodexReadsAfterReturn = 0;
+  failScreenReadsAfterReturn = false;
   private pendingText = "";
   private returnCount = 0;
+  private queuedCodexReadsRemaining = 0;
   private mode: "idle" | "working" = "idle";
 
   async listWorkspaces() {
@@ -144,17 +166,23 @@ class FakeClaudeSurfaceClient {
       return;
     }
 
-    this.mode = "idle";
+    this.queuedCodexReadsRemaining = this.queuedCodexReadsAfterReturn;
+    this.mode = this.keepWorkingStatusWhilePending ? "working" : "idle";
   }
 
   async readScreen(surface: string, opts?: { lines?: number }) {
     if (surface !== this.surface) {
       throw new Error(`Unknown surface: ${surface}`);
     }
+    if (this.failScreenReadsAfterReturn && this.returnCount > 0) {
+      throw new Error("screen temporarily unavailable");
+    }
 
+    const text = this.renderScreen();
+    this.screenReads.push(text);
     return {
       surface,
-      text: this.renderScreen(),
+      text,
       lines: opts?.lines ?? 30,
       scrollback_used: false,
     };
@@ -165,11 +193,21 @@ class FakeClaudeSurfaceClient {
   }
 
   private renderScreen(): string {
+    const tail = this.pendingText.slice(-160);
+    if (this.cli === "codex") {
+      const status = this.mode === "working" ? "Working (11s)" : "";
+      if (this.pendingText && this.queuedCodexReadsRemaining > 0) {
+        this.queuedCodexReadsRemaining -= 1;
+        const truncated = `${this.pendingText.slice(0, 42)}…`;
+        return `OpenAI Codex\n${status}\n\nMessages to be submitted after next tool call\n  ↳ ${truncated}\n\n› \n\n  gpt-5.6-sol xhigh`;
+      }
+      return `OpenAI Codex\n${status}\n\n› ${tail}\n\n  gpt-5.6-sol xhigh`;
+    }
+
     if (this.mode === "working") {
       return "Claude Code\n✻ Working\n";
     }
 
-    const tail = this.pendingText.slice(-160);
     return `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
   }
 }
@@ -821,29 +859,107 @@ describe("enter reliability", () => {
     expect(events[0]?.submit_verified).toBeNull();
   });
 
-  it("does not retry Enter for allow_busy agent sends with ambiguous pending input", async () => {
+  it("Probe B: rejects an allow_busy Codex receipt when Return leaves the follow-up in the composer", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
     server = createReliabilityServer(client);
-    registerAgent(server, { state: "ready" });
+    registerAgent(server, { state: "working", cli: "codex" });
+    const followUp = "Probe B follow-up evidence ".repeat(22).slice(0, 541);
 
     const result = await callTool(server, "send_to", {
       agent_id: "agent-1",
-      text: "stack this while busy",
+      text: followUp,
       press_enter: true,
       allow_busy: true,
     });
     const parsed = parseResult(result);
     const events = readEventLog().filter((event) => event.event_type === "send_to");
 
-    expect(parsed.ok).toBe(true);
-    expect(parsed.submit_verified).toBeNull();
+    expect(followUp).toHaveLength(541);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(client.sendCalls.join("")).toBe(followUp);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBe(false);
+    expect(events[0]?.retry_count).toBe(0);
+  }, 10_000);
+
+  it("Probe E: rejects working status across a truncated Codex queue-to-composer transition", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.queuedCodexReadsAfterReturn = 1;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "codex" });
+    const followUp = "Probe E queued follow-up evidence ".repeat(20).slice(0, 541);
+    const tail = followUp.slice(-80);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: followUp,
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter((event) => event.event_type === "send_to");
+    const queuedScreen = client.screenReads.find((screen) =>
+      screen.includes("Messages to be submitted after next tool call"),
+    );
+    const composerScreen = client.screenReads.find(
+      (screen) =>
+        !screen.includes("Messages to be submitted after next tool call") &&
+        screen.includes("› ") &&
+        screen.includes(tail),
+    );
+
+    expect(followUp).toHaveLength(541);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(queuedScreen).toContain("↳ Probe E queued follow-up evidence");
+    expect(queuedScreen).not.toContain(tail);
+    expect(composerScreen).toContain("› ");
+    expect(composerScreen).toContain(tail);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.submit_verified).toBe(false);
+    expect(events[0]?.retry_count).toBe(0);
+  }, 10_000);
+
+  it("fails closed when requested agent submission verification cannot read the screen", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.failScreenReadsAfterReturn = true;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "unavailable verification evidence",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const events = readEventLog().filter((event) => event.event_type === "send_to");
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
     expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBeNull();
+    expect(events[0]?.submit_verified).toBe(false);
     expect(events[0]?.retry_count).toBe(0);
   }, 10_000);
 

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -2,11 +2,60 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer } from "../src/server.js";
+import { createServer, __submitEvidenceTestHooks } from "../src/server.js";
 import type { AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-enter-reliability-test");
 const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-enter-reliability-test.sock";
+const CURSOR_ACCEPTED_PROMPT =
+  "Print exactly TASK_DONE on its own line, then stop. Do nothing else.";
+const CURSOR_TASK_DONE_SCREEN = readFileSync(
+  new URL("./fixtures/cursor-2026-06-04-task-done.txt", import.meta.url),
+  "utf8",
+);
+const CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN = readFileSync(
+  new URL(
+    "./fixtures/cursor-pr343-live-accepted-response.txt",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN = readFileSync(
+  new URL(
+    "./fixtures/cursor-pr343-v2-immediate-working-response.txt",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const CURSOR_PR343_V2_PRE_RETURN_SCREEN =
+  CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN.replace(
+    "\n ⠀⠞ Working\n",
+    "\n",
+  );
+const CURSOR_PARSED_WORKING_WITHOUT_RESPONSE_SCREEN =
+  CURSOR_TASK_DONE_SCREEN.replace("\n  TASK_DONE\n", "\n  ⬡ Running...\n");
+const CURSOR_BOOT_READY_SCREEN = readFileSync(
+  new URL("./fixtures/cursor-2026-06-04-boot-ready.txt", import.meta.url),
+  "utf8",
+);
+const CODEX_PLACEHOLDER_SCREEN = readFileSync(
+  new URL(
+    "./fixtures/spawn/codex-0.144.3-surface-489-working.txt",
+    import.meta.url,
+  ),
+  "utf8",
+).replace(/\nWorking \([^\n]*\)\n/, "\n");
+const CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN = readFileSync(
+  new URL(
+    "./fixtures/painpoints/codex-pr343-live-queued-followup.txt",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const PR343_LIVE_QUEUE_PAYLOAD =
+  "PR343_LIVE_QUEUE_CORRELATION_B_20260802T001445Z_" +
+  "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(7) +
+  "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVW";
 
 function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -70,10 +119,20 @@ class FakeClaudeSurfaceClient {
   readonly renameTabCalls: string[] = [];
   requiredReturns = 2;
   completionMode: "idle" | "working" = "working";
-  cli: "claude" | "codex" = "claude";
+  cli: "claude" | "codex" | "cursor" = "claude";
   keepWorkingStatusWhilePending = false;
   queuedCodexReadsAfterReturn = 0;
+  wrapQueuedCodexHeading = false;
+  decorateQueuedCodexChrome = false;
+  queuedCodexVisibleText: string | null = null;
+  staleCodexQueueTranscriptAfterReturn = false;
   failScreenReadsAfterReturn = false;
+  screenReadFailuresWithPendingBeforeReturn = 0;
+  screenReadFailuresAfterReturn = 0;
+  postReturnScreenReadAttempts = 0;
+  preReturnScreenText: string | null = null;
+  postReturnScreenText: string | null = null;
+  postReturnPendingScreenText: string | null = null;
   private pendingText = "";
   private returnCount = 0;
   private queuedCodexReadsRemaining = 0;
@@ -174,8 +233,29 @@ class FakeClaudeSurfaceClient {
     if (surface !== this.surface) {
       throw new Error(`Unknown surface: ${surface}`);
     }
-    if (this.failScreenReadsAfterReturn && this.returnCount > 0) {
-      throw new Error("screen temporarily unavailable");
+    if (
+      this.returnCount === 0 &&
+      this.pendingText &&
+      this.screenReadFailuresWithPendingBeforeReturn > 0
+    ) {
+      this.screenReadFailuresWithPendingBeforeReturn = Math.max(
+        0,
+        this.screenReadFailuresWithPendingBeforeReturn - 1,
+      );
+      throw new Error("pre-Return screen temporarily unavailable");
+    }
+    if (this.returnCount > 0) {
+      this.postReturnScreenReadAttempts += 1;
+      if (
+        this.failScreenReadsAfterReturn ||
+        this.screenReadFailuresAfterReturn > 0
+      ) {
+        this.screenReadFailuresAfterReturn = Math.max(
+          0,
+          this.screenReadFailuresAfterReturn - 1,
+        );
+        throw new Error("screen temporarily unavailable");
+      }
     }
 
     const text = this.renderScreen();
@@ -194,12 +274,37 @@ class FakeClaudeSurfaceClient {
 
   private renderScreen(): string {
     const tail = this.pendingText.slice(-160);
+    if (this.returnCount === 0 && this.preReturnScreenText !== null) {
+      return this.preReturnScreenText;
+    }
+    if (this.pendingText && this.postReturnPendingScreenText !== null) {
+      return this.postReturnPendingScreenText;
+    }
+    if (!this.pendingText && this.postReturnScreenText !== null) {
+      return this.postReturnScreenText;
+    }
     if (this.cli === "codex") {
       const status = this.mode === "working" ? "Working (11s)" : "";
       if (this.pendingText && this.queuedCodexReadsRemaining > 0) {
         this.queuedCodexReadsRemaining -= 1;
-        const truncated = `${this.pendingText.slice(0, 42)}…`;
-        return `OpenAI Codex\n${status}\n\nMessages to be submitted after next tool call\n  ↳ ${truncated}\n\n› \n\n  gpt-5.6-sol xhigh`;
+        const queueText = this.queuedCodexVisibleText ?? this.pendingText;
+        const truncated = `${queueText.slice(0, 42)}…`;
+        const queueHeading = this.wrapQueuedCodexHeading
+          ? "Messages to be submitted after next\n  tool call"
+          : "Messages to be submitted after next tool call";
+        const renderedHeading = this.decorateQueuedCodexChrome
+          ? queueHeading
+              .split("\n")
+              .map((line) => `│ ${line}`)
+              .join("\n")
+          : queueHeading;
+        const renderedItem = this.decorateQueuedCodexChrome
+          ? `│   ↳ ${truncated}`
+          : `  ↳ ${truncated}`;
+        return `OpenAI Codex\n${status}\n\n${renderedHeading}\n${renderedItem}\n\n› \n\n  gpt-5.6-sol xhigh`;
+      }
+      if (!this.pendingText && this.staleCodexQueueTranscriptAfterReturn) {
+        return `OpenAI Codex\n\n› Quote this historical UI exactly:\n  Messages to be submitted after next tool call\n    ↳ already submitted transcript text\n\n• The quoted lines above are transcript prose, not live queue chrome.\n\n${status}\n\n› \n\n  gpt-5.6-sol xhigh`;
       }
       return `OpenAI Codex\n${status}\n\n› ${tail}\n\n  gpt-5.6-sol xhigh`;
     }
@@ -891,6 +996,137 @@ describe("enter reliability", () => {
     expect(events[0]?.retry_count).toBe(0);
   }, 10_000);
 
+  it("rejects the exact PR343 live Codex queue fixture for allow_busy send_to", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.postReturnPendingScreenText =
+      CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "codex" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: PR343_LIVE_QUEUE_PAYLOAD,
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(PR343_LIVE_QUEUE_PAYLOAD).toHaveLength(541);
+    expect(CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN).toContain(
+      "• Messages to be submitted after next tool call (press esc to interrupt and send\n  immediately)",
+    );
+    expect(CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN).toContain(
+      "↳ PR343_LIVE_QUEUE_CORRELATION_B_20260802T001445Z_",
+    );
+    expect(CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN).toContain(
+      "› Summarize recent commits",
+    );
+    expect(client.sendCalls.join("")).toBe(PR343_LIVE_QUEUE_PAYLOAD);
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("rejects a correlated live Codex queue on the first verification frame within 600ms", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.postReturnPendingScreenText =
+      CODEX_PR343_LIVE_QUEUED_FOLLOWUP_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "codex" });
+    const tool = server._registeredTools.send_to;
+    const startedAt = Date.now();
+    let settledAt: number | null = null;
+
+    const resultPromise = tool
+      .handler(
+        {
+          agent_id: "agent-1",
+          text: PR343_LIVE_QUEUE_PAYLOAD,
+          press_enter: true,
+          allow_busy: true,
+        },
+        {} as any,
+      )
+      .then((result: any) => {
+        settledAt = Date.now();
+        return result;
+      });
+    for (
+      let elapsed = 0;
+      elapsed < 10_000 && settledAt === null;
+      elapsed += 50
+    ) {
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    const result = await resultPromise;
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(settledAt).not.toBeNull();
+    expect(settledAt! - startedAt).toBeLessThanOrEqual(600);
+    expect(client.postReturnScreenReadAttempts).toBe(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("bounds a definitive allow_busy queued/composer failure to 600ms", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "codex" });
+    const tool = server._registeredTools.send_to;
+    const startedAt = Date.now();
+    let settledAt: number | null = null;
+
+    const resultPromise = tool
+      .handler(
+        {
+          agent_id: "agent-1",
+          text: "bounded busy interjection",
+          press_enter: true,
+          allow_busy: true,
+        },
+        {} as any,
+      )
+      .then((result: any) => {
+        settledAt = Date.now();
+        return result;
+      });
+    for (
+      let elapsed = 0;
+      elapsed < 10_000 && settledAt === null;
+      elapsed += 50
+    ) {
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    const result = await resultPromise;
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.submit_verified).toBe(false);
+    expect(settledAt).not.toBeNull();
+    expect(settledAt! - startedAt).toBeLessThanOrEqual(600);
+    expect(client.postReturnScreenReadAttempts).toBeGreaterThanOrEqual(2);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
   it("Probe E: rejects working status across a truncated Codex queue-to-composer transition", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
@@ -936,6 +1172,128 @@ describe("enter reliability", () => {
     expect(events[0]?.retry_count).toBe(0);
   }, 10_000);
 
+  it("ignores stale queue-like transcript prose when the current Codex composer is clear", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "codex";
+    client.completionMode = "working";
+    client.staleCodexQueueTranscriptAfterReturn = true;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "codex" });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "new submission after historical queue discussion",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReads.at(-1)).toContain(
+      "Messages to be submitted after next tool call",
+    );
+    expect(client.screenReads.at(-1)).toContain(
+      "The quoted lines above are transcript prose",
+    );
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("detects a wrapped live Codex queue heading before accepting working status", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.queuedCodexReadsAfterReturn = 1;
+    client.wrapQueuedCodexHeading = true;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "codex" });
+    const followUp = "narrow-pane queued follow-up ".repeat(20).slice(0, 541);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: followUp,
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const queuedScreen = client.screenReads.find((screen) =>
+      screen.includes("Messages to be submitted after next"),
+    );
+
+    expect(queuedScreen).toContain(
+      "Messages to be submitted after next\n  tool call",
+    );
+    expect(queuedScreen).toContain("↳ narrow-pane queued follow-up");
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("rejects decorated wrapped Codex queue chrome correlated to this send", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.queuedCodexReadsAfterReturn = 1;
+    client.wrapQueuedCodexHeading = true;
+    client.decorateQueuedCodexChrome = true;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "codex" });
+    const followUp = "decorated correlated queue payload ".repeat(18).slice(0, 541);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: followUp,
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const queuedScreen = client.screenReads.find((screen) =>
+      screen.includes("│ Messages to be submitted after next"),
+    );
+
+    expect(queuedScreen).toContain("│   tool call");
+    expect(queuedScreen).toContain("│   ↳ decorated correlated queue payload");
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+  }, 10_000);
+
+  it("ignores adjacent Codex queue chrome for another sender's visible prefix", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 99;
+    client.cli = "codex";
+    client.keepWorkingStatusWhilePending = true;
+    client.queuedCodexReadsAfterReturn = 1;
+    client.queuedCodexVisibleText =
+      "another sender's queued follow-up with unrelated content";
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "codex" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "this receipt belongs to a different submitted message",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReads.some((screen) => screen.includes("another sender"))).toBe(
+      true,
+    );
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+  }, 10_000);
+
   it("fails closed when requested agent submission verification cannot read the screen", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
@@ -962,6 +1320,245 @@ describe("enter reliability", () => {
     expect(events[0]?.submit_verified).toBe(false);
     expect(events[0]?.retry_count).toBe(0);
   }, 10_000);
+
+  it("retries a transient first post-Return screen read before failing verification", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "working";
+    client.screenReadFailuresAfterReturn = 1;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "delivered before a transient screen read failure",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.postReturnScreenReadAttempts).toBeGreaterThanOrEqual(2);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("accepts live Cursor response evidence when the composer retains accepted text", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.postReturnScreenText = CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "cursor" });
+
+    expect(
+      __submitEvidenceTestHooks.screenShowsPendingInput(
+        CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN,
+        "CURSOR_WORKING_PROBE",
+      ),
+    ).toBe(true);
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "CURSOR_WORKING_PROBE",
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReads.at(-1)).toContain("│ … Thought for 1ms");
+    expect(client.screenReads.at(-1)).toContain(
+      "Running the read-only test command for CURSOR_WORKING_PROBE",
+    );
+    expect(client.screenReads.at(-1)).not.toContain("⬡ Running...");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("rejects unchanged historical Cursor response evidence for a repeated send", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.preReturnScreenText =
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN;
+    client.postReturnScreenText =
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "cursor" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "CURSOR_WORKING_PROBE",
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReads[0]).toBe(
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN,
+    );
+    expect(client.screenReads.at(-1)).toBe(
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN,
+    );
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("fails closed for retained-composer Cursor evidence when the baseline is unavailable", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.screenReadFailuresWithPendingBeforeReturn = 1;
+    client.postReturnScreenText = CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "cursor" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "CURSOR_WORKING_PROBE",
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReadFailuresWithPendingBeforeReturn).toBe(0);
+    expect(client.screenReads.at(-1)).toBe(
+      CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN,
+    );
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("accepts a newly created Cursor Working response relative to the pre-Return screen", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.preReturnScreenText = CURSOR_PR343_V2_PRE_RETURN_SCREEN;
+    client.postReturnScreenText =
+      CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "working", cli: "cursor" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: "CURSOR_WORKING_PROBE",
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(CURSOR_PR343_V2_PRE_RETURN_SCREEN).not.toContain("⠀⠞ Working");
+    expect(client.screenReads.at(-1)).toContain("⠀⠞ Working");
+    expect(parsed.screen?.status).toBe("idle");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it("does not accept parsed Cursor working status without post-submit response evidence", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.cli = "cursor";
+    client.postReturnScreenText = CURSOR_PARSED_WORKING_WITHOUT_RESPONSE_SCREEN;
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "ready", cli: "cursor" });
+
+    const result = await callToolInTimerSteps(server, "send_to", {
+      agent_id: "agent-1",
+      text: CURSOR_ACCEPTED_PROMPT,
+      press_enter: true,
+      allow_busy: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(client.screenReads.at(-1)).toContain("⬡ Running...");
+    expect(client.screenReads.at(-1)).not.toContain("Thought for");
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  }, 10_000);
+
+  it.each([
+    {
+      cli: "codex" as const,
+      screen: CODEX_PLACEHOLDER_SCREEN,
+      placeholder: "Implement {feature}",
+    },
+    {
+      cli: "cursor" as const,
+      screen: CURSOR_BOOT_READY_SCREEN,
+      placeholder: "Plan, search, build anything",
+    },
+  ])(
+    "treats the real $cli placeholder composer as cleared submit evidence",
+    async ({ cli, screen, placeholder }) => {
+      const client = new FakeClaudeSurfaceClient();
+      client.requiredReturns = 1;
+      client.cli = cli;
+      client.postReturnScreenText = screen;
+      server = createReliabilityServer(client);
+      registerAgent(server, { state: "ready", cli });
+
+      expect(screen).toContain(placeholder);
+      expect(
+        __submitEvidenceTestHooks.extractComposerInputRegion(screen),
+      ).toBe("");
+
+      const result = await callToolInTimerSteps(server, "send_to", {
+        agent_id: "agent-1",
+        text: `new ${cli} request after placeholder`,
+        press_enter: true,
+      });
+      const parsed = parseResult(result);
+
+      expect(result.isError).not.toBe(true);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.submit_verified).toBe(true);
+      expect(parsed.retry_count).toBe(0);
+    },
+    10_000,
+  );
+
+  it("keeps literal non-placeholder Cursor composer text pending", () => {
+    const pendingText = "literal pending Cursor input";
+    const screen = CURSOR_BOOT_READY_SCREEN.replace(
+      "Plan, search, build anything",
+      pendingText,
+    );
+
+    expect(
+      __submitEvidenceTestHooks.extractComposerInputRegion(screen),
+    ).toContain(pendingText);
+    expect(
+      __submitEvidenceTestHooks.screenShowsPendingInput(screen, pendingText),
+    ).toBe(true);
+  });
 
   it("does not verify send_input to an uncached shell from prompt clearing", async () => {
     const client = new FakeShellSurfaceClient();

--- a/tests/fixtures/cursor-pr343-live-accepted-response.txt
+++ b/tests/fixtures/cursor-pr343-live-accepted-response.txt
@@ -1,0 +1,21 @@
+  Cursor Agent
+  v2026.07.23-e383d2b
+
+  Read and follow
+  /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-curso
+  r.mdCURSOR_WORKING_PROBE
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 1ms                                                                    │
+  │ Running the read-only test command for CURSOR_WORKING_PROBE. Will respond with       │
+  │ CURSOR_WORKING_ACK upon completion. No edits, commits, or pushes will be made.       │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  Running the probe test, then I'll reply with the exact ACK.
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Read and follow /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime
+    -target-cursor.mdCURSOR_WORKING_PROBE
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  Auto · 11.3%                                                              Run Everything
+  ~/Gits/cmuxlayer · 49bda98

--- a/tests/fixtures/cursor-pr343-v2-immediate-working-response.txt
+++ b/tests/fixtures/cursor-pr343-v2-immediate-working-response.txt
@@ -1,0 +1,100 @@
+  $ bun run test -- tests/screen-parser.test.ts 2.9s in current dir
+    … 9 output lines hidden · ctrl+o to expand
+       Duration  235ms (transform 59ms, setup 7ms, collect 56ms, tests 22ms, environment …
+
+  CURSOR_WORKING_ACK
+
+                                                                                           
+  Read and follow                                                                          
+  /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-curso       
+  r.mdCURSOR_WORKING_PROBERun the read-only command bun run test --                        
+  tests/screen-parser.test.ts now; respond FANOUT_PREP_DONE only after it exits.           
+                                                                                           
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 2.0s                                                                   │
+  │ Reading the defect lane instructions and preparing to run the specified test.        │
+  │                                                                                      │
+  │ Noted a conflict between the CURSOR_WORKING_PROBE response and the                   │
+  │ FANOUT_PREP_DONE                                                                     │
+  │ instruction. The latter appears to override the former for this specific message.    │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 1ms                                                                    │
+  │ The test exited successfully. I will respond with FANOUT_PREP_DONE.                  │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  $ bun run test -- tests/screen-parser.test.ts 1.1s in current dir
+    … 9 output lines hidden · ctrl+o to expand
+       Duration  246ms (transform 57ms, setup 5ms, collect 60ms, tests 22ms, environment …
+
+  FANOUT_PREP_DONE
+
+                                                                                           
+  Read and follow                                                                          
+  /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-curso       
+  r.mdCURSOR_WORKING_PROBERun the read-only command bun run test --                        
+  tests/screen-parser.test.ts now; respond FANOUT_PREP_DONE only after it exits.Run        
+  the read-only command bun run test -- tests/screen-parser.test.ts now; respond           
+  FANOUT_PREP_2_DONE only after it exits.                                                  
+                                                                                           
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 1ms                                                                    │
+  │ Running the screen parser test again. FANOUT_PREP_2_DONE will be sent only after     │
+  │ the                                                                                  │
+  │ process exits.                                                                       │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 1ms                                                                    │
+  │ The test exited successfully. The response will be FANOUT_PREP_2_DONE.               │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  $ bun run test -- tests/screen-parser.test.ts 1.6s in current dir
+    … 9 output lines hidden · ctrl+o to expand
+       Duration  236ms (transform 61ms, setup 6ms, collect 59ms, tests 24ms, environment …
+
+  FANOUT_PREP_2_DONE
+
+                                                                                           
+  Read and follow                                                                          
+  /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-curso       
+  r.mdCURSOR_WORKING_PROBERun the read-only command bun run test --                        
+  tests/screen-parser.test.ts now; respond FANOUT_PREP_DONE only after it exits.Run        
+  the read-only command bun run test -- tests/screen-parser.test.ts now; respond           
+  FANOUT_PREP_2_DONE only after it exits.PR343_FANOUT_LATENCY_PROBE_DO_NOT_ACT             
+                                                                                           
+
+  ┌──────────────────────────────────────────────────────────────────────────────────────┐
+  │ … Thought for 1.9s                                                                   │
+  │ The message ends with a latency probe flag instructing not to act.                   │
+  │                                                                                      │
+  │ I will remain silent and skip both test commands and the FANOUT responses.           │
+  └──────────────────────────────────────────────────────────────────────────────────────┘
+
+  Waiting — no action taken.
+
+                                                                                           
+  Read and follow                                                                          
+  /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-curso       
+  r.mdCURSOR_WORKING_PROBERun the read-only command bun run test --                        
+  tests/screen-parser.test.ts now; respond FANOUT_PREP_DONE only after it exits.Run        
+  the read-only command bun run test -- tests/screen-parser.test.ts now; respond           
+  FANOUT_PREP_2_DONE only after it                                                         
+  exits.PR343_FANOUT_LATENCY_PROBE_DO_NOT_ACTCURSOR_WORKING_PROBE                          
+                                                                                           
+
+ ⠀⠞ Working
+    Tip: Use /debug to instrument and debug complex problems.
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Read and follow                                                                        
+    /Users/etanheyman/Gits/cmuxlayer/docs.local/defect-lane/pr343-runtime-target-cursor.m  
+    dCURSOR_WORKING_PROBERun the read-only command bun run test --                         
+    tests/screen-parser.test.ts now; respond FANOUT_PREP_DONE only after it exits.Run the  
+     read-only command bun run test -- tests/screen-parser.test.ts now; respond            
+    FANOUT_PREP_2_DONE only after it                                                       
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  Auto · 11.9%                                                              Run Everything
+  ~/Gits/cmuxlayer · 49bda98

--- a/tests/fixtures/painpoints/codex-pr343-live-queued-followup.txt
+++ b/tests/fixtures/painpoints/codex-pr343-live-queued-followup.txt
@@ -1,0 +1,80 @@
+  └ brainlayer.brain_search({"query":"cmuxlayer PR 343 runtime target Codex defect lane
+        runtime-target-
+        codex","project":"cmuxlayer","source":"all","detail":"full","num_results":10})
+    ## Search results for "cmuxlayer PR 343 runtime target Codex defect lane…" - 10 of 10
+        shown
+
+    ### 1. WHAT: Completed the uncommitted Claude NOT_SHIP action round for cmuxlayer PR
+        #343 on source head 1…
+    - ID: brainbar-a3f7ab53-0ee
+    - Source: brainbar-store
+    - Date: 2026-08-01
+    - Preview: WHAT: Completed the uncommitted Claude NOT_SHIP action round for cmuxlayer PR
+        #343 on source head 191b963. Added fixture-backed Cursor accepted-text...
+
+• Explored
+  └ Read SKILL.md (systematic-debugging skill), SKILL.md (verification-before-completion
+  skill),
+         SKILL.md (test-driven-development skill), SKILL.md (never-fabricate skill)
+
+• Ran wc -l /Users/etanheyman/.codex/superpowers/skills/verification-before-completion/
+  │ SKILL.md /Users/etanheyman/Gits/golems/skills/golem-powers/never-fabricate/SKILL.md
+  └      139 /Users/etanheyman/.codex/superpowers/skills/verification-before-completion/
+    SKILL.md
+         448 /Users/etanheyman/Gits/golems/skills/golem-powers/never-fabricate/SKILL.md
+         587 total
+
+• Explored
+  └ Read SKILL.md (verification-before-completion skill), SKILL.md (never-fabricate skill),
+         pr343-runtime-target-codex.md
+
+• Called brainlayer.brain_expand({"chunk_id":"brainbar-a3f7ab53-0ee","before":0,"after":0})
+  └ ┌─ brain_expand: brainbar-a3f7ab53-0ee
+    ├─ Target
+    │ WHAT: Completed the uncommitted Claude NOT_SHIP action round for cmuxlayer PR #343 on
+        source head 191b963. Added fixture-backed Cursor accepted-text compatibility, exact
+        Codex/Cursor placeholder normalization, live-composer-scoped decorated/wrapped Codex
+        queue detection correlated to the current submitted prefix, explicit non-retry-safe
+        supersede_submit_unverified semantics with...
+
+• Called brainlayer.brain_expand({"chunk_id":"brainbar-d46a50f8-4f4","before":0,"after":0})
+  └ ┌─ brain_expand: brainbar-d46a50f8-4f4
+    ├─ Target
+    │ USER CORRECTION [fabrication]: I labeled the live Probe C runtime as source commit
+        e8021c4 even though only the worktree/source base was e8021c4. User corrected: the
+        parent verified the running MCP processes load /opt/homebrew/Cellar/
+        cmuxlayer/0.4.16/libexec/dist/index.js, which has no commit stamp and lacks the
+        merged dense-guard marker. Quote: 'do not call the live runtime e80...
+
+• Called brainlayer.brain_expand({"chunk_id":"brainbar-f51aafd0-f96","before":0,"after":0})
+  └ ┌─ brain_expand: brainbar-f51aafd0-f96
+    ├─ Target
+    │ WHAT: Independent Claude review of cmuxlayer PR #343 at head
+        191b963cdeb24ffe7d41862c40608c94927e87d1 returned NOT_SHIP and was posted at
+        https://github.com/EtanHey/cmuxlayer/pull/343#issuecomment-5153344489. WHY: the real
+        repo fixture tests/fixtures/cursor-2026-06-04-task-done.txt proves Cursor retains
+        accepted prompt text after TASK_DONE; the PR's global pending-text-over-work...
+
+────────────────────────────────────────────────────────────────────────────────────────────
+
+• CODEX_TARGET_READY
+
+─ Worked for 1m 08s ────────────────────────────────────────────────────────────────────────
+
+
+› Run the read-only command node -e 'setTimeout(()=>{},30000)' now; respond HOLD_30_DONE
+  only after it exits.
+
+
+Working (0s • esc to interrupt)
+
+• Messages to be submitted after next tool call (press esc to interrupt and send
+  immediately)
+  ↳ PR343_LIVE_QUEUE_CORRELATION_B_20260802T001445Z_abcdefghijklmnopqrstuvwxyz0123456789ABCD
+    EFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcd
+    efghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123
+    …
+ 
+› Summarize recent commits
+ 
+  gpt-5.6-sol xhigh · ~/Gits/cmuxlayer

--- a/tests/painpoint-replay.test.ts
+++ b/tests/painpoint-replay.test.ts
@@ -67,6 +67,7 @@ function readPainpointFixture(fileName: string): PainpointFixture {
     "claude-ask-user-question-overlay": "interactive_overlay",
     "claude-ask-user-question-picker-2026-07-13": "interactive_overlay",
     "claude-permission-confirmation": "permission_prompt",
+    "codex-pr343-live-queued-followup": "busy",
     "codex-update-menu": "interactive_overlay",
     "bare-shell-and-bare-gemini-prompt": "shell",
   };
@@ -173,6 +174,7 @@ describe("Phase 0 painpoint replay corpus", () => {
       "claude-ask-user-question-overlay",
       "claude-ask-user-question-picker-2026-07-13",
       "claude-permission-confirmation",
+      "codex-pr343-live-queued-followup",
       "codex-update-menu",
       "empty-dead-pane-submit",
       "long-inline-prompt-wedge",

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1033,6 +1033,15 @@ ctrl+c to stop
     expect(parsed.context_pct).toBe(23);
   });
 
+  it("parses the live Cursor braille Working spinner as working", () => {
+    const parsed = parseScreen(
+      readFixture("cursor-pr343-v2-immediate-working-response.txt"),
+    );
+
+    expect(parsed.agent_type).toBe("cursor");
+    expect(parsed.status).toBe("working");
+  });
+
   it("parses Cursor Agent idle with Idle line, comma tokens, and Model line", () => {
     const parsed = parseScreen(`
 Auto · 10% · 1 file edited

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -8197,6 +8197,95 @@ codex>
     expect(state.goal_file).toBe(goalPath);
   });
 
+  it("supersede_agent_goal reports an unverified pane side effect without patching the registry", async () => {
+    const goalPath = join(TEST_DIR, "queued-mission.md");
+    writeFileSync(goalPath, "# Queued mission\n\nReplace the active work.\n", "utf8");
+    const baseExec = makeLifecycleExec();
+    let goalWasWritten = false;
+    const supersedeExec = vi.fn(async (cmd, args) => {
+      const text = String(args[args.length - 1] ?? "");
+      if (args.includes("send") && text.startsWith("/goal ")) {
+        goalWasWritten = true;
+      }
+      const result = await baseExec(cmd, args);
+      if (goalWasWritten && args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: `OpenAI Codex\nWorking (3s • esc to interrupt)\n\n• Messages to be submitted after next tool call (press esc to interrupt and send\n  immediately)\n  ↳ /goal Read and execute this goal file until complete: ${goalPath}\n\n› Summarize recent commits\n\n  gpt-5.6-sol xhigh`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return result;
+    });
+    const server = createLifecycleServer(supersedeExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const stateMgr = engine.stateMgr;
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const registry = engine.getRegistry();
+    const ready = stateMgr.transition(currentAgentId, "ready");
+    registry.set(currentAgentId, ready);
+    const working = stateMgr.transition(currentAgentId, "working", {
+      task_summary: "original mission",
+      goal_file: null,
+    });
+    registry.set(currentAgentId, working);
+
+    vi.useFakeTimers();
+    try {
+      const resultPromise = supersede.handler(
+        {
+          agent_id: agentId,
+          goal_file: goalPath,
+          summary: "queued replacement mission",
+        },
+        {} as any,
+      );
+      for (let elapsed = 0; elapsed < 10_000; elapsed += 100) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      const result = await resultPromise;
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(result.isError).toBe(true);
+      expect(parsed).toMatchObject({
+        error_code: "supersede_submit_unverified",
+        submit_verified: false,
+        retry_count: 0,
+        registry_updated: false,
+        goal_delivery_state: "unverified_pane_side_effect",
+        retry_safe: false,
+      });
+      expect(parsed.recovery).toContain("Do not retry");
+      expect(goalWasWritten).toBe(true);
+
+      const state = stateMgr.readState(currentAgentId);
+      expect(state?.task_summary).not.toBe("queued replacement mission");
+      expect(state?.goal_file).not.toBe(goalPath);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 10_000);
+
   it("supersede_agent_goal updates the canonical record when called through an alias", async () => {
     const goalPath = join(TEST_DIR, "alias-mission.md");
     writeFileSync(goalPath, "# Mission\n\nUse the canonical state.\n", "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -8270,6 +8270,7 @@ codex>
       expect(parsed).toMatchObject({
         error_code: "supersede_submit_unverified",
         submit_verified: false,
+        submit_verification_reason: "input_still_pending",
         retry_count: 0,
         registry_updated: false,
         goal_delivery_state: "unverified_pane_side_effect",

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -8287,6 +8287,62 @@ codex>
     }
   }, 10_000);
 
+  it("supersede_agent_goal rejects a null submit receipt without patching an error-state agent", async () => {
+    const goalPath = join(TEST_DIR, "unverified-error-state-mission.md");
+    writeFileSync(goalPath, "# Mission\n\nDo not record without proof.\n", "utf8");
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+
+    const spawnResult = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+      },
+      {} as any,
+    );
+    const agentId = (
+      spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
+    ).agent_id;
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const stateMgr = engine.stateMgr;
+    const currentAgentId = resolveCurrentTestAgentId(stateMgr, agentId);
+    const registry = engine.getRegistry();
+    const errored = stateMgr.updateRecord(currentAgentId, {
+      state: "error",
+      error: "stale terminal error",
+      task_summary: "original mission",
+      goal_file: null,
+    });
+    registry.set(currentAgentId, errored);
+
+    const result = await supersede.handler(
+      {
+        agent_id: agentId,
+        goal_file: goalPath,
+        summary: "unverified replacement mission",
+        allow_busy: false,
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      error_code: "supersede_submit_unverified",
+      submit_verified: false,
+      registry_updated: false,
+      retry_safe: false,
+    });
+    const state = stateMgr.readState(currentAgentId);
+    expect(state?.state).toBe("error");
+    expect(state?.task_summary).toBe("original mission");
+    expect(state?.goal_file).toBeNull();
+  });
+
   it("supersede_agent_goal updates the canonical record when called through an alias", async () => {
     const goalPath = join(TEST_DIR, "alias-mission.md");
     writeFileSync(goalPath, "# Mission\n\nUse the canonical state.\n", "utf8");

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3024,6 +3024,7 @@ describe("tool handler integration", () => {
   });
 
   it("send_command fails closed when tracked-agent verification has no screen evidence (F8)", async () => {
+    vi.useFakeTimers();
     const stateDir = processScopedTmpDir("cmuxlayer-f8-send-command");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
@@ -3056,23 +3057,28 @@ describe("tool handler integration", () => {
       skipAgentLifecycle: true,
     });
     const tool = (server as any)._registeredTools["send_command"];
-    const result = await runWithFakeTimers(
-      () =>
-        tool.handler(
-          { surface: "surface:6", command: "codex resume 123" },
-          {} as any,
-        ),
-      6_000,
-    );
-    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(data.ok).toBe(false);
-    expect(data.submit_verified).toBe(false);
-    expect(data.submit_verification_reason).toBe("surface_screen_empty");
-    expect(data.retry_safe).toBe(false);
-    expect(data.retry_count).toBe(0);
-    expect(data.error).toContain("Enter submit could not be verified");
-    rmSync(stateDir, { recursive: true, force: true });
+    try {
+      const result = await runWithFakeTimers(
+        () =>
+          tool.handler(
+            { surface: "surface:6", command: "codex resume 123" },
+            {} as any,
+          ),
+        6_000,
+      );
+      const data =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      expect(result.isError).toBe(true);
+      expect(data.ok).toBe(false);
+      expect(data.submit_verified).toBe(false);
+      expect(data.submit_verification_reason).toBe("surface_screen_empty");
+      expect(data.retry_safe).toBe(false);
+      expect(data.retry_count).toBe(0);
+      expect(data.error).toContain("Enter submit could not be verified");
+    } finally {
+      vi.useRealTimers();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("send_command returns delivered + cached identity after positive submit verification (F8)", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3024,7 +3024,6 @@ describe("tool handler integration", () => {
   });
 
   it("send_command fails closed when tracked-agent verification has no screen evidence (F8)", async () => {
-    vi.useFakeTimers();
     const stateDir = processScopedTmpDir("cmuxlayer-f8-send-command");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
@@ -3057,6 +3056,7 @@ describe("tool handler integration", () => {
       skipAgentLifecycle: true,
     });
     const tool = (server as any)._registeredTools["send_command"];
+    vi.useFakeTimers();
     try {
       const result = await runWithFakeTimers(
         () =>

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3126,7 +3126,6 @@ describe("tool handler integration", () => {
       {} as any,
     );
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
-
     expect(result.isError).not.toBe(true);
     expect(data.delivered).toBe(true);
     expect(data.submit_verified).toBe(true);


### PR DESCRIPTION
## Summary

- require observable post-submit evidence before reporting relay delivery
- recognize Codex's real queued-follow-up chrome only when the visible queued item correlates with the submitted text
- recognize fresh Cursor response activity even when Cursor retains or truncates the composer after submission
- fail supersede safely without patching registry state when the pane side effect cannot be verified

Related: #364

## Review fixes

- scoped queue detection to Codex queue chrome and submitted-text correlation, preventing stale/global transcript matches
- reassembled wrapped/decorated Codex queue headings from terminal rows
- retained bounded transient screen-read polling from current `main`
- added exact live Codex/Cursor terminal fixtures, placeholder normalization, and structured supersede failure assertions
- reproduced the retained-composer Cursor v3 false negative from its raw runtime poll and added a regression for the fresh `Working` transition
- preserved literal submissions that equal CLI placeholder copy and reject supersede unless its receipt is explicitly verified
- made terminal captures cross-platform, corrected post-Return fixture timing, and classify the live Cursor braille `Working` spinner as working

## Verification

- `bun run typecheck`
- `bun run build`
- `bun run test` — 107 files passed; 2,477 tests passed, 1 skipped
- `git diff --check`
- push hook: nightly contract receipts, terminal-state regressions, and full Vitest suite passed on the final head

## Evidence boundary

Delivery is accepted only from evidence newer than the pre-submit baseline and correlated with the submitted content. Unchanged historical Cursor responses, unrelated queue blocks, dirty composers without fresh activity, and unverified supersede side effects remain failures.


— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019fe5df","ts":"2026-08-09T10:06:37Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject false submit receipts in relay by verifying Codex queue and Cursor response evidence
> - Adds `cursorSubmittedResponseEvidenceSignatures` to detect Cursor Working/Thinking/Running activity and thought blocks as a pre/post-Return baseline, treating fresh post-Return evidence as positive submit verification even when the composer still shows text.
> - Adds `screenShowsQueuedAgentInput` to detect Codex live queue chrome correlated to the submitted text and fail submit verification immediately when a match is found.
> - Adds `normalizeKnownPlaceholderComposerInput` to collapse known placeholder texts (Codex `Implement {feature}`, Cursor `Plan, search, build anything`) to empty so they do not falsely indicate pending input.
> - `supersede_agent_goal` now fails closed on unverified submits, returning a structured `supersede_submit_unverified` error without patching the agent registry.
> - `allow_busy` sends are now subject to submit verification using a shorter 500 ms timeout (`BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS`), and `markAgentWorking` is only called when verification succeeds.
> - Adds a braille Working spinner regex (`CURSOR_BRAILLE_WORKING_RE`) so Cursor screens with the braille spinner are classified as working status in `inferStatus`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4fd710.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->