### PR TITLE
fix: derive agent placement from declared job role

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3620,6 +3620,14 @@ export class AgentEngine {
         },
         {
           ...healthTopologyOverrides(agent, surfaceTopology),
+          parent_role: agent.parent_agent_id
+            ? (() => {
+                const parent =
+                  this.registry.get(agent.parent_agent_id) ??
+                  this.stateMgr.readState(agent.parent_agent_id);
+                return parent ? inferRecordRoleOrNull(parent) : null;
+              })()
+            : null,
           harvestability,
         },
       );
@@ -4701,11 +4709,6 @@ export class AgentEngine {
     let spawnDepth = 0;
     let parentAgentId: string | null = null;
     let parentAgent: AgentRecord | null = null;
-    const role = inferAgentRole({
-      role: spawnParams.role,
-      cli: spawnParams.cli,
-      launcherName: launcherNameForCli(spawnParams.repo, spawnParams.cli),
-    });
 
     if (spawnParams.parent_agent_id) {
       let parent =
@@ -4751,6 +4754,22 @@ export class AgentEngine {
       parentAgentId = parent.agent_id;
       parentAgent = parent;
     }
+
+    // Job role is authoritative. When no role was declared, spawn context is
+    // stronger evidence than the CLI: a worker's child is worker work even if
+    // the selected harness is Claude. CLI/launcher inference is the final
+    // compatibility fallback only (#378).
+    const role = spawnParams.role !== undefined
+      ? inferAgentRole({ role: spawnParams.role })
+      : parentAgent && inferRecordRoleOrNull(parentAgent) === "worker"
+        ? "worker"
+        : inferAgentRole({
+            cli: spawnParams.cli,
+            launcherName: launcherNameForCli(
+              spawnParams.repo,
+              spawnParams.cli,
+            ),
+          });
 
     this.spawnGuard.check(spawnParams.workspace);
 

--- a/src/agent-health-input.ts
+++ b/src/agent-health-input.ts
@@ -1,4 +1,4 @@
-import type { AgentRecord } from "./agent-types.js";
+import type { AgentRecord, AgentRole } from "./agent-types.js";
 import type {
   AgentHealthInput,
   AgentTopologyHealthInput,
@@ -22,6 +22,7 @@ export interface ParsedSurfaceHealthInput {
 }
 
 export interface AgentHealthInputOverrides {
+  parent_role?: AgentRole | null;
   monitor_alive?: boolean | null;
   stale_count?: number;
   screen_status?: string | null;
@@ -130,6 +131,7 @@ export async function buildAgentHealthInput(
       : (await deps.resolveCollapsedMonitors?.(ownerSeats)) ?? [];
 
   return {
+    parent_role: overrides.parent_role,
     monitor_alive: alive,
     inbox_channel_dir_deleted: inboxChannelDirDeleted,
     stale_count: staleCount,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -31,6 +31,7 @@ export type AgentHealthIssueCode =
   | "ambiguous_repo_cwd_label"
   | "seat_identity_mismatch"
   | "non_claude_orchestrator"
+  | "worker_spawned_orchestrator"
   | "topology_three_or_more_columns"
   | "orchestrator_not_leftmost"
   | "worker_in_leftmost_column";
@@ -54,6 +55,7 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   orchestrator_not_leftmost: "blocking",
   worker_in_leftmost_column: "blocking",
   non_claude_orchestrator: "blocking",
+  worker_spawned_orchestrator: "blocking",
   inbox_channel_dir_deleted: "blocking",
   monitor_collapsed: "blocking",
   stale_inbox_dispatches: "blocking",
@@ -72,6 +74,7 @@ export interface AgentTopologyHealthInput {
 }
 
 export interface AgentHealthInput {
+  parent_role?: AgentRole | null;
   monitor_alive?: boolean | null;
   inbox_channel_dir_deleted?: boolean | null;
   stale_count?: number;
@@ -524,6 +527,18 @@ export function evaluateAgentHealth(
       issues,
       "non_claude_orchestrator",
       "non-Claude agent was assigned orchestrator topology role; use worker unless this is the single explicit left-side coordinator",
+    );
+  }
+  if (
+    agent.cli === "claude" &&
+    role === "orchestrator" &&
+    input.parent_role === "worker"
+  ) {
+    addIssue(
+      issueCodes,
+      issues,
+      "worker_spawned_orchestrator",
+      "Claude agent spawned by a worker was assigned orchestrator topology role; reviewer and other worker-spawned jobs must remain workers",
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9139,7 +9139,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const callerSurface = currentCallerContext()?.surfaceId?.trim();
       if (!callerSurface) return null;
       const normalizedSurface = callerSurface.toLowerCase();
-      const records = [...registry.list(), ...stateMgr.listStates()];
+      const records = [...registry.list(), ...stateMgr.listStates()].filter(
+        (agent) => !TERMINAL_AGENT_STATES.has(agent.state),
+      );
       return (
         records.find(
           (agent) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -6004,6 +6004,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     overrides?: AgentHealthInputOverrides,
     topologyOverride?: SurfaceTopologySnapshot | null,
   ) => {
+    const parent = agent.parent_agent_id
+      ? (context.lifecycleRegistry?.get(agent.parent_agent_id) ??
+        stateMgr.readState(agent.parent_agent_id))
+      : null;
+    const parentRole = parent ? inferRecordRoleOrNull(parent) : null;
     const topology =
       topologyOverride === undefined
         ? await collectSurfaceTopology()
@@ -6069,6 +6074,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       {
         ...overrides,
+        parent_role: overrides?.parent_role ?? parentRole,
         ...safeSurfaceOverrides,
       },
     );
@@ -9129,6 +9135,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return registryDirect;
     };
 
+    const resolveCurrentCallerAgent = (): AgentRecord | null => {
+      const callerSurface = currentCallerContext()?.surfaceId?.trim();
+      if (!callerSurface) return null;
+      const normalizedSurface = callerSurface.toLowerCase();
+      const records = [...registry.list(), ...stateMgr.listStates()];
+      return (
+        records.find(
+          (agent) =>
+            agent.surface_uuid?.trim().toLowerCase() === normalizedSurface,
+        ) ??
+        records.find((agent) => agent.surface_id === callerSurface) ??
+        null
+      );
+    };
+
     const resolveManagedDeliveryRoute = async (
       agentId: string,
     ): Promise<{ surface: string; workspace?: string }> => {
@@ -9491,7 +9512,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      `${PANE_INPUT_BREAKAGE_GUIDANCE} Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. The created tab is focused long enough to initialize, then the exact origin focus is restored; pass focus:true to stay on the created tab. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately. ${ZSH_BANG_INLINE_WARNING}`,
+      `${PANE_INPUT_BREAKAGE_GUIDANCE} Spawn a managed AI agent in a terminal surface and return an agent_id plus lean routing and delivery evidence by default; pass verbose:true for the full legacy response including informational health and bookkeeping. For collabs, call list_agents/get_agent_state first and reuse or supersede a viable existing agent instead of spawning a duplicate lane. Unless workspace is explicitly provided, the new agent should land in the caller/current workspace; workers should land in the right worker pane by role. Declared role/placement is authoritative; CLI and launcher identity are fallback hints only. A managed worker caller is recorded as parent and its child is forced to worker with a warning. The created tab is focused long enough to initialize, then the exact origin focus is restored; pass focus:true to stay on the created tab. Use send_to and wait_for with the returned agent_id instead of remembering the created surface. If prompt or boot_prompt_path is provided, waits for the agent ready prompt, submits that boot instruction, and returns after submission evidence; submission is not proof of task completion or healthy lifecycle state. Multi-paragraph inline prompts are refused for interactive agents unless allow_long_inline:true. Prefer boot_prompt_path: it is checked before spawning and safely submits multiline or over-cap files as one \`Read and follow <path>\` pointer after readiness. Without a boot prompt, returns immediately and wait_for can be used separately. ${ZSH_BANG_INLINE_WARNING}`,
       {
         repo: z
           .string()
@@ -9552,17 +9573,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe(
-            "ID of the parent agent for hierarchical spawning. Parent must exist.",
+            "ID of the parent agent for hierarchical spawning. Normally inferred from the managed caller surface; pass explicitly only when no managed caller supplies the hierarchy. Parent must exist.",
           ),
         role: legacyCompatibleAgentRoleSchema()
           .optional()
           .describe(
-            "Optional placement role. Defaults from launcher: *Claude=orchestrator, *Codex/*Cursor=worker.",
+            "Optional placement role. An explicit declaration is authoritative; CLI/launcher identity is only a fallback hint. A managed worker caller is the safety exception and forces its child to worker with a warning.",
           ),
         placement: legacyCompatibleAgentRoleSchema()
           .optional()
           .describe(
-            "Canonical role-driven placement. role remains accepted as a compatibility spelling.",
+            "Canonical role-driven placement. An explicit declaration is authoritative; CLI/launcher identity is only a fallback hint. role remains accepted as a compatibility spelling.",
           ),
         auto_archive_on_done: z
           .boolean()
@@ -9619,7 +9640,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.placement ?? args.role,
             selectedRoleField,
           );
-          const effectiveRole = normalizedRole.role;
           resolveSpawnModelPolicy(args.cli, args.model);
           resolveSpawnEffort(args.cli, args.effort);
           const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
@@ -9638,8 +9658,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : null;
 
           await refreshManagedMetadataBestEffort(args.parent_agent_id);
-          const parentWorkspace = args.parent_agent_id
-            ? (engine.getAgentState(args.parent_agent_id)?.workspace_id ??
+          await refreshManagedMetadataBestEffort();
+          const callerAgent = resolveCurrentCallerAgent();
+          const callerRole = callerAgent
+            ? inferRecordRoleOrNull(callerAgent)
+            : null;
+          const callerIsWorker = callerRole === "worker";
+          const effectiveParentAgentId = callerIsWorker
+            ? callerAgent!.agent_id
+            : (args.parent_agent_id ?? callerAgent?.agent_id);
+          const effectiveRole = callerIsWorker
+            ? "worker"
+            : normalizedRole.role;
+          const workerCallerWarning = callerIsWorker
+            ? `Worker caller ${callerAgent!.agent_id} forced child role to worker and recorded itself as parent; worker-spawned agents cannot claim orchestrator placement.`
+            : undefined;
+          // TODO(#378): a future policy decision may refuse worker-initiated
+          // spawn_agent calls entirely. Current binding is force+warn.
+          if (
+            effectiveParentAgentId &&
+            effectiveParentAgentId !== args.parent_agent_id
+          ) {
+            await refreshManagedMetadataBestEffort(effectiveParentAgentId);
+          }
+          const parentWorkspace = effectiveParentAgentId
+            ? (engine.getAgentState(effectiveParentAgentId)?.workspace_id ??
               undefined)
             : undefined;
           const targetResolution = await resolvePlacementWorkspace({
@@ -9658,7 +9701,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             cli: args.cli,
             launcherName: launcherNameForCli(args.repo, args.cli),
           });
-          await refreshManagedMetadataBestEffort();
           const existingSameLaneAgents = args.force_new
             ? []
             : registry
@@ -9726,7 +9768,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               mcp_env: worktree.mcpEnv,
               mcp_profile_label: worktree.mcpProfileLabel,
               worktree_branch: worktree.prepared?.branch,
-              parent_agent_id: args.parent_agent_id,
+              parent_agent_id: effectiveParentAgentId,
               role: effectiveRole,
               auto_archive_on_done: args.auto_archive_on_done ?? false,
               max_cost_per_agent: args.max_cost_per_agent,
@@ -9790,6 +9832,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const placementWarnings = [
             ...targetResolution.warnings,
             ...(normalizedRole.warning ? [normalizedRole.warning] : []),
+            ...(workerCallerWarning ? [workerCallerWarning] : []),
           ];
           if (placementWarnings.length > 0) {
             result.warnings = [

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -217,6 +217,21 @@ describe("agent lifecycle health", () => {
     expect(health.issue_codes).toContain("non_claude_orchestrator");
   });
 
+  it("#378 health: flags a Claude orchestrator spawned by a worker", () => {
+    const health = evaluateAgentHealth(
+      makeRecord({
+        cli: "claude",
+        role: "orchestrator",
+        parent_agent_id: "parent-worker",
+        surface_provenance: "cmuxlayer_spawn",
+      }),
+      { monitor_alive: true, parent_role: "worker" },
+    );
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.issue_codes).toContain("worker_spawned_orchestrator");
+  });
+
   it("marks unexpected three-column topology as unhealthy", () => {
     const health = evaluateAgentHealth(makeRecord(), {
       monitor_alive: true,

--- a/tests/agent-hierarchy.test.ts
+++ b/tests/agent-hierarchy.test.ts
@@ -142,6 +142,65 @@ describe("Agent Hierarchy", () => {
     expect(childAgent!.parent_agent_id).toBe(root.agent_id);
   });
 
+  it("#378 binding: an unclassified Claude child of a worker inherits worker role", async () => {
+    const parent = makeRecord({
+      agent_id: "parent-worker",
+      surface_id: "surface:parent",
+      role: "worker",
+    });
+    stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+
+    await engine.spawnAgent({
+      repo: "cmuxlayer",
+      model: "sonnet",
+      cli: "claude",
+      prompt: "Review PR #380",
+      parent_agent_id: parent.agent_id,
+    });
+
+    const child = engine
+      .getRegistry()
+      .list()
+      .find((agent) => agent.parent_agent_id === parent.agent_id);
+    expect(child).toMatchObject({
+      cli: "claude",
+      role: "worker",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+    });
+  });
+
+  it("#378 binding: a declared orchestrator role is authoritative over parent and CLI hints", async () => {
+    const parent = makeRecord({
+      agent_id: "parent-worker-explicit-role",
+      surface_id: "surface:parent-explicit-role",
+      role: "worker",
+    });
+    stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+
+    await engine.spawnAgent({
+      repo: "cmuxlayer",
+      model: "sonnet",
+      cli: "claude",
+      role: "orchestrator",
+      prompt: "Lead the next scoped task",
+      parent_agent_id: parent.agent_id,
+    });
+
+    const child = engine
+      .getRegistry()
+      .list()
+      .find((agent) => agent.parent_agent_id === parent.agent_id);
+    expect(child).toMatchObject({
+      cli: "claude",
+      role: "orchestrator",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+    });
+  });
+
   it("spawnAgent rejects when spawn_depth would exceed MAX_SPAWN_DEPTH", async () => {
     // Build a chain: root → depth1 → depth2
     const root = await engine.spawnAgent({

--- a/tests/layout-policy.test.ts
+++ b/tests/layout-policy.test.ts
@@ -315,6 +315,17 @@ describe("layout policy", () => {
     ).toBe("worker");
   });
 
+  it("#378 binding: declared worker role is authoritative over the Claude CLI hint", () => {
+    expect(
+      inferAgentRole({
+        cli: "claude",
+        launcherName: "cmuxlayerClaude",
+        title: "cmuxlayerClaude: review PR #380",
+        role: "worker",
+      }),
+    ).toBe("worker");
+  });
+
   it("does not let repo names that end with launcher suffixes affect non-launcher CLIs", () => {
     expect(
       inferAgentRole({

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2252,6 +2252,57 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("#378 binding: a worker caller forces reviewer-Claude to worker and records parentage", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const parent = makeServerAgentRecord({
+      agent_id: "cmuxlayerCodex-parent",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      cli: "codex",
+      role: "worker",
+      task_summary: "Implement #379",
+      task_done_detected_at: null,
+    });
+    engine.stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+    mockExec.mockClear();
+
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:1", surfaceId: parent.surface_id },
+      () =>
+        spawn.handler(
+          {
+            repo: "cmuxlayer",
+            cli: "claude",
+            role: "orchestrator",
+            prompt: "Review PR #380",
+            force_new: true,
+          },
+          {} as any,
+        ),
+    );
+    const parsed = parseToolResult(result);
+    const child = engine.getAgentState(parsed.agent_id);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.role).toBe("worker");
+    expect(parsed.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/worker caller.*forced.*role.*worker/i),
+      ]),
+    );
+    expect(child).toMatchObject({
+      cli: "claude",
+      role: "worker",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+    });
+  });
+
   it("stop_agent logs a durable close entry carrying caller, force, and target", async () => {
     const server = createLifecycleServer(mockExec);
     const stopTool = (server as any)._registeredTools["stop_agent"];

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2303,6 +2303,65 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
+  it("#378 MEDIUM-A: a terminal caller record cannot shadow the live registry on a reused surface", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const deadWorker = makeServerAgentRecord({
+      agent_id: "cmuxlayerCodex-dead",
+      surface_id: "surface:reused",
+      workspace_id: "workspace:1",
+      state: "done",
+      repo: "cmuxlayer",
+      cli: "codex",
+      role: "worker",
+      task_done_detected_at: "2026-08-10T00:00:00Z",
+    });
+    const liveLead = makeServerAgentRecord({
+      agent_id: "cmuxlayerClaude-live",
+      surface_id: "surface:reused",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      cli: "claude",
+      role: "orchestrator",
+      task_done_detected_at: null,
+    });
+    engine.stateMgr.writeState(deadWorker);
+    engine.stateMgr.writeState(liveLead);
+    engine.getRegistry().set(deadWorker.agent_id, deadWorker);
+    engine.getRegistry().set(liveLead.agent_id, liveLead);
+    mockExec.mockClear();
+
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:1", surfaceId: "surface:reused" },
+      () =>
+        spawn.handler(
+          {
+            repo: "cmuxlayer",
+            cli: "claude",
+            role: "orchestrator",
+            prompt: "Lead the next task",
+            force_new: true,
+          },
+          {} as any,
+        ),
+    );
+    const parsed = parseToolResult(result);
+    const child = engine.getAgentState(parsed.agent_id);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.role).toBe("orchestrator");
+    expect(parsed.warnings ?? []).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/worker caller/i)]),
+    );
+    expect(child).toMatchObject({
+      role: "orchestrator",
+      parent_agent_id: liveLead.agent_id,
+      spawn_depth: 1,
+    });
+  });
+
   it("stop_agent logs a durable close entry carrying caller, force, and target", async () => {
     const server = createLifecycleServer(mockExec);
     const stopTool = (server as any)._registeredTools["stop_agent"];


### PR DESCRIPTION
## Summary
- make declared role/placement authoritative and use parent spawn context before CLI fallback
- infer managed caller parentage; force worker callers' children to worker with a warning and preserve the refusal-policy TODO
- flag worker-spawned Claude orchestrators as unhealthy
- encode #378's reviewer-Claude worker intent in layout, hierarchy, handler, and health regressions

## Verification
- `bun run typecheck`
- `bun run build`
- `bun run test` — 107 files passed; 2,497 tests passed; 1 skipped
- real `dist/index.js` MCP schema probe confirmed declared role is authoritative and CLI is fallback-only
- local CodeRabbit review unavailable due temporary OSS rate limit; reviewer routing remains with the lead

## Known residual

- An orchestrator/lead spawning `cli:"claude"` without a declared role still falls back to `orchestrator`. Reviewer-Claude therefore still requires explicit `role:"worker"`; changing that fallback or requiring a declared Claude role is a separate policy decision.

Refs #378

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaee","ts":"2026-08-10T09:36:15Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn hierarchy, role assignment, and MCP `spawn_agent` behavior—operators relying on Claude-default orchestrator placement or explicit worker-spawned orchestrators will see different outcomes and warnings.
> 
> **Overview**
> **Agent placement and hierarchy now treat declared `role`/`placement` as authoritative**, with CLI/launcher inference only as a fallback. When a role is omitted, a **worker parent causes the child to inherit `worker`** even if the harness is Claude—addressing reviewer-Claude misclassified as orchestrator.
> 
> The **`spawn_agent` MCP handler** resolves the managed caller from the current surface (non-terminal agents only), infers parentage from that caller, and when the caller is a worker **forces the child to `worker`**, sets itself as `parent_agent_id`, and returns a warning (explicit orchestrator requests are overridden). Tool docs and schema descriptions were updated to match.
> 
> **Health checks** gain optional `parent_role` on the input (filled during sweeps and server evaluation) and a blocking issue **`worker_spawned_orchestrator`** when a Claude orchestrator has a worker parent.
> 
> Regression tests cover engine spawn role precedence, health flagging, worker-caller forcing in `spawn_agent`, and live-vs-dead caller resolution on a reused surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910c995d396f5a889fdfc378d5a0176234a844ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive child agent role from declared job role and parent worker status
> - When `spawn_agent` is called by a worker agent, the child is forced to role `worker` and the caller is recorded as the parent, with a warning returned to the caller.
> - An explicitly declared role in spawn parameters is authoritative and overrides both parent and CLI inference.
> - Adds a new blocking health issue `worker_spawned_orchestrator` to flag Claude agents assigned `orchestrator` role whose parent is a `worker`.
> - Health evaluation now receives the parent agent's inferred role via `parent_role` in `AgentHealthInputOverrides`, enabling lineage-aware checks.
> - A new `resolveCurrentCallerAgent` helper in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/382/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) finds the calling agent by surface context to derive implicit parentage and role.
> - Behavioral Change: worker callers can no longer spawn orchestrator-role children without being overridden and flagged as unhealthy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 910c995.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->