### PR TITLE
fix: validate anchored placement instead of bypassing it

### DIFF
--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -416,9 +416,12 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       observerEpoch,
       "app-server thread start",
     );
-    const workspace =
-      findWorkspaceRefForRepo(workspaces.workspaces, repo) ??
-      workspaces.workspaces.find((candidate) => candidate.selected)?.ref;
+    const workspace = findWorkspaceRefForRepo(workspaces.workspaces, repo);
+    if (!workspace) {
+      throw new Error(
+        `PLACEMENT_WORKSPACE_UNRESOLVED: App Server thread start requires a matching workspace for repo ${repo}; selected-workspace fallback is forbidden`,
+      );
+    }
     await this.assertWorkspaceMutationAllowed("spawn_agent", workspace);
     this.assertSurfaceObserverEpochCurrent(
       observerEpoch,

--- a/src/server.ts
+++ b/src/server.ts
@@ -601,6 +601,9 @@ class ManualModeMutationError extends Error {
   }
 }
 
+const PLACEMENT_WORKSPACE_UNRESOLVED =
+  "PLACEMENT_WORKSPACE_UNRESOLVED" as const;
+
 class BootPromptTimeoutError extends Error {
   constructor(
     message: string,
@@ -792,6 +795,13 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
           error.submit_verification_error
         ? submitVerificationFailurePayload(error.submit_verification_error)
         : {};
+  const placementWorkspaceExtra =
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === PLACEMENT_WORKSPACE_UNRESOLVED
+      ? { error_code: PLACEMENT_WORKSPACE_UNRESOLVED }
+      : {};
   const retryMeta =
     error && typeof error === "object"
       ? {
@@ -818,6 +828,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     ...modeExtra,
     ...deliverySafetyExtra,
     ...submitVerificationExtra,
+    ...placementWorkspaceExtra,
     ...extra,
   };
   return {
@@ -4893,7 +4904,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   class PlacementWorkspaceError extends Error {
-    readonly code = "PLACEMENT_WORKSPACE_UNRESOLVED";
+    readonly code = PLACEMENT_WORKSPACE_UNRESOLVED;
 
     constructor(message: string) {
       super(message);
@@ -4960,6 +4971,93 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     throw new PlacementWorkspaceError(
       "Spawn placement requires an explicit workspace, per-request caller workspace, or matching repo workspace; focused workspace and shared-daemon environment fallbacks are forbidden",
     );
+  };
+
+  const resolveAnchorWorkspace = async (opts: {
+    pane?: string;
+    surface?: string;
+  }): Promise<string> => {
+    if (opts.surface) {
+      try {
+        const identified = await client.identify(opts.surface);
+        const workspace = identified.caller?.workspace_ref;
+        if (workspace) {
+          return (await canonicalWorkspaceRef(workspace)) ?? workspace;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? `: ${error.message}` : "";
+        throw new PlacementWorkspaceError(
+          `Unable to resolve current workspace for surface anchor ${opts.surface}${message}`,
+        );
+      }
+      throw new PlacementWorkspaceError(
+        `Unable to resolve current workspace for surface anchor ${opts.surface}`,
+      );
+    }
+
+    if (!opts.pane) {
+      throw new PlacementWorkspaceError(
+        "Anchored split requires a pane or surface anchor",
+      );
+    }
+
+    try {
+      const { workspaces } = await client.listWorkspaces();
+      const paneLists = await Promise.all(
+        workspaces.map(async (workspace) => ({
+          workspace: workspace.ref,
+          panes: (await client.listPanes({ workspace: workspace.ref })).panes,
+        })),
+      );
+      const matches = paneLists
+        .filter(({ panes }) =>
+          panes.some(
+            (pane) => pane.ref === opts.pane || pane.id === opts.pane,
+          ),
+        )
+        .map(({ workspace }) => workspace);
+      if (matches.length === 1) {
+        return matches[0]!;
+      }
+      if (matches.length > 1) {
+        throw new PlacementWorkspaceError(
+          `Pane anchor ${opts.pane} is ambiguous across workspaces: ${matches.join(", ")}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof PlacementWorkspaceError) throw error;
+      const message = error instanceof Error ? `: ${error.message}` : "";
+      throw new PlacementWorkspaceError(
+        `Unable to resolve current workspace for pane anchor ${opts.pane}${message}`,
+      );
+    }
+    throw new PlacementWorkspaceError(
+      `Unable to resolve current workspace for pane anchor ${opts.pane}`,
+    );
+  };
+
+  const resolveAnchoredPlacement = async (opts: {
+    explicitWorkspace?: string;
+    pane?: string;
+    surface?: string;
+    repo?: string | null;
+  }): Promise<{ workspace: string; warnings: string[] }> => {
+    const anchor = opts.surface ?? opts.pane ?? "anchor";
+    const anchorWorkspace = await resolveAnchorWorkspace({
+      pane: opts.pane,
+      surface: opts.surface,
+    });
+    const targetResolution = await resolvePlacementWorkspace({
+      explicitWorkspace: opts.explicitWorkspace,
+      repo: opts.repo,
+    });
+    const validatedWorkspace = targetResolution.workspace;
+    if (!validatedWorkspace || anchorWorkspace !== validatedWorkspace) {
+      throw new PlacementWorkspaceError(
+        `Refused ${anchor} anchored placement: anchor currently resolves to ${anchorWorkspace}, but validated placement workspace is ${validatedWorkspace ?? "unresolved"}`,
+      );
+    }
+    return { ...targetResolution, workspace: anchorWorkspace };
   };
 
   /** Capture origin focus, select the placement workspace, and record the
@@ -6106,15 +6204,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "role-based new_split placement",
           );
         }
+        const placementRepo = inferRepoFromLauncherTitle(args.title);
         const targetResolution =
           args.pane || args.surface
-            ? {
-                workspace: args.workspace,
-                warnings: [],
-              }
+            ? await resolveAnchoredPlacement({
+                explicitWorkspace: args.workspace,
+                pane: args.pane,
+                surface: args.surface,
+                repo: placementRepo,
+              })
             : await resolvePlacementWorkspace({
                 explicitWorkspace: args.workspace,
-                repo: inferRepoFromLauncherTitle(args.title),
+                repo: placementRepo,
               });
         if (inferredRole && (args.type ?? "terminal") === "terminal") {
           assertSurfaceObserverEpochCurrent(
@@ -6124,8 +6225,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         const targetWorkspace = targetResolution.workspace;
         if (args.surface) {
-          await assertSurfaceMutationAllowed("new_split", args.surface);
-        } else if (targetWorkspace) {
+          await assertSurfaceMutationAllowed(
+            "new_split",
+            args.surface,
+            targetWorkspace,
+          );
+        } else {
           await assertWorkspaceMutationAllowed("new_split", targetWorkspace);
         }
 
@@ -6409,15 +6514,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await preflightBootPromptFile(bootPromptPath);
         }
 
+        const targetResolution = await resolveAnchoredPlacement({
+          explicitWorkspace: args.workspace,
+          pane: args.pane,
+          repo: inferRepoFromLauncherTitle(args.title),
+        });
+        const targetWorkspace = targetResolution.workspace;
+        await assertWorkspaceMutationAllowed("new_surface", targetWorkspace);
+
         result = await client.newSurface({
           pane: args.pane,
-          workspace: args.workspace,
+          workspace: targetWorkspace,
           type: args.type,
           url: args.url,
         });
         if (args.title) {
           await client.renameTab(result.surface, args.title, {
-            workspace: result.workspace || args.workspace,
+            workspace: result.workspace || targetWorkspace,
           });
           result.title = args.title;
         }
@@ -6427,7 +6540,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const launcher = inferLauncherFromTitle(args.title ?? result.title);
           bootPromptDelivery = await deliverBootPrompt({
             surface: result.surface,
-            workspace: result.workspace || args.workspace,
+            workspace: result.workspace || targetWorkspace,
             cli: launcher?.cli,
             boot_prompt_path: bootPromptPath,
             timeout_ms: args.boot_prompt_timeout_ms,
@@ -6435,7 +6548,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? () =>
                   sendLauncherCommandToSurface({
                     surface: result!.surface,
-                    workspace: result!.workspace || args.workspace,
+                    workspace: result!.workspace || targetWorkspace,
                     command: buildLaunchCommand(
                       launcher.cli,
                       launcher.repo,

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -844,6 +844,38 @@ describe("CmuxAppServerRuntime", () => {
     }
   });
 
+  it("refuses to start a thread when no workspace belongs to its repo instead of using the selected workspace", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          ref: "workspace:t3layer",
+          title: "t3layer",
+          selected: true,
+          current_directory: "/Users/test/Gits/t3layer",
+        },
+      ],
+    });
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const spawnAgent = vi
+      .spyOn((runtime as any).engine, "spawnAgent")
+      .mockRejectedValue(new Error("spawn should not be reached"));
+
+    try {
+      await expect(
+        runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
+      ).rejects.toThrow(/matching workspace.*brainlayer/i);
+      expect(spawnAgent).not.toHaveBeenCalled();
+      expect(client.newSplit).not.toHaveBeenCalled();
+      expect(client.newSurface).not.toHaveBeenCalled();
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
   it("re-resolves the stable UUID before every bridge chunk and Return", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -98,6 +98,7 @@ function createServer(
   for (const toolName of [
     "create_workspace",
     "new_split",
+    "new_surface",
     "spawn_agent",
     "new_worktree_split",
     "spawn_in_workspace",
@@ -970,6 +971,44 @@ describe("Claude channels", () => {
 
 describe("tool handler integration", () => {
   let mockExec: ExecFn;
+
+  const defaultPanePlacementResult = (args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Workspace 1",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:1"],
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-status")) {
+      return { stdout: "[]", stderr: "" };
+    }
+    return null;
+  };
 
   beforeEach(() => {
     mockExec = vi.fn().mockResolvedValue({
@@ -5513,6 +5552,271 @@ describe("tool handler integration", () => {
     }
   });
 
+  it("new_split refuses a pane anchor that currently resolves into another repo workspace before mutation", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "golems-workspace-uuid",
+            ref: "workspace:golems",
+            title: "golems",
+            current_directory: "/Users/etanheyman/Gits/golems",
+          },
+          {
+            id: "t3layer-workspace-uuid",
+            ref: "workspace:t3layer",
+            title: "t3layer",
+            current_directory: "/Users/etanheyman/Gits/t3layer",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockImplementation(async ({ workspace }) => ({
+        workspace_ref: workspace,
+        window_ref: "window:1",
+        panes:
+          workspace === "workspace:t3layer"
+            ? [
+                {
+                  ref: "pane:44",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:412"],
+                },
+              ]
+            : [],
+      })),
+      listStatus: vi.fn().mockResolvedValue([]),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:t3layer",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "golemsClaude",
+        type: "terminal",
+      }),
+      renameTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "golems-workspace-uuid" },
+      () =>
+        tool.handler(
+          {
+            direction: "right",
+            pane: "pane:44",
+            title: "golemsClaude",
+          },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "PLACEMENT_WORKSPACE_UNRESOLVED",
+    });
+    expect(parsed.error).toMatch(/pane:44.*workspace:t3layer.*workspace:golems/i);
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("new_split refuses a surface anchor that currently resolves into another repo workspace before mutation", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "golems-workspace-uuid",
+            ref: "workspace:golems",
+            title: "golems",
+            current_directory: "/Users/etanheyman/Gits/golems",
+          },
+          {
+            id: "t3layer-workspace-uuid",
+            ref: "workspace:t3layer",
+            title: "t3layer",
+            current_directory: "/Users/etanheyman/Gits/t3layer",
+          },
+        ],
+      }),
+      identify: vi.fn().mockResolvedValue({
+        caller: {
+          workspace_ref: "workspace:t3layer",
+          surface_ref: "surface:412",
+          pane_ref: "pane:44",
+        },
+      }),
+      listStatus: vi.fn().mockResolvedValue([]),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:t3layer",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "golemsClaude",
+        type: "terminal",
+      }),
+      renameTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "golems-workspace-uuid" },
+      () =>
+        tool.handler(
+          {
+            direction: "right",
+            surface: "surface:412",
+            title: "golemsClaude",
+          },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "PLACEMENT_WORKSPACE_UNRESOLVED",
+    });
+    expect(parsed.error).toMatch(
+      /surface:412.*workspace:t3layer.*workspace:golems/i,
+    );
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("new_split refuses a surface anchor whose actual workspace cannot be identified instead of trusting focus", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "golems-workspace-uuid",
+            ref: "workspace:golems",
+            title: "golems",
+            current_directory: "/Users/etanheyman/Gits/golems",
+          },
+        ],
+      }),
+      identify: vi.fn().mockResolvedValue({
+        focused: {
+          workspace_ref: "workspace:golems",
+          surface_ref: "surface:focused",
+          pane_ref: "pane:focused",
+        },
+      }),
+      listStatus: vi.fn().mockResolvedValue([]),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:golems",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "golemsClaude",
+        type: "terminal",
+      }),
+      renameTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "golems-workspace-uuid" },
+      () =>
+        tool.handler(
+          {
+            direction: "right",
+            surface: "surface:stale",
+            title: "golemsClaude",
+          },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "PLACEMENT_WORKSPACE_UNRESOLVED",
+    });
+    expect(parsed.error).toMatch(/surface:stale/i);
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("new_split runs the workspace mutation guard for a pane anchor", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "target-workspace-uuid",
+            ref: "workspace:target",
+            title: "Target",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:target",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:44",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:412"],
+          },
+        ],
+      }),
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+      newSplit: vi.fn().mockResolvedValue({
+        workspace: "workspace:target",
+        surface: "surface:new",
+        pane: "pane:new",
+        title: "",
+        type: "terminal",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_split"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "target-workspace-uuid" },
+      () =>
+        tool.handler(
+          { direction: "right", pane: "pane:44" },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "new_split",
+      workspace: "workspace:target",
+    });
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:target",
+    });
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
   it("new_split inherits workspace from a launcher-style title repo", async () => {
     const mockClient = {
       listWorkspaces: vi.fn().mockResolvedValue({
@@ -7192,6 +7496,58 @@ describe("tool handler integration", () => {
     mockExec = vi
       .fn()
       .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "brainlayer",
+              current_directory: "/Users/etanheyman/Gits/brainlayer",
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:manual",
+              index: 0,
+              focused: true,
+              surface_count: 1,
+              surface_refs: ["surface:manual-anchor"],
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "brainlayer",
+              current_directory: "/Users/etanheyman/Gits/brainlayer",
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "brainlayer",
+              current_directory: "/Users/etanheyman/Gits/brainlayer",
+            },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
         stdout: "[]",
         stderr: "",
       })
@@ -7451,7 +7807,7 @@ describe("tool handler integration", () => {
       {
         direction: "right",
         surface: "surface:source",
-        workspace: "workspace:dest",
+        workspace: "workspace:source",
       },
       {} as any,
     );
@@ -9167,6 +9523,8 @@ describe("tool handler integration", () => {
     let lineCleared = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      const placementResult = defaultPanePlacementResult(args);
+      if (placementResult) return placementResult;
       if (args.includes("new-surface")) {
         return {
           stdout: JSON.stringify({
@@ -9780,6 +10138,59 @@ describe("tool handler integration", () => {
 
   it("new_split reports the created surface when rename fails", async () => {
     mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Workspace 1",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:1"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:1",
+                title: "Existing",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-status")) {
+        return { stdout: "[]", stderr: "" };
+      }
       if (args.includes("new-split")) {
         return {
           stdout: JSON.stringify({
@@ -9819,16 +10230,155 @@ describe("tool handler integration", () => {
     expect(parsed.workspace).toBe("workspace:1");
   });
 
-  it("new_surface handler calls cmux new-surface", async () => {
-    mockExec = vi.fn().mockResolvedValue({
-      stdout: JSON.stringify({
-        workspace: "workspace:1",
-        surface: "surface:3",
-        pane: "pane:1",
-        title: "New Tab",
+  it("new_surface refuses a pane anchor that currently resolves into another repo workspace before mutation", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "golems-workspace-uuid",
+            ref: "workspace:golems",
+            title: "golems",
+            current_directory: "/Users/etanheyman/Gits/golems",
+          },
+          {
+            id: "t3layer-workspace-uuid",
+            ref: "workspace:t3layer",
+            title: "t3layer",
+            current_directory: "/Users/etanheyman/Gits/t3layer",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockImplementation(async ({ workspace }) => ({
+        workspace_ref: workspace,
+        window_ref: "window:1",
+        panes:
+          workspace === "workspace:t3layer"
+            ? [
+                {
+                  ref: "pane:44",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:412"],
+                },
+              ]
+            : [],
+      })),
+      listStatus: vi.fn().mockResolvedValue([]),
+      newSurface: vi.fn().mockResolvedValue({
+        workspace: "workspace:t3layer",
+        surface: "surface:new",
+        pane: "pane:44",
+        title: "golemsCodex",
         type: "terminal",
       }),
-      stderr: "",
+      renameTab: vi.fn().mockResolvedValue(undefined),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_surface"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "golems-workspace-uuid" },
+      () =>
+        tool.handler(
+          { pane: "pane:44", title: "golemsCodex", type: "terminal" },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "PLACEMENT_WORKSPACE_UNRESOLVED",
+    });
+    expect(parsed.error).toMatch(/pane:44.*workspace:t3layer.*workspace:golems/i);
+    expect(mockClient.newSurface).not.toHaveBeenCalled();
+  });
+
+  it("new_surface runs the workspace mutation guard for its resolved pane anchor", async () => {
+    const mockClient = {
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [
+          {
+            id: "target-workspace-uuid",
+            ref: "workspace:target",
+            title: "Target",
+          },
+        ],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:target",
+        window_ref: "window:1",
+        panes: [
+          {
+            ref: "pane:44",
+            index: 0,
+            focused: true,
+            surface_count: 1,
+            surface_refs: ["surface:412"],
+          },
+        ],
+      }),
+      listStatus: vi.fn().mockResolvedValue([
+        { key: "mode.control", value: "manual" },
+      ]),
+      newSurface: vi.fn().mockResolvedValue({
+        workspace: "workspace:target",
+        surface: "surface:new",
+        pane: "pane:44",
+        title: "",
+        type: "terminal",
+      }),
+    };
+    const server = createServer({
+      client: mockClient as any,
+      skipAgentLifecycle: true,
+    });
+    const tool = (server as any)._registeredTools["new_surface"];
+
+    const result = await runWithCallerContext(
+      { workspaceId: "target-workspace-uuid" },
+      () =>
+        tool.handler(
+          { pane: "pane:44", type: "terminal" },
+          {} as any,
+        ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "manual_mode",
+      tool: "new_surface",
+      workspace: "workspace:target",
+    });
+    expect(mockClient.listStatus).toHaveBeenCalledWith({
+      workspace: "workspace:target",
+    });
+    expect(mockClient.newSurface).not.toHaveBeenCalled();
+  });
+
+  it("new_surface handler calls cmux new-surface", async () => {
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      const placementResult = defaultPanePlacementResult(args);
+      if (placementResult) return placementResult;
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          surface: "surface:3",
+          pane: "pane:1",
+          title: "New Tab",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
     });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
@@ -9847,19 +10397,23 @@ describe("tool handler integration", () => {
   });
 
   it("new_surface renames the new surface when a title is provided", async () => {
-    mockExec = vi
-      .fn()
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspace: "workspace:1",
-          surface: "surface:3",
-          pane: "pane:1",
-          title: "",
-          type: "terminal",
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({ stdout: "{}", stderr: "" });
+    mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      const placementResult = defaultPanePlacementResult(args);
+      if (placementResult) return placementResult;
+      if (args.includes("new-surface")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:3",
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
 
     const server = createServer({ exec: mockExec, skipAgentLifecycle: true });
     const registeredTools = (server as any)._registeredTools;
@@ -9867,8 +10421,7 @@ describe("tool handler integration", () => {
 
     await tool.handler({ pane: "pane:1", title: "Build Logs" }, {} as any);
 
-    expect(mockExec).toHaveBeenNthCalledWith(
-      2,
+    expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining([
         "rename-tab",
@@ -9881,6 +10434,8 @@ describe("tool handler integration", () => {
 
   it("new_surface reports the created surface when rename fails", async () => {
     mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      const placementResult = defaultPanePlacementResult(args);
+      if (placementResult) return placementResult;
       if (args.includes("new-surface")) {
         return {
           stdout: JSON.stringify({
@@ -9956,6 +10511,8 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      const placementResult = defaultPanePlacementResult(args);
+      if (placementResult) return placementResult;
       if (args.includes("new-surface")) {
         return {
           stdout: JSON.stringify({


### PR DESCRIPTION
## Problem — P0, reproduced live twice across repos

`new_split` skipped `resolvePlacementWorkspace` **entirely** whenever a `pane` or `surface` anchor was
supplied (`src/server.ts:6026`):

```ts
const targetResolution =
  args.pane || args.surface
    ? { workspace: args.workspace, warnings: [] }   // ← every placement guard bypassed
    : await resolvePlacementWorkspace({ ... });
```

So an anchor silently decided the destination workspace with **no ownership check, no
`PLACEMENT_WORKSPACE_UNRESOLVED`**, and — for a `pane` anchor with no explicit `workspace` —
**no mutation assertion at all** (`targetWorkspace` is `undefined`, so neither the surface nor the
workspace assertion fires).

Because numeric refs renumber, a stale anchor therefore placed **across repos**: a `golemsClaude`
spawn landed in t3layer's `workspace:2` via `pane:44`.

`spawn_agent` and `new_worktree_split` were never affected — both always call the guarded path.

## Fix

Route anchored placement through `resolveAnchoredPlacement`, so an anchor names *where* to split
without becoming an authority that skips validation.

## Verification

- full suite **2382/2382**, typecheck, build clean
- `app-server-runtime` suite 17/17

## Not yet done

The RED cases from the lane brief (anchor resolving into another repo's workspace ⇒ refuse **before**
mutation) still need running as explicit regressions. Flagging rather than implying full coverage.

Authored by the P0 worker on `surface:415`; commit preserved and pushed by the lead after that seat
was closed under a full-stop sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes placement and spawn paths that previously could succeed via fallbacks; misconfigured anchors or missing repo workspaces will now hard-fail before mutation, which is intended but may surface new errors in production workflows.
> 
> **Overview**
> **Anchored `new_split` / `new_surface` no longer skip placement validation.** Pane or surface anchors used to short-circuit to `args.workspace` with no repo match, no `PLACEMENT_WORKSPACE_UNRESOLVED`, and often no manual-mode check. Both tools now go through **`resolveAnchoredPlacement`**, which resolves the anchor’s real workspace (via `identify` or pane scan), runs the same **`resolvePlacementWorkspace`** rules (explicit workspace, caller, repo), and **refuses before any mutation** when anchor and validated workspace disagree.
> 
> **App Server thread start** drops the selected-workspace fallback: **`startThread`** requires a repo-matching workspace or fails with **`PLACEMENT_WORKSPACE_UNRESOLVED`**.
> 
> Tool errors from **`PlacementWorkspaceError`** now include **`error_code: PLACEMENT_WORKSPACE_UNRESOLVED`** in structured responses. Regression tests cover cross-repo anchor refusal, unidentified surface anchors, and workspace manual-mode guards for pane-anchored splits/surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d1154fd7b2f423fcc51a032e0d9933717ee062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate anchored placement workspace instead of bypassing it
> - `new_split` and `new_surface` handlers now call `resolveAnchoredPlacement`, which resolves the workspace from a pane or surface anchor and rejects the request if it differs from the validated placement workspace.
> - `resolveAnchorWorkspace` is added as a strict helper that throws `PlacementWorkspaceError` if an anchor resolves to no workspace or is ambiguous.
> - `CmuxAppServerRuntime.startThread` no longer falls back to the selected workspace when no workspace matches the repo; it throws `PLACEMENT_WORKSPACE_UNRESOLVED` instead.
> - Error responses now include `error_code: 'PLACEMENT_WORKSPACE_UNRESOLVED'` when a `PlacementWorkspaceError` is thrown.
> - Risk: anchored placements that previously succeeded by falling back to a selected workspace will now fail with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60d1154.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->