### PR TITLE
fix: capture resumable Codex rollout sessions

### DIFF
--- a/docs/plans/2026-08-11-a3-session-capture-resume.md
+++ b/docs/plans/2026-08-11-a3-session-capture-resume.md
@@ -1,0 +1,49 @@
+# A3 Session Capture and Resume Correctness Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make managed Codex agents resumable from their real rollout UUID and emit runnable, harness-correct recovery commands from clean registry fields.
+
+**Architecture:** Split boot-session identity capture by harness. Codex trusts only the bounded rollout-directory lookup matched to launch cwd/time (and prompt when needed); existing Claude/Cursor paths retain their current resolver and screen behavior. Resume command construction validates the full UUID and uses an explicitly clean launcher name or a sanitized repo-derived launcher.
+
+**Tech Stack:** TypeScript, Node.js filesystem APIs, Vitest, cmuxlayer registry/engine.
+
+---
+
+### Task 1: Pin Codex rollout-only capture
+
+**Files:**
+- Modify: `tests/agent-engine.test.ts`
+- Modify: `src/agent-engine.ts`
+- Modify: `src/harness-session.ts` only if candidate matching needs a narrow helper
+
+1. Add a test whose Codex screen contains an unrelated contextual UUID while the matching rollout JSONL contains the real session UUID.
+2. Record the expected failure in `docs.local/tasks/a3-capture-brief.md` under `PREDICTION` before running the test.
+3. Run the focused Vitest case and verify it fails because the screen UUID is captured.
+4. Add the smallest per-harness capture strategy so Codex never falls through to screen scraping and resolves only from rollout metadata matched to spawn cwd/time.
+5. Re-run the focused case and existing boot-session capture cases.
+
+### Task 2: Pin clean, full-ID resume commands
+
+**Files:**
+- Modify: `tests/agent-engine.test.ts`
+- Modify: `src/agent-command.ts`
+- Modify: `src/agent-facade.ts` only if clean launcher provenance belongs at the facade boundary
+
+1. Add tests for the exact golems #695 canonical Codex command, full Claude UUID, and a polluted auto-discovered title/repo value.
+2. Run the focused cases and verify the pollution case fails for the expected reason.
+3. Validate full session UUIDs and launcher identifiers; fall back to a sanitized repo-derived launcher when the stored launcher is not clean.
+4. Re-run the focused cases and route/facade tests.
+
+### Task 3: Verify the decisive lifecycle receipt
+
+**Files:**
+- Modify: `tests/agent-engine.test.ts` or `tests/server-agent-tools.test.ts`
+- Append: `docs.local/tasks/a3-capture-brief.md`
+
+1. Add an integration-level test representing a spawned Codex agent whose rollout appears after spawn, then assert `resumable: true` and an exact runnable `resume_command` after lifecycle termination.
+2. Run it red if any production behavior remains absent, implement only the missing behavior, and re-run green.
+3. Run typecheck, focused tests, the full suite, and a real managed Codex spawn/stop/resume probe against the built binary.
+4. Obtain a Claude pair review, address findings, and repeat verification.
+5. Append the PREDICTION-vs-result diff and verification receipt to the task brief, ending with `DONE_A3_LANE`.
+6. Sign the commit/PR, push `fix/a3-session-capture`, open the PR referencing #364 and #361, and dispatch the PR URL to `cmuxlayerClaude`.

--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -20,23 +20,53 @@ export function sanitizeRepoName(repo: string): string {
   return safeRepo;
 }
 
