### PR TITLE
fix: make inbox monitor dispatch receipts truthful

### DIFF
--- a/docs/plans/2026-08-05-inbox-monitor-receipt-gate.md
+++ b/docs/plans/2026-08-05-inbox-monitor-receipt-gate.md
@@ -1,0 +1,99 @@
+# Inbox Monitor Receipt Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop `dispatch_to_agent` from reporting ordinary success when no real inbox reader has ever been armed, without turning a temporarily stale reader into a fleet-wide false failure.
+
+**Architecture:** Keep inbox-reader truth in `src/inbox.ts`, where the agent-authored heartbeat already lives. Classify the reader as `never-armed`, `alive`, or `stale`. Always preserve the durable append and existing recovery nudge, but return a non-success, non-retryable receipt for `never-armed`; stale readers retain explicit degraded success. Do not use the independent deadman registry or a server boot marker as evidence that an inbox reader exists.
+
+**Tech Stack:** TypeScript, Vitest, MCP tool handlers.
+
+---
+
+### Task 1: Pin the three-state reader contract
+
+**Files:**
+- Modify: `tests/inbox.test.ts`
+- Modify: `tests/inbox-nudge.test.ts`
+- Modify: `tests/spawn-monitor-boot.test.ts`
+
+**Step 1: Write the failing tests**
+
+- Assert no agent heartbeat yields `never-armed`.
+- Assert a fresh agent heartbeat yields `alive`.
+- Assert an old agent heartbeat yields `stale`.
+- Assert dispatch to `never-armed` returns `ok:false`, `error_code:"inbox_monitor_never_armed"`, and still appends the message durably so the fallback wake/replay path is not lost.
+- Assert stale-but-previously-armed dispatch remains durable and returns an explicit degraded receipt.
+- Keep the healthy dispatch regression green.
+- Preserve the spawn boot-marker regression: server boot metadata alone does not make the inbox reader alive.
+
+**Step 2: Run tests to verify RED**
+
+Run: `TMPDIR=<isolated> bun run test -- tests/inbox.test.ts tests/inbox-nudge.test.ts tests/spawn-monitor-boot.test.ts`
+
+Expected: FAIL because the three-state helper and receipt fields do not exist and unarmed dispatch still returns `ok:true`.
+
+### Task 2: Implement the minimum truthful gate
+
+**Files:**
+- Modify: `src/inbox.ts`
+- Modify: `src/server.ts`
+
+**Step 1: Add the reader-state helper**
+
+```ts
+export type InboxMonitorState = "never-armed" | "alive" | "stale";
+
+export function inboxMonitorState(
+  agentId: string,
+  maxAgeMs: number,
+  opts?: InboxOpts,
+): InboxMonitorState {
+  const heartbeat = readLastAgentHeartbeat(agentId, opts);
+  if (!heartbeat) return "never-armed";
+  const ageMs = nowOf(opts) - heartbeat.ts_ms;
+  return ageMs >= 0 && ageMs <= maxAgeMs ? "alive" : "stale";
+}
+```
+
+Have `monitorAlive()` delegate to this helper so there is one classification source.
+
+**Step 2: Make dispatch receipts reflect reader state**
+
+- Resolve `monitor_state` before calling `dispatch()`.
+- Keep the durable append and nudge behavior for all states.
+- For `never-armed`, return a tool error with `error_code`, `monitor_state`, `monitor_alive:false`, the existing `dispatched:<stored message>` object, `durable:true`, and `retryable:false`; the message id tells callers not to retry and duplicate it.
+- For `stale`, append durably, retain current `nudge:auto` recovery, and return `delivery_status:"queued_monitor_stale"`.
+- For `alive`, append durably and return `delivery_status:"monitor_live"`.
+
+**Step 3: Run focused tests to verify GREEN**
+
+Run: `TMPDIR=<isolated> bun run test -- tests/inbox.test.ts tests/inbox-nudge.test.ts tests/spawn-monitor-boot.test.ts`
+
+Expected: all focused tests pass.
+
+### Task 3: Verify and publish the worker endpoint
+
+**Files:**
+- Verify all changed files.
+
+**Step 1: Run repository gates**
+
+Run:
+
+```bash
+TMPDIR=<isolated> bun run typecheck
+TMPDIR=<isolated> bun run build
+TMPDIR=<isolated> bun run test
+TMPDIR=<isolated> bun run pre-pr
+```
+
+Expected: typecheck/build exit 0; 2,433 baseline tests plus new tests pass; pre-PR harness passes.
+
+**Step 2: Run the daemon/client gate**
+
+Because `src/server.ts` is MCP/daemon code, start the branch build through an isolated daemon/socket and issue real `inbox_check` and `dispatch_to_agent` requests. Verify `never-armed` is non-OK, stale is explicit/degraded, and healthy remains OK.
+
+**Step 3: Commit, push, and open a ready PR**
+
+Run the bounded local CodeRabbit command if available, commit only owned files, push `fix/inbox-monitor-lifecycle`, and create a ready PR. Per the worker brief, do not spawn or invoke a reviewer; post the PR URL and the unresolved lifecycle-arming architecture boundary to `@cmuxlayer` on FLEET-STANDING.

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -82,6 +82,8 @@ export interface MonitorHeartbeat {
   source: MonitorHeartbeatSource;
 }
 
