### PR TITLE
fix: enforce spawn readiness and submit verification contracts

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -147,6 +147,7 @@ export interface SpawnAgentParams {
   model?: string;
   cli: CliType;
   prompt: string;
+  boot_prompt_timeout_ms?: number;
   boot_prompt_pending?: boolean;
   workspace?: string;
   cwd?: string;
@@ -179,6 +180,19 @@ export interface SpawnAgentResult {
   model_policy?: SpawnModelPolicy;
   cwd?: string;
   mcp_env?: string;
+}
+
+export class AgentLaunchError extends Error {
+  constructor(
+    message: string,
+    readonly agent_id: string,
+    readonly surface_id: string,
+    readonly workspace_id?: string,
+    readonly launch_cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentLaunchError";
+  }
 }
 
 function isWorktreeLaunch(
@@ -310,6 +324,7 @@ export interface AgentEngineOptions {
     stableSurfaceIdentity?: string | null;
     workspace?: string;
     command: string;
+    timeout_ms?: number;
     assertSurfaceBindingCurrent: () => Promise<void>;
   }) => Promise<void>;
   /**
@@ -1850,6 +1865,7 @@ export class AgentEngine {
     command: string,
     agentId: string,
     observerEpoch: SurfaceObserverEpoch,
+    timeoutMs?: number,
   ): Promise<void> {
     const expectedRoute = this.resolveAgentRoute(agentId);
     if (surface !== expectedRoute.surface_id) {
@@ -1885,6 +1901,7 @@ export class AgentEngine {
         ...this.stableSurfaceWriteOptions(expectedRoute.surface_uuid),
         workspace,
         command,
+        timeout_ms: timeoutMs,
         assertSurfaceBindingCurrent,
       });
       return;
@@ -4747,6 +4764,7 @@ export class AgentEngine {
         launchCmd,
         agentId,
         surface.observerEpoch,
+        spawnParams.boot_prompt_timeout_ms,
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -4765,7 +4783,13 @@ export class AgentEngine {
       } catch {
         // Preserve the original launch error for the caller.
       }
-      throw error;
+      throw new AgentLaunchError(
+        message,
+        failedAgentId,
+        surface.surface,
+        surface.actual_workspace ?? surface.workspace,
+        error,
+      );
     }
     this.schedulePostSpawnLivenessAssertion(agentId);
     const seatWarnings =

--- a/src/server.ts
+++ b/src/server.ts
@@ -4596,14 +4596,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !snapshot ||
           !screenShowsPendingInput(snapshot.text, sanitizedText)
         ) {
-          await waitForBootPromptSubmitEvidence({
-            surface: deliveryRoute.surface,
-            workspace: deliveryRoute.workspace,
-            text: sanitizedText,
-            timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
-            baseline_metrics: readiness.metrics,
-            beforeRead: assertDeliveryRouteCurrent,
-          });
+          try {
+            await waitForBootPromptSubmitEvidence({
+              surface: deliveryRoute.surface,
+              workspace: deliveryRoute.workspace,
+              text: sanitizedText,
+              timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
+              baseline_metrics: readiness.metrics,
+              beforeRead: assertDeliveryRouteCurrent,
+            });
+          } catch (fallbackError) {
+            if (fallbackError instanceof SurfaceGoneError) {
+              throw fallbackError;
+            }
+            const deliveredChars = chunks
+              .slice(0, sentChunks)
+              .reduce((sum, chunk) => sum + chunk.length, 0);
+            const fallbackMessage =
+              fallbackError instanceof Error
+                ? fallbackError.message
+                : String(fallbackError);
+            throw new BootPromptDeliveryError(
+              `Boot prompt delivery failed after ${deliveredChars} chars: ${fallbackMessage}`,
+              deliveredChars,
+              error,
+            );
+          }
           return {
             bytes: Buffer.byteLength(sanitizedText, "utf8"),
             retry_count: error.retry_count,

--- a/src/server.ts
+++ b/src/server.ts
@@ -470,6 +470,8 @@ type BroadcastReceipt = {
   seat: string;
   delivered: boolean;
   submit_verified: boolean | null;
+  submit_verification_reason?: SubmitVerificationFailureReason;
+  retry_safe?: false;
   error?: string;
   skipped?: string;
 };
@@ -489,6 +491,8 @@ export interface DeliveryRecord {
   press_enter: boolean;
   verify_submit: boolean;
   submit_verified: boolean | null;
+  submit_verification_reason?: SubmitVerificationFailureReason;
+  retry_safe?: false;
   retry_count: number;
   rename_to_task?: string;
   started_at: string;
@@ -507,15 +511,32 @@ class DeliveryError extends Error {
   }
 }
 
+type SubmitVerificationFailureReason =
+  | "surface_read_unavailable"
+  | "surface_screen_empty"
+  | "input_still_pending"
+  | "working_status_not_observed"
+  | "submit_evidence_absent";
+
 class SubmitVerificationError extends Error {
+  readonly retry_safe = false;
+
   constructor(
     message: string,
     readonly retry_count: number,
+    readonly reason: SubmitVerificationFailureReason,
   ) {
     super(message);
     this.name = "SubmitVerificationError";
   }
 }
+
+const submitVerificationFailurePayload = (error: SubmitVerificationError) => ({
+  submit_verified: false as const,
+  submit_verification_reason: error.reason,
+  retry_safe: error.retry_safe,
+  retry_count: error.retry_count,
+});
 
 class DeliverySafetyGateError extends Error {
   readonly delivered = false;
@@ -567,6 +588,7 @@ class BootPromptDeliveryError extends Error {
   constructor(
     message: string,
     readonly delivered_chars: number,
+    readonly submit_verification_error?: SubmitVerificationError,
   ) {
     super(message);
     this.name = "BootPromptDeliveryError";
@@ -736,6 +758,13 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
           screen: error.screen,
         }
       : {};
+  const submitVerificationExtra =
+    error instanceof SubmitVerificationError
+      ? submitVerificationFailurePayload(error)
+      : error instanceof BootPromptDeliveryError &&
+          error.submit_verification_error
+        ? submitVerificationFailurePayload(error.submit_verification_error)
+        : {};
   const retryMeta =
     error && typeof error === "object"
       ? {
@@ -761,6 +790,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     ...retryMeta,
     ...modeExtra,
     ...deliverySafetyExtra,
+    ...submitVerificationExtra,
     ...extra,
   };
   return {
@@ -2867,6 +2897,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     failed_chunk: record.failed_chunk ?? null,
     error: record.error ?? null,
     submit_verified: record.submit_verified,
+    submit_verification_reason: record.submit_verification_reason ?? null,
+    retry_safe: record.retry_safe ?? null,
     retry_count: record.retry_count,
   });
 
@@ -3499,11 +3531,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     allow_recovery_enter_retry?: boolean;
     timeout_ms?: number;
     beforeMutation?: () => Promise<void>;
-  }): Promise<{ submit_verified: boolean | null; retry_count: number }> => {
+  }): Promise<{
+    submit_verified: boolean | null;
+    submit_verification_reason: SubmitVerificationFailureReason | null;
+    retry_count: number;
+  }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
       // command was at or below SEND_INPUT_CHUNK_THRESHOLD; it is not a failure.
-      return { submit_verified: null, retry_count: 0 };
+      return {
+        submit_verified: null,
+        submit_verification_reason: null,
+        retry_count: 0,
+      };
     }
 
     const timeoutMs = opts.timeout_ms ?? SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS;
@@ -3521,6 +3561,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let lastRetryEligiblePendingInput = false;
     let retryEligiblePendingSince: number | null = null;
     let retriedAt: number | null = null;
+    let sawReadableScreen = false;
+    let sawBlankScreen = false;
     const screenIncludesSubmittedText = (screenText: string): boolean => {
       const trimmed = opts.text.trim();
       if (!trimmed) {
@@ -3536,21 +3578,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         throwOnSurfaceGone: true,
       });
       if (!snapshot) {
-        return {
-          submit_verified: noSubmitEvidenceResult,
-          retry_count: retryCount,
-        };
+        await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
+        continue;
       }
 
       if (!snapshot.text.trim()) {
-        return {
-          submit_verified: noSubmitEvidenceResult,
-          retry_count: retryCount,
-        };
+        sawBlankScreen = true;
+        await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
+        continue;
       }
+      sawReadableScreen = true;
 
       if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
-        return { submit_verified: true, retry_count: retryCount };
+        return {
+          submit_verified: true,
+          submit_verification_reason: null,
+          retry_count: retryCount,
+        };
       }
 
       const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
@@ -3568,7 +3612,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !screenIncludesSubmittedText(snapshot.text);
         if (allowClearedComposerSubmitEvidence) {
           sawAllowedClearedComposerEvidence = true;
-          return { submit_verified: true, retry_count: retryCount };
+          return {
+            submit_verified: true,
+            submit_verification_reason: null,
+            retry_count: retryCount,
+          };
         }
       }
 
@@ -3631,22 +3679,45 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         retryEligiblePendingInput &&
         Date.now() - retriedAt >= SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS
       ) {
-        return { submit_verified: false, retry_count: retryCount };
+        return {
+          submit_verified: false,
+          submit_verification_reason: "input_still_pending",
+          retry_count: retryCount,
+        };
       }
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
+    if (sawClearedComposerEvidence && sawAllowedClearedComposerEvidence) {
+      return {
+        submit_verified: true,
+        submit_verification_reason: null,
+        retry_count: retryCount,
+      };
+    }
+
+    const submitVerified =
+      opts.require_working_status ||
+      lastHasPendingInput ||
+      lastRetryEligiblePendingInput ||
+      !sawReadableScreen
+        ? false
+        : noSubmitEvidenceResult;
+    const failureReason: SubmitVerificationFailureReason | null =
+      submitVerified !== false
+        ? null
+        : lastHasPendingInput || lastRetryEligiblePendingInput
+          ? "input_still_pending"
+          : !sawReadableScreen
+            ? sawBlankScreen
+              ? "surface_screen_empty"
+              : "surface_read_unavailable"
+            : opts.require_working_status
+              ? "working_status_not_observed"
+              : "submit_evidence_absent";
     return {
-      submit_verified:
-        sawClearedComposerEvidence && sawAllowedClearedComposerEvidence
-          ? true
-          : opts.require_working_status
-            ? false
-            : lastHasPendingInput
-              ? false
-              : lastRetryEligiblePendingInput
-                ? false
-                : noSubmitEvidenceResult,
+      submit_verified: submitVerified,
+      submit_verification_reason: failureReason,
       retry_count: retryCount,
     };
   };
@@ -3704,6 +3775,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       0,
     );
     let submit_verified: boolean | null = null;
+    let submit_verification_reason: SubmitVerificationFailureReason | null =
+      null;
     let retry_count = 0;
 
     if (opts.press_enter) {
@@ -3738,6 +3811,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         beforeMutation: opts.beforeMutation,
       });
       submit_verified = verification.submit_verified;
+      submit_verification_reason = verification.submit_verification_reason;
       retry_count = verification.retry_count;
     }
 
@@ -3765,6 +3839,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       throw new SubmitVerificationError(
         `Enter submit could not be verified for ${opts.surface} within ${timeoutMs}ms`,
         retry_count,
+        submit_verification_reason ?? "submit_evidence_absent",
       );
     }
 
@@ -4546,6 +4621,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       throw new BootPromptDeliveryError(
         `Boot prompt delivery failed after ${deliveredChars} chars: ${message}`,
         deliveredChars,
+        error instanceof SubmitVerificationError ? error : undefined,
       );
     }
   };
@@ -4834,6 +4910,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       } catch (error) {
         if (error instanceof SubmitVerificationError) {
           record.submit_verified = false;
+          record.submit_verification_reason = error.reason;
+          record.retry_safe = error.retry_safe;
           record.retry_count = error.retry_count;
         } else if (error instanceof DeliverySafetyGateError) {
           record.submit_verified = error.submit_verified;
@@ -8058,6 +8136,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       model?: string | null;
       mcpEnv?: string;
       originalCommand?: string;
+      timeout_ms?: number;
     }): Promise<void> => {
       const record = resolveSpawnRecord(opts.agentId, opts.surface);
       if (!record) {
@@ -8098,6 +8177,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         surface: route.surface,
         workspace: route.workspace,
         command,
+        timeout_ms: opts.timeout_ms,
         relaunch: true,
         assertSurfaceBindingCurrent,
       });
@@ -8424,9 +8504,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .int()
           .positive()
           .optional()
-          .default(BOOT_PROMPT_TIMEOUT_MS)
           .describe(
-            "Timeout in milliseconds for initial shell readiness and the agent ready prompt",
+            "Optional timeout override in milliseconds for initial shell readiness, agent launch readiness, and the boot prompt. When omitted, each phase keeps its established default (10s shell, 15s launch, 60s boot prompt).",
           ),
         workspace: z
           .string()
@@ -8676,6 +8755,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     model: result.model ?? args.model,
                     mcpEnv: result.mcp_env,
                     originalCommand: originalLaunchCommand,
+                    timeout_ms: args.boot_prompt_timeout_ms,
                   }),
               });
 
@@ -8913,9 +8993,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .int()
           .positive()
           .optional()
-          .default(BOOT_PROMPT_TIMEOUT_MS)
           .describe(
-            "Timeout in milliseconds for initial shell readiness and the agent ready prompt",
+            "Optional timeout override in milliseconds for initial shell readiness, agent launch readiness, and the boot prompt. When omitted, each phase keeps its established default (10s shell, 15s launch, 60s boot prompt).",
           ),
         workspace: z.string().optional().describe("Target workspace ref"),
         worktree: worktreeArgSchema
@@ -9022,6 +9101,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   model: result!.model ?? args.model,
                   mcpEnv: result!.mcp_env,
                   originalCommand: originalLaunchCommand,
+                  timeout_ms: args.boot_prompt_timeout_ms,
                 }),
             });
             canonicalizeSpawnResult(result);
@@ -9945,6 +10025,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     : e instanceof DeliverySafetyGateError
                       ? e.submit_verified
                       : null,
+                ...(e instanceof SubmitVerificationError
+                  ? {
+                      submit_verification_reason: e.reason,
+                      retry_safe: e.retry_safe,
+                    }
+                  : {}),
                 error: e instanceof Error ? e.message : String(e),
               });
             }
@@ -10730,10 +10816,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
           }
           if (e instanceof SubmitVerificationError) {
-            return err(e, {
-              submit_verified: false,
-              retry_count: e.retry_count,
-            });
+            return err(e, submitVerificationFailurePayload(e));
           }
           return err(e);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import {
 } from "./cmux-observer-identity.js";
 import {
   AgentEngine,
+  AgentLaunchError,
   buildLaunchCommand,
   resolveSweepTiming,
   type AgentLifecycleEvent,
@@ -3506,6 +3507,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     const timeoutMs = opts.timeout_ms ?? SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS;
+    // Once verification is requested, missing or inconclusive evidence is a
+    // failed verification. The spawn launcher probe remains advisory because
+    // agent-readiness detection is authoritative for that one internal path.
+    const noSubmitEvidenceResult =
+      opts.source_event === "spawn_agent" ? null : false;
     const startedAt = Date.now();
     let retried = false;
     let retryCount = 0;
@@ -3530,11 +3536,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         throwOnSurfaceGone: true,
       });
       if (!snapshot) {
-        return { submit_verified: null, retry_count: retryCount };
+        return {
+          submit_verified: noSubmitEvidenceResult,
+          retry_count: retryCount,
+        };
       }
 
       if (!snapshot.text.trim()) {
-        return { submit_verified: null, retry_count: retryCount };
+        return {
+          submit_verified: noSubmitEvidenceResult,
+          retry_count: retryCount,
+        };
       }
 
       if (isSubmitVerifiedStatus(snapshot.parsed.status)) {
@@ -3634,7 +3646,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? false
               : lastRetryEligiblePendingInput
                 ? false
-                : null,
+                : noSubmitEvidenceResult,
       retry_count: retryCount,
     };
   };
@@ -4221,6 +4233,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     stableSurfaceIdentity?: string | null;
     workspace?: string;
     command: string;
+    timeout_ms?: number;
     relaunch?: boolean;
     assertSurfaceBindingCurrent?: () => Promise<void>;
   }): Promise<void> => {
@@ -4234,6 +4247,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       await waitForLaunchShellReady({
         surface: opts.surface,
         workspace: opts.workspace,
+        timeout_ms: opts.timeout_ms,
       });
     }
     await opts.assertSurfaceBindingCurrent?.();
@@ -4293,6 +4307,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await waitForLaunchShellReady({
             surface: opts.surface,
             workspace: opts.workspace,
+            timeout_ms: opts.timeout_ms,
             require_fresh_shell_prompt: true,
           });
         };
@@ -4349,6 +4364,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await waitForAgentLaunchReady({
             surface: opts.surface,
             workspace: opts.workspace,
+            timeout_ms: opts.timeout_ms,
             onUpdateShellRelaunch: relaunchOriginalCommand,
           });
         }
@@ -7878,6 +7894,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             stableSurfaceIdentity,
             workspace,
             command,
+            timeout_ms,
             assertSurfaceBindingCurrent,
           }) => {
             originalLaunchCommandsBySurface.set(surface, command);
@@ -7887,6 +7904,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 stableSurfaceIdentity,
                 workspace,
                 command,
+                timeout_ms,
                 assertSurfaceBindingCurrent,
               });
             } catch (error) {
@@ -8408,7 +8426,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default(BOOT_PROMPT_TIMEOUT_MS)
           .describe(
-            "Timeout in milliseconds waiting for the agent ready prompt",
+            "Timeout in milliseconds for initial shell readiness and the agent ready prompt",
           ),
         workspace: z
           .string()
@@ -8602,6 +8620,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               auto_archive_on_done: args.auto_archive_on_done ?? false,
               max_cost_per_agent: args.max_cost_per_agent,
               crash_recover: args.crash_recover,
+              boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
               on_surface_created: async () => {
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
@@ -8837,6 +8856,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("spawn_agent", formattedData),
           );
         } catch (e) {
+          if (e instanceof AgentLaunchError) {
+            if (e.launch_cause instanceof DeliverySafetyGateError) {
+              return err(e.launch_cause, {
+                agent_id: e.agent_id,
+                surface_id: e.surface_id,
+                workspace_id: e.workspace_id,
+                error_code: e.launch_cause.error_code,
+                submit_verified: e.launch_cause.submit_verified,
+                screen: e.launch_cause.screen,
+              });
+            }
+            if (e.launch_cause instanceof SurfaceGoneError) {
+              return err(
+                e.launch_cause,
+                surfaceGonePayload(e.launch_cause, {
+                  agent_id: e.agent_id,
+                  surface_id: e.surface_id,
+                  workspace_id: e.workspace_id,
+                }),
+              );
+            }
+            return err(e, {
+              agent_id: e.agent_id,
+              surface_id: e.surface_id,
+              workspace_id: e.workspace_id,
+            });
+          }
           if (e instanceof DeliverySafetyGateError) {
             return err(e, {
               error_code: e.error_code,
@@ -8867,7 +8913,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .int()
           .positive()
           .optional()
-          .default(BOOT_PROMPT_TIMEOUT_MS),
+          .default(BOOT_PROMPT_TIMEOUT_MS)
+          .describe(
+            "Timeout in milliseconds for initial shell readiness and the agent ready prompt",
+          ),
         workspace: z.string().optional().describe("Target workspace ref"),
         worktree: worktreeArgSchema
           .optional()
@@ -8937,6 +8986,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 focusRestoreLease,
               );
             },
+            boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
           });
           const originalLaunchCommand = originalLaunchCommandsBySurface.get(
             result.surface_id,
@@ -9045,6 +9095,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : mutationWorkspace,
             { waitForReady: false },
           );
+          if (e instanceof AgentLaunchError) {
+            if (e.launch_cause instanceof DeliverySafetyGateError) {
+              return err(e.launch_cause, {
+                agent_id: e.agent_id,
+                surface_id: e.surface_id,
+                workspace_id: e.workspace_id,
+                error_code: e.launch_cause.error_code,
+                submit_verified: e.launch_cause.submit_verified,
+                screen: e.launch_cause.screen,
+              });
+            }
+            if (e.launch_cause instanceof SurfaceGoneError) {
+              return err(
+                e.launch_cause,
+                surfaceGonePayload(e.launch_cause, {
+                  agent_id: e.agent_id,
+                  surface_id: e.surface_id,
+                  workspace_id: e.workspace_id,
+                }),
+              );
+            }
+            return err(e, {
+              agent_id: e.agent_id,
+              surface_id: e.surface_id,
+              workspace_id: e.workspace_id,
+            });
+          }
           if (e instanceof DeliverySafetyGateError) {
             return err(e, {
               error_code: e.error_code,

--- a/src/server.ts
+++ b/src/server.ts
@@ -6181,18 +6181,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           result?.workspace,
           { waitForReady: false },
         );
+        const createdIdentity = result
+          ? {
+              surface: result.surface,
+              workspace: result.workspace,
+              ...(result.surface_id ? { surface_id: result.surface_id } : {}),
+            }
+          : {};
         if (e instanceof SurfaceGoneError) {
-          return err(e, surfaceGonePayload(e));
+          return err(e, surfaceGonePayload(e, createdIdentity));
         }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             last_10_lines: e.last_10_lines,
           });
         }
         if (e instanceof BootPromptUpdateMenuBlockedError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             error_code: e.error_code,
             last_10_lines: e.last_10_lines,
             recovery: e.recovery,
@@ -6200,11 +6207,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         if (e instanceof BootPromptDeliveryError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             delivered_chars: e.delivered_chars,
           });
         }
-        return err(e);
+        return err(e, createdIdentity);
       }
     },
   );
@@ -6308,18 +6315,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        const createdIdentity = result
+          ? {
+              surface: result.surface,
+              workspace: result.workspace,
+              ...(result.surface_id ? { surface_id: result.surface_id } : {}),
+            }
+          : {};
         if (e instanceof SurfaceGoneError) {
-          return err(e, surfaceGonePayload(e));
+          return err(e, surfaceGonePayload(e, createdIdentity));
         }
         if (e instanceof BootPromptTimeoutError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             last_10_lines: e.last_10_lines,
           });
         }
         if (e instanceof BootPromptUpdateMenuBlockedError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             error_code: e.error_code,
             last_10_lines: e.last_10_lines,
             recovery: e.recovery,
@@ -6327,11 +6341,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         if (e instanceof BootPromptDeliveryError) {
           return err(e, {
-            surface: result?.surface,
+            ...createdIdentity,
             delivered_chars: e.delivered_chars,
           });
         }
-        return err(e);
+        return err(e, createdIdentity);
       }
     },
   );
@@ -9193,6 +9207,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : mutationWorkspace,
             { waitForReady: false },
           );
+          const createdIdentity = result
+            ? {
+                agent_id: result.agent_id,
+                surface_id: result.surface_id,
+                workspace_id: result.workspace_id ?? mutationWorkspace,
+              }
+            : {};
           if (e instanceof AgentLaunchError) {
             if (e.launch_cause instanceof DeliverySafetyGateError) {
               return err(e.launch_cause, {
@@ -9222,6 +9243,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           if (e instanceof DeliverySafetyGateError) {
             return err(e, {
+              ...createdIdentity,
               error_code: e.error_code,
               submit_verified: e.submit_verified,
               screen: e.screen,
@@ -9229,11 +9251,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           if (e instanceof SubmitVerificationError) {
             return err(e, {
+              ...createdIdentity,
               submit_verified: false,
               retry_count: e.retry_count,
             });
           }
-          return err(e);
+          if (e instanceof SurfaceGoneError) {
+            return err(e, surfaceGonePayload(e, createdIdentity));
+          }
+          if (e instanceof BootPromptTimeoutError) {
+            return err(e, {
+              ...createdIdentity,
+              last_10_lines: e.last_10_lines,
+            });
+          }
+          if (e instanceof BootPromptUpdateMenuBlockedError) {
+            return err(e, {
+              ...createdIdentity,
+              error_code: e.error_code,
+              last_10_lines: e.last_10_lines,
+              recovery: e.recovery,
+            });
+          }
+          if (e instanceof BootPromptDeliveryError) {
+            return err(e, {
+              ...createdIdentity,
+              delivered_chars: e.delivered_chars,
+            });
+          }
+          return err(e, createdIdentity);
         }
       },
     );
@@ -9277,6 +9323,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         let focusRestoreLease: FocusRestoreLease | null = null;
         let workspace: string | undefined;
         let lastSurface: string | undefined;
+        let activeSpawnIdentity:
+          | {
+              agent_id: string;
+              surface_id: string;
+              workspace_id: string | null;
+            }
+          | undefined;
+        const createdAgentIdentities: Array<{
+          agent_id: string;
+          surface_id: string;
+          workspace_id: string | null;
+        }> = [];
+        const spawnedAgents: Array<{
+          agent_id: string;
+          surface_id: string;
+          repo: string;
+          cli: CliType;
+          role: AgentRole;
+          health?: ReturnType<typeof evaluateAgentHealth>;
+          monitor_boot?: MonitorBootResult;
+          boot_prompt_delivered?: boolean;
+          boot_prompt_submit_verified?: boolean | null;
+        }> = [];
+        const leanSpawnedAgents: Record<string, unknown>[] = [];
         try {
           await assertWorkspaceMutationAllowed(
             "spawn_in_workspace",
@@ -9305,21 +9375,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             focusRestoreLease,
           );
 
-          const spawnedAgents: Array<{
-            agent_id: string;
-            surface_id: string;
-            repo: string;
-            cli: CliType;
-            role: AgentRole;
-            health?: ReturnType<typeof evaluateAgentHealth>;
-            monitor_boot?: MonitorBootResult;
-            boot_prompt_delivered?: boolean;
-            boot_prompt_submit_verified?: boolean | null;
-          }> = [];
-          const leanSpawnedAgents: Record<string, unknown>[] = [];
-
           for (const agent of args.agents) {
             const hasPrompt = hasInlinePrompt(agent.prompt);
+            activeSpawnIdentity = undefined;
             const result = await engine.spawnAgent({
               repo: agent.repo,
               model: agent.model,
@@ -9335,6 +9393,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 );
               },
             });
+            activeSpawnIdentity = {
+              agent_id: result.agent_id,
+              surface_id: result.surface_id,
+              workspace_id: result.workspace_id ?? workspace ?? null,
+            };
+            createdAgentIdentities.push(activeSpawnIdentity);
+            lastSurface = result.surface_id;
             const originalLaunchCommand = originalLaunchCommandsBySurface.get(
               result.surface_id,
             );
@@ -9368,6 +9433,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               });
 
               canonicalizeSpawnResult(result);
+              activeSpawnIdentity.agent_id = result.agent_id;
+              activeSpawnIdentity.workspace_id =
+                result.workspace_id ?? workspace ?? null;
               const updated = stateMgr.updateRecord(result.agent_id, {
                 task_summary:
                   bootPromptDelivery.prompt_text ?? agent.prompt ?? "",
@@ -9441,7 +9509,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
 
-          lastSurface = spawnedAgents[spawnedAgents.length - 1]?.surface_id;
           const focusRestoreWarning = await restoreFocusAfterRender(
             focusRestoreLease,
             lastSurface,
@@ -9494,8 +9561,53 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace,
             { waitForReady: false },
           );
+          const failedIdentity =
+            e instanceof AgentLaunchError
+              ? {
+                  agent_id: e.agent_id,
+                  surface_id: e.surface_id,
+                  workspace_id: e.workspace_id ?? null,
+                }
+              : activeSpawnIdentity;
+          const failureAgents = [...createdAgentIdentities];
+          if (
+            failedIdentity &&
+            !failureAgents.some(
+              (candidate) =>
+                candidate.agent_id === failedIdentity.agent_id &&
+                candidate.surface_id === failedIdentity.surface_id,
+            )
+          ) {
+            failureAgents.push(failedIdentity);
+          }
+          const failureIdentityPayload = {
+            ...(workspace ? { workspace, workspace_id: workspace } : {}),
+            ...(failedIdentity ?? {}),
+            ...(failureAgents.length > 0 ? { agents: failureAgents } : {}),
+          };
+          if (e instanceof AgentLaunchError) {
+            if (e.launch_cause instanceof DeliverySafetyGateError) {
+              return err(e.launch_cause, {
+                ...failureIdentityPayload,
+                error_code: e.launch_cause.error_code,
+                submit_verified: e.launch_cause.submit_verified,
+                screen: e.launch_cause.screen,
+              });
+            }
+            if (e.launch_cause instanceof SurfaceGoneError) {
+              return err(
+                e.launch_cause,
+                surfaceGonePayload(
+                  e.launch_cause,
+                  failureIdentityPayload,
+                ),
+              );
+            }
+            return err(e, failureIdentityPayload);
+          }
           if (e instanceof DeliverySafetyGateError) {
             return err(e, {
+              ...failureIdentityPayload,
               error_code: e.error_code,
               submit_verified: e.submit_verified,
               screen: e.screen,
@@ -9503,11 +9615,38 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           if (e instanceof SubmitVerificationError) {
             return err(e, {
+              ...failureIdentityPayload,
               submit_verified: false,
               retry_count: e.retry_count,
             });
           }
-          return err(e);
+          if (e instanceof SurfaceGoneError) {
+            return err(
+              e,
+              surfaceGonePayload(e, failureIdentityPayload),
+            );
+          }
+          if (e instanceof BootPromptTimeoutError) {
+            return err(e, {
+              ...failureIdentityPayload,
+              last_10_lines: e.last_10_lines,
+            });
+          }
+          if (e instanceof BootPromptUpdateMenuBlockedError) {
+            return err(e, {
+              ...failureIdentityPayload,
+              error_code: e.error_code,
+              last_10_lines: e.last_10_lines,
+              recovery: e.recovery,
+            });
+          }
+          if (e instanceof BootPromptDeliveryError) {
+            return err(e, {
+              ...failureIdentityPayload,
+              delivered_chars: e.delivered_chars,
+            });
+          }
+          return err(e, failureIdentityPayload);
         }
       },
     );

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -350,6 +350,44 @@ class FakeSlowClearingAgentClient extends FakeClaudeSurfaceClient {
   }
 }
 
+class FakeTransientVerificationReadClient extends FakeClaudeSurfaceClient {
+  verificationReadAttempts = 0;
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (this.sendCalls.length > 0) {
+      this.verificationReadAttempts += 1;
+      if (this.verificationReadAttempts === 1) {
+        throw new Error("EAGAIN: transient cmux read failure");
+      }
+    }
+    return super.readScreen(surface, opts);
+  }
+}
+
+class FakeUnavailableVerificationScreenClient extends FakeClaudeSurfaceClient {
+  verificationReadAttempts = 0;
+
+  constructor(private readonly unavailableMode: "throw" | "blank") {
+    super();
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (this.sendCalls.length === 0) {
+      return super.readScreen(surface, opts);
+    }
+    this.verificationReadAttempts += 1;
+    if (this.unavailableMode === "throw") {
+      throw new Error("EAGAIN: cmux read unavailable");
+    }
+    return {
+      surface,
+      text: "",
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+}
+
 function createReliabilityServer(client: FakeClaudeSurfaceClient) {
   const server = createServer({
     client: client as any,
@@ -461,6 +499,8 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendCalls.join("")).toHaveLength(2000);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
@@ -532,7 +572,7 @@ describe("enter reliability", () => {
     },
   );
 
-  it("leaves send_to submit verification unknown when agent text remains ambiguously pending", async () => {
+  it("reports send_to input as still pending when the composer never clears", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -549,6 +589,8 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
     expect(
@@ -590,6 +632,72 @@ describe("enter reliability", () => {
     ).toBe(true);
   });
 
+  it("keeps polling after a transient verification read failure instead of false-failing a landed send", async () => {
+    const client = new FakeTransientVerificationReadClient();
+    client.requiredReturns = 1;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "land once despite EAGAIN",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
+    expect(client.verificationReadAttempts).toBeGreaterThanOrEqual(2);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  });
+
+  it.each([
+    ["unavailable reads", "throw", "surface_read_unavailable"],
+    ["blank screens", "blank", "surface_screen_empty"],
+  ] as const)(
+    "fails closed only after a full verification window of %s and returns a non-retry-safe reason",
+    async (_name, mode, expectedReason) => {
+      const client = new FakeUnavailableVerificationScreenClient(mode);
+      client.requiredReturns = 1;
+      server = createReliabilityServer(client);
+      registerAgent(server);
+
+      const tool = (server as any)._registeredTools["send_to"];
+      let settled = false;
+      const resultPromise = tool.handler(
+        {
+          agent_id: "agent-1",
+          text: "land once but evidence stays unavailable",
+          press_enter: true,
+        },
+        {} as any,
+      );
+      void resultPromise.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(4_900);
+      expect(settled).toBe(false);
+      expect(client.verificationReadAttempts).toBeGreaterThan(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await resultPromise;
+      const parsed = parseResult(result);
+
+      expect(result.isError).toBe(true);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.submit_verified).toBe(false);
+      expect(parsed.submit_verification_reason).toBe(expectedReason);
+      expect(parsed.retry_safe).toBe(false);
+      expect(
+        client.sendKeyCalls.filter((key) => key === "return"),
+      ).toHaveLength(1);
+    },
+  );
+
   it("does not retry Enter for send_command when the agent composer remains ambiguously pending", async () => {
     const client = new FakeClaudeSurfaceClient();
     server = createReliabilityServer(client);
@@ -606,6 +714,8 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
@@ -620,7 +730,7 @@ describe("enter reliability", () => {
     ).toBe(true);
   }, 10_000);
 
-  it("leaves short send_command verification unknown when agent text remains ambiguously pending", async () => {
+  it("reports short send_command input as still pending when the composer never clears", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -636,6 +746,8 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
@@ -650,7 +762,7 @@ describe("enter reliability", () => {
     ).toBe(true);
   }, 10_000);
 
-  it("leaves short send_input verification unknown when agent text remains ambiguously pending", async () => {
+  it("reports short send_input as still pending when the composer never clears", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
     server = createReliabilityServer(client);
@@ -667,6 +779,8 @@ describe("enter reliability", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,

--- a/tests/false-green-empty-surface.test.ts
+++ b/tests/false-green-empty-surface.test.ts
@@ -147,7 +147,7 @@ describe("false-green empty surface protection", () => {
     expect(parsed.submit_verified).toBeNull();
   });
 
-  it("runs submit verification when isolated state has an interactive record for the surface", async () => {
+  it("fails closed when tracked send_command verification has no positive screen evidence", async () => {
     vi.useFakeTimers();
     const now = "2026-07-01T20:56:00.000Z";
     const record: AgentRecord = {
@@ -207,8 +207,10 @@ describe("false-green empty surface protection", () => {
     const result = await resultPromise;
 
     const parsed = parseToolResult(result);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.submit_verified).toBeNull();
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.retry_count).toBe(0);
     expect(
       (mockExec as any).mock.calls.filter(([, args]: [string, string[]]) =>
         args.includes("send-key") && args.includes("return"),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -79,6 +79,7 @@ const AGENT_TOOLS = [
 
 function makeLifecycleExec(opts?: {
   closeKeepsSurface?: boolean;
+  shellNeverReady?: boolean;
   surfaceUuid?: string;
 }): ExecFn {
   let readyText = "What can I help you with?\n>";
@@ -207,7 +208,7 @@ function makeLifecycleExec(opts?: {
       return {
         stdout: JSON.stringify({
           surface: "surface:new",
-          text: readyText,
+          text: opts?.shellNeverReady ? "terminal initializing" : readyText,
           lines: 20,
           scrollback_used: false,
         }),
@@ -3419,6 +3420,83 @@ describe("agent lifecycle tool handlers", () => {
       "cmux",
       expect.arrayContaining(["new-split"]),
     );
+  });
+
+  it("spawn_agent applies boot_prompt_timeout_ms to initial shell readiness", async () => {
+    vi.useFakeTimers();
+    try {
+      const server = createLifecycleServer(
+        makeLifecycleExec({ shellNeverReady: true }),
+      );
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "readiness timeout contract",
+          boot_prompt_timeout_ms: 90_000,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(90_100);
+      const result = await resultPromise;
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "Timed out after 90000ms waiting for shell readiness",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent reports the created agent and surface when initial shell readiness fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const server = createLifecycleServer(
+        makeLifecycleExec({ shellNeverReady: true }),
+      );
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+      const engine = (server as any)._registeredTools["interact"]._engine;
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "readiness failure identity",
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Timed out after 20ms");
+      expect(parsed.error).toContain("waiting for shell readiness");
+      expect(parsed.agent_id).toEqual(expect.any(String));
+      expect(parsed.surface_id).toBe("surface:new");
+      expect(parsed.workspace_id).toBe("ws:1");
+
+      const state = engine.stateMgr
+        .listStates()
+        .find((candidate: AgentRecord) =>
+          candidate.surface_id === parsed.surface_id
+        );
+      expect(state).toBeDefined();
+      expect(state?.agent_id).toBe(parsed.agent_id);
+      expect(state?.state).toBe("error");
+      expect(state?.error).toContain("waiting for shell readiness");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("spawn_agent reports readiness timeout without poisoning agent state", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3430,16 +3430,14 @@ describe("agent lifecycle tool handlers", () => {
       );
       const spawn = (server as any)._registeredTools["spawn_agent"];
 
-      const resultPromise = spawn.handler(
-        {
-          repo: "brainlayer",
-          model: "codex",
-          cli: "codex",
-          prompt: "readiness timeout contract",
-          boot_prompt_timeout_ms: 90_000,
-        },
-        {} as any,
-      );
+      const spawnArgs = spawn.inputSchema.parse({
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "readiness timeout contract",
+        boot_prompt_timeout_ms: 90_000,
+      });
+      const resultPromise = spawn.handler(spawnArgs, {} as any);
       await vi.advanceTimersByTimeAsync(90_100);
       const result = await resultPromise;
       const parsed =
@@ -3518,10 +3516,10 @@ describe("agent lifecycle tool handlers", () => {
       const state = engine.stateMgr
         .listStates()
         .find((candidate: AgentRecord) =>
-          candidate.surface_id === parsed.surface_id
+          candidate.agent_id === parsed.agent_id
         );
       expect(state).toBeDefined();
-      expect(state?.agent_id).toBe(parsed.agent_id);
+      expect(state?.surface_id).toBe(parsed.surface_id);
       expect(state?.state).toBe("error");
       expect(state?.error).toContain("waiting for shell readiness");
     } finally {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3714,6 +3714,74 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("new_worktree_split reports the created identity when boot prompt verification fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
+      const worktreePath = join(
+        gitsDir,
+        "cmuxlayer.wt",
+        "boot-verification-failure-worker",
+      );
+      const worktreeExec = vi.fn().mockImplementation(async () => {
+        mkdirSync(worktreePath, { recursive: true });
+        return { stdout: "", stderr: "" };
+      });
+      const baseExec = makeLifecycleExec();
+      let promptSent = false;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        const text = String(args.at(-1) ?? "");
+        if (args.includes("send") && text === "verify this prompt") {
+          promptSent = true;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (promptSent && args.includes("send-key")) {
+          return { stdout: "{}", stderr: "" };
+        }
+        if (promptSent && args.includes("read-screen")) {
+          throw new Error("screen unavailable after prompt delivery");
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createTrackedServer({
+        exec,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const tool = (server as any)._registeredTools["new_worktree_split"];
+
+      const resultPromise = tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "verify this prompt",
+          worktree: { name: "boot verification failure worker" },
+          boot_prompt_timeout_ms: 23,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await resultPromise;
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.agent_id).toEqual(expect.any(String));
+      expect(parsed.surface_id).toBe("surface:new");
+      expect(parsed.workspace_id).toBe("workspace:1");
+      expect(parsed.submit_verification_reason).toBe(
+        "surface_read_unavailable",
+      );
+      expect(parsed.retry_safe).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("spawn_agent reports readiness timeout without poisoning agent state", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3454,6 +3454,36 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("spawn_agent preserves the 10000ms shell-readiness default when no override is supplied", async () => {
+    vi.useFakeTimers();
+    try {
+      const server = createLifecycleServer(
+        makeLifecycleExec({ shellNeverReady: true }),
+      );
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const spawnArgs = spawn.inputSchema.parse({
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt: "default readiness timeout contract",
+      });
+      const resultPromise = spawn.handler(spawnArgs, {} as any);
+      await vi.advanceTimersByTimeAsync(60_100);
+      const result = await resultPromise;
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "Timed out after 10000ms waiting for shell readiness",
+      );
+      expect(parsed.error).not.toContain("60000ms");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("spawn_agent reports the created agent and surface when initial shell readiness fails", async () => {
     vi.useFakeTimers();
     try {
@@ -3494,6 +3524,193 @@ describe("agent lifecycle tool handlers", () => {
       expect(state?.agent_id).toBe(parsed.agent_id);
       expect(state?.state).toBe("error");
       expect(state?.error).toContain("waiting for shell readiness");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent applies boot_prompt_timeout_ms to agent-launch readiness", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseExec = makeLifecycleExec();
+      let launcherSentAt: number | null = null;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        if (
+          args.includes("send") &&
+          /[A-Za-z0-9_.-]+Codex\b/.test(String(args.at(-1) ?? ""))
+        ) {
+          launcherSentAt ??= Date.now();
+        }
+        if (args.includes("read-screen")) {
+          if (
+            launcherSentAt !== null &&
+            Date.now() - launcherSentAt < 200
+          ) {
+            throw new Error("EAGAIN: launcher screen not readable yet");
+          }
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text:
+                launcherSentAt === null
+                  ? "$ "
+                  : "agent launcher still starting",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createLifecycleServer(exec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "agent-launch timeout contract",
+          boot_prompt_timeout_ms: 37,
+        },
+        {} as any,
+      );
+      for (let elapsed = 0; elapsed < 1_000; elapsed += 50) {
+        await vi.advanceTimersByTimeAsync(50);
+      }
+      const result = await resultPromise;
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "Timed out after 37ms waiting for agent launch readiness",
+      );
+      expect(parsed.agent_id).toEqual(expect.any(String));
+      expect(parsed.surface_id).toBe("surface:new");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent applies boot_prompt_timeout_ms to the post-update fresh-shell retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseExec = makeLifecycleExec();
+      let launcherSentAt: number | null = null;
+      let clearingForRelaunch = false;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        if (
+          args.includes("send") &&
+          /[A-Za-z0-9_.-]+Codex\b/.test(String(args.at(-1) ?? ""))
+        ) {
+          launcherSentAt ??= Date.now();
+        }
+        if (args.includes("send-key") && args.includes("ctrl-c")) {
+          clearingForRelaunch = true;
+        }
+        if (args.includes("read-screen")) {
+          let text = "$ ";
+          if (clearingForRelaunch) {
+            text = "terminal initializing after update";
+          } else if (launcherSentAt !== null) {
+            const elapsed = Date.now() - launcherSentAt;
+            text =
+              elapsed < 200
+                ? "agent launcher still starting"
+                : elapsed < 325
+                  ? "Updating Codex CLI from 0.142.5 → 0.143.0 …"
+                  : "Update ran successfully! Please restart Codex.\netan@mac % ";
+          }
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text,
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createLifecycleServer(exec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "fresh-shell timeout contract",
+          boot_prompt_timeout_ms: 400,
+        },
+        {} as any,
+      );
+      for (let elapsed = 0; elapsed < 2_000; elapsed += 50) {
+        await vi.advanceTimersByTimeAsync(50);
+      }
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await resultPromise;
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "Timed out after 400ms waiting for shell readiness",
+      );
+      expect(clearingForRelaunch).toBe(true);
+      expect(parsed.agent_id).toEqual(expect.any(String));
+      expect(parsed.surface_id).toBe("surface:new");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("new_worktree_split reports the created identity when initial readiness fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
+      const worktreePath = join(
+        gitsDir,
+        "cmuxlayer.wt",
+        "readiness-failure-worker",
+      );
+      const worktreeExec = vi.fn().mockImplementation(async () => {
+        mkdirSync(worktreePath, { recursive: true });
+        return { stdout: "", stderr: "" };
+      });
+      const server = createTrackedServer({
+        exec: makeLifecycleExec({ shellNeverReady: true }),
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const tool = (server as any)._registeredTools["new_worktree_split"];
+
+      const resultPromise = tool.handler(
+        {
+          repo: "cmuxlayer",
+          model: "codex",
+          cli: "codex",
+          worktree: { name: "readiness failure worker" },
+          boot_prompt_timeout_ms: 23,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "Timed out after 23ms waiting for shell readiness",
+      );
+      expect(parsed.agent_id).toEqual(expect.any(String));
+      expect(parsed.surface_id).toBe("surface:new");
+      expect(parsed.workspace_id).toBe("ws:1");
     } finally {
       vi.useRealTimers();
     }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2845,7 +2845,7 @@ describe("tool handler integration", () => {
     expect(result.content[0].text).toContain("delivered to surface:unknown");
   });
 
-  it("send_command returns delivered + identity + submit_verified (F8)", async () => {
+  it("send_command fails closed when tracked-agent verification has no screen evidence (F8)", async () => {
     const stateDir = processScopedTmpDir("cmuxlayer-f8-send-command");
     rmSync(stateDir, { recursive: true, force: true });
     mkdirSync(stateDir, { recursive: true });
@@ -2883,13 +2883,11 @@ describe("tool handler integration", () => {
       {} as any,
     );
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(data.delivered).toBe(true);
-    expect(data.surface).toBe("surface:6");
-    expect(data.title).toBe("cmuxlayerCodex");
-    expect(data.model).toBe("GPT-5.5");
-    expect(data.agent_type).toBe("codex");
-    expect("submit_verified" in data).toBe(true);
-    expect(result.content[0].text).toContain("delivered to cmuxlayerCodex");
+    expect(result.isError).toBe(true);
+    expect(data.ok).toBe(false);
+    expect(data.submit_verified).toBe(false);
+    expect(data.retry_count).toBe(0);
+    expect(data.error).toContain("Enter submit could not be verified");
     rmSync(stateDir, { recursive: true, force: true });
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7510,7 +7510,11 @@ describe("tool handler integration", () => {
               },
               {} as any,
             ),
-          10_000,
+          // The end-to-end update path can consume two launcher submit-
+          // verification windows plus several independent 2s readiness
+          // phases. This is only the fake-clock driver ceiling; the production
+          // timeout asserted above remains boot_prompt_timeout_ms: 2_000.
+          30_000,
         );
         const parsed =
           result.structuredContent ?? JSON.parse(result.content[0].text);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7513,7 +7513,7 @@ describe("tool handler integration", () => {
           // The end-to-end update path can consume two launcher submit-
           // verification windows plus several independent 2s readiness
           // phases. This is only the fake-clock driver ceiling; the production
-          // timeout asserted above remains boot_prompt_timeout_ms: 2_000.
+          // timeout supplied to this call remains boot_prompt_timeout_ms: 2_000.
           30_000,
         );
         const parsed =
@@ -9561,6 +9561,47 @@ describe("tool handler integration", () => {
     );
   });
 
+  it("new_split reports the created surface when rename fails", async () => {
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:2",
+            pane: "pane:1",
+            title: "New",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("rename-tab")) {
+        throw new Error("rename failed after split creation");
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await tool.handler(
+      {
+        direction: "right",
+        pane: "pane:1",
+        workspace: "workspace:1",
+        title: "Build Task",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("rename failed after split creation");
+    expect(parsed.surface).toBe("surface:2");
+    expect(parsed.workspace).toBe("workspace:1");
+  });
+
   it("new_surface handler calls cmux new-surface", async () => {
     mockExec = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({
@@ -9619,6 +9660,46 @@ describe("tool handler integration", () => {
         "Build Logs",
       ]),
     );
+  });
+
+  it("new_surface reports the created surface when rename fails", async () => {
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:3",
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("rename-tab")) {
+        throw new Error("rename failed after surface creation");
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+
+    const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
+    const tool = (server as any)._registeredTools["new_surface"];
+
+    const result = await tool.handler(
+      {
+        pane: "pane:1",
+        workspace: "workspace:1",
+        title: "Build Logs",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("rename failed after surface creation");
+    expect(parsed.surface).toBe("surface:3");
+    expect(parsed.workspace).toBe("workspace:1");
   });
 
   it("new_surface rejects missing boot_prompt_path before creating a tab", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7510,7 +7510,7 @@ describe("tool handler integration", () => {
               },
               {} as any,
             ),
-          5_000,
+          10_000,
         );
         const parsed =
           result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -9301,6 +9301,11 @@ describe("tool handler integration", () => {
     expect(result.isError).toBe(true);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Timed out");
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe(
+      "working_status_not_observed",
+    );
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.boot_prompt_delivered).not.toBe(true);
     expect(returnPresses).toBe(1);
   }, 10_000);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2878,16 +2878,105 @@ describe("tool handler integration", () => {
       skipAgentLifecycle: true,
     });
     const tool = (server as any)._registeredTools["send_command"];
-    const result = await tool.handler(
-      { surface: "surface:6", command: "codex resume 123" },
-      {} as any,
+    const result = await runWithFakeTimers(
+      () =>
+        tool.handler(
+          { surface: "surface:6", command: "codex resume 123" },
+          {} as any,
+        ),
+      6_000,
     );
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(result.isError).toBe(true);
     expect(data.ok).toBe(false);
     expect(data.submit_verified).toBe(false);
+    expect(data.submit_verification_reason).toBe("surface_screen_empty");
+    expect(data.retry_safe).toBe(false);
     expect(data.retry_count).toBe(0);
     expect(data.error).toContain("Enter submit could not be verified");
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("send_command returns delivered + cached identity after positive submit verification (F8)", async () => {
+    const stateDir = processScopedTmpDir("cmuxlayer-f8-send-command-positive");
+    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(stateDir, { recursive: true });
+    const stateMgr = new StateManager(stateDir);
+    stateMgr.writeState({
+      agent_id: "codex-positive-1",
+      surface_id: "surface:positive",
+      state: "idle",
+      repo: "cmuxlayer",
+      model: "GPT-5.5",
+      cli: "codex",
+      cli_session_id: null,
+      task_summary: "cmuxlayerCodex positive",
+      pid: null,
+      version: 1,
+      created_at: "2026-06-04T00:00:00Z",
+      updated_at: "2026-06-04T00:00:00Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+    });
+
+    const mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:positive",
+            text: "gpt-5.5 xhigh · 99% left\nWorking (1s • esc to interrupt)",
+            lines: 30,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const server = createServer({
+      exec: mockExec,
+      stateDir,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["send_command"];
+    const result = await tool.handler(
+      { surface: "surface:positive", command: "codex resume verified" },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).not.toBe(true);
+    expect(data.delivered).toBe(true);
+    expect(data.submit_verified).toBe(true);
+    expect(data.surface).toBe("surface:positive");
+    expect(data.title).toBe("cmuxlayerCodex positive");
+    expect(data.model).toBe("GPT-5.5");
+    expect(data.agent_type).toBe("codex");
+    expect(result.content[0].text).toContain(
+      "delivered to cmuxlayerCodex positive",
+    );
+    expect(
+      mockExec.mock.calls.some(
+        ([, args]) =>
+          args.includes("send") &&
+          args.includes("--surface") &&
+          args.includes("surface:positive") &&
+          args.includes("codex resume verified"),
+      ),
+    ).toBe(true);
+    expect(
+      mockExec.mock.calls.some(
+        ([, args]) =>
+          args.includes("send-key") &&
+          args.includes("--surface") &&
+          args.includes("surface:positive") &&
+          args.includes("return"),
+      ),
+    ).toBe(true);
     rmSync(stateDir, { recursive: true, force: true });
   });
 
@@ -9282,6 +9371,9 @@ describe("tool handler integration", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Boot prompt delivery failed");
     expect(parsed.error).toContain("Enter submit could not be verified");
+    expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submit_verification_reason).toBe("input_still_pending");
+    expect(parsed.retry_safe).toBe(false);
     expect(parsed.boot_prompt_delivered).not.toBe(true);
     expect(returnPresses).toBe(1);
   }, 10_000);

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -219,6 +219,60 @@ describe("workspace spawn tools", () => {
     ).toEqual(["workspace:grid", "workspace:grid"]);
   });
 
+  it("spawn_in_workspace reports every created identity when a later launch fails", async () => {
+    const client = makeWorkspaceClient();
+    let launcherSends = 0;
+    client.send.mockImplementation(async () => {
+      launcherSends += 1;
+      if (launcherSends === 2) {
+        throw new Error("second launcher send failed");
+      }
+    });
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = getTool(server, "spawn_in_workspace");
+
+    const result = await tool.handler(
+      {
+        workspace_title: "red-team",
+        agents: [
+          { repo: "brainlayer", model: "sonnet", cli: "claude", role: "orchestrator" },
+          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
+        ],
+      },
+      {},
+    );
+    const parsed = parseStructuredResult<{
+      ok: boolean;
+      error: string;
+      agent_id?: string;
+      surface_id?: string;
+      workspace_id?: string;
+      agents?: Array<{ agent_id: string; surface_id: string; workspace_id?: string }>;
+    }>(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("second launcher send failed");
+    expect(parsed.agent_id).toEqual(expect.any(String));
+    expect(parsed.surface_id).toBe("surface:2");
+    expect(parsed.workspace_id).toBe("workspace:grid");
+    expect(parsed.agents).toEqual([
+      expect.objectContaining({
+        agent_id: expect.any(String),
+        surface_id: "surface:1",
+        workspace_id: "workspace:grid",
+      }),
+      expect.objectContaining({
+        agent_id: parsed.agent_id,
+        surface_id: "surface:2",
+        workspace_id: "workspace:grid",
+      }),
+    ]);
+  });
+
   it("spawn_in_workspace surfaces the stale-build warning at the aggregate level", async () => {
     // spawn_in_workspace rebuilds its response from per-agent objects (which
     // drop result.warnings), so a stale MCP serving a multi-agent workspace


### PR DESCRIPTION
## Summary

- honor `boot_prompt_timeout_ms` across initial shell, agent-launch, post-update relaunch, and boot-prompt readiness while preserving omitted phase defaults (10s / 15s / 60s)
- return created agent/surface/workspace identities across every managed spawn path, raw surface creation path, and batch member when a post-creation operation fails, so callers can recover or clean up surviving surfaces
- make submit verification fail closed only after the full evidence window, with machine-readable failure reasons and `retry_safe: false`
- propagate submit-verification metadata through foreground sends, background delivery records, broadcasts, and wrapped boot-prompt errors

## Verification

- independent Claude pair-review plus completeness audit, followed by explicit cmuxlayer lead acceptance: **ACCEPT**
- rebased onto merged focus-restore PR #346 (`3e5a7af`)
- exact #346 focus gate on the combined tree: **16 / 16 passed** (independently reproduced by the cmuxlayer lead)
- isolated serial combined suite: **106 files / 2362 tests passed**
- CI-version Vitest 3.2.4 full parallel suite: **106 files / 2362 tests passed**
- pre-push full suite: **106 files / 2362 tests passed**
- typecheck, build, and `git diff --check`: pass

## Rebase conflict resolution

PR #346 overlapped this branch in the spawn lifecycle. The only manual content conflict was in `src/server.ts`; it was resolved on behavior, keeping #346's focus lease lifecycle (`focusTargetBeforeSplit`, `on_surface_created`, and restore-after-readiness/error) while also threading this PR's explicit readiness timeout into the engine call. On failure, focus restoration remains best-effort and runs before the original `AgentLaunchError` or boot-delivery error is returned. The post-update relaunch reuses the captured surface and lease.

The first fresh CI run exposed a test-driver-only ceiling in the auto-update integration test. Its fake-clock budget is now 30s to encompass two launcher submit-verification windows plus the independent 2s readiness phases; the production input remains `boot_prompt_timeout_ms: 2_000`. This ceiling moved twice during the lane (5s → 10s → 30s). A third raise is a red flag, not a routine adjustment; follow-up work should assert the number of readiness phases directly instead of using elapsed virtual time as the implicit detector.

## Boundaries

- production contract test was not rerun
- installed v0.4.17 does not contain this change; merge does not deploy because the formula pins a tag
- structural prevention of future identity omissions is tracked in #348; it is intentionally not built in this PR
- separate stale numeric-surface/workspace routing defects and placement enforcement remain out of scope
- no release or fleet reconnect is part of this PR; the cmuxlayer lead owns the batched 0.4.18 release and reconnect sweep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spawn/launch and terminal submit-verification behavior in `server.ts` and `agent-engine.ts`, which can flip previously ambiguous outcomes to explicit failures and alter timeout semantics for clients relying on old defaults.
> 
> **Overview**
> Tightens **agent spawn readiness** and **Enter/submit verification** so callers get predictable timeouts and honest failure metadata.
> 
> **`boot_prompt_timeout_ms`** is threaded from `spawn_agent` / `new_worktree_split` through `AgentEngine` launch into shell readiness, agent-launch readiness, post-update relaunch, and boot-prompt delivery. The schema no longer defaults this field to 60s on spawn tools—when omitted, each phase keeps its existing default (10s shell, 15s launch, 60s boot prompt).
> 
> **Launch failures** are wrapped in **`AgentLaunchError`** with `agent_id`, `surface_id`, `workspace_id`, and the underlying cause; spawn handlers map that (and nested safety/surface-gone errors) into structured tool error payloads so a surface that was created before readiness failed is still identifiable.
> 
> **Submit verification** stops treating missing screen evidence as success or `null` for most paths: the verifier **polls through transient read failures and blank screens**, then **fails closed** after the full window with **`submit_verification_reason`** (`input_still_pending`, `surface_screen_empty`, `surface_read_unavailable`, `working_status_not_observed`, `submit_evidence_absent`) and **`retry_safe: false`**. That metadata flows through `send_to`, broadcasts, delivery records, and boot-prompt delivery errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276ccb801e3b2cfef95be83280cd5d4962ea4d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable boot-prompt timeouts across agent launch, recovery, and workspace workflows.
  * Added detailed launch failure information, including affected agent, surface, and workspace.
  * Submit verification now reports explicit failure reasons and retry safety.
  * Workspace batch launches now identify successfully created and failed agents.

* **Bug Fixes**
  * Prevented unverified submissions from being reported as successful.
  * Avoided duplicate retries when evidence is unavailable or input remains pending.
  * Improved shell readiness and launch-timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spawn readiness timeouts and structured submit verification failure reasons
> - Introduces `AgentLaunchError` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/345/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) so spawn failures carry agent/surface/workspace identity and the original cause, replacing bare error rethrows.
> - Adds `SubmitVerificationFailureReason` union type and a `reason` field on `SubmitVerificationError`; the verification polling loop now returns specific reasons (`input_still_pending`, `surface_screen_empty`, `surface_read_unavailable`, `working_status_not_observed`, `submit_evidence_absent`) instead of returning null on transient failures.
> - Propagates `boot_prompt_timeout_ms` through spawn, relaunch, and launcher command paths so callers control shell/agent readiness wait windows; the schema default is removed in favor of downstream defaults.
> - Error payloads for `spawn_agent`, `spawn_in_workspace`, `send_to`, `send_command`, `new_surface`, and `new_worktree_split` now include `submit_verification_reason`, `retry_safe`, and created identity fields (`agent_id`, `surface_id`, `workspace_id`).
> - Risk: `boot_prompt_timeout_ms` no longer has a schema-level default, so callers omitting it will rely on internal defaults rather than a fixed value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cc6163.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
