### PR TITLE
fix: harden agent spawn failures

### DIFF
--- a/docs/plans/2026-08-12-spawn-robustness.md
+++ b/docs/plans/2026-08-12-spawn-robustness.md
@@ -1,0 +1,82 @@
+# Spawn Robustness Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make every surface-creating spawn path recoverable and diagnosable when shell readiness, launcher submission, or post-creation work fails.
+
+**Architecture:** Share shell-prompt recognition between the MCP and app-server paths, and introduce one creation-failure scope that records identities as soon as cmux creates them and attaches those identities to any later error without changing the error's runtime type. Centralize readiness diagnostics for direct and `AgentLaunchError`-wrapped failures. Treat a launcher that returns to a shell as an explicit launch failure, verify a pending launcher command actually leaves the prompt after Return, and roll back a newly created worktree only after a failed launcher surface is closed.
+
+**Tech Stack:** TypeScript, Vitest, cmux client abstractions, MCP tool structured responses.
+
+---
+
+### Task 1: Shared shell-prompt contract
+
+**Files:**
+- Create: `src/shell-prompt.ts`
+- Modify: `src/server.ts`
+- Modify: `src/app-server-runtime.ts`
+- Test: `tests/shell-prompt.test.ts`
+- Test: `tests/app-server-runtime.test.ts`
+
+1. Write failing table tests for ready prompts ending in `$`, `%`, `#`, `>`, `❯`, `›`, and `»`, plus negative cases where text remains after the prompt terminator.
+2. Run the focused tests and confirm `>`/Unicode prompts fail under the current matchers.
+3. Add one shared matcher and replace both private implementations.
+4. Run the focused tests green.
+
+### Task 2: Structural created-identity propagation
+
+**Files:**
+- Create: `src/created-identity.ts`
+- Modify: `src/server.ts`
+- Test: `tests/created-identity.test.ts`
+- Test: `tests/server.test.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+1. Write failing unit tests proving an unclassified post-creation error receives the recorded identity, pre-creation errors receive none, prior batch identities accumulate, and error-supplied metadata cannot overwrite identity fields.
+2. Write integration regressions that inject unknown post-creation failures in raw and managed creation paths.
+3. Run focused tests and confirm identity is absent before implementation.
+4. Add a creation scope that records identities and decorates any thrown error while preserving `instanceof` and `cause` behavior; make `err()` merge recorded identity last.
+5. Record identities immediately after every current creation seam: `new_split`, `new_surface`, terminal `spawn`, managed `spawn`, `new_worktree_split`, and each `spawn_in_workspace` member.
+6. Run focused tests green.
+
+### Task 3: Readiness and launcher diagnostics
+
+**Files:**
+- Modify: `src/agent-engine.ts`
+- Modify: `src/server.ts`
+- Test: `tests/server.test.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+1. Write failing regressions for an `AgentLaunchError` wrapping a readiness timeout and for a launcher returning to a shell with terminal error text.
+2. Run focused tests and confirm `last_10_lines`/launcher text is lost or reduced to a generic timeout.
+3. Set standard `Error.cause` on `AgentLaunchError`, recursively recover timeout diagnostics, and expose them through the shared error formatter.
+4. Detect stable return-to-shell after launcher submission and return the captured terminal tail as diagnostics instead of waiting for a generic timeout.
+5. Run focused tests green.
+
+### Task 4: Return verification and post-launch rollback
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/server.test.ts`
+- Test: `tests/server-agent-tools.test.ts`
+
+1. Write failing regressions where Return reports success but the launcher command remains at the shell prompt, and where a launcher failure after surface creation leaks a new worktree/branch/surface.
+2. Run focused tests and confirm both failures.
+3. After sending Return to a pending launcher command, require screen evidence that the pending command cleared or a supported CLI became ready.
+4. On launch-phase `AgentLaunchError`, close the created surface, then roll back the newly created worktree and branch; preserve created identity and append cleanup diagnostics if either cleanup step fails.
+5. Run focused tests green.
+
+### Task 5: Verification and worker handoff
+
+**Files:**
+- Modify: `/Users/etanheyman/Gits/cmuxlayer/docs.local/plan/stability-v2/phase-7/findings.md`
+- Modify: `/Users/etanheyman/Gits/cmuxlayer/docs.local/plan/stability-v2/collab.md`
+
+1. Write a PREDICTION block before suite execution with expected focused/full outcomes and likely failure boundaries.
+2. Run focused suites, typecheck, build, full tests, and `git diff --check`; compare actuals against the prediction.
+3. Run the daemon/runtime gate with a real cmuxlayer client because this lane changes MCP spawn behavior.
+4. Review the final diff and run the bounded local CodeRabbit pre-commit review.
+5. Commit with the live agent-identity trailer, push the assigned branch, and open a signed ready-for-review PR.
+6. Append the collab log line and inbox-ping `cmuxlayerClaude-9c55eb04` with the PR URL. If the inbox is unarmed, append the PR URL as the final line of `phase-7/findings.md`.
+

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -235,6 +235,7 @@ export interface SpawnAgentParams {
    * the surface, before launcher I/O or readiness polling can give the user time to move.
    */
   on_surface_created?: (surface: {
+    agent_id: string;
     surface: string;
     workspace?: string;
   }) => void | Promise<void>;
@@ -261,8 +262,9 @@ export class AgentLaunchError extends Error {
     readonly surface_id: string,
     readonly workspace_id?: string,
     readonly launch_cause?: unknown,
+    readonly launch_phase: "focus" | "launch" = "launch",
   ) {
-    super(message);
+    super(message, launch_cause === undefined ? undefined : { cause: launch_cause });
     this.name = "AgentLaunchError";
   }
 }
@@ -5389,6 +5391,7 @@ export class AgentEngine {
     }
     try {
       await spawnParams.on_surface_created?.({
+        agent_id: agentId,
         surface: surface.surface,
         workspace: createdWorkspace,
       });
@@ -5408,6 +5411,7 @@ export class AgentEngine {
         surface.surface,
         createdWorkspace,
         surfaceFocusError,
+        "focus",
       );
     }
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -23,6 +23,7 @@ import type { InboxOpts } from "./inbox.js";
 import { parseScreen } from "./screen-parser.js";
 import { sanitizeTerminalInput } from "./sanitize.js";
 import { matchReadyPattern } from "./pattern-registry.js";
+import { matchesShellPrompt } from "./shell-prompt.js";
 import { assertMutationAllowed } from "./mode-policy.js";
 import { findWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
@@ -150,10 +151,6 @@ function chunkTerminalInput(text: string, chunkSize: number): string[] {
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function matchesShellPrompt(text: string): boolean {
-  return /(?:^|\n)[^\n]*[$%#]\s*$/.test(text);
 }
 
 function deriveRepoFromCwd(cwd: string): string {

--- a/src/created-identity.ts
+++ b/src/created-identity.ts
@@ -1,0 +1,64 @@
+const CREATED_IDENTITY = Symbol("cmuxlayer.created_identity");
+
+type CreatedIdentityCarrier = {
+  [CREATED_IDENTITY]?: Record<string, unknown>;
+};
+
+function asError(error: unknown): Error & CreatedIdentityCarrier {
+  if (error instanceof Error) {
+    return error as Error & CreatedIdentityCarrier;
+  }
+  return new Error(String(error), { cause: error }) as Error &
+    CreatedIdentityCarrier;
+}
+
+export class CreatedIdentityScope {
+  private readonly identity: Record<string, unknown> = {};
+
+  record(identity: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(identity)) {
+      if (value !== undefined) {
+        this.identity[key] = value;
+      }
+    }
+  }
+
+  append(
+    key: string,
+    identity: Record<string, unknown>,
+    sameIdentity: (left: Record<string, unknown>, right: Record<string, unknown>) => boolean,
+  ): void {
+    const current = Array.isArray(this.identity[key])
+      ? ([...(this.identity[key] as Record<string, unknown>[])] as Record<
+          string,
+          unknown
+        >[])
+      : [];
+    const index = current.findIndex((candidate) =>
+      sameIdentity(candidate, identity),
+    );
+    if (index >= 0) {
+      current[index] = { ...current[index], ...identity };
+    } else {
+      current.push({ ...identity });
+    }
+    this.identity[key] = current;
+  }
+
+  attach(error: unknown): Error {
+    const target = asError(error);
+    const existing = target[CREATED_IDENTITY] ?? {};
+    Object.defineProperty(target, CREATED_IDENTITY, {
+      configurable: true,
+      value: { ...existing, ...this.identity },
+    });
+    return target;
+  }
+}
+
+export function createdIdentityFromError(
+  error: unknown,
+): Record<string, unknown> {
+  if (!(error instanceof Error)) return {};
+  return { ...((error as Error & CreatedIdentityCarrier)[CREATED_IDENTITY] ?? {}) };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,6 +119,15 @@ import {
   parseScreen,
 } from "./screen-parser.js";
 import {
+  launcherFailureFromShell,
+  matchShellPromptLine,
+  matchesShellPrompt,
+} from "./shell-prompt.js";
+import {
+  CreatedIdentityScope,
+  createdIdentityFromError,
+} from "./created-identity.js";
+import {
   dispatch,
   ensureInboxFile,
   inboxCursorPath,
@@ -778,6 +787,16 @@ class BootPromptTimeoutError extends Error {
   }
 }
 
+class LauncherReadinessError extends Error {
+  constructor(
+    message: string,
+    readonly last_10_lines: string[],
+  ) {
+    super(message);
+    this.name = "LauncherReadinessError";
+  }
+}
+
 class BootPromptDeliveryError extends Error {
   constructor(
     message: string,
@@ -966,6 +985,15 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     error.code === PLACEMENT_WORKSPACE_UNRESOLVED
       ? { error_code: PLACEMENT_WORKSPACE_UNRESOLVED }
       : {};
+  const readinessTimeout = findErrorInChain(
+    error,
+    (candidate): candidate is BootPromptTimeoutError | LauncherReadinessError =>
+      candidate instanceof BootPromptTimeoutError ||
+      candidate instanceof LauncherReadinessError,
+  );
+  const readinessExtra = readinessTimeout
+    ? { last_10_lines: readinessTimeout.last_10_lines }
+    : {};
   const retryMeta =
     error && typeof error === "object"
       ? {
@@ -993,13 +1021,32 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     ...deliverySafetyExtra,
     ...submitVerificationExtra,
     ...placementWorkspaceExtra,
+    ...readinessExtra,
     ...extra,
+    ...createdIdentityFromError(error),
   };
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
     isError: true,
   };
+}
+
+function findErrorInChain<T extends Error>(
+  error: unknown,
+  predicate: (error: Error) => error is T,
+): T | null {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current instanceof Error && !seen.has(current)) {
+    if (predicate(current)) return current;
+    seen.add(current);
+    current =
+      current instanceof AgentLaunchError && current.launch_cause !== undefined
+        ? current.launch_cause
+        : current.cause;
+  }
+  return null;
 }
 
 function requireValue(
@@ -1719,36 +1766,6 @@ function inferRepoFromLauncherTitle(title?: string): string | null {
 
 function isLauncherShellCommand(command: string): boolean {
   return /(?:^|\s)[\w.-]+(?:Claude|Codex|Cursor|Gemini)(?=\s|$)/.test(command);
-}
-
-function matchShellPromptLine(
-  line: string,
-  opts?: { allowRootInput?: boolean },
-): { input: string } | null {
-  const normalized = line.trimEnd();
-  const barePrompt = normalized.match(/^\s*([$%])(?:\s+(.*))?$/);
-  if (barePrompt) {
-    return { input: barePrompt[2] ?? "" };
-  }
-  const rootPrompt = normalized.match(/^\s*#(?:\s+(.*))?$/);
-  if (rootPrompt && (!rootPrompt[1] || opts?.allowRootInput)) {
-    return { input: rootPrompt[1] ?? "" };
-  }
-
-  const prefixedPrompt = normalized.match(
-    /^\s*(?:(?:\S+@\S+)(?:\s+(?:~|\/)\S*)?|(?:\S+\s+)?(?:~|\/)\S*)(?:\s+\[[^\]]+\])?\s*[$%#](?:\s+(.*))?$/,
-  );
-  return prefixedPrompt ? { input: prefixedPrompt[1] ?? "" } : null;
-}
-
-function matchesShellPrompt(text: string): boolean {
-  const lines = normalizeTerminalText(text).split("\n");
-  let end = lines.length;
-  while (end > 0 && !lines[end - 1]?.trim()) {
-    end -= 1;
-  }
-  const prompt = end > 0 ? matchShellPromptLine(lines[end - 1] ?? "") : null;
-  return prompt?.input.trim() === "";
 }
 
 function shouldHandleCodexUpdateMenu(
@@ -4551,6 +4568,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const now = Date.now();
         const updateState = parsed.cli_update_state;
 
+        const launcherFailure = launcherFailureFromShell(screen.text);
+        if (launcherFailure) {
+          throw new LauncherReadinessError(
+            `Launcher exited before reaching readiness on ${target.surface}: ${launcherFailure}`,
+            tailLines(lastText, 10),
+          );
+        }
+
         if (shouldHandleCodexUpdateMenu(opts.cli, screen.text)) {
           if (codexUpdateMenuAccepted) {
             const elapsedSinceAcceptMs =
@@ -4684,6 +4709,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       } catch (error) {
         if (
           error instanceof BootPromptTimeoutError ||
+          error instanceof LauncherReadinessError ||
           error instanceof BootPromptUpdateMenuBlockedError
         ) {
           throw error;
@@ -4857,6 +4883,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const parsed = parseScreen(screen.text);
         const now = Date.now();
 
+        const launcherFailure = launcherFailureFromShell(screen.text);
+        if (launcherFailure) {
+          throw new LauncherReadinessError(
+            `Launcher exited before reaching readiness on ${opts.surface}: ${launcherFailure}`,
+            tailLines(lastText, 10),
+          );
+        }
+
         if (parsed.cli_update_state === "updating") {
           updateWasSeen = true;
           updateStartedAt ??= now;
@@ -4925,7 +4959,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           return;
         }
       } catch (error) {
-        if (error instanceof BootPromptTimeoutError) {
+        if (
+          error instanceof BootPromptTimeoutError ||
+          error instanceof LauncherReadinessError
+        ) {
           throw error;
         }
         if (isSurfaceGoneReadFailure(error, opts.surface)) {
@@ -5011,6 +5048,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return false;
           }
 
+          const verifyPendingCommandSubmitted = async (): Promise<void> => {
+            const startedAt = Date.now();
+            let lastText = screen.text;
+            while (
+              Date.now() - startedAt < SEND_INPUT_RECOVERY_ENTER_DELAY_MS
+            ) {
+              const confirmation = await readLauncherScreen();
+              lastText = confirmation.text;
+              if (
+                !screenShowsPendingShellInput(lastText, sanitizedCommand) ||
+                READY_PATTERN_CLIS.some(
+                  (cli) => matchReadyPattern(cli, lastText).matched,
+                )
+              ) {
+                return;
+              }
+              const remaining =
+                SEND_INPUT_RECOVERY_ENTER_DELAY_MS -
+                (Date.now() - startedAt);
+              if (remaining <= 0) break;
+              await delay(Math.min(LAUNCH_SHELL_READY_POLL_MS, remaining));
+            }
+            throw new LauncherReadinessError(
+              `launcher command remained pending after Return on ${opts.surface}`,
+              tailLines(lastText, 10),
+            );
+          };
+
           try {
             // Return is a mutation: retrying after a lost acknowledgement can
             // submit into the newly started CLI. Probe before any fallback.
@@ -5018,20 +5083,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await client.sendKey(opts.surface, "return", {
               workspace: opts.workspace,
             });
+            await verifyPendingCommandSubmitted();
             return true;
           } catch (error) {
             if (isSurfaceGoneReadFailure(error, opts.surface)) {
               throw new SurfaceGoneError(opts.surface, error);
             }
             try {
-              const confirmation = await readLauncherScreen();
-              return !screenShowsPendingShellInput(
-                confirmation.text,
-                sanitizedCommand,
-              );
+              await verifyPendingCommandSubmitted();
+              return true;
             } catch (confirmationError) {
               if (isSurfaceGoneReadFailure(confirmationError, opts.surface)) {
                 throw new SurfaceGoneError(opts.surface, confirmationError);
+              }
+              if (confirmationError instanceof LauncherReadinessError) {
+                throw confirmationError;
               }
               throw error;
             }
@@ -5094,6 +5160,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             error instanceof Error ? error.message : String(error);
           if (!/Enter submit could not be verified/.test(message)) {
             throw error;
+          }
+          const pendingScreen = await client.readScreen(opts.surface, {
+            workspace: opts.workspace,
+            lines: 80,
+            scrollback: false,
+          });
+          if (
+            screenShowsPendingShellInput(
+              pendingScreen.text,
+              sanitizedCommand,
+            )
+          ) {
+            throw new LauncherReadinessError(
+              `launcher command remained pending after Return on ${opts.surface}`,
+              tailLines(pendingScreen.text, 10),
+            );
           }
           // The command can remain visible in shell history while the launcher is
           // already booting. Readiness detection is the authoritative launch check.
@@ -6956,6 +7038,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       let result: CmuxNewSplitResult | undefined;
       let focusRestoreLease: FocusRestoreLease | null = null;
+      const creation = new CreatedIdentityScope();
       try {
         const normalizedRole = normalizeToolAgentRole(args.role, "role");
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
@@ -7106,6 +7189,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   url: args.url,
                   title: args.title,
                 });
+          creation.record({
+            surface: result.surface,
+            workspace: result.workspace,
+            ...(result.surface_id ? { surface_id: result.surface_id } : {}),
+          });
           assertSurfaceObserverEpochCurrent(
             rolePlacementObserverEpoch,
             "role-based new_split placement",
@@ -7126,6 +7214,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             type: args.type,
             url: args.url,
             title: args.title,
+          });
+          creation.record({
+            surface: result.surface,
+            workspace: result.workspace,
+            ...(result.surface_id ? { surface_id: result.surface_id } : {}),
           });
         }
         if (args.focus === true) {
@@ -7216,6 +7309,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        const caught = creation.attach(e);
         // Creation or boot delivery may fail after cmuxlayer selected a target
         // workspace. Return focus when the user has not moved since then.
         await restoreFocusAfterRender(
@@ -7231,30 +7325,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...(result.surface_id ? { surface_id: result.surface_id } : {}),
             }
           : {};
-        if (e instanceof SurfaceGoneError) {
-          return err(e, surfaceGonePayload(e, createdIdentity));
+        if (caught instanceof SurfaceGoneError) {
+          return err(caught, surfaceGonePayload(caught, createdIdentity));
         }
-        if (e instanceof BootPromptTimeoutError) {
-          return err(e, {
+        if (caught instanceof BootPromptTimeoutError) {
+          return err(caught, {
             ...createdIdentity,
-            last_10_lines: e.last_10_lines,
+            last_10_lines: caught.last_10_lines,
           });
         }
-        if (e instanceof BootPromptUpdateMenuBlockedError) {
-          return err(e, {
+        if (caught instanceof BootPromptUpdateMenuBlockedError) {
+          return err(caught, {
             ...createdIdentity,
-            error_code: e.error_code,
-            last_10_lines: e.last_10_lines,
-            recovery: e.recovery,
+            error_code: caught.error_code,
+            last_10_lines: caught.last_10_lines,
+            recovery: caught.recovery,
           });
         }
-        if (e instanceof BootPromptDeliveryError) {
-          return err(e, {
+        if (caught instanceof BootPromptDeliveryError) {
+          return err(caught, {
             ...createdIdentity,
-            delivered_chars: e.delivered_chars,
+            delivered_chars: caught.delivered_chars,
           });
         }
-        return err(e, createdIdentity);
+        return err(caught, createdIdentity);
       }
     },
   );
@@ -7291,6 +7385,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       let result: CmuxNewSurfaceResult | undefined;
+      const creation = new CreatedIdentityScope();
       try {
         const bootPromptPath = getBootPromptPath(args.boot_prompt_path);
         if (bootPromptPath) {
@@ -7315,6 +7410,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           workspace: targetWorkspace,
           type: args.type,
           url: args.url,
+        });
+        creation.record({
+          surface: result.surface,
+          workspace: result.workspace,
+          ...(result.surface_id ? { surface_id: result.surface_id } : {}),
         });
         if (args.title) {
           await client.renameTab(result.surface, args.title, {
@@ -7366,6 +7466,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           data,
         );
       } catch (e) {
+        const caught = creation.attach(e);
         const createdIdentity = result
           ? {
               surface: result.surface,
@@ -7373,30 +7474,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...(result.surface_id ? { surface_id: result.surface_id } : {}),
             }
           : {};
-        if (e instanceof SurfaceGoneError) {
-          return err(e, surfaceGonePayload(e, createdIdentity));
+        if (caught instanceof SurfaceGoneError) {
+          return err(caught, surfaceGonePayload(caught, createdIdentity));
         }
-        if (e instanceof BootPromptTimeoutError) {
-          return err(e, {
+        if (caught instanceof BootPromptTimeoutError) {
+          return err(caught, {
             ...createdIdentity,
-            last_10_lines: e.last_10_lines,
+            last_10_lines: caught.last_10_lines,
           });
         }
-        if (e instanceof BootPromptUpdateMenuBlockedError) {
-          return err(e, {
+        if (caught instanceof BootPromptUpdateMenuBlockedError) {
+          return err(caught, {
             ...createdIdentity,
-            error_code: e.error_code,
-            last_10_lines: e.last_10_lines,
-            recovery: e.recovery,
+            error_code: caught.error_code,
+            last_10_lines: caught.last_10_lines,
+            recovery: caught.recovery,
           });
         }
-        if (e instanceof BootPromptDeliveryError) {
-          return err(e, {
+        if (caught instanceof BootPromptDeliveryError) {
+          return err(caught, {
             ...createdIdentity,
-            delivered_chars: e.delivered_chars,
+            delivered_chars: caught.delivered_chars,
           });
         }
-        return err(e, createdIdentity);
+        return err(caught, createdIdentity);
       }
     },
   );
@@ -9915,6 +10016,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.mutating,
       async (args) => {
+        const creation = new CreatedIdentityScope();
         try {
           if (args.type === "terminal") {
             if (
@@ -9962,6 +10064,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     ...(placement.pane ? { pane: placement.pane } : {}),
                     focus: args.focus,
                   });
+            creation.record({
+              surface_id: created.surface,
+              workspace_id: created.workspace ?? workspace ?? null,
+            });
             if (args.cwd) {
               await client.send(
                 created.surface,
@@ -10094,6 +10200,56 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.worktree,
             args.mcp_profile as McpProfile | undefined,
           );
+          const cleanupFailedLauncherArtifacts = async (
+            error: Error,
+            agentId: string,
+            surface: string,
+            workspace?: string,
+          ): Promise<boolean> => {
+            const record = engine.getAgentState(agentId);
+            const cleanupSurface = record?.surface_uuid?.trim() || surface;
+            try {
+              await client.closeSurface(cleanupSurface, { workspace });
+            } catch (cleanupError) {
+              error.message = `${error.message}. Failed to close launcher surface ${cleanupSurface}: ${
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError)
+              }`;
+              return false;
+            }
+            const current = engine.getAgentState(agentId);
+            if (current && !TERMINAL_AGENT_STATES.has(current.state)) {
+              try {
+                const failed = stateMgr.transition(agentId, "error", {
+                  error: `Launcher surface closed after failed readiness: ${error.message}`,
+                });
+                registry.set(agentId, failed);
+              } catch (stateError) {
+                error.message = `${error.message}. Failed to mark closed launcher agent ${agentId} terminal: ${
+                  stateError instanceof Error
+                    ? stateError.message
+                    : String(stateError)
+                }`;
+              }
+            }
+            if (worktree.prepared?.created && worktree.repoRoot) {
+              try {
+                await rollbackPreparedWorktree(
+                  worktree.repoRoot,
+                  worktree.prepared,
+                  opts?.worktreeExec,
+                );
+              } catch (rollbackError) {
+                error.message = `${error.message}. Worktree rollback also failed: ${
+                  rollbackError instanceof Error
+                    ? rollbackError.message
+                    : String(rollbackError)
+                }`;
+              }
+            }
+            return true;
+          };
           let focusRestoreLease = await focusTargetBeforeSplit(
             spawnWorkspace,
             args.focus !== true,
@@ -10124,6 +10280,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               boot_prompt_timeout_ms: args.boot_prompt_timeout_ms,
               on_surface_created: async (created) => {
                 surfaceCreated = true;
+                creation.record({
+                  agent_id: created.agent_id,
+                  surface_id: created.surface,
+                  workspace_id: created.workspace ?? spawnWorkspace ?? null,
+                });
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
                   created,
@@ -10131,6 +10292,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               },
             });
           } catch (e) {
+            if (
+              e instanceof AgentLaunchError &&
+              e.launch_phase === "launch" &&
+              !(e.launch_cause instanceof SurfaceGoneError)
+            ) {
+              await cleanupFailedLauncherArtifacts(
+                e,
+                e.agent_id,
+                e.surface_id,
+                e.workspace_id,
+              );
+            }
             let rollbackError: unknown = null;
             if (
               !surfaceCreated &&
@@ -10197,6 +10370,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
           let bootPromptDelivery:
             Awaited<ReturnType<typeof deliverBootPrompt>> | undefined;
+          let launcherSurfaceClosed = false;
           try {
             {
               const deliveryWorkspace = spawnDeliveryWorkspace(
@@ -10259,6 +10433,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
           } catch (e) {
+            creation.attach(e);
+            if (e instanceof LauncherReadinessError) {
+              launcherSurfaceClosed = await cleanupFailedLauncherArtifacts(
+                e,
+                result.agent_id,
+                result.surface_id,
+                spawnDeliveryWorkspace(result, spawnWorkspace),
+              );
+            }
             const message = e instanceof Error ? e.message : String(e);
             const clearBootPromptPending = () => {
               const record = resolveSpawnRecord(
@@ -10300,7 +10483,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               // timeout, restore immediately instead of starting a second wait.
               await restoreFocusAfterRender(
                 focusRestoreLease,
-                result.surface_id,
+                launcherSurfaceClosed ? undefined : result.surface_id,
                 spawnDeliveryWorkspace(result, spawnWorkspace),
                 { waitForReady: false },
               );
@@ -10419,44 +10602,47 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("spawn_agent", formattedData),
           );
         } catch (e) {
-          if (e instanceof AgentLaunchError) {
-            if (e.launch_cause instanceof DeliverySafetyGateError) {
-              return err(e.launch_cause, {
-                agent_id: e.agent_id,
-                surface_id: e.surface_id,
-                workspace_id: e.workspace_id,
-                error_code: e.launch_cause.error_code,
-                submit_verified: e.launch_cause.submit_verified,
-                screen: e.launch_cause.screen,
+          const caught = creation.attach(e);
+          if (caught instanceof AgentLaunchError) {
+            if (caught.launch_cause instanceof DeliverySafetyGateError) {
+              creation.attach(caught.launch_cause);
+              return err(caught.launch_cause, {
+                agent_id: caught.agent_id,
+                surface_id: caught.surface_id,
+                workspace_id: caught.workspace_id,
+                error_code: caught.launch_cause.error_code,
+                submit_verified: caught.launch_cause.submit_verified,
+                screen: caught.launch_cause.screen,
               });
             }
-            if (e.launch_cause instanceof SurfaceGoneError) {
+            if (caught.launch_cause instanceof SurfaceGoneError) {
+              creation.attach(caught.launch_cause);
               return err(
-                e.launch_cause,
-                surfaceGonePayload(e.launch_cause, {
-                  agent_id: e.agent_id,
-                  surface_id: e.surface_id,
-                  workspace_id: e.workspace_id,
+                caught.launch_cause,
+                surfaceGonePayload(caught.launch_cause, {
+                  agent_id: caught.agent_id,
+                  surface_id: caught.surface_id,
+                  workspace_id: caught.workspace_id,
                 }),
               );
             }
-            return err(e, {
-              agent_id: e.agent_id,
-              surface_id: e.surface_id,
-              workspace_id: e.workspace_id,
+            return err(caught, {
+              agent_id: caught.agent_id,
+              surface_id: caught.surface_id,
+              workspace_id: caught.workspace_id,
             });
           }
-          if (e instanceof DeliverySafetyGateError) {
-            return err(e, {
-              error_code: e.error_code,
-              submit_verified: e.submit_verified,
-              screen: e.screen,
+          if (caught instanceof DeliverySafetyGateError) {
+            return err(caught, {
+              error_code: caught.error_code,
+              submit_verified: caught.submit_verified,
+              screen: caught.screen,
             });
           }
-          if (e instanceof SurfaceGoneError) {
-            return err(e, surfaceGonePayload(e));
+          if (caught instanceof SurfaceGoneError) {
+            return err(caught, surfaceGonePayload(caught));
           }
-          return err(e);
+          return err(caught);
         }
       },
     );
@@ -10506,6 +10692,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.mutating,
       async (args) => {
+        const creation = new CreatedIdentityScope();
         let focusRestoreLease: FocusRestoreLease | null = null;
         let result: Awaited<ReturnType<typeof engine.spawnAgent>> | undefined;
         let mutationWorkspace: string | undefined;
@@ -10561,6 +10748,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             crash_recover: args.crash_recover,
             on_surface_created: async (created) => {
               surfaceCreated = true;
+              creation.record({
+                agent_id: created.agent_id,
+                surface_id: created.surface,
+                workspace_id: created.workspace ?? mutationWorkspace ?? null,
+              });
               focusRestoreLease = await capturePostCreationFocus(
                 focusRestoreLease,
                 created,
@@ -10665,7 +10857,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             formatOk("new_worktree_split", formattedData),
           );
         } catch (e) {
-          let caught: unknown = e;
+          let caught: unknown = creation.attach(e);
           if (
             !result &&
             !surfaceCreated &&
@@ -10694,6 +10886,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
           }
+          caught = creation.attach(caught);
           await restoreFocusAfterRender(
             focusRestoreLease,
             result?.surface_id,
@@ -10819,6 +11012,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.mutating,
       async (args) => {
+        const creation = new CreatedIdentityScope();
         const originFocus = await currentFocusTarget();
         let focusRestoreLease: FocusRestoreLease | null = null;
         let workspace: string | undefined;
@@ -10889,6 +11083,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!workspace) {
             throw new Error("create_workspace returned an empty workspace ref");
           }
+          creation.record({ workspace, workspace_id: workspace });
 
           focusRestoreLease = await focusTargetBeforeSplit(
             workspace,
@@ -10914,6 +11109,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               role: agent.role,
               auto_archive_on_done: false,
               on_surface_created: async (created) => {
+                const identity = {
+                  agent_id: created.agent_id,
+                  surface_id: created.surface,
+                  workspace_id: created.workspace ?? workspace ?? null,
+                };
+                creation.record(identity);
+                creation.append(
+                  "agents",
+                  identity,
+                  (left, right) =>
+                    left.surface_id === right.surface_id,
+                );
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
                   created,
@@ -10925,6 +11132,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               surface_id: result.surface_id,
               workspace_id: result.workspace_id ?? workspace ?? null,
             };
+            creation.record(activeSpawnIdentity);
+            creation.append(
+              "agents",
+              activeSpawnIdentity,
+              (left, right) => left.surface_id === right.surface_id,
+            );
             createdAgentIdentities.push(activeSpawnIdentity);
             lastSurface = result.surface_id;
             const originalLaunchCommand = originalLaunchCommandsBySurface.get(
@@ -11090,6 +11303,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             },
           );
         } catch (e) {
+          const caught = creation.attach(e);
           await restoreFocusAfterRender(
             focusRestoreLease,
             lastSurface,
@@ -11097,11 +11311,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             { waitForReady: false },
           );
           const failedIdentity =
-            e instanceof AgentLaunchError
+            caught instanceof AgentLaunchError
               ? {
-                  agent_id: e.agent_id,
-                  surface_id: e.surface_id,
-                  workspace_id: e.workspace_id ?? null,
+                  agent_id: caught.agent_id,
+                  surface_id: caught.surface_id,
+                  workspace_id: caught.workspace_id ?? null,
                 }
               : activeSpawnIdentity;
           const failureAgents = [...createdAgentIdentities];
@@ -11120,62 +11334,64 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ...(failedIdentity ?? {}),
             ...(failureAgents.length > 0 ? { agents: failureAgents } : {}),
           };
-          if (e instanceof AgentLaunchError) {
-            if (e.launch_cause instanceof DeliverySafetyGateError) {
-              return err(e.launch_cause, {
+          if (caught instanceof AgentLaunchError) {
+            if (caught.launch_cause instanceof DeliverySafetyGateError) {
+              creation.attach(caught.launch_cause);
+              return err(caught.launch_cause, {
                 ...failureIdentityPayload,
-                error_code: e.launch_cause.error_code,
-                submit_verified: e.launch_cause.submit_verified,
-                screen: e.launch_cause.screen,
+                error_code: caught.launch_cause.error_code,
+                submit_verified: caught.launch_cause.submit_verified,
+                screen: caught.launch_cause.screen,
               });
             }
-            if (e.launch_cause instanceof SurfaceGoneError) {
+            if (caught.launch_cause instanceof SurfaceGoneError) {
+              creation.attach(caught.launch_cause);
               return err(
-                e.launch_cause,
-                surfaceGonePayload(e.launch_cause, failureIdentityPayload),
+                caught.launch_cause,
+                surfaceGonePayload(caught.launch_cause, failureIdentityPayload),
               );
             }
-            return err(e, failureIdentityPayload);
+            return err(caught, failureIdentityPayload);
           }
-          if (e instanceof DeliverySafetyGateError) {
-            return err(e, {
+          if (caught instanceof DeliverySafetyGateError) {
+            return err(caught, {
               ...failureIdentityPayload,
-              error_code: e.error_code,
-              submit_verified: e.submit_verified,
-              screen: e.screen,
+              error_code: caught.error_code,
+              submit_verified: caught.submit_verified,
+              screen: caught.screen,
             });
           }
-          if (e instanceof SubmitVerificationError) {
-            return err(e, {
+          if (caught instanceof SubmitVerificationError) {
+            return err(caught, {
               ...failureIdentityPayload,
               submit_verified: false,
-              retry_count: e.retry_count,
+              retry_count: caught.retry_count,
             });
           }
-          if (e instanceof SurfaceGoneError) {
-            return err(e, surfaceGonePayload(e, failureIdentityPayload));
+          if (caught instanceof SurfaceGoneError) {
+            return err(caught, surfaceGonePayload(caught, failureIdentityPayload));
           }
-          if (e instanceof BootPromptTimeoutError) {
-            return err(e, {
+          if (caught instanceof BootPromptTimeoutError) {
+            return err(caught, {
               ...failureIdentityPayload,
-              last_10_lines: e.last_10_lines,
+              last_10_lines: caught.last_10_lines,
             });
           }
-          if (e instanceof BootPromptUpdateMenuBlockedError) {
-            return err(e, {
+          if (caught instanceof BootPromptUpdateMenuBlockedError) {
+            return err(caught, {
               ...failureIdentityPayload,
-              error_code: e.error_code,
-              last_10_lines: e.last_10_lines,
-              recovery: e.recovery,
+              error_code: caught.error_code,
+              last_10_lines: caught.last_10_lines,
+              recovery: caught.recovery,
             });
           }
-          if (e instanceof BootPromptDeliveryError) {
-            return err(e, {
+          if (caught instanceof BootPromptDeliveryError) {
+            return err(caught, {
               ...failureIdentityPayload,
-              delivered_chars: e.delivered_chars,
+              delivered_chars: caught.delivered_chars,
             });
           }
-          return err(e, failureIdentityPayload);
+          return err(caught, failureIdentityPayload);
         }
       },
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -2316,8 +2316,19 @@ export function screenShowsPendingShellInput(
   let activePromptIndex = -1;
   for (let index = end - 1; index >= 0; index -= 1) {
     const line = lines[index]?.trimEnd() ?? "";
-    const prompt = matchShellPromptLine(line, promptOptions);
+    const strictPrompt = matchShellPromptLine(line, {
+      ...promptOptions,
+      strict: true,
+    });
+    const prompt = strictPrompt ?? matchShellPromptLine(line, promptOptions);
     if (prompt) {
+      // The readiness matcher intentionally accepts any decorated $/%/#
+      // suffix. Only use that loose fallback as pending-input evidence for a
+      // launcher command; ordinary output such as "Building... 62%" is not a
+      // trustworthy prompt anchor.
+      if (!strictPrompt && !promptOptions.allowRootInput) {
+        return false;
+      }
       activePromptIndex = index;
       break;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5048,34 +5048,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return false;
           }
 
-          const verifyPendingCommandSubmitted = async (): Promise<void> => {
-            const startedAt = Date.now();
-            let lastText = screen.text;
-            while (
-              Date.now() - startedAt < SEND_INPUT_RECOVERY_ENTER_DELAY_MS
-            ) {
-              const confirmation = await readLauncherScreen();
-              lastText = confirmation.text;
-              if (
-                !screenShowsPendingShellInput(lastText, sanitizedCommand) ||
-                READY_PATTERN_CLIS.some(
-                  (cli) => matchReadyPattern(cli, lastText).matched,
-                )
-              ) {
-                return;
-              }
-              const remaining =
-                SEND_INPUT_RECOVERY_ENTER_DELAY_MS -
-                (Date.now() - startedAt);
-              if (remaining <= 0) break;
-              await delay(Math.min(LAUNCH_SHELL_READY_POLL_MS, remaining));
-            }
-            throw new LauncherReadinessError(
-              `launcher command remained pending after Return on ${opts.surface}`,
-              tailLines(lastText, 10),
-            );
-          };
-
           try {
             // Return is a mutation: retrying after a lost acknowledgement can
             // submit into the newly started CLI. Probe before any fallback.
@@ -5083,21 +5055,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await client.sendKey(opts.surface, "return", {
               workspace: opts.workspace,
             });
-            await verifyPendingCommandSubmitted();
             return true;
           } catch (error) {
             if (isSurfaceGoneReadFailure(error, opts.surface)) {
               throw new SurfaceGoneError(opts.surface, error);
             }
             try {
-              await verifyPendingCommandSubmitted();
-              return true;
+              const confirmation = await readLauncherScreen();
+              return !screenShowsPendingShellInput(
+                confirmation.text,
+                sanitizedCommand,
+              );
             } catch (confirmationError) {
               if (isSurfaceGoneReadFailure(confirmationError, opts.surface)) {
                 throw new SurfaceGoneError(opts.surface, confirmationError);
-              }
-              if (confirmationError instanceof LauncherReadinessError) {
-                throw confirmationError;
               }
               throw error;
             }
@@ -5161,30 +5132,42 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!/Enter submit could not be verified/.test(message)) {
             throw error;
           }
-          const pendingScreen = await client.readScreen(opts.surface, {
-            workspace: opts.workspace,
-            lines: 80,
-            scrollback: false,
-          });
-          if (
-            screenShowsPendingShellInput(
-              pendingScreen.text,
-              sanitizedCommand,
-            )
-          ) {
-            throw new LauncherReadinessError(
-              `launcher command remained pending after Return on ${opts.surface}`,
-              tailLines(pendingScreen.text, 10),
-            );
-          }
           // The command can remain visible in shell history while the launcher is
           // already booting. Readiness detection is the authoritative launch check.
-          await waitForAgentLaunchReady({
-            surface: opts.surface,
-            workspace: opts.workspace,
-            timeout_ms: opts.timeout_ms,
-            onUpdateShellRelaunch: relaunchOriginalCommand,
-          });
+          try {
+            await waitForAgentLaunchReady({
+              surface: opts.surface,
+              workspace: opts.workspace,
+              timeout_ms: opts.timeout_ms,
+              onUpdateShellRelaunch: relaunchOriginalCommand,
+            });
+          } catch (readinessError) {
+            let pendingScreen;
+            try {
+              pendingScreen = await client.readScreen(opts.surface, {
+                workspace: opts.workspace,
+                lines: 80,
+                scrollback: false,
+              });
+            } catch (readError) {
+              if (isSurfaceGoneReadFailure(readError, opts.surface)) {
+                throw new SurfaceGoneError(opts.surface, readError);
+              }
+              throw readinessError;
+            }
+            if (
+              screenShowsPendingShellInput(
+                pendingScreen.text,
+                sanitizedCommand,
+              )
+            ) {
+              throw new LauncherReadinessError(
+                `launcher command remained pending after Return on ${opts.surface}`,
+                tailLines(pendingScreen.text, 10),
+              );
+            }
+            throw readinessError;
+          }
         }
       },
       {
@@ -10295,7 +10278,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (
               e instanceof AgentLaunchError &&
               e.launch_phase === "launch" &&
-              !(e.launch_cause instanceof SurfaceGoneError)
+              e.launch_cause instanceof LauncherReadinessError
             ) {
               await cleanupFailedLauncherArtifacts(
                 e,

--- a/src/shell-prompt.ts
+++ b/src/shell-prompt.ts
@@ -1,0 +1,54 @@
+const SHELL_PROMPT_TERMINATOR = "[$%#>❯›»]";
+
+export function matchShellPromptLine(
+  line: string,
+  opts?: { allowRootInput?: boolean },
+): { input: string } | null {
+  const normalized = line.trimEnd();
+  const barePrompt = normalized.match(
+    new RegExp(`^\\s*(${SHELL_PROMPT_TERMINATOR})(?:\\s+(.*))?$`, "u"),
+  );
+  if (barePrompt && barePrompt[1] !== "#") {
+    return { input: barePrompt[2] ?? "" };
+  }
+  if (
+    barePrompt?.[1] === "#" &&
+    (!barePrompt[2] || opts?.allowRootInput)
+  ) {
+    return { input: barePrompt[2] ?? "" };
+  }
+
+  const prefixedPrompt = normalized.match(
+    new RegExp(
+      `^\\s*(?:(?:\\S+@\\S+)(?:\\s+(?:~|\\/)\\S*)?|(?:.*\\s)?(?:~|\\/)\\S*)(?:\\s+\\[[^\\]]+\\])?\\s*${SHELL_PROMPT_TERMINATOR}(?:\\s+(.*))?$`,
+      "u",
+    ),
+  );
+  return prefixedPrompt ? { input: prefixedPrompt[1] ?? "" } : null;
+}
+
+export function matchesShellPrompt(text: string): boolean {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  let end = lines.length;
+  while (end > 0 && !lines[end - 1]?.trim()) {
+    end -= 1;
+  }
+  const prompt = end > 0 ? matchShellPromptLine(lines[end - 1] ?? "") : null;
+  return prompt?.input.trim() === "";
+}
+
+export function launcherFailureFromShell(text: string): string | null {
+  if (!matchesShellPrompt(text)) return null;
+  const lines = text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd());
+  while (lines.length > 0 && !lines.at(-1)?.trim()) lines.pop();
+  if (lines.length < 2) return null;
+  const adjacentLine = lines.at(-2)?.trim() ?? "";
+  return /(?:command not found|no such file(?: or directory)?|permission denied|traceback \(most recent call last\)|invalid (?:option|argument|model|effort))/i.test(
+    adjacentLine,
+  )
+    ? adjacentLine
+    : null;
+}

--- a/src/shell-prompt.ts
+++ b/src/shell-prompt.ts
@@ -18,6 +18,13 @@ export function matchShellPromptLine(
     return { input: barePrompt[2] ?? "" };
   }
 
+  // Preserve the app-server's established contract: any decorated prompt
+  // ending in $, %, or # is ready. Pending input follows the terminator and
+  // therefore cannot match this suffix-only fallback.
+  if (/^.+[$%#]$/u.test(normalized)) {
+    return { input: "" };
+  }
+
   const prefixedPrompt = normalized.match(
     new RegExp(
       `^\\s*(?:(?:\\S+@\\S+)(?:\\s+(?:~|\\/)\\S*)?|(?:.*\\s)?(?:~|\\/)\\S*)(?:\\s+\\[[^\\]]+\\])?\\s*${SHELL_PROMPT_TERMINATOR}(?:\\s+(.*))?$`,

--- a/src/shell-prompt.ts
+++ b/src/shell-prompt.ts
@@ -2,7 +2,7 @@ const SHELL_PROMPT_TERMINATOR = "[$%#>❯›»]";
 
 export function matchShellPromptLine(
   line: string,
-  opts?: { allowRootInput?: boolean },
+  opts?: { allowRootInput?: boolean; strict?: boolean },
 ): { input: string } | null {
   const normalized = line.trimEnd();
   const barePrompt = normalized.match(
@@ -18,11 +18,15 @@ export function matchShellPromptLine(
     return { input: barePrompt[2] ?? "" };
   }
 
-  // Preserve the app-server's established contract: any decorated prompt
-  // ending in $, %, or # is ready. Pending input follows the terminator and
-  // therefore cannot match this suffix-only fallback.
-  if (/^.+[$%#]$/u.test(normalized)) {
-    return { input: "" };
+  if (!opts?.strict) {
+    // Preserve the app-server's established readiness contract while still
+    // exposing text after the decorated terminator to pending-input checks.
+    const decoratedPrompt = normalized.match(
+      /^.+?[$%#](?:\s+(.*))?$/u,
+    );
+    if (decoratedPrompt) {
+      return { input: decoratedPrompt[1] ?? "" };
+    }
   }
 
   const prefixedPrompt = normalized.match(
@@ -35,17 +39,28 @@ export function matchShellPromptLine(
 }
 
 export function matchesShellPrompt(text: string): boolean {
+  return matchesShellPromptWithOptions(text, false);
+}
+
+export function matchesShellPromptStrict(text: string): boolean {
+  return matchesShellPromptWithOptions(text, true);
+}
+
+function matchesShellPromptWithOptions(text: string, strict: boolean): boolean {
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
   let end = lines.length;
   while (end > 0 && !lines[end - 1]?.trim()) {
     end -= 1;
   }
-  const prompt = end > 0 ? matchShellPromptLine(lines[end - 1] ?? "") : null;
+  const prompt =
+    end > 0
+      ? matchShellPromptLine(lines[end - 1] ?? "", { strict })
+      : null;
   return prompt?.input.trim() === "";
 }
 
 export function launcherFailureFromShell(text: string): string | null {
-  if (!matchesShellPrompt(text)) return null;
+  if (!matchesShellPromptStrict(text)) return null;
   const lines = text
     .replace(/\r\n?/g, "\n")
     .split("\n")

--- a/tests/created-identity.test.ts
+++ b/tests/created-identity.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreatedIdentityScope,
+  createdIdentityFromError,
+} from "../src/created-identity.js";
+
+class UnclassifiedPostCreationError extends Error {}
+
+describe("CreatedIdentityScope", () => {
+  it("attaches recorded identity without changing the error type or cause", () => {
+    const cause = new Error("socket stderr");
+    const error = new UnclassifiedPostCreationError("later failure", {
+      cause,
+    });
+    const scope = new CreatedIdentityScope();
+    scope.record({ surface: "surface:7", workspace: "workspace:2" });
+
+    const attached = scope.attach(error);
+
+    expect(attached).toBe(error);
+    expect(attached).toBeInstanceOf(UnclassifiedPostCreationError);
+    expect(attached.cause).toBe(cause);
+    expect(createdIdentityFromError(attached)).toEqual({
+      surface: "surface:7",
+      workspace: "workspace:2",
+    });
+  });
+
+  it("does not invent identity before creation", () => {
+    const scope = new CreatedIdentityScope();
+    expect(createdIdentityFromError(scope.attach(new Error("preflight")))).toEqual(
+      {},
+    );
+  });
+
+  it("accumulates prior batch identities and updates the failing member", () => {
+    const scope = new CreatedIdentityScope();
+    const sameSurface = (
+      left: Record<string, unknown>,
+      right: Record<string, unknown>,
+    ) => left.surface_id === right.surface_id;
+    scope.append(
+      "agents",
+      { agent_id: "pending-a", surface_id: "surface:a" },
+      sameSurface,
+    );
+    scope.append(
+      "agents",
+      { agent_id: "agent-a", surface_id: "surface:a" },
+      sameSurface,
+    );
+    scope.append(
+      "agents",
+      { agent_id: "agent-b", surface_id: "surface:b" },
+      sameSurface,
+    );
+
+    expect(createdIdentityFromError(scope.attach(new Error("batch")))).toEqual({
+      agents: [
+        { agent_id: "agent-a", surface_id: "surface:a" },
+        { agent_id: "agent-b", surface_id: "surface:b" },
+      ],
+    });
+  });
+});

--- a/tests/fixtures/golem-dispatch-contract.zsh
+++ b/tests/fixtures/golem-dispatch-contract.zsh
@@ -1,0 +1,22 @@
+# Hermetic CI snapshot of the launcher clauses cmuxlayer's spawn schema relies on.
+if [[ -n "${CLAUDE_MODEL:-}" ]]; then
+  _claude_model="$CLAUDE_MODEL"
+else
+  _claude_model="claude-opus-5[1m]"
+fi
+
+_golem_parse_codex_flags() {
+  _flag_codex_effort="xhigh"
+  case "$1" in
+    --effort)
+      case "$2" in
+        medium|high|xhigh|ultra) _flag_codex_effort="$2" ;;
+      esac
+      ;;
+  esac
+}
+
+_golem_launch_cursor() {
+  _golem_refuse_agent_model_override "$@"
+  REPOGOLEM_ALLOW_MODEL="${REPOGOLEM_ALLOW_MODEL:-0}"
+}

--- a/tests/model-policy-drift.test.ts
+++ b/tests/model-policy-drift.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   CODEX_EFFORT_VALUES,
@@ -98,16 +99,34 @@ describe("model-policy drift gate", () => {
   });
 });
 
-const dispatchPath = join(
+const installedDispatchPath = join(
   homedir(),
   ".config/ralphtools/golem-dispatch.zsh",
 );
-const launcherAbsent = !existsSync(dispatchPath);
+const contractFixturePath = fileURLToPath(
+  new URL("./fixtures/golem-dispatch-contract.zsh", import.meta.url),
+);
+const dispatchPath = existsSync(installedDispatchPath)
+  ? installedDispatchPath
+  : contractFixturePath;
 
-describe.skipIf(launcherAbsent)("model-policy parity with installed golem-dispatch", () => {
-  // Read lazily in beforeAll, not at describe-body collection time: a skipped
-  // suite (installed launcher absent, e.g. CI) still evaluates the describe
-  // body, so a top-level readFileSync would throw before the skip takes effect.
+describe("hermetic golem-dispatch contract", () => {
+  it("keeps the CI fallback parseable and aligned", () => {
+    const fixture = readFileSync(contractFixturePath, "utf8");
+    expect(parseClaudeDefault(fixture)).toBe(
+      MODEL_POLICY_CONTRACT.cli.claude.defaultModel,
+    );
+    expect(parseCodexEffortValues(fixture)).toEqual(CODEX_EFFORT_VALUES);
+    expect(parseCursorLauncher(fixture)).toContain(
+      "_golem_refuse_agent_model_override",
+    );
+    expect(fixture).toContain(MODEL_OVERRIDE_ENV);
+  });
+});
+
+describe("model-policy parity with golem-dispatch contract", () => {
+  // Developer machines check the installed launcher. CI checks the committed
+  // launcher-contract snapshot so this suite never silently disappears.
   let dispatchText: string;
   beforeAll(() => {
     dispatchText = readFileSync(dispatchPath, "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3900,6 +3900,90 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("spawn_agent ignores transient shell-rc errors above percentage boot progress", async () => {
+    vi.useFakeTimers();
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      const repoRoot = join(TEST_DIR, ".config", "ralph-progress");
+      const registryPath = join(TEST_DIR, "launchers-progress.zsh");
+      const worktreePath = join(repoRoot, ".worktrees", "boot-progress");
+      mkdirSync(repoRoot, { recursive: true });
+      writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
+      vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+      const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+        if (args.includes("worktree") && args.includes("add")) {
+          mkdirSync(worktreePath, { recursive: true });
+        }
+        return { stdout: "", stderr: "" };
+      });
+      const baseExec = makeLifecycleExec();
+      let launcherSentAt: number | null = null;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        if (
+          args.includes("send") &&
+          /ralphCodex\b/.test(String(args.at(-1) ?? ""))
+        ) {
+          launcherSentAt = Date.now();
+          return { stdout: "{}", stderr: "" };
+        }
+        if (launcherSentAt !== null && args.includes("read-screen")) {
+          const elapsed = Date.now() - launcherSentAt;
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text:
+                elapsed < 500
+                  ? "zsh: command not found: pyenv\n⠋ Installing... 62%"
+                  : "codex> ",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createTrackedServer({
+        exec,
+        stateDir: TEST_DIR,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "ralph",
+          cli: "codex",
+          role: "worker",
+          worktree: {
+            name: "boot-progress",
+            branch: "wt/boot-progress",
+          },
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(launcherSentAt).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(3_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed).toMatchObject({ ok: true });
+      expect(
+        exec.mock.calls.some(([, args]) => args.includes("close-surface")),
+      ).toBe(false);
+      expect(worktreeExec).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove"]),
+      );
+      expect(existsSync(worktreePath)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("spawn_agent keeps a generic launch-timeout surface and worktree recoverable", async () => {
     vi.useFakeTimers();
     try {
@@ -4730,7 +4814,7 @@ describe("agent lifecycle tool handlers", () => {
     ).toBe(true);
   }, 10_000);
 
-  it("spawn_agent fails with pending launcher evidence when Return never submits", async () => {
+  it("spawn_agent fails with decorated-prompt pending evidence when Return never submits", async () => {
     vi.useFakeTimers();
     try {
       const baseExec = makeLifecycleExec();
@@ -4750,7 +4834,7 @@ describe("agent lifecycle tool handlers", () => {
           return {
             stdout: JSON.stringify({
               surface: "surface:new",
-              text: "$ voicelayerCodex -s",
+              text: "bash-5.2$ voicelayerCodex -s",
               lines: 20,
               scrollback_used: false,
             }),
@@ -4778,7 +4862,9 @@ describe("agent lifecycle tool handlers", () => {
       expect(parsed.error).toContain(
         "launcher command remained pending after Return",
       );
-      expect(parsed.last_10_lines).toContain("$ voicelayerCodex -s");
+      expect(parsed.last_10_lines).toContain(
+        "bash-5.2$ voicelayerCodex -s",
+      );
       expect(launcherReturns).toBeGreaterThanOrEqual(1);
     } finally {
       vi.useRealTimers();

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -50,6 +50,7 @@ const hermeticSpawnStateDirs: string[] = [];
 let hermeticSpawnFixtureSequence = 0;
 const originalLauncherRegistryPath =
   process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
+const originalAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
 
 afterEach(async () => {
   if (originalLauncherRegistryPath === undefined) {
@@ -57,6 +58,11 @@ afterEach(async () => {
   } else {
     process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH =
       originalLauncherRegistryPath;
+  }
+  if (originalAllowModel === undefined) {
+    delete process.env.REPOGOLEM_ALLOW_MODEL;
+  } else {
+    process.env.REPOGOLEM_ALLOW_MODEL = originalAllowModel;
   }
   await Promise.allSettled(
     serverContexts.map(
@@ -93,6 +99,7 @@ const AGENT_TOOLS = [
 function makeLifecycleExec(opts?: {
   closeKeepsSurface?: boolean;
   createdWorkspace?: string;
+  shellPrompt?: string;
   shellNeverReady?: boolean;
   surfaceUuid?: string;
 }): ExecFn {
@@ -131,7 +138,7 @@ function makeLifecycleExec(opts?: {
         createdSurfaceCount === 1
           ? "surface:new"
           : `surface:new-${createdSurfaceCount}`;
-      readyText = "$ ";
+      readyText = opts?.shellPrompt ?? "$ ";
       promptPending = false;
     }
     if (args.includes("close-surface") && !opts?.closeKeepsSurface) {
@@ -1217,6 +1224,7 @@ describe("lean spawn tool responses", () => {
   });
 
   it("spawn_agent rejects an unsupported model before creating a surface", async () => {
+    delete process.env.REPOGOLEM_ALLOW_MODEL;
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -3737,6 +3745,99 @@ describe("agent lifecycle tool handlers", () => {
     expect(existsSync(worktreePath)).toBe(true);
   });
 
+  it("spawn_agent closes a failed launcher surface before rolling back its new worktree", async () => {
+    vi.useFakeTimers();
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      const repoRoot = join(TEST_DIR, ".config", "ralph-launch-failure");
+      const registryPath = join(TEST_DIR, "launchers-post-surface-rollback.zsh");
+      const worktreePath = join(repoRoot, ".worktrees", "post-surface-failure");
+      mkdirSync(repoRoot, { recursive: true });
+      writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
+      vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+      const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+        if (args.includes("worktree") && args.includes("add")) {
+          mkdirSync(worktreePath, { recursive: true });
+        }
+        if (args.includes("worktree") && args.includes("remove")) {
+          rmSync(worktreePath, { recursive: true, force: true });
+        }
+        return { stdout: "", stderr: "" };
+      });
+      const baseExec = makeLifecycleExec({ surfaceUuid: "surface-uuid:new" });
+      let launcherSent = false;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        if (
+          args.includes("send") &&
+          /ralphCodex\b/.test(String(args.at(-1) ?? ""))
+        ) {
+          launcherSent = true;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (launcherSent && args.includes("read-screen")) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "zsh: command not found: ralphCodex\n$ ",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createTrackedServer({
+        exec,
+        stateDir: TEST_DIR,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "ralph",
+          cli: "codex",
+          role: "worker",
+          worktree: {
+            name: "post-surface-failure",
+            branch: "wt/post-surface-failure",
+          },
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("zsh: command not found: ralphCodex");
+      expect(parsed.surface_id).toBe("surface:new");
+      expect(exec).toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["close-surface", "surface-uuid:new"]),
+      );
+      expect(worktreeExec).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove", "--force", worktreePath]),
+      );
+      expect(worktreeExec).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["branch", "-D", "wt/post-surface-failure"]),
+      );
+      const getState = (server as any)._registeredTools["get_agent_state"];
+      const state = parseToolResult(
+        await getState.handler({ agent_id: parsed.agent_id }, {} as any),
+      );
+      expect(state.state).toBe("error");
+      expect(existsSync(worktreePath)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("new_worktree_split rolls back a newly created worktree and branch when spawning fails", async () => {
     const gitsDir = join(TEST_DIR, "Gits");
     const repoRoot = join(gitsDir, "cmuxlayer");
@@ -4510,6 +4611,61 @@ describe("agent lifecycle tool handlers", () => {
     ).toBe(true);
   }, 10_000);
 
+  it("spawn_agent fails with pending launcher evidence when Return never submits", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseExec = makeLifecycleExec();
+      let launcherSent = false;
+      let launcherReturns = 0;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        const text = String(args.at(-1) ?? "");
+        if (args.includes("send") && text === "voicelayerCodex -s") {
+          launcherSent = true;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (launcherSent && args.includes("send-key") && args.includes("return")) {
+          launcherReturns += 1;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (launcherSent && args.includes("read-screen")) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "$ voicelayerCodex -s",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createLifecycleServer(exec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "voicelayer",
+          model: "codex",
+          cli: "codex",
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain(
+        "launcher command remained pending after Return",
+      );
+      expect(parsed.last_10_lines).toContain("$ voicelayerCodex -s");
+      expect(launcherReturns).toBeGreaterThanOrEqual(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
@@ -4751,6 +4907,58 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it.each(["user in ~/repo > ", "❯ ", "› ", "» "])(
+    "spawn_agent launches from a ready %s shell prompt",
+    async (shellPrompt) => {
+      const server = createLifecycleServer(makeLifecycleExec({ shellPrompt }));
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const result = await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      const parsed = parseToolResult(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.surface_id).toBe("surface:new");
+    },
+  );
+
+  it("spawn terminal preserves created identity when cwd delivery fails", async () => {
+    const baseExec = makeLifecycleExec();
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (
+        args.includes("send") &&
+        String(args.at(-1) ?? "").startsWith("cd -- ")
+      ) {
+        throw new Error("deliberate terminal cwd failure");
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      {
+        version: 1,
+        type: "terminal",
+        cwd: "/tmp/cmuxlayer-p7-terminal",
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("deliberate terminal cwd failure");
+    expect(parsed.surface_id).toBe("surface:new");
+    expect(parsed.workspace_id).toBe("workspace:1");
+  });
+
   it("spawn_agent preserves the 10000ms shell-readiness default when no override is supplied", async () => {
     vi.useFakeTimers();
     try {
@@ -4888,6 +5096,9 @@ describe("agent lifecycle tool handlers", () => {
       );
       expect(parsed.agent_id).toEqual(expect.any(String));
       expect(parsed.surface_id).toBe("surface:new");
+      expect(parsed.last_10_lines).toContain(
+        "agent launcher still starting",
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -5015,6 +5226,7 @@ describe("agent lifecycle tool handlers", () => {
       expect(parsed.agent_id).toEqual(expect.any(String));
       expect(parsed.surface_id).toBe("surface:new");
       expect(parsed.workspace_id).toBe("ws:1");
+      expect(parsed.last_10_lines).toContain("terminal initializing");
     } finally {
       vi.useRealTimers();
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3838,6 +3838,125 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("spawn_agent waits through an 800ms launcher first-paint delay without cleanup", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseExec = makeLifecycleExec();
+      let launcherSentAt: number | null = null;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        const text = String(args.at(-1) ?? "");
+        if (args.includes("send") && text === "voicelayerCodex -s") {
+          launcherSentAt = Date.now();
+          return { stdout: "{}", stderr: "" };
+        }
+        if (
+          launcherSentAt !== null &&
+          args.includes("send-key") &&
+          args.includes("return")
+        ) {
+          return { stdout: "{}", stderr: "" };
+        }
+        if (launcherSentAt !== null && args.includes("read-screen")) {
+          const elapsed = Date.now() - launcherSentAt;
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text:
+                elapsed < 800
+                  ? "$ voicelayerCodex -s"
+                  : "codex> ",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createLifecycleServer(exec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "voicelayer",
+          model: "codex",
+          cli: "codex",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(launcherSentAt).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(3_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed.error).toBeUndefined();
+      expect(parsed).toMatchObject({ ok: true });
+      expect(
+        exec.mock.calls.some(([, args]) => args.includes("close-surface")),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spawn_agent keeps a generic launch-timeout surface and worktree recoverable", async () => {
+    vi.useFakeTimers();
+    try {
+      const gitsDir = join(TEST_DIR, "Gits");
+      const repoRoot = join(TEST_DIR, ".config", "ralph-timeout");
+      const registryPath = join(TEST_DIR, "launchers-timeout.zsh");
+      const worktreePath = join(repoRoot, ".worktrees", "launch-timeout");
+      mkdirSync(repoRoot, { recursive: true });
+      writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
+      vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+      const worktreeExec = vi.fn().mockImplementation(async (_cmd, args) => {
+        if (args.includes("worktree") && args.includes("add")) {
+          mkdirSync(worktreePath, { recursive: true });
+        }
+        return { stdout: "", stderr: "" };
+      });
+      const exec = makeLifecycleExec({ shellNeverReady: true });
+      const server = createTrackedServer({
+        exec,
+        stateDir: TEST_DIR,
+        sessionIdentityResolver: () => null,
+        worktreeHomeDir: gitsDir,
+        worktreeExec,
+      });
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+
+      const resultPromise = spawn.handler(
+        {
+          repo: "ralph",
+          cli: "codex",
+          role: "worker",
+          worktree: {
+            name: "launch-timeout",
+            branch: "wt/launch-timeout",
+          },
+          boot_prompt_timeout_ms: 20,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("waiting for shell readiness");
+      expect(
+        exec.mock.calls.some(([, args]) => args.includes("close-surface")),
+      ).toBe(false);
+      expect(worktreeExec).not.toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["worktree", "remove"]),
+      );
+      expect(existsSync(worktreePath)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("new_worktree_split rolls back a newly created worktree and branch when spawning fails", async () => {
     const gitsDir = join(TEST_DIR, "Gits");
     const repoRoot = join(gitsDir, "cmuxlayer");

--- a/tests/shell-prompt.test.ts
+++ b/tests/shell-prompt.test.ts
@@ -16,6 +16,10 @@ describe("shell prompt recognition", () => {
     "» ",
     "user in ~/code/cmuxlayer > ",
     "etan@mac ~/Gits/cmuxlayer [main] ❯ ",
+    "➜  cmuxlayer git:(main) $ ",
+    "[etan@mac cmuxlayer]$ ",
+    "cmuxlayer (main) % ",
+    "bash-5.2$ ",
   ])("accepts a ready %s prompt", (prompt) => {
     expect(matchesShellPrompt(`old output\n${prompt}`)).toBe(true);
   });
@@ -24,6 +28,7 @@ describe("shell prompt recognition", () => {
     "> cmuxlayerCodex -s",
     "❯ cmuxlayerClaude -s",
     "user in ~/code/cmuxlayer > still pending",
+    "bash-5.2$ cmuxlayerCodex -s",
   ])("rejects pending input at %s", (prompt) => {
     expect(matchesShellPrompt(prompt)).toBe(false);
   });

--- a/tests/shell-prompt.test.ts
+++ b/tests/shell-prompt.test.ts
@@ -47,4 +47,24 @@ describe("shell prompt recognition", () => {
     expect(launcherFailureFromShell("build failed earlier\nsummary\n$ ")).toBeNull();
     expect(launcherFailureFromShell("error: cached warning\n$ ")).toBeNull();
   });
+
+  it.each([
+    "⠋ Building bundle... 62%",
+    "Installing dependencies  45%",
+    "Context left: 12%",
+    "Total cost: $",
+    "issue #",
+  ])("does not treat a loose readiness suffix as launcher-exit evidence: %s", (line) => {
+    expect(
+      launcherFailureFromShell(`zsh: command not found: pyenv\n${line}`),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["➜  cmuxlayer git:(main) $ ralphCodex -s", "ralphCodex -s"],
+    ["bash-5.2$ ralphCodex -s", "ralphCodex -s"],
+    ["[etan@mac cmuxlayer]$ ralphCodex -s", "ralphCodex -s"],
+  ])("captures pending input from decorated prompt %s", (line, input) => {
+    expect(matchShellPromptLine(line)).toEqual({ input });
+  });
 });

--- a/tests/shell-prompt.test.ts
+++ b/tests/shell-prompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  launcherFailureFromShell,
+  matchShellPromptLine,
+  matchesShellPrompt,
+} from "../src/shell-prompt.js";
+
+describe("shell prompt recognition", () => {
+  it.each([
+    "$ ",
+    "% ",
+    "# ",
+    "> ",
+    "❯ ",
+    "› ",
+    "» ",
+    "user in ~/code/cmuxlayer > ",
+    "etan@mac ~/Gits/cmuxlayer [main] ❯ ",
+  ])("accepts a ready %s prompt", (prompt) => {
+    expect(matchesShellPrompt(`old output\n${prompt}`)).toBe(true);
+  });
+
+  it.each([
+    "> cmuxlayerCodex -s",
+    "❯ cmuxlayerClaude -s",
+    "user in ~/code/cmuxlayer > still pending",
+  ])("rejects pending input at %s", (prompt) => {
+    expect(matchesShellPrompt(prompt)).toBe(false);
+  });
+
+  it("keeps root input fail-closed unless explicitly allowed", () => {
+    expect(matchShellPromptLine("# rm -rf example")).toBeNull();
+    expect(
+      matchShellPromptLine("# echo safe", { allowRootInput: true }),
+    ).toEqual({ input: "echo safe" });
+  });
+
+  it("recognizes only adjacent, specific launcher failure evidence", () => {
+    expect(
+      launcherFailureFromShell("zsh: command not found: cmuxlayerCodex\n$ "),
+    ).toBe("zsh: command not found: cmuxlayerCodex");
+    expect(launcherFailureFromShell("build failed earlier\nsummary\n$ ")).toBeNull();
+    expect(launcherFailureFromShell("error: cached warning\n$ ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- recognize conventional ASCII and Unicode shell prompts through one shared matcher without treating pending input as readiness
- preserve created workspace, surface, and agent identities across every post-creation failure path
- expose terminal readiness evidence, verify launcher Return submission, and detect specific launcher failures without matching stale history
- close failed launcher surfaces by stable UUID, mark agents terminal, and roll back newly-created worktrees
- keep launcher/model parity checks active in CI through a committed hermetic dispatch-contract fixture

## Verification

- `bun run typecheck`
- `bun run build`
- `bun run test` — 113 files passed; 2,597 tests passed; 1 intentional skip
- push hook `run_tests.sh` — passed
- branch-built MCP stdio probe — initialized and returned 43 tools including `spawn_agent`
- CodeRabbit local review — 0 findings after fixes
- real-cmux contract lane — safely skipped because only the production socket was pinned; no production override used

Closes #340.
Closes #348.
Closes #349.
Closes #381.

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019ff742","ts":"2026-08-12T19:05:10Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core MCP spawn_agent/new_split behavior including automatic surface close and worktree rollback on launcher failures; misclassification of shell state could close healthy tabs or roll back valid worktrees.
> 
> **Overview**
> **Hardens every MCP surface-creating spawn path** so failures stay diagnosable and partially created resources can be recovered instead of leaving orphaned tabs, worktrees, or opaque timeouts.
> 
> **Shared shell readiness** moves prompt detection into `shell-prompt.ts` (ASCII and Unicode terminators, strict vs loose matching) and uses it from the MCP server and app-server runtime. Readiness polling now treats a launcher that lands back on a shell with adjacent failure text as `LauncherReadinessError` with `last_10_lines`, and tightens pending-input detection so progress lines like `62%` are not mistaken for prompts.
> 
> **Created identity on errors** adds `CreatedIdentityScope` to record workspace/surface/agent IDs right after cmux creation and attach them to thrown errors without changing `instanceof` or `cause`; the shared `err()` formatter merges that metadata (including batched `spawn_in_workspace` agents) into structured tool failures.
> 
> **Launcher submit verification and cleanup** after Return, if readiness still fails and the screen still shows the launcher command at the prompt, the flow fails fast with terminal tail evidence. On launch-phase `AgentLaunchError` / `LauncherReadinessError`, `spawn_agent` closes the surface (stable UUID), marks the agent terminal when needed, and rolls back a newly created worktree/branch; generic timeouts still leave resources for manual recovery. `AgentLaunchError` gains `launch_phase`, standard `Error.cause`, and `on_surface_created` now includes `agent_id`.
> 
> **Tests and CI** add broad Vitest coverage for prompts, identity, rollback, and pending Return; model-policy drift tests use a committed `golem-dispatch-contract.zsh` fixture when the installed launcher is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b2ea0d4974c6e3c140d2ea133162d5624f1a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved launch readiness detection and reporting.
  - Added clearer diagnostics for launcher, terminal, timeout, and surface failures.
  - Preserved details about resources created before a failure.
  - Added support for recognizing common shell prompt formats.

- **Bug Fixes**
  - Failed launches now clean up incomplete resources safely.
  - Prevented unsafe retries when launcher commands remain pending.
  - Improved handling of failed worktree creation and closed agents.

- **Tests**
  - Expanded coverage for launch failures, cleanup, shell prompts, diagnostics, and launcher contracts.

- **Documentation**
  - Added an implementation plan for more reliable and diagnosable spawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden agent spawn failures with launcher diagnostics, rollback, and identity propagation
> - Adds `launcherFailureFromShell` in [`shell-prompt.ts`](https://github.com/EtanHey/cmuxlayer/pull/397/files#diff-8906643eb8e405dd1c0186c957d64fa4f4f05ac1fc7ce6e630b56a05224f8b94) to detect early launcher exit-to-shell errors (command not found, permission denied, etc.) and surface `last_10_lines` in error responses.
> - Introduces `CreatedIdentityScope` in [`created-identity.ts`](https://github.com/EtanHey/cmuxlayer/pull/397/files#diff-b0d1641c7670c4da08e5aec614dd0860d01238f429f4ee38fe72f422973d4847) to attach structured identity (agent, surface, workspace IDs) to thrown errors without altering `instanceof` or `cause`.
> - `spawn_agent` now closes failed launcher surfaces and rolls back newly created worktrees/branches when a `LauncherReadinessError` occurs during the launch phase.
> - Fixes false-positive prompt detection in `screenShowsPendingShellInput`: non-launcher contexts no longer treat arbitrary output ending in `%/#/$` as a shell prompt.
> - Consolidates shell-prompt matching into a shared [`shell-prompt.ts`](https://github.com/EtanHey/cmuxlayer/pull/397/files#diff-8906643eb8e405dd1c0186c957d64fa4f4f05ac1fc7ce6e630b56a05224f8b94) module, removing duplicate local implementations from [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/397/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [`app-server-runtime.ts`](https://github.com/EtanHey/cmuxlayer/pull/397/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9b2ea0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->