### PR TITLE
fix: state the launcher's real effort default and accept its full ladder

### DIFF
--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,10 +1,15 @@
 import type { CliType } from "./agent-types.js";
 
 export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
+// Must stay in sync with golem-dispatch.zsh:446 — the launcher is the authority.
+// `low` and `max` were added there; omitting them here made `max` (Etan's pin for
+// some lanes) impossible to express through spawn_agent at all.
 export const CODEX_EFFORT_VALUES = [
+  "low",
   "medium",
   "high",
   "xhigh",
+  "max",
   "ultra",
 ] as const;
 export type CodexEffort = (typeof CODEX_EFFORT_VALUES)[number];
@@ -202,11 +207,7 @@ export function resolveLaunchModelFlag(
   }
 
   const alias = ownModelAlias(cli, normalizeModelKey(requested));
-  if (
-    cli === "claude" &&
-    alias !== "sonnet" &&
-    !opts?.allowModelOverride
-  ) {
+  if (cli === "claude" && alias !== "sonnet" && !opts?.allowModelOverride) {
     return null;
   }
   return alias ?? null;
@@ -222,7 +223,9 @@ export function resolveSpawnModelPolicy(
   const requestedWasOmitted = requestedModel.length === 0;
   const overrideAllowed = envFlagEnabled(env[MODEL_OVERRIDE_ENV]);
   const defaultModel = contract.defaultModel;
-  const requestedOrDefault = requestedWasOmitted ? defaultModel : requestedModel;
+  const requestedOrDefault = requestedWasOmitted
+    ? defaultModel
+    : requestedModel;
   const resolvedRequested = resolveModelAlias(cli, requestedOrDefault);
 
   // Cursor deliberately accepts arbitrary model strings behind its escape

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,10 +156,7 @@ import type {
   ParsedScreenResult,
 } from "./types.js";
 import { normalizeKeyName } from "./key-names.js";
-import {
-  currentCallerContext,
-  type CallerContext,
-} from "./caller-context.js";
+import { currentCallerContext, type CallerContext } from "./caller-context.js";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
   matchReadyPattern,
@@ -347,7 +344,7 @@ export const DEFAULT_SEND_INPUT_MAX_INLINE_CHARS = 1_800;
 const PANE_INPUT_BREAKAGE_GUIDANCE =
   "Max 2-3 short lines. Longer payloads BREAK the receiving pane — write the payload to a file and send one line: `Read and follow <path>`.";
 const ZSH_BANG_INLINE_WARNING =
-  'WARNING — a `!` in an inline brief may be consumed by zsh history expansion before it reaches the worker, leaving the worker idle with no task; file-backed payloads avoid that shell interpretation.';
+  "WARNING — a `!` in an inline brief may be consumed by zsh history expansion before it reaches the worker, leaving the worker idle with no task; file-backed payloads avoid that shell interpretation.";
 export const SEND_INPUT_PASTE_BATCH_MAX_BYTES = 16_000;
 const SEND_INPUT_CHUNK_DELAY_MS = 5;
 const SEND_INPUT_RETRY_ATTEMPTS = 3;
@@ -1404,10 +1401,7 @@ function assertDenseInlineInputAllowed(opts: {
   const inputCharacterCount = Array.from(opts.value).length;
   const longestUnbrokenRun = opts.value
     .split(/\r?\n/)
-    .reduce(
-      (longest, line) => Math.max(longest, Array.from(line).length),
-      0,
-    );
+    .reduce((longest, line) => Math.max(longest, Array.from(line).length), 0);
   if (longestUnbrokenRun <= DENSE_INLINE_POLICY_MAX_UNBROKEN_CHARS) {
     return;
   }
@@ -1463,7 +1457,11 @@ function assertBroadcastInlineInputAllowed(text: string): void {
     );
   }
 
-  assertDenseInlineInputAllowed({ tool: "broadcast", arg: "text", value: text });
+  assertDenseInlineInputAllowed({
+    tool: "broadcast",
+    arg: "text",
+    value: text,
+  });
 }
 
 function broadcastRoleMatches(
@@ -4976,10 +4974,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const cwd = workspace?.current_directory?.trim();
     if (!cwd || workspaceDirectoryRepoMatchScore(repo, cwd) > 0) return;
     const title = workspace?.title?.trim();
-    const titleCandidates = [
-      inferRepoFromLauncherTitle(title),
-      title,
-    ].filter(
+    const titleCandidates = [inferRepoFromLauncherTitle(title), title].filter(
       (candidate, index, all): candidate is string =>
         Boolean(candidate) && all.indexOf(candidate) === index,
     );
@@ -5058,9 +5053,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       );
       const matches = paneLists
         .filter(({ panes }) =>
-          panes.some(
-            (pane) => pane.ref === opts.pane || pane.id === opts.pane,
-          ),
+          panes.some((pane) => pane.ref === opts.pane || pane.id === opts.pane),
         )
         .map(({ workspace }) => workspace);
       if (matches.length === 1) {
@@ -5119,9 +5112,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): Promise<FocusRestoreLease | null> => {
     if (!targetWorkspace) return null;
     const prior =
-      capturedPrior === undefined
-        ? await currentFocusTarget()
-        : capturedPrior;
+      capturedPrior === undefined ? await currentFocusTarget() : capturedPrior;
     const placementFocus =
       capturedPrior === undefined ? prior : await currentFocusTarget();
     if (!placementFocus || placementFocus.workspace !== targetWorkspace) {
@@ -5157,9 +5148,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const sameExactFocus = (left: FocusTarget, right: FocusTarget): boolean =>
     Boolean(
       left.surface &&
-        right.surface &&
-        left.workspace === right.workspace &&
-        left.surface === right.surface,
+      right.surface &&
+      left.workspace === right.workspace &&
+      left.surface === right.surface,
     );
 
   /**
@@ -5415,17 +5406,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .map((record) => record.surface_uuid?.trim())
         .filter((uuid): uuid is string => Boolean(uuid)),
     );
-    const registryUuid = registryUuids.size === 1 ? [...registryUuids][0] : null;
+    const registryUuid =
+      registryUuids.size === 1 ? [...registryUuids][0] : null;
     const expectedUuid = capturedUuid ?? registryUuid;
     const topologyObserverEpoch = context.surfaceObserverEpoch;
     const topology = await collectSurfaceTopology();
 
     if (topology?.complete === true) {
       const uuidTargetRef = findSurfaceRefByUuid(topology, requestedSurface);
-      captureSurfaceIdentities(
-        topology.surfaceIdByRef,
-        topologyObserverEpoch,
-      );
+      captureSurfaceIdentities(topology.surfaceIdByRef, topologyObserverEpoch);
       const currentUuidAtRequestedRef =
         topology.surfaceIdByRef.get(requestedSurface) ?? null;
       if (
@@ -5638,8 +5627,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       .sort((a, b) => {
         if (b.version !== a.version) return b.version - a.version;
         return (
-          new Date(b.updated_at).getTime() -
-          new Date(a.updated_at).getTime()
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
         );
       });
 
@@ -5788,8 +5776,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const spawnDeliveryWorkspace = (
     result: { workspace_id?: string },
     fallback?: string,
-  ): string | undefined =>
-    result.workspace_id || fallback;
+  ): string | undefined => result.workspace_id || fallback;
 
   const isLeadLikeSurfaceTitle = (title: string): boolean =>
     /\b(?:lead|orchestrator|coordinator|coord)\b/i.test(title);
@@ -6644,9 +6631,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.workspace || targetWorkspace,
           );
         } else {
-          focusRestoreLease = await capturePostCreationFocus(
-            focusRestoreLease,
-          );
+          focusRestoreLease = await capturePostCreationFocus(focusRestoreLease);
         }
         if (args.title) {
           await client.renameTab(result.surface, args.title, {
@@ -7450,12 +7435,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         let codexAgentBeforeRead: AgentRecord | null = null;
-        const hasCodexRolloutCandidate = stateMgr.listStates().some(
-          (agent) =>
-            agent.cli === "codex" &&
-            Boolean(agent.surface_uuid?.trim()) &&
-            Boolean(agent.cli_session_path),
-        );
+        const hasCodexRolloutCandidate = stateMgr
+          .listStates()
+          .some(
+            (agent) =>
+              agent.cli === "codex" &&
+              Boolean(agent.surface_uuid?.trim()) &&
+              Boolean(agent.cli_session_path),
+          );
         if (hasCodexRolloutCandidate) {
           const topologyBeforeRead = await collectSurfaceTopology(
             args.workspace,
@@ -7491,11 +7478,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               result.text,
               pickLatestSurfaceModel(stateMgr, result.surface),
             ),
-            resolveHarnessStateForSurface(
-              stateMgr,
-              result.surface,
-              codexAgent,
-            ),
+            resolveHarnessStateForSurface(stateMgr, result.surface, codexAgent),
           ),
           codexFill,
         );
@@ -7607,7 +7590,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const surfaces = await client.listPaneSurfaces({
             workspace: route.workspace,
           });
-          const surface = surfaces.surfaces.find((s) => s.ref === route.surface);
+          const surface = surfaces.surfaces.find(
+            (s) => s.ref === route.surface,
+          );
           const currentTitle = surface?.title ?? "";
           finalTitle = replaceTaskSuffix(currentTitle, args.title);
         }
@@ -7795,10 +7780,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             .listStates()
             .find(
               (record) =>
-                ((route.stableSurfaceIdentity && record.surface_uuid
+                (route.stableSurfaceIdentity && record.surface_uuid
                   ? record.surface_uuid.toLowerCase() ===
                     route.stableSurfaceIdentity.toLowerCase()
-                  : record.surface_id === route.surface)) &&
+                  : record.surface_id === route.surface) &&
                 !TERMINAL_AGENT_STATES.has(record.state),
             );
           if (backingAgent) {
@@ -7867,10 +7852,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 .listStates()
                 .find(
                   (record) =>
-                    ((route.stableSurfaceIdentity && record.surface_uuid
+                    (route.stableSurfaceIdentity && record.surface_uuid
                       ? record.surface_uuid.toLowerCase() ===
                         route.stableSurfaceIdentity.toLowerCase()
-                      : record.surface_id === route.surface)) &&
+                      : record.surface_id === route.surface) &&
                     !TERMINAL_AGENT_STATES.has(record.state),
                 );
               if (remainingLiveAgent) {
@@ -8747,12 +8732,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       try {
         const existing = input.agentId
           ? engine.getAgentState(input.agentId)
-          : (registry.list().find((record) =>
-              input.surfaceUuid
-                ? record.surface_uuid?.toLowerCase() ===
-                  input.surfaceUuid.toLowerCase()
-                : record.surface_id === input.surfaceId,
-            ) ?? null);
+          : (registry
+              .list()
+              .find((record) =>
+                input.surfaceUuid
+                  ? record.surface_uuid?.toLowerCase() ===
+                    input.surfaceUuid.toLowerCase()
+                  : record.surface_id === input.surfaceId,
+              ) ?? null);
         if (!existing) return;
 
         const updated =
@@ -9209,7 +9196,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .enum(CODEX_EFFORT_VALUES)
           .optional()
           .describe(
-            "Optional Codex reasoning effort passed to the repoGolem launcher. Accepted values: medium, high, xhigh, ultra. The launcher defaults to xhigh when omitted; max is not accepted by the current launcher.",
+            "Codex reasoning effort, passed to the repoGolem launcher. CHOOSE THIS DELIBERATELY PER MISSION — it is a cost decision, not a default to inherit. Accepted: low, medium, high, xhigh, max, ultra. The launcher defaults to HIGH when omitted (golem-dispatch.zsh:431). Per /agent-routing, MEDIUM is the settled floor for well-specified implementation lanes — use it unless the task genuinely needs more; xhigh and above burn budget fast and are rarely warranted for a lane with a clear brief.",
           ),
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])
@@ -9501,8 +9488,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 const updated = stateMgr.updateRecord(result.agent_id, {
                   task_summary: bootPromptDelivery.prompt_text,
                   boot_prompt_pending: false,
-                  prompt_delivered:
-                    bootPromptDelivery.submit_verified === true,
+                  prompt_delivered: bootPromptDelivery.submit_verified === true,
                   submit_verified: bootPromptDelivery.submit_verified,
                 });
                 registry.set(result.agent_id, updated);
@@ -9615,10 +9601,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
           if (focusRestoreWarning) {
-            result.warnings = [
-              ...(result.warnings ?? []),
-              focusRestoreWarning,
-            ];
+            result.warnings = [...(result.warnings ?? []), focusRestoreWarning];
           }
 
           await refreshManagedMetadataBestEffort(result.agent_id);
@@ -9883,10 +9866,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             { waitForReady: !hasPrompt },
           );
           if (focusRestoreWarning) {
-            result.warnings = [
-              ...(result.warnings ?? []),
-              focusRestoreWarning,
-            ];
+            result.warnings = [...(result.warnings ?? []), focusRestoreWarning];
           }
           await refreshManagedMetadataBestEffort(result.agent_id);
           await lifecycleSeatManifestPublisher({
@@ -10136,9 +10116,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // current focus cannot prove it already is. The lease drives
           // focus-back only while the user has not moved since cmuxlayer's
           // latest placement mutation.
-          focusRestoreLease = await capturePostCreationFocus(
-            focusRestoreLease,
-          );
+          focusRestoreLease = await capturePostCreationFocus(focusRestoreLease);
 
           for (const agent of normalizedAgents) {
             const hasPrompt = hasInlinePrompt(agent.prompt);
@@ -10366,10 +10344,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (e.launch_cause instanceof SurfaceGoneError) {
               return err(
                 e.launch_cause,
-                surfaceGonePayload(
-                  e.launch_cause,
-                  failureIdentityPayload,
-                ),
+                surfaceGonePayload(e.launch_cause, failureIdentityPayload),
               );
             }
             return err(e, failureIdentityPayload);
@@ -10390,10 +10365,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
           }
           if (e instanceof SurfaceGoneError) {
-            return err(
-              e,
-              surfaceGonePayload(e, failureIdentityPayload),
-            );
+            return err(e, surfaceGonePayload(e, failureIdentityPayload));
           }
           if (e instanceof BootPromptTimeoutError) {
             return err(e, {

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+  CODEX_EFFORT_VALUES,
   MODEL_OVERRIDE_ENV,
   MODEL_POLICY_CONTRACT,
   resolveSpawnModelPolicy,
@@ -117,6 +118,47 @@ describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
       contractDefault,
       `golem-dispatch default ${dispatchDefault} must match MODEL_POLICY_CONTRACT cli.claude.defaultModel ${contractDefault}`,
     ).toBe(dispatchDefault);
+  });
+
+  it("keeps the Codex effort ladder aligned with the launcher", () => {
+    // RED 2026-08-05: the launcher gained `low` and `max` and moved its default
+    // xhigh -> high; cmuxlayer's enum and tool description did not follow. The
+    // stale description is what agents read at dispatch time, so it normalised
+    // xhigh fleet-wide and cost real usage. Nothing guarded effort — only model.
+    const ladder = dispatchText.match(/low\|medium\|high\|xhigh\|max\|ultra/);
+    expect(
+      ladder,
+      "golem-dispatch.zsh must still expose the low|medium|high|xhigh|max|ultra ladder",
+    ).not.toBeNull();
+
+    for (const value of ["low", "medium", "high", "xhigh", "max", "ultra"]) {
+      expect(
+        CODEX_EFFORT_VALUES as readonly string[],
+        `CODEX_EFFORT_VALUES must accept "${value}" — the launcher does`,
+      ).toContain(value);
+    }
+  });
+
+  it("states the launcher's REAL effort default, not a stale one", () => {
+    const declared = dispatchText.match(/_flag_codex_effort="([a-z]+)"/)?.[1];
+    expect(declared, "could not parse _flag_codex_effort default").toBeTruthy();
+
+    // The tool description is the text agents read at dispatch time. If it names
+    // a different default than the launcher actually uses, every agent inherits
+    // the wrong one.
+    const serverText = readFileSync(
+      join(process.cwd(), "src", "server.ts"),
+      "utf8",
+    );
+    const claimed = serverText.match(
+      /launcher defaults to ([A-Za-z]+) when omitted/i,
+    )?.[1];
+    if (claimed) {
+      expect(
+        claimed.toLowerCase(),
+        `spawn_agent effort description claims "${claimed}" but golem-dispatch.zsh defaults to "${declared}"`,
+      ).toBe(declared);
+    }
   });
 
   it("refuses Cursor agent -m overrides in both policy paths", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -686,7 +686,14 @@ describe("lean spawn tool responses", () => {
     );
   });
 
-  it("spawn_agent schema rejects max effort before invoking the handler", () => {
+  // CHANGED 2026-08-05, deliberately, with rationale: this asserted `max` must be
+  // REJECTED, which was correct when golem-dispatch.zsh's ladder was
+  // medium|high|xhigh|ultra. golems #657 added `low` and `max`, and Etan pins some
+  // lanes at max — so cmuxlayer rejecting it made his own pin impossible to express.
+  // The launcher is the authority; this test encoded a contract that no longer holds.
+  // Inverted to assert acceptance, NOT deleted, so the ladder stays pinned in both
+  // directions.
+  it("spawn_agent schema accepts max effort — the launcher's ladder is the authority", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -697,19 +704,16 @@ describe("lean spawn tool responses", () => {
       effort: "max",
     });
 
-    expect(parsed.success).toBe(false);
-    expect(parsed.error.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: "invalid_enum_value",
-          received: "max",
-          options: ["medium", "high", "xhigh", "ultra"],
-        }),
-      ]),
-    );
-    expect(
-      mockExec.mock.calls.some(([, callArgs]) => callArgs.includes("new-split")),
-    ).toBe(false);
+    expect(parsed.success).toBe(true);
+
+    // And a value the launcher genuinely does not accept must still be refused,
+    // so this stays a real gate rather than an open door.
+    const bogus = spawn.inputSchema.safeParse({
+      repo: "cmuxlayer",
+      cli: "codex",
+      effort: "turbo",
+    });
+    expect(bogus.success).toBe(false);
   });
 
   it("spawn_agent rejects Codex effort for another CLI before creating a surface", async () => {


### PR DESCRIPTION
## RED — costing real usage, reported by @orc

`src/server.ts` told every agent, at dispatch time:

> "The launcher defaults to **xhigh** when omitted; max is not accepted by the current launcher."

Both halves are false now:

```
golem-dispatch.zsh:431   _flag_codex_effort="high"                      ← default is HIGH
golem-dispatch.zsh:446   low|medium|high|xhigh|max|ultra                ← max IS accepted
cmuxlayer CODEX_EFFORT_VALUES  [medium, high, xhigh, ultra]             ← low + max missing
```

The tool description is the text agents read when choosing effort, so the stale value
**normalised xhigh fleet-wide** against both the launcher and `/agent-routing`. Etan closed two
brainlayer Codexes over it.

Third defect: because the enum omitted `max`, **Etan's own pin for some lanes could not be expressed
through `spawn_agent` at all.**

## Fix
- `CODEX_EFFORT_VALUES` accepts the launcher's full ladder (`low…ultra`).
- Description states the **real** default (high) and makes effort an explicit mission choice, naming
  **medium** as `/agent-routing`'s settled floor for well-specified lanes.
- **Adds the drift guard that never existed.** Model parity was pinned; effort was not — which is
  exactly why this drifted silently while the Opus-4.8 pin got caught the same day.

## ⚠️ One test was INVERTED, deliberately — flagging rather than burying it
`spawn_agent schema rejects max effort` asserted `max` must be **refused**. That was correct when the
launcher's ladder was `medium|high|xhigh|ultra`. **golems #657 added `low` and `max`.** The launcher is
the authority, so the test encoded a contract that no longer holds.

It is **inverted, not deleted** — it now asserts `max` is accepted *and* that a genuinely invalid value
(`turbo`) is still refused, so the ladder stays pinned in both directions rather than becoming an open
door. Rationale is in a comment at the test.

## Verification
Full suite **2449/2449**, typecheck clean. Drift guards: 6/6.

**Needs a release to take effect** — the description lives in the running binary, and merged is not
deployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what agents see at dispatch time and which effort values pass validation, directly affecting Codex cost and lane pins; no auth or data-path changes.
> 
> **Overview**
> **Aligns cmuxlayer’s Codex effort handling with `golem-dispatch.zsh` so `spawn_agent` accepts the full ladder and documents the launcher’s real default.**
> 
> `CODEX_EFFORT_VALUES` now includes **`low`** and **`max`** (in addition to medium/high/xhigh/ultra), with a comment tying the enum to the launcher. That unblocks effort values such as **`max`** that were previously rejected by the Zod schema even though the launcher accepts them.
> 
> The **`spawn_agent` `effort` field description** is rewritten: it lists the full accepted set, states the launcher defaults to **`high`** when effort is omitted (replacing the stale **xhigh** claim and the incorrect “max not accepted” note), and frames effort as an explicit cost/routing choice (including **medium** as the floor for well-specified lanes per `/agent-routing`).
> 
> **Drift guards** in `tests/model-policy-drift.test.ts` now pin Codex effort parity with `golem-dispatch.zsh` (ladder regex + enum membership, and matching the declared `_flag_codex_effort` default to the server description). `tests/server-agent-tools.test.ts` **inverts** the old “reject max” schema test so **`max` parses** while bogus values like **`turbo`** still fail.
> 
> Most other `server.ts` / `model-policy.ts` hunks are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8fc0d9acea066f25b0ae64d67edc8deec2302f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `low` and `max` to the accepted Codex effort ladder in `CODEX_EFFORT_VALUES`
> - Expands the `CODEX_EFFORT_VALUES` tuple in [model-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/359/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d) to include `"low"` and `"max"`, matching the full ladder supported by the launcher.
> - Updates the spawn agent schema test in [server-agent-tools.test.ts](https://github.com/EtanHey/cmuxlayer/pull/359/files#diff-b02b20318090fbe2fe9736638b282662f0d778996959f4a29828dc0dab2debff) to assert `"max"` is accepted and adds a negative case for unsupported values like `"turbo"`.
> - Adds drift-detection tests in [model-policy-drift.test.ts](https://github.com/EtanHey/cmuxlayer/pull/359/files#diff-34cf6f9dcef9f8112e36436649447aeb516f4073f30d2e153ca9e684972d7826) to keep `CODEX_EFFORT_VALUES` and the documented default effort in sync with the launcher.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a8fc0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `low` and `max` Codex effort levels.
  * Updated effort guidance to document supported values and defaults.

* **Bug Fixes**
  * Codex effort validation now correctly accepts `max` while continuing to reject unsupported values.

* **Tests**
  * Added coverage to verify consistency between configured effort levels, launch behavior, and server tool defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->