### PR TITLE
fix: enforce ratified two-role placement

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -73,6 +73,7 @@ import {
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
 import {
+  normalizeWorkspaceRefAlias,
   reposEquivalent,
   resolveWorkspaceRefForRepo,
 } from "./repo-workspace.js";
@@ -1805,8 +1806,8 @@ export class AgentEngine {
       };
       if (
         createdSurface.actual_workspace &&
-        createdSurface.actual_workspace.replace(/^ws:/, "workspace:") !==
-          createdSurface.workspace.replace(/^ws:/, "workspace:")
+        normalizeWorkspaceRefAlias(createdSurface.actual_workspace) !==
+          normalizeWorkspaceRefAlias(createdSurface.workspace)
       ) {
         await this.cleanupUnboundCreatedSurface(
           createdSurface,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1803,7 +1803,11 @@ export class AgentEngine {
         observerEpoch,
         observerId,
       };
-      if (createdSurface.actual_workspace) {
+      if (
+        createdSurface.actual_workspace &&
+        createdSurface.actual_workspace.replace(/^ws:/, "workspace:") !==
+          createdSurface.workspace.replace(/^ws:/, "workspace:")
+      ) {
         await this.cleanupUnboundCreatedSurface(
           createdSurface,
           "agent-placement",
@@ -1847,11 +1851,9 @@ export class AgentEngine {
       return surface;
     }
     if (
-      surface.workspace === requestedWorkspace ||
-      surface.workspace.replace(/^ws:/, "workspace:") ===
-        requestedWorkspace.replace(/^ws:/, "workspace:")
+      surface.workspace === requestedWorkspace
     ) {
-      return { ...surface, workspace: requestedWorkspace };
+      return surface;
     }
     return {
       ...surface,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -172,7 +172,6 @@ export interface SpawnAgentResult {
   agent_id: string;
   surface_id: string;
   workspace_id?: string;
-  actual_workspace_id?: string;
   state: AgentState;
   model?: string;
   requested_model?: string;
@@ -243,7 +242,6 @@ type AgentSurfacePlacement = CmuxNewSplitResult | CmuxNewSurfaceResult;
 
 type CreatedAgentSurface = AgentSurfacePlacement & {
   actual_workspace?: string;
-  warnings?: string[];
   observerEpoch: SurfaceObserverEpoch;
   observerId: string | null;
 };
@@ -981,7 +979,7 @@ export class AgentEngine {
       degraded: false,
       reason: null,
     };
-    if (agent.state !== "done" || role === "orchestrator" || role === "ic") {
+    if (agent.state !== "done" || role === "orchestrator") {
       return {
         closeable: false,
         closure_artifact_verified: null,
@@ -1732,7 +1730,7 @@ export class AgentEngine {
           surfaceObservation,
         ) ?? null;
       if (extraRoleSurfaceIds) {
-        for (const role of ["orchestrator", "ic", "worker"] as const) {
+        for (const role of ["orchestrator", "worker"] as const) {
           for (const surfaceId of extraRoleSurfaceIds[role]) {
             if (liveSurfaceIds.has(surfaceId)) {
               roleSurfaceIds[role].add(surfaceId);
@@ -1800,11 +1798,23 @@ export class AgentEngine {
       // Transfer the created handle to the caller before any post-mutation
       // epoch assertion can throw. The caller owns cleanup until it durably
       // binds this exact surface into agent state.
-      return {
-        ...this.withWorkspacePlacementWarning(surface, workspace),
+      const createdSurface: CreatedAgentSurface = {
+        ...this.withWorkspacePlacementObservation(surface, workspace),
         observerEpoch,
         observerId,
       };
+      if (createdSurface.actual_workspace) {
+        await this.cleanupUnboundCreatedSurface(
+          createdSurface,
+          "agent-placement",
+        );
+        throw new PlacementSurfaceBindingError(
+          `Spawn placement blocked: requested ${createdSurface.workspace} ` +
+            `but cmux returned ${createdSurface.actual_workspace} for surface ` +
+            `${createdSurface.surface}`,
+        );
+      }
+      return createdSurface;
     } catch (error) {
       if (
         isAgentRoleInferenceError(error) ||
@@ -1820,33 +1830,33 @@ export class AgentEngine {
         type: "terminal",
       });
       return {
-        ...this.withWorkspacePlacementWarning(surface, workspace),
+        ...this.withWorkspacePlacementObservation(surface, workspace),
         observerEpoch,
         observerId,
       };
     }
   }
 
-  private withWorkspacePlacementWarning(
+  private withWorkspacePlacementObservation(
     surface: AgentSurfacePlacement,
     requestedWorkspace: string | undefined,
   ): AgentSurfacePlacement & {
     actual_workspace?: string;
-    warnings?: string[];
   } {
-    if (
-      !requestedWorkspace ||
-      !surface.workspace ||
-      surface.workspace === requestedWorkspace
-    ) {
+    if (!requestedWorkspace || !surface.workspace) {
       return surface;
     }
-    const warning = `Spawn placement mismatch: requested ${requestedWorkspace} but cmux returned ${surface.workspace} for surface ${surface.surface}`;
+    if (
+      surface.workspace === requestedWorkspace ||
+      surface.workspace.replace(/^ws:/, "workspace:") ===
+        requestedWorkspace.replace(/^ws:/, "workspace:")
+    ) {
+      return { ...surface, workspace: requestedWorkspace };
+    }
     return {
       ...surface,
       workspace: requestedWorkspace,
       actual_workspace: surface.workspace,
-      warnings: [warning],
     };
   }
 
@@ -3857,7 +3867,7 @@ export class AgentEngine {
     const candidates = this.registry.list().filter((agent) => {
       if (opts.agentIds && !opts.agentIds.has(agent.agent_id)) return false;
       if (!eligibleForTrigger(agent)) return false;
-      if (canonicalRoleColumn(inferRecordRoleOrNull(agent) ?? "ic") === null) {
+      if (inferRecordRoleOrNull(agent) === null) {
         return false;
       }
       return true;
@@ -4598,6 +4608,13 @@ export class AgentEngine {
       launcherName: preflight?.launcherName ?? null,
       registry: this.seatRegistry,
     });
+    if (seatIdentity.seat_identity_status === "mismatch") {
+      throw new Error(
+        `Spawn blocked by seat identity mismatch: ${
+          seatIdentity.seat_identity_error ?? "registry identity mismatch"
+        }`,
+      );
+    }
 
     // 1. Create cmux surface using the deterministic worker layout policy.
     const surface = await this.createAgentSurface(spawnParams.workspace, {
@@ -4792,24 +4809,15 @@ export class AgentEngine {
       );
     }
     this.schedulePostSpawnLivenessAssertion(agentId);
-    const seatWarnings =
-      seatIdentity.seat_identity_status === "mismatch" &&
-      seatIdentity.seat_identity_error
-        ? [`Seat identity mismatch: ${seatIdentity.seat_identity_error}`]
-        : [];
-
     return {
       agent_id: agentId,
       surface_id: surface.surface,
       workspace_id: surface.workspace,
-      actual_workspace_id: surface.actual_workspace,
       state: "booting",
       model: modelPolicy.effective_model,
       requested_model: modelPolicy.requested_model,
       warnings: [
         ...modelPolicy.warnings,
-        ...(surface.warnings ?? []),
-        ...seatWarnings,
       ],
       model_policy: modelPolicy,
       cwd: spawnParams.cwd,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -253,7 +253,7 @@ function inferTopologyRole(
   agent: AgentRecord,
   input: AgentHealthInput,
 ): AgentRole | null {
-  if (agent.role) return agent.role;
+  if (agent.role) return inferRecordRoleOrNull(agent);
 
   return (
     inferRoleOrNull({ title: input.surface_title ?? undefined }) ??
@@ -482,7 +482,6 @@ export function evaluateAgentHealth(
   if (
     agent.state === "done" &&
     role !== "orchestrator" &&
-    role !== "ic" &&
     input.harvestability?.evidence_channel.degraded === true
   ) {
     addIssue(
@@ -516,7 +515,11 @@ export function evaluateAgentHealth(
     }
   }
 
-  if (agent.cli !== "claude" && role === "orchestrator") {
+  if (
+    agent.cli !== "claude" &&
+    role === "orchestrator" &&
+    agent.surface_provenance !== "cmuxlayer_spawn"
+  ) {
     addIssue(
       issueCodes,
       issues,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -517,8 +517,7 @@ export function evaluateAgentHealth(
 
   if (
     agent.cli !== "claude" &&
-    role === "orchestrator" &&
-    agent.surface_provenance !== "cmuxlayer_spawn"
+    role === "orchestrator"
   ) {
     addIssue(
       issueCodes,

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -297,7 +297,7 @@ function roleFromSeatOrLauncher(input: {
     return "orchestrator";
   }
   if (seatRole === "ic") {
-    return "ic";
+    return "worker";
   }
   if (seatRole === "worker") {
     return "worker";
@@ -2281,7 +2281,7 @@ export class AgentRegistry {
       if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
-      if (agent.role === "orchestrator" || agent.role === "ic") {
+      if (agent.role === "orchestrator") {
         continue;
       }
       if (this.matchingLiveSurface(agent, surfaces)) {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -25,6 +25,7 @@ import type { CmuxSurface } from "./types.js";
 import { extractPrefix } from "./naming.js";
 import {
   inferAgentRole,
+  inferRecordRoleOrNull,
   isAgentRoleInferenceError,
 } from "./layout-policy.js";
 import {
@@ -2281,7 +2282,7 @@ export class AgentRegistry {
       if (shouldRetainCrashRecoveryError(agent)) {
         continue;
       }
-      if (agent.role === "orchestrator") {
+      if (inferRecordRoleOrNull(agent) === "orchestrator") {
         continue;
       }
       if (this.matchingLiveSurface(agent, surfaces)) {

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -15,7 +15,7 @@ export type AgentState =
 export type CliType = "claude" | "codex" | "gemini" | "kiro" | "cursor";
 
 export type AgentQuality = "unknown" | "verified" | "suspect" | "degraded";
-export type AgentRole = "orchestrator" | "ic" | "worker";
+export type AgentRole = "orchestrator" | "worker";
 export type SurfaceProvenance = "cmuxlayer_spawn" | "unknown";
 export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -9,6 +9,7 @@ import {
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
 import { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
+import { callerContextFromEnv } from "./caller-context.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
@@ -153,6 +154,8 @@ export async function startInProcessRuntime(
   const client = await createCmuxClient();
   const serverOpts: CreateServerOptions = {
     client,
+    safetyCallerContextProvider: () =>
+      callerContextFromEnv(opts.env ?? process.env),
     outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,

--- a/src/layout-policy.ts
+++ b/src/layout-policy.ts
@@ -20,7 +20,6 @@ interface PaneLayout {
   pane: CmuxPane;
   surfaces: CmuxPaneSurfaces["surfaces"];
   orchestratorCount: number;
-  icCount: number;
   workerCount: number;
   unknownCount: number;
   roleCount: number;
@@ -29,7 +28,6 @@ interface PaneLayout {
 
 export interface RoleSurfaceIds {
   orchestrator: Set<string>;
-  ic: Set<string>;
   worker: Set<string>;
   unknown?: Set<string>;
 }
@@ -45,7 +43,6 @@ export interface AgentPlacementContext {
 function emptyRoleSurfaceIds(): RoleSurfaceIds {
   return {
     orchestrator: new Set(),
-    ic: new Set(),
     worker: new Set(),
     unknown: new Set(),
   };
@@ -57,7 +54,6 @@ function normalizeRoleSurfaceIds(
   if (!("worker" in input)) {
     return {
       orchestrator: new Set(),
-      ic: new Set(),
       worker: new Set(input),
       unknown: new Set(),
     };
@@ -82,15 +78,13 @@ function describePaneLayouts(
     const orchestratorCount = roles.filter(
       (role) => role === "orchestrator",
     ).length;
-    const icCount = roles.filter((role) => role === "ic").length;
     const workerCount = roles.filter((role) => role === "worker").length;
     const unknownCount = roles.filter((role) => role === "unknown").length;
-    const roleCount = orchestratorCount + icCount + workerCount;
+    const roleCount = orchestratorCount + workerCount;
     return {
       pane,
       surfaces,
       orchestratorCount,
-      icCount,
       workerCount,
       unknownCount,
       roleCount,
@@ -104,7 +98,6 @@ function roleForSurface(
   roleSurfaceIds: RoleSurfaceIds,
 ): AgentRole | "unknown" | null {
   if (roleSurfaceIds.orchestrator.has(surface.ref)) return "orchestrator";
-  if (roleSurfaceIds.ic.has(surface.ref)) return "ic";
   if (roleSurfaceIds.worker.has(surface.ref)) return "worker";
   if (roleSurfaceIds.unknown?.has(surface.ref)) return "unknown";
   if (surface.type === "terminal") return roleFromLauncherLabel(surface.title);
@@ -166,6 +159,24 @@ export function deriveRoleColumnIndex(
   return deriveColumnIndex(renderedPanes.length > 0 ? renderedPanes : panes);
 }
 
+export class PlacementTopologyError extends Error {
+  readonly code = "PLACEMENT_TOPOLOGY_BLOCKED";
+
+  constructor(readonly columnCount: number) {
+    super(
+      `Role placement blocked: workspace has ${columnCount} columns; the two-column lead/worker invariant allows at most two`,
+    );
+    this.name = "PlacementTopologyError";
+  }
+}
+
+function assertTwoColumnPlacementTopology(panes: CmuxPane[]): void {
+  const columnCount = new Set(deriveRoleColumnIndex(panes).values()).size;
+  if (columnCount > 2) {
+    throw new PlacementTopologyError(columnCount);
+  }
+}
+
 export function canonicalRoleColumn(role: AgentRole): number | null {
   if (role === "orchestrator") return 0;
   if (role === "worker") return 1;
@@ -196,20 +207,10 @@ export function topPaneInRoleColumn(
   );
 }
 
-function isDedicatedIcPane(layout: PaneLayout): boolean {
-  return (
-    layout.icCount > 0 &&
-    layout.orchestratorCount === 0 &&
-    layout.workerCount === 0 &&
-    layout.nonRoleCount === 0
-  );
-}
-
 function isDedicatedWorkerPane(layout: PaneLayout): boolean {
   return (
     layout.workerCount > 0 &&
     layout.orchestratorCount === 0 &&
-    layout.icCount === 0 &&
     layout.nonRoleCount === 0
   );
 }
@@ -270,6 +271,12 @@ function roleFromCli(cli: string | undefined): AgentRole | null {
   }
 }
 
+function normalizeExplicitRole(
+  role: AgentRole | "ic" | undefined,
+): AgentRole | undefined {
+  return role === "ic" ? "worker" : role;
+}
+
 export function canInferAgentRole(input: {
   role?: AgentRole;
   launcherName?: string;
@@ -290,7 +297,8 @@ export function inferAgentRole(input: {
   title?: string;
   cli?: string;
 }): AgentRole {
-  if (input.role) return input.role;
+  const explicitRole = normalizeExplicitRole(input.role);
+  if (explicitRole) return explicitRole;
 
   const launcherRole =
     roleFromLauncherLabel(input.launcherName) ??
@@ -324,7 +332,7 @@ export function inferRecordRole(
   agent: Pick<AgentRecord, "role" | "cli" | "repo">,
 ): AgentRole {
   return (
-    agent.role ??
+    normalizeExplicitRole(agent.role) ??
     inferAgentRole({
       cli: agent.cli,
       launcherName: launcherNameForCli(agent.repo, agent.cli),
@@ -350,7 +358,6 @@ export function collectRoleSurfaceIds(
 ): RoleSurfaceIds {
   const ids: RoleSurfaceIds = {
     orchestrator: new Set(),
-    ic: new Set(),
     worker: new Set(),
     unknown: new Set(),
   };
@@ -377,7 +384,6 @@ export function collectRoleSurfaceIds(
  * - orchestrators dock at the current top of column 0
  * - workers dock at the current top of column 1, independent of pane fill
  * - a missing worker column is seeded to the right of the top lead pane
- * - IC placement retains its existing hierarchy-aware policy
  */
 export function chooseAgentSpawnPlacement(
   panes: CmuxPane[],
@@ -385,17 +391,10 @@ export function chooseAgentSpawnPlacement(
   roleSurfaceIdsInput: ReadonlySet<string> | RoleSurfaceIds,
   context: AgentPlacementContext = {},
 ): AgentSpawnPlacement {
+  assertTwoColumnPlacementTopology(panes);
   const roleSurfaceIds = normalizeRoleSurfaceIds(roleSurfaceIdsInput);
   const role = context.role ?? "worker";
   const layouts = describePaneLayouts(panes, paneSurfaces, roleSurfaceIds);
-  const columnByPane = deriveColumnIndex(panes);
-  const byColumnThenIndex = (a: PaneLayout, b: PaneLayout): number => {
-    const aColumn = columnByPane.get(a.pane.ref) ?? a.pane.index;
-    const bColumn = columnByPane.get(b.pane.ref) ?? b.pane.index;
-    return aColumn - bColumn || a.pane.index - b.pane.index;
-  };
-  const rightmostByColumn = (candidates: PaneLayout[]) =>
-    [...candidates].sort(byColumnThenIndex).at(-1);
 
   if (layouts.length === 0) {
     return { kind: "split", direction: "right" };
@@ -419,25 +418,6 @@ export function chooseAgentSpawnPlacement(
       direction: "right",
       ...(leadPane ? { pane: leadPane.ref } : {}),
     };
-  }
-
-  const workerPanes = layouts.filter(isDedicatedWorkerPane);
-  const icPanes = layouts.filter(isDedicatedIcPane);
-
-  if (role === "ic") {
-    const icPane = rightmostByColumn(icPanes);
-    if (icPane) {
-      return { kind: "surface", pane: icPane.pane.ref };
-    }
-    const workerPane = rightmostByColumn(workerPanes);
-    if (workerPane) {
-      return {
-        kind: "split",
-        direction: "up",
-        pane: workerPane.pane.ref,
-      };
-    }
-    return { kind: "split", direction: "right" };
   }
 
   return { kind: "split", direction: "right" };

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -4,6 +4,11 @@ export function pathBaseName(path: string): string {
   return index >= 0 ? normalized.slice(index + 1) : normalized;
 }
 
+/** Canonicalize only cmux's documented short workspace-ref alias. */
+export function normalizeWorkspaceRefAlias(value: string): string {
+  return value.trim().replace(/^ws:/, "workspace:");
+}
+
 function repoIdentityToken(input: string): string {
   const normalized = input.trim().replace(/\/+$/, "");
   if (!normalized) return "";

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,10 @@ import type {
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
-import { currentCallerContext } from "./caller-context.js";
+import {
+  currentCallerContext,
+  type CallerContext,
+} from "./caller-context.js";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
   matchReadyPattern,
@@ -157,6 +160,7 @@ import {
   screenHasReadyAgentIdentity,
 } from "./pattern-registry.js";
 import {
+  normalizeWorkspaceRefAlias,
   reposEquivalent,
   resolveWorkspaceRefForRepo,
   workspaceDirectoryRepoMatchScore,
@@ -2090,6 +2094,11 @@ export interface CreateServerOptions {
   lifecycleInitializer?: () => Promise<void>;
   /** Skip agent lifecycle initialization (for testing low-level tools only) */
   skipAgentLifecycle?: boolean;
+  /**
+   * In-process-only caller identity used by safety gates, never placement.
+   * Shared-daemon entrypoints intentionally leave this unset.
+   */
+  safetyCallerContextProvider?: () => CallerContext | undefined;
   /** Override the per-session resident-tool palette (primarily for entry wiring/tests). */
   defaultPalette?: string;
   /** Opt into Claude Code channel notifications for lifecycle events */
@@ -4686,7 +4695,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): boolean => {
     const normalized = candidate.trim();
     if (!normalized) return false;
-    const aliasNormalized = normalized.replace(/^ws:/, "workspace:");
+    const aliasNormalized = normalizeWorkspaceRefAlias(normalized);
     return (
       workspace.ref === normalized ||
       workspace.id === normalized ||
@@ -4735,12 +4744,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // A request-scoped workspace ID remains authoritative when enumeration
       // is temporarily unavailable; only daemon env and UI focus are banned.
     }
-    return workspaceCandidate?.replace(/^ws:/, "workspace:");
+    return workspaceCandidate
+      ? normalizeWorkspaceRefAlias(workspaceCandidate)
+      : undefined;
   };
 
   /** Per-request caller workspace only; shared-daemon env/focus are not caller identity. */
   const currentCallerWorkspace = async (): Promise<string | undefined> => {
     return callerWorkspaceStrict();
+  };
+
+  /**
+   * Caller workspace for mutation safety only. In-process runtimes have no
+   * transport metadata, so their process-local env can supplement the strict
+   * request context without ever influencing spawn placement.
+   */
+  const currentSafetyCallerWorkspace = async (): Promise<
+    string | undefined
+  > => {
+    const requestWorkspace = await callerWorkspaceStrict();
+    if (requestWorkspace) return requestWorkspace;
+    const fallbackWorkspace =
+      opts?.safetyCallerContextProvider?.()?.workspaceId;
+    return fallbackWorkspace
+      ? await canonicalWorkspaceRef(fallbackWorkspace)
+      : undefined;
   };
 
   /** Currently-focused workspace ref, or undefined if it can't be read. */
@@ -4805,6 +4833,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
     const cwd = workspace?.current_directory?.trim();
     if (!cwd || workspaceDirectoryRepoMatchScore(repo, cwd) > 0) return;
+    const title = workspace?.title?.trim();
+    const titleCandidates = [
+      inferRepoFromLauncherTitle(title),
+      title,
+    ].filter(
+      (candidate, index, all): candidate is string =>
+        Boolean(candidate) && all.indexOf(candidate) === index,
+    );
+    const identifiedRepo = titleCandidates.find(
+      (candidate) => workspaceDirectoryRepoMatchScore(candidate, cwd) > 0,
+    );
+    if (!identifiedRepo || reposEquivalent(identifiedRepo, repo)) return;
     throw new PlacementWorkspaceError(
       `Refused placement in ${workspace?.ref ?? workspaceRef}: workspace directory ${cwd} does not belong to repo ${repo}`,
     );
@@ -5284,7 +5324,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     result: { workspace_id?: string },
     fallback?: string,
   ): string | undefined =>
-    result.workspace_id ?? fallback;
+    result.workspace_id || fallback;
 
   const isLeadLikeSurfaceTitle = (title: string): boolean =>
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
@@ -5775,7 +5815,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       try {
         await assertWorkspaceMutationAllowed(
           "create_workspace",
-          await currentCallerWorkspace(),
+          await currentSafetyCallerWorkspace(),
         );
         const result = await client.createWorkspace(args.title);
         const data = {
@@ -5844,7 +5884,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const liveAgents = agents.filter(
           (agent) => !TERMINAL_AGENT_STATES.has(agent.state),
         );
-        const callerWorkspace = await currentCallerWorkspace();
+        const callerWorkspace = await currentSafetyCallerWorkspace();
         const deletingCallerWorkspace = callerWorkspace === targetWorkspace;
 
         if (!args.force && (deletingCallerWorkspace || liveAgents.length > 0)) {
@@ -9403,7 +9443,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           await assertWorkspaceMutationAllowed(
             "spawn_in_workspace",
-            args.reuse_workspace ?? (await currentCallerWorkspace()),
+            args.reuse_workspace ?? (await currentSafetyCallerWorkspace()),
           );
           // A newly created workspace may auto-focus immediately, so capture
           // the user's origin before createWorkspace can move it.

--- a/src/server.ts
+++ b/src/server.ts
@@ -159,6 +159,7 @@ import {
 import {
   reposEquivalent,
   resolveWorkspaceRefForRepo,
+  workspaceDirectoryRepoMatchScore,
 } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
@@ -457,6 +458,30 @@ export const THIN_CORE_LEGACY_REPLACEMENTS: Readonly<Record<string, string>> = {
 };
 
 const BroadcastRoleSchema = z.enum(["leads", "workers", "all"]);
+const legacyCompatibleAgentRoleSchema = () =>
+  z
+    .enum(["orchestrator", "worker"])
+    .catch((context) => context.input as AgentRole);
+
+function normalizeToolAgentRole(
+  input: unknown,
+  field: "role" | "placement",
+): { role: AgentRole | undefined; warning: string | undefined } {
+  if (input === undefined) return { role: undefined, warning: undefined };
+  if (input === "ic") {
+    return {
+      role: "worker",
+      warning: `Legacy ${field}=\"ic\" was coerced to \"worker\"; placement now has only orchestrator/worker columns`,
+    };
+  }
+  if (input === "orchestrator" || input === "worker") {
+    return { role: input, warning: undefined };
+  }
+  throw new Error(
+    `Invalid ${field}=${JSON.stringify(input)}; expected orchestrator or worker`,
+  );
+}
+
 const BroadcastArgsSchema = z.object({
   text: z.string(),
   role: BroadcastRoleSchema.optional().default("leads"),
@@ -1362,7 +1387,7 @@ function broadcastRoleMatches(
 ): boolean {
   if (requestedRole === "all") return true;
   if (requestedRole === "workers") return agentRole === "worker";
-  return agentRole === "orchestrator" || agentRole === "ic";
+  return agentRole === "orchestrator";
 }
 
 function inferBroadcastRecordRole(agent: AgentRecord): AgentRole | null {
@@ -2928,7 +2953,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       : roleRecords;
     const ids = collectRoleSurfaceIds(observedRoleRecords);
     if (liveSurfaceIds) {
-      for (const role of ["orchestrator", "ic", "worker"] as const) {
+      for (const role of ["orchestrator", "worker"] as const) {
         for (const surfaceId of ids[role]) {
           if (!liveSurfaceIds.has(surfaceId)) {
             ids[role].delete(surfaceId);
@@ -4692,24 +4717,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   const callerWorkspaceStrict = async (): Promise<string | undefined> => {
+    const callerContext = currentCallerContext();
+    const workspaceCandidate = callerContext?.workspaceId?.trim();
+    const candidates = [workspaceCandidate, callerContext?.tabId].filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    );
     try {
       const { workspaces } = await client.listWorkspaces();
-      const callerContext = currentCallerContext();
-      const requestCandidates = [
-        callerContext?.workspaceId,
-        callerContext?.tabId,
-      ].filter(
-        (value): value is string =>
-          typeof value === "string" && value.trim().length > 0,
-      );
-      const envCandidates =
-        requestCandidates.length > 0
-          ? []
-          : [process.env.CMUX_WORKSPACE_ID, process.env.CMUX_TAB_ID].filter(
-              (value): value is string =>
-                typeof value === "string" && value.trim().length > 0,
-            );
-      const candidates = [...requestCandidates, ...envCandidates];
       for (const candidate of candidates) {
         const match = workspaces.find((workspace) =>
           envWorkspaceMatches(workspace, candidate),
@@ -4717,15 +4732,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         if (match) return match.ref;
       }
     } catch {
-      return undefined;
+      // A request-scoped workspace ID remains authoritative when enumeration
+      // is temporarily unavailable; only daemon env and UI focus are banned.
     }
-    return undefined;
+    return workspaceCandidate?.replace(/^ws:/, "workspace:");
   };
 
-  /** Caller pane workspace ref first, then focused workspace as fallback. */
+  /** Per-request caller workspace only; shared-daemon env/focus are not caller identity. */
   const currentCallerWorkspace = async (): Promise<string | undefined> => {
-    const callerWorkspace = await callerWorkspaceStrict();
-    return callerWorkspace ?? (await currentFocusedWorkspace());
+    return callerWorkspaceStrict();
   };
 
   /** Currently-focused workspace ref, or undefined if it can't be read. */
@@ -4765,41 +4780,62 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return workspace ? { workspace } : null;
   };
 
-  const focusedWorkspaceFallbackWarning =
-    "No explicit workspace, caller workspace, or repo workspace could be resolved; falling back to the currently focused workspace.";
+  class PlacementWorkspaceError extends Error {
+    readonly code = "PLACEMENT_WORKSPACE_UNRESOLVED";
+
+    constructor(message: string) {
+      super(message);
+      this.name = "PlacementWorkspaceError";
+    }
+  }
+
+  const assertWorkspaceBelongsToRepo = async (
+    workspaceRef: string,
+    repo: string | null | undefined,
+  ): Promise<void> => {
+    if (!repo) return;
+    let workspace: CmuxWorkspace | undefined;
+    try {
+      const listed = await client.listWorkspaces();
+      workspace = listed.workspaces.find((candidate) =>
+        envWorkspaceMatches(candidate, workspaceRef),
+      );
+    } catch {
+      return;
+    }
+    const cwd = workspace?.current_directory?.trim();
+    if (!cwd || workspaceDirectoryRepoMatchScore(repo, cwd) > 0) return;
+    throw new PlacementWorkspaceError(
+      `Refused placement in ${workspace?.ref ?? workspaceRef}: workspace directory ${cwd} does not belong to repo ${repo}`,
+    );
+  };
 
   const resolvePlacementWorkspace = async (opts: {
     explicitWorkspace?: string;
     callerWorkspace?: string;
     repo?: string | null;
-    allowFocusedFallback?: boolean;
   }): Promise<{ workspace?: string; warnings: string[] }> => {
     const explicitWorkspace = opts.explicitWorkspace
       ? await canonicalWorkspaceRef(opts.explicitWorkspace)
       : undefined;
-    if (explicitWorkspace)
+    if (explicitWorkspace) {
+      await assertWorkspaceBelongsToRepo(explicitWorkspace, opts.repo);
       return { workspace: explicitWorkspace, warnings: [] };
+    }
 
     const callerWorkspace =
       opts.callerWorkspace ?? (await callerWorkspaceStrict());
-    if (callerWorkspace) return { workspace: callerWorkspace, warnings: [] };
+    if (callerWorkspace) {
+      await assertWorkspaceBelongsToRepo(callerWorkspace, opts.repo);
+      return { workspace: callerWorkspace, warnings: [] };
+    }
 
     const repoWorkspace = await resolveWorkspaceForRepo(opts.repo);
     if (repoWorkspace) return { workspace: repoWorkspace, warnings: [] };
 
-    if (opts.allowFocusedFallback === false) {
-      return { workspace: undefined, warnings: [] };
-    }
-
-    const focusedWorkspace = await currentFocusedWorkspace();
-    if (focusedWorkspace) {
-      return {
-        workspace: focusedWorkspace,
-        warnings: [focusedWorkspaceFallbackWarning],
-      };
-    }
-
-    return { workspace: undefined, warnings: [] };
+    throw new PlacementWorkspaceError(
+      "Spawn placement requires an explicit workspace, per-request caller workspace, or matching repo workspace; focused workspace and shared-daemon environment fallbacks are forbidden",
+    );
   };
 
   /** Capture origin focus, select the placement workspace, and record the
@@ -5244,23 +5280,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return evaluateAgentHealth(agent, input);
   };
 
-  const agentForSpawnHealth = (
-    agent: AgentRecord,
-    result: { workspace_id?: string; warnings?: string[] },
-  ): AgentRecord => {
-    const placementMismatch =
-      result.warnings?.some((warning) =>
-        warning.startsWith("Spawn placement mismatch:"),
-      ) ?? false;
-    if (!placementMismatch || !result.workspace_id) return agent;
-    return { ...agent, workspace_id: result.workspace_id };
-  };
-
   const spawnDeliveryWorkspace = (
-    result: { actual_workspace_id?: string; workspace_id?: string },
+    result: { workspace_id?: string },
     fallback?: string,
   ): string | undefined =>
-    result.actual_workspace_id ?? result.workspace_id ?? fallback;
+    result.workspace_id ?? fallback;
 
   const isLeadLikeSurfaceTitle = (title: string): boolean =>
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
@@ -5890,11 +5914,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .describe("Surface type"),
       url: z.string().optional().describe("URL for browser surfaces"),
       title: z.string().optional().describe("Tab title"),
-      role: z
-        .enum(["orchestrator", "ic", "worker"])
+      role: legacyCompatibleAgentRoleSchema()
         .optional()
         .describe(
-          "Agent role drives deterministic column placement: orchestrator/ic → LEFT column (leads, the Claude that coordinates), worker → RIGHT column (Codex/Cursor that implement/gather). Defaults from title launcher suffix: *Claude=orchestrator, *Codex/*Cursor=worker. Pass this instead of trying to control left/right via direction.",
+          "Agent role drives deterministic column placement: orchestrator → LEFT column (leads, the Claude that coordinates), worker → RIGHT column (Codex/Cursor that implement/gather). Defaults from title launcher suffix: *Claude=orchestrator, *Codex/*Cursor=worker. Pass this instead of trying to control left/right via direction.",
         ),
       focus: z
         .boolean()
@@ -5922,14 +5945,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       let result: CmuxNewSplitResult | undefined;
       let focusRestoreLease: FocusRestoreLease | null = null;
       try {
+        const normalizedRole = normalizeToolAgentRole(args.role, "role");
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         const shouldInferRole =
-          Boolean(args.role) ||
+          Boolean(normalizedRole.role) ||
           (!args.pane &&
             !args.surface &&
             canInferAgentRole({ title: args.title }));
         const inferredRole = shouldInferRole
-          ? inferAgentRole({ role: args.role, title: args.title })
+          ? inferAgentRole({ role: normalizedRole.role, title: args.title })
           : null;
         if (
           inferredRole &&
@@ -6143,13 +6167,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const data: Record<string, unknown> = { ...result };
         data.placement = actualPlacement;
         data.direction = actualDirection;
-        const warnings = [
+        const responseWarnings = [
           ...targetResolution.warnings,
+          ...(normalizedRole.warning ? [normalizedRole.warning] : []),
           ...(focusRequestWarning ? [focusRequestWarning] : []),
           ...(focusRestoreWarning ? [focusRestoreWarning] : []),
         ];
-        if (warnings.length > 0) {
-          data.warnings = warnings;
+        if (responseWarnings.length > 0) {
+          data.warning = responseWarnings.join(" | ");
+          data.warnings = responseWarnings;
         }
         if (inferredRole) {
           data.role = inferredRole;
@@ -8561,14 +8587,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "ID of the parent agent for hierarchical spawning. Parent must exist.",
           ),
-        role: z
-          .enum(["orchestrator", "ic", "worker"])
+        role: legacyCompatibleAgentRoleSchema()
           .optional()
           .describe(
             "Optional placement role. Defaults from launcher: *Claude=orchestrator, *Codex/*Cursor=worker.",
           ),
-        placement: z
-          .enum(["orchestrator", "ic", "worker"])
+        placement: legacyCompatibleAgentRoleSchema()
           .optional()
           .describe(
             "Canonical role-driven placement. role remains accepted as a compatibility spelling.",
@@ -8615,6 +8639,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         try {
+          const selectedRoleField =
+            args.placement !== undefined ? "placement" : "role";
+          const normalizedRole = normalizeToolAgentRole(
+            args.placement ?? args.role,
+            selectedRoleField,
+          );
+          const effectiveRole = normalizedRole.role;
           const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
           assertBootPromptMode(args.prompt, bootPromptPath);
           assertInlineInputAllowed({
@@ -8663,7 +8694,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.worktree,
             args.mcp_profile as McpProfile | undefined,
           );
-          const effectiveRole = args.placement ?? args.role;
           const requestedRole = inferAgentRole({
             role: effectiveRole,
             cli: args.cli,
@@ -8755,10 +8785,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
           originalLaunchCommandsBySurface.delete(result.surface_id);
           appendStaleBuildWarning(result);
-          if (targetResolution.warnings.length > 0) {
+          const placementWarnings = [
+            ...targetResolution.warnings,
+            ...(normalizedRole.warning ? [normalizedRole.warning] : []),
+          ];
+          if (placementWarnings.length > 0) {
             result.warnings = [
               ...(result.warnings ?? []),
-              ...targetResolution.warnings,
+              ...placementWarnings,
             ];
           }
 
@@ -8921,7 +8955,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
             ? await evaluateServerAgentHealth(
-                agentForSpawnHealth(currentAgent, result),
+                currentAgent,
                 {
                   ...healthTopologyOverrides(currentAgent, topology),
                 },
@@ -9164,7 +9198,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const topology = currentAgent ? await collectSurfaceTopology() : null;
           const health = currentAgent
             ? await evaluateServerAgentHealth(
-                agentForSpawnHealth(currentAgent, result),
+                currentAgent,
                 {
                   ...healthTopologyOverrides(currentAgent, topology),
                 },
@@ -9297,7 +9331,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               repo: z.string(),
               model: z.string(),
               cli: z.enum(["claude", "codex", "cursor", "gemini", "kiro"]),
-              role: z.enum(["orchestrator", "worker", "ic"]).optional(),
+              role: legacyCompatibleAgentRoleSchema().optional(),
               prompt: z.string().optional(),
             }),
           )
@@ -9348,6 +9382,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }> = [];
         const leanSpawnedAgents: Record<string, unknown>[] = [];
         try {
+          const normalizedAgents = args.agents.map((agent) => {
+            const normalizedRole = normalizeToolAgentRole(agent.role, "role");
+            return {
+              ...agent,
+              role: normalizedRole.role,
+              compatibilityWarning: normalizedRole.warning,
+            };
+          });
+          const compatibilityWarnings = normalizedAgents.flatMap((agent) =>
+            agent.compatibilityWarning ? [agent.compatibilityWarning] : [],
+          );
+          if (args.reuse_workspace) {
+            for (const agent of normalizedAgents) {
+              await assertWorkspaceBelongsToRepo(
+                args.reuse_workspace,
+                agent.repo,
+              );
+            }
+          }
           await assertWorkspaceMutationAllowed(
             "spawn_in_workspace",
             args.reuse_workspace ?? (await currentCallerWorkspace()),
@@ -9375,7 +9428,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             focusRestoreLease,
           );
 
-          for (const agent of args.agents) {
+          for (const agent of normalizedAgents) {
             const hasPrompt = hasInlinePrompt(agent.prompt);
             activeSpawnIdentity = undefined;
             const result = await engine.spawnAgent({
@@ -9471,7 +9524,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : null;
             const health = currentAgent
               ? await evaluateServerAgentHealth(
-                  agentForSpawnHealth(currentAgent, result),
+                  currentAgent,
                   {
                     ...healthTopologyOverrides(currentAgent, topology),
                   },
@@ -9523,12 +9576,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const workspaceWarnings = [
             ...(staleWarning ? [staleWarning] : []),
             ...(focusRestoreWarning ? [focusRestoreWarning] : []),
+            ...compatibilityWarnings,
           ];
 
           const formattedData = {
             workspace,
             agents: spawnedAgents.length,
-            ...(staleWarning ? { warning: staleWarning } : {}),
+            ...(workspaceWarnings.length > 0
+              ? { warning: workspaceWarnings.join(" | ") }
+              : {}),
           };
           const responseData = {
             workspace,
@@ -10058,13 +10114,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "broadcast",
-      `Fan out a short pointer-style message to registered agents by role using the same guarded delivery path as send_to. Defaults to role=leads (orchestrator + ic). Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters; for larger payloads write a file and broadcast "Read and follow <path>". Returns per-agent receipts so one failed target never hides the rest. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
+      `Fan out a short pointer-style message to registered agents by role using the same guarded delivery path as send_to. Defaults to role=leads (orchestrator). Inline text is capped at ${SEND_INPUT_MAX_INLINE_CHARS} characters; for larger payloads write a file and broadcast "Read and follow <path>". Returns per-agent receipts so one failed target never hides the rest. ${DENSE_INLINE_ROUTING_GUIDANCE} ${ZSH_BANG_INLINE_WARNING}`,
       {
         text: BroadcastArgsSchema.shape.text.describe(
           `Message to broadcast. Capped at ${SEND_INPUT_MAX_INLINE_CHARS} inline characters; write larger payloads to a file and broadcast "Read and follow <path>".`,
         ),
         role: BroadcastArgsSchema.shape.role.describe(
-          "Target role set: leads means orchestrator + ic; workers means worker; all means every registered agent.",
+          "Target role set: leads means orchestrator; workers means worker; all means every registered agent.",
         ),
         exclude: BroadcastArgsSchema.shape.exclude.describe(
           "Agent IDs to skip in addition to the caller's own agent.",

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -33,6 +33,18 @@ type AgentRecordPatch = Partial<
   Omit<AgentRecord, "agent_id" | "created_at" | "updated_at" | "version" | "state">
 >;
 
+type PersistedAgentRecord = Omit<AgentRecord, "role"> & {
+  role?: AgentRole | "ic";
+};
+
+function normalizePersistedAgentRecord(
+  record: PersistedAgentRecord,
+): AgentRecord {
+  const role: AgentRole | undefined =
+    record.role === "ic" ? "worker" : record.role;
+  return { ...record, role };
+}
+
 export interface SurfaceSessionIndexEntry {
   agent_id: string;
   workspace_id: string | null;
@@ -207,7 +219,9 @@ export class StateManager {
     const stateFile = this.stateFilePath(dirName);
     if (!existsSync(stateFile)) return null;
     try {
-      return JSON.parse(readFileSync(stateFile, "utf-8")) as AgentRecord;
+      return normalizePersistedAgentRecord(
+        JSON.parse(readFileSync(stateFile, "utf-8")) as PersistedAgentRecord,
+      );
     } catch {
       return null;
     }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -61,22 +61,22 @@ function mockSpawnExit(code: number): {
 
 function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
   return {
-    newSplit: vi.fn().mockResolvedValue({
-      workspace: "ws:1",
+    newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
+      workspace: opts?.workspace ?? "ws:1",
       surface: "surface:new",
       surface_id: "11111111-2222-4333-8444-555555555555",
       pane: "pane:1",
       title: "",
       type: "terminal",
-    } satisfies CmuxNewSplitResult),
-    newSurface: vi.fn().mockResolvedValue({
-      workspace: "ws:1",
+    }) satisfies CmuxNewSplitResult),
+    newSurface: vi.fn().mockImplementation(async (opts) => ({
+      workspace: opts?.workspace ?? "ws:1",
       surface: "surface:new",
       surface_id: "11111111-2222-4333-8444-555555555555",
-      pane: "pane:1",
+      pane: opts.pane,
       title: "",
       type: "terminal",
-    }),
+    })),
     send: vi.fn().mockResolvedValue(undefined),
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({
@@ -727,6 +727,41 @@ describe("AgentEngine", () => {
       });
     });
 
+    it("blocks a seat identity mismatch before creating a surface", async () => {
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => ({ launcherName: "cmuxlayerCodex" }),
+        sessionIdentityResolver: () => null,
+        seatRegistry: {
+          brainlayerClaude: {
+            repo: "brainlayer",
+            launchers: { codex: "brainlayerCodex" },
+            lane: "brainlayer",
+            role: "worker",
+          },
+          cmuxlayerClaude: {
+            repo: "cmuxlayer",
+            launchers: { codex: "cmuxlayerCodex" },
+            lane: "cmuxlayer",
+            role: "worker",
+          },
+        },
+      });
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          cli: "codex",
+          prompt: "Must not occupy the wrong seat",
+        }),
+      ).rejects.toThrow(/Spawn blocked by seat identity mismatch.*cmuxlayer/i);
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+      expect(stateMgr.listStates()).toHaveLength(0);
+    });
+
     it("treats orchestrator repo spawns through orc launchers as the same registry seat", async () => {
       engine.dispose();
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
@@ -983,7 +1018,7 @@ describe("AgentEngine", () => {
       );
     });
 
-    it("warns when cmux returns a spawned surface in a different workspace than requested", async () => {
+    it("blocks and cleans up when cmux returns a spawned surface in a different workspace than requested", async () => {
       (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
         panes: [
           {
@@ -1011,18 +1046,28 @@ describe("AgentEngine", () => {
         type: "terminal",
       });
 
-      const result = await engine.spawnAgent({
-        repo: "brainlayer",
-        model: "gpt-5.4",
-        cli: "codex",
-        prompt: "Fix placement",
-        workspace: "workspace:intended",
-      });
-
-      expect(result.workspace_id).toBe("workspace:intended");
-      expect(result.warnings).toContain(
-        "Spawn placement mismatch: requested workspace:intended but cmux returned workspace:wrong for surface surface:new",
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          prompt: "Fix placement",
+          workspace: "workspace:intended",
+        }),
+      ).rejects.toThrow(
+        "Spawn placement blocked: requested workspace:intended but cmux returned workspace:wrong for surface surface:new",
       );
+      expect(mockClient.closeSurface).toHaveBeenCalledWith(
+        "surface:new",
+        expect.objectContaining({
+          workspace: "workspace:wrong",
+          collapsePane: false,
+          beforeMutation: expect.any(Function),
+        }),
+      );
+      expect(stateMgr.listStates()).toHaveLength(0);
+      expect(mockClient.renameTab).not.toHaveBeenCalled();
+      expect(mockClient.send).not.toHaveBeenCalled();
     });
 
     it("inherits the workspace whose current directory matches the target repo", async () => {
@@ -1169,7 +1214,7 @@ describe("AgentEngine", () => {
         surface_uuid: persistedUuid,
         workspace_id: "workspace:old",
         state: "ready",
-        role: "ic",
+        role: "worker",
         cli: "claude",
         repo: "brainlayer",
         parent_agent_id: null,
@@ -1309,7 +1354,7 @@ describe("AgentEngine", () => {
         surface_uuid: parentUuid,
         workspace_id: "workspace:parent",
         state: "ready",
-        role: "ic",
+        role: "worker",
         cli: "claude",
         repo: "brainlayer",
       });
@@ -1382,7 +1427,7 @@ describe("AgentEngine", () => {
         surface_uuid: stableUuid,
         workspace_id: "workspace:parent",
         state: "ready",
-        role: "ic",
+        role: "worker",
         cli: "claude",
         repo: "brainlayer",
       });
@@ -1684,12 +1729,12 @@ describe("AgentEngine", () => {
         model: "sonnet",
         cli: "claude",
         prompt: "Coordinate gap F",
-        role: "ic",
+        role: "worker",
         workspace: "ws:1",
       });
 
-      expect(mockClient.newSplit).toHaveBeenCalledWith("up", {
-        pane: "pane:left",
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right-recycled",
         type: "terminal",
         workspace: "ws:1",
       });
@@ -1791,18 +1836,16 @@ describe("AgentEngine", () => {
         model: "sonnet",
         cli: "claude",
         prompt: "Coordinate gap F",
-        role: "ic",
+        role: "worker",
         workspace: "ws:1",
       });
 
-      expect(mockClient.newSplit).toHaveBeenCalledWith("right", {
-        type: "terminal",
+      expect(mockClient.newSurface).toHaveBeenCalledWith({
+        pane: "pane:right",
         workspace: "ws:1",
+        type: "terminal",
       });
-      expect(mockClient.newSplit).not.toHaveBeenCalledWith(
-        "up",
-        expect.objectContaining({ pane: "pane:right" }),
-      );
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
     });
 
     it("refuses placement from a successful truncated pane enumeration", async () => {
@@ -2247,6 +2290,70 @@ describe("AgentEngine", () => {
       expect(stateMgr.listStates()).toHaveLength(0);
     });
 
+    it("refuses a third-column workspace before creating an orphan surface", async () => {
+      (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:left",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:lead"],
+            pixel_frame: { x: 0, y: 0, width: 400, height: 900 },
+          },
+          {
+            ref: "pane:right",
+            index: 1,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:worker"],
+            pixel_frame: { x: 400, y: 0, width: 400, height: 900 },
+          },
+          {
+            ref: "pane:third",
+            index: 2,
+            focused: false,
+            surface_count: 1,
+            surface_refs: ["surface:unexpected"],
+            pixel_frame: { x: 800, y: 0, width: 400, height: 900 },
+          },
+        ],
+      });
+      (
+        mockClient.listPaneSurfaces as ReturnType<typeof vi.fn>
+      ).mockImplementation(async ({ pane }: { pane?: string }) => ({
+        workspace_ref: "ws:1",
+        window_ref: "window:1",
+        pane_ref: pane,
+        surfaces: [
+          makeSurface(
+            pane === "pane:left"
+              ? "surface:lead"
+              : pane === "pane:right"
+                ? "surface:worker"
+                : "surface:unexpected",
+          ),
+        ],
+      }));
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          cli: "codex",
+          prompt: "Refuse placement into a third-column workspace",
+          workspace: "ws:1",
+        }),
+      ).rejects.toThrow(/three columns|at most two|two-column/i);
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(stateMgr.listStates()).toHaveLength(0);
+    });
+
     it("refuses launch when the surface observer changes during tab rename", async () => {
       engine.dispose();
       let currentObserverId = "cmux:/tmp/cmux-primary.sock";
@@ -2373,16 +2480,16 @@ describe("AgentEngine", () => {
       expect(mockClient.sendKey).not.toHaveBeenCalled();
     });
 
-    it("persists explicit role on spawned agents", async () => {
+    it("persists the explicit worker role on spawned agents", async () => {
       const result = await engine.spawnAgent({
         repo: "brainlayer",
         model: "sonnet",
         cli: "claude",
         prompt: "Coordinate work",
-        role: "ic",
+        role: "worker",
       });
 
-      expect(stateMgr.readState(result.agent_id)?.role).toBe("ic");
+      expect(stateMgr.readState(result.agent_id)?.role).toBe("worker");
     });
 
     it("infers worker role for Codex spawns and uses the worker pane", async () => {
@@ -2407,7 +2514,6 @@ describe("AgentEngine", () => {
         spawnPreflight: async () => {},
         roleSurfaceIdsProvider: () => ({
           orchestrator: new Set(),
-          ic: new Set(),
           worker: new Set(["surface:worker-shell"]),
         }),
       });
@@ -2513,7 +2619,6 @@ describe("AgentEngine", () => {
         spawnPreflight: async () => {},
         roleSurfaceIdsProvider: () => ({
           orchestrator: new Set(["surface:orc"]),
-          ic: new Set(),
           worker: new Set(["surface:worker-shell"]),
         }),
       });
@@ -2633,7 +2738,7 @@ describe("AgentEngine", () => {
           state: "ready",
           surface_id: "surface:ic",
           cli: "claude",
-          role: "ic",
+          role: "worker",
         }),
       );
       liveSurfaces = [makeSurface("surface:ic")];
@@ -2816,7 +2921,7 @@ describe("AgentEngine", () => {
             state: "ready",
             surface_id: "surface:claude-ic-done",
             cli: "claude",
-            role: "ic",
+            role: "worker",
             auto_archive_on_done: true,
           }),
         );
@@ -3782,7 +3887,7 @@ describe("AgentEngine", () => {
       });
     });
 
-    it("sends crash recovery resume commands to the actual cmux workspace on placement mismatch", async () => {
+    it("blocks crash recovery and cleans the unbound surface on placement mismatch", async () => {
       engine.dispose();
       const observerId = "cmux:/tmp/recovery-owner.sock";
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces, {
@@ -3838,20 +3943,27 @@ describe("AgentEngine", () => {
 
       await engine.runSweep();
 
-      expect(mockClient.send).toHaveBeenCalledWith(
+      expect(mockClient.send).not.toHaveBeenCalledWith(
         "surface:new",
         "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
         expect.objectContaining({ workspace: "workspace:wrong" }),
       );
-      expect(mockClient.sendKey).toHaveBeenCalledWith("surface:new", "return", {
-        workspace: "workspace:wrong",
-        stableSurfaceIdentity: SPAWN_SURFACE_UUID,
-      });
+      expect(mockClient.sendKey).not.toHaveBeenCalled();
+      expect(mockClient.closeSurface).toHaveBeenCalledWith(
+        "surface:new",
+        expect.objectContaining({
+          workspace: "workspace:wrong",
+          collapsePane: false,
+        }),
+      );
       expect(engine.getAgentState("agent-crash-mismatch")?.workspace_id).toBe(
-        "workspace:wrong",
+        "workspace:intended",
       );
       expect(engine.getAgentState("agent-crash-mismatch")?.state).toBe(
-        "booting",
+        "error",
+      );
+      expect(engine.getAgentState("agent-crash-mismatch")?.error).toContain(
+        "Spawn placement blocked: requested workspace:intended but cmux returned workspace:wrong",
       );
     });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3943,11 +3943,7 @@ describe("AgentEngine", () => {
 
       await engine.runSweep();
 
-      expect(mockClient.send).not.toHaveBeenCalledWith(
-        "surface:new",
-        "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
-        expect.objectContaining({ workspace: "workspace:wrong" }),
-      );
+      expect(mockClient.send).not.toHaveBeenCalled();
       expect(mockClient.sendKey).not.toHaveBeenCalled();
       expect(mockClient.closeSurface).toHaveBeenCalledWith(
         "surface:new",

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -205,16 +205,6 @@ describe("agent lifecycle health", () => {
 
   it("marks non-Claude orchestrators as role health failures", () => {
     const health = evaluateAgentHealth(
-      makeRecord({ cli: "codex", role: "orchestrator" }),
-      { monitor_alive: true },
-    );
-
-    expect(health.status).toBe("unhealthy");
-    expect(health.issue_codes).toContain("non_claude_orchestrator");
-  });
-
-  it("accepts an explicitly managed non-Claude orchestrator as the single left-side coordinator", () => {
-    const health = evaluateAgentHealth(
       makeRecord({
         cli: "codex",
         role: "orchestrator",
@@ -223,7 +213,8 @@ describe("agent lifecycle health", () => {
       { monitor_alive: true },
     );
 
-    expect(health.issue_codes).not.toContain("non_claude_orchestrator");
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("non_claude_orchestrator");
   });
 
   it("marks unexpected three-column topology as unhealthy", () => {

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -213,6 +213,19 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("non_claude_orchestrator");
   });
 
+  it("accepts an explicitly managed non-Claude orchestrator as the single left-side coordinator", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        cli: "codex",
+        role: "orchestrator",
+        surface_provenance: "cmuxlayer_spawn",
+      }),
+      { monitor_alive: true },
+    );
+
+    expect(health.issue_codes).not.toContain("non_claude_orchestrator");
+  });
+
   it("marks unexpected three-column topology as unhealthy", () => {
     const health = evaluateAgentHealth(makeRecord(), {
       monitor_alive: true,

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -2618,7 +2618,7 @@ describe("AgentRegistry", () => {
       });
     });
 
-    it("keeps absent terminal lead roles while purging absent terminal workers", async () => {
+    it("keeps absent terminal orchestrators while legacy IC records normalize and purge as workers", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "orchestrator-terminal",
@@ -2650,15 +2650,12 @@ describe("AgentRegistry", () => {
 
       const purged = await registry.purgeTerminal({ confirmationMs: 0 });
 
-      expect(purged).toBe(1);
+      expect(purged).toBe(2);
       expect(registry.get("orchestrator-terminal")).toMatchObject({
         agent_id: "orchestrator-terminal",
         role: "orchestrator",
       });
-      expect(registry.get("ic-terminal")).toMatchObject({
-        agent_id: "ic-terminal",
-        role: "ic",
-      });
+      expect(registry.get("ic-terminal")).toBeNull();
       expect(registry.get("worker-terminal")).toBeNull();
     });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -2629,6 +2629,16 @@ describe("AgentRegistry", () => {
       );
       stateMgr.writeState(
         makeRecord({
+          agent_id: "inferred-orchestrator-terminal",
+          state: "done",
+          surface_id: "surface:missing-inferred-orchestrator",
+          role: undefined,
+          cli: "claude",
+          repo: "cmuxlayer",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
           agent_id: "ic-terminal",
           state: "error",
           surface_id: "surface:missing-ic",
@@ -2654,6 +2664,9 @@ describe("AgentRegistry", () => {
       expect(registry.get("orchestrator-terminal")).toMatchObject({
         agent_id: "orchestrator-terminal",
         role: "orchestrator",
+      });
+      expect(registry.get("inferred-orchestrator-terminal")).toMatchObject({
+        agent_id: "inferred-orchestrator-terminal",
       });
       expect(registry.get("ic-terminal")).toBeNull();
       expect(registry.get("worker-terminal")).toBeNull();

--- a/tests/audit-fixes.test.ts
+++ b/tests/audit-fixes.test.ts
@@ -336,7 +336,12 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
     // First spawn a parent
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const parentResult = await spawn.handler(
-      { repo: "test", model: "sonnet", cli: "claude" },
+      {
+        repo: "test",
+        model: "sonnet",
+        cli: "claude",
+        workspace: "workspace:1",
+      },
       {} as any,
     );
     const parentId = (
@@ -349,6 +354,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
         repo: "test",
         model: "haiku",
         cli: "claude",
+        workspace: "workspace:1",
         parent_agent_id: parentId,
       },
       {} as any,
@@ -368,6 +374,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
         repo: "test",
         model: "opus",
         cli: "claude",
+        workspace: "workspace:1",
         max_cost_per_agent: 5.0,
       },
       {} as any,
@@ -386,6 +393,7 @@ describe("spawn_agent MCP schema includes parent_agent_id and max_cost_per_agent
         repo: "test",
         model: "sonnet",
         cli: "claude",
+        workspace: "workspace:1",
         prompt: "orphan",
         parent_agent_id: "nonexistent-agent",
       },

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1988,6 +1988,7 @@ describe("CmuxLayerDaemon", () => {
         repo: "brainlayer",
         model: "gpt-5.4",
         cli: "codex",
+        workspace: "workspace:1",
       },
     });
     const agentId = String(spawned.structuredContent?.agent_id);
@@ -2214,6 +2215,7 @@ describe("CmuxLayerDaemon", () => {
           repo: "brainlayer",
           model: "gpt-5.4",
           cli: "codex",
+          workspace: "workspace:1",
         },
       });
       const agentId = String(spawned.structuredContent?.agent_id);

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -35,6 +35,7 @@ import {
   TEST_SURFACE_OBSERVER_OWNER,
   withTestSurfaceObserver,
 } from "./helpers/test-surface-observer.js";
+import { runWithCallerContext } from "../src/caller-context.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-inbox-nudge");
 const PRIMARY_SURFACE_UUID = "11111111-1111-4111-8111-111111111111";
@@ -192,15 +193,19 @@ function createInboxServer(exec: ExecFn, inboxDir: string) {
 
 async function spawnTestAgent(server: any): Promise<string> {
   const tool = server._registeredTools["spawn_agent"];
-  const result = await tool.handler(
-    {
-      repo: "brainlayer",
-      model: "sonnet",
-      cli: "claude",
-      role: "ic",
-      prompt: "task",
-    },
-    {} as any,
+  const result = await runWithCallerContext(
+    { workspaceId: "workspace:1" },
+    () =>
+      tool.handler(
+        {
+          repo: "brainlayer",
+          model: "sonnet",
+          cli: "claude",
+          role: "worker",
+          prompt: "task",
+        },
+        {} as any,
+      ),
   );
   const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);
   expect(parsed.ok).toBe(true);

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   chooseAgentSpawnPlacement,
   chooseSurfaceClosePolicy,
+  collectRoleSurfaceIds,
   deriveColumnIndex,
   inferAgentRole,
   launcherNameForCli,
 } from "../src/layout-policy.js";
+import type { AgentRecord } from "../src/agent-types.js";
 import type { CmuxPane, CmuxPaneSurfaces, CmuxSurface } from "../src/types.js";
 
 function makePane(
@@ -186,7 +188,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       {
@@ -232,13 +233,51 @@ describe("layout policy", () => {
       ],
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker"]),
       },
       { role: "worker" },
     );
 
     expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+  });
+
+  it("refuses role placement when the workspace already has a third rendered column", () => {
+    const panes = [
+      makePane("pane:left", 0, ["surface:orchestrator"], {
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 900,
+      }),
+      makePane("pane:right", 1, ["surface:worker"], {
+        x: 400,
+        y: 0,
+        width: 400,
+        height: 900,
+      }),
+      makePane("pane:third", 2, ["surface:unexpected"], {
+        x: 800,
+        y: 0,
+        width: 400,
+        height: 900,
+      }),
+    ];
+
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        [
+          makePaneSurfaces("pane:left", ["surface:orchestrator"]),
+          makePaneSurfaces("pane:right", ["surface:worker"]),
+          makePaneSurfaces("pane:third", ["surface:unexpected"]),
+        ],
+        {
+          orchestrator: new Set(["surface:orchestrator"]),
+          worker: new Set(["surface:worker"]),
+        },
+        { role: "worker" },
+      ),
+    ).toThrow(/three columns|at most two|two-column/i);
   });
 
   it("infers default role from repoGolem launcher names", () => {
@@ -272,8 +311,8 @@ describe("layout policy", () => {
 
   it("lets an explicit role override launcher inference", () => {
     expect(
-      inferAgentRole({ launcherName: "skillcreatorClaude", role: "ic" }),
-    ).toBe("ic");
+      inferAgentRole({ launcherName: "skillcreatorClaude", role: "worker" }),
+    ).toBe("worker");
   });
 
   it("does not let repo names that end with launcher suffixes affect non-launcher CLIs", () => {
@@ -312,7 +351,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orc"]),
-        ic: new Set(),
         worker: new Set(["surface:worker-1"]),
       },
       { role: "orchestrator" },
@@ -346,7 +384,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "orchestrator" },
@@ -390,8 +427,7 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(["surface:voicelayer-lead"]),
-        worker: new Set(),
+        worker: new Set(["surface:voicelayer-lead"]),
       },
       { role: "orchestrator" },
     );
@@ -399,7 +435,7 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:left" });
   });
 
-  it("places orchestrators in pane:1 for the live lead-pane fixture with one IC record", () => {
+  it("places orchestrators in pane:1 when a normalized legacy IC record is a worker", () => {
     const panes = [
       makePane(
         "pane:1",
@@ -460,8 +496,7 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(["surface:voicelayer-lead"]),
-        worker: new Set(),
+        worker: new Set(["surface:voicelayer-lead"]),
       },
       { role: "orchestrator" },
     );
@@ -517,7 +552,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(),
         worker: new Set(["surface:stale-worker"]),
       },
       { role: "orchestrator" },
@@ -583,8 +617,7 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(["surface:stale-ic"]),
-        worker: new Set(),
+        worker: new Set(["surface:stale-ic"]),
       },
       { role: "orchestrator" },
     );
@@ -611,7 +644,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "worker" },
@@ -633,35 +665,28 @@ describe("layout policy", () => {
     });
   });
 
-  it("places the first IC in the right column above existing workers", () => {
-    const panes = [
-      makePane("pane:left", 0, ["surface:orc"]),
-      makePane("pane:right", 1, ["surface:worker-1"]),
-    ];
-    const paneSurfaces = [
-      makePaneSurfaces("pane:left", ["surface:orc"]),
-      makePaneSurfaces("pane:right", ["surface:worker-1"]),
-    ];
+  it("seeds the worker column to the right and never creates the old vertical IC split", () => {
+    const panes = [makePane("pane:left", 0, ["surface:orc"])];
+    const paneSurfaces = [makePaneSurfaces("pane:left", ["surface:orc"])];
 
     const placement = chooseAgentSpawnPlacement(
       panes,
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orc"]),
-        ic: new Set(),
-        worker: new Set(["surface:worker-1"]),
+        worker: new Set(),
       },
-      { role: "ic" },
+      { role: "worker" },
     );
 
     expect(placement).toEqual({
       kind: "split",
-      direction: "up",
-      pane: "pane:right",
+      direction: "right",
+      pane: "pane:left",
     });
   });
 
-  it("docks the first worker in column 1 without inventing a row rule", () => {
+  it("classifies an existing legacy IC-labelled surface as a right-column worker", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -676,12 +701,11 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orc"]),
-        ic: new Set(["surface:ic"]),
-        worker: new Set(),
+        worker: new Set(["surface:ic"]),
       },
       {
         role: "worker",
-        parentRole: "ic",
+        parentRole: "worker",
         parentSurfaceId: "surface:ic",
         childWorkerSurfaceIds: new Set(),
       },
@@ -690,7 +714,20 @@ describe("layout policy", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
   });
 
-  it("ignores a third worker column for a parent IC's first child", () => {
+  it("normalizes an in-memory legacy IC record before collecting role surfaces", () => {
+    const legacyAgent = {
+      role: "ic",
+      cli: "claude",
+      repo: "cmuxlayer",
+      surface_id: "surface:legacy-ic",
+    } as unknown as Pick<AgentRecord, "role" | "cli" | "repo" | "surface_id">;
+    const ids = collectRoleSurfaceIds([legacyAgent]);
+
+    expect(ids.worker).toEqual(new Set(["surface:legacy-ic"]));
+    expect(ids.orchestrator).toEqual(new Set());
+  });
+
+  it("blocks a child worker spawn when a third rendered column exists", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -702,26 +739,20 @@ describe("layout policy", () => {
       makePaneSurfaces("pane:other-workers", ["surface:worker-1"]),
     ];
 
-    const placement = chooseAgentSpawnPlacement(
-      panes,
-      paneSurfaces,
-      {
-        orchestrator: new Set(["surface:orc"]),
-        ic: new Set(["surface:ic"]),
-        worker: new Set(["surface:worker-1"]),
-      },
-      {
-        role: "worker",
-        parentRole: "ic",
-        parentSurfaceId: "surface:ic",
-        childWorkerSurfaceIds: new Set(),
-      },
-    );
-
-    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        {
+          orchestrator: new Set(["surface:orc"]),
+          worker: new Set(["surface:ic", "surface:worker-1"]),
+        },
+        { role: "worker", parentRole: "worker" },
+      ),
+    ).toThrow(/two-column/i);
   });
 
-  it("keeps sibling workers in canonical column 1 instead of a child row", () => {
+  it("blocks sibling worker placement when a third rendered column exists", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:orc"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -733,23 +764,17 @@ describe("layout policy", () => {
       makePaneSurfaces("pane:children", ["surface:child-1"]),
     ];
 
-    const placement = chooseAgentSpawnPlacement(
-      panes,
-      paneSurfaces,
-      {
-        orchestrator: new Set(["surface:orc"]),
-        ic: new Set(["surface:ic"]),
-        worker: new Set(["surface:child-1"]),
-      },
-      {
-        role: "worker",
-        parentRole: "ic",
-        parentSurfaceId: "surface:ic",
-        childWorkerSurfaceIds: new Set(["surface:child-1"]),
-      },
-    );
-
-    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        {
+          orchestrator: new Set(["surface:orc"]),
+          worker: new Set(["surface:ic", "surface:child-1"]),
+        },
+        { role: "worker", parentRole: "worker" },
+      ),
+    ).toThrow(/two-column/i);
   });
 
   it("docks the first child worker into an existing right-column non-lead pane", () => {
@@ -767,7 +792,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       {
@@ -799,7 +823,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker-1"]),
       },
       {
@@ -831,7 +854,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:child-1", "surface:child-2"]),
       },
       {
@@ -995,7 +1017,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "worker" },
@@ -1076,7 +1097,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(),
         worker: new Set(),
         unknown: new Set(["surface:unknown-worker"]),
       },
@@ -1114,7 +1134,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
         unknown: new Set(["surface:unknown-worker"]),
       },
@@ -1149,7 +1168,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
         unknown: new Set(["surface:unknown-worker"]),
       },
@@ -1177,7 +1195,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
         unknown: new Set(["surface:unknown-worker"]),
       },
@@ -1205,7 +1222,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "worker" },
@@ -1215,7 +1231,7 @@ describe("layout policy", () => {
     expect(placement).not.toEqual({ kind: "split", direction: "right" });
   });
 
-  it("uses column 1 instead of a sparse third column for parentless workers", () => {
+  it("blocks parentless worker placement when a sparse third column exists", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"]),
       makePane("pane:ic", 1, ["surface:ic"]),
@@ -1227,18 +1243,17 @@ describe("layout policy", () => {
       makePaneSurfaces("pane:right", ["surface:shell"]),
     ];
 
-    const placement = chooseAgentSpawnPlacement(
-      panes,
-      paneSurfaces,
-      {
-        orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(["surface:ic"]),
-        worker: new Set(),
-      },
-      { role: "worker" },
-    );
-
-    expect(placement).toEqual({ kind: "surface", pane: "pane:ic" });
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        {
+          orchestrator: new Set(["surface:orchestrator"]),
+          worker: new Set(["surface:ic"]),
+        },
+        { role: "worker" },
+      ),
+    ).toThrow(/two-column/i);
   });
 
   it("uses the existing column-1 pane without imposing a worker row", () => {
@@ -1256,8 +1271,7 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(["surface:ic"]),
-        worker: new Set(),
+        worker: new Set(["surface:ic"]),
       },
       { role: "worker" },
     );
@@ -1280,7 +1294,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:stale-worker"]),
       },
       { role: "worker" },
@@ -1300,7 +1313,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "worker" },
@@ -1324,7 +1336,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       {
@@ -1358,7 +1369,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker-1"]),
       },
       { role: "worker", worktree: true },
@@ -1382,7 +1392,6 @@ describe("layout policy", () => {
       paneSurfaces,
       {
         orchestrator: new Set(),
-        ic: new Set(),
         worker: new Set(),
       },
       { role: "worker" },
@@ -1488,7 +1497,7 @@ describe("layout policy", () => {
     });
   });
 
-  it("uses canonical column 1 when multiple worker columns exist", () => {
+  it("blocks placement when workers already occupy multiple columns", () => {
     const panes = [
       makePane("pane:left", 0, ["surface:interactive"]),
       makePane("pane:right", 1, ["surface:worker-1"]),
@@ -1500,13 +1509,13 @@ describe("layout policy", () => {
       makePaneSurfaces("pane:rightmost", ["surface:worker-2"]),
     ];
 
-    const placement = chooseAgentSpawnPlacement(
-      panes,
-      paneSurfaces,
-      new Set(["surface:worker-1", "surface:worker-2"]),
-    );
-
-    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        new Set(["surface:worker-1", "surface:worker-2"]),
+      ),
+    ).toThrow(/two-column/i);
   });
 });
 
@@ -1539,7 +1548,6 @@ describe("worktree worker placement — always right, never left", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(),
       },
       {
@@ -1576,7 +1584,6 @@ describe("worktree worker placement — always right, never left", () => {
         paneSurfaces,
         {
           orchestrator: new Set(["surface:orchestrator"]),
-          ic: new Set(),
           worker: new Set(),
         },
         {
@@ -1611,7 +1618,6 @@ describe("worktree worker placement — always right, never left", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker-1"]),
       },
       {
@@ -1629,7 +1635,7 @@ describe("worktree worker placement — always right, never left", () => {
     assertNeverLeft(placement);
   });
 
-  it("(b2) ignores a stray third column and docks in the canonical right column", () => {
+  it("(b2) blocks worktree placement when a stray third column exists", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
       makePane("pane:right", 1, ["surface:worker-1"], rightColumn),
@@ -1646,24 +1652,17 @@ describe("worktree worker placement — always right, never left", () => {
       makePaneSurfaces("pane:rightmost", ["surface:worker-2"]),
     ];
 
-    const placement = chooseAgentSpawnPlacement(
-      panes,
-      paneSurfaces,
-      {
-        orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
-        worker: new Set(["surface:worker-1", "surface:worker-2"]),
-      },
-      {
-        role: "worker",
-        parentRole: "orchestrator",
-        parentSurfaceId: "surface:orchestrator",
-        worktree: true,
-      },
-    );
-
-    expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
-    assertNeverLeft(placement);
+    expect(() =>
+      chooseAgentSpawnPlacement(
+        panes,
+        paneSurfaces,
+        {
+          orchestrator: new Set(["surface:orchestrator"]),
+          worker: new Set(["surface:worker-1", "surface:worker-2"]),
+        },
+        { role: "worker", worktree: true },
+      ),
+    ).toThrow(/two-column/i);
   });
 
   it("docks at the current top of the right column regardless of pane fill", () => {
@@ -1693,7 +1692,6 @@ describe("worktree worker placement — always right, never left", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker"]),
       },
       { role: "worker", worktree: true },
@@ -1702,7 +1700,7 @@ describe("worktree worker placement — always right, never left", () => {
     expect(placement).toEqual({ kind: "surface", pane: "pane:right-top" });
   });
 
-  it("keeps N worker spawns in the same canonical right-column top pane", () => {
+  it("blocks repeated worker placement while a third column remains", () => {
     const panes = [
       makePane("pane:lead", 0, ["surface:orchestrator"], leftColumn),
       makePane("pane:right", 1, ["surface:worker-0"], rightColumn),
@@ -1713,33 +1711,24 @@ describe("worktree worker placement — always right, never left", () => {
         height: 900,
       }),
     ];
-    const workerSurfaceIds = new Set([
-      "surface:worker-0",
-      "surface:worker-leftover",
-    ]);
-    const rightSurfaces = ["surface:worker-0"];
-
-    for (let index = 1; index <= 5; index += 1) {
-      const placement = chooseAgentSpawnPlacement(
+    expect(() =>
+      chooseAgentSpawnPlacement(
         panes,
         [
           makePaneSurfaces("pane:lead", ["surface:orchestrator"]),
-          makePaneSurfaces("pane:right", rightSurfaces),
+          makePaneSurfaces("pane:right", ["surface:worker-0"]),
           makePaneSurfaces("pane:leftover", ["surface:worker-leftover"]),
         ],
         {
           orchestrator: new Set(["surface:orchestrator"]),
-          ic: new Set(),
-          worker: workerSurfaceIds,
+          worker: new Set([
+            "surface:worker-0",
+            "surface:worker-leftover",
+          ]),
         },
         { role: "worker", worktree: true },
-      );
-
-      expect(placement).toEqual({ kind: "surface", pane: "pane:right" });
-      const spawned = `surface:worker-${index}`;
-      rightSurfaces.push(spawned);
-      workerSurfaceIds.add(spawned);
-    }
+      ),
+    ).toThrow(/two-column/i);
   });
 
   it("docks a lead in the top of column 0 even when that pane is worker-filled", () => {
@@ -1768,7 +1757,6 @@ describe("worktree worker placement — always right, never left", () => {
       ],
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:stray-worker", "surface:worker"]),
       },
       { role: "orchestrator" },
@@ -1808,7 +1796,6 @@ describe("worktree worker placement — always right, never left", () => {
       paneSurfaces,
       {
         orchestrator: new Set(["surface:orchestrator"]),
-        ic: new Set(),
         worker: new Set(["surface:worker-left", "surface:worker-right"]),
       },
       { role: "worker", worktree: true },

--- a/tests/mcp-quality.test.ts
+++ b/tests/mcp-quality.test.ts
@@ -134,12 +134,14 @@ describe("close_surface cleans up agent registry", () => {
       agent_id: "done-agent",
       surface_id: "surface:99",
       state: "done",
+      role: "worker",
     });
     const errorRecord = makeRecord({
       agent_id: "errored-agent",
       surface_id: "surface:100",
       state: "error",
       error: "surface disappeared",
+      role: "worker",
     });
     stateMgr.writeState(doneRecord);
     stateMgr.writeState(errorRecord);

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -49,6 +49,7 @@ async function spawnReadyAgent(server: any) {
       repo: "brainlayer",
       model: "sonnet",
       cli: "claude",
+      workspace: "workspace:1",
     },
     {} as any,
   );
@@ -734,6 +735,7 @@ describe("pane input pointer discipline", () => {
         repo: "brainlayer",
         model: "codex",
         cli: "codex",
+        workspace: "workspace:1",
         prompt: "x".repeat(2_000),
         allow_long_inline: true,
       },
@@ -769,6 +771,7 @@ describe("pane input pointer discipline", () => {
         repo: "brainlayer",
         model: "codex",
         cli: "codex",
+        workspace: "workspace:1",
         boot_prompt_path: promptPath,
       },
       {} as any,

--- a/tests/repo-workspace.test.ts
+++ b/tests/repo-workspace.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
   findWorkspaceRefForRepo,
+  normalizeWorkspaceRefAlias,
   repoNameMatchesWorkspaceDirectory,
   reposEquivalent,
   resolveWorkspaceRefForRepo,
   workspaceDirectoryRepoMatchScore,
 } from "../src/repo-workspace.js";
+
+describe("normalizeWorkspaceRefAlias", () => {
+  it("canonicalizes only the documented ws: ref alias", () => {
+    expect(normalizeWorkspaceRefAlias("ws:12")).toBe("workspace:12");
+    expect(normalizeWorkspaceRefAlias(" workspace:12 ")).toBe("workspace:12");
+    expect(normalizeWorkspaceRefAlias("scratch")).toBe("scratch");
+  });
+});
 
 describe("workspaceDirectoryRepoMatchScore", () => {
   it("scores an exact repo-root basename highest", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1900,6 +1900,51 @@ describe("agent lifecycle tool handlers", () => {
     ).toBe(false);
   });
 
+  it("spawn_agent allows an explicit workspace whose cwd does not identify a repo", async () => {
+    const baseExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (Array.isArray(args) && args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:brainlayer",
+                title: "brainlayerClaude",
+                selected: true,
+                current_directory: "/Users/etanheyman",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec as ExecFn);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "workspace:brainlayer",
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(
+      exec.mock.calls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          (args.includes("new-split") || args.includes("new-surface")),
+      ),
+    ).toBe(true);
+  });
+
   it("spawn_agent preserves parent workspace inheritance when workspace is omitted", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     process.env.CMUX_WORKSPACE_ID = "workspace:caller";
@@ -2420,6 +2465,36 @@ describe("agent lifecycle tool handlers", () => {
     const workspaceIndex = argv.indexOf("--workspace");
     expect(workspaceIndex).toBeGreaterThanOrEqual(0);
     expect(argv[workspaceIndex + 1]).toBe("workspace:1");
+  });
+
+  it("spawn_agent delivers prompts to the resolved workspace when cmux returns an empty workspace", async () => {
+    const exec = makeLifecycleExec({ createdWorkspace: "" });
+    const server = createLifecycleServer(exec);
+    const tool = (server as any)._registeredTools["spawn_agent"];
+    const prompt = "empty backend workspace fallback";
+
+    const result = await tool.handler(
+      {
+        repo: "brainlayer",
+        model: "codex",
+        cli: "codex",
+        prompt,
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(parsed.ok).toBe(true);
+    const promptSendCall = (exec as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([, args]) => {
+        const argv = args as string[];
+        return argv.includes("send") && argv.includes(prompt);
+      },
+    );
+    expect(promptSendCall).toBeDefined();
+    expect(promptSendCall![1]).toEqual(
+      expect.arrayContaining(["--workspace", "workspace:1"]),
+    );
   });
 
   it("spawn_agent deliberately allowed inline prompts preserve blank lines without empty chunks", async () => {
@@ -4432,14 +4507,14 @@ describe("agent lifecycle tool handlers", () => {
   it("broadcast returns per-lead receipts when one delivery fails without aborting others", async () => {
     const records = [
       makeServerAgentRecord({
-        agent_id: "ic-ok-1",
+        agent_id: "orc-ok-1",
         surface_id: "surface:ok-1",
         state: "ready",
         role: "orchestrator",
         task_summary: "first ok lead",
       }),
       makeServerAgentRecord({
-        agent_id: "ic-fail",
+        agent_id: "orc-fail",
         surface_id: "surface:fail",
         state: "ready",
         role: "orchestrator",
@@ -4479,12 +4554,12 @@ describe("agent lifecycle tool handlers", () => {
     expect(receipts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          agent_id: "ic-ok-1",
+          agent_id: "orc-ok-1",
           delivered: true,
           submit_verified: true,
         }),
         expect.objectContaining({
-          agent_id: "ic-fail",
+          agent_id: "orc-fail",
           delivered: false,
           submit_verified: null,
           error: expect.stringContaining("send failed for surface:fail"),
@@ -4628,7 +4703,7 @@ describe("agent lifecycle tool handlers", () => {
         role: "orchestrator",
       }),
       makeServerAgentRecord({
-        agent_id: "ic-working",
+        agent_id: "orc-working",
         surface_id: "surface:working",
         state: "working",
         role: "orchestrator",
@@ -4668,7 +4743,7 @@ describe("agent lifecycle tool handlers", () => {
           submit_verified: null,
         }),
         expect.objectContaining({
-          agent_id: "ic-working",
+          agent_id: "orc-working",
           delivered: false,
           submit_verified: null,
           skipped: "not_interactive:working",

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -83,6 +83,7 @@ const AGENT_TOOLS = [
 
 function makeLifecycleExec(opts?: {
   closeKeepsSurface?: boolean;
+  createdWorkspace?: string;
   shellNeverReady?: boolean;
   surfaceUuid?: string;
 }): ExecFn {
@@ -222,7 +223,8 @@ function makeLifecycleExec(opts?: {
 
     const workspaceIndex = args.indexOf("--workspace");
     const workspace =
-      workspaceIndex >= 0 ? String(args[workspaceIndex + 1]) : "ws:1";
+      opts?.createdWorkspace ??
+      (workspaceIndex >= 0 ? String(args[workspaceIndex + 1]) : "ws:1");
     return {
       stdout: JSON.stringify({
         workspace,
@@ -3599,7 +3601,10 @@ describe("agent lifecycle tool handlers", () => {
     vi.useFakeTimers();
     try {
       const server = createLifecycleServer(
-        makeLifecycleExec({ shellNeverReady: true }),
+        makeLifecycleExec({
+          createdWorkspace: "ws:1",
+          shellNeverReady: true,
+        }),
       );
       const spawn = (server as any)._registeredTools["spawn_agent"];
       const engine = (server as any)._registeredTools["interact"]._engine;
@@ -3792,7 +3797,10 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: "", stderr: "" };
       });
       const server = createTrackedServer({
-        exec: makeLifecycleExec({ shellNeverReady: true }),
+        exec: makeLifecycleExec({
+          createdWorkspace: "ws:1",
+          shellNeverReady: true,
+        }),
         stateDir: TEST_DIR,
         disableSpawnPreflight: true,
         sessionIdentityResolver: () => null,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -38,6 +38,10 @@ import {
 import { SurfaceWriteLivenessTracker } from "../src/surface-write-liveness.js";
 import { makeCodexRolloutFillProvider } from "../src/codex-rollout-fill.js";
 import type { CodexRolloutFill } from "../src/codex-rollout-fill.js";
+import {
+  currentCallerContext,
+  runWithCallerContext,
+} from "../src/caller-context.js";
 
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
@@ -216,9 +220,12 @@ function makeLifecycleExec(opts?: {
       };
     }
 
+    const workspaceIndex = args.indexOf("--workspace");
+    const workspace =
+      workspaceIndex >= 0 ? String(args[workspaceIndex + 1]) : "ws:1";
     return {
       stdout: JSON.stringify({
-        workspace: "ws:1",
+        workspace,
         surface: "surface:new",
         ...(opts?.surfaceUuid ? { surface_id: opts.surfaceUuid } : {}),
         pane: "pane:1",
@@ -230,7 +237,10 @@ function makeLifecycleExec(opts?: {
   });
 }
 
-function createTrackedServer(opts: Omit<CreateServerOptions, "context">) {
+function createTrackedServer(
+  opts: Omit<CreateServerOptions, "context">,
+  defaultCallerContext = true,
+) {
   const testObserverOwnerId = (): string | null => {
     const currentSocketPath = (
       opts.client as { currentSocketPath?: () => string | null } | undefined
@@ -261,7 +271,30 @@ function createTrackedServer(opts: Omit<CreateServerOptions, "context">) {
   };
   const context = createServerContext(normalizedOpts);
   serverContexts.push(context);
-  return createServer({ ...normalizedOpts, context });
+  const server = createServer({ ...normalizedOpts, context });
+  if (defaultCallerContext) {
+    const registeredTools = (server as any)._registeredTools as Record<
+      string,
+      { handler?: (...handlerArgs: any[]) => any }
+    >;
+    for (const toolName of [
+      "spawn_agent",
+      "new_worktree_split",
+      "spawn_in_workspace",
+      "new_split",
+    ]) {
+      const tool = registeredTools?.[toolName];
+      if (!tool?.handler) continue;
+      const handler = tool.handler.bind(tool);
+      tool.handler = (...handlerArgs: any[]) =>
+        currentCallerContext()
+          ? handler(...handlerArgs)
+          : runWithCallerContext({ workspaceId: "workspace:1" }, () =>
+              handler(...handlerArgs),
+            );
+    }
+  }
+  return server;
 }
 
 function createLifecycleServer(exec: ExecFn) {
@@ -1665,12 +1698,15 @@ describe("agent lifecycle tool handlers", () => {
       identify: vi.fn().mockResolvedValue({}),
       browser: vi.fn().mockResolvedValue({}),
     };
-    const server = createTrackedServer({
-      client: mockClient as any,
-      stateDir: TEST_DIR,
-      disableSpawnPreflight: true,
-      sessionIdentityResolver: () => null,
-    });
+    const server = createTrackedServer(
+      {
+        client: mockClient as any,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      },
+      false,
+    );
     const tool = (server as any)._registeredTools["spawn_agent"];
 
     const result = await tool.handler(
@@ -1693,7 +1729,7 @@ describe("agent lifecycle tool handlers", () => {
   it("spawn_agent prefers the caller pane workspace over the selected workspace when workspace is omitted", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     const previousTabId = process.env.CMUX_TAB_ID;
-    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    process.env.CMUX_WORKSPACE_ID = "selected-workspace-uuid";
     delete process.env.CMUX_TAB_ID;
 
     try {
@@ -1710,14 +1746,14 @@ describe("agent lifecycle tool handlers", () => {
               ref: "workspace:1",
               title: "Voice Remediation",
               selected: false,
-              current_directory: "/repo/orchestrator",
+              current_directory: "/repo/voicelayer",
             },
             {
               id: "selected-workspace-uuid",
               ref: "workspace:5",
               title: "Other Active Workspace",
               selected: true,
-              current_directory: "/repo/voicelayer",
+              current_directory: "/repo/t3layer",
             },
           ],
         }),
@@ -1777,13 +1813,17 @@ describe("agent lifecycle tool handlers", () => {
       });
       const tool = (server as any)._registeredTools["spawn_agent"];
 
-      const result = await tool.handler(
-        {
-          repo: "voicelayer",
-          model: "gpt-5.5",
-          cli: "codex",
-        },
-        {} as any,
+      const result = await runWithCallerContext(
+        { workspaceId: "caller-workspace-uuid" },
+        () =>
+          tool.handler(
+            {
+              repo: "voicelayer",
+              model: "gpt-5.5",
+              cli: "codex",
+            },
+            {} as any,
+          ),
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -1804,6 +1844,58 @@ describe("agent lifecycle tool handlers", () => {
         process.env.CMUX_TAB_ID = previousTabId;
       }
     }
+  });
+
+  it("spawn_agent refuses an explicit workspace owned by another repo before mutation", async () => {
+    const baseExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (Array.isArray(args) && args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:brainlayer",
+                title: "brainlayer",
+                selected: false,
+                current_directory: "/Users/etanheyman/Gits/brainlayer",
+              },
+              {
+                ref: "workspace:t3layer",
+                title: "t3layer",
+                selected: true,
+                current_directory: "/Users/etanheyman/Gits/t3layer",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec as ExecFn);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "worker",
+        workspace: "workspace:t3layer",
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/workspace.*t3layer.*brainlayer|brainlayer.*workspace.*t3layer/i);
+    expect(
+      exec.mock.calls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          (args.includes("new-split") || args.includes("new-surface")),
+      ),
+    ).toBe(false);
   });
 
   it("spawn_agent preserves parent workspace inheritance when workspace is omitted", async () => {
@@ -2069,25 +2161,26 @@ describe("agent lifecycle tool handlers", () => {
     expect(persisted.model).toBe("claude-opus-5[1m]");
   });
 
-  it("spawn_agent accepts explicit role and returns persisted role", async () => {
+  it("spawn_agent coerces legacy placement=ic to worker and reports the compatibility correction", async () => {
     const server = createLifecycleServer(mockExec);
     const tool = (server as any)._registeredTools["spawn_agent"];
 
-    const result = await tool.handler(
-      {
-        repo: "brainlayer",
-        model: "sonnet",
-        cli: "claude",
-        role: "ic",
-        prompt: "coordinate task",
-      },
-      {} as any,
-    );
+    const args = tool.inputSchema.parse({
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+      placement: "ic",
+      prompt: "coordinate task",
+    });
+    const result = await tool.handler(args, {} as any);
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
-    expect(parsed.role).toBe("ic");
+    expect(parsed.role).toBe("worker");
+    expect(parsed.warnings.join(" | ")).toMatch(
+      /legacy.*ic.*worker|ic.*coerc.*worker/i,
+    );
     expect(parsed.health).toBeUndefined();
 
     const stateTool = (server as any)._registeredTools["get_agent_state"];
@@ -2097,7 +2190,7 @@ describe("agent lifecycle tool handlers", () => {
     );
     const persisted =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
-    expect(persisted.role).toBe("ic");
+    expect(persisted.role).toBe("worker");
   });
 
   it("spawn_agent sends inline prompt after the agent is ready", async () => {
@@ -2295,7 +2388,7 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
-  it("spawn_agent delivers inline prompts to the actual workspace after placement mismatch", async () => {
+  it("spawn_agent canonicalizes a ws: alias and delivers inline prompts to the requested workspace", async () => {
     const server = createLifecycleServer(mockExec);
     const tool = (server as any)._registeredTools["spawn_agent"];
     const prompt = "fix placement mismatch prompt delivery";
@@ -2753,7 +2846,7 @@ describe("agent lifecycle tool handlers", () => {
   it("new_worktree_split defaults to the caller workspace instead of the selected workspace", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     const previousTabId = process.env.CMUX_TAB_ID;
-    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    process.env.CMUX_WORKSPACE_ID = "selected-workspace-uuid";
     delete process.env.CMUX_TAB_ID;
     try {
       const gitsDir = join(TEST_DIR, "Gits");
@@ -2778,7 +2871,7 @@ describe("agent lifecycle tool handlers", () => {
               ref: "workspace:caller",
               title: "Caller",
               selected: false,
-              current_directory: "/repo/orchestrator",
+              current_directory: repoRoot,
             },
             {
               id: "selected-workspace-uuid",
@@ -2847,14 +2940,18 @@ describe("agent lifecycle tool handlers", () => {
       });
       const tool = (server as any)._registeredTools["new_worktree_split"];
 
-      const result = await tool.handler(
-        {
-          repo: "cmuxlayer",
-          model: "codex",
-          cli: "codex",
-          worktree: { name: "caller worker" },
-        },
-        {} as any,
+      const result = await runWithCallerContext(
+        { workspaceId: "caller-workspace-uuid" },
+        () =>
+          tool.handler(
+            {
+              repo: "cmuxlayer",
+              model: "codex",
+              cli: "codex",
+              worktree: { name: "caller worker" },
+            },
+            {} as any,
+          ),
       );
       const parsed = parseToolResult(result);
 
@@ -3176,7 +3273,15 @@ describe("agent lifecycle tool handlers", () => {
         stderr: "",
       };
     });
-    const server = createLifecycleServer(mockExec);
+    const server = createTrackedServer(
+      {
+        exec: mockExec,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      },
+      false,
+    );
     const tool = (server as any)._registeredTools["spawn_agent"];
 
     const result = await tool.handler(
@@ -3318,7 +3423,15 @@ describe("agent lifecycle tool handlers", () => {
         stderr: "",
       };
     });
-    const server = createLifecycleServer(mockExec);
+    const server = createTrackedServer(
+      {
+        exec: mockExec,
+        stateDir: TEST_DIR,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      },
+      false,
+    );
     const tool = (server as any)._registeredTools["spawn_agent"];
 
     const result = await tool.handler(
@@ -4169,7 +4282,7 @@ describe("agent lifecycle tool handlers", () => {
           agent_id: "ic-target",
           surface_id: "surface:ic",
           state: "ready",
-          role: "ic",
+          role: "orchestrator",
           task_summary: "ic lane",
         }),
         makeServerAgentRecord({
@@ -4183,7 +4296,7 @@ describe("agent lifecycle tool handlers", () => {
           agent_id: "ic-excluded",
           surface_id: "surface:excluded",
           state: "ready",
-          role: "ic",
+          role: "orchestrator",
           task_summary: "excluded lane",
         }),
         makeServerAgentRecord({
@@ -4314,14 +4427,14 @@ describe("agent lifecycle tool handlers", () => {
         agent_id: "ic-ok-1",
         surface_id: "surface:ok-1",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
         task_summary: "first ok lead",
       }),
       makeServerAgentRecord({
         agent_id: "ic-fail",
         surface_id: "surface:fail",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
         task_summary: "failing lead",
       }),
       makeServerAgentRecord({
@@ -4417,7 +4530,7 @@ describe("agent lifecycle tool handlers", () => {
         agent_id: "ic-target",
         surface_id: "surface:ic",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
       }),
     ];
     const { server, sendCalls, sendKeyCalls } =
@@ -4446,7 +4559,7 @@ describe("agent lifecycle tool handlers", () => {
         agent_id: "ic-target",
         surface_id: "surface:ic",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
       }),
     ];
     const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(records);
@@ -4475,7 +4588,7 @@ describe("agent lifecycle tool handlers", () => {
         agent_id: "ic-stale",
         surface_id: "surface:stale",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
         task_summary: "possibly stale lead",
       }),
     ];
@@ -4504,13 +4617,13 @@ describe("agent lifecycle tool handlers", () => {
         agent_id: "ic-ready",
         surface_id: "surface:ready",
         state: "ready",
-        role: "ic",
+        role: "orchestrator",
       }),
       makeServerAgentRecord({
         agent_id: "ic-working",
         surface_id: "surface:working",
         state: "working",
-        role: "ic",
+        role: "orchestrator",
       }),
       makeServerAgentRecord({
         agent_id: "orc-done",
@@ -4710,10 +4823,10 @@ describe("agent lifecycle tool handlers", () => {
         role: "orchestrator",
       }),
       makeServerAgentRecord({
-        agent_id: "ic-target",
-        surface_id: "surface:ic",
+        agent_id: "worker-target-2",
+        surface_id: "surface:worker-2",
         state: "ready",
-        role: "ic",
+        role: "worker",
       }),
       makeServerAgentRecord({
         agent_id: "worker-target",
@@ -4733,10 +4846,12 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed).toMatchObject({
       ok: true,
       role: "workers",
-      target_count: 1,
-      delivered_count: 1,
+      target_count: 2,
+      delivered_count: 2,
     });
-    expect(sendCalls.map((call) => call.surface)).toEqual(["surface:worker"]);
+    expect(sendCalls.map((call) => call.surface).sort()).toEqual(
+      ["surface:worker", "surface:worker-2"].sort(),
+    );
 
     sendCalls.splice(0);
 
@@ -4753,7 +4868,7 @@ describe("agent lifecycle tool handlers", () => {
       delivered_count: 3,
     });
     expect(sendCalls.map((call) => call.surface).sort()).toEqual(
-      ["surface:orc", "surface:ic", "surface:worker"].sort(),
+      ["surface:orc", "surface:worker-2", "surface:worker"].sort(),
     );
   });
 
@@ -5493,29 +5608,36 @@ describe("agent lifecycle tool handlers", () => {
     ).toContain("closure_without_artifact");
   });
 
-  it("get_agent_state does not require worker closure artifacts for done IC agents", async () => {
+  it("get_agent_state normalizes persisted legacy IC agents to workers that require closure artifacts", async () => {
     const server = createLifecycleServer(mockExec);
     const getState = registeredTestTool(server, "get_agent_state");
     const engine = testLifecycleEngine(server);
     const agentId = "claude-cmuxlayer-ic-done";
-    const doneIc = makeServerAgentRecord({
+    const doneWorker = makeServerAgentRecord({
       agent_id: agentId,
       cli: "claude",
-      role: "ic",
-      task_summary: "integration coordinator",
+      role: "worker",
+      task_summary: "legacy integration coordinator",
     });
-    engine.stateMgr.writeState(doneIc);
-    engine.getRegistry().set(agentId, doneIc);
+    engine.stateMgr.writeState(doneWorker);
+    writeFileSync(
+      join(TEST_DIR, agentId, "state.json"),
+      JSON.stringify({ ...doneWorker, role: "ic" }),
+      "utf8",
+    );
+    const normalized = engine.stateMgr.readState(agentId);
+    expect(normalized?.role).toBe("worker");
+    engine.getRegistry().set(agentId, normalized!);
 
     const result = await getState.handler({ agent_id: agentId }, {});
     const parsed = parseToolResult(result);
     expect(parsed.harvestability).toMatchObject({
       closeable: false,
-      closure_artifact_verified: null,
+      closure_artifact_verified: false,
     });
     expect(
       (parsed.health as { issue_codes: string[] }).issue_codes,
-    ).not.toContain("closure_without_artifact");
+    ).toContain("closure_without_artifact");
   });
 
   it("get_agent_state does not mark non-done workers unhealthy for missing completion evidence", async () => {

--- a/tests/server-delete-workspace.test.ts
+++ b/tests/server-delete-workspace.test.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "../src/server.js";
 import { StateManager } from "../src/state-manager.js";
-import { runWithCallerContext } from "../src/caller-context.js";
+import {
+  callerContextFromEnv,
+  runWithCallerContext,
+} from "../src/caller-context.js";
 
 const roots: string[] = [];
 
@@ -92,7 +95,10 @@ function mockClient(opts?: { callerTarget?: boolean; surface?: boolean }) {
 describe("delete_workspace", () => {
   it("is registered off-default for deferred ToolSearch loading", async () => {
     const { client } = mockClient();
-    const server = createServer({ client: client as any, skipAgentLifecycle: true });
+    const server = createServer({
+      client: client as any,
+      skipAgentLifecycle: true,
+    });
     const tool = (server as any)._registeredTools.delete_workspace;
 
     expect(tool._meta).toMatchObject({
@@ -104,7 +110,10 @@ describe("delete_workspace", () => {
 
   it("removes an empty workspace and returns the removed diff", async () => {
     const { client } = mockClient();
-    const server = createServer({ client: client as any, skipAgentLifecycle: true });
+    const server = createServer({
+      client: client as any,
+      skipAgentLifecycle: true,
+    });
     const tool = (server as any)._registeredTools.delete_workspace;
 
     const result = await tool.handler({ workspace: "workspace:7" }, {} as any);
@@ -212,6 +221,38 @@ describe("delete_workspace", () => {
       agents: [],
     });
     await server.close();
+  });
+
+  it("refuses the in-process environment caller workspace without force", async () => {
+    const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
+    process.env.CMUX_WORKSPACE_ID = "workspace:7";
+    const { client } = mockClient({ callerTarget: true });
+    const server = createServer({
+      client: client as any,
+      skipAgentLifecycle: true,
+      safetyCallerContextProvider: () => callerContextFromEnv(),
+    });
+    const tool = (server as any)._registeredTools.delete_workspace;
+
+    try {
+      const result = await tool.handler(
+        { workspace: "workspace:7" },
+        {} as any,
+      );
+
+      expect(client.deleteWorkspace).not.toHaveBeenCalled();
+      expect(result.structuredContent).toMatchObject({
+        refused: true,
+        caller_workspace: true,
+      });
+    } finally {
+      await server.close();
+      if (previousWorkspaceId === undefined) {
+        delete process.env.CMUX_WORKSPACE_ID;
+      } else {
+        process.env.CMUX_WORKSPACE_ID = previousWorkspaceId;
+      }
+    }
   });
 
   it.each(["ws:7", "7", "scratch"])(

--- a/tests/server-delete-workspace.test.ts
+++ b/tests/server-delete-workspace.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "../src/server.js";
 import { StateManager } from "../src/state-manager.js";
+import { runWithCallerContext } from "../src/caller-context.js";
 
 const roots: string[] = [];
 
@@ -198,7 +199,10 @@ describe("delete_workspace", () => {
     const server = createServer({ client: client as any, skipAgentLifecycle: true });
     const tool = (server as any)._registeredTools.delete_workspace;
 
-    const result = await tool.handler({ workspace: "workspace:7" }, {} as any);
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:7" },
+      () => tool.handler({ workspace: "workspace:7" }, {} as any),
+    );
 
     expect(client.deleteWorkspace).not.toHaveBeenCalled();
     expect(result.structuredContent).toMatchObject({
@@ -220,9 +224,9 @@ describe("delete_workspace", () => {
       });
       const tool = (server as any)._registeredTools.delete_workspace;
 
-      const result = await tool.handler(
-        { workspace: workspaceAlias },
-        {} as any,
+      const result = await runWithCallerContext(
+        { workspaceId: "workspace:7" },
+        () => tool.handler({ workspace: workspaceAlias }, {} as any),
       );
 
       expect(client.deleteWorkspace).not.toHaveBeenCalled();

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6629,56 +6629,42 @@ describe("tool handler integration", () => {
     },
   );
 
-  it("new_split coerces legacy IC placement to the worker column without an up split", async () => {
+  it("new_split follows a remembered role surface UUID instead of its recycled ref", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
-    let moved = false;
-    let splitCount = 0;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-panes")) {
         return {
           stdout: JSON.stringify({
             workspace_ref: "workspace:1",
             window_ref: "window:1",
-            panes: moved
-              ? [
-                  {
-                    ref: "pane:left",
-                    index: 0,
-                    focused: false,
-                    surface_count: 1,
-                    surface_refs: ["surface:moved-worker"],
-                    surface_ids: [stableUuid],
-                    pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
-                  },
-                  {
-                    ref: "pane:right-recycled",
-                    index: 1,
-                    focused: true,
-                    surface_count: 1,
-                    surface_refs: ["surface:remembered-worker"],
-                    surface_ids: ["uuid-recycled"],
-                    pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
-                  },
-                ]
-              : [
-                  {
-                    ref: "pane:left",
-                    index: 0,
-                    focused: true,
-                    surface_count: 1,
-                    surface_refs: ["surface:manual"],
-                    surface_ids: ["uuid-manual"],
-                    pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
-                  },
-                ],
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:moved-worker"],
+                surface_ids: [stableUuid],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right-recycled",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:remembered-worker"],
+                surface_ids: ["uuid-recycled"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+              },
+            ],
           }),
           stderr: "",
         };
       }
       if (args.includes("list-pane-surfaces")) {
         const pane = String(args[args.indexOf("--pane") + 1] ?? "");
-        const surface = moved
-          ? pane === "pane:left"
+        const surface =
+          pane === "pane:left"
             ? {
                 ref: "surface:moved-worker",
                 id: stableUuid,
@@ -6688,12 +6674,7 @@ describe("tool handler integration", () => {
                 ref: "surface:remembered-worker",
                 id: "uuid-recycled",
                 title: "foreign shell",
-              }
-          : {
-              ref: "surface:manual",
-              id: "uuid-manual",
-              title: "manual",
-            };
+              };
         return {
           stdout: JSON.stringify({
             workspace_ref: "workspace:1",
@@ -6711,30 +6692,12 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      if (args.includes("new-split")) {
-        splitCount += 1;
-        return {
-          stdout: JSON.stringify({
-            workspace: "workspace:1",
-            surface:
-              splitCount === 1
-                ? "surface:remembered-worker"
-                : "surface:second-worker",
-            surface_id:
-              splitCount === 1 ? stableUuid : "uuid-second-worker",
-            pane: splitCount === 1 ? "pane:right" : "pane:new-right",
-            title: "",
-            type: "terminal",
-          }),
-          stderr: "",
-        };
-      }
       if (args.includes("new-surface")) {
         return {
           stdout: JSON.stringify({
             workspace: "workspace:1",
-            surface: "surface:wrong-recycled-tab",
-            surface_id: "uuid-wrong-tab",
+            surface: "surface:new-worker",
+            surface_id: "uuid-new-worker",
             pane: "pane:right-recycled",
             title: "",
             type: "terminal",
@@ -6744,46 +6707,169 @@ describe("tool handler integration", () => {
       }
       return { stdout: "{}", stderr: "" };
     });
-    const server = createServer({
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-role-uuid-memory");
+    rmSync(stateDir, { recursive: true, force: true });
+    const context = createServerContext({
       exec: mockExec,
       skipAgentLifecycle: true,
-      stateDir: join(CHANNEL_TEST_DIR, "new-split-role-uuid-memory"),
+      stateDir,
+      controlHealthIntervalMs: 0,
     });
-    const tool = (server as any)._registeredTools["new_split"];
+    context.roleSurfaceOverrides.set("surface:remembered-worker", {
+      role: "worker",
+      workspace: "workspace:1",
+      surfaceUuid: stableUuid,
+    });
+    const server = createServer({ context, skipAgentLifecycle: true });
 
-    await tool.handler(
-      { direction: "right", role: "worker", workspace: "workspace:1" },
-      {} as any,
-    );
-    moved = true;
-    const second = await tool.handler(
-      { direction: "right", role: "ic", workspace: "workspace:1" },
-      {} as any,
-    );
-    const parsed =
-      second.structuredContent ?? JSON.parse(second.content[0].text);
+    try {
+      const tool = (server as any)._registeredTools["new_split"];
+      const result = await tool.handler(
+        { direction: "right", role: "worker", workspace: "workspace:1" },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.surface).toBe("surface:wrong-recycled-tab");
-    expect(parsed.placement).toBe("surface");
-    expect(parsed.role).toBe("worker");
-    expect(parsed.warnings.join(" | ")).toMatch(/legacy.*ic.*worker/i);
-    expect(mockExec).not.toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining([
-        "new-split",
-        "up",
-        "--surface",
-        "surface:moved-worker",
-      ]),
-    );
-    expect(mockExec).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining([
-        "new-surface",
-        "--pane",
-        "pane:right-recycled",
-      ]),
-    );
+      expect(parsed.ok).toBe(true);
+      expect(context.roleSurfaceOverrides.has("surface:remembered-worker")).toBe(
+        false,
+      );
+      expect(
+        context.roleSurfaceOverrides.get("surface:moved-worker"),
+      ).toMatchObject({
+        role: "worker",
+        workspace: "workspace:1",
+        surfaceUuid: stableUuid,
+      });
+      expect(mockExec).not.toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["--surface", "surface:remembered-worker"]),
+      );
+    } finally {
+      await server.close();
+      context.dispose();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("new_split coerces legacy IC placement to the worker column without an up split", async () => {
+    mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:left",
+                index: 0,
+                focused: false,
+                surface_count: 1,
+                surface_refs: ["surface:lead"],
+                surface_ids: ["uuid-lead"],
+                pixel_frame: { x: 0, y: 0, width: 500, height: 900 },
+              },
+              {
+                ref: "pane:right-worker",
+                index: 1,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:worker"],
+                surface_ids: ["uuid-worker"],
+                pixel_frame: { x: 500, y: 0, width: 500, height: 900 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        const pane = String(args[args.indexOf("--pane") + 1] ?? "");
+        const surface =
+          pane === "pane:left"
+            ? {
+                ref: "surface:lead",
+                id: "uuid-lead",
+                title: "cmuxlayerClaude",
+              }
+            : {
+                ref: "surface:worker",
+                id: "uuid-worker",
+                title: "cmuxlayerCodex",
+              };
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces: [
+              {
+                ...surface,
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:second-worker",
+            surface_id: "uuid-second-worker",
+            pane: "pane:right-worker",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
+    const stateDir = join(CHANNEL_TEST_DIR, "new-split-legacy-ic-geometry");
+    rmSync(stateDir, { recursive: true, force: true });
+    const context = createServerContext({
+      exec: mockExec,
+      skipAgentLifecycle: true,
+      stateDir,
+      controlHealthIntervalMs: 0,
+    });
+    const server = createServer({ context, skipAgentLifecycle: true });
+
+    try {
+      const tool = (server as any)._registeredTools["new_split"];
+      const result = await tool.handler(
+        { direction: "right", role: "ic", workspace: "workspace:1" },
+        {} as any,
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+
+      expect(parsed.surface).toBe("surface:second-worker");
+      expect(parsed.placement).toBe("surface");
+      expect(parsed.role).toBe("worker");
+      expect(parsed.warnings.join(" | ")).toMatch(/legacy.*ic.*worker/i);
+      expect(mockExec).not.toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["new-split", "up"]),
+      );
+      expect(mockExec).toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining([
+          "new-surface",
+          "--pane",
+          "pane:right-worker",
+        ]),
+      );
+    } finally {
+      await server.close();
+      context.dispose();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("new_split does not prune role overrides from other workspaces", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -16,6 +16,10 @@ import { AgentRegistry } from "../src/agent-registry.js";
 import { AgentEngine } from "../src/agent-engine.js";
 import { dispatch, writeHeartbeat } from "../src/inbox.js";
 import type { FleetSidebarPublication } from "../src/fleet-sidebar.js";
+import {
+  currentCallerContext,
+  runWithCallerContext,
+} from "../src/caller-context.js";
 
 type InputDeliveryTestModule = typeof import("../src/server.js") & {
   SEND_INPUT_PASTE_BATCH_MAX_BYTES: number;
@@ -57,6 +61,43 @@ function createServerContext(
 }
 
 function createServer(
+  ...args: Parameters<typeof createServerImpl>
+): ReturnType<typeof createServerImpl> {
+  const server = createServerImpl(withTestObserver(args[0]));
+  const registeredTools = (server as any)._registeredTools as Record<
+    string,
+    { handler?: (...handlerArgs: any[]) => any }
+  >;
+  for (const toolName of [
+    "create_workspace",
+    "new_split",
+    "spawn_agent",
+    "new_worktree_split",
+    "spawn_in_workspace",
+  ]) {
+    const tool = registeredTools?.[toolName];
+    if (!tool?.handler) continue;
+    const handler = tool.handler.bind(tool);
+    tool.handler = (...handlerArgs: any[]) =>
+      currentCallerContext()
+        ? handler(...handlerArgs)
+        : runWithCallerContext({ workspaceId: "workspace:1" }, () =>
+            handler(...handlerArgs),
+          );
+  }
+  const close = server.close.bind(server);
+  server.close = async () => {
+    try {
+      await close();
+    } finally {
+      openServers.delete(server);
+    }
+  };
+  openServers.add(server);
+  return server;
+}
+
+function createServerWithoutCallerContext(
   ...args: Parameters<typeof createServerImpl>
 ): ReturnType<typeof createServerImpl> {
   const server = createServerImpl(withTestObserver(args[0]));
@@ -361,6 +402,51 @@ describe("createServer", () => {
     });
 
     await client.close();
+  });
+
+  it("advertises only orchestrator and worker in every placement-role enum", async () => {
+    const stateDir = processScopedTmpDir("cmuxlayer-role-schema-test");
+    rmSync(stateDir, { recursive: true, force: true });
+    const server = createServer({
+      stateDir,
+      exec: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      }),
+    });
+    const client = new Client({ name: "role-schema-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const tools = (await client.listTools()).tools;
+    const schemaFor = (name: string) => {
+      const schema = tools.find((tool) => tool.name === name)?.inputSchema as
+        | {
+            properties?: Record<string, any>;
+          }
+        | undefined;
+      expect(schema, `${name} must be tool-visible`).toBeDefined();
+      return schema!;
+    };
+    const publicRoles = ["orchestrator", "worker"];
+
+    expect(schemaFor("new_split").properties?.role.enum).toEqual(publicRoles);
+    expect(schemaFor("spawn_agent").properties?.role.enum).toEqual(publicRoles);
+    expect(schemaFor("spawn_agent").properties?.placement.enum).toEqual(
+      publicRoles,
+    );
+    expect(
+      schemaFor("spawn_in_workspace").properties?.agents.items.properties.role
+        .enum,
+    ).toEqual(publicRoles);
+
+    await client.close();
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("registers Claude channel capability when enabled", () => {
@@ -961,7 +1047,10 @@ describe("tool handler integration", () => {
     });
     const tool = (server as any)._registeredTools["create_workspace"];
 
-    const result = await tool.handler({ title: "red-team" }, {} as any);
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:manual" },
+      () => tool.handler({ title: "red-team" }, {} as any),
+    );
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -5079,7 +5168,7 @@ describe("tool handler integration", () => {
   it("new_split defaults to the caller workspace instead of the selected workspace", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     const previousTabId = process.env.CMUX_TAB_ID;
-    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    process.env.CMUX_WORKSPACE_ID = "focused-workspace-uuid";
     delete process.env.CMUX_TAB_ID;
     try {
       const mockClient = {
@@ -5121,7 +5210,10 @@ describe("tool handler integration", () => {
       });
       const tool = (server as any)._registeredTools["new_split"];
 
-      const result = await tool.handler({ direction: "right" }, {} as any);
+      const result = await runWithCallerContext(
+        { workspaceId: "caller-workspace-uuid" },
+        () => tool.handler({ direction: "right" }, {} as any),
+      );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
 
@@ -5151,7 +5243,7 @@ describe("tool handler integration", () => {
   it("new_split honors an explicit workspace before caller and focused workspaces", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     const previousTabId = process.env.CMUX_TAB_ID;
-    process.env.CMUX_WORKSPACE_ID = "caller-workspace-uuid";
+    process.env.CMUX_WORKSPACE_ID = "voice-workspace-uuid";
     delete process.env.CMUX_TAB_ID;
     try {
       const mockClient = {
@@ -5239,7 +5331,7 @@ describe("tool handler integration", () => {
               ref: "workspace:caller",
               title: "Caller",
               selected: false,
-              current_directory: "/repo/orchestrator",
+              current_directory: "/repo/voicelayer",
             },
             {
               id: "voice-workspace-uuid",
@@ -5284,9 +5376,13 @@ describe("tool handler integration", () => {
       });
       const tool = (server as any)._registeredTools["new_split"];
 
-      const result = await tool.handler(
-        { direction: "right", title: "voicelayerCodex" },
-        {} as any,
+      const result = await runWithCallerContext(
+        { workspaceId: "caller-workspace-uuid" },
+        () =>
+          tool.handler(
+            { direction: "right", title: "voicelayerCodex" },
+            {} as any,
+          ),
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -5313,7 +5409,7 @@ describe("tool handler integration", () => {
     }
   });
 
-  it("new_split warns when it falls back to the focused workspace", async () => {
+  it("new_split refuses missing caller and repo context without consulting focus", async () => {
     const previousWorkspaceId = process.env.CMUX_WORKSPACE_ID;
     const previousTabId = process.env.CMUX_TAB_ID;
     delete process.env.CMUX_WORKSPACE_ID;
@@ -5352,7 +5448,7 @@ describe("tool handler integration", () => {
           scrollback_used: false,
         }),
       };
-      const server = createServer({
+      const server = createServerWithoutCallerContext({
         client: mockClient as any,
         skipAgentLifecycle: true,
       });
@@ -5362,14 +5458,9 @@ describe("tool handler integration", () => {
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
 
-      expect(parsed.ok).toBe(true);
-      expect(mockClient.newSplit).toHaveBeenCalledWith(
-        "right",
-        expect.objectContaining({ workspace: "workspace:focused" }),
-      );
-      expect(parsed.warnings).toEqual([
-        expect.stringContaining("focused workspace"),
-      ]);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/workspace.*(caller|repo|explicit)/i);
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
     } finally {
       if (previousWorkspaceId === undefined) {
         delete process.env.CMUX_WORKSPACE_ID;
@@ -5445,7 +5536,7 @@ describe("tool handler integration", () => {
       selectWorkspace: vi.fn().mockResolvedValue(undefined),
       renameTab: vi.fn().mockResolvedValue(undefined),
     };
-    const server = createServer({
+    const server = createServerWithoutCallerContext({
       client: mockClient as any,
       skipAgentLifecycle: true,
     });
@@ -5532,7 +5623,7 @@ describe("tool handler integration", () => {
       selectWorkspace: vi.fn().mockResolvedValue(undefined),
       renameTab: vi.fn().mockResolvedValue(undefined),
     };
-    const server = createServer({
+    const server = createServerWithoutCallerContext({
       client: mockClient as any,
       skipAgentLifecycle: true,
     });
@@ -6538,7 +6629,7 @@ describe("tool handler integration", () => {
     },
   );
 
-  it("new_split follows a remembered role surface UUID instead of its recycled ref", async () => {
+  it("new_split coerces legacy IC placement to the worker column without an up split", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     let moved = false;
     let splitCount = 0;
@@ -6672,9 +6763,11 @@ describe("tool handler integration", () => {
     const parsed =
       second.structuredContent ?? JSON.parse(second.content[0].text);
 
-    expect(parsed.surface).toBe("surface:second-worker");
-    expect(parsed.placement).toBe("split");
-    expect(mockExec).toHaveBeenCalledWith(
+    expect(parsed.surface).toBe("surface:wrong-recycled-tab");
+    expect(parsed.placement).toBe("surface");
+    expect(parsed.role).toBe("worker");
+    expect(parsed.warnings.join(" | ")).toMatch(/legacy.*ic.*worker/i);
+    expect(mockExec).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
         "new-split",
@@ -6683,7 +6776,7 @@ describe("tool handler integration", () => {
         "surface:moved-worker",
       ]),
     );
-    expect(mockExec).not.toHaveBeenCalledWith(
+    expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
         "new-surface",

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -139,6 +139,7 @@ describe("spawn monitor boot", () => {
         model: "sonnet",
         cli: "claude",
         role: "orchestrator",
+        workspace: "workspace:1",
         verbose: true,
       },
       {} as any,
@@ -170,6 +171,7 @@ describe("spawn monitor boot", () => {
         model: "gpt-5.4",
         cli: "codex",
         role: "worker",
+        workspace: "workspace:1",
       },
       {} as any,
     );
@@ -206,6 +208,7 @@ describe("spawn monitor boot", () => {
           model: "sonnet",
           cli: "claude",
           role: "orchestrator",
+          workspace: "workspace:1",
           verbose: true,
         },
         {} as any,
@@ -235,6 +238,7 @@ describe("spawn monitor boot", () => {
         model: "sonnet",
         cli: "claude",
         role: "orchestrator",
+        workspace: "workspace:1",
       },
       {} as any,
     );

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/server.js";
 import { inboxPath, monitorAlive } from "../src/inbox.js";
 import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
+import { runWithCallerContext } from "../src/caller-context.js";
 
 const TEST_DIR = join(tmpdir(), "cmuxlayer-spawn-workspace-test");
 
@@ -327,14 +328,23 @@ describe("workspace spawn tools", () => {
     });
     const tool = (server as any)._registeredTools["spawn_in_workspace"];
 
-    const result = await tool.handler(
-      {
-        workspace_title: "red-team",
-        agents: [
-          { repo: "cmuxlayer", model: "gpt-5.4", cli: "codex", role: "worker" },
-        ],
-      },
-      {} as any,
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:manual" },
+      () =>
+        tool.handler(
+          {
+            workspace_title: "red-team",
+            agents: [
+              {
+                repo: "cmuxlayer",
+                model: "gpt-5.4",
+                cli: "codex",
+                role: "worker",
+              },
+            ],
+          },
+          {} as any,
+        ),
     );
 
     const parsed =
@@ -384,6 +394,52 @@ describe("workspace spawn tools", () => {
     });
   });
 
+  it("spawn_in_workspace refuses a reused workspace owned by another repo before mutation", async () => {
+    const client = makeWorkspaceClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          ref: "workspace:t3layer",
+          title: "t3layer",
+          current_directory: "/Users/etanheyman/Gits/t3layer",
+        },
+      ],
+    });
+    const server = createServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const tool = getTool(server, "spawn_in_workspace");
+
+    const result = await tool.handler(
+      {
+        workspace_title: "ignored-title",
+        reuse_workspace: "workspace:t3layer",
+        agents: [
+          {
+            repo: "brainlayer",
+            model: "gpt-5.4",
+            cli: "codex",
+            role: "worker",
+          },
+        ],
+      },
+      {} as any,
+    );
+    const parsed = parseStructuredResult<{ ok: boolean; error?: string }>(
+      result,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/workspace.*t3layer.*brainlayer|brainlayer.*workspace.*t3layer/i);
+    expect(client.createWorkspace).not.toHaveBeenCalled();
+    expect(client.selectWorkspace).not.toHaveBeenCalled();
+    expect(client.newSplit).not.toHaveBeenCalled();
+    expect(client.newSurface).not.toHaveBeenCalled();
+  });
+
   it("spawn_in_workspace refuses a manual-mode reused workspace before selecting", async () => {
     const client = makeWorkspaceClient();
     client.listStatus.mockResolvedValue([
@@ -423,7 +479,7 @@ describe("workspace spawn tools", () => {
     expect(client.newSplit).not.toHaveBeenCalled();
   });
 
-  it("same-repo child spawn inherits parent workspace and reports wrong actual workspace as unhealthy", async () => {
+  it("same-repo child spawn inherits parent workspace and blocks a wrong actual workspace without leaking", async () => {
     const fixture = readWrongWorkspaceFixture();
     const repo = repoLabelFromFixturePath(fixture.parent_agent.repo);
     const childRepo = repoLabelFromFixturePath(fixture.spawn_request.repo);
@@ -538,26 +594,29 @@ describe("workspace spawn tools", () => {
       },
       {},
     );
-    const child = parseStructuredResult<{
-      ok: boolean;
-      workspace_id?: string;
-      warnings?: string[];
-      health?: { status: string; issue_codes: string[] };
-    }>(childResult);
+    const child = parseStructuredResult<{ ok: boolean; error?: string }>(
+      childResult,
+    );
 
     expect(client.newSplit.mock.calls[1]?.[1]?.workspace).toBe(
       fixture.parent_agent.workspace_id,
     );
-    expect(child.ok).toBe(true);
-    expect(child.workspace_id).toBe(fixture.parent_agent.workspace_id);
-    expect(child.warnings).toEqual([
-      expect.stringMatching(/Spawn placement mismatch/),
-    ]);
-    expect(child.health).toMatchObject({
-      status: "unhealthy",
-      issue_codes: expect.arrayContaining([
-        "registry_surface_workspace_mismatch",
-      ]),
-    });
+    expect(childResult.isError).toBe(true);
+    expect(child.ok).toBe(false);
+    expect(child.error).toContain(
+      `Spawn placement blocked: requested ${fixture.parent_agent.workspace_id} but cmux returned workspace:B`,
+    );
+    expect(client.closeSurface).toHaveBeenCalledWith(
+      "surface:2",
+      expect.objectContaining({
+        workspace: "workspace:B",
+        collapsePane: false,
+      }),
+    );
+    expect(client.send).not.toHaveBeenCalledWith(
+      "surface:2",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -106,6 +106,22 @@ describe("StateManager", () => {
       const mgr = new StateManager(TEST_DIR);
       expect(mgr.readState("nonexistent-agent")).toBeNull();
     });
+
+    it("normalizes a persisted legacy IC record into the worker column", () => {
+      const mgr = new StateManager(TEST_DIR);
+      const record = makeRecord({ agent_id: "legacy-ic-agent" });
+      const agentDir = join(TEST_DIR, record.agent_id);
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(
+        join(agentDir, "state.json"),
+        JSON.stringify({ ...record, role: "ic" }),
+      );
+
+      expect(mgr.readState(record.agent_id)).toMatchObject({
+        agent_id: "legacy-ic-agent",
+        role: "worker",
+      });
+    });
   });
 
   describe("transition", () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -24,7 +24,10 @@ const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-v2-test.sock";
 function callTool(server: any, name: string, args: Record<string, unknown>) {
   const tool = server._registeredTools[name];
   if (!tool) throw new Error(`Tool not found: ${name}`);
-  return tool.handler(args, {} as any);
+  return tool.handler(
+    name === "spawn_agent" ? { workspace: "workspace:1", ...args } : args,
+    {} as any,
+  );
 }
 
 function parseResult(result: any): any {


### PR DESCRIPTION
## Summary

- Enforce the ratified two-role law: public agent roles are orchestrator (the existing lead spelling) and worker only. Legacy ic input and persisted state normalize to worker with a compatibility warning.
- Enforce deterministic two-column placement across spawn entrypoints. More than two rendered columns, seat identity mismatch, backend workspace mismatch, unresolved placement authority, and known foreign-repo workspaces now block before durable spawn state or launch.
- Remove shared-daemon environment and focused-workspace placement fallbacks; use explicit workspace, per-request caller context, parent workspace, or a matching repo workspace.
- Keep orchestrator naming unchanged in this lane, per the 2026-08-02 ratified addendum.

## Ratified law

This PR implements docs.local/defect-lane/addendum-241-ratified-two-roles.md together with the placement and workspace-leak addenda. The canonical runtime roles are lead/orchestrator and worker; ic is compatibility input only and receives no independent seat or column.

## Verification

- npm test -- --reporter=dot: 106/106 files, 2,337/2,337 tests passed
- npm run typecheck: passed
- npm run build: passed
- npm run pre-pr: 63/63 harness tests passed
- Push hook: full 2,337-test suite passed again
- CodeRabbit local gate: SKIPPED because the OSS CLI rate limit was exhausted; required red-team/blue-team fallback completed, disposition lint passed, and its 9 checker tests passed

## Live cmux evidence

Used only scratch workspace UUID 4D0C2DFC-5012-4746-920F-269F6B9D62EA (never workspace 1 or 2). Freshly resolved source surface UUID F4EE5030-ED4C-4DB6-BE78-EB30EA4CB5D3 was moved beside worker target UUID 5A468E80-8E8B-4FD9-A6C7-B938FB9792CF. Post-move topology reported column_count=2. The scratch workspace was then deleted by UUID and confirmed absent.

## Sequencing

This branch intentionally remains based on v0.4.17 and is currently one commit behind origin/main. Do not merge out of lane order; @cmuxlayer owns independent reviewer routing and merge sequencing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core spawn/placement, role semantics, and workspace resolution—callers that relied on `ic`, focused-workspace fallback, or mismatch warnings will break; misconfiguration now fails hard instead of degrading gracefully.
> 
> **Overview**
> Implements the ratified **two-column lead/worker** model: **`ic` is removed** as a public role—tool input and persisted state normalize to **`worker`** with compatibility warnings, and dedicated IC placement (including vertical splits) is gone.
> 
> **Spawn and placement are fail-closed** instead of warn-and-continue: seat identity mismatch and cmux returning a surface in a **different workspace** than requested now **abort and clean up** the unbound surface; workspaces with **more than two rendered columns** throw before creating surfaces. **`actual_workspace_id`** and placement-mismatch warnings are dropped from spawn results.
> 
> **Workspace authority is tightened**: placement no longer falls back to focused or shared-daemon env; callers need explicit workspace, per-request caller context, parent workspace, or repo-matched workspace, with **`assertWorkspaceBelongsToRepo`** refusing cross-repo targets. In-process entrypoints wire **`safetyCallerContextProvider`** so mutation safety can use process env without affecting placement; **`broadcast` “leads”** means orchestrator only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1fb72e542dd2f77ef97d62a2f2cfefd187e5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce ratified two-role placement by removing 'ic' and blocking mismatched spawns
> - Removes the `ic` role from `AgentRole` and all placement logic; persisted and tool-supplied `ic` values are normalized to `worker` at read/call time across [state-manager.ts](https://github.com/EtanHey/cmuxlayer/pull/347/files#diff-48f5aae831d763ad62d5e44527c3e96d45cfccfa451f8f81674c26e9bb0448a8), [server.ts](https://github.com/EtanHey/cmuxlayer/pull/347/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), and [layout-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/347/files#diff-bcf83a4c87a8a384dfa8befe55d139737fb29364f7d2e88780da3e9b51d8daed).
> - Spawn is now blocked (with surface cleanup) when cmux returns a workspace that doesn't match the requested one, or when a seat identity mismatch is detected before surface creation.
> - Adds a `PlacementTopologyError` that rejects spawns when a workspace already has more than two columns.
> - `resolveTargetWorkspace` no longer falls back to focused workspace; an explicit or per-request caller workspace is required, and the resolved workspace must belong to the target repo.
> - Introduces `normalizeWorkspaceRefAlias` to canonicalize the `ws:` shorthand to `workspace:` consistently.
> - Risk: any callers relying on `actual_workspace_id` in spawn results, placement warnings, or the focused-workspace fallback for caller identity will break silently or receive errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd1fb72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter workspace-aware agent placement and routing.
  - Enforced supported two-column layouts, with clear failures when placement cannot be completed.
  - Added safer seat and workspace validation before launching agents.

- **Bug Fixes**
  - Prevented agents from launching in the wrong workspace, with automatic cleanup.
  - Improved role placement, health checks, broadcasts, and terminal cleanup.
  - Legacy `ic` roles are now treated as worker roles and normalized automatically.
  - Added compatibility warnings for legacy placement requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->