### PR TITLE
fix: reap orphaned channel markers

### DIFF
--- a/docs/plans/2026-08-03-channel-marker-reaper-design.md
+++ b/docs/plans/2026-08-03-channel-marker-reaper-design.md
@@ -1,0 +1,51 @@
+# Channel Marker Reaper Design
+
+## Problem
+
+Every inbox write creates a `.channel-dirs/<encoded-agent-id>.created` marker. Successful
+pending-to-real registration removes the pending channel directory through `StateManager.renameState`,
+but it does not remove the pending marker. Failed or mocked spawns can leave both the marker and its
+channel directory behind. Vitest already isolates its registry state, but its inbox path still falls
+back to the live `~/.cmux/agents` tree, so test runs are an active production-state leaker.
+
+The marker is not disposable bookkeeping. It lets health checks distinguish a channel directory that
+never existed from one that existed and was later deleted. Cleanup must therefore preserve markers for
+every known agent identity.
+
+## Safety Rule
+
+Automatic backlog cleanup may remove only a marker whose decoded identity:
+
+1. matches the canonical timestamped pending-id form;
+2. is older than the retention window embedded in that pending id; and
+3. is absent from both the in-memory registry and persisted agent state captured for the sweep.
+
+The reaper never removes non-pending markers or markers for known agents. The decision and unlink run
+synchronously against one known-id snapshot, so lifecycle mutation cannot interleave inside the
+process. Missing files during multi-process cleanup are harmless; other filesystem errors are counted
+and retained.
+
+Successful pending-to-real registration is a stronger proof than retention: after the final state has
+been persisted and the registry rename succeeds, the old pending marker is removed immediately. A
+failed transition leaves the marker untouched.
+
+## Components
+
+- `src/inbox.ts` owns pending-marker parsing, transition cleanup, and the retention-based reaper.
+- `src/agent-engine.ts` invokes transition cleanup only after registry/state rename and runs the
+  backlog reaper on a time gate using the union of registry and persisted identities.
+- `src/server.ts` routes implicit Vitest inbox writes to a process-scoped temporary directory unless
+  a test explicitly supplies another inbox directory. This keeps injected state-manager paths
+  untouched while preventing live-home writes.
+
+The reaper enumerates `.channel-dirs` only on its explicit maintenance interval. Ordinary spawn writes,
+health reads, `list_agents`, and `resync_agents` retain their existing single-path operations.
+
+## Verification
+
+- Unit tests cover known, young, malformed, non-pending, and safely reapable markers.
+- An engine test proves pending-to-real transition cleanup happens only after successful registration.
+- A server test proves Vitest's implicit inbox base is isolated from the live home path.
+- A live saturated-directory probe proves spawn success at more than 50,000 entries.
+- Before/after live counts and health/list latency measurements are reported separately; they do not
+  claim adjacent sidebar, click, `pane_died`, or stale-reference defects are fixed.

--- a/docs/plans/2026-08-03-channel-marker-reaper.md
+++ b/docs/plans/2026-08-03-channel-marker-reaper.md
@@ -1,0 +1,76 @@
+# Channel Marker Reaper Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop pending channel-marker leakage at identity finalization, safely reap retained orphans,
+and prevent Vitest from writing mocked spawn channels into live user state.
+
+**Architecture:** Keep marker lifecycle logic in `src/inbox.ts`; let `AgentEngine` provide the
+authoritative known-agent snapshot and the successful pending-to-real transition hook. Give implicit
+Vitest inbox writes a process-scoped temporary root in `src/server.ts`.
+
+**Tech Stack:** TypeScript, Node filesystem APIs, Vitest, cmuxlayer `AgentEngine` lifecycle.
+
+---
+
+### Task 1: Marker safety primitives
+
+**Files:**
+- Modify: `tests/inbox.test.ts`
+- Modify: `src/inbox.ts`
+
+1. Add failing tests for transition cleanup, retention, known-agent protection, non-pending
+   protection, and bounded repeated cleanup.
+2. Run `npx vitest run tests/inbox.test.ts` and confirm the new API is missing.
+3. Implement strict pending-id parsing, safe unlink, and a concise reaper result.
+4. Re-run the focused test and confirm it passes.
+
+### Task 2: Pending-to-real cleanup and periodic backlog reaping
+
+**Files:**
+- Modify: `tests/agent-engine.test.ts`
+- Modify: `src/agent-engine.ts`
+
+1. Add a failing lifecycle test that creates a pending marker, finalizes a real session id, and
+   expects only the pending marker to disappear.
+2. Run the focused test and confirm the pending marker remains before implementation.
+3. Call marker cleanup after each successful pending identity rename and add a time-gated backlog
+   pass using known registry plus persisted ids.
+4. Run the focused engine tests and the inbox tests.
+
+### Task 3: Stop the active Vitest leaker
+
+**Files:**
+- Modify: `tests/server.test.ts`
+- Modify: `src/server.ts`
+
+1. Add a failing test proving an implicit Vitest inbox path uses an isolated process-temporary
+   directory.
+2. Run the test and verify it exposes the live-home fallback.
+3. Route implicit Vitest inbox state to a process-scoped temporary directory; preserve explicit
+   `inboxBaseDir`, injected state-manager paths, and the production default.
+4. Run server, inbox, and engine focused tests. Confirm a full suite creates zero new live markers.
+
+### Task 4: Verification and live cleanup
+
+**Files:**
+- Verify all modified files and tests.
+
+1. Run typecheck, build, focused tests, and the full suite with isolated `TMPDIR`.
+2. Run the reaper in dry-run mode against live state and verify every candidate satisfies the safety
+   rule; then execute the authorized backlog cleanup.
+3. Recount `.channel-dirs`, measure 24 marker lookups and `list_agents`, and verify a successful managed
+   spawn exists whose timestamp predates the saturated-directory measurement.
+4. Re-read the diff and requirement checklist before committing.
+
+### Task 5: PR loop
+
+**Files:**
+- Commit only the plan, source, and tests owned by this lane.
+
+1. Run bounded local CodeRabbit review, commit, and push without bypassing hooks.
+2. Open a ready-for-review PR with before/after counts, latency evidence, safety rule, active-leaker
+   root cause, and baseline RED disclosure.
+3. Request the routed Codex review, read all feedback, address blocking findings, and request re-review.
+4. Merge with a merge commit only after the review loop and checks are clean; verify the remote merge.
+5. Update FLEET-STANDING for `@orc` and `@cmuxlayer` with the PR URL and verified measurements.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -133,7 +133,12 @@ import {
   type SurfaceObserverIdProvider,
   type SurfaceTopologySnapshot,
 } from "./surface-topology.js";