+export type InboxMonitorState = "never-armed" | "alive" | "stale";
+
 export interface DispatchInput {
   from: string;
   to?: string;
@@ -452,9 +454,23 @@ export function monitorAlive(
   maxAgeMs: number,
   opts?: InboxOpts,
 ): boolean {
+  return inboxMonitorState(agentId, maxAgeMs, opts) === "alive";
+}
+
+/**
+ * Distinguish a reader that has never proved it was armed from one that was
+ * armed previously but is temporarily stale. Only agent-authored heartbeats
+ * count; server boot markers are audit metadata, not reader liveness.
+ */
+export function inboxMonitorState(
+  agentId: string,
+  maxAgeMs: number,
+  opts?: InboxOpts,
+): InboxMonitorState {
   const heartbeat = readLastAgentHeartbeat(agentId, opts);
-  if (!heartbeat) return false;
-  return nowOf(opts) - heartbeat.ts_ms <= maxAgeMs;
+  if (!heartbeat) return "never-armed";
+  const ageMs = nowOf(opts) - heartbeat.ts_ms;
+  return ageMs >= 0 && ageMs <= maxAgeMs ? "alive" : "stale";
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,6 +110,7 @@ import {
 import {
   dispatch,
   ensureInboxFile,
+  inboxMonitorState,
   inboxPath,
   monitorAlive,
   pendingDispatches,
@@ -8155,7 +8156,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // directly into the agent's surface, regardless of registry state.
   server.tool(
     "dispatch_to_agent",
-    "Append a task to an agent's inbox FILE (the deterministic write channel). The agent acts on it via a persistent native Monitor on its inbox — NO send_input/TUI typing. If the recipient's monitor heartbeat is stale/absent, nudge='auto' (default) best-effort types a one-line inbox pointer into the agent's surface — independent of agent lifecycle state. Address to:'orc' to flag the orchestrator (own-tag triage). Channel is EPHEMERAL plumbing — set persist:true only for decisions that should be brain_store'd.",
+    "Append a task to an agent's inbox FILE (the deterministic write channel). The agent acts on it via a persistent native Monitor on its inbox — NO send_input/TUI typing. If the recipient's monitor heartbeat is stale/absent, nudge='auto' (default) best-effort types a one-line inbox pointer into the agent's surface — independent of agent lifecycle state. A never-armed reader returns a non-retryable error after the durable append; a previously armed but stale reader returns explicit degraded success. Address to:'orc' to flag the orchestrator (own-tag triage). Channel is EPHEMERAL plumbing — set persist:true only for decisions that should be brain_store'd.",
     {
       agent_id: z
         .string()
@@ -8199,11 +8200,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           inboxOpts,
         );
         context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
-        const monitor_alive = monitorAlive(
+        const monitor_state = inboxMonitorState(
           args.agent_id,
           INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS,
           inboxOpts,
         );
+        const monitor_alive = monitor_state === "alive";
         const pending = pendingDispatches(
           args.agent_id,
           AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
@@ -8270,13 +8272,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               stale_count: pending.length,
             })
           : undefined;
-        return ok({
+        const delivery_status =
+          monitor_state === "alive"
+            ? "monitor_live"
+            : monitor_state === "stale"
+              ? "queued_monitor_stale"
+              : "queued_monitor_never_armed";
+        const receipt = {
           dispatched: msg,
           inbox: inboxPath(args.agent_id, inboxOpts),
+          durable: true,
+          delivery_status,
           monitor_alive,
+          monitor_state,
           health,
           nudge,
-        });
+        };
+        if (monitor_state === "never-armed") {
+          return err(
+            "inbox message was queued, but the recipient has never proved that its inbox monitor is armed",
+            {
+              error_code: "inbox_monitor_never_armed",
+              retryable: false,
+              ...receipt,
+            },
+          );
+        }
+        return ok(receipt);
       } catch (e) {
         return err(e);
       }

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -10,8 +10,10 @@
  *     stale/absent, best-effort type a one-line inbox pointer into the agent's
  *     surface — REGARDLESS of registry state (error/done included).
  *   - heartbeat fresh → no nudge (monitor will deliver).
- *   - agent unknown to the registry → dispatch still succeeds, nudge skipped.
- *   - nudge="never" → file append only.
+ *   - no agent-authored heartbeat ever → message remains durable, but the
+ *     receipt is a non-retryable error instead of false delivery success.
+ *   - stale heartbeat → explicit degraded success plus the recovery nudge.
+ *   - nudge="never" → file append only; receipt truth is unchanged.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
@@ -24,7 +26,11 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
-import { agentDir, writeHeartbeat, readInbox } from "../src/inbox.js";
+import {
+  agentDir,
+  writeHeartbeat,
+  readInbox,
+} from "../src/inbox.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import {
   FleetSidebarPublisher,
@@ -231,7 +237,7 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     rmSync(inboxDir, { recursive: true, force: true });
   });
 
-  it("nudges via the agent's surface when heartbeat is absent — even in a TERMINAL state", async () => {
+  it("returns a non-success durable receipt when never armed, while still nudging a TERMINAL agent", async () => {
     const agentId = await spawnTestAgent(server);
 
     // Poison-equivalent: force a terminal state. The nudge must still go out.
@@ -254,7 +260,13 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
+    expect(parsed.monitor_state).toBe("never-armed");
+    expect(parsed.delivery_status).toBe("queued_monitor_never_armed");
+    expect(parsed.retryable).toBe(false);
+    expect(parsed.durable).toBe(true);
+    expect(parsed.dispatched.task).toBe("GO");
     expect(parsed.monitor_alive).toBe(false);
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(true);
@@ -270,6 +282,34 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     expect(
       readInbox(agentId, { baseDir: inboxDir }).map((m) => m.task),
     ).toContain("GO");
+  });
+
+  it("returns explicit degraded success when a previously armed monitor is stale", async () => {
+    const agentId = await spawnTestAgent(server);
+    writeHeartbeat(agentId, { baseDir: inboxDir, now: () => 1 });
+
+    const dispatchTool = server._registeredTools["dispatch_to_agent"];
+    const result = await dispatchTool.handler(
+      {
+        agent_id: agentId,
+        task: "GO",
+        from: "orc",
+        tag: "dispatch",
+        persist: false,
+        nudge: "auto",
+      },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.monitor_alive).toBe(false);
+    expect(parsed.monitor_state).toBe("stale");
+    expect(parsed.delivery_status).toBe("queued_monitor_stale");
+    expect(parsed.nudge.attempted).toBe(true);
+    expect(parsed.nudge.sent).toBe(true);
+    expect(readInbox(agentId, { baseDir: inboxDir })).toHaveLength(1);
   });
 
   it("does NOT nudge when the monitor heartbeat is fresh", async () => {
@@ -294,6 +334,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.monitor_alive).toBe(true);
+    expect(parsed.monitor_state).toBe("alive");
+    expect(parsed.delivery_status).toBe("monitor_live");
     expect(parsed.nudge.attempted).toBe(false);
     expect(sendCalls(exec).length).toBe(before);
   });
@@ -539,7 +581,7 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     ).toHaveLength(1);
   });
 