+const FULL_SESSION_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const LAUNCHER_SUFFIX: Partial<Record<CliType, string>> = {
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+  gemini: "Gemini",
+};
+
+function cleanLauncherName(
+  _cli: CliType,
+  launcherName: string | null | undefined,
+): string | null {
+  if (!launcherName) return null;
+  const trimmed = launcherName.trim();
+  if (!/^[a-zA-Z][a-zA-Z0-9._-]*$/.test(trimmed)) return null;
+  return trimmed;
+}
+
 export function buildResumeCommand(
   cli: CliType,
   repo: string,
   sessionId: string,
   launcherName?: string | null,
 ): string {
-  const safeRepo = sanitizeRepoName(repo);
+  if (!FULL_SESSION_UUID_RE.test(sessionId)) {
+    throw new Error(
+      `Invalid session id: "${sessionId}". A full session UUID is required.`,
+    );
+  }
+  const suffix = LAUNCHER_SUFFIX[cli];
+  const launcher =
+    cleanLauncherName(cli, launcherName) ??
+    (suffix ? `${sanitizeRepoName(repo)}${suffix}` : null);
   switch (cli) {
     case "claude":
-      return `${launcherName ?? `${safeRepo}Claude`} -s --resume ${sessionId}`;
+      return `${launcher} -s --resume ${sessionId}`;
     case "codex":
-      return `${launcherName ?? `${safeRepo}Codex`} --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
+      return `${launcher} --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`;
     case "gemini":
-      return `${launcherName ?? `${safeRepo}Gemini`} -s --resume ${sessionId}`;
-    case "kiro":
+      return `${launcher} -s --resume ${sessionId}`;
+    case "kiro": {
+      const safeRepo = sanitizeRepoName(repo);
       return `cd ~/Gits/${safeRepo} && ${AGENT_ENV} kiro-cli chat --resume-id ${sessionId}`;
+    }
     case "cursor":
-      return `${launcherName ?? `${safeRepo}Cursor`} -s --resume ${sessionId}`;
+      return `${launcher} -s --resume ${sessionId}`;
   }
 }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -109,6 +109,7 @@ import {
 import {
   launcherNameCandidates,
   resolveLauncherNameFromRegistry,
+  resolveRepoRootFromLauncherRegistry,
   type LauncherSuffix,
 } from "./launcher-registry.js";
 import { buildAgentHealthInput } from "./agent-health-input.js";
@@ -292,6 +293,7 @@ function sessionCollisionSuffix(sessionId: string): string {
  */
 export interface SpawnPreflightResult {
   launcherName?: string;
+  repoRoot?: string;
 }
 
 export interface CrashRecoveryMutationInput {
@@ -978,21 +980,25 @@ export class AgentEngine {
         if (params.cli === "claude") {
           return {
             launcherName: await assertLauncherAvailable(params.repo, "Claude"),
+            repoRoot: resolveRepoRootFromLauncherRegistry(params.repo),
           };
         }
         if (params.cli === "codex") {
           return {
             launcherName: await assertLauncherAvailable(params.repo, "Codex"),
+            repoRoot: resolveRepoRootFromLauncherRegistry(params.repo),
           };
         }
         if (params.cli === "cursor") {
           return {
             launcherName: await assertLauncherAvailable(params.repo, "Cursor"),
+            repoRoot: resolveRepoRootFromLauncherRegistry(params.repo),
           };
         }
         if (params.cli === "gemini") {
           return {
             launcherName: await assertLauncherAvailable(params.repo, "Gemini"),
+            repoRoot: resolveRepoRootFromLauncherRegistry(params.repo),
           };
         }
       });
@@ -2002,6 +2008,7 @@ export class AgentEngine {
 
   private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
     return Boolean(
+      agent.cli !== "codex" &&
       this.selfRegistrationSessionResolver &&
       TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state) &&
       JSONL_HARNESSES.has(agent.cli) &&
@@ -2159,15 +2166,10 @@ export class AgentEngine {
   }
 
   /**
-   * Default session-identity resolution: self-registration READ (PRIMARY) then
-   * the deprecated transcript scan (last-resort fallback). Self-registration is
-   * the P0 root fix — agents append their real session id to the registry at
-   * boot, so we read it instead of scanning `~/.claude`/`~/.codex` and inferring
-   * by cwd+recency (which breaks with raw spawns + worktrees + many agents per
-   * repo). The scan is only reached when self-registration returns null (unset in
-   * bare construction, or a hook-less agent with no registry entry) and no
-   * injected fallback override is present; #336's bounded deferred-capture marker
-   * still guards that fallback.
+   * Default session-identity resolution is harness-specific. Codex identity is
+   * sourced only from its rollout JSONL because its screen does not reliably
+   * expose the UUID and self-registration can race or carry unrelated identity.
+   * Claude/Cursor retain self-registration first, then transcript fallback.
    */
   private resolveSessionIdentityWithSelfRegistration(
     agent: AgentRecord,
@@ -2564,7 +2566,10 @@ export class AgentEngine {
       }
     }
 
-    if (!this.isBootCaptureWindowOpen(captureAgent)) {
+    if (
+      captureAgent.cli === "codex" ||
+      !this.isBootCaptureWindowOpen(captureAgent)
+    ) {
       return captureAgent;
     }
 
@@ -3099,6 +3104,16 @@ export class AgentEngine {
       let createdSurface: CreatedAgentSurface | null = null;
       let createdSurfaceBound = false;
       try {
+        const sessionId = agent.cli_session_id;
+        if (!sessionId) {
+          throw new Error("Crash recovery requires a captured session id");
+        }
+        const resumeCmd = buildResumeCommand(
+          agent.cli,
+          agent.repo,
+          sessionId,
+          agent.launcher_name,
+        );
         await this.beforeCrashRecoveryMutation?.({
           phase: "placement",
           agent_id: agent.agent_id,
@@ -3165,12 +3180,6 @@ export class AgentEngine {
         });
         this.registry.set(agent.agent_id, booting);
 
-        const resumeCmd = buildResumeCommand(
-          agent.cli,
-          agent.repo,
-          agent.cli_session_id!,
-          agent.launcher_name,
-        );
         await this.sendLaunchCommand(
           surface.surface,
           resumeWorkspace,
@@ -4884,6 +4893,7 @@ export class AgentEngine {
     this.spawnGuard.check(spawnParams.workspace);
 
     const preflight = await this.spawnPreflight(spawnParams);
+    const launchCwd = spawnParams.cwd ?? preflight?.repoRoot ?? null;
     const seatIdentity = assertSeatIdentity({
       repo: spawnParams.repo,
       cli: spawnParams.cli,
@@ -4998,7 +5008,7 @@ export class AgentEngine {
       prompt_delivered: false,
       parsed_model: null,
       model_mismatch: null,
-      launch_cwd: spawnParams.cwd ?? null,
+      launch_cwd: launchCwd,
       mcp_profile: spawnParams.mcp_profile_label ?? null,
       worktree_path: spawnParams.cwd ?? null,
       worktree_branch: spawnParams.worktree_branch ?? null,
@@ -5139,7 +5149,7 @@ export class AgentEngine {
         ...modelPolicy.warnings,
       ],
       model_policy: modelPolicy,
-      cwd: spawnParams.cwd,
+      cwd: launchCwd ?? undefined,
       mcp_env: spawnParams.mcp_env,
     };
   }
@@ -5379,7 +5389,7 @@ export class AgentEngine {
       workspace_id: agent.workspace_id ?? null,
       state: agent.state,
       session_id: agent.cli_session_id,
-      resumable: !!agent.cli_session_id,
+      resumable: !!resumeCommand,
       ...(resumeCommand ? { resume_command: resumeCommand } : {}),
     };
   }

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -9,19 +9,22 @@ export type AgentStatePayload = AgentRecord & {
 export function resumeCommandForAgent(
   record: Pick<AgentRecord, "cli" | "repo" | "cli_session_id" | "launcher_name">,
 ): string | undefined {
-  return record.cli_session_id
-    ? buildResumeCommand(
-        record.cli,
-        record.repo,
-        record.cli_session_id,
-        record.launcher_name,
-      )
-    : undefined;
+  if (!record.cli_session_id) return undefined;
+  try {
+    return buildResumeCommand(
+      record.cli,
+      record.repo,
+      record.cli_session_id,
+      record.launcher_name,
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export function toPublicAgent(record: AgentRecord): PublicAgent {
   const resumeCommand = resumeCommandForAgent(record);
-  const resumable = !!record.cli_session_id;
+  const resumable = !!resumeCommand;
   return {
     agent_id: record.agent_id,
     repo: record.repo,
@@ -39,7 +42,7 @@ export function toAgentStatePayload(record: AgentRecord): AgentStatePayload {
   const resumeCommand = resumeCommandForAgent(record);
   return {
     ...record,
-    resumable: !!record.cli_session_id,
+    resumable: !!resumeCommand,
     ...(resumeCommand ? { resume_command: resumeCommand } : {}),
   };
 }
@@ -58,7 +61,7 @@ export function buildRouteTable(
       workspace_id: record.workspace_id ?? null,
       state: record.state,
       session_id: record.cli_session_id,
-      resumable: !!record.cli_session_id,
+      resumable: !!resumeCommand,
       ...(resumeCommand ? { resume_command: resumeCommand } : {}),
     };
     const existing = routes.get(record.agent_id);

--- a/src/format.ts
+++ b/src/format.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentRecord, PublicAgent } from "./agent-types.js";
-import { buildResumeCommand } from "./agent-command.js";
+import { resumeCommandForAgent } from "./agent-facade.js";
 import type { CmuxSurface, ParsedScreenResult } from "./types.js";
 
 function truncate(text: string, maxLen: number = 60): string {
@@ -212,8 +212,11 @@ export function formatAgentState(agent: AgentRecord): string {
   lines.push(`\u2502 surface: ${agent.surface_id}  cli: ${agent.cli}`);
   if (agent.cli_session_id) {
     lines.push(`\u2502 session: ${agent.cli_session_id}`);
+    const resumeCommand = resumeCommandForAgent(agent);
     lines.push(
-      `\u2502 resume: ${buildResumeCommand(agent.cli, agent.repo, agent.cli_session_id, agent.launcher_name)}`,
+      resumeCommand
+        ? `\u2502 resume: ${resumeCommand}`
+        : "\u2502 resumable: false (no runnable resume command)",
     );
   } else {
     lines.push("\u2502 resumable: false (no cli_session_id)");

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -616,7 +616,10 @@ function promptFieldContainsExpectedText(
         return [item];
       }
       const block = asRecord(item);
-      if (block?.type === "text" && typeof block.text === "string") {
+      if (
+        (block?.type === "text" || block?.type === "input_text") &&
+        typeof block.text === "string"
+      ) {
         return [block.text];
       }
       return [];
@@ -628,7 +631,10 @@ function promptFieldContainsExpectedText(
     );
   }
   const block = asRecord(value);
-  if (block?.type === "text" && typeof block.text === "string") {
+  if (
+    (block?.type === "text" || block?.type === "input_text") &&
+    typeof block.text === "string"
+  ) {
     return promptTextMatchesExpected(block.text, expectedText);
   }
   return false;
@@ -657,8 +663,12 @@ function recordPromptFields(event: Record<string, unknown>): unknown[] {
   }
 
   const payloadType = typeof payload?.type === "string" ? payload.type : null;
+  const payloadRole = typeof payload?.role === "string" ? payload.role : null;
   if (payloadType === "user_message" || payloadType === "user") {
     fields.push(payload?.message, payload?.text, payload?.input);
+  }
+  if (payloadType === "message" && payloadRole === "user") {
+    fields.push(payload?.content, payload?.message, payload?.text);
   }
 
   return fields;

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -25,6 +25,7 @@ import {
   resolveSweepTiming,
 } from "../src/agent-engine.js";
 import { launcherNameCandidates } from "../src/launcher-registry.js";
+import { toAgentStatePayload } from "../src/agent-facade.js";
 import { StateManager } from "../src/state-manager.js";
 import {
   AgentRegistry,
@@ -726,7 +727,10 @@ describe("AgentEngine", () => {
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
       const resolvingEngine = new AgentEngine(stateMgr, registry, mockClient, {
         // agent-html-host registered only as the hyphen-stripped form.
-        spawnPreflight: async () => ({ launcherName: "agenthtmlhostCursor" }),
+        spawnPreflight: async () => ({
+          launcherName: "agenthtmlhostCursor",
+          repoRoot: "/Users/etanheyman/Gits/agent-html-host",
+        }),
         sessionIdentityResolver: () => null,
       });
 
@@ -741,6 +745,9 @@ describe("AgentEngine", () => {
       expect(launchCmd).toBe("agenthtmlhostCursor -s");
       const state = resolvingEngine.getAgentState(result.agent_id);
       expect(state?.launcher_name).toBe("agenthtmlhostCursor");
+      expect(state?.launch_cwd).toBe(
+        "/Users/etanheyman/Gits/agent-html-host",
+      );
 
       resolvingEngine.dispose();
     });
@@ -749,7 +756,10 @@ describe("AgentEngine", () => {
       engine.dispose();
       const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
       engine = new AgentEngine(stateMgr, registry, mockClient, {
-        spawnPreflight: async () => ({ launcherName: "cmuxlayerCodex" }),
+        spawnPreflight: async () => ({
+          launcherName: "cmuxlayerCodex",
+          repoRoot: process.cwd(),
+        }),
         sessionIdentityResolver: () => null,
         seatRegistry: {
           cmuxlayerClaude: {
@@ -3556,6 +3566,35 @@ describe("AgentEngine", () => {
       expect(recovered?.respawn_attempts).toBe(1);
     });
 
+    it("rejects an invalid crash-recovery session before creating a surface", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-crash-short-session",
+          state: "error",
+          surface_id: "surface:dead-short-session",
+          repo: "brainlayer",
+          model: "gpt-5.4",
+          cli: "codex",
+          cli_session_id: "019d9aa5",
+          crash_recover: true,
+          error: "Surface surface:dead-short-session disappeared",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:witness")];
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(engine.getAgentState("agent-crash-short-session")).toMatchObject({
+        state: "error",
+        surface_id: "surface:dead-short-session",
+        respawn_attempts: 0,
+        error: expect.stringMatching(/full session UUID/i),
+      });
+    });
+
     it.each(["tab_close", "workspace_teardown"] as const)(
       "treats a cmux UI %s as terminal before crash recovery",
       async (closeOrigin) => {
@@ -4220,7 +4259,218 @@ describe("AgentEngine", () => {
     });
 
     afterEach(() => {
+      vi.unstubAllEnvs();
       vi.useRealTimers();
+    });
+
+    it("never captures a Codex session id from screen output", async () => {
+      const screenSessionId = "11111111-2222-7333-8444-555555555555";
+      vi.setSystemTime(new Date("2026-08-11T10:00:30.000Z"));
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-rollout-only",
+          repo: "cmuxlayer",
+          model: "gpt-5.6-sol",
+          cli: "codex",
+          surface_id: "surface:rollout-only",
+          state: "booting",
+          task_summary: "Fix rollout-only capture",
+          created_at: "2026-08-11T10:00:00.000Z",
+          updated_at: "2026-08-11T10:00:00.000Z",
+          launch_cwd: "/Users/etanheyman/Gits/cmuxlayer",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:rollout-only")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:rollout-only",
+        text: [
+          "OpenAI Codex",
+          `To continue this session, run codex resume ${screenSessionId}`,
+          "›",
+        ].join("\n"),
+        lines: 80,
+        scrollback_used: true,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.captureBootSessionId(
+        "cmuxlayerCodex-pending-rollout-only",
+      );
+
+      expect(
+        engine.getAgentState("cmuxlayerCodex-pending-rollout-only"),
+      ).toMatchObject({
+        cli_session_id: null,
+      });
+      expect(engine.getAgentState("cmuxlayerCodex-11111111")).toBeNull();
+    });
+
+    it("matches Codex rollout identity by cwd and spawn window", async () => {
+      const codexHome = join(TEST_DIR, "codex-home-matching");
+      const rolloutRoot = join(codexHome, "sessions", "2026", "08", "11");
+      const launchCwd = "/tmp/cmuxlayer-a3-rollout-target";
+      const correctSessionId = "019fec96-588d-7000-8000-000000000001";
+      const wrongCwdSessionId = "019fec96-588d-7000-8000-000000000002";
+      const staleSessionId = "019fec96-588d-7000-8000-000000000003";
+      const task = "Match this exact A3 rollout prompt";
+      mkdirSync(rolloutRoot, { recursive: true });
+      const writeRollout = (
+        name: string,
+        sessionId: string,
+        cwd: string,
+        mtime: string,
+      ): string => {
+        const path = join(rolloutRoot, name);
+        writeFileSync(
+          path,
+          [
+            JSON.stringify({
+              type: "session_meta",
+              payload: { id: sessionId, cwd },
+            }),
+            JSON.stringify({
+              type: "response_item",
+              payload: {
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: task }],
+              },
+            }),
+          ].join("\n"),
+        );
+        const timestamp = new Date(mtime);
+        utimesSync(path, timestamp, timestamp);
+        return path;
+      };
+      const correctPath = writeRollout(
+        "rollout-correct.jsonl",
+        correctSessionId,
+        launchCwd,
+        "2026-08-11T10:00:02.000Z",
+      );
+      writeRollout(
+        "rollout-wrong-cwd.jsonl",
+        wrongCwdSessionId,
+        "/tmp/other-repo",
+        "2026-08-11T10:00:03.000Z",
+      );
+      writeRollout(
+        "rollout-stale.jsonl",
+        staleSessionId,
+        launchCwd,
+        "2026-08-11T09:59:40.000Z",
+      );
+      vi.stubEnv("CODEX_HOME", codexHome);
+      try {
+        vi.setSystemTime(new Date("2026-08-11T10:00:05.000Z"));
+        engine.dispose();
+        const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+        engine = new AgentEngine(stateMgr, registry, mockClient, {
+          spawnPreflight: async () => {},
+        });
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "cmuxlayerCodex-pending-rollout-match",
+            repo: "cmuxlayer",
+            cli: "codex",
+            model: "gpt-5.6-sol",
+            state: "booting",
+            surface_id: "surface:rollout-match",
+            task_summary: task,
+            launch_cwd: launchCwd,
+            created_at: "2026-08-11T10:00:00.000Z",
+            updated_at: "2026-08-11T10:00:00.000Z",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:rollout-match")];
+        await registry.reconstitute();
+
+        await engine.captureBootSessionId(
+          "cmuxlayerCodex-pending-rollout-match",
+        );
+
+        expect(engine.getAgentState("cmuxlayerCodex-019fec96")).toMatchObject({
+          cli_session_id: correctSessionId,
+          cli_session_path: correctPath,
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it("uses Codex rollout identity instead of self-registration", async () => {
+      const rolloutSessionId = "019fec96-588d-7000-8000-000000000000";
+      const registeredSessionId = "aaaaaaaa-bbbb-7ccc-8ddd-eeeeeeeeeeee";
+      const rolloutPath =
+        "/Users/etanheyman/.codex/sessions/2026/08/11/rollout-2026-08-11T10-05-00-019fec96-588d-7000-8000-000000000000.jsonl";
+      const transcriptResolver = vi.fn(() => ({
+        session_id: rolloutSessionId,
+        path: rolloutPath,
+      }));
+      const selfRegistrationResolver = vi.fn(() => ({
+        session_id: registeredSessionId,
+        path: null,
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: transcriptResolver,
+        selfRegistrationSessionResolver: selfRegistrationResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "cmuxlayerCodex-pending-source",
+          repo: "cmuxlayer",
+          cli: "codex",
+          model: "gpt-5.6-sol",
+          state: "booting",
+          surface_id: "surface:rollout-source",
+          surface_uuid: "11111111-2222-4333-8444-555555555555",
+          task_summary: "Fix rollout identity source",
+          launch_cwd: "/Users/etanheyman/Gits/cmuxlayer",
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:rollout-source"),
+          id: "11111111-2222-4333-8444-555555555555",
+        },
+      ];
+      await engine.getRegistry().reconstitute();
+
+      await engine.captureBootSessionId("cmuxlayerCodex-pending-source");
+
+      expect(selfRegistrationResolver).not.toHaveBeenCalled();
+      expect(transcriptResolver).toHaveBeenCalledTimes(1);
+      expect(engine.getAgentState("cmuxlayerCodex-019fec96")).toMatchObject({
+        cli_session_id: rolloutSessionId,
+        cli_session_path: rolloutPath,
+      });
+      expect(engine.getAgentState("cmuxlayerCodex-aaaaaaaa")).toBeNull();
+    });
+
+    it("does not advertise an unrunnable legacy session route", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "brainlayerClaude-legacy-route",
+          repo: "brainlayerClaude [surface:199]",
+          cli: "claude",
+          cli_session_id: "019fec96-588d-7000-8000-000000000004",
+          launcher_name: null,
+        }),
+      );
+      await engine.getRegistry().reconstitute();
+
+      expect(engine.resolveAgentRoute("brainlayerClaude-legacy-route")).toEqual(
+        expect.objectContaining({
+          session_id: "019fec96-588d-7000-8000-000000000004",
+          resumable: false,
+        }),
+      );
+      expect(
+        engine.resolveAgentRoute("brainlayerClaude-legacy-route"),
+      ).not.toHaveProperty("resume_command");
     });
 
     it("reads a moved UUID surface instead of a recycled cached ref", async () => {
@@ -4230,7 +4480,9 @@ describe("AgentEngine", () => {
       vi.setSystemTime(new Date("2026-07-14T08:00:00.000Z"));
       stateMgr.writeState(
         makeRecord({
-          agent_id: "brainlayerCodex-pending-moved",
+          agent_id: "brainlayerClaude-pending-moved",
+          cli: "claude",
+          model: "sonnet",
           state: "booting",
           surface_id: "surface:old",
           surface_uuid: stableUuid,
@@ -4247,7 +4499,7 @@ describe("AgentEngine", () => {
       (mockClient.readScreen as ReturnType<typeof vi.fn>).mockImplementation(
         async (surface: string) => ({
           surface,
-          text: `To continue this session, run codex resume ${
+          text: `Session ID: ${
             surface === "surface:new-route" ? targetSession : foreignSession
           }`,
           lines: 80,
@@ -4256,7 +4508,7 @@ describe("AgentEngine", () => {
       );
 
       const captured = await engine.captureBootSessionId(
-        "brainlayerCodex-pending-moved",
+        "brainlayerClaude-pending-moved",
       );
 
       expect(captured?.cli_session_id).toBe(targetSession);
@@ -4271,14 +4523,6 @@ describe("AgentEngine", () => {
     });
 
     it.each([
-      [
-        "codex",
-        "codex",
-        "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
-        `gpt-5.4
-Working (12s • esc to interrupt)
-To continue this session, run codex resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e`,
-      ],
       [
         "claude",
         "sonnet",
@@ -4335,9 +4579,8 @@ Resumable session: 8c2f7f0c-00ee-4c6e-856d-cc7ae91f5274`,
       liveSurfaces = [makeSpawnSurface()];
       (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
         surface: "surface:new",
-        text: `gpt-5.4
-Working (12s • esc to interrupt)
-To continue this session, run codex resume ${sessionId}`,
+        text: `Claude Code
+Session ID: ${sessionId}`,
         lines: 80,
         scrollback_used: true,
       });
@@ -4346,14 +4589,14 @@ To continue this session, run codex resume ${sessionId}`,
 
       const result = await engine.spawnAgent({
         repo: "brainlayer",
-        model: "gpt-5.4",
-        cli: "codex",
+        model: "sonnet",
+        cli: "claude",
         prompt: "Fix gap F",
       });
 
-      const finalAgentId = "brainlayerCodex-019d9aa5";
+      const finalAgentId = "brainlayerClaude-019d9aa5";
       expect(result.agent_id).toMatch(
-        /^brainlayerCodex-pending-\d+-[a-z0-9]+$/,
+        /^brainlayerClaude-pending-\d+-[a-z0-9]+$/,
       );
       writeHeartbeat(result.agent_id, { baseDir: TEST_DIR });
       const pendingMarker = join(
@@ -4534,7 +4777,7 @@ To continue this session, run codex resume ${sessionId}`,
       });
     });
 
-    it("captures session identity after the initial boot window for a long-stuck ready pane", async () => {
+    it("does not capture Codex screen identity after the initial boot window", async () => {
       vi.setSystemTime(new Date("2026-06-25T08:02:30.000Z"));
       const sessionId = "019f0010-1111-7222-8333-444455556666";
       stateMgr.writeState(
@@ -4567,15 +4810,15 @@ To continue this session, run codex resume ${sessionId}`,
 
       await engine.runSweep();
 
-      expect(engine.getAgentState("cmuxlayerCodex-019f0010")).toMatchObject({
-        agent_id: "cmuxlayerCodex-019f0010",
+      expect(engine.getAgentState("cmuxlayerCodex-pending-late")).toMatchObject({
+        agent_id: "cmuxlayerCodex-pending-late",
         state: "ready",
-        cli_session_id: sessionId,
-        cli_session_path: null,
+        cli_session_id: null,
       });
-      expect(engine.resolveAgentRoute("cmuxlayerCodex-019f0010")).toMatchObject({
-        session_id: sessionId,
-        resumable: true,
+      expect(engine.getAgentState("cmuxlayerCodex-019f0010")).toBeNull();
+      expect(engine.resolveAgentRoute("cmuxlayerCodex-pending-late")).toMatchObject({
+        session_id: null,
+        resumable: false,
       });
     });
 
@@ -5247,6 +5490,111 @@ To continue this session, run codex resume ${sessionId}`,
       } finally {
         vi.unstubAllEnvs();
       }
+    });
+
+    it("keeps a rollout-captured Codex spawn resumable after a mid-task stop", async () => {
+      const sessionId = "019fec96-588d-7000-8000-000000000000";
+      vi.setSystemTime(new Date("2026-08-11T10:10:00.000Z"));
+      const codexHome = join(TEST_DIR, "codex-home-decisive");
+      const sessionPath = join(
+        codexHome,
+        "sessions",
+        "2026",
+        "08",
+        "11",
+        `rollout-2026-08-11T10-10-00-${sessionId}.jsonl`,
+      );
+      mkdirSync(join(sessionPath, ".."), { recursive: true });
+      const prompt = "Prove resumability after a mid-task stop";
+      writeFileSync(
+        sessionPath,
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId, cwd: process.cwd() },
+          }),
+          JSON.stringify({
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: prompt }],
+            },
+          }),
+        ].join("\n"),
+      );
+      const rolloutMtime = new Date("2026-08-11T10:10:01.000Z");
+      utimesSync(sessionPath, rolloutMtime, rolloutMtime);
+      vi.stubEnv("CODEX_HOME", codexHome);
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => ({ launcherName: "cmuxlayerCodex" }),
+        stopPostConditionTimeoutMs: 20,
+      });
+      liveSurfaces = [makeSpawnSurface()];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:new",
+        text: "OpenAI Codex\nWorking (12s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: true,
+      });
+      const spawned = await engine.spawnAgent({
+        repo: "cmuxlayer",
+        model: "codex",
+        cli: "codex",
+        prompt,
+        cwd: process.cwd(),
+      });
+      const spawnedRecord = engine
+        .listAgents()
+        .find((agent) => agent.surface_id === "surface:new");
+      expect(spawnedRecord?.launch_cwd).toBeTruthy();
+      writeFileSync(
+        sessionPath,
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId, cwd: spawnedRecord?.launch_cwd },
+          }),
+          JSON.stringify({
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: prompt }],
+            },
+          }),
+        ].join("\n"),
+      );
+      utimesSync(sessionPath, rolloutMtime, rolloutMtime);
+      await engine.captureBootSessionId(spawnedRecord!.agent_id);
+      const finalAgentId = "cmuxlayerCodex-019fec96";
+      stateMgr.transition(finalAgentId, "ready");
+      const working = stateMgr.transition(finalAgentId, "working");
+      registry.set(finalAgentId, working);
+      liveSurfaces.push({
+        ...makeSurface("surface:witness"),
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      });
+      (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async (surface: string) => {
+          liveSurfaces = liveSurfaces.filter(
+            (candidate) => candidate.ref !== surface,
+          );
+        },
+      );
+
+      await engine.stopAgent(finalAgentId);
+
+      expect(engine.resolveAgentRoute(finalAgentId)).toMatchObject({
+        state: "done",
+        session_id: sessionId,
+        resumable: true,
+        resume_command:
+          "cmuxlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019fec96-588d-7000-8000-000000000000",
+      });
+      vi.unstubAllEnvs();
     });
   });
 
@@ -11128,6 +11476,60 @@ describe("buildResumeCommand", () => {
     expect(buildResumeCommand("kiro", "brainlayer", sessionId)).toBe(
       "cd ~/Gits/brainlayer && MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 kiro-cli chat --resume-id 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
+  });
+
+  it("uses a clean launcher field when the legacy repo field contains a tab title", () => {
+    expect(
+      buildResumeCommand(
+        "claude",
+        "brainlayer-lead PR647-red-baseline",
+        sessionId,
+        "brainlayerClaude",
+      ),
+    ).toBe(
+      "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+  });
+
+  it("falls back to the clean repo launcher when launcher_name is decorated", () => {
+    expect(
+      buildResumeCommand(
+        "codex",
+        "brainlayer",
+        sessionId,
+        "brainlayerCodex [surface:606]",
+      ),
+    ).toBe(
+      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+  });
+
+  it("honors a clean registered launcher alias", () => {
+    expect(
+      buildResumeCommand("codex", "matchmat", sessionId, "mm-worker"),
+    ).toBe(
+      "mm-worker --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    );
+  });
+
+  it("rejects session prefixes instead of emitting an unusable resume command", () => {
+    expect(() =>
+      buildResumeCommand("claude", "brainlayer", "019d9aa5"),
+    ).toThrow(/full session UUID/i);
+  });
+
+  it("does not advertise resumable when no clean launcher can be derived", () => {
+    const payload = toAgentStatePayload(
+      makeRecord({
+        cli: "claude",
+        repo: "brainlayer-lead PR647-red-baseline",
+        launcher_name: null,
+        cli_session_id: sessionId,
+      }),
+    );
+
+    expect(payload.resumable).toBe(false);
+    expect(payload).not.toHaveProperty("resume_command");
   });
 });
 

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -15,7 +15,7 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
     repo: "brainlayer",
     model: "sonnet",
     cli: "claude",
-    cli_session_id: "session-1",
+    cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     task_summary: "Fix the bug",
     pid: null,
     version: 1,
@@ -43,11 +43,12 @@ describe("agent facade projections", () => {
       repo: "brainlayer",
       model: "sonnet",
       state: "ready",
-      session_id: "session-1",
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
       resumable: true,
       submit_verified: null,
       model_mismatch: null,
-      resume_command: "brainlayerClaude -s --resume session-1",
+      resume_command:
+        "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
     expect((projected as any).surface_id).toBeUndefined();
   });
@@ -99,9 +100,10 @@ describe("agent route table", () => {
       surface_uuid: "11111111-2222-4333-8444-555555555555",
       workspace_id: "ws:1",
       state: "ready",
-      session_id: "session-1",
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
       resumable: true,
-      resume_command: "brainlayerClaude -s --resume session-1",
+      resume_command:
+        "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
     expect(table.get("agent-2")?.surface_id).toBe("surface:2");
   });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatDelivery } from "../src/format.js";
+import { formatAgentState, formatDelivery } from "../src/format.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
 describe("formatDelivery", () => {
   it("renders a phone-readable delivered line with full identity", () => {
@@ -69,5 +70,38 @@ describe("formatDelivery", () => {
         submit_verified: null,
       }),
     ).toContain("submit_verified=null (not attempted)");
+  });
+});
+
+describe("formatAgentState", () => {
+  it("renders a legacy short session as non-resumable instead of throwing", () => {
+    const agent = {
+      agent_id: "legacyCodex-019d9aa5",
+      surface_id: "surface:1",
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "cmuxlayer",
+      model: "gpt-5.6-sol",
+      cli: "codex",
+      cli_session_id: "019d9aa5",
+      task_summary: "legacy row",
+      pid: null,
+      version: 1,
+      created_at: "2026-08-11T10:00:00.000Z",
+      updated_at: "2026-08-11T10:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: false,
+      respawn_attempts: 0,
+      user_killed: false,
+    } satisfies AgentRecord;
+
+    expect(formatAgentState(agent)).toContain(
+      "resumable: false (no runnable resume command)",
+    );
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -4971,7 +4971,7 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
-  it("list_agents returns healthy rows when one persisted repo is corrupt", async () => {
+  it("list_agents keeps a corrupt legacy repo visible but not resumable", async () => {
     const routeClient = makeUuidRouteClient([
       {
         ref: "surface:healthy",
@@ -5000,7 +5000,7 @@ describe("agent lifecycle tool handlers", () => {
       workspace_id: "workspace:1",
       state: "ready",
       repo: "cmuxlayer",
-      cli_session_id: "healthy-session",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });
     const corrupt = makeServerAgentRecord({
       agent_id: "corrupt-agent",
@@ -5009,7 +5009,7 @@ describe("agent lifecycle tool handlers", () => {
       workspace_id: "workspace:1",
       state: "ready",
       repo: "brainlayerClaude [surface:199]",
-      cli_session_id: "corrupt-session",
+      cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f4f",
     });
     for (const record of [healthy, corrupt]) {
       engine.stateMgr.writeState(record);
@@ -5033,14 +5033,13 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agents).toEqual([
       expect.objectContaining({ agent_id: "healthy-agent" }),
-    ]);
-    expect(parsed.skipped_agents).toEqual([
       expect.objectContaining({
         agent_id: "corrupt-agent",
-        error: expect.stringMatching(/repo|launcher/i),
+        resumable: false,
       }),
     ]);
-    expect(result.content[0]?.text).toMatch(/skipped.*corrupt-agent/i);
+    expect(parsed.agents[1]).not.toHaveProperty("resume_command");
+    expect(parsed.skipped_agents).toBeUndefined();
   });
 
   it("send_to keeps registry repo ownership when a title contains a surface suffix", async () => {


### PR DESCRIPTION
## Summary

- make Codex session capture rollout-only: match the real rollout JSONL by resolved launch cwd, spawn window, and exact boot prompt instead of scraping screen UUIDs or accepting self-registration
- require full per-harness session UUIDs and clean launcher fields before advertising `resumable`, while keeping legacy damaged rows visible and fail-closed
- validate crash-recovery commands before placement mutations and keep state/route/formatter projections consistent
- preserve Claude, Cursor, Gemini, and Kiro behavior while recognizing Codex 0.147's real `response_item` / `input_text` prompt shape

Refs #364, #361.

## Verification

- `npm run typecheck`
- `npm run build`
- fresh post-rebase suite: 384/384 suites; 2,522 passed, 0 failed, 1 skipped
- pre-push gate: 107 files; 2,522 passed, 0 failed, 1 skipped
- Claude pair review: three passes, final verdict clean
- local CodeRabbit review: one non-blocking stale cleanup suggestion; suite-level `afterEach` already guarantees environment restoration after assertion failures
- live built-binary probe through `dist/index.js` against real cmux: spawned a real Codex worker, captured rollout UUID `019ff05b-4a38-7403-9b3c-99d338ba5c97`, stopped it mid-task, then observed `state: done`, `resumable: true`, and `cmuxlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019ff05b-4a38-7403-9b3c-99d338ba5c97`

## Scope

Worker endpoint is PR opened; the lead owns remote review routing and merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d43e308f255d6446a3507b5c86bc284bc8653d4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019ff032","ts":"2026-08-11T10:27:25Z"} -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session recovery with validated, runnable resume commands.
  * Codex sessions can now be recovered using captured rollout session IDs.
  * Resume commands use the correct repository working directory and launcher settings.
  * Improved prompt detection across additional message formats.

* **Bug Fixes**
  * Agents with invalid or incomplete session IDs are now clearly marked non-resumable instead of producing unusable commands.
  * Improved recovery reliability after interrupted or stopped sessions.
  * Preserved visibility for agents from unavailable or corrupted repositories while accurately showing their recovery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->