### PR TITLE
fix: focus spawned agent surfaces before launch

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -168,8 +168,8 @@ export interface SpawnAgentParams {
   auto_archive_on_done?: boolean;
   max_cost_per_agent?: number;
   crash_recover?: boolean;
-  /** Internal lifecycle hook: runs immediately after cmux creates the surface,
-   * before launcher I/O or readiness polling can give the user time to move.
+  /** Internal lifecycle hook: runs immediately after cmux creates and focuses
+   * the surface, before launcher I/O or readiness polling can give the user time to move.
    */
   on_surface_created?: (surface: {
     surface: string;
@@ -668,6 +668,10 @@ interface AgentEngineClient {
   renameTab(
     surface: string,
     title: string,
+    opts?: { workspace?: string },
+  ): Promise<void>;
+  focusSurface(
+    surface: string,
     opts?: { workspace?: string },
   ): Promise<void>;
   selectWorkspace(workspace: string): Promise<void>;
@@ -4778,13 +4782,37 @@ export class AgentEngine {
       await this.cleanupUnboundCreatedSurface(surface, "agent-placement");
       throw error;
     }
+    const createdWorkspace = surface.actual_workspace ?? surface.workspace;
+    let surfaceFocusError: unknown = null;
+    try {
+      // A tab created in an unfocused pane does not initialize its terminal.
+      // Focus the exact returned surface before any shell/readiness I/O.
+      await this.client.focusSurface(surface.surface, {
+        workspace: createdWorkspace,
+      });
+    } catch (error) {
+      surfaceFocusError = error;
+    }
     try {
       await spawnParams.on_surface_created?.({
         surface: surface.surface,
-        workspace: surface.actual_workspace ?? surface.workspace,
+        workspace: createdWorkspace,
       });
     } catch {
       // Focus observation is advisory and must never discard a created handle.
+    }
+    if (surfaceFocusError) {
+      const message =
+        surfaceFocusError instanceof Error
+          ? surfaceFocusError.message
+          : String(surfaceFocusError);
+      throw new AgentLaunchError(
+        `Failed to focus created surface ${surface.surface}: ${message}`,
+        agentId,
+        surface.surface,
+        createdWorkspace,
+        surfaceFocusError,
+      );
     }
 
     // 2. Write initial state (creating → booting)

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4802,6 +4802,8 @@ export class AgentEngine {
       // Focus observation is advisory and must never discard a created handle.
     }
     if (surfaceFocusError) {
+      // Keep the unbound surface recoverable: AgentLaunchError returns its
+      // identity so the caller can inspect, retry, or close the failed tab.
       const message =
         surfaceFocusError instanceof Error
           ? surfaceFocusError.message

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -672,7 +672,10 @@ interface AgentEngineClient {
   ): Promise<void>;
   focusSurface(
     surface: string,
-    opts?: { workspace?: string },
+    opts?: {
+      workspace?: string;
+      beforeMutation?: () => Promise<void>;
+    },
   ): Promise<void>;
   selectWorkspace(workspace: string): Promise<void>;
   listPanes(opts?: { workspace?: string }): Promise<{
@@ -4789,6 +4792,12 @@ export class AgentEngine {
       // Focus the exact returned surface before any shell/readiness I/O.
       await this.client.focusSurface(surface.surface, {
         workspace: createdWorkspace,
+        beforeMutation: async () => {
+          this.assertSurfaceObserverEpochCurrent(
+            surface.observerEpoch,
+            "agent focus",
+          );
+        },
       });
     } catch (error) {
       surfaceFocusError = error;

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -324,12 +324,17 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
           this.runWorkspaceMutation("rename_tab", renameOpts?.workspace, () =>
             this.client.renameTab(surface, title, renameOpts),
           ),
-        focusSurface: (surface, focusOpts) =>
-          this.runWorkspaceMutation(
+        focusSurface: (surface, focusOpts) => {
+          const { beforeMutation, ...clientOpts } = focusOpts ?? {};
+          return this.runWorkspaceMutation(
             "focus_surface",
             focusOpts?.workspace,
-            () => this.client.focusSurface(surface, focusOpts),
-          ),
+            async () => {
+              await beforeMutation?.();
+              return this.client.focusSurface(surface, clientOpts);
+            },
+          );
+        },
         selectWorkspace: (workspace) =>
           this.runWorkspaceMutation("select_workspace", workspace, () =>
             this.client.selectWorkspace(workspace),
@@ -713,6 +718,14 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         "focus_surface",
         prior.workspace,
       );
+      const currentAfterPolicy = await this.currentFocusTargetBestEffort();
+      if (
+        !currentAfterPolicy ||
+        currentAfterPolicy.workspace !== expected.workspace ||
+        currentAfterPolicy.surface !== expected.surface
+      ) {
+        return;
+      }
       if (
         !isSurfaceObserverEpochCurrent(observerEpoch, () =>
           this.getSurfaceObserverEpoch(),

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -449,8 +449,10 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         ...(workspace ? { workspace } : {}),
         ...(priorFocus
           ? {
-              on_surface_created: async () => {
-                createdFocus = await this.currentFocusTargetBestEffort();
+              on_surface_created: ({ surface, workspace: createdWorkspace }) => {
+                createdFocus = createdWorkspace
+                  ? { workspace: createdWorkspace, surface }
+                  : null;
               },
             }
           : {}),

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -319,6 +319,12 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
           this.runWorkspaceMutation("rename_tab", renameOpts?.workspace, () =>
             this.client.renameTab(surface, title, renameOpts),
           ),
+        focusSurface: (surface, focusOpts) =>
+          this.runWorkspaceMutation(
+            "focus_surface",
+            focusOpts?.workspace,
+            () => this.client.focusSurface(surface, focusOpts),
+          ),
         selectWorkspace: (workspace) =>
           this.runWorkspaceMutation("select_workspace", workspace, () =>
             this.client.selectWorkspace(workspace),

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -673,7 +673,9 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     }
   }
 
-  private async currentFocusTargetBestEffort(): Promise<AppServerFocusTarget | null> {
+  private async currentFocusTargetBestEffort(): Promise<
+    AppServerFocusTarget | null
+  > {
     try {
       const focused = (await this.client.identify()).focused;
       const workspace = focused?.workspace_ref?.trim();
@@ -707,11 +709,22 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       return;
     }
     try {
+      await this.assertWorkspaceMutationAllowed(
+        "focus_surface",
+        prior.workspace,
+      );
+      if (
+        !isSurfaceObserverEpochCurrent(observerEpoch, () =>
+          this.getSurfaceObserverEpoch(),
+        )
+      ) {
+        return;
+      }
       await this.client.focusSurface(prior.surface, {
         workspace: prior.workspace,
       });
     } catch {
-      // Thread creation succeeded; keep focus restoration advisory.
+      // Thread creation succeeded; keep policy/transport restore failures advisory.
     }
   }
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -57,6 +57,11 @@ const LAUNCH_SHELL_READY_POLL_MS = 100;
 
 type CmuxLikeClient = CmuxClient | CmuxSocketClient;
 
+interface AppServerFocusTarget {
+  workspace: string;
+  surface: string;
+}
+
 function controlModeFromStatusEntries(entries: unknown): ControlMode {
   if (!Array.isArray(entries)) return "autonomous";
   const entry = entries.find((candidate): candidate is CmuxStatusEntry => {
@@ -433,23 +438,40 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       observerEpoch,
       "app-server thread start",
     );
-    const result = await this.engine.spawnAgent({
-      repo,
-      model: input.model ?? "codex",
-      cli: "codex",
-      prompt: `App Server bridge session for ${repo}`,
-      ...(workspace ? { workspace } : {}),
-    });
+    const priorFocus = await this.currentFocusTargetBestEffort();
+    let createdFocus: AppServerFocusTarget | null = null;
+    try {
+      const result = await this.engine.spawnAgent({
+        repo,
+        model: input.model ?? "codex",
+        cli: "codex",
+        prompt: `App Server bridge session for ${repo}`,
+        ...(workspace ? { workspace } : {}),
+        ...(priorFocus
+          ? {
+              on_surface_created: async () => {
+                createdFocus = await this.currentFocusTargetBestEffort();
+              },
+            }
+          : {}),
+      });
 
-    this.threadCwds.set(result.agent_id, input.cwd);
-    await this.waitForCodexPrompt(result.agent_id);
+      this.threadCwds.set(result.agent_id, input.cwd);
+      await this.waitForCodexPrompt(result.agent_id);
 
-    const agent = this.engine.getAgentState(result.agent_id);
-    if (!agent) {
-      throw new Error(`Agent disappeared after spawn: ${result.agent_id}`);
+      const agent = this.engine.getAgentState(result.agent_id);
+      if (!agent) {
+        throw new Error(`Agent disappeared after spawn: ${result.agent_id}`);
+      }
+
+      return toBridgeThread(input.cwd, createdAt, agent);
+    } finally {
+      await this.restoreFocusIfUnmovedBestEffort(
+        priorFocus,
+        createdFocus,
+        observerEpoch,
+      );
     }
-
-    return toBridgeThread(input.cwd, createdAt, agent);
   }
 
   async readThread(threadId: string): Promise<BridgeThread | null> {
@@ -646,6 +668,48 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       return this.observerEpochProvider()?.trim() || null;
     } catch {
       return null;
+    }
+  }
+
+  private async currentFocusTargetBestEffort(): Promise<AppServerFocusTarget | null> {
+    try {
+      const focused = (await this.client.identify()).focused;
+      const workspace = focused?.workspace_ref?.trim();
+      const surface = focused?.surface_ref?.trim();
+      return workspace && surface ? { workspace, surface } : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async restoreFocusIfUnmovedBestEffort(
+    prior: AppServerFocusTarget | null,
+    expected: AppServerFocusTarget | null,
+    observerEpoch: SurfaceObserverEpoch,
+  ): Promise<void> {
+    if (
+      !prior ||
+      !expected ||
+      !isSurfaceObserverEpochCurrent(observerEpoch, () =>
+        this.getSurfaceObserverEpoch(),
+      )
+    ) {
+      return;
+    }
+    const current = await this.currentFocusTargetBestEffort();
+    if (
+      !current ||
+      current.workspace !== expected.workspace ||
+      current.surface !== expected.surface
+    ) {
+      return;
+    }
+    try {
+      await this.client.focusSurface(prior.surface, {
+        workspace: prior.workspace,
+      });
+    } catch {
+      // Thread creation succeeded; keep focus restoration advisory.
     }
   }
 

--- a/src/mode-policy.ts
+++ b/src/mode-policy.ts
@@ -25,6 +25,7 @@ const MUTATING_TOOLS = new Set([
   "boot_prompt",
   "send_key",
   "rename_tab",
+  "focus_surface",
   "close_surface",
   "browser_surface",
   "spawn_agent",

--- a/src/server.ts
+++ b/src/server.ts
@@ -5137,10 +5137,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   /** Refresh the lease immediately after the surface mutation. */
   const capturePostCreationFocus = async (
     lease: FocusRestoreLease | null,
+    created?: { surface: string; workspace?: string },
   ): Promise<FocusRestoreLease | null> => {
     if (!lease) return null;
+    if (created?.surface) {
+      return {
+        ...lease,
+        expected: {
+          workspace: created.workspace ?? lease.expected.workspace,
+          surface: created.surface,
+        },
+      };
+    }
     const expected = await currentFocusTarget();
-    return expected?.surface ? { ...lease, expected } : null;
+    return expected?.surface ? { ...lease, expected } : lease;
   };
 
   const sameExactFocus = (left: FocusTarget, right: FocusTarget): boolean =>
@@ -9398,9 +9408,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               max_cost_per_agent: args.max_cost_per_agent,
               crash_recover: args.crash_recover,
               boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
-              on_surface_created: async () => {
+              on_surface_created: async (created) => {
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
+                  created,
                 );
               },
             });
@@ -9788,9 +9799,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             role: "worker",
             auto_archive_on_done: args.auto_archive_on_done ?? false,
             crash_recover: args.crash_recover,
-            on_surface_created: async () => {
+            on_surface_created: async (created) => {
               focusRestoreLease = await capturePostCreationFocus(
                 focusRestoreLease,
+                created,
               );
             },
             boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
@@ -10116,9 +10128,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               workspace,
               role: agent.role,
               auto_archive_on_done: false,
-              on_surface_created: async () => {
+              on_surface_created: async (created) => {
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
+                  created,
                 );
               },
             });

--- a/src/server.ts
+++ b/src/server.ts
@@ -8590,11 +8590,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : undefined;
           },
           focusSurface: async (surface, focusOpts) => {
+            const { beforeMutation, ...clientOpts } = focusOpts ?? {};
             await assertWorkspaceMutationAllowed(
               "agent_engine",
               focusOpts?.workspace,
             );
-            return client.focusSurface(surface, focusOpts);
+            await beforeMutation?.();
+            return client.focusSurface(surface, clientOpts);
           },
           selectWorkspace: async (workspace) => {
             await assertWorkspaceMutationAllowed("agent_engine", workspace);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8579,6 +8579,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? client.renameTab(surface, title, renameOpts)
               : undefined;
           },
+          focusSurface: async (surface, focusOpts) => {
+            await assertWorkspaceMutationAllowed(
+              "agent_engine",
+              focusOpts?.workspace,
+            );
+            return client.focusSurface(surface, focusOpts);
+          },
           selectWorkspace: async (workspace) => {
             await assertWorkspaceMutationAllowed("agent_engine", workspace);
             return client.selectWorkspace(workspace);
@@ -9153,7 +9160,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      `${PANE_INPUT_BREAKAGE_GUIDANCE} Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately. ${ZSH_BANG_INLINE_WARNING}`,
+      `${PANE_INPUT_BREAKAGE_GUIDANCE} Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. The created tab is focused long enough to initialize, then the exact origin focus is restored; pass focus:true to stay on the created tab. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately. ${ZSH_BANG_INLINE_WARNING}`,
       {
         repo: z
           .string()
@@ -9249,6 +9256,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .default(false)
           .describe(
             "When true, suppress same repo/workspace/role duplicate-lane warnings. Default false so collab leads see reusable existing agents before spawning another lane.",
+          ),
+        focus: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Leave focus on the created agent tab instead of restoring the exact origin after initialization.",
           ),
         allow_long_inline: z
           .boolean()
@@ -9359,8 +9373,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const spawnPrompt = hasInlinePrompt(args.prompt)
             ? args.prompt
             : (bootPromptText ?? "");
-          let focusRestoreLease =
-            await focusTargetBeforeSplit(spawnWorkspace);
+          let focusRestoreLease = await focusTargetBeforeSplit(
+            spawnWorkspace,
+            args.focus !== true,
+          );
           let result: Awaited<ReturnType<typeof engine.spawnAgent>>;
           try {
             result = await engine.spawnAgent({

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -86,6 +86,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
       lines: 20,
       scrollback_used: false,
     }),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
     renameTab: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -343,6 +343,49 @@ describe("AgentEngine", () => {
       );
     });
 
+    it("refuses created-surface focus when the observer changes before focus mutation", async () => {
+      engine.dispose();
+      const ownerId = "cmux:/tmp/cmux.sock#socket=1:2:3:4";
+      let observerEpoch = `${ownerId}@socket:1`;
+      const scopedRegistry = new AgentRegistry(
+        stateMgr,
+        async () => liveSurfaces,
+        {
+          observerIdProvider: () => ownerId,
+          observerEpochProvider: () => observerEpoch,
+        },
+      );
+      engine = new AgentEngine(stateMgr, scopedRegistry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+      });
+      (mockClient.focusSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async (
+          _surface: string,
+          opts?: { beforeMutation?: () => Promise<void> },
+        ) => {
+          observerEpoch = `${ownerId}@socket:2`;
+          await opts?.beforeMutation?.();
+        },
+      );
+
+      await expect(
+        engine.spawnAgent({
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          prompt: "Do not focus across an observer epoch",
+          workspace: "ws:1",
+        }),
+      ).rejects.toThrow(/surface observer changed.*agent focus/i);
+
+      expect(mockClient.focusSurface).toHaveBeenCalledWith(
+        "surface:new",
+        expect.objectContaining({ beforeMutation: expect.any(Function) }),
+      );
+      expect(stateMgr.listStates()).toHaveLength(0);
+    });
+
     it.each([
       {
         label: "explicit Claude worker",

--- a/tests/agent-hierarchy.test.ts
+++ b/tests/agent-hierarchy.test.ts
@@ -34,6 +34,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
       lines: 20,
       scrollback_used: false,
     }),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
     renameTab: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -912,12 +912,6 @@ describe("CmuxAppServerRuntime", () => {
       })
       .mockResolvedValueOnce({
         focused: {
-          workspace_ref: "workspace:app",
-          surface_ref: "surface:new",
-        },
-      })
-      .mockResolvedValueOnce({
-        focused: {
           workspace_ref:
             focusedAtRestore === "surface:new"
               ? "workspace:app"
@@ -948,6 +942,7 @@ describe("CmuxAppServerRuntime", () => {
       await expect(
         runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
       ).resolves.toMatchObject({ threadId: record.agent_id });
+      expect(client.identify).toHaveBeenCalledTimes(2);
       expect(client.focusSurface).toHaveBeenCalledTimes(expectedRestoreCalls);
       if (expectedRestoreCalls > 0) {
         expect(client.focusSurface).toHaveBeenCalledWith("surface:origin", {

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -883,6 +883,7 @@ describe("CmuxAppServerRuntime", () => {
       name: "restores the exact origin after a bridge thread initializes",
       focusedAtRestore: "surface:new",
       expectedRestoreCalls: 1,
+      expectedIdentifyCalls: 3,
       manualAtRestore: false,
       reconnectAtRestore: false,
     },
@@ -890,6 +891,7 @@ describe("CmuxAppServerRuntime", () => {
       name: "does not steal focus back after the user moves during initialization",
       focusedAtRestore: "surface:user-move",
       expectedRestoreCalls: 0,
+      expectedIdentifyCalls: 2,
       manualAtRestore: false,
       reconnectAtRestore: false,
     },
@@ -897,6 +899,7 @@ describe("CmuxAppServerRuntime", () => {
       name: "does not restore focus after the origin switches to manual mode",
       focusedAtRestore: "surface:new",
       expectedRestoreCalls: 0,
+      expectedIdentifyCalls: 2,
       manualAtRestore: true,
       reconnectAtRestore: false,
     },
@@ -904,6 +907,7 @@ describe("CmuxAppServerRuntime", () => {
       name: "does not restore focus after the cmux observer reconnects",
       focusedAtRestore: "surface:new",
       expectedRestoreCalls: 0,
+      expectedIdentifyCalls: 3,
       manualAtRestore: false,
       reconnectAtRestore: true,
     },
@@ -912,6 +916,7 @@ describe("CmuxAppServerRuntime", () => {
     async ({
       focusedAtRestore,
       expectedRestoreCalls,
+      expectedIdentifyCalls,
       manualAtRestore,
       reconnectAtRestore,
     }) => {
@@ -953,7 +958,16 @@ describe("CmuxAppServerRuntime", () => {
               surface_ref: focusedAtRestore,
             },
           };
-        });
+        })
+        .mockImplementation(async () => ({
+          focused: {
+            workspace_ref:
+              focusedAtRestore === "surface:new"
+                ? "workspace:app"
+                : "workspace:other",
+            surface_ref: focusedAtRestore,
+          },
+        }));
       const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
       const record = makeRecord();
       vi.spyOn((runtime as any).engine, "spawnAgent").mockImplementation(
@@ -979,7 +993,7 @@ describe("CmuxAppServerRuntime", () => {
         await expect(
           runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
         ).resolves.toMatchObject({ threadId: record.agent_id });
-        expect(client.identify).toHaveBeenCalledTimes(2);
+        expect(client.identify).toHaveBeenCalledTimes(expectedIdentifyCalls);
         expect(client.focusSurface).toHaveBeenCalledTimes(expectedRestoreCalls);
         if (expectedRestoreCalls > 0) {
           expect(client.focusSurface).toHaveBeenCalledWith("surface:origin", {
@@ -992,6 +1006,65 @@ describe("CmuxAppServerRuntime", () => {
       }
     },
   );
+
+  it("does not restore focus after it moves during mutation policy lookup", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          ref: "workspace:app",
+          title: "brainlayer",
+          selected: true,
+          current_directory: "/Users/test/Gits/brainlayer",
+        },
+      ],
+    });
+    let focusedSurface = "surface:new";
+    client.identify.mockImplementation(async () => ({
+      focused: {
+        workspace_ref: "workspace:app",
+        surface_ref: focusedSurface,
+      },
+    }));
+    client.listStatus.mockResolvedValueOnce([]);
+    client.listStatus.mockImplementation(async () => {
+      focusedSurface = "surface:user-move";
+      return [];
+    });
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const record = makeRecord();
+    vi.spyOn((runtime as any).engine, "spawnAgent").mockImplementation(
+      async (params: any) => {
+        await params.on_surface_created?.({
+          surface: "surface:new",
+          workspace: "workspace:app",
+        });
+        return {
+          agent_id: record.agent_id,
+          surface_id: "surface:new",
+          workspace_id: "workspace:app",
+          state: "booting",
+        };
+      },
+    );
+    vi.spyOn(runtime as any, "waitForCodexPrompt").mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn((runtime as any).engine, "getAgentState").mockReturnValue(record);
+
+    try {
+      await expect(
+        runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
+      ).resolves.toMatchObject({ threadId: record.agent_id });
+      expect(client.identify).toHaveBeenCalledTimes(3);
+      expect(client.focusSurface).not.toHaveBeenCalled();
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
 
   it("re-resolves the stable UUID before every bridge chunk and Return", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -883,77 +883,115 @@ describe("CmuxAppServerRuntime", () => {
       name: "restores the exact origin after a bridge thread initializes",
       focusedAtRestore: "surface:new",
       expectedRestoreCalls: 1,
+      manualAtRestore: false,
+      reconnectAtRestore: false,
     },
     {
       name: "does not steal focus back after the user moves during initialization",
       focusedAtRestore: "surface:user-move",
       expectedRestoreCalls: 0,
+      manualAtRestore: false,
+      reconnectAtRestore: false,
     },
-  ])("$name", async ({ focusedAtRestore, expectedRestoreCalls }) => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
-    mkdirSync(TEST_DIR, { recursive: true });
-    const client = makeClient();
-    client.listWorkspaces.mockResolvedValue({
-      workspaces: [
-        {
-          ref: "workspace:app",
-          title: "brainlayer",
-          selected: true,
-          current_directory: "/Users/test/Gits/brainlayer",
-        },
-      ],
-    });
-    client.identify
-      .mockResolvedValueOnce({
-        focused: {
-          workspace_ref: "workspace:origin",
-          surface_ref: "surface:origin",
-        },
-      })
-      .mockResolvedValueOnce({
-        focused: {
-          workspace_ref:
-            focusedAtRestore === "surface:new"
-              ? "workspace:app"
-              : "workspace:other",
-          surface_ref: focusedAtRestore,
-        },
-      });
-    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
-    const record = makeRecord();
-    vi.spyOn((runtime as any).engine, "spawnAgent").mockImplementation(
-      async (params: any) => {
-        await params.on_surface_created?.({
-          surface: "surface:new",
-          workspace: "workspace:app",
-        });
-        return {
-          agent_id: record.agent_id,
-          surface_id: "surface:new",
-          workspace_id: "workspace:app",
-          state: "booting",
-        };
-      },
-    );
-    vi.spyOn(runtime as any, "waitForCodexPrompt").mockResolvedValue(undefined);
-    vi.spyOn((runtime as any).engine, "getAgentState").mockReturnValue(record);
-
-    try {
-      await expect(
-        runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
-      ).resolves.toMatchObject({ threadId: record.agent_id });
-      expect(client.identify).toHaveBeenCalledTimes(2);
-      expect(client.focusSurface).toHaveBeenCalledTimes(expectedRestoreCalls);
-      if (expectedRestoreCalls > 0) {
-        expect(client.focusSurface).toHaveBeenCalledWith("surface:origin", {
-          workspace: "workspace:origin",
-        });
-      }
-    } finally {
-      runtime.dispose();
+    {
+      name: "does not restore focus after the origin switches to manual mode",
+      focusedAtRestore: "surface:new",
+      expectedRestoreCalls: 0,
+      manualAtRestore: true,
+      reconnectAtRestore: false,
+    },
+    {
+      name: "does not restore focus after the cmux observer reconnects",
+      focusedAtRestore: "surface:new",
+      expectedRestoreCalls: 0,
+      manualAtRestore: false,
+      reconnectAtRestore: true,
+    },
+  ])(
+    "$name",
+    async ({
+      focusedAtRestore,
+      expectedRestoreCalls,
+      manualAtRestore,
+      reconnectAtRestore,
+    }) => {
       rmSync(TEST_DIR, { recursive: true, force: true });
-    }
-  });
+      mkdirSync(TEST_DIR, { recursive: true });
+      const client = makeClient();
+      client.listWorkspaces.mockResolvedValue({
+        workspaces: [
+          {
+            ref: "workspace:app",
+            title: "brainlayer",
+            selected: true,
+            current_directory: "/Users/test/Gits/brainlayer",
+          },
+        ],
+      });
+      if (manualAtRestore) {
+        client.listStatus
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([{ key: "mode.control", value: "manual" }]);
+      }
+      let socketPath = "/tmp/cmux-app-test.sock";
+      client.currentSocketPath.mockImplementation(() => socketPath);
+      client.identify
+        .mockResolvedValueOnce({
+          focused: {
+            workspace_ref: "workspace:origin",
+            surface_ref: "surface:origin",
+          },
+        })
+        .mockImplementationOnce(async () => {
+          if (reconnectAtRestore) socketPath = "/tmp/cmux-reconnected.sock";
+          return {
+            focused: {
+              workspace_ref:
+                focusedAtRestore === "surface:new"
+                  ? "workspace:app"
+                  : "workspace:other",
+              surface_ref: focusedAtRestore,
+            },
+          };
+        });
+      const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+      const record = makeRecord();
+      vi.spyOn((runtime as any).engine, "spawnAgent").mockImplementation(
+        async (params: any) => {
+          await params.on_surface_created?.({
+            surface: "surface:new",
+            workspace: "workspace:app",
+          });
+          return {
+            agent_id: record.agent_id,
+            surface_id: "surface:new",
+            workspace_id: "workspace:app",
+            state: "booting",
+          };
+        },
+      );
+      vi.spyOn(runtime as any, "waitForCodexPrompt").mockResolvedValue(
+        undefined,
+      );
+      vi.spyOn((runtime as any).engine, "getAgentState").mockReturnValue(record);
+
+      try {
+        await expect(
+          runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
+        ).resolves.toMatchObject({ threadId: record.agent_id });
+        expect(client.identify).toHaveBeenCalledTimes(2);
+        expect(client.focusSurface).toHaveBeenCalledTimes(expectedRestoreCalls);
+        if (expectedRestoreCalls > 0) {
+          expect(client.focusSurface).toHaveBeenCalledWith("surface:origin", {
+            workspace: "workspace:origin",
+          });
+        }
+      } finally {
+        runtime.dispose();
+        rmSync(TEST_DIR, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("re-resolves the stable UUID before every bridge chunk and Return", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -59,6 +59,8 @@ function makeClient() {
       type: "terminal",
     }),
     newSurface: vi.fn(),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
+    identify: vi.fn(),
     selectWorkspace: vi.fn(),
     send: vi.fn().mockResolvedValue(undefined),
     sendKey: vi.fn().mockResolvedValue(undefined),
@@ -870,6 +872,88 @@ describe("CmuxAppServerRuntime", () => {
       expect(spawnAgent).not.toHaveBeenCalled();
       expect(client.newSplit).not.toHaveBeenCalled();
       expect(client.newSurface).not.toHaveBeenCalled();
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "restores the exact origin after a bridge thread initializes",
+      focusedAtRestore: "surface:new",
+      expectedRestoreCalls: 1,
+    },
+    {
+      name: "does not steal focus back after the user moves during initialization",
+      focusedAtRestore: "surface:user-move",
+      expectedRestoreCalls: 0,
+    },
+  ])("$name", async ({ focusedAtRestore, expectedRestoreCalls }) => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          ref: "workspace:app",
+          title: "brainlayer",
+          selected: true,
+          current_directory: "/Users/test/Gits/brainlayer",
+        },
+      ],
+    });
+    client.identify
+      .mockResolvedValueOnce({
+        focused: {
+          workspace_ref: "workspace:origin",
+          surface_ref: "surface:origin",
+        },
+      })
+      .mockResolvedValueOnce({
+        focused: {
+          workspace_ref: "workspace:app",
+          surface_ref: "surface:new",
+        },
+      })
+      .mockResolvedValueOnce({
+        focused: {
+          workspace_ref:
+            focusedAtRestore === "surface:new"
+              ? "workspace:app"
+              : "workspace:other",
+          surface_ref: focusedAtRestore,
+        },
+      });
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const record = makeRecord();
+    vi.spyOn((runtime as any).engine, "spawnAgent").mockImplementation(
+      async (params: any) => {
+        await params.on_surface_created?.({
+          surface: "surface:new",
+          workspace: "workspace:app",
+        });
+        return {
+          agent_id: record.agent_id,
+          surface_id: "surface:new",
+          workspace_id: "workspace:app",
+          state: "booting",
+        };
+      },
+    );
+    vi.spyOn(runtime as any, "waitForCodexPrompt").mockResolvedValue(undefined);
+    vi.spyOn((runtime as any).engine, "getAgentState").mockReturnValue(record);
+
+    try {
+      await expect(
+        runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
+      ).resolves.toMatchObject({ threadId: record.agent_id });
+      expect(client.focusSurface).toHaveBeenCalledTimes(expectedRestoreCalls);
+      if (expectedRestoreCalls > 0) {
+        expect(client.focusSurface).toHaveBeenCalledWith("surface:origin", {
+          workspace: "workspace:origin",
+        });
+      }
     } finally {
       runtime.dispose();
       rmSync(TEST_DIR, { recursive: true, force: true });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -255,6 +255,7 @@ function createPlacementClient(
         },
       ),
     newSurface: vi.fn(),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
     send: vi.fn().mockResolvedValue(undefined),
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({

--- a/tests/mode-policy.test.ts
+++ b/tests/mode-policy.test.ts
@@ -61,6 +61,7 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("stop_agent")).toBe(true);
     expect(isMutatingTool("kill")).toBe(true);
     expect(isMutatingTool("agent_engine")).toBe(true);
+    expect(isMutatingTool("focus_surface")).toBe(true);
   });
 
   it("returns false for list_surfaces", () => {
@@ -109,6 +110,9 @@ describe("assertMutationAllowed", () => {
       /manual/i,
     );
     expect(() => assertMutationAllowed("agent_engine", "manual")).toThrow(
+      /manual/i,
+    );
+    expect(() => assertMutationAllowed("focus_surface", "manual")).toThrow(
       /manual/i,
     );
     expect(() => assertMutationAllowed("kill", "manual")).toThrow(/manual/i);

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -33,6 +33,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
       lines: 20,
       scrollback_used: false,
     }),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
     renameTab: vi.fn().mockResolvedValue(undefined),
     setStatus: vi.fn().mockResolvedValue(undefined),
     closeSurface: vi.fn().mockResolvedValue(undefined),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10101,15 +10101,24 @@ describe("auto-focus discipline (focus target before split, restore after render
     };
     focusSurfaceFails?: boolean;
     focusCreatedSurfaceFails?: boolean;
+    failFocusObservationAfterCreation?: boolean;
   }): { exec: ExecFn; calls: string[][] } {
     const calls: string[][] = [];
     const lifecycleExec = makeLifecycleExec();
     let focusedWorkspace = opts?.selectedWorkspace ?? "workspace:1";
     let focusedSurface = opts?.focusedSurface ?? "surface:origin";
     let spawnCreated = false;
+    let createdSurfaceReadStarted = false;
     const exec = vi.fn(async (cmd: string, args: string[]) => {
       calls.push(args);
       if (args.includes("identify")) {
+        if (
+          opts?.failFocusObservationAfterCreation &&
+          spawnCreated &&
+          !createdSurfaceReadStarted
+        ) {
+          throw new Error("transient post-creation identify failure");
+        }
         return {
           stdout: JSON.stringify({
             caller: {
@@ -10163,6 +10172,14 @@ describe("auto-focus discipline (focus target before split, restore after render
           }),
           stderr: "",
         };
+      }
+      if (
+        opts?.failFocusObservationAfterCreation &&
+        spawnCreated &&
+        !createdSurfaceReadStarted &&
+        args.includes("list-workspaces")
+      ) {
+        throw new Error("transient post-creation workspace-list failure");
       }
       if (opts?.roleTopology && args.includes("list-panes")) {
         return {
@@ -10242,6 +10259,13 @@ describe("auto-focus discipline (focus target before split, restore after render
           }),
           stderr: "",
         };
+      }
+      if (
+        spawnCreated &&
+        args.includes("read-screen") &&
+        args.includes("surface:new")
+      ) {
+        createdSurfaceReadStarted = true;
       }
       if (
         spawnCreated &&
@@ -10462,6 +10486,41 @@ describe("auto-focus discipline (focus target before split, restore after render
       expect(result.structuredContent.ok).toBe(true);
       expect(focusSurfaceIdx(calls, "surface:new")).toBeGreaterThanOrEqual(0);
       expect(focusSurfaceIdx(calls, "surface:worker")).toBe(-1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent restores the exact origin without re-observing post-creation focus", async () => {
+    vi.useFakeTimers();
+    try {
+      const { exec, calls } = makeFocusLifecycleExec({
+        focusedSurface: "surface:worker",
+        roleTopology: true,
+        focusGatesCreatedSurfaceReadiness: true,
+        failFocusObservationAfterCreation: true,
+      });
+      const server = createLifecycleServer(exec);
+      const tool = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = tool.handler(
+        {
+          repo: "cmuxlayer",
+          cli: "claude",
+          placement: "orchestrator",
+          workspace: "workspace:1",
+          force_new: true,
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+
+      expect(result.structuredContent.ok).toBe(true);
+      expect(focusSurfaceIdx(calls, "surface:worker")).toBeGreaterThan(
+        firstReadScreenIdx(calls),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1854,6 +1854,7 @@ describe("agent lifecycle tool handlers", () => {
         };
       }),
       newSurface: vi.fn(),
+      focusSurface: vi.fn().mockResolvedValue(undefined),
       send: vi.fn().mockResolvedValue(undefined),
       sendKey: vi.fn().mockResolvedValue(undefined),
       readScreen: vi.fn().mockResolvedValue({
@@ -1961,6 +1962,7 @@ describe("agent lifecycle tool handlers", () => {
           };
         }),
         newSurface: vi.fn(),
+        focusSurface: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
         sendKey: vi.fn().mockResolvedValue(undefined),
         readScreen: vi.fn().mockResolvedValue({
@@ -3163,6 +3165,7 @@ describe("agent lifecycle tool handlers", () => {
           };
         }),
         newSurface: vi.fn(),
+        focusSurface: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
         sendKey: vi.fn().mockResolvedValue(undefined),
         readScreen: vi.fn().mockResolvedValue({
@@ -6279,6 +6282,7 @@ codex>
         };
       }),
       newSurface: vi.fn(),
+      focusSurface: vi.fn().mockResolvedValue(undefined),
       send: vi.fn().mockResolvedValue(undefined),
       sendKey: vi.fn().mockResolvedValue(undefined),
       readScreen: vi.fn().mockResolvedValue({
@@ -10089,11 +10093,14 @@ describe("auto-focus discipline (focus target before split, restore after render
   function makeFocusLifecycleExec(opts?: {
     selectedWorkspace?: string;
     focusedSurface?: string;
+    roleTopology?: boolean;
+    focusGatesCreatedSurfaceReadiness?: boolean;
     moveFocusDuringReadinessTo?: {
       workspace: string;
       surface: string;
     };
     focusSurfaceFails?: boolean;
+    focusCreatedSurfaceFails?: boolean;
   }): { exec: ExecFn; calls: string[][] } {
     const calls: string[][] = [];
     const lifecycleExec = makeLifecycleExec();
@@ -10120,11 +10127,21 @@ describe("auto-focus discipline (focus target before split, restore after render
         };
       }
       if (args.includes("rpc") && args.includes("surface.focus")) {
-        if (opts?.focusSurfaceFails) throw new Error("focus restore failed");
         const payload = JSON.parse(args.at(-1) ?? "{}") as {
           surface_id?: string;
           workspace_id?: string;
         };
+        if (
+          (opts?.focusSurfaceFails && payload.surface_id !== "surface:new") ||
+          (opts?.focusCreatedSurfaceFails &&
+            payload.surface_id === "surface:new")
+        ) {
+          throw new Error(
+            payload.surface_id === "surface:new"
+              ? "created surface focus failed"
+              : "focus restore failed",
+          );
+        }
         focusedWorkspace = payload.workspace_id ?? focusedWorkspace;
         focusedSurface = payload.surface_id ?? focusedSurface;
         return { stdout: "{}", stderr: "" };
@@ -10143,6 +10160,102 @@ describe("auto-focus discipline (focus target before split, restore after render
           stdout: JSON.stringify({
             workspace: "workspace:2",
             title: "Review team",
+          }),
+          stderr: "",
+        };
+      }
+      if (opts?.roleTopology && args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:lead",
+                index: 0,
+                focused:
+                  focusedSurface === "surface:lead" ||
+                  focusedSurface === "surface:new",
+                surface_count: spawnCreated ? 2 : 1,
+                surface_refs: [
+                  "surface:lead",
+                  ...(spawnCreated ? ["surface:new"] : []),
+                ],
+                selected_surface_ref: spawnCreated
+                  ? "surface:new"
+                  : "surface:lead",
+                pixel_frame: { x: 0, y: 0, width: 800, height: 900 },
+              },
+              {
+                ref: "pane:worker",
+                index: 1,
+                focused: focusedSurface === "surface:worker",
+                surface_count: 1,
+                surface_refs: ["surface:worker"],
+                selected_surface_ref: "surface:worker",
+                pixel_frame: { x: 800, y: 0, width: 800, height: 900 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (opts?.roleTopology && args.includes("list-pane-surfaces")) {
+        const pane = args[args.indexOf("--pane") + 1];
+        const surfaces =
+          pane === "pane:worker"
+            ? [
+                {
+                  ref: "surface:worker",
+                  title: "cmuxlayerCodex",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ]
+            : [
+                {
+                  ref: "surface:lead",
+                  title: "cmuxlayerClaude",
+                  type: "terminal",
+                  index: 0,
+                  selected: !spawnCreated,
+                },
+                ...(spawnCreated
+                  ? [
+                      {
+                        ref: "surface:new",
+                        title: "cmuxlayerClaude [surface:new]",
+                        type: "terminal",
+                        index: 1,
+                        selected: true,
+                      },
+                    ]
+                  : []),
+              ];
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: pane,
+            surfaces,
+          }),
+          stderr: "",
+        };
+      }
+      if (
+        spawnCreated &&
+        opts?.focusGatesCreatedSurfaceReadiness &&
+        args.includes("read-screen") &&
+        args.includes("surface:new") &&
+        focusedSurface !== "surface:new"
+      ) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: "terminal initializing",
+            lines: 20,
+            scrollback_used: false,
           }),
           stderr: "",
         };
@@ -10250,6 +10363,144 @@ describe("auto-focus discipline (focus target before split, restore after render
     expect(result.structuredContent.ok).toBe(true);
     expect(selectIdx(calls, "workspace:2")).toBeGreaterThanOrEqual(0);
     expect(focusSurfaceIdx(calls, "surface:origin")).toBeGreaterThanOrEqual(0);
+  });
+
+  it.each([
+    {
+      name: "orchestrator tab while the worker pane holds focus",
+      placement: "orchestrator" as const,
+      cli: "claude" as const,
+      origin: "surface:worker",
+    },
+    {
+      name: "orchestrator tab while the lead pane holds focus",
+      placement: "orchestrator" as const,
+      cli: "claude" as const,
+      origin: "surface:lead",
+    },
+    {
+      name: "worker tab while the lead pane holds focus",
+      placement: "worker" as const,
+      cli: "codex" as const,
+      origin: "surface:lead",
+    },
+  ])(
+    "spawn_agent boots a $name, then restores the exact origin",
+    async ({ placement, cli, origin }) => {
+      vi.useFakeTimers();
+      try {
+        const { exec, calls } = makeFocusLifecycleExec({
+          focusedSurface: origin,
+          roleTopology: true,
+          focusGatesCreatedSurfaceReadiness: true,
+        });
+        const server = createLifecycleServer(exec);
+        const tool = (server as any)._registeredTools["spawn_agent"];
+
+        const resultPromise = tool.handler(
+          {
+            repo: "cmuxlayer",
+            cli,
+            placement,
+            workspace: "workspace:1",
+            force_new: true,
+            boot_prompt_timeout_ms: 20,
+          },
+          {} as any,
+        );
+        await vi.advanceTimersByTimeAsync(100);
+        const result = await resultPromise;
+
+        expect(result.structuredContent.ok).toBe(true);
+        expect(result.structuredContent.surface_id).toBe("surface:new");
+        const created = calls.findIndex((args) =>
+          args.includes("new-surface"),
+        );
+        const focusedCreated = focusSurfaceIdx(calls, "surface:new");
+        const firstCreatedRead = calls.findIndex(
+          (args, index) =>
+            index > created &&
+            args.includes("read-screen") &&
+            args.includes("surface:new"),
+        );
+        const restoredOrigin = focusSurfaceIdx(calls, origin);
+
+        expect(created).toBeGreaterThanOrEqual(0);
+        expect(focusedCreated).toBeGreaterThan(created);
+        expect(firstCreatedRead).toBeGreaterThan(focusedCreated);
+        expect(restoredOrigin).toBeGreaterThan(firstCreatedRead);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("spawn_agent with focus=true boots on and leaves focus on the created tab", async () => {
+    vi.useFakeTimers();
+    try {
+      const { exec, calls } = makeFocusLifecycleExec({
+        focusedSurface: "surface:worker",
+        roleTopology: true,
+        focusGatesCreatedSurfaceReadiness: true,
+      });
+      const server = createLifecycleServer(exec);
+      const tool = (server as any)._registeredTools["spawn_agent"];
+      const args = tool.inputSchema.parse({
+        repo: "cmuxlayer",
+        cli: "claude",
+        placement: "orchestrator",
+        workspace: "workspace:1",
+        force_new: true,
+        focus: true,
+        boot_prompt_timeout_ms: 20,
+      });
+
+      const resultPromise = tool.handler(args, {} as any);
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+
+      expect(result.structuredContent.ok).toBe(true);
+      expect(focusSurfaceIdx(calls, "surface:new")).toBeGreaterThanOrEqual(0);
+      expect(focusSurfaceIdx(calls, "surface:worker")).toBe(-1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent fails fast with the created identity when the tab cannot be focused", async () => {
+    vi.useFakeTimers();
+    try {
+      const { exec } = makeFocusLifecycleExec({
+        focusedSurface: "surface:worker",
+        roleTopology: true,
+        focusGatesCreatedSurfaceReadiness: true,
+        focusCreatedSurfaceFails: true,
+      });
+      const server = createLifecycleServer(exec);
+      const tool = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = tool.handler(
+        {
+          repo: "cmuxlayer",
+          cli: "claude",
+          placement: "orchestrator",
+          workspace: "workspace:1",
+          force_new: true,
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+
+      expect(result.structuredContent.ok).toBe(false);
+      expect(result.structuredContent.error).toMatch(/focus.*surface:new/i);
+      expect(result.structuredContent.agent_id).toEqual(expect.any(String));
+      expect(result.structuredContent.surface_id).toBe("surface:new");
+      expect(result.structuredContent.error).not.toMatch(/readiness|timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("new_worktree_split restores the prior surface after a cross-workspace spawn", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1181,6 +1181,7 @@ describe("tool handler integration", () => {
         };
       }),
       newSurface: vi.fn(),
+      focusSurface: vi.fn().mockResolvedValue(undefined),
       send: vi.fn().mockResolvedValue(undefined),
       sendKey: vi.fn().mockResolvedValue(undefined),
       readScreen: vi.fn().mockResolvedValue({

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -111,6 +111,7 @@ function makeWorkspaceClient() {
       };
     }),
     newSurface: vi.fn(),
+    focusSurface: vi.fn().mockResolvedValue(undefined),
     send: vi.fn().mockResolvedValue(undefined),
     sendKey: vi.fn().mockResolvedValue(undefined),
     readScreen: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- focus the exact surface returned by role-driven agent placement before launcher I/O
- preserve the existing focus lease so normal spawns restore the exact origin and focus:true stays on the new tab
- fail immediately with agent_id, surface_id, and workspace_id if the created tab cannot be focused
- cover orchestrator/worker placement from both lead and worker focus origins

## Verification
- full suite: 106 files, 2,380 tests passed (baseline 2,375; +5 contracts)
- focused lifecycle suite: 485 tests passed
- npm run pre-pr: 63 tests passed
- npm run typecheck
- npm run build
- git diff --check
- local CodeRabbit review completed; one minor lease suggestion was checked and rejected because the current lease already spans preflight/failure and focus:true intentionally disables restoration
- real cmux probe: worker surface:381 in right-column pane:24 spawned orchestrator Claude surface:402, reached ready, restored surface:381, and cleaned up the probe

## Scope
No release or installed-runtime change; the lead owns release/reconnect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn and focus lifecycle across agent engine, MCP tools, and app-server bridge; mistakes could break boot or steal focus, but behavior is gated by leases, epochs, and extensive new tests.
> 
> **Overview**
> Fixes agent spawn when the new tab sits in an **unfocused pane** by calling **`focusSurface` on the created surface** in `AgentEngine.spawnAgent` **before** launcher/readiness I/O. Focus failures surface as **`AgentLaunchError`** with `agent_id`, `surface_id`, and workspace so the tab stays recoverable.
> 
> **`spawn_agent`** documents transient focus during init and adds **`focus`** (default `false`): when false, the existing focus-restore lease runs; when true, focus stays on the new tab. **`capturePostCreationFocus`** now keys the lease off the **created surface** from `on_surface_created` instead of re-querying focus.
> 
> **`focus_surface`** is threaded through the engine client, app-server runtime (with `beforeMutation` epoch checks), and server **`agent_engine`** wrapper, and is registered as a **mutating tool** in manual mode.
> 
> **App Server bridge** `startThread` snapshots origin focus before spawn and **restores it in `finally`** only if focus is still on the new tab and policy/observer state unchanged (skips if the user moved, manual mode blocks, or observer reconnects).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad53ae4d9c29dd13c31be900743ca6b913a28c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Focus spawned agent surfaces before launch and restore origin focus after initialization
> - `AgentEngine.spawnAgent` now explicitly focuses the newly created surface before any shell/readiness I/O; if focusing fails, it rejects with `AgentLaunchError` including the surface identity.
> - After a thread spawns, `CmuxAppServerRuntime.startThread` restores the prior focus target unless the user moved focus, the observer epoch changed, or workspace mutation policy forbids it.
> - The `spawn_agent` tool adds a `focus` boolean parameter (default `false`); setting it to `true` keeps focus on the created tab instead of restoring the origin.
> - `focus_surface` is added to `MUTATING_TOOLS`, blocking it in manual mode.
> - Behavioral Change: spawning an agent now transiently steals focus for initialization, then restores the caller's surface by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ad53ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional focus control when creating agent surfaces.
  * Newly created surfaces are focused before initialization completes.
  * Original focus is restored automatically when appropriate.
  * Spawn responses now identify the created surface and support reliable focus behavior.

* **Bug Fixes**
  * Improved handling of focus failures with actionable launch errors.
  * Prevented focus restoration when the current context has changed or manual mode blocks the operation.

* **Tests**
  * Expanded coverage for focus, restoration, failure handling, and mode restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->