### PR TITLE
fix: resolve registered worktree roots and rollback leaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,10 @@
 @AGENTS.md
+
+## Worktree spawn contract
+
+- For managed worktree spawns, `repo` selects the repoGolem registration and names the worker; it
+  does not imply `~/Gits/<repo>`.
+- Resolve the repository root from the absolute path in the launcher registry. Registered roots
+  outside `~/Gits` are valid, and their default worktrees live at `<registered-root>/.worktrees/`.
+- If spawning fails after cmuxlayer creates a worktree, remove both that worktree and its new branch.
+  Never roll back a reused worktree.

--- a/src/launcher-registry.ts
+++ b/src/launcher-registry.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import type { CliType } from "./agent-types.js";
 import { sanitizeRepoName } from "./agent-command.js";
 
@@ -141,17 +141,34 @@ export function resolveLauncherPrefix(
   input: string,
   entries: readonly LauncherRegistryEntry[],
 ): string | null {
+  return resolveLauncherEntry(input, entries)?.prefix ?? null;
+}
+
+function resolveLauncherEntry(
+  input: string,
+  entries: readonly LauncherRegistryEntry[],
+): LauncherRegistryEntry | null {
   const normalized = normalizeLauncherKey(input);
-  for (const entry of entries) {
-    if (
-      normalizeLauncherKey(entry.prefix) === normalized ||
+  const exactPrefix = entries.find(
+    (entry) => normalizeLauncherKey(entry.prefix) === normalized,
+  );
+  if (exactPrefix) return exactPrefix;
+
+  const fallbackMatches = entries.filter(
+    (entry) =>
       normalizeLauncherKey(entry.repoBasename) === normalized ||
-      normalizeLauncherKey(entry.path) === normalized
-    ) {
-      return entry.prefix;
-    }
+      normalizeLauncherKey(entry.path) === normalized,
+  );
+  if (fallbackMatches.length === 0) return null;
+  const paths = new Set(fallbackMatches.map((entry) => resolve(entry.path)));
+  if (paths.size > 1) {
+    throw new Error(
+      `Ambiguous launcher registry match for repo "${input}": ${fallbackMatches
+        .map((entry) => `${entry.prefix}=${entry.path}`)
+        .join(", ")}. Use the exact launcher prefix.`,
+    );
   }
-  return null;
+  return fallbackMatches[0] ?? null;
 }
 
 function launcherName(prefix: string, suffix: LauncherSuffix): string {
@@ -205,4 +222,26 @@ export function resolveLauncherNameFromRegistry(
       `Registry source: ${sourcePath}. ` +
       `Registered launchers: ${registeredLauncherSummary(entries)}.`,
   );
+}
+
+export function resolveRepoRootFromLauncherRegistry(
+  repo: string,
+  options?: LauncherRegistryOptions,
+): string {
+  const { entries, sourcePath } = loadLauncherRegistry(options);
+  const entry = resolveLauncherEntry(repo, entries);
+  if (!entry) {
+    throw new Error(
+      `Launcher registry miss for repo "${repo}". ` +
+        `Registry source: ${sourcePath}. ` +
+        `Registered launchers: ${registeredLauncherSummary(entries)}.`,
+    );
+  }
+  if (!isAbsolute(entry.path)) {
+    throw new Error(
+      `Launcher registry path for repo "${repo}" must be absolute: ` +
+        `"${entry.path}" in ${sourcePath}.`,
+    );
+  }
+  return resolve(entry.path);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 import { constants as fsConstants, mkdtempSync, rmSync } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import {
   CMUXLAYER_DEFAULT_PALETTE_ENV,
@@ -198,9 +198,11 @@ import {
 import {
   formatMcpProfileEnv,
   prepareWorktree,
+  rollbackPreparedWorktree,
   type McpProfile,
   type WorktreeExec,
 } from "./worktree.js";
+import { resolveRepoRootFromLauncherRegistry } from "./launcher-registry.js";
 import {
   loadSeatRegistryFromConfig,
   type SeatRegistry,
@@ -9236,14 +9238,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
 
       const profile = mcpProfile ?? "inherit";
+      const repoRoot = disableSpawnPreflight
+        ? resolve(opts?.worktreeHomeDir ?? join(homedir(), "Gits"), repo)
+        : resolveRepoRootFromLauncherRegistry(repo);
       const prepared = await prepareWorktree({
         repo,
+        repoRoot,
         worktree: worktree as Parameters<typeof prepareWorktree>[0]["worktree"],
         exec: opts?.worktreeExec,
         homeGitsDir: opts?.worktreeHomeDir,
       });
       return {
         prepared,
+        repoRoot,
         mcpProfileLabel: typeof profile === "string" ? profile : "custom",
         mcpEnv: formatMcpProfileEnv(profile),
       };
@@ -9534,7 +9541,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         worktree: worktreeArgSchema
           .optional()
           .describe(
-            "When set, create or reuse a git worktree before launch. true uses <repo>/.worktrees/<generated-name> (in-repo convention; legacy ~/Gits/<repo>.wt read-fallback until ~2026-09); object fields can set name, path, branch, base, create, and reuse.",
+            "When set, create or reuse a git worktree before launch. A repoGolem registration with an absolute path is required; that registry path is the repo root. true uses <registered-root>/.worktrees/<generated-name> (legacy ~/Gits/<repo>.wt read-fallback until ~2026-09). If a later spawn step fails before a recoverable surface exists, a newly created worktree and branch are rolled back. Object fields can set name, path, branch, base, create, and reuse.",
           ),
         mcp_profile: mcpProfileSchema
           .optional()
@@ -9646,11 +9653,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "spawn_agent",
             comparisonWorkspace,
           );
-          const worktree = await prepareSpawnWorktree(
-            args.repo,
-            args.worktree,
-            args.mcp_profile as McpProfile | undefined,
-          );
           const requestedRole = inferAgentRole({
             role: effectiveRole,
             cli: args.cli,
@@ -9697,10 +9699,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const spawnPrompt = hasInlinePrompt(args.prompt)
             ? args.prompt
             : (bootPromptText ?? "");
+          // Prepare only after every non-spawn gate has passed. From this point
+          // onward the catch below owns rollback for any newly created worktree.
+          const worktree = await prepareSpawnWorktree(
+            args.repo,
+            args.worktree,
+            args.mcp_profile as McpProfile | undefined,
+          );
           let focusRestoreLease = await focusTargetBeforeSplit(
             spawnWorkspace,
             args.focus !== true,
           );
+          let surfaceCreated = false;
           let result: Awaited<ReturnType<typeof engine.spawnAgent>>;
           try {
             result = await engine.spawnAgent({
@@ -9723,6 +9733,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               crash_recover: args.crash_recover,
               boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
               on_surface_created: async (created) => {
+                surfaceCreated = true;
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
                   created,
@@ -9730,6 +9741,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               },
             });
           } catch (e) {
+            let rollbackError: unknown = null;
+            if (
+              !surfaceCreated &&
+              worktree.prepared?.created &&
+              worktree.repoRoot
+            ) {
+              try {
+                await rollbackPreparedWorktree(
+                  worktree.repoRoot,
+                  worktree.prepared,
+                  opts?.worktreeExec,
+                );
+              } catch (error) {
+                rollbackError = error;
+              }
+            }
             try {
               await restoreFocusAfterRender(
                 focusRestoreLease,
@@ -9738,6 +9765,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               );
             } catch {
               // Preserve the original spawn error response.
+            }
+            if (rollbackError) {
+              const rollback =
+                rollbackError instanceof Error
+                  ? rollbackError.message
+                  : String(rollbackError);
+              if (e instanceof Error) {
+                e.message = `${e.message}. Worktree rollback also failed: ${rollback}`;
+                throw e;
+              }
+              throw new Error(
+                `${String(e)}. Worktree rollback also failed: ${rollback}`,
+                { cause: e },
+              );
             }
             throw e;
           }
@@ -10042,7 +10083,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         worktree: worktreeArgSchema
           .optional()
           .describe(
-            "Worktree options. Defaults to true, creating/reusing <repo>/.worktrees/<generated-name> (in-repo convention).",
+            "Worktree options. A repoGolem registration with an absolute path is required. Defaults to true, creating/reusing <registered-root>/.worktrees/<generated-name>; a newly created worktree and branch are rolled back if spawn fails before a recoverable surface exists (legacy ~/Gits/<repo>.wt read-fallback until ~2026-09).",
           ),
         mcp_profile: mcpProfileSchema
           .optional()
@@ -10063,6 +10104,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         let focusRestoreLease: FocusRestoreLease | null = null;
         let result: Awaited<ReturnType<typeof engine.spawnAgent>> | undefined;
         let mutationWorkspace: string | undefined;
+        let surfaceCreated = false;
+        let worktree:
+          | Awaited<ReturnType<typeof prepareSpawnWorktree>>
+          | undefined;
         try {
           resolveSpawnModelPolicy(args.cli, args.model);
           assertBootPromptMode(args.prompt, null);
@@ -10087,12 +10132,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "new_worktree_split",
             mutationWorkspace,
           );
-          const worktree = await prepareSpawnWorktree(
+          focusRestoreLease = await focusTargetBeforeSplit(mutationWorkspace);
+          worktree = await prepareSpawnWorktree(
             args.repo,
             args.worktree ?? true,
             args.mcp_profile as McpProfile | undefined,
           );
-          focusRestoreLease = await focusTargetBeforeSplit(mutationWorkspace);
           const hasPrompt = hasInlinePrompt(args.prompt);
           result = await engine.spawnAgent({
             repo: args.repo,
@@ -10110,6 +10155,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             auto_archive_on_done: args.auto_archive_on_done ?? false,
             crash_recover: args.crash_recover,
             on_surface_created: async (created) => {
+              surfaceCreated = true;
               focusRestoreLease = await capturePostCreationFocus(
                 focusRestoreLease,
                 created,
@@ -10214,6 +10260,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("new_worktree_split", formattedData),
           );
         } catch (e) {
+          let caught: unknown = e;
+          if (
+            !result &&
+            !surfaceCreated &&
+            worktree?.prepared?.created &&
+            worktree.repoRoot
+          ) {
+            try {
+              await rollbackPreparedWorktree(
+                worktree.repoRoot,
+                worktree.prepared,
+                opts?.worktreeExec,
+              );
+            } catch (rollbackError) {
+              const rollback =
+                rollbackError instanceof Error
+                  ? rollbackError.message
+                  : String(rollbackError);
+              if (e instanceof Error) {
+                e.message = `${e.message}. Worktree rollback also failed: ${rollback}`;
+                caught = e;
+              } else {
+                caught = new Error(
+                  `${String(e)}. Worktree rollback also failed: ${rollback}`,
+                  { cause: e },
+                );
+              }
+            }
+          }
           await restoreFocusAfterRender(
             focusRestoreLease,
             result?.surface_id,
@@ -10229,72 +10304,72 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 workspace_id: result.workspace_id ?? mutationWorkspace,
               }
             : {};
-          if (e instanceof AgentLaunchError) {
-            if (e.launch_cause instanceof DeliverySafetyGateError) {
-              return err(e.launch_cause, {
-                agent_id: e.agent_id,
-                surface_id: e.surface_id,
-                workspace_id: e.workspace_id,
-                error_code: e.launch_cause.error_code,
-                submit_verified: e.launch_cause.submit_verified,
-                screen: e.launch_cause.screen,
+          if (caught instanceof AgentLaunchError) {
+            if (caught.launch_cause instanceof DeliverySafetyGateError) {
+              return err(caught.launch_cause, {
+                agent_id: caught.agent_id,
+                surface_id: caught.surface_id,
+                workspace_id: caught.workspace_id,
+                error_code: caught.launch_cause.error_code,
+                submit_verified: caught.launch_cause.submit_verified,
+                screen: caught.launch_cause.screen,
               });
             }
-            if (e.launch_cause instanceof SurfaceGoneError) {
+            if (caught.launch_cause instanceof SurfaceGoneError) {
               return err(
-                e.launch_cause,
-                surfaceGonePayload(e.launch_cause, {
-                  agent_id: e.agent_id,
-                  surface_id: e.surface_id,
-                  workspace_id: e.workspace_id,
+                caught.launch_cause,
+                surfaceGonePayload(caught.launch_cause, {
+                  agent_id: caught.agent_id,
+                  surface_id: caught.surface_id,
+                  workspace_id: caught.workspace_id,
                 }),
               );
             }
-            return err(e, {
-              agent_id: e.agent_id,
-              surface_id: e.surface_id,
-              workspace_id: e.workspace_id,
+            return err(caught, {
+              agent_id: caught.agent_id,
+              surface_id: caught.surface_id,
+              workspace_id: caught.workspace_id,
             });
           }
-          if (e instanceof DeliverySafetyGateError) {
-            return err(e, {
+          if (caught instanceof DeliverySafetyGateError) {
+            return err(caught, {
               ...createdIdentity,
-              error_code: e.error_code,
-              submit_verified: e.submit_verified,
-              screen: e.screen,
+              error_code: caught.error_code,
+              submit_verified: caught.submit_verified,
+              screen: caught.screen,
             });
           }
-          if (e instanceof SubmitVerificationError) {
-            return err(e, {
+          if (caught instanceof SubmitVerificationError) {
+            return err(caught, {
               ...createdIdentity,
               submit_verified: false,
-              retry_count: e.retry_count,
+              retry_count: caught.retry_count,
             });
           }
-          if (e instanceof SurfaceGoneError) {
-            return err(e, surfaceGonePayload(e, createdIdentity));
+          if (caught instanceof SurfaceGoneError) {
+            return err(caught, surfaceGonePayload(caught, createdIdentity));
           }
-          if (e instanceof BootPromptTimeoutError) {
-            return err(e, {
+          if (caught instanceof BootPromptTimeoutError) {
+            return err(caught, {
               ...createdIdentity,
-              last_10_lines: e.last_10_lines,
+              last_10_lines: caught.last_10_lines,
             });
           }
-          if (e instanceof BootPromptUpdateMenuBlockedError) {
-            return err(e, {
+          if (caught instanceof BootPromptUpdateMenuBlockedError) {
+            return err(caught, {
               ...createdIdentity,
-              error_code: e.error_code,
-              last_10_lines: e.last_10_lines,
-              recovery: e.recovery,
+              error_code: caught.error_code,
+              last_10_lines: caught.last_10_lines,
+              recovery: caught.recovery,
             });
           }
-          if (e instanceof BootPromptDeliveryError) {
-            return err(e, {
+          if (caught instanceof BootPromptDeliveryError) {
+            return err(caught, {
               ...createdIdentity,
-              delivered_chars: e.delivered_chars,
+              delivered_chars: caught.delivered_chars,
             });
           }
-          return err(e, createdIdentity);
+          return err(caught, createdIdentity);
         }
       },
     );

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -91,13 +91,25 @@ function canonicalPath(path: string): string {
   }
 }
 
-function assertInside(root: string, path: string): void {
-  const resolvedRoot = resolve(root);
-  const resolvedPath = resolve(path);
-  const rel = relative(resolvedRoot, resolvedPath);
-  if (rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(`Worktree path ${path} must be inside ${root}`);
+function isInside(root: string, path: string): boolean {
+  const rel = relative(resolve(root), resolve(path));
+  return !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+function assertAllowedWorktreePath(
+  repoRoot: string,
+  homeGitsDir: string,
+  path: string,
+): void {
+  if (
+    isInside(repoRoot, path) ||
+    (isInside(homeGitsDir, repoRoot) && isInside(homeGitsDir, path))
+  ) {
+    return;
   }
+  throw new Error(
+    `Worktree path ${path} must be inside ${repoRoot} or ${homeGitsDir}`,
+  );
 }
 
 function normalizeWorktreeRequest(
@@ -241,7 +253,6 @@ export async function prepareWorktree(
   const repo = sanitizeRepoName(input.repo);
   const homeGitsDir = resolve(input.homeGitsDir ?? join(homedir(), "Gits"));
   const repoRoot = resolve(input.repoRoot ?? join(homeGitsDir, repo));
-  assertInside(homeGitsDir, repoRoot);
   const exec = input.exec ?? defaultExec;
 
   const spec = normalizeWorktreeRequest(repo, input.worktree);
@@ -271,13 +282,14 @@ export async function prepareWorktree(
       throw new Error(`Unable to generate a unique worktree path for ${repo}`);
     }
   }
-  assertInside(homeGitsDir, worktreePath);
+  assertAllowedWorktreePath(repoRoot, homeGitsDir, worktreePath);
 
   // Read the legacy sibling location during migration, but always create new
   // worktrees under <repo>/.worktrees. TODO remove .wt read-path after migration, ~2026-09.
   if (
     !spec.path &&
     !spec.generatedName &&
+    isInside(homeGitsDir, repoRoot) &&
     !existsSync(worktreePath) &&
     spec.reuse &&
     existsSync(legacyPath)
@@ -323,16 +335,71 @@ export async function prepareWorktree(
     worktreePath,
     spec.base,
   ]);
-  mkdirSync(worktreePath, { recursive: true });
-
-  return {
+  const prepared: PreparedWorktree = {
     path: worktreePath,
     name: basename(worktreePath),
     branch,
     base: spec.base,
     created: true,
     reused: false,
-    node_modules_linked: linkNodeModules(repoRoot, worktreePath),
-    mcp_json_copied: copyMcpJson(repoRoot, worktreePath),
+    node_modules_linked: false,
+    mcp_json_copied: false,
   };
+  try {
+    mkdirSync(worktreePath, { recursive: true });
+    prepared.node_modules_linked = linkNodeModules(repoRoot, worktreePath);
+    prepared.mcp_json_copied = copyMcpJson(repoRoot, worktreePath);
+    return prepared;
+  } catch (error) {
+    try {
+      await rollbackPreparedWorktree(repoRoot, prepared, exec);
+    } catch (rollbackError) {
+      const original = error instanceof Error ? error.message : String(error);
+      const rollback =
+        rollbackError instanceof Error
+          ? rollbackError.message
+          : String(rollbackError);
+      throw new Error(
+        `${original}. Worktree rollback also failed for ${prepared.path} (${prepared.branch}): ${rollback}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
+export async function rollbackPreparedWorktree(
+  repoRoot: string,
+  prepared: PreparedWorktree,
+  exec: WorktreeExec = defaultExec,
+): Promise<void> {
+  if (!prepared.created) return;
+
+  const failures: string[] = [];
+  try {
+    await exec("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "remove",
+      "--force",
+      prepared.path,
+    ]);
+  } catch (error) {
+    failures.push(
+      `worktree remove failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    await exec("git", ["-C", repoRoot, "branch", "-D", prepared.branch]);
+  } catch (error) {
+    failures.push(
+      `branch delete failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Cleanup required for worktree ${prepared.path} and branch ${prepared.branch}: ${failures.join("; ")}`,
+    );
+  }
 }

--- a/tests/launcher-registry.test.ts
+++ b/tests/launcher-registry.test.ts
@@ -3,6 +3,7 @@ import {
   parseLauncherRegistry,
   resolveLauncherNameFromRegistry,
   resolveLauncherPrefix,
+  resolveRepoRootFromLauncherRegistry,
 } from "../src/launcher-registry.js";
 
 const REGISTRY = `
@@ -56,6 +57,60 @@ describe("launcher registry", () => {
         sourcePath: "/tmp/launchers.zsh",
       }),
     ).toBe("mmClaude");
+  });
+
+  it("resolves the registered repo path independently of the registry key", () => {
+    const entries = parseLauncherRegistry(REGISTRY, "/tmp/launchers.zsh");
+
+    expect(
+      resolveRepoRootFromLauncherRegistry("hyphen", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toBe("/Users/etanheyman/Gits/hyphen-repo");
+  });
+
+  it("prefers an exact registry prefix over an earlier basename alias", () => {
+    const entries = parseLauncherRegistry(
+      `repoGolem alias "/tmp/other/golems"\nrepoGolem golems "/tmp/canonical"\n`,
+      "/tmp/launchers.zsh",
+    );
+
+    expect(
+      resolveRepoRootFromLauncherRegistry("golems", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toBe("/tmp/canonical");
+  });
+
+  it("rejects an ambiguous basename match across different registry paths", () => {
+    const entries = parseLauncherRegistry(
+      `repoGolem first "/tmp/one/shared"\nrepoGolem second "/tmp/two/shared"\n`,
+      "/tmp/launchers.zsh",
+    );
+
+    expect(() =>
+      resolveRepoRootFromLauncherRegistry("shared", {
+        entries,
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toThrow(/Ambiguous launcher registry match.*first=.*second=.*exact launcher prefix/s);
+  });
+
+  it("rejects a relative registry repo path instead of resolving it from cmuxlayer cwd", () => {
+    expect(() =>
+      resolveRepoRootFromLauncherRegistry("relative", {
+        entries: [
+          {
+            prefix: "relative",
+            path: "../somewhere-else",
+            repoBasename: "somewhere-else",
+          },
+        ],
+        sourcePath: "/tmp/launchers.zsh",
+      }),
+    ).toThrow(/must be absolute.*\.\.\/somewhere-else.*launchers\.zsh/s);
   });
 
   it("throws a self-answering miss error with source and registered launchers", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -47,8 +47,16 @@ let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
 const hermeticSpawnStateDirs: string[] = [];
 let hermeticSpawnFixtureSequence = 0;
+const originalLauncherRegistryPath =
+  process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
 
 afterEach(async () => {
+  if (originalLauncherRegistryPath === undefined) {
+    delete process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
+  } else {
+    process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH =
+      originalLauncherRegistryPath;
+  }
   await Promise.allSettled(
     serverContexts.map(
       (context) => context.lifecycleStartPromise ?? Promise.resolve(),
@@ -2874,6 +2882,331 @@ describe("agent lifecycle tool handlers", () => {
         `cmuxlayerCodex -s -w '${worktreePath}'`,
       ]),
     );
+  });
+
+  it("spawn_agent resolves a mismatched repo key from the launcher registry path", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "skill-creator");
+    const registryPath = join(TEST_DIR, "launchers.zsh");
+    const worktreePath = join(repoRoot, ".worktrees", "registry-root");
+    mkdirSync(repoRoot, { recursive: true });
+    writeFileSync(
+      registryPath,
+      `repoGolem skillcreator "${repoRoot}"\n`,
+    );
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const worktreeExec = vi.fn().mockImplementation(async () => {
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "skillcreator",
+        cli: "codex",
+        role: "worker",
+        worktree: { name: "registry-root" },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.worktree.path).toBe(worktreePath);
+    expect(worktreeExec).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["-C", repoRoot, "worktree", "add"]),
+    );
+    expect(worktreeExec).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["-C", join(gitsDir, "skillcreator")]),
+    );
+  });
+
+  it("spawn_agent supports a registry repo path outside the Gits directory without redirecting", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(TEST_DIR, ".config", "ralph");
+    const registryPath = join(TEST_DIR, "launchers-outside-gits.zsh");
+    const worktreePath = join(repoRoot, ".worktrees", "outside-root");
+    mkdirSync(repoRoot, { recursive: true });
+    writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const worktreeExec = vi.fn().mockImplementation(async () => {
+      mkdirSync(worktreePath, { recursive: true });
+      return { stdout: "", stderr: "" };
+    });
+    const server = createTrackedServer({
+      exec: mockExec,
+      stateDir: TEST_DIR,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "ralph",
+        cli: "codex",
+        role: "worker",
+        worktree: { name: "outside-root" },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.worktree.path).toBe(worktreePath);
+    expect(
+      worktreeExec.mock.calls.some(([, args]) =>
+        args.includes(join(gitsDir, "ralph")),
+      ),
+    ).toBe(false);
+  });
+
+  it("spawn_agent rejects an unregistered repo before worktree or focus mutation", async () => {
+    const registryPath = join(TEST_DIR, "launchers-missing-repo.zsh");
+    writeFileSync(
+      registryPath,
+      `repoGolem cmuxlayer "${join(TEST_DIR, "Gits", "cmuxlayer")}"\n`,
+    );
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const lifecycleExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(lifecycleExec);
+    const worktreeExec = vi.fn();
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: join(TEST_DIR, "Gits"),
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "wt-eval-scratch",
+        cli: "codex",
+        role: "worker",
+        worktree: true,
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/Launcher registry miss.*wt-eval-scratch/s);
+    expect(worktreeExec).not.toHaveBeenCalled();
+    expect(
+      exec.mock.calls.some(([, args]) =>
+        args.includes("select-workspace") || args.includes("surface.focus"),
+      ),
+    ).toBe(false);
+  });
+
+  it("spawn_agent rolls back a newly created worktree and branch when spawning fails", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(TEST_DIR, ".config", "ralph");
+    const registryPath = join(TEST_DIR, "launchers-rollback.zsh");
+    const worktreePath = join(repoRoot, ".worktrees", "spawn-failure");
+    mkdirSync(repoRoot, { recursive: true });
+    writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(worktreePath, { recursive: true });
+      }
+      if (args.includes("worktree") && args.includes("remove")) {
+        rmSync(worktreePath, { recursive: true, force: true });
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const lifecycleExec = makeLifecycleExec();
+    const failingExec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (args.includes("new-split") || args.includes("new-surface")) {
+        throw new Error("deliberate spawn failure");
+      }
+      return lifecycleExec(cmd, args);
+    });
+    const server = createTrackedServer({
+      exec: failingExec,
+      stateDir: TEST_DIR,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "ralph",
+        cli: "codex",
+        role: "worker",
+        worktree: {
+          name: "spawn-failure",
+          branch: "wt/spawn-failure",
+        },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("deliberate spawn failure");
+    expect(worktreeExec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "remove",
+      "--force",
+      worktreePath,
+    ]);
+    expect(worktreeExec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "branch",
+      "-D",
+      "wt/spawn-failure",
+    ]);
+    expect(existsSync(worktreePath)).toBe(false);
+  });
+
+  it("spawn_agent preserves a newly created worktree when a recoverable surface survives", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "cmuxlayer");
+    const worktreePath = join(repoRoot, ".worktrees", "recoverable-surface");
+    mkdirSync(repoRoot, { recursive: true });
+    const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(worktreePath, { recursive: true });
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const lifecycleExec = makeLifecycleExec();
+    const failingFocusExec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (
+        args.includes("rpc") &&
+        args.includes("surface.focus") &&
+        args.some((value) => String(value).includes("surface:new"))
+      ) {
+        throw new Error("deliberate created-surface focus failure");
+      }
+      return lifecycleExec(cmd, args);
+    });
+    const server = createTrackedServer({
+      exec: failingFocusExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+        worktree: {
+          name: "recoverable-surface",
+          branch: "wt/recoverable-surface",
+        },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("deliberate created-surface focus failure");
+    expect(parsed.surface_id).toBe("surface:new");
+    expect(worktreeExec).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["worktree", "remove"]),
+    );
+    expect(worktreeExec).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["branch", "-D"]),
+    );
+    expect(existsSync(worktreePath)).toBe(true);
+  });
+
+  it("new_worktree_split rolls back a newly created worktree and branch when spawning fails", async () => {
+    const gitsDir = join(TEST_DIR, "Gits");
+    const repoRoot = join(gitsDir, "cmuxlayer");
+    const worktreePath = join(repoRoot, ".worktrees", "legacy-spawn-failure");
+    mkdirSync(repoRoot, { recursive: true });
+    const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(worktreePath, { recursive: true });
+      }
+      if (args.includes("worktree") && args.includes("remove")) {
+        rmSync(worktreePath, { recursive: true, force: true });
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const lifecycleExec = makeLifecycleExec();
+    const failingExec = vi.fn().mockImplementation(async (cmd, args) => {
+      if (args.includes("new-split") || args.includes("new-surface")) {
+        throw new Error("deliberate legacy spawn failure");
+      }
+      return lifecycleExec(cmd, args);
+    });
+    const server = createTrackedServer({
+      exec: failingExec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: gitsDir,
+      worktreeExec,
+    });
+    const tool = (server as any)._registeredTools["new_worktree_split"];
+
+    const result = await tool.handler(
+      {
+        repo: "cmuxlayer",
+        cli: "codex",
+        worktree: {
+          name: "legacy-spawn-failure",
+          branch: "wt/legacy-spawn-failure",
+        },
+      },
+      {} as any,
+    );
+
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("deliberate legacy spawn failure");
+    expect(worktreeExec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "remove",
+      "--force",
+      worktreePath,
+    ]);
+    expect(worktreeExec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "branch",
+      "-D",
+      "wt/legacy-spawn-failure",
+    ]);
+    expect(existsSync(worktreePath)).toBe(false);
   });
 
   it("new_worktree_split launches a worker with the requested MCP profile", async () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import {
   formatMcpProfileEnv,
   prepareWorktree,
+  rollbackPreparedWorktree,
 } from "../src/worktree.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-worktree-test");
@@ -379,6 +380,73 @@ describe("worktree helpers", () => {
     expect(readFileSync(join(worktreePath, ".mcp.json"), "utf8")).toBe(
       mcpConfig,
     );
+  });
+
+  it("rolls back a newly created worktree when post-add setup fails", async () => {
+    const repoRoot = join(TEST_ROOT, "repo");
+    const worktreePath = join(repoRoot, ".worktrees", "setup-failure");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(join(repoRoot, ".mcp.json"));
+    const exec = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("worktree") && args.includes("add")) {
+        mkdirSync(worktreePath, { recursive: true });
+      }
+      if (args.includes("worktree") && args.includes("remove")) {
+        rmSync(worktreePath, { recursive: true, force: true });
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(
+      prepareWorktree({
+        repo: "cmuxlayer",
+        repoRoot,
+        homeGitsDir: TEST_ROOT,
+        worktree: {
+          name: "setup-failure",
+          branch: "wt/setup-failure",
+        },
+        exec,
+      }),
+    ).rejects.toThrow();
+
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "worktree",
+      "remove",
+      "--force",
+      worktreePath,
+    ]);
+    expect(exec).toHaveBeenCalledWith("git", [
+      "-C",
+      repoRoot,
+      "branch",
+      "-D",
+      "wt/setup-failure",
+    ]);
+    expect(existsSync(worktreePath)).toBe(false);
+  });
+
+  it("never rolls back a reused worktree", async () => {
+    const exec = vi.fn();
+
+    await rollbackPreparedWorktree(
+      join(TEST_ROOT, "repo"),
+      {
+        path: join(TEST_ROOT, "repo", ".worktrees", "existing"),
+        name: "existing",
+        branch: "wt/existing",
+        base: "HEAD",
+        created: false,
+        reused: true,
+        node_modules_linked: false,
+        mcp_json_copied: false,
+      },
+      exec,
+    );
+
+    expect(exec).not.toHaveBeenCalled();
   });
 
   it("copies .mcp.json when reusing an existing worktree", async () => {


### PR DESCRIPTION
## Summary

- resolve managed worktree repo roots from absolute launcher-registry paths instead of `~/Gits/<repo-key>`
- support registered roots outside `~/Gits` while preventing legacy-path redirection
- roll back newly created worktrees and branches when spawn fails before a surface exists; preserve reused worktrees and recoverable live surfaces
- apply the same rollback contract to deprecated `new_worktree_split`
- prefer exact registry prefixes and reject ambiguous fallback matches across different repository paths

## Verification

- `bun run test` — 107 files passed, 2,491 tests passed, 1 skipped
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- local CodeRabbit review — 0 findings on the final diff
- built-server live probe — `spawn_agent(repo:"skillcreator", effort:"medium", worktree:...)` returned `ok:true` with cwd `/Users/etanheyman/Gits/skill-creator/.worktrees/p2-live-probe-20260809-1537`; the probe agent, surface, worktree, and branch were cleaned up

## Release note

Do not merge this PR independently. It is held for the v0.4.25 release decision alongside #374.

The Phase 2 plan also names the repogolem skill, but that file is owned by the separate `golems` repository and cannot land in this cmuxlayer PR. Its existing worktree section already distinguishes pre-created `-w` paths from worktrees created by `spawn_agent`.

Follow-up scope retained explicitly: registry-derived workspace matching for aliases whose key and directory differ beyond case/hyphens, and the newly documented requirement that all worktree-capable CLIs (including Kiro) use registered absolute roots.

<!-- agent-identity: seat=cmuxlayerCodex role=worker harness=codex model=gpt-5.6-sol session=019fe668 ts=2026-08-09T12:37:30Z -->
— cmuxlayerCodex (worker) · codex/gpt-5.6-sol

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent spawn and git worktree lifecycle (registry resolution, path rules, automatic cleanup); mistakes could mis-locate repos or delete branches, but behavior is gated on registry entries and extensive tests.
> 
> **Overview**
> **Worktree repo roots** for managed spawns now come from the **absolute path** in the repoGolem launcher registry via `resolveRepoRootFromLauncherRegistry`, not from `~/Gits/<repo>`. Registry lookup prefers an exact prefix match, rejects ambiguous basename/path fallbacks, and requires absolute paths. Default worktrees use `<registered-root>/.worktrees/`; paths may live under the registered root or under `~/Gits` when the root is inside Gits.
> 
> **Rollback** adds `rollbackPreparedWorktree` (git worktree remove + branch delete) when post-create setup fails in `prepareWorktree`, and in **`spawn_agent`** / **`new_worktree_split`** when spawn fails **before** `on_surface_created`—only for **newly created** worktrees, not reused ones or when a recoverable surface already exists. **`spawn_agent`** defers worktree preparation until after other spawn gates pass.
> 
> Docs in **CLAUDE.md** and spawn tool descriptions document the contract. Tests cover registry resolution, outside-Gits roots, unregistered repos, rollback, and preserved worktrees on recoverable failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aff5972fcb934e2d31cae4a3ff3c180ad95e1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree root resolution from launcher registry and add rollback on spawn failure
> - `resolveRepoRootFromLauncherRegistry` is added to [launcher-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/375/files#diff-8dbe1f62bf5830e9bf985cfd067c4d85a8af7dc9df4a4fabc375f8d16cb28d1a) to look up a repo's absolute root from the registry, supporting repos outside `~/Gits`. Ambiguous or relative-path entries throw explicit errors.
> - `prepareWorktree` in [worktree.ts](https://github.com/EtanHey/cmuxlayer/pull/375/files#diff-a63b9f0a6ce7c2e7f7dd324524256bcd98a8e8829d98b8b844d630fdd23ae56d) now accepts any registered repo root (not just paths under `~/Gits`) and validates worktree paths via a new `assertAllowedWorktreePath` helper.
> - `rollbackPreparedWorktree` is added to remove a newly created worktree and its branch if post-add setup fails; reused worktrees are never rolled back.
> - `spawn_agent` and `new_worktree_split` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/375/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now resolve the repo root from the registry before mutations, roll back newly created worktrees on failure, and skip rollback if a surface was already created.
> - Behavioral Change: `resolveLauncherPrefix` now prefers exact registry prefix matches and throws on ambiguous fallback matches across different paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2aff597. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->