### PR TITLE
fix: remove machine-initiated context compaction

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3830,22 +3830,31 @@ export class AgentEngine {
             });
             this.registry.set(agentId, updated);
 
-            if (agent.spawn_depth === 0) {
-              // Root agent: send /compact
-              const compactRoute = await this.resolveAgentIoRoute(agentId);
-              await this.client.send(compactRoute.surface_id, "/compact", {
-                workspace: compactRoute.workspace_id ?? undefined,
-                ...this.stableSurfaceWriteOptions(compactRoute.surface_uuid),
-              });
-              const returnRoute = await this.resolveAgentIoRoute(agentId);
-              await this.client.sendKey(returnRoute.surface_id, "return", {
-                workspace: returnRoute.workspace_id ?? undefined,
-                ...this.stableSurfaceWriteOptions(returnRoute.surface_uuid),
-              });
-            } else {
+            try {
               await this.client.log(
-                `context-limit: depth ${agent.spawn_depth} agent ${agent.repo} degraded; leaving pane running for orchestrator decision`,
+                `context-limit: depth ${agent.spawn_depth} agent ${agent.repo} degraded at ${contextPct}%; leaving pane running for orchestrator decision`,
                 { level: "warning", source: "cmuxlayer" },
+              );
+            } catch {
+              // Logging is advisory; a root-agent nudge must still be attempted.
+            }
+
+            if (agent.spawn_depth === 0) {
+              const nudgeRoute = await this.resolveAgentIoRoute(agentId);
+              await this.client.send(
+                nudgeRoute.surface_id,
+                `[cmuxlayer] context at ${contextPct}% — checkpoint at-risk work and /compact when safe`,
+                {
+                  workspace: nudgeRoute.workspace_id ?? undefined,
+                  ...this.stableSurfaceWriteOptions(nudgeRoute.surface_uuid),
+                  beforeMutation: async () => {
+                    await this.resolveUnchangedAgentIoRoute(
+                      agentId,
+                      nudgeRoute,
+                      "context-limit nudge",
+                    );
+                  },
+                },
               );
             }
           }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3462,9 +3462,8 @@ describe("AgentEngine", () => {
       expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
     });
 
