### PR TITLE
test: catch hyphenated N-tool forms; allow 12-palette count (PR #362 review finding)

### DIFF
--- a/tests/tool-count-drift.test.ts
+++ b/tests/tool-count-drift.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 const REPO_ROOT = join(import.meta.dirname, "..");
 const EXPECTED_TOOL_COUNT = 42;
 const EXPECTED_DEFAULT_PALETTE_COUNT = 12;
+// 42 is the callable-tool count; 12 is the signed default-palette count.
+const EXPECTED_DOCUMENTED_COUNTS = new Set([
+  EXPECTED_TOOL_COUNT,
+  EXPECTED_DEFAULT_PALETTE_COUNT,
+]);
 const RUN_DRIFT_CHECK = process.env.CMUXLAYER_RUN_TOOL_COUNT_DRIFT === "1";
 
 // The plan calls this registration source `registerTool(`. cmuxlayer's current
@@ -14,7 +19,8 @@ const RUN_DRIFT_CHECK = process.env.CMUXLAYER_RUN_TOOL_COUNT_DRIFT === "1";
 const REGISTRATION_PATTERN =
   /\b(?:registerTool|server\.tool)\s*\(\s*["']([^"']+)["']/g;
 const DOCUMENTED_COUNT_PATTERN =
-  /\b(\d+)( |%20)(?:MCP )?tools\b/gi;
+  /\b(\d+)(?:[ -]|%20)(?:MCP )?tools?\b/gi;
+// Known blind spot: "N registered" phrasing is intentionally not matched.
 
 const EXCLUDED_DIRECTORY_PARTS = new Set(["site", "out", ".next"]);
 const EXCLUDED_PATHS = new Set([
@@ -83,13 +89,14 @@ function claimsIn(documents: Document[]): CountClaim[] {
       // public claims. Dated release-note/changelog blocks follow the same rule.
       if (/^\s*-\s*(?:before|after):/i.test(line)) continue;
       for (const match of line.matchAll(DOCUMENTED_COUNT_PATTERN)) {
+        const count = Number(match[1]);
         const isDefaultPaletteClaim =
-          /default (?:MCP )?palette|palette/i.test(line) &&
-          Number(match[1]) === EXPECTED_DEFAULT_PALETTE_COUNT;
+          /default (?:MCP )?palette|thin-core default|palette/i.test(line) &&
+          count === EXPECTED_DEFAULT_PALETTE_COUNT;
         claims.push({
           path,
           line: lineIndex + 1,
-          count: Number(match[1]),
+          count,
           expected: isDefaultPaletteClaim
             ? EXPECTED_DEFAULT_PALETTE_COUNT
             : EXPECTED_TOOL_COUNT,
@@ -103,7 +110,9 @@ function claimsIn(documents: Document[]): CountClaim[] {
 
 function assertDocumentedCounts(documents: Document[], expected: number): void {
   const staleClaims = claimsIn(documents).filter(
-    (claim) => claim.count !== claim.expected,
+    (claim) =>
+      !EXPECTED_DOCUMENTED_COUNTS.has(claim.count) ||
+      claim.count !== claim.expected,
   );
   if (staleClaims.length === 0) return;
 
@@ -152,5 +161,14 @@ describe("tool-count drift guard", () => {
         EXPECTED_TOOL_COUNT,
       ),
     ).toThrow("fixtures/tool-count-badge.md:1 documents 41; source registers 42");
+  });
+
+  it("recognizes hyphenated singular tool counts", () => {
+    expect(() =>
+      assertDocumentedCounts(
+        [{ path: "fixtures/tool-count-hyphen.md", content: "The server exposes 41-tool default.\n" }],
+        EXPECTED_TOOL_COUNT,
+      ),
+    ).toThrow("fixtures/tool-count-hyphen.md:1 documents 41; source registers 42");
   });
 });


### PR DESCRIPTION
Follow-up to #362 (merged mid-review-cycle during Etan's cmuxlayer pass — same timing as voicelayer #417/#418). This is the stranded review-fix commit: the reviewer found the claim regex missed hyphenated forms like README:79's "12-tool thin-core default", so a future regression to e.g. "35-tool" would be invisible. Widens the pattern, allows the legitimate {42 callable, 12 default-palette} pair, adds a fixture test for the hyphenated form, and documents the "N registered" phrasing as a known blind spot.

Verified: drift check still red on exactly the three known stale lines (no new false positives), full suite 2452 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation-scan logic changes with no runtime or security impact.
> 
> **Overview**
> **Tightens the tool-count documentation drift guard** so hyphenated phrasing (e.g. `41-tool`) and the legitimate **12** default-palette count are covered without false positives on the callable **42**.
> 
> The documented-count regex now accepts hyphen or space/`%20` before `tool`/`tools`, and palette lines matching `thin-core default` still expect **12**. Stale detection treats only **42** and **12** as allowed documented numbers (must also match each line’s expected callable vs palette role). A fixture test asserts hyphenated singular counts go red when wrong, and a comment notes **"N registered"** wording is still intentionally unmatched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed182b57f65aebf2d0a03ea87802548aa1923020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tool-count drift tests to catch hyphenated N-tool forms and allow 12-palette count
> Updates the tool-count drift guard in [tool-count-drift.test.ts](https://github.com/EtanHey/cmuxlayer/pull/363/files#diff-d8076c1fa1b6448d059f95f77929ac75af621a8b1f379d1be869a2c856115d91) to handle edge cases found in PR #362 review.
>
> - Broadens `DOCUMENTED_COUNT_PATTERN` regex to match hyphenated forms like `41-tool` and singular `tool` in addition to plural `tools`
> - Introduces `EXPECTED_DOCUMENTED_COUNTS` as a Set containing both `EXPECTED_TOOL_COUNT` (42) and `EXPECTED_DEFAULT_PALETTE_COUNT` (12), so assertions flag any count outside this set as stale
> - Expands default-palette detection in `claimsIn` to also match `thin-core default` phrasing
> - Adds a test case verifying that hyphenated singular tool counts (e.g. `41-tool`) are caught as stale
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed182b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->