### PR TITLE
test: add cmuxlayer tool-count drift guard

### DIFF
--- a/tests/tool-count-drift.test.ts
+++ b/tests/tool-count-drift.test.ts
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+const EXPECTED_TOOL_COUNT = 42;
+const EXPECTED_DEFAULT_PALETTE_COUNT = 12;
+const RUN_DRIFT_CHECK = process.env.CMUXLAYER_RUN_TOOL_COUNT_DRIFT === "1";
+
+// The plan calls this registration source `registerTool(`. cmuxlayer's current
+// MCP SDK integration spells the same operation `server.tool(`; support both
+// spellings so the guard checks the live registration source while preserving
+// the plan's intended seam.
+const REGISTRATION_PATTERN =
+  /\b(?:registerTool|server\.tool)\s*\(\s*["']([^"']+)["']/g;
+const DOCUMENTED_COUNT_PATTERN =
+  /\b(\d+)( |%20)(?:MCP )?tools\b/gi;
+
+const EXCLUDED_DIRECTORY_PARTS = new Set(["site", "out", ".next"]);
+const EXCLUDED_PATHS = new Set([
+  "docs/design/track-4-send-to-wait-for-facade.md",
+]);
+
+type Document = { path: string; content: string };
+type CountClaim = {
+  path: string;
+  line: number;
+  count: number;
+  expected: number;
+  text: string;
+};
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRECTORY_PARTS.has(entry.name) || entry.name === ".next") {
+        return [];
+      }
+      return sourceFiles(absolutePath);
+    }
+    return entry.name.endsWith(".ts") ? [absolutePath] : [];
+  });
+}
+
+function registeredToolNames(root = join(REPO_ROOT, "src")): string[] {
+  return sourceFiles(root).flatMap((filePath) => {
+    const source = readFileSync(filePath, "utf8");
+    return [...source.matchAll(REGISTRATION_PATTERN)].map((match) => match[1]);
+  });
+}
+
+function documentedFiles(root = REPO_ROOT): Document[] {
+  // GEMINI.md is an operator-local surface and is globally ignored in this
+  // checkout; include it when present without making clean CI checkouts fail.
+  const paths = ["README.md", "GEMINI.md"].filter((path) =>
+    existsSync(join(root, path)),
+  );
+  const docsRoot = join(root, "docs");
+  const walk = (directory: string): string[] =>
+    readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      const absolutePath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "out" || entry.name === ".next") return [];
+        return walk(absolutePath);
+      }
+      return entry.name.endsWith(".md") ? [absolutePath] : [];
+    });
+
+  return [...paths.map((path) => join(root, path)), ...walk(docsRoot)]
+    .map((absolutePath) => ({
+      path: relative(root, absolutePath).split(sep).join("/"),
+      content: readFileSync(absolutePath, "utf8"),
+    }))
+    .filter(({ path }) => !EXCLUDED_PATHS.has(path));
+}
+
+function claimsIn(documents: Document[]): CountClaim[] {
+  return documents.flatMap(({ path, content }) => {
+    const claims: CountClaim[] = [];
+    for (const [lineIndex, line] of content.split("\n").entries()) {
+      // before/after bullets are historical design measurements, not current
+      // public claims. Dated release-note/changelog blocks follow the same rule.
+      if (/^\s*-\s*(?:before|after):/i.test(line)) continue;
+      for (const match of line.matchAll(DOCUMENTED_COUNT_PATTERN)) {
+        const isDefaultPaletteClaim =
+          /default (?:MCP )?palette|palette/i.test(line) &&
+          Number(match[1]) === EXPECTED_DEFAULT_PALETTE_COUNT;
+        claims.push({
+          path,
+          line: lineIndex + 1,
+          count: Number(match[1]),
+          expected: isDefaultPaletteClaim
+            ? EXPECTED_DEFAULT_PALETTE_COUNT
+            : EXPECTED_TOOL_COUNT,
+          text: line.trim(),
+        });
+      }
+    }
+    return claims;
+  });
+}
+
+function assertDocumentedCounts(documents: Document[], expected: number): void {
+  const staleClaims = claimsIn(documents).filter(
+    (claim) => claim.count !== claim.expected,
+  );
+  if (staleClaims.length === 0) return;
+
+  const details = staleClaims
+    .map(
+      (claim) =>
+        `${claim.path}:${claim.line} documents ${claim.count}; source registers ${expected} (${claim.text})`,
+    )
+    .join("\n");
+  throw new Error(`tool-count drift detected:\n${details}`);
+}
+
+describe("tool-count drift guard", () => {
+  it.skipIf(!RUN_DRIFT_CHECK)(
+    "keeps documented callable-tool counts equal to registrations",
+    () => {
+    const names = registeredToolNames();
+    expect(names).toHaveLength(EXPECTED_TOOL_COUNT);
+    expect(new Set(names).size).toBe(EXPECTED_TOOL_COUNT);
+
+    assertDocumentedCounts(documentedFiles(), names.length);
+    },
+  );
+
+  it("goes red when a fixture count is mutated", () => {
+    const fixture = "The server exposes 42 tools.\n";
+    const mutatedFixture = fixture.replace("42", "41");
+
+    expect(() =>
+      assertDocumentedCounts(
+        [{ path: "fixtures/tool-count.md", content: mutatedFixture }],
+        EXPECTED_TOOL_COUNT,
+      ),
+    ).toThrow(
+      "fixtures/tool-count.md:1 documents 41; source registers 42 (The server exposes 41 tools.)",
+    );
+  });
+
+  it("recognizes URL-encoded badge counts", () => {
+    expect(() =>
+      assertDocumentedCounts(
+        [{
+          path: "fixtures/tool-count-badge.md",
+          content: "badge/MCP-41%20tools-green.svg",
+        }],
+        EXPECTED_TOOL_COUNT,
+      ),
+    ).toThrow("fixtures/tool-count-badge.md:1 documents 41; source registers 42");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Vitest drift guard that enumerates the 42 registered cmuxlayer tools.
- Check README.md, GEMINI.md when present, and docs/ for stale callable-tool counts.
- Match both plain and URL-encoded badge forms; exclude build artifacts and historical before/after records.
- Keep the 12-tool default palette claim distinct from the 42-tool callable count.

## RED proof
- `CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1 bun test tests/tool-count-drift.test.ts --run` fails on the pre-fix tree with README 35 (prose and badge) and GEMINI.md 22.
- Normal `bun run test` runs the file with the live drift assertion skip-tagged until C1/C2 land; self-tests still run.

## Test plan
- `bun run typecheck`
- `bun run test` — 2451 passed, 1 skipped
- Opt-in drift run intentionally RED as documented above.

Do not merge until C1/C2 documentation fixes land and the opt-in drift check is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or production behavior impact; the live drift assertion is opt-in until documentation fixes land.
> 
> **Overview**
> Introduces **`tests/tool-count-drift.test.ts`**, a Vitest **tool-count drift guard** that keeps public documentation aligned with how many MCP tools cmuxlayer actually registers.
> 
> The opt-in integration test (`CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1`) walks `src/` for `registerTool(` / `server.tool(` registrations, asserts **42** unique tools, and scans **README.md**, optional **GEMINI.md**, and **`docs/`** for prose or badge-style “N tools” claims (including URL-encoded forms). It treats the **12-tool default palette** separately, skips build dirs and historical before/after lines, and fails with file:line details when counts drift. Default **`bun run test`** skips that heavy check but still runs fixture tests that prove the matcher catches wrong counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a34417b5a8ff18c04523aff207024aa1a921f9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation to ensure the documented tool count matches the tools available in the product.
  * Added checks for duplicate or missing tool registrations and stale count references.
  * Validation supports tool counts shown in documentation badges and standard registration formats.
  * Generated and historical files are excluded to reduce false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tool-count drift guard test suite for cmuxlayer
> - Adds [tests/tool-count-drift.test.ts](https://github.com/EtanHey/cmuxlayer/pull/362/files#diff-d8076c1fa1b6448d059f95f77929ac75af621a8b1f379d1be869a2c856115d91) with a vitest suite that detects drift between registered tool counts and counts documented in markdown files.
> - The live drift check (scanning source for `registerTool`/`server.tool` calls and comparing against docs) only runs when `CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1` is set.
> - Two always-on tests validate error message correctness for mismatched counts, including URL-encoded badge counts (e.g. `%20tools`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a34417b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->