-  it("dispatch still succeeds for an agent unknown to the registry (nudge skipped, not failed)", async () => {
+  it("keeps an unknown agent's message durable but does not report false success", async () => {
     const dispatchTool = server._registeredTools["dispatch_to_agent"];
     const result = await dispatchTool.handler(
       {
@@ -555,7 +597,10 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
+    expect(parsed.monitor_state).toBe("never-armed");
+    expect(parsed.retryable).toBe(false);
     expect(parsed.nudge.attempted).toBe(false);
     expect(parsed.nudge.sent).toBe(false);
     expect(readInbox("ghost-agent", { baseDir: inboxDir })).toHaveLength(1);
@@ -594,7 +639,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(false);
     expect(parsed.nudge.error_code).toBe("blocked_by_permission_prompt");
@@ -633,7 +679,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(false);
     expect(parsed.nudge.error_code).toBe("blocked_by_interactive_prompt");
@@ -663,12 +710,14 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
+    expect(parsed.retryable).toBe(false);
     expect(parsed.nudge.attempted).toBe(false);
     expect(sendCalls(exec).length).toBe(before);
   });
 
-  it("a failed nudge send never fails the dispatch (file append is the contract)", async () => {
+  it("a failed nudge send does not lose the durable never-armed dispatch", async () => {
     const agentId = await spawnTestAgent(server);
     // Make subsequent send calls explode.
     (exec as ReturnType<typeof vi.fn>).mockImplementation(
@@ -693,7 +742,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(false);
     expect(parsed.nudge.reason).toMatch(/socket down|failed/i);
@@ -792,7 +842,8 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
     expect(parsed.nudge.attempted).toBe(true);
     expect(parsed.nudge.sent).toBe(false);
     expect(parsed.nudge.reason).toMatch(/recycled/i);

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -14,6 +14,7 @@ import {
   agentDir,
   dispatch,
   dispatchOnce,
+  inboxMonitorState,
   inboxPath,
   monitorAlive,
   pendingDispatches,
@@ -219,13 +220,27 @@ describe("inbox write-channel", () => {
     clock = 20_000;
     writeHeartbeat("a5", opts);
     clock = 20_500;
+    expect(inboxMonitorState("a5", 1_000, opts)).toBe("alive");
     expect(monitorAlive("a5", 1_000, opts)).toBe(true);
     clock = 22_000; // 2000ms since heartbeat
+    expect(inboxMonitorState("a5", 1_000, opts)).toBe("stale");
     expect(monitorAlive("a5", 1_000, opts)).toBe(false);
   });
 
   it("FM#1 monitorAlive is false when no heartbeat exists", () => {
+    expect(inboxMonitorState("never-armed", 1_000, opts)).toBe(
+      "never-armed",
+    );
     expect(monitorAlive("never-armed", 1_000, opts)).toBe(false);
+  });
+
+  it("FM#1 treats a future-dated agent heartbeat as stale", () => {
+    clock = 50_000;
+    writeHeartbeat("clock-skewed", opts);
+    clock = 40_000;
+
+    expect(inboxMonitorState("clock-skewed", 1_000, opts)).toBe("stale");
+    expect(monitorAlive("clock-skewed", 1_000, opts)).toBe(false);
   });
 
   it("FM#1 server boot markers do not prove monitor liveness", () => {
@@ -236,6 +251,7 @@ describe("inbox write-channel", () => {
       ts_ms: 25_000,
       source: "server_boot",
     });
+    expect(inboxMonitorState("a5-boot", 1_000, opts)).toBe("never-armed");
     expect(monitorAlive("a5-boot", 1_000, opts)).toBe(false);
 
     writeHeartbeat("a5-boot", opts);

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -228,7 +228,7 @@ describe("spawn monitor boot", () => {
     }
   });
 
-  it("nudges the first orchestrator dispatch until the agent heartbeats", async () => {
+  it("durably nudges but does not report delivery success until the agent heartbeats", async () => {
     const spawn = server._registeredTools["spawn_agent"];
     const dispatch = server._registeredTools["dispatch_to_agent"];
 
@@ -257,7 +257,12 @@ describe("spawn monitor boot", () => {
     );
 
     const parsed = parseToolResult(result);
-    expect(parsed.ok).toBe(true);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_code).toBe("inbox_monitor_never_armed");
+    expect(parsed.monitor_state).toBe("never-armed");
+    expect(parsed.delivery_status).toBe("queued_monitor_never_armed");
+    expect(parsed.retryable).toBe(false);
+    expect(parsed.durable).toBe(true);
     expect(parsed.monitor_alive).toBe(false);
     expect(parsed.health.issue_codes).toContain("inbox_monitor_not_alive");
     expect(parsed.nudge.attempted).toBe(true);


### PR DESCRIPTION
## Summary

- classify inbox readers as `never-armed`, `stale`, or `alive` from agent-authored heartbeats
- preserve durable append and the guarded nudge fallback, while returning a non-retryable error instead of plain success when no reader has ever proved it was armed
- return explicit degraded success for stale readers and normal success for live readers
- keep server boot markers honest and treat future-dated heartbeats as stale

## Root cause

The generic deadman monitor registry and the inbox reader heartbeat are independent systems. Registering a deadman monitor or writing `server_boot` metadata does not start or prove a live inbox reader. The prior false-liveness behavior was already reverted, but `dispatch_to_agent` still returned ordinary success for a never-armed inbox.

## Impact

Callers can now distinguish an unarmed reader from a temporarily stale reader without losing the durable message or the state-independent recovery nudge. `retryable:false` and the returned stored message ID prevent duplicate retries after the append.

## Verification

- `bun run typecheck`
- `bun run build`
- `bun run test` — 106 files, 2,435 tests passed (baseline: 2,433)
- `bun run pre-pr` — 63 tests passed
- real branch daemon + stdio proxy + MCP client: verified never-armed non-success, stale degraded success, alive success, and `inbox_check`
- local CodeRabbit review: 0 findings after one clock-skew fix
- push hook: full suite passed

## Follow-up boundary

This PR deliberately does not fake automatic monitor arming. A real cross-harness reader connector is still required for fresh spawns and auto-discovered agents; `server_boot` and the independent deadman registry cannot provide that proof. The live verification also exposed that `CmuxLayerDaemonOptions.inboxBaseDir` is not forwarded to per-connection `createServer`; that separate daemon wiring defect is left out of this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP semantics for `dispatch_to_agent` (callers may have assumed `ok: true` meant delivery); behavior is intentional and covered by broad test updates, but orchestration code must handle the new error path.
> 
> **Overview**
> **`dispatch_to_agent` no longer returns plain success when the recipient has never armed an inbox reader.** Messages are still appended durably and the existing `nudge=auto` wake path runs unchanged; only the MCP receipt reflects reality.
> 
> Reader liveness is now a three-way classification in `inbox.ts`: **`never-armed`** (no agent heartbeat), **`alive`** (fresh agent heartbeat), or **`stale`** (expired or future-dated heartbeat). `monitorAlive()` delegates to `inboxMonitorState()` so there is a single source of truth; **`server_boot` heartbeats still do not count** as proof the reader is armed.
> 
> Receipt behavior: **`never-armed`** → `ok: false`, `error_code: inbox_monitor_never_armed`, `retryable: false`, plus `delivery_status: queued_monitor_never_armed` and the stored message; **`stale`** → `ok: true` with `delivery_status: queued_monitor_stale`; **`alive`** → `ok: true` with `delivery_status: monitor_live`. Responses also expose `monitor_state` and `durable: true`.
> 
> Tests and an implementation plan doc were updated to lock in the contract (including spawn-before-first-heartbeat and unknown-agent cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a78d251fca72bff2fe9ec8091266abd4f6e1115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `dispatch_to_agent` receipts to accurately reflect inbox monitor state
> - Introduces a three-state `InboxMonitorState` type (`never-armed`, `alive`, `stale`) in [inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/357/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) via a new `inboxMonitorState` helper; `monitorAlive` now returns false for future-dated or missing heartbeats.
> - `dispatch_to_agent` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/357/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) uses `inboxMonitorState` to set `delivery_status` (`monitor_live`, `queued_monitor_stale`, `queued_monitor_never_armed`) and `monitor_state` on all receipts, which now also carry `durable: true`.
> - When the recipient has never heartbeated, `dispatch_to_agent` returns a non-OK, non-retryable error with `error_code: "inbox_monitor_never_armed"` while still durably queueing the message and attempting a nudge.
> - Behavioral Change: callers that previously received an OK receipt for dispatches to agents with no heartbeat will now receive a non-OK response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a78d25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->