-import type { InboxOpts } from "./inbox.js";
+import {
+  DEFAULT_CHANNEL_MARKER_RETENTION_MS,
+  reapOrphanedPendingChannelMarkers,
+  removePendingChannelMarkerAfterRegistration,
+  type InboxOpts,
+} from "./inbox.js";
 import {
   buildFleetSidebarSnapshot,
   DEFAULT_FLEET_WORKING_NO_PROGRESS_TIMEOUT_MS,
@@ -400,6 +405,8 @@ const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
 const FLEET_SIDEBAR_WAKE_REPUBLISH_DELAY_MS = 500;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
+const CHANNEL_MARKER_REAP_INTERVAL_MS = 60 * 60 * 1_000;
+const CHANNEL_MARKER_REAP_RETRY_MS = 60 * 1_000;
 const STOP_POST_CONDITION_POLL_MS = 50;
 const BOOT_SESSION_CAPTURE_LINES = 80;
 const MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS = 3;
@@ -815,6 +822,8 @@ export class AgentEngine {
   private launchCommandSender?: AgentEngineOptions["launchCommandSender"];
   private beforeCrashRecoveryMutation?: AgentEngineOptions["beforeCrashRecoveryMutation"];
   private inboxOpts?: InboxOpts;
+  private lastChannelMarkerReapAt: number | null = null;
+  private lastChannelMarkerReapFailureAt: number | null = null;
   private sessionIdentityResolver: SessionIdentityResolver;
   private hasCustomSessionIdentityResolver: boolean;
   private selfRegistrationSessionResolver: SessionIdentityResolver | null;
@@ -2278,6 +2287,11 @@ export class AgentEngine {
         updated = this.stateMgr.renameState(previousAgentId, collisionAgentId);
         this.registry.rename(previousAgentId, collisionAgentId, updated);
         this.transferAgentRenameMemory(previousAgentId, collisionAgentId);
+        removePendingChannelMarkerAfterRegistration(
+          previousAgentId,
+          collisionAgentId,
+          this.inboxOpts,
+        );
         return updated;
       }
       const sessionPath =
@@ -2300,6 +2314,11 @@ export class AgentEngine {
       this.registry.rename(updated.agent_id, finalAgentId, canonicalFinal);
       this.transferAgentRenameMemory(updated.agent_id, finalAgentId);
       this.stateMgr.removeState(updated.agent_id);
+      removePendingChannelMarkerAfterRegistration(
+        updated.agent_id,
+        finalAgentId,
+        this.inboxOpts,
+      );
       return canonicalFinal;
     }
 
@@ -2307,6 +2326,11 @@ export class AgentEngine {
     updated = this.stateMgr.renameState(previousAgentId, finalAgentId);
     this.registry.rename(previousAgentId, finalAgentId, updated);
     this.transferAgentRenameMemory(previousAgentId, finalAgentId);
+    removePendingChannelMarkerAfterRegistration(
+      previousAgentId,
+      finalAgentId,
+      this.inboxOpts,
+    );
     return updated;
   }
 
@@ -4273,6 +4297,7 @@ export class AgentEngine {
       now: Date.now(),
     };
     await this.registry.reconcile(surfacelessConfirmation);
+    await this.reapChannelMarkersBestEffort();
     await this.registry.evictSurfaceless(surfacelessConfirmation);
     await this.recoverCrashedAgents();
 
@@ -4287,6 +4312,52 @@ export class AgentEngine {
     await this.reconcileRolePlacements("idle");
     await this.syncSidebar();
     await this.drainOutboxBestEffort();
+  }
+
+  private async reapChannelMarkersBestEffort(): Promise<void> {
+    if (!this.inboxOpts) return;
+    const now = Date.now();
+    if (
+      this.lastChannelMarkerReapAt !== null &&
+      now - this.lastChannelMarkerReapAt < CHANNEL_MARKER_REAP_INTERVAL_MS
+    ) {
+      return;
+    }
+    if (
+      this.lastChannelMarkerReapFailureAt !== null &&
+      now - this.lastChannelMarkerReapFailureAt < CHANNEL_MARKER_REAP_RETRY_MS
+    ) {
+      return;
+    }
+    try {
+      const knownAgentIds = new Set([
+        ...this.registry.list().map((agent) => agent.agent_id),
+        ...this.stateMgr.listStates().map((agent) => agent.agent_id),
+      ]);
+      const result = reapOrphanedPendingChannelMarkers(knownAgentIds, {
+        ...this.inboxOpts,
+        now: () => now,
+        retentionMs: DEFAULT_CHANNEL_MARKER_RETENTION_MS,
+      });
+      if (result.errors > 0) {
+        this.lastChannelMarkerReapFailureAt = now;
+      } else {
+        this.lastChannelMarkerReapAt = now;
+        this.lastChannelMarkerReapFailureAt = null;
+      }
+      if (result.reaped > 0 || result.errors > 0) {
+        await this.client.log(
+          `channel-marker reaper: reaped=${result.reaped} retained_known=${result.retained_known} retained_young=${result.retained_young} errors=${result.errors}`,
+          {
+            level: result.errors > 0 ? "warning" : "info",
+            source: "agent-engine",
+          },
+        );
+      }
+    } catch {
+      this.lastChannelMarkerReapFailureAt = now;
+      // Marker cleanup is maintenance; lifecycle reconciliation must continue.
+    }
   }
 
   /**

--- a/src/app-server-index.ts
+++ b/src/app-server-index.ts
@@ -15,7 +15,7 @@ function writeJson(message: unknown): void {
 
 async function main() {
   const client = await createCmuxClient();
-  const runtime = new CmuxAppServerRuntime({ client });
+  const runtime = new CmuxAppServerRuntime({ client, inboxOpts: {} });
   await runtime.initialize();
 
   const bridge = new CodexAppServerBridge({

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -19,6 +19,7 @@ import {
 } from "./cmux-observer-identity.js";
 import { AgentDiscovery } from "./agent-discovery.js";
 import { StateManager } from "./state-manager.js";
+import type { InboxOpts } from "./inbox.js";
 import { parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { matchReadyPattern } from "./pattern-registry.js";
@@ -180,6 +181,7 @@ function toBridgeThread(
 export interface CmuxAppServerRuntimeOptions {
   client: CmuxLikeClient;
   stateDir?: string;
+  inboxOpts?: InboxOpts;
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
   surfaceObserverOwnerIdProvider?: () => string | null | undefined;
   surfaceObserverEpochProvider?: () => string | null | undefined;
@@ -378,6 +380,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         monitorRegistryPath: defaultMonitorRegistryPath(),
         monitorRegistryNotify: httpNotifyMonitorDeadman,
         selfRegistrationSessionResolver: makeSelfRegistrationSessionResolver(),
+        inboxOpts: opts.inboxOpts,
         closeForensicsRunner: createDefaultCloseForensicsRunner({
           stateMgr: this.stateMgr,
           listSurfacesForRefMap: surfaceProvider,

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -20,7 +20,14 @@
 //
 // send_input is KEPT as the fallback path — this channel is additive (belt-and-suspenders) until
 // proven in production.
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -49,6 +56,23 @@ export interface InboxOpts {
   baseDir?: string;
   /** Injectable clock for determinism (default Date.now). */
   now?: () => number;
+}
+
+export const DEFAULT_CHANNEL_MARKER_RETENTION_MS = 24 * 60 * 60 * 1_000;
+
+export interface ChannelMarkerReaperOpts extends InboxOpts {
+  retentionMs?: number;
+  dryRun?: boolean;
+}
+
+export interface ChannelMarkerReapResult {
+  scanned: number;
+  reapable: number;
+  reaped: number;
+  retained_known: number;
+  retained_young: number;
+  retained_non_pending: number;
+  errors: number;
 }
 
 export type MonitorHeartbeatSource = "agent" | "server_boot";
@@ -96,6 +120,122 @@ function channelMarkerDir(opts?: InboxOpts): string {
 
 function channelMarkerPath(agentId: string, opts?: InboxOpts): string {
   return join(channelMarkerDir(opts), `${encodeURIComponent(agentId)}.created`);
+}
+
+const PENDING_AGENT_ID_RE = /^.+-pending-(\d+)-[a-z0-9]+$/i;
+
+function pendingAgentCreatedAtMs(agentId: string): number | null {
+  const match = agentId.match(PENDING_AGENT_ID_RE);
+  if (!match?.[1]) return null;
+  const seconds = Number.parseInt(match[1], 10);
+  if (!Number.isSafeInteger(seconds) || seconds < 0) return null;
+  return seconds * 1_000;
+}
+
+function markerAgentId(fileName: string): string | null {
+  if (!fileName.endsWith(".created")) return null;
+  try {
+    return decodeURIComponent(fileName.slice(0, -".created".length));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A completed pending-to-real registration makes the provisional marker
+ * meaningless. Call only after state and registry rename have both succeeded.
+ */
+export function removePendingChannelMarkerAfterRegistration(
+  previousAgentId: string,
+  finalAgentId: string,
+  opts?: InboxOpts,
+): boolean {
+  if (
+    previousAgentId === finalAgentId ||
+    pendingAgentCreatedAtMs(previousAgentId) === null ||
+    pendingAgentCreatedAtMs(finalAgentId) !== null
+  ) {
+    return false;
+  }
+  try {
+    unlinkSync(channelMarkerPath(previousAgentId, opts));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reap only retained markers for timestamped pending identities that are old
+ * enough and absent from the caller's authoritative known-agent snapshot.
+ * Non-pending and known-agent markers preserve the deleted-after-create health
+ * signal. The pending id timestamp avoids one stat per marker in a saturated
+ * directory.
+ */
+export function reapOrphanedPendingChannelMarkers(
+  knownAgentIds: Iterable<string>,
+  opts: ChannelMarkerReaperOpts = {},
+): ChannelMarkerReapResult {
+  const result: ChannelMarkerReapResult = {
+    scanned: 0,
+    reapable: 0,
+    reaped: 0,
+    retained_known: 0,
+    retained_young: 0,
+    retained_non_pending: 0,
+    errors: 0,
+  };
+  let fileNames: string[];
+  try {
+    fileNames = readdirSync(channelMarkerDir(opts));
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? (error as { code?: unknown }).code
+        : null;
+    if (code !== "ENOENT") result.errors += 1;
+    return result;
+  }
+  const known = new Set(knownAgentIds);
+  const now = nowOf(opts);
+  const requestedRetentionMs =
+    opts.retentionMs ?? DEFAULT_CHANNEL_MARKER_RETENTION_MS;
+  const retentionMs = Number.isFinite(requestedRetentionMs)
+    ? Math.max(0, Math.trunc(requestedRetentionMs))
+    : DEFAULT_CHANNEL_MARKER_RETENTION_MS;
+
+  for (const fileName of fileNames) {
+    result.scanned += 1;
+    const agentId = markerAgentId(fileName);
+    const createdAt = agentId ? pendingAgentCreatedAtMs(agentId) : null;
+    if (!agentId || createdAt === null) {
+      result.retained_non_pending += 1;
+      continue;
+    }
+    if (known.has(agentId)) {
+      result.retained_known += 1;
+      continue;
+    }
+    if (now - createdAt < retentionMs) {
+      result.retained_young += 1;
+      continue;
+    }
+
+    result.reapable += 1;
+    if (opts.dryRun) continue;
+    try {
+      unlinkSync(join(channelMarkerDir(opts), fileName));
+      result.reaped += 1;
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? (error as { code?: unknown }).code
+          : null;
+      if (code !== "ENOENT") result.errors += 1;
+    }
+  }
+
+  return result;
 }
 
 function ensureChannelDirForWrite(agentId: string, opts?: InboxOpts): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,6 +111,7 @@ import {
   recommendedMonitorCommand,
   replayUndelivered,
   writeHeartbeat,
+  type InboxOpts,
 } from "./inbox.js";
 import {
   applyHarnessState,
@@ -2388,6 +2389,16 @@ export function createServerContext(
   return context;
 }
 
+export function resolveServerInboxBaseDir(input: {
+  explicitBaseDir?: string;
+  isVitest: boolean;
+}): string | undefined {
+  if (input.explicitBaseDir) return input.explicitBaseDir;
+  return input.isVitest
+    ? join(tmpdir(), `cmuxlayer-vitest-inbox-${process.pid}`)
+    : undefined;
+}
+
 function formatLifecycleChannelContent(
   event: AgentLifecycleEvent,
   agent: AgentRecord,
@@ -2518,9 +2529,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       result.warnings = [...(result.warnings ?? []), warning];
     }
   };
-  const inboxOpts = opts?.inboxBaseDir
-    ? { baseDir: opts.inboxBaseDir }
-    : undefined;
+  const inboxBaseDir = resolveServerInboxBaseDir({
+    explicitBaseDir: opts?.inboxBaseDir,
+    isVitest: process.env.VITEST === "true",
+  });
+  if (inboxBaseDir && process.env.VITEST === "true" && !opts?.inboxBaseDir) {
+    registerAutoVitestStateDir(inboxBaseDir);
+  }
+  const inboxOpts: InboxOpts = inboxBaseDir ? { baseDir: inboxBaseDir } : {};
   const ensureMonitorBoot = (agentId: string): MonitorBootResult => {
     let monitorCommand = "";
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2237,8 +2237,22 @@ export interface CmuxServerContext {
 
 const DEFAULT_CONTROL_HEALTH_INTERVAL_MS = 60_000;
 const MIN_CONTROL_HEALTH_INTERVAL_MS = 5_000;
-const autoVitestStateDirs = new Set<string>();
-let autoVitestStateCleanupRegistered = false;
+interface AutoVitestTempCleanupState {
+  dirs: Set<string>;
+  registered: boolean;
+}
+
+type AutoVitestTempCleanupGlobal = typeof globalThis & {
+  __cmuxlayerAutoVitestTempCleanupV1?: AutoVitestTempCleanupState;
+};
+
+const autoVitestTempCleanupGlobal = globalThis as AutoVitestTempCleanupGlobal;
+const autoVitestTempCleanupState =
+  autoVitestTempCleanupGlobal.__cmuxlayerAutoVitestTempCleanupV1 ??
+  (autoVitestTempCleanupGlobal.__cmuxlayerAutoVitestTempCleanupV1 = {
+    dirs: new Set<string>(),
+    registered: false,
+  });
 
 function resolveControlHealthIntervalMs(input?: number): number {
   const raw =
@@ -2255,23 +2269,23 @@ function resolveControlHealthIntervalMs(input?: number): number {
   return Math.max(MIN_CONTROL_HEALTH_INTERVAL_MS, Math.floor(raw));
 }
 
-function registerAutoVitestStateDir(stateDir: string): void {
-  autoVitestStateDirs.add(stateDir);
-  if (autoVitestStateCleanupRegistered) {
+function registerAutoVitestTempDir(dir: string): void {
+  autoVitestTempCleanupState.dirs.add(dir);
+  if (autoVitestTempCleanupState.registered) {
     return;
   }
-  autoVitestStateCleanupRegistered = true;
+  autoVitestTempCleanupState.registered = true;
   process.once("exit", () => {
-    for (const dir of autoVitestStateDirs) {
+    for (const dir of autoVitestTempCleanupState.dirs) {
       rmSync(dir, { recursive: true, force: true });
     }
-    autoVitestStateDirs.clear();
+    autoVitestTempCleanupState.dirs.clear();
   });
 }
 
-function removeAutoVitestStateDir(stateDir: string): void {
-  autoVitestStateDirs.delete(stateDir);
-  rmSync(stateDir, { recursive: true, force: true });
+function removeAutoVitestTempDir(dir: string): void {
+  autoVitestTempCleanupState.dirs.delete(dir);
+  rmSync(dir, { recursive: true, force: true });
 }
 
 export function createServerContext(
@@ -2293,7 +2307,7 @@ export function createServerContext(
     autoVitestStateDir ??
     join(homedir(), ".local", "state", "cmux-agents");
   if (autoVitestStateDir) {
-    registerAutoVitestStateDir(autoVitestStateDir);
+    registerAutoVitestTempDir(autoVitestStateDir);
   }
   const stateMgr = opts?.stateManager ?? new StateManager(stateDir);
   const readObserverProvider = (
@@ -2381,7 +2395,7 @@ export function createServerContext(
       context.lifecycleStartPromise = null;
       context.lifecycleStartError = null;
       if (autoVitestStateDir) {
-        removeAutoVitestStateDir(autoVitestStateDir);
+        removeAutoVitestTempDir(autoVitestStateDir);
       }
     },
   };
@@ -2534,7 +2548,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     isVitest: process.env.VITEST === "true",
   });
   if (inboxBaseDir && process.env.VITEST === "true" && !opts?.inboxBaseDir) {
-    registerAutoVitestStateDir(inboxBaseDir);
+    registerAutoVitestTempDir(inboxBaseDir);
   }
   const inboxOpts: InboxOpts = inboxBaseDir ? { baseDir: inboxBaseDir } : {};
   const ensureMonitorBoot = (agentId: string): MonitorBootResult => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../src/agent-types.js";
 import { SpawnGuard, SpawnRateLimitedError } from "../src/spawn-guard.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
+import { writeHeartbeat } from "../src/inbox.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
 
@@ -252,6 +253,7 @@ describe("AgentEngine", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir: TEST_DIR },
     });
   });
 
@@ -4314,6 +4316,13 @@ To continue this session, run codex resume ${sessionId}`,
       expect(result.agent_id).toMatch(
         /^brainlayerCodex-pending-\d+-[a-z0-9]+$/,
       );
+      writeHeartbeat(result.agent_id, { baseDir: TEST_DIR });
+      const pendingMarker = join(
+        TEST_DIR,
+        ".channel-dirs",
+        `${encodeURIComponent(result.agent_id)}.created`,
+      );
+      expect(existsSync(pendingMarker)).toBe(true);
 
       await vi.advanceTimersByTimeAsync(1000);
 
@@ -4329,6 +4338,66 @@ To continue this session, run codex resume ${sessionId}`,
       });
       expect(stateMgr.readState(result.agent_id)).toBeNull();
       expect(stateMgr.readState(finalAgentId)?.agent_id).toBe(finalAgentId);
+      expect(existsSync(pendingMarker)).toBe(false);
+    });
+
+    it("periodically reaps only old pending markers absent from registry and state", async () => {
+      vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"));
+      const nowSeconds = Math.floor(Date.now() / 1_000);
+      const oldOrphan = `brainlayerClaude-pending-${nowSeconds - 90_000}-dead`;
+      const oldKnown = `brainlayerClaude-pending-${nowSeconds - 90_000}-live`;
+      writeHeartbeat(oldOrphan, { baseDir: TEST_DIR });
+      writeHeartbeat(oldKnown, { baseDir: TEST_DIR });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: oldKnown,
+          surface_id: "surface:known-pending",
+          state: "error",
+        }),
+      );
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(
+        existsSync(
+          join(
+            TEST_DIR,
+            ".channel-dirs",
+            `${encodeURIComponent(oldOrphan)}.created`,
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        existsSync(
+          join(
+            TEST_DIR,
+            ".channel-dirs",
+            `${encodeURIComponent(oldKnown)}.created`,
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("retries marker maintenance promptly after a filesystem error", async () => {
+      vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"));
+      const markerDir = join(TEST_DIR, ".channel-dirs");
+      writeFileSync(markerDir, "not a directory");
+
+      await engine.runSweep();
+
+      rmSync(markerDir, { force: true });
+      const oldOrphan = `brainlayerClaude-pending-${Math.floor(Date.now() / 1_000) - 90_000}-retry`;
+      writeHeartbeat(oldOrphan, { baseDir: TEST_DIR });
+      const markerPath = join(
+        markerDir,
+        `${encodeURIComponent(oldOrphan)}.created`,
+      );
+      vi.setSystemTime(new Date(Date.now() + 60_000));
+
+      await engine.runSweep();
+
+      expect(existsSync(markerPath)).toBe(false);
     });
 
     it("captures the real session id from transcript metadata when the screen has no UUID", async () => {

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -102,6 +102,35 @@ function makeRecord(): AgentRecord {
 }
 
 describe("CmuxAppServerRuntime", () => {
+  it("passes its inbox directory to the engine marker reaper", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const inboxDir = join(TEST_DIR, "inbox");
+    const markerDir = join(inboxDir, ".channel-dirs");
+    const oldPendingId = `cmuxlayerCodex-pending-${Math.floor(
+      (Date.now() - 25 * 60 * 60 * 1_000) / 1_000,
+    )}-orphan`;
+    const markerPath = join(
+      markerDir,
+      `${encodeURIComponent(oldPendingId)}.created`,
+    );
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(markerPath, "");
+    const runtime = new CmuxAppServerRuntime({
+      client: makeClient(),
+      stateDir: TEST_DIR,
+      inboxOpts: { baseDir: inboxDir },
+    });
+
+    try {
+      await (runtime as any).engine.runSweep();
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes discovery within its TTL after an observer reconnect", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { appendFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -11,8 +17,10 @@ import {
   inboxPath,
   monitorAlive,
   pendingDispatches,
+  reapOrphanedPendingChannelMarkers,
   readInbox,
   readLastHeartbeat,
+  removePendingChannelMarkerAfterRegistration,
   recommendedCodexWatch,
   recommendedMonitorCommand,
   replayUndelivered,
@@ -27,6 +35,117 @@ const opts = { baseDir, now: () => clock };
 afterAll(() => rmSync(baseDir, { recursive: true, force: true }));
 
 describe("inbox write-channel", () => {
+  it("removes only the provisional marker after pending-to-real registration", () => {
+    const pendingId = "brainlayerClaude-pending-1000-dead";
+    const finalId = "brainlayerClaude-12345678";
+    writeHeartbeat(pendingId, opts);
+    writeHeartbeat(finalId, opts);
+
+    expect(
+      removePendingChannelMarkerAfterRegistration(pendingId, finalId, opts),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(baseDir, ".channel-dirs", `${encodeURIComponent(pendingId)}.created`),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(baseDir, ".channel-dirs", `${encodeURIComponent(finalId)}.created`),
+      ),
+    ).toBe(true);
+  });
+
+  it("reaps only retained pending markers that are old and unknown", () => {
+    const reapDir = mkdtempSync(join(tmpdir(), "cmux-inbox-reap-"));
+    const reapOpts = { baseDir: reapDir, now: () => 2_000_000 };
+    const oldOrphan = "brainlayerClaude-pending-1000-dead";
+    const oldKnown = "brainlayerClaude-pending-1000-live";
+    const youngOrphan = "brainlayerClaude-pending-1900-young";
+    const realAgent = "brainlayerClaude-12345678";
+    const malformedMarker = "malformed%ZZ.created";
+    try {
+      for (const agentId of [oldOrphan, oldKnown, youngOrphan, realAgent]) {
+        writeHeartbeat(agentId, reapOpts);
+      }
+      appendFileSync(join(reapDir, ".channel-dirs", malformedMarker), "");
+
+      const result = reapOrphanedPendingChannelMarkers(new Set([oldKnown]), {
+        ...reapOpts,
+        retentionMs: 500_000,
+      });
+
+      expect(result).toMatchObject({
+        scanned: 5,
+        reapable: 1,
+        reaped: 1,
+        retained_known: 1,
+        retained_young: 1,
+        retained_non_pending: 2,
+        errors: 0,
+      });
+      expect(
+        existsSync(
+          join(reapDir, ".channel-dirs", `${encodeURIComponent(oldOrphan)}.created`),
+        ),
+      ).toBe(false);
+      for (const agentId of [oldKnown, youngOrphan, realAgent]) {
+        expect(
+          existsSync(
+            join(reapDir, ".channel-dirs", `${encodeURIComponent(agentId)}.created`),
+          ),
+        ).toBe(true);
+      }
+      expect(
+        existsSync(join(reapDir, ".channel-dirs", malformedMarker)),
+      ).toBe(true);
+    } finally {
+      rmSync(reapDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps marker count bounded across repeated orphan creation and reaping", () => {
+    const reapDir = mkdtempSync(join(tmpdir(), "cmux-inbox-bounded-"));
+    try {
+      for (let cycle = 1; cycle <= 20; cycle += 1) {
+        const agentId = `testClaude-pending-${cycle * 10}-cycle${cycle}`;
+        writeHeartbeat(agentId, { baseDir: reapDir });
+        reapOrphanedPendingChannelMarkers([], {
+          baseDir: reapDir,
+          now: () => (cycle * 10 + 2) * 1_000,
+          retentionMs: 1_000,
+        });
+        expect(readdirSync(join(reapDir, ".channel-dirs"))).toHaveLength(0);
+      }
+    } finally {
+      rmSync(reapDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails safe when an invalid retention value is supplied", () => {
+    const reapDir = mkdtempSync(join(tmpdir(), "cmux-inbox-invalid-retention-"));
+    const pendingId = "testClaude-pending-1000-invalid";
+    try {
+      writeHeartbeat(pendingId, { baseDir: reapDir });
+
+      const result = reapOrphanedPendingChannelMarkers([], {
+        baseDir: reapDir,
+        now: () => 2_000_000,
+        retentionMs: Number.NaN,
+      });
+
+      expect(result.reaped).toBe(0);
+      expect(result.retained_young).toBe(1);
+      expect(
+        existsSync(
+          join(reapDir, ".channel-dirs", `${encodeURIComponent(pendingId)}.created`),
+        ),
+      ).toBe(true);
+    } finally {
+      rmSync(reapDir, { recursive: true, force: true });
+    }
+  });
+
   it("dispatch appends a message with defaults (to=agent, tag=dispatch) and id", () => {
     const m = dispatch("a1", { from: "orc", task: "do X" }, opts);
     expect(m.to).toBe("a1");

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import {
   createServer as createServerImpl,
   createServerContext as createServerContextImpl,
+  resolveServerInboxBaseDir,
   __submitEvidenceTestHooks,
   type CreateServerOptions,
 } from "../src/server.js";
@@ -40,6 +41,32 @@ type InputDeliveryTestModule = typeof import("../src/server.js") & {
 
 const openServers = new Set<ReturnType<typeof createServerImpl>>();
 const TEST_OBSERVER_OWNER = "cmux:/tmp/cmuxlayer-server-test.sock";
+
+describe("server inbox isolation", () => {
+  it("routes implicit Vitest inbox writes to the isolated state directory", () => {
+    expect(
+      resolveServerInboxBaseDir({
+        explicitBaseDir: undefined,
+        isVitest: true,
+      }),
+    ).toBe(join(tmpdir(), `cmuxlayer-vitest-inbox-${process.pid}`));
+  });
+
+  it("preserves explicit and production inbox locations", () => {
+    expect(
+      resolveServerInboxBaseDir({
+        explicitBaseDir: "/tmp/explicit-inbox",
+        isVitest: true,
+      }),
+    ).toBe("/tmp/explicit-inbox");
+    expect(
+      resolveServerInboxBaseDir({
+        explicitBaseDir: undefined,
+        isVitest: false,
+      }),
+    ).toBeUndefined();
+  });
+});
 
 function withTestObserver(opts: CreateServerOptions = {}): CreateServerOptions {
   if (opts.context) return opts;


### PR DESCRIPTION
## Outcome

- Reduced live `.channel-dirs` entries from 95,186 to 5,621 by deleting 89,565 old unknown pending markers. Preserved 5,570 young pending and all 51 non-pending markers; zero unlink errors.
- Stopped the source leak: successful pending-to-real registration now removes the provisional marker only after state and registry rename succeed.
- Stopped Vitest from writing mocked inbox channels into `~/.cmux/agents`; the full suite produced a zero live-marker delta.
- Added an hourly safe backlog pass with a one-minute retry after filesystem errors.

## Safety rule

The backlog reaper only deletes canonical timestamped pending markers older than 24 hours and absent from both live registry and persisted state. It never deletes agent channel directories, inbox data, heartbeats, messages, non-pending markers, known-agent markers, or young pending markers. Successful identity finalization is the stronger proof and removes the provisional marker immediately after durable registration.

## Measurements

- Directory enumeration: 549.479 ms before -> 3.128 ms after.
- 24 existing marker stats: 2.043 ms before -> 2.552 ms after.
- `list_agents(repo=cmuxlayer)`: 90 ms cold / 19 ms warm median before -> 51 ms cold / 22 ms warm median after.
- Result: the cleanup fixes entry-count/enumeration latency. It does not substantiate the claimed per-agent stat/sidebar mechanism and does not claim sidebar, click, `pane_died`, or stale-ref defects are fixed.
- A managed agent currently working was spawned when at least 94,801 pending entries already existed, confirming saturation did not block spawn correctness.

## Root cause and cmux answer

A full baseline test run minted 55 live markers in its exact 14-second window, including 35 `brainlayerClaude` and 7 `testClaude`; server tests isolated registry state but not inbox state. At installed cmux 0.64.20 commit `14e3400b9`, upstream source contains no `.channel-dirs` or `.cmux/agents` reference, so cmux does not enumerate this marker directory during spawn/list/resync. cmuxlayer only enumerates it in the new hourly maintenance pass.

## Verification

- `npm run pre-pr`: 63/63 passed.
- Full pre-push suite: 106 files, 2,383/2,383 tests passed.
- Typecheck and build passed.
- Full suite live marker audit: 5,852 -> 5,852, zero created and zero removed.
- Local CodeRabbit review was bounded; the valid retry finding was fixed. A test-seam suggestion was rejected because engine spawn does not itself write inbox data.

Closes the P0 channel-marker defect lane.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem maintenance on agent identity transitions and periodic `.channel-dirs` scans; deletion is gated by strict pending/age/known-agent rules but mistakes could affect health semantics for deleted channels.
> 
> **Overview**
> Fixes **pending `.channel-dirs` marker leakage** by unlinking the provisional marker only after a successful pending-to-real rename, and by **hourly backlog reaping** (1-minute retry on FS errors) of timestamped pending markers older than 24h that are not in registry or persisted state—non-pending and known-agent markers are kept.
> 
> **`src/inbox.ts`** adds `removePendingChannelMarkerAfterRegistration`, `reapOrphanedPendingChannelMarkers` (with `dryRun` and reap stats), and pending-id parsing from marker filenames.
> 
> **`src/agent-engine.ts`** wires immediate cleanup on every successful identity rename path and calls the reaper from `runSweep` when `inboxOpts` is configured.
> 
> **`src/server.ts`** introduces `resolveServerInboxBaseDir` so implicit Vitest runs use a process-scoped temp inbox (registered for exit cleanup) instead of the live home tree; explicit `inboxBaseDir` and production defaults are unchanged. **`CmuxAppServerRuntime`** can pass `inboxOpts` through to the engine.
> 
> Design/implementation plan docs and focused unit, engine, server, and app-server-runtime tests cover safety cases and the Vitest isolation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6069c7b42fbec9ed4f4942cd63077d1c0242c2eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix orphaned channel markers by reaping pending markers after registration and on periodic sweeps
> - Adds `removePendingChannelMarkerAfterRegistration` to [inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/355/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) to immediately unlink provisional pending markers after a successful pending-to-real agent registration.
> - Adds `reapOrphanedPendingChannelMarkers` to enumerate `.channel-dirs`, classify markers, and delete old pending markers not present in the known-agent set, respecting a default 1-hour retention window.
> - `AgentEngine` calls the immediate cleanup at all pending-to-final rename sites and runs the periodic reaper during sweeps, throttled to once per hour with a 1-minute retry on failure.
> - Under Vitest, `createServer` now routes inbox writes to a process-scoped temp directory to avoid polluting the live home path.
> - Behavioral Change: sweeps now emit an info or warning log line when markers are reaped or an error occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6069c7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->