### PR TITLE
fix: use in-repo worktrees by default

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9534,7 +9534,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         worktree: worktreeArgSchema
           .optional()
           .describe(
-            "When set, create or reuse a git worktree before launch. true uses ~/Gits/<repo>.wt/<generated-name>; object fields can set name, path, branch, base, create, and reuse.",
+            "When set, create or reuse a git worktree before launch. true uses <repo>/.worktrees/<generated-name> (in-repo convention; legacy ~/Gits/<repo>.wt read-fallback until ~2026-09); object fields can set name, path, branch, base, create, and reuse.",
           ),
         mcp_profile: mcpProfileSchema
           .optional()
@@ -10042,7 +10042,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         worktree: worktreeArgSchema
           .optional()
           .describe(
-            "Worktree options. Defaults to true, creating/reusing ~/Gits/<repo>.wt/<generated-name>.",
+            "Worktree options. Defaults to true, creating/reusing <repo>/.worktrees/<generated-name> (in-repo convention).",
           ),
         mcp_profile: mcpProfileSchema
           .optional()

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -195,6 +195,16 @@ function parseWorktreeListPaths(stdout: string): string[] {
     .map((line) => line.slice("worktree ".length));
 }
 
+async function warnIfWorktreesNotIgnored(repoRoot: string, exec: WorktreeExec): Promise<void> {
+  try {
+    await exec("git", ["-C", repoRoot, "check-ignore", "-q", "--", ".worktrees"]);
+  } catch {
+    console.warn(
+      `[cmuxlayer] ${repoRoot} does not ignore .worktrees/; add it to .gitignore to keep generated worktrees out of commits`,
+    );
+  }
+}
+
 async function assertExistingWorktree(
   path: string,
   repoRoot: string,
@@ -235,9 +245,11 @@ export async function prepareWorktree(
   const exec = input.exec ?? defaultExec;
 
   const spec = normalizeWorktreeRequest(repo, input.worktree);
+  const defaultPath = join(repoRoot, ".worktrees", spec.name);
+  const legacyPath = join(homeGitsDir, `${repo}.wt`, spec.name);
   let worktreePath = spec.path
     ? resolve(spec.path)
-    : join(homeGitsDir, `${repo}.wt`, spec.name);
+    : defaultPath;
   if (spec.generatedName && !spec.path) {
     for (let attempts = 0; attempts < 10; attempts++) {
       const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
@@ -249,7 +261,7 @@ export async function prepareWorktree(
         break;
       }
       spec.name = defaultWorkerName(repo);
-      worktreePath = join(homeGitsDir, `${repo}.wt`, spec.name);
+      worktreePath = join(repoRoot, ".worktrees", spec.name);
     }
     const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
     if (
@@ -260,6 +272,18 @@ export async function prepareWorktree(
     }
   }
   assertInside(homeGitsDir, worktreePath);
+
+  // Read the legacy sibling location during migration, but always create new
+  // worktrees under <repo>/.worktrees. TODO remove .wt read-path after migration, ~2026-09.
+  if (
+    !spec.path &&
+    !spec.generatedName &&
+    !existsSync(worktreePath) &&
+    spec.reuse &&
+    existsSync(legacyPath)
+  ) {
+    worktreePath = legacyPath;
+  }
 
   if (existsSync(worktreePath)) {
     if (!spec.reuse) {
@@ -287,6 +311,7 @@ export async function prepareWorktree(
   }
 
   mkdirSync(dirname(worktreePath), { recursive: true });
+  await warnIfWorktreesNotIgnored(repoRoot, exec);
   const branch = spec.branch ?? defaultWorktreeBranch(spec.name);
   await exec("git", [
     "-C",
@@ -298,6 +323,7 @@ export async function prepareWorktree(
     worktreePath,
     spec.base,
   ]);
+  mkdirSync(worktreePath, { recursive: true });
 
   return {
     path: worktreePath,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2812,7 +2812,7 @@ describe("agent lifecycle tool handlers", () => {
     const repoRoot = join(gitsDir, "cmuxlayer");
     mkdirSync(repoRoot, { recursive: true });
     const worktreeExec = vi.fn().mockImplementation(async () => {
-      mkdirSync(join(gitsDir, "cmuxlayer.wt", "skill-eval"), {
+      mkdirSync(join(gitsDir, "cmuxlayer", ".worktrees", "skill-eval"), {
         recursive: true,
       });
       return { stdout: "", stderr: "" };
@@ -2844,7 +2844,7 @@ describe("agent lifecycle tool handlers", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    const worktreePath = join(gitsDir, "cmuxlayer.wt", "skill-eval");
+    const worktreePath = join(gitsDir, "cmuxlayer", ".worktrees", "skill-eval");
     expect(parsed.ok).toBe(true);
     expect(parsed.worktree).toMatchObject({
       path: worktreePath,
@@ -2881,7 +2881,7 @@ describe("agent lifecycle tool handlers", () => {
     const repoRoot = join(gitsDir, "cmuxlayer");
     mkdirSync(repoRoot, { recursive: true });
     const worktreeExec = vi.fn().mockImplementation(async () => {
-      mkdirSync(join(gitsDir, "cmuxlayer.wt", "sterile-worker"), {
+      mkdirSync(join(gitsDir, "cmuxlayer", ".worktrees", "sterile-worker"), {
         recursive: true,
       });
       return { stdout: "", stderr: "" };
@@ -2910,7 +2910,7 @@ describe("agent lifecycle tool handlers", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    const worktreePath = join(gitsDir, "cmuxlayer.wt", "sterile-worker");
+    const worktreePath = join(gitsDir, "cmuxlayer", ".worktrees", "sterile-worker");
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("worker");
     expect(parsed.mcp_profile).toBe("sterile");
@@ -2931,7 +2931,7 @@ describe("agent lifecycle tool handlers", () => {
   it("new_worktree_split publishes its worktree cwd through the injected manifest writer", async () => {
     const gitsDir = join(TEST_DIR, "Gits");
     mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
-    const worktreePath = join(gitsDir, "cmuxlayer.wt", "manifest-worker");
+    const worktreePath = join(gitsDir, "cmuxlayer", ".worktrees", "manifest-worker");
     const worktreeExec = vi.fn().mockImplementation(async () => {
       mkdirSync(worktreePath, { recursive: true });
       return { stdout: "", stderr: "" };
@@ -3118,7 +3118,7 @@ describe("agent lifecycle tool handlers", () => {
       const repoRoot = join(gitsDir, "cmuxlayer");
       mkdirSync(repoRoot, { recursive: true });
       const worktreeExec = vi.fn().mockImplementation(async () => {
-        mkdirSync(join(gitsDir, "cmuxlayer.wt", "caller-worker"), {
+        mkdirSync(join(gitsDir, "cmuxlayer", ".worktrees", "caller-worker"), {
           recursive: true,
         });
         return { stdout: "", stderr: "" };
@@ -4053,7 +4053,8 @@ describe("agent lifecycle tool handlers", () => {
       mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
       const worktreePath = join(
         gitsDir,
-        "cmuxlayer.wt",
+        "cmuxlayer",
+        ".worktrees",
         "readiness-failure-worker",
       );
       const worktreeExec = vi.fn().mockImplementation(async () => {
@@ -4106,7 +4107,8 @@ describe("agent lifecycle tool handlers", () => {
       mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
       const worktreePath = join(
         gitsDir,
-        "cmuxlayer.wt",
+        "cmuxlayer",
+        ".worktrees",
         "boot-verification-failure-worker",
       );
       const worktreeExec = vi.fn().mockImplementation(async () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -59,8 +59,8 @@ describe("worktree helpers", () => {
     expect(second.name).toMatch(/^cmuxlayer-worker-[a-z0-9]{6}$/);
     expect(first.name).not.toBe(second.name);
     expect(first.name).not.toContain("1783204101457");
-    expect(first.path).toBe(join(TEST_ROOT, "cmuxlayer.wt", first.name));
-    expect(second.path).toBe(join(TEST_ROOT, "cmuxlayer.wt", second.name));
+    expect(first.path).toBe(join(repoRoot, ".worktrees", first.name));
+    expect(second.path).toBe(join(repoRoot, ".worktrees", second.name));
   });
 
   it("retries generated default names instead of reusing a colliding worktree", async () => {
@@ -69,8 +69,8 @@ describe("worktree helpers", () => {
     const secondId = (0.25).toString(36).slice(2, 8).padEnd(6, "0");
     const collidingName = `cmuxlayer-worker-${firstId}`;
     const nextName = `cmuxlayer-worker-${secondId}`;
-    const collidingPath = join(TEST_ROOT, "cmuxlayer.wt", collidingName);
-    const nextPath = join(TEST_ROOT, "cmuxlayer.wt", nextName);
+    const collidingPath = join(repoRoot, ".worktrees", collidingName);
+    const nextPath = join(repoRoot, ".worktrees", nextName);
     mkdirSync(repoRoot, { recursive: true });
     mkdirSync(collidingPath, { recursive: true });
     vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
@@ -124,7 +124,7 @@ describe("worktree helpers", () => {
     const collidingName = `cmuxlayer-worker-${firstId}`;
     const nextName = `cmuxlayer-worker-${secondId}`;
     const collidingBranch = `wt/${collidingName}`;
-    const nextPath = join(TEST_ROOT, "cmuxlayer.wt", nextName);
+    const nextPath = join(repoRoot, ".worktrees", nextName);
     mkdirSync(repoRoot, { recursive: true });
     vi.spyOn(Math, "random").mockReturnValueOnce(0.5).mockReturnValueOnce(0.25);
     const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
@@ -180,7 +180,7 @@ describe("worktree helpers", () => {
     });
 
     expect(result).toMatchObject({
-      path: join(TEST_ROOT, "cmuxlayer.wt", "skill-eval"),
+      path: join(repoRoot, ".worktrees", "skill-eval"),
       branch: "fix/skill-eval",
       base: "origin/main",
       created: true,
@@ -193,7 +193,7 @@ describe("worktree helpers", () => {
       "add",
       "-b",
       "fix/skill-eval",
-      join(TEST_ROOT, "cmuxlayer.wt", "skill-eval"),
+      join(repoRoot, ".worktrees", "skill-eval"),
       "origin/main",
     ]);
   });
@@ -250,6 +250,57 @@ describe("worktree helpers", () => {
     );
   });
 
+  it("reuses a legacy sibling worktree during the migration window", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const legacyPath = join(TEST_ROOT, "cmuxlayer.wt", "legacy");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(legacyPath, { recursive: true });
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("list")) {
+        return { stdout: worktreeListOutput([repoRoot, legacyPath]), stderr: "" };
+      }
+      return { stdout: "true\n", stderr: "" };
+    });
+
+    const result = await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "legacy", reuse: true },
+      exec,
+    });
+
+    expect(result).toMatchObject({ path: legacyPath, reused: true, created: false });
+    expect(exec).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["worktree", "add"]),
+    );
+  });
+
+  it("warns when the target repo does not ignore the in-repo worktree directory", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(repoRoot, ".worktrees", "unignored");
+    mkdirSync(repoRoot, { recursive: true });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("check-ignore")) throw new Error("not ignored");
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(worktreePath, { recursive: true });
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await prepareWorktree({
+      repo: "cmuxlayer",
+      repoRoot,
+      homeGitsDir: TEST_ROOT,
+      worktree: { name: "unignored" },
+      exec,
+    });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("does not ignore .worktrees/"));
+  });
+
   it("reuses a repo worktree when git reports canonical paths through a symlink", async () => {
     const actualGitsDir = join(TEST_ROOT, "actual-gits");
     const linkedGitsDir = join(TEST_ROOT, "linked-gits");
@@ -289,7 +340,7 @@ describe("worktree helpers", () => {
     const repoRoot = join(TEST_ROOT, "repo");
     mkdirSync(join(repoRoot, "node_modules"), { recursive: true });
     const exec = vi.fn().mockImplementation(async () => {
-      const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "deps");
+      const worktreePath = join(repoRoot, ".worktrees", "deps");
       mkdirSync(worktreePath, { recursive: true });
       return { stdout: "", stderr: "" };
     });
@@ -307,7 +358,7 @@ describe("worktree helpers", () => {
 
   it("copies .mcp.json byte-for-byte into a newly created worktree", async () => {
     const repoRoot = join(TEST_ROOT, "repo");
-    const worktreePath = join(TEST_ROOT, "cmuxlayer.wt", "with-mcp");
+    const worktreePath = join(repoRoot, ".worktrees", "with-mcp");
     const mcpConfig = '{\n  "mcpServers": {\n    "cmuxlayer": {}\n  }\n}\n';
     mkdirSync(repoRoot, { recursive: true });
     writeFileSync(join(repoRoot, ".mcp.json"), mcpConfig);


### PR DESCRIPTION
## Summary
- default generated worktrees now live under `<repo>/.worktrees/<name>`
- reuse reads legacy `~/Gits/<repo>.wt/<name>` paths during migration
- warn when the target repository does not ignore `.worktrees/`

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run` (2479 passed, 1 skipped)

Leaving open for routed review as requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where agent workers are created on disk and how reuse resolves paths; legacy fallback limits breakage, but callers or scripts hard-coded to `.wt` paths may still miss worktrees unless they use reuse or update paths.
> 
> **Overview**
> **Default worktree paths** now resolve to `<repoRoot>/.worktrees/<name>` instead of the sibling layout `~/Gits/<repo>.wt/<name>`. Generated-name collision retries and MCP tool descriptions in `server.ts` are updated to match.
> 
> **Migration behavior:** when reuse is requested, no custom path is set, and the new default path is missing, `prepareWorktree` still picks up an existing **legacy** `~/Gits/<repo>.wt/<name>` checkout (planned removal ~2026-09). New worktrees are always created under `.worktrees/`.
> 
> **Operational guardrails:** before `git worktree add`, the code runs `git check-ignore` on `.worktrees` and logs a `[cmuxlayer]` warning if the repo does not ignore that directory. A post-add `mkdirSync` on the worktree path is also added.
> 
> Tests in `worktree.test.ts` and agent-tool integration tests assert the new paths plus legacy reuse and ignore warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb81dd1ee63592dc8ee9fc8a6f79d979b9aa4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change default worktree location to in-repo `.worktrees/<name>` path
> - Changes the default worktree path in `prepareWorktree` ([src/worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/374/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d)) from a sibling directory `<homeGitsDir>/<repo>.wt/<name>` to `<repoRoot>/.worktrees/<name>`.
> - Adds a migration fallback: when `reuse` is true and a legacy sibling path exists but the new in-repo path does not, the legacy worktree is reused instead of creating a new one.
> - Adds `warnIfWorktreesNotIgnored`, which warns via `console.warn` if `.worktrees/` is not listed in the repo's `.gitignore`.
> - Behavioral Change: existing workflows that relied on sibling-directory worktrees will silently migrate on next reuse; new worktrees will be created inside the repo root.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized beb81dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worktrees are now created by default inside the repository’s `.worktrees` directory.
  - Existing legacy worktree paths can be reused during migration when explicitly requested.
  - A warning appears if `.worktrees` is not excluded from version control.
  - Worktree directories are ensured to exist after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->