-    it("auto-compacts with workspace scope and re-resolves before Return", async () => {
+    it("sends an unsubmitted context nudge with workspace scope", async () => {
       const stableUuid = "11111111-2222-4333-8444-555555555555";
-      const recycledUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
       const record = makeRecord({
         agent_id: "agent-auto-compact-route",
         state: "ready",
@@ -3490,41 +3489,22 @@ describe("AgentEngine", () => {
         lines: 20,
         scrollback_used: false,
       });
-      (mockClient.send as ReturnType<typeof vi.fn>).mockImplementation(
-        async (_surface: string, text: string) => {
-          if (text !== "/compact") return;
-          liveSurfaces = [
-            {
-              ...makeSurface("surface:compact-old"),
-              id: recycledUuid,
-              workspace_ref: "workspace:compact-old",
-            },
-            {
-              ...makeSurface("surface:compact-final"),
-              id: stableUuid,
-              workspace_ref: "workspace:compact-final",
-            },
-          ];
-        },
-      );
-
       await engine.runSweep();
 
       expect(mockClient.send).toHaveBeenCalledWith(
         "surface:compact-old",
+        "[cmuxlayer] context at 95% — checkpoint at-risk work and /compact when safe",
+        expect.objectContaining({
+          workspace: "workspace:compact-old",
+          beforeMutation: expect.any(Function),
+        }),
+      );
+      expect(mockClient.send).not.toHaveBeenCalledWith(
+        expect.anything(),
         "/compact",
-        { workspace: "workspace:compact-old" },
-      );
-      expect(mockClient.sendKey).toHaveBeenCalledWith(
-        "surface:compact-final",
-        "return",
-        { workspace: "workspace:compact-final" },
-      );
-      expect(mockClient.sendKey).not.toHaveBeenCalledWith(
-        "surface:compact-old",
-        "return",
         expect.anything(),
       );
+      expect(mockClient.sendKey).not.toHaveBeenCalled();
     });
 
     it("respawns a crashed agent with its captured session id when crash recovery is enabled", async () => {

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -1,6 +1,6 @@
 /**
  * TDD tests for Task 19 — Quality Tracking.
- * Tests parseContextPercent, quality field, /compact at 80%, warn for depth>0.
+ * Tests parseContextPercent and quality warnings/nudges at high context usage.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
@@ -191,7 +191,7 @@ describe("Quality Tracking (sweep)", () => {
     expect(agent!.quality).toBe("unknown");
   });
 
-  it("at 80% context, depth-0 agent sends /compact command", async () => {
+  it("at 80% context, depth-0 agent is degraded and nudged without submitting /compact", async () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: "a1",
@@ -213,16 +213,60 @@ describe("Quality Tracking (sweep)", () => {
 
     await engine.runSweep();
 
-    // Should send /compact + return
-    expect(mockClient.send).toHaveBeenCalledWith("s:1", "/compact", {
-      workspace: "workspace:quality",
-    });
-    expect(mockClient.sendKey).toHaveBeenCalledWith("s:1", "return", {
-      workspace: "workspace:quality",
-    });
+    expect(engine.getAgentState("a1")?.quality).toBe("degraded");
+    expect(mockClient.log).toHaveBeenCalledWith(
+      expect.stringContaining("context-limit: depth 0 agent brainlayer degraded at 80%"),
+      { level: "warning", source: "cmuxlayer" },
+    );
+    expect(mockClient.send).toHaveBeenCalledWith(
+      "s:1",
+      "[cmuxlayer] context at 80% — checkpoint at-risk work and /compact when safe",
+      expect.objectContaining({
+        workspace: "workspace:quality",
+        beforeMutation: expect.any(Function),
+      }),
+    );
+    expect(mockClient.send).not.toHaveBeenCalledWith(
+      "s:1",
+      "/compact",
+      expect.anything(),
+    );
+    expect(mockClient.sendKey).not.toHaveBeenCalled();
   });
 
-  it("auto-compact follows a stable UUID after its cached surface ref is recycled", async () => {
+  it("still nudges a depth-0 agent when warning logging fails", async () => {
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "log-failure",
+        state: "working",
+        surface_id: "s:log-failure",
+        spawn_depth: 0,
+      }),
+    );
+    liveSurfaces = [makeSurface("s:log-failure")];
+    await engine.getRegistry().reconstitute();
+    (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+      surface: "s:log-failure",
+      text: "gpt-5.5 · 5% left · ~/Gits/cmuxlayer\nWorking (1m • esc to interrupt)",
+      lines: 5,
+      scrollback_used: false,
+    });
+    (mockClient.log as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("log unavailable"),
+    );
+
+    await engine.runSweep();
+
+    expect(engine.getAgentState("log-failure")?.quality).toBe("degraded");
+    expect(mockClient.send).toHaveBeenCalledWith(
+      "s:log-failure",
+      "[cmuxlayer] context at 95% — checkpoint at-risk work and /compact when safe",
+      expect.objectContaining({ workspace: "workspace:quality" }),
+    );
+    expect(mockClient.sendKey).not.toHaveBeenCalled();
+  });
+
+  it("context nudge follows a stable UUID after its cached surface ref is recycled", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     stateMgr.writeState(
       makeRecord({
@@ -262,19 +306,18 @@ describe("Quality Tracking (sweep)", () => {
 
     expect(mockClient.send).toHaveBeenCalledWith(
       "surface:new",
-      "/compact",
-      { workspace: "workspace:quality" },
-    );
-    expect(mockClient.sendKey).toHaveBeenCalledWith(
-      "surface:new",
-      "return",
-      { workspace: "workspace:quality" },
+      "[cmuxlayer] context at 95% — checkpoint at-risk work and /compact when safe",
+      expect.objectContaining({
+        workspace: "workspace:quality",
+        beforeMutation: expect.any(Function),
+      }),
     );
     expect(mockClient.send).not.toHaveBeenCalledWith(
-      "surface:old",
+      expect.anything(),
       "/compact",
       expect.anything(),
     );
+    expect(mockClient.sendKey).not.toHaveBeenCalled();
   });
 
   it("at 80% context, depth-1 agent is warned but not killed", async () => {


### PR DESCRIPTION
## Summary

- preserve the quality sweep's `quality: "degraded"` transition at 80% context
- replace machine-submitted `/compact` + Return with a warning log and an unsubmitted plain-text nudge for root agents
- guard the nudge against stale surface routes and keep it independent from advisory log failures

## Verification

- `bun run test` — 107 files passed; 2,499 tests passed; 1 skipped
- `bun run typecheck`
- `bun run build`
- targeted TDD regression: 296 tests passed across `quality-tracking` and `agent-engine`

Refs: `orchestrator/collab/2026-08-10-cmuxlayer-auto-compact-removal.md`

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feb6a","ts":"2026-08-10T11:32:27Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated terminal I/O on high context for root agents; mis-routing could still send text to the wrong pane, though beforeMutation and stable UUID guards mitigate that.
> 
> **Overview**
> When the quality sweep sees **≥80% context**, it still sets **`quality: "degraded"`**, but it no longer **submits `/compact` and Return** on root agents.
> 
> For **depth-0** agents it now sends an **unsubmitted** plain-text nudge (`[cmuxlayer] context at …% — checkpoint at-risk work and /compact when safe`) with **workspace scope**, **`beforeMutation` route re-validation**, and **stable surface identity**—same pattern as other guarded terminal writes. **Depth > 0** behavior is unchanged: warn only, leave the pane running for the orchestrator.
> 
> **Warning logs** include the **percent** and are wrapped in **try/catch** so a logging failure cannot block the nudge. Tests were updated to match the new contract and add coverage for **nudge when `log` fails**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15f2b185c4555f723cbbff482360d4ec5480c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-context handling with clearer warnings and safer workspace-scoped nudges.
  * Root agents now receive validated checkpoint guidance instead of automatic compaction commands.
  * Nudges continue even when warning logs fail.
  * Prevented stale screen information from being used after an agent surface moves.

* **Tests**
  * Expanded coverage for context warnings, degraded agent status, logging failures, and relocated agent surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace auto-submitted `/compact` command with a nudge message for depth-0 agents at high context usage
> - When context usage reaches ≥80%, depth-0 agents previously had `/compact` and a `return` keypress auto-submitted; these are replaced with an unsubmitted nudge message: `[cmuxlayer] context at {pct}% — checkpoint at-risk work and /compact when safe`.
> - Non-root agents only receive a degraded quality mark and a warning log; no pane interaction occurs.
> - The nudge send includes workspace scoping, stable surface write options, and a `beforeMutation` hook that validates the route binding via `resolveUnchangedAgentIoRoute` before writing.
> - If the warning log throws, the nudge is still attempted for depth-0 agents.
> - Behavioral Change: depth-0 agents no longer have `/compact` auto-submitted on their behalf; compaction is now user-initiated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e15f2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->