### PR TITLE
fix: reject incompatible Codex effort before spawn

### DIFF
--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,15 +1,14 @@
 import type { CliType } from "./agent-types.js";
 
 export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
-// Must stay in sync with golem-dispatch.zsh:446 — the launcher is the authority.
-// `low` and `max` were added there; omitting them here made `max` (Etan's pin for
-// some lanes) impossible to express through spawn_agent at all.
+// Cross-version repoGolem compatibility set. A shell can retain an older loaded
+// launcher function after the source file is upgraded, so values supported only
+// by newer launchers must not be advertised by spawn_agent: validation has to
+// reject them before any worktree or surface is created.
 export const CODEX_EFFORT_VALUES = [
-  "low",
   "medium",
   "high",
   "xhigh",
-  "max",
   "ultra",
 ] as const;
 export type CodexEffort = (typeof CODEX_EFFORT_VALUES)[number];
@@ -170,7 +169,7 @@ export function resolveSpawnEffort(
 
   if (!(CODEX_EFFORT_VALUES as readonly string[]).includes(requested)) {
     throw new Error(
-      `Invalid Codex effort "${requested}". Accepted values: ${CODEX_EFFORT_VALUES.join(", ")}. No agent was spawned.`,
+      `Invalid Codex effort "${requested}" (expected: ${CODEX_EFFORT_VALUES.join(", ")}). No agent was spawned.`,
     );
   }
   if (cli !== "codex") {

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,10 +1,10 @@
 import type { CliType } from "./agent-types.js";
 
 export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
-// Cross-version repoGolem compatibility set. A shell can retain an older loaded
-// launcher function after the source file is upgraded, so values supported only
-// by newer launchers must not be advertised by spawn_agent: validation has to
-// reject them before any worktree or surface is created.
+// Match the installed repoGolem launcher sourced by fresh interactive shells
+// (~/.config/ralphtools/golem-dispatch.zsh), not the potentially newer golems
+// checkout. The drift gate fails when that live contract changes; validation
+// must still reject mismatches before any worktree or surface is created.
 export const CODEX_EFFORT_VALUES = [
   "medium",
   "high",

--- a/src/server.ts
+++ b/src/server.ts
@@ -9506,7 +9506,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .enum(CODEX_EFFORT_VALUES)
           .optional()
           .describe(
-            "Codex reasoning effort, passed to the repoGolem launcher. CHOOSE THIS DELIBERATELY PER MISSION — it is a cost decision, not a default to inherit. Accepted cross-version Codex values: medium, high, xhigh, ultra. Newer launchers may support additional values, but spawn_agent rejects them before creating a worktree or surface because already-loaded launcher functions can be older. The launcher defaults to HIGH when omitted (golem-dispatch.zsh:431). Per /agent-routing, MEDIUM is the settled floor for well-specified implementation lanes — use it unless the task genuinely needs more; xhigh and above burn budget fast and are rarely warranted for a lane with a clear brief.",
+            "Codex reasoning effort, passed to the repoGolem launcher. CHOOSE THIS DELIBERATELY PER MISSION — it is a cost decision, not a default to inherit. The installed launcher currently accepts: medium, high, xhigh, ultra. spawn_agent rejects other values before creating a worktree or surface. The live launcher defaults to XHIGH when omitted (~/.config/ralphtools/golem-dispatch.zsh). Per /agent-routing, MEDIUM is the settled floor for well-specified implementation lanes — use it unless the task genuinely needs more; xhigh and above burn budget fast and are rarely warranted for a lane with a clear brief.",
           ),
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])

--- a/src/server.ts
+++ b/src/server.ts
@@ -9506,7 +9506,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .enum(CODEX_EFFORT_VALUES)
           .optional()
           .describe(
-            "Codex reasoning effort, passed to the repoGolem launcher. CHOOSE THIS DELIBERATELY PER MISSION — it is a cost decision, not a default to inherit. Accepted: low, medium, high, xhigh, max, ultra. The launcher defaults to HIGH when omitted (golem-dispatch.zsh:431). Per /agent-routing, MEDIUM is the settled floor for well-specified implementation lanes — use it unless the task genuinely needs more; xhigh and above burn budget fast and are rarely warranted for a lane with a clear brief.",
+            "Codex reasoning effort, passed to the repoGolem launcher. CHOOSE THIS DELIBERATELY PER MISSION — it is a cost decision, not a default to inherit. Accepted cross-version Codex values: medium, high, xhigh, ultra. Newer launchers may support additional values, but spawn_agent rejects them before creating a worktree or surface because already-loaded launcher functions can be older. The launcher defaults to HIGH when omitted (golem-dispatch.zsh:431). Per /agent-routing, MEDIUM is the settled floor for well-specified implementation lanes — use it unless the task genuinely needs more; xhigh and above burn budget fast and are rarely warranted for a lane with a clear brief.",
           ),
         cli: z
           .enum(["claude", "codex", "gemini", "kiro", "cursor"])

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -38,6 +38,24 @@ function parseCursorLauncher(dispatchText: string): string {
   return launcher![1];
 }
 
+function parseCodexEffortValues(dispatchText: string): string[] {
+  const parser = dispatchText.match(
+    /_golem_parse_codex_flags\(\)\s*\{([\s\S]*?)\n\}/,
+  );
+  expect(
+    parser,
+    "could not parse _golem_parse_codex_flags from installed launcher",
+  ).not.toBeNull();
+  const ladder = parser![1].match(
+    /\n\s*([a-z]+(?:\|[a-z]+)+)\)\s+_flag_codex_effort="\$2"/,
+  );
+  expect(
+    ladder,
+    "could not parse Codex effort ladder from installed launcher",
+  ).not.toBeNull();
+  return ladder![1].split("|");
+}
+
 describe("model-policy drift gate", () => {
   it("pins the server-side model policy contract used by spawn_agent", () => {
     expect(MODEL_OVERRIDE_ENV).toBe("REPOGOLEM_ALLOW_MODEL");
@@ -92,14 +110,14 @@ describe("model-policy drift gate", () => {
 
 const dispatchPath = join(
   homedir(),
-  "Gits/golems/scripts/repogolem/golem-dispatch.zsh",
+  ".config/ralphtools/golem-dispatch.zsh",
 );
-const golemsAbsent = !existsSync(dispatchPath);
+const launcherAbsent = !existsSync(dispatchPath);
 
-describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
+describe.skipIf(launcherAbsent)("model-policy parity with installed golem-dispatch", () => {
   // Read lazily in beforeAll, not at describe-body collection time: a skipped
-  // suite (golems absent, e.g. CI) still evaluates the describe body, so a
-  // top-level readFileSync would throw ENOENT before the skip takes effect.
+  // suite (installed launcher absent, e.g. CI) still evaluates the describe
+  // body, so a top-level readFileSync would throw before the skip takes effect.
   let dispatchText: string;
   beforeAll(() => {
     dispatchText = readFileSync(dispatchPath, "utf8");
@@ -121,29 +139,11 @@ describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
   });
 
   it("keeps the advertised Codex effort ladder compatible with the launcher", () => {
-    const ladder = dispatchText.match(/low\|medium\|high\|xhigh\|max\|ultra/);
+    const installedValues = parseCodexEffortValues(dispatchText);
     expect(
-      ladder,
-      "golem-dispatch.zsh must still expose the low|medium|high|xhigh|max|ultra ladder",
-    ).not.toBeNull();
-
-    for (const value of CODEX_EFFORT_VALUES) {
-      expect(
-        ladder?.[0].split("|") ?? [],
-        `the launcher must accept every effort advertised by spawn_agent: "${value}"`,
-      ).toContain(value as string);
-    }
-
-    // Do not widen this assertion to equality. A running interactive shell can
-    // retain an older launcher function after golem-dispatch.zsh is upgraded;
-    // cmuxlayer intentionally advertises the cross-version safe subset so its
-    // preflight rejects unsupported values before creating resources (#379).
-    expect(CODEX_EFFORT_VALUES).toEqual([
-      "medium",
-      "high",
-      "xhigh",
-      "ultra",
-    ]);
+      CODEX_EFFORT_VALUES,
+      "spawn_agent must advertise exactly the values accepted by the launcher sourced by fresh interactive shells",
+    ).toEqual(installedValues);
   });
 
   it("states the launcher's REAL effort default, not a stale one", () => {

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -120,23 +120,30 @@ describe.skipIf(golemsAbsent)("model-policy parity with golem-dispatch", () => {
     ).toBe(dispatchDefault);
   });
 
-  it("keeps the Codex effort ladder aligned with the launcher", () => {
-    // RED 2026-08-05: the launcher gained `low` and `max` and moved its default
-    // xhigh -> high; cmuxlayer's enum and tool description did not follow. The
-    // stale description is what agents read at dispatch time, so it normalised
-    // xhigh fleet-wide and cost real usage. Nothing guarded effort — only model.
+  it("keeps the advertised Codex effort ladder compatible with the launcher", () => {
     const ladder = dispatchText.match(/low\|medium\|high\|xhigh\|max\|ultra/);
     expect(
       ladder,
       "golem-dispatch.zsh must still expose the low|medium|high|xhigh|max|ultra ladder",
     ).not.toBeNull();
 
-    for (const value of ["low", "medium", "high", "xhigh", "max", "ultra"]) {
+    for (const value of CODEX_EFFORT_VALUES) {
       expect(
-        CODEX_EFFORT_VALUES as readonly string[],
-        `CODEX_EFFORT_VALUES must accept "${value}" — the launcher does`,
-      ).toContain(value);
+        ladder?.[0].split("|") ?? [],
+        `the launcher must accept every effort advertised by spawn_agent: "${value}"`,
+      ).toContain(value as string);
     }
+
+    // Do not widen this assertion to equality. A running interactive shell can
+    // retain an older launcher function after golem-dispatch.zsh is upgraded;
+    // cmuxlayer intentionally advertises the cross-version safe subset so its
+    // preflight rejects unsupported values before creating resources (#379).
+    expect(CODEX_EFFORT_VALUES).toEqual([
+      "medium",
+      "high",
+      "xhigh",
+      "ultra",
+    ]);
   });
 
   it("states the launcher's REAL effort default, not a stale one", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -694,34 +694,72 @@ describe("lean spawn tool responses", () => {
     );
   });
 
-  // CHANGED 2026-08-05, deliberately, with rationale: this asserted `max` must be
-  // REJECTED, which was correct when golem-dispatch.zsh's ladder was
-  // medium|high|xhigh|ultra. golems #657 added `low` and `max`, and Etan pins some
-  // lanes at max — so cmuxlayer rejecting it made his own pin impossible to express.
-  // The launcher is the authority; this test encoded a contract that no longer holds.
-  // Inverted to assert acceptance, NOT deleted, so the ladder stays pinned in both
-  // directions.
-  it("spawn_agent schema accepts max effort — the launcher's ladder is the authority", () => {
+  it("spawn_agent schema advertises only the cross-version Codex effort set", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
-    const parsed = spawn.inputSchema.safeParse({
-      repo: "cmuxlayer",
-      cli: "codex",
-      effort: "max",
-    });
+    for (const effort of ["medium", "high", "xhigh", "ultra"]) {
+      expect(
+        spawn.inputSchema.safeParse({
+          repo: "cmuxlayer",
+          cli: "codex",
+          effort,
+        }).success,
+      ).toBe(true);
+    }
 
-    expect(parsed.success).toBe(true);
+    for (const effort of ["low", "max", "turbo"]) {
+      expect(
+        spawn.inputSchema.safeParse({
+          repo: "cmuxlayer",
+          cli: "codex",
+          effort,
+        }).success,
+      ).toBe(false);
+    }
+  });
 
-    // And a value the launcher genuinely does not accept must still be refused,
-    // so this stays a real gate rather than an open door.
-    const bogus = spawn.inputSchema.safeParse({
-      repo: "cmuxlayer",
-      cli: "codex",
-      effort: "turbo",
+  it("spawn_agent rejects launcher-incompatible effort before creating a worktree or surface", async () => {
+    const repoRoot = join(TEST_DIR, "Gits", "cmuxlayer");
+    const registryPath = join(TEST_DIR, "launchers-effort-preflight.zsh");
+    mkdirSync(repoRoot, { recursive: true });
+    writeFileSync(registryPath, `repoGolem cmuxlayer "${repoRoot}"\n`);
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const worktreeExec = vi.fn();
+    const exec = makeLifecycleExec();
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      sessionIdentityResolver: () => null,
+      worktreeHomeDir: join(TEST_DIR, "Gits"),
+      worktreeExec,
     });
-    expect(bogus.success).toBe(false);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        repo: "cmuxlayer",
+        cli: "codex",
+        effort: "low",
+        worktree: {
+          name: "incompatible-effort",
+          branch: "wt/incompatible-effort",
+        },
+      },
+      {} as any,
+    );
+
+    expect(result.structuredContent).toMatchObject({ ok: false });
+    expect(result.structuredContent.error).toContain(
+      'Invalid Codex effort "low" (expected: medium, high, xhigh, ultra)',
+    );
+    expect(worktreeExec).not.toHaveBeenCalled();
+    expect(
+      (exec as any).mock.calls.some(([, args]: [string, string[]]) =>
+        args.includes("new-split") || args.includes("new-surface"),
+      ),
+    ).toBe(false);
   });
 
   it("spawn_agent rejects Codex effort for another CLI before creating a surface", async () => {


### PR DESCRIPTION
## Summary
- restrict `spawn_agent` to the cross-version Codex effort set accepted by live launcher functions
- reject incompatible effort before worktree, branch, or surface creation
- document why the schema is intentionally a safe subset of newer launcher source

## Verification
- `bun run typecheck`
- `bun run build`
- `bun run test` — 107 files passed; 2,492 tests passed; 1 skipped
- real `dist/index.js` MCP probe rejected `effort:"low"` with the four-value enum and created no worktree or branch
- `coderabbit review --agent` — 0 findings across 4 changed files

Refs #379 (remaining fixes tracked in #381)

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaee","ts":"2026-08-10T09:18:13Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent dispatch validation and advertised effort options; callers using `low` or `max` will fail spawn, but incompatible values are blocked before worktree/surface creation.
> 
> **Overview**
> **Codex effort** for `spawn_agent` is narrowed to **`medium`, `high`, `xhigh`, `ultra`** so the MCP schema and `resolveSpawnEffort` match what the **installed** repoGolem launcher (`~/.config/ralphtools/golem-dispatch.zsh`) accepts in practice. Values such as **`low`** and **`max`** that may exist in a newer golems checkout are **rejected at validation** with a clearer error before any worktree, branch, or surface is created.
> 
> The **`spawn_agent` effort field description** is updated to list only those four values and to document the live launcher default (**XHIGH** when omitted), replacing stale references to a six-value ladder and an older default.
> 
> **Drift/parity tests** now read the installed dispatch script (not the golems repo path), parse the Codex effort ladder from `_golem_parse_codex_flags`, and assert `CODEX_EFFORT_VALUES` equals that ladder. **Server tests** cover schema acceptance/rejection and a preflight failure path that ensures incompatible effort does not trigger worktree or surface setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c41c438d42d087cd40d1e8baaba22c297a3e9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject incompatible Codex effort values before worktree or surface creation
> - Removes `"low"` and `"max"` from `CODEX_EFFORT_VALUES` in [model-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/380/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d), leaving the accepted ladder as `medium`, `high`, `xhigh`, `ultra` to match the installed launcher at `~/.config/ralphtools/golem-dispatch.zsh`.
> - Updates the `resolveSpawnEffort` error message format from `Accepted values: ...` to `(expected: ...)` and updates the `spawn_agent` zod schema description to reflect the new ladder.
> - Adds a preflight rejection test that confirms `spawn_agent` with `cli=codex` and `effort=low` returns a structured error with no worktree or surface side effects.
> - Behavioral Change: `effort=low` and `effort=max` are now rejected before any spawn occurs; previously `max` was accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c41c43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Codex effort options to the supported values: `medium`, `high`, `xhigh`, and `ultra`.
  * Unsupported effort values are now rejected before any work begins, with clearer error messaging.
  * Added validation to prevent setup changes when an invalid effort is provided.

* **Tests**
  * Expanded coverage for supported and rejected effort values across launcher compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
