### PR TITLE
fix: pass explicit Codex models through launcher

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -113,6 +113,7 @@ import {
   type HarnessSessionWithMeta,
 } from "./harness-session.js";
 import {
+  MODEL_OVERRIDE_ENV,
   resolveLaunchModelFlag,
   resolveSpawnEffort,
   resolveSpawnModelPolicy,
@@ -818,6 +819,10 @@ function formatModelArg(modelFlag: string): string {
   return isSafeShellToken(modelFlag) ? modelFlag : shellQuote(modelFlag);
 }
 
+function modelMatchesDefaultForLaunch(cli: CliType, model?: string): boolean {
+  return cli === "codex" && model?.trim().toLowerCase() === "codex";
+}
+
 export function buildLaunchCommand(
   cli: CliType,
   repo: string,
@@ -836,7 +841,11 @@ export function buildLaunchCommand(
 ): string {
   const safeRepo = sanitizeRepoName(repo);
   const modelFlag = resolveLaunchModelFlag(cli, model, {
-    allowModelOverride: opts?.allowModelOverride,
+    allowModelOverride:
+      opts?.allowModelOverride ??
+      (cli === "codex" &&
+        Boolean(model?.trim()) &&
+        !modelMatchesDefaultForLaunch(cli, model)),
   });
   const formattedModelFlag = modelFlag ? formatModelArg(modelFlag) : null;
   const launcherModelArgs = formattedModelFlag
@@ -849,7 +858,13 @@ export function buildLaunchCommand(
   const launcherWorktreeArg = opts?.cwd ? ` -w ${shellQuote(opts.cwd)}` : "";
   const launcherEffortArg = opts?.effort ? ` -E ${opts.effort}` : "";
   const rawCdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
-  const envPrefix = opts?.envPrefix ? `${opts.envPrefix} ` : "";
+  const codexModelOverride =
+    cli === "codex" && modelFlag !== null && modelFlag !== "codex";
+  const envParts = [
+    codexModelOverride ? `${MODEL_OVERRIDE_ENV}=1` : null,
+    opts?.envPrefix ?? null,
+  ].filter((part): part is string => Boolean(part));
+  const envPrefix = envParts.length > 0 ? `${envParts.join(" ")} ` : "";
   switch (cli) {
     case "claude":
       // repoGolem launcher handles env vars via ralph-registry

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -15,6 +16,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
 import {
@@ -349,6 +351,77 @@ export interface SpawnPreflightResult {
   repoRoot?: string;
 }
 
+export type CodexModelListRunner = (
+  args: string[],
+) => Promise<{ stdout: string; stderr?: string }>;
+
+const execFileAsync = promisify(execFile);
+
+async function defaultCodexModelListRunner(
+  args: string[],
+): Promise<{ stdout: string; stderr?: string }> {
+  return execFileAsync("codex", args, {
+    timeout: 10_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+}
+
+function parseCodexModelSlugs(stdout: string): string[] {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `Codex model discovery returned invalid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }. No agent was spawned.`,
+    );
+  }
+  const models =
+    payload && typeof payload === "object" && "models" in payload
+      ? (payload as { models?: unknown }).models
+      : null;
+  const slugs = Array.isArray(models)
+    ? models.flatMap((model) => {
+        if (typeof model === "string") return [model];
+        if (model && typeof model === "object" && "slug" in model) {
+          const slug = (model as { slug?: unknown }).slug;
+          return typeof slug === "string" ? [slug] : [];
+        }
+        return [];
+      })
+    : [];
+  if (slugs.length === 0) {
+    throw new Error(
+      "Codex model discovery returned no models. No agent was spawned.",
+    );
+  }
+  return slugs;
+}
+
+async function validateCodexModel(
+  model: string | undefined,
+  runner: CodexModelListRunner,
+): Promise<void> {
+  if (!model?.trim() || model.trim().toLowerCase() === "codex") return;
+
+  let result: { stdout: string; stderr?: string };
+  try {
+    result = await runner(["debug", "models", "--bundled"]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to discover Codex models: ${message}. No agent was spawned.`,
+    );
+  }
+  const models = parseCodexModelSlugs(result.stdout);
+  if (!models.includes(model.trim())) {
+    throw new Error(
+      `Unsupported Codex model "${model.trim()}". Codex models: ${models.join(", ")}. No agent was spawned.`,
+    );
+  }
+}
+
 export interface CrashRecoveryMutationInput {
   phase: "placement" | "resume";
   agent_id: string;
@@ -360,6 +433,7 @@ export interface AgentEngineOptions {
   spawnPreflight?: (
     params: SpawnAgentParams,
   ) => Promise<SpawnPreflightResult | void>;
+  codexModelListRunner?: CodexModelListRunner;
   spawnGuard?: SpawnGuard;
   postSpawnLivenessMs?: number;
   stopPostConditionTimeoutMs?: number;
@@ -921,6 +995,7 @@ export class AgentEngine {
   private spawnPreflight: (
     params: SpawnAgentParams,
   ) => Promise<SpawnPreflightResult | void>;
+  private codexModelListRunner: CodexModelListRunner;
   private spawnGuard: SpawnGuard;
   private postSpawnLivenessMs: number;
   private stopPostConditionTimeoutMs: number;
@@ -1068,6 +1143,8 @@ export class AgentEngine {
         process.env.CMUXLAYER_STOP_POST_CONDITION_TIMEOUT_MS,
         DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS,
       );
+    this.codexModelListRunner =
+      opts?.codexModelListRunner ?? defaultCodexModelListRunner;
     this.spawnPreflight =
       opts?.spawnPreflight ??
       (async (params): Promise<SpawnPreflightResult | void> => {
@@ -1078,6 +1155,7 @@ export class AgentEngine {
           };
         }
         if (params.cli === "codex") {
+          await validateCodexModel(params.model, this.codexModelListRunner);
           return {
             launcherName: await assertLauncherAvailable(params.repo, "Codex"),
             repoRoot: resolveRepoRootFromLauncherRegistry(params.repo),

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -3,8 +3,8 @@ import type { CliType } from "./agent-types.js";
 export const MODEL_OVERRIDE_ENV = "REPOGOLEM_ALLOW_MODEL";
 // Match the installed repoGolem launcher sourced by fresh interactive shells
 // (~/.config/ralphtools/golem-dispatch.zsh), not the potentially newer golems
-// checkout. The drift gate fails when that live contract changes; validation
-// must still reject mismatches before any worktree or surface is created.
+// checkout. Codex model validation is delegated to `codex debug models
+// --bundled` during spawn preflight, before any worktree or surface is created.
 export const CODEX_EFFORT_VALUES = [
   "medium",
   "high",
@@ -227,7 +227,8 @@ export function resolveSpawnModelPolicy(
       cli,
       requested_model: requestedModel,
       effective_model: requestedModel,
-      launcher_model: requestedModel,
+      launcher_model:
+        requestedModel.toLowerCase() === "codex" ? null : requestedModel,
       coerced: false,
       warnings: [],
       override_env: MODEL_OVERRIDE_ENV,

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -70,17 +70,9 @@ export const MODEL_POLICY_CONTRACT: {
       defaultModel: "codex",
       allowModelOverrideByDefault: false,
       forbiddenModelPatterns: [],
-      modelAliases: {
-        "gpt-5": "gpt-5",
-        "gpt-5-codex": "gpt-5-codex",
-        "gpt-5.3": "gpt-5.3",
-        "gpt-5.3-codex": "gpt-5.3-codex",
-        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
-        "gpt-5.4": "gpt-5.4",
-        "gpt-5.4-mini": "gpt-5.4-mini",
-        "gpt-5.5": "gpt-5.5",
-        "gpt-5.5-mini": "gpt-5.5-mini",
-      },
+      // Codex model names are owned by the launcher. Keep no parallel alias
+      // table here: explicit names pass through under the launcher contract.
+      modelAliases: {},
     },
     claude: {
       defaultModel: "claude-opus-5[1m]",
@@ -197,7 +189,7 @@ export function resolveLaunchModelFlag(
 
   if (cli === "codex") {
     if (modelMatchesDefault(cli, requested)) return null;
-    if (!opts?.allowModelOverride) return null;
+    return opts?.allowModelOverride ? requested : null;
   }
 
   if (cli === "cursor") {
@@ -226,6 +218,22 @@ export function resolveSpawnModelPolicy(
     ? defaultModel
     : requestedModel;
   const resolvedRequested = resolveModelAlias(cli, requestedOrDefault);
+
+  // The repoGolem Codex launcher is the single source of truth for model
+  // names. Explicit Codex models are forwarded with the override escape hatch
+  // so launcher validation/refusal remains authoritative.
+  if (cli === "codex" && !requestedWasOmitted) {
+    return {
+      cli,
+      requested_model: requestedModel,
+      effective_model: requestedModel,
+      launcher_model: requestedModel,
+      coerced: false,
+      warnings: [],
+      override_env: MODEL_OVERRIDE_ENV,
+      override_allowed: true,
+    };
+  }
 
   // Cursor deliberately accepts arbitrary model strings behind its escape
   // hatch. Every launcher-backed CLI, however, has a finite alias table. Do

--- a/src/server.ts
+++ b/src/server.ts
@@ -9308,7 +9308,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           {
             cwd: launchCwd,
             envPrefix: opts.mcpEnv,
-            allowModelOverride: process.env.REPOGOLEM_ALLOW_MODEL === "1",
+            allowModelOverride:
+              record.cli === "codex"
+                ? Boolean(
+                    record.model?.trim() &&
+                      record.model.trim().toLowerCase() !== "codex",
+                  )
+                : process.env.REPOGOLEM_ALLOW_MODEL === "1",
           },
         );
       const route = await resolveManagedDeliveryRoute(record.agent_id);
@@ -9674,7 +9680,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe(
-            "OPTIONAL — leave UNSET so the launcher pins the top-tier model. Only set this if you have a specific reason NOT to use the top model (e.g. a deliberately cheaper 'sonnet' pass, or a non-claude engine variant like 'codex'). Never pass 'opus' for claude — the top Claude model is already the default.",
+            "OPTIONAL — leave UNSET so the launcher pins the top-tier model. For cli:'codex', an explicit model is checked against Codex's runtime model list before any worktree or surface is created, then passed through to the launcher. Never pass 'opus' for claude — the top Claude model is already the default.",
           ),
         effort: z
           .enum(CODEX_EFFORT_VALUES)

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -11411,6 +11411,12 @@ describe("buildLaunchCommand", () => {
     );
   });
 
+  it("passes an explicit Codex model with the launcher override env", () => {
+    expect(
+      buildLaunchCommand("codex", "brainlayer", "gpt-5.6-luna"),
+    ).toBe("REPOGOLEM_ALLOW_MODEL=1 brainlayerCodex -s -m gpt-5.6-luna");
+  });
+
   it("passes an explicit Codex effort to the repoGolem launcher", () => {
     expect(
       buildLaunchCommand("codex", "brainlayer", undefined, undefined, {
@@ -11419,13 +11425,15 @@ describe("buildLaunchCommand", () => {
     ).toBe("brainlayerCodex -s -E medium");
   });
 
-  it("adds safe model flags for recognized launcher model aliases", () => {
+  it("adds safe model flags for launcher-owned Codex model names", () => {
     expect(buildLaunchCommand("claude", "brainlayer", "sonnet")).toBe(
       "brainlayerClaude -s -S",
     );
     expect(
       buildLaunchCommand("codex", "brainlayer", "gpt-5.3-codex-spark"),
-    ).toBe("brainlayerCodex -s");
+    ).toBe(
+      "REPOGOLEM_ALLOW_MODEL=1 brainlayerCodex -s -m gpt-5.3-codex-spark",
+    );
     expect(
       buildLaunchCommand(
         "codex",
@@ -11434,7 +11442,9 @@ describe("buildLaunchCommand", () => {
         undefined,
         { allowModelOverride: true },
       ),
-    ).toBe("brainlayerCodex -s -m gpt-5.3-codex-spark");
+    ).toBe(
+      "REPOGOLEM_ALLOW_MODEL=1 brainlayerCodex -s -m gpt-5.3-codex-spark",
+    );
     expect(buildLaunchCommand("codex", "brainlayer", "codex")).toBe(
       "brainlayerCodex -s",
     );
@@ -11454,15 +11464,15 @@ describe("buildLaunchCommand", () => {
     );
   });
 
-  it("omits unsafe or unrecognized model values instead of passing them raw", () => {
+  it("shell-quotes arbitrary launcher-owned Codex model values", () => {
     expect(
       buildLaunchCommand("claude", "brainlayer", "Opus 4.8 (1M context)"),
     ).toBe("brainlayerClaude -s");
     expect(buildLaunchCommand("codex", "brainlayer", "gpt-5.5 xhigh")).toBe(
-      "brainlayerCodex -s",
+      "REPOGOLEM_ALLOW_MODEL=1 brainlayerCodex -s -m 'gpt-5.5 xhigh'",
     );
     expect(buildLaunchCommand("codex", "brainlayer", "codex;rm-rf")).toBe(
-      "brainlayerCodex -s",
+      "REPOGOLEM_ALLOW_MODEL=1 brainlayerCodex -s -m 'codex;rm-rf'",
     );
     expect(buildLaunchCommand("gemini", "golems", "constructor")).toBe(
       "golemsGemini -s",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
+  execFile: execFileMock,
 }));
 
 import {

--- a/tests/fixtures/spawn/codex-auto-update-restart.json
+++ b/tests/fixtures/spawn/codex-auto-update-restart.json
@@ -1,5 +1,5 @@
 {
-  "launcher_command": "cmuxlayerCodex -s -m gpt-5.5",
+  "launcher_command": "REPOGOLEM_ALLOW_MODEL=1 cmuxlayerCodex -s -m gpt-5.5",
   "screens": {
     "launcher": "etan@mac % cmuxlayerCodex -s -m gpt-5.5",
     "interactive_update": "  ✨ Update available! 0.142.5 -> 0.143.0\n\n  Release notes: https://github.com/openai/codex/releases/latest\n\n› 1. Update now (runs `npm install -g @openai/codex@latest`)\n  2. Skip\n  3. Skip until next version\n\n  Press enter to continue",

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -74,21 +74,11 @@ describe("model-policy drift gate", () => {
     const codex = MODEL_POLICY_CONTRACT.cli.codex;
     expect(codex.allowModelOverrideByDefault).toBe(false);
 
-    const codexCoerced = resolveSpawnModelPolicy("codex", "gpt-5.5", {});
-    expect(codexCoerced.coerced).toBe(true);
-    expect(codexCoerced.effective_model).toBe(codex.defaultModel);
-    expect(codexCoerced.launcher_model).toBeNull();
-    expect(codexCoerced.warnings).toHaveLength(1);
-    expect(codexCoerced.warnings[0]).toContain("CODEX MODEL POLICY");
-    expect(codexCoerced.warnings[0]).toContain("gpt-5.5");
-
-    const codexEscaped = resolveSpawnModelPolicy("codex", "gpt-5.5", {
-      [MODEL_OVERRIDE_ENV]: "1",
-    });
-    expect(codexEscaped.coerced).toBe(false);
-    expect(codexEscaped.effective_model).toBe("gpt-5.5");
-    expect(codexEscaped.launcher_model).toBe("gpt-5.5");
-    expect(codexEscaped.override_allowed).toBe(true);
+    const codexPassthrough = resolveSpawnModelPolicy("codex", "gpt-5.6-luna", {});
+    expect(codexPassthrough.coerced).toBe(false);
+    expect(codexPassthrough.effective_model).toBe("gpt-5.6-luna");
+    expect(codexPassthrough.launcher_model).toBe("gpt-5.6-luna");
+    expect(codexPassthrough.override_allowed).toBe(true);
 
     const coerced = resolveSpawnModelPolicy("cursor", "sonnet-4", {});
     expect(coerced.coerced).toBe(true);

--- a/tests/model-policy.test.ts
+++ b/tests/model-policy.test.ts
@@ -42,35 +42,19 @@ describe("model policy contract", () => {
     expect(escaped.override_allowed).toBe(true);
   });
 
-  it("does not pass Codex model overrides to repoGolem launchers without the escape env", () => {
-    const coerced = resolveSpawnModelPolicy("codex", "gpt-5.5", {});
+  it("passes any explicit Codex model to the launcher override path", () => {
+    const policy = resolveSpawnModelPolicy("codex", "gpt-5.6-luna", {});
 
-    expect(coerced.effective_model).toBe("codex");
-    expect(coerced.launcher_model).toBeNull();
-    expect(coerced.coerced).toBe(true);
-    expect(coerced.warnings[0]).toContain("CODEX MODEL POLICY");
-    expect(coerced.warnings[0]).toContain("gpt-5.5");
-
-    const escaped = resolveSpawnModelPolicy("codex", "gpt-5.5", {
-      [MODEL_OVERRIDE_ENV]: "1",
-    });
-
-    expect(escaped.effective_model).toBe("gpt-5.5");
-    expect(escaped.launcher_model).toBe("gpt-5.5");
-    expect(escaped.coerced).toBe(false);
-    expect(escaped.override_allowed).toBe(true);
+    expect(policy.effective_model).toBe("gpt-5.6-luna");
+    expect(policy.launcher_model).toBe("gpt-5.6-luna");
+    expect(policy.coerced).toBe(false);
+    expect(policy.override_allowed).toBe(true);
 
     expect(
-      resolveLaunchModelFlag("codex", "gpt-5.5", {
-        allowModelOverride: false,
-      }),
-    ).toBeNull();
-
-    expect(
-      resolveLaunchModelFlag("codex", "gpt-5.5", {
+      resolveLaunchModelFlag("codex", "gpt-5.6-luna", {
         allowModelOverride: true,
       }),
-    ).toBe("gpt-5.5");
+    ).toBe("gpt-5.6-luna");
   });
 
   it("resolves omitted models to per-CLI defaults without pinning launcher args", () => {
@@ -120,17 +104,4 @@ describe("model policy contract", () => {
     ).toBe("haiku");
   });
 
-  it("rejects an unknown Codex model before the legacy override coercion", () => {
-    expect(() =>
-      resolveSpawnModelPolicy("codex", "gpt-5.6-sol", {}),
-    ).toThrow(
-      /Unsupported model "gpt-5\.6-sol".*would actually run "codex".*Accepted models: codex.*No agent was spawned/,
-    );
-
-    expect(() =>
-      resolveSpawnModelPolicy("codex", "gpt-5.6-sol", {
-        [MODEL_OVERRIDE_ENV]: "1",
-      }),
-    ).toThrow(/Unsupported model "gpt-5\.6-sol"/);
-  });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -161,7 +161,7 @@ function makeLifecycleExec(opts?: {
       }
       if (
         text.trim() &&
-        !/^\s*[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b.*(?:^|\s)-s(?:\s|$)/.test(
+        !/^\s*(?:[A-Z_]+=\S+\s+)*[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b.*(?:^|\s)-s(?:\s|$)/.test(
           text,
         )
       ) {
@@ -692,20 +692,21 @@ describe("lean spawn tool responses", () => {
     });
   });
 
-  it("spawn_agent surfaces a real model coercion in lean mode", async () => {
+  it("spawn_agent surfaces Codex model pass-through in lean mode", async () => {
     const server = createLifecycleServer(makeLifecycleExec());
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
     const result = await spawn.handler(
-      { repo: "cmuxlayer", model: "gpt-5.5", cli: "codex" },
+      { repo: "cmuxlayer", model: "gpt-5.5", cli: "codex", verbose: true },
       {} as any,
     );
 
     expect(result.structuredContent.model_policy).toMatchObject({
-      coerced: true,
-      effective_model: "codex",
+      coerced: false,
+      effective_model: "gpt-5.5",
+      launcher_model: "gpt-5.5",
+      override_allowed: true,
     });
-    expect(result.structuredContent.warnings).not.toHaveLength(0);
   });
 
   it("spawn_agent passes an explicit Codex effort to the launcher", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9128,7 +9128,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send")) {
         const text = String(args.at(-1) ?? "");
-        if (text.startsWith("cmuxlayerCodex ")) {
+        if (text.includes("cmuxlayerCodex ")) {
           launcherSent = true;
         }
         return { stdout: "{}", stderr: "" };

--- a/tests/spawn-agent-preflight.test.ts
+++ b/tests/spawn-agent-preflight.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AgentEngine } from "../src/agent-engine.js";
@@ -97,5 +97,38 @@ describe("spawn_agent launcher preflight", () => {
     expect(stateMgr.listStates()).toHaveLength(0);
     expect(engine.listAgents()).toHaveLength(0);
     expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown Codex model from Codex's bundled model list before creating anything", async () => {
+    const registryPath = join(TEST_DIR, "launchers.zsh");
+    writeFileSync(
+      registryPath,
+      'repoGolem cmuxlayer "/Users/etanheyman/Gits/cmuxlayer"\n',
+    );
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const defaultEngine = new AgentEngine(stateMgr, new AgentRegistry(stateMgr, async () => []), mockClient, {
+      codexModelListRunner: async () => ({
+        stdout: JSON.stringify({ models: [{ slug: "gpt-5.6-luna" }] }),
+        stderr: "",
+      }),
+    });
+
+    try {
+      await expect(
+        defaultEngine.spawnAgent({
+          repo: "cmuxlayer",
+          model: "gpt-9.9-totally-not-a-model",
+          cli: "codex",
+          prompt: "",
+        }),
+      ).rejects.toThrow(
+        /Unsupported Codex model "gpt-9\.9-totally-not-a-model".*gpt-5\.6-luna.*No agent was spawned/s,
+      );
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(stateMgr.listStates()).toHaveLength(0);
+    } finally {
+      defaultEngine.dispose();
+      vi.unstubAllEnvs();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Remove cmuxlayer’s Codex model alias gate so explicit model names are owned by the repoGolem launcher.
- Forward explicit Codex models as `REPOGOLEM_ALLOW_MODEL=1 … -m <model>` while preserving launcher refusal behavior.
- Update regression coverage and launch fixtures for the pass-through contract.

## Test plan
- `bun run typecheck`
- `bun run test -- --reporter=dot`
- `bun run pre-pr` executed by the push hook: 111 files passed, 2,554 tests passed, 1 skipped.

— cmuxlayerCodex (worker) · codex/gpt-5.6-luna
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-luna","model_source":"user-confirmed","session":"unknown","ts":"2026-08-12T16:00:00+03:00"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex spawn preflight and launch-command construction, including a new external `codex` CLI call for model discovery. Incorrect validation or env/flag wiring could block or mis-launch Codex agents.
> 
> **Overview**
> **Explicit Codex models now pass through to the launcher** instead of being coerced or gated by a local alias table.
> 
> `resolveSpawnModelPolicy` short-circuits for any explicit Codex model (`coerced=false`, `override_allowed=true`), and `buildLaunchCommand` prepends `REPOGOLEM_ALLOW_MODEL=1` with `-m <model>`. The static Codex alias table is emptied so the launcher owns model names.
> 
> **Spawn preflight now validates** non-default Codex models via `codex debug models --bundled` before creating a worktree or surface, rejecting unknown models early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f02595da09ba1313062bad8ba64e0ffe67bfbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass explicit Codex models through the launcher with preflight validation
> - Explicit non-default Codex models are now validated against `codex debug models --bundled` during spawn preflight, rejecting unsupported models before any surfaces or state are created.
> - Launch commands for Codex with an explicit model now include `REPOGOLEM_ALLOW_MODEL=1` and a `-m <model>` argument; the default `codex` model omits both.
> - `resolveSpawnModelPolicy` passes Codex models through unchanged instead of coercing or warning, with `override_allowed: true`.
> - Static `modelAliases` for Codex are removed from [model-policy.ts](https://github.com/EtanHey/cmuxlayer/pull/396/files#diff-2b154b92b8428cf5dc0d8f4ee8a9dd927908d0bd6108df9880d4e534e342c95d); model name ownership is now delegated to the Codex launcher.
> - Behavioral Change: spawning with an unknown Codex model now fails early with a descriptive error listing discovered models.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e8f0259. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Codex now supports explicit model selection, including custom model names.
  - Selected models are passed through unchanged with model override support.
  - Existing environment prefixes and shell quoting remain supported.
  - Omitting a model uses the launcher’s top-tier default.

- **Bug Fixes**
  - Unsupported Codex models are rejected before work begins, with supported options shown.
  - Improved handling of Codex relaunches and launch commands with prefixed environment settings.
  - Claude model validation and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->