### PR TITLE
fix: preserve managed agent IDs across discovery churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "pre-pr:harness": "vitest run tests/live-agent-harness.test.ts tests/live-agent-harness-ci.test.ts tests/live-agent-harness-replay.test.ts tests/pre-pr-scripts.test.ts",
     "pre-pr:live": "bun run live:harness",
     "live:worker-placement": "tsx scripts/run-live-worker-placement-repro.ts",
+    "live:id-churn": "tsx scripts/run-live-id-churn-probe.ts",
     "install:fleet-sidebar": "node scripts/install-fleet-sidebar.mjs",
     "install:fleet-sidebar:dev": "node scripts/install-fleet-sidebar-dev.mjs",
     "bench:daemon": "node scripts/bench-daemon.mjs",

--- a/scripts/run-live-id-churn-probe.ts
+++ b/scripts/run-live-id-churn-probe.ts
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+type Payload = Record<string, any>;
+type SpawnedAgent = {
+  agent_id: string;
+  surface_id: string;
+  workspace_id: string;
+};
+
+const sleep = (ms: number) => new Promise((settle) => setTimeout(settle, ms));
+
+function stringEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function payload(result: Awaited<ReturnType<Client["callTool"]>>): Payload {
+  if (result.structuredContent && typeof result.structuredContent === "object") {
+    return result.structuredContent as Payload;
+  }
+  const text = result.content.find(
+    (item): item is Extract<typeof item, { type: "text" }> =>
+      item.type === "text",
+  )?.text;
+  if (!text) throw new Error("tool returned no structured or text payload");
+  try {
+    return JSON.parse(text) as Payload;
+  } catch {
+    return { ok: false, error: text };
+  }
+}
+
+async function connect(
+  entry: string,
+  caller?: { workspace: string; surface: string },
+): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: process.cwd(),
+    env: stringEnv({
+      ...process.env,
+      CMUXLAYER_DEV: "1",
+      CMUXLAYER_FORCE_INPROCESS: "1",
+      ...(caller
+        ? {
+            CMUX_WORKSPACE_ID: caller.workspace,
+            CMUX_SURFACE_ID: caller.surface,
+          }
+        : {}),
+    }),
+    stderr: "inherit",
+  });
+  const client = new Client({
+    name: "cmuxlayer-live-id-churn-probe",
+    version: "1",
+  });
+  await client.connect(transport);
+  return client;
+}
+
+async function rawCall(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+  timeout = 60_000,
+): Promise<Payload> {
+  return payload(
+    await client.callTool(
+      { name, arguments: args },
+      undefined,
+      { timeout },
+    ),
+  );
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+  timeout = 60_000,
+): Promise<Payload> {
+  const result = await rawCall(client, name, args, timeout);
+  if (result.ok !== true) {
+    throw new Error(`${name} failed: ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+function requireSpawn(result: Payload, label: string): SpawnedAgent {
+  const agentId = result.agent_id;
+  const surfaceId = result.surface_id;
+  const workspaceId = result.workspace_id;
+  if (
+    typeof agentId !== "string" ||
+    typeof surfaceId !== "string" ||
+    typeof workspaceId !== "string"
+  ) {
+    throw new Error(`${label} spawn returned no identity triple: ${JSON.stringify(result)}`);
+  }
+  return {
+    agent_id: agentId,
+    surface_id: surfaceId,
+    workspace_id: workspaceId,
+  };
+}
+
+function trackCreatedSurface(
+  result: Payload,
+  fallbackWorkspace: string,
+  surfaces: Map<string, string>,
+): void {
+  if (typeof result.surface_id !== "string") return;
+  surfaces.set(
+    result.surface_id,
+    typeof result.workspace_id === "string"
+      ? result.workspace_id
+      : fallbackWorkspace,
+  );
+}
+
+function readDurableState(agentId: string): Payload {
+  const statePath = join(
+    homedir(),
+    ".local",
+    "state",
+    "cmux-agents",
+    agentId,
+    "state.json",
+  );
+  return JSON.parse(readFileSync(statePath, "utf8")) as Payload;
+}
+
+function assertContinuity(
+  result: Payload,
+  expected: {
+    agentId: string;
+    sessionId: string;
+    parentAgentId: string;
+  },
+  phase: string,
+): void {
+  const record = result;
+  const failures = [
+    record.agent_id === expected.agentId
+      ? null
+      : `agent_id=${JSON.stringify(record.agent_id)}`,
+    record.cli_session_id === expected.sessionId
+      ? null
+      : `cli_session_id=${JSON.stringify(record.cli_session_id)}`,
+    record.parent_agent_id === expected.parentAgentId
+      ? null
+      : `parent_agent_id=${JSON.stringify(record.parent_agent_id)}`,
+  ].filter(Boolean);
+  if (failures.length > 0) {
+    throw new Error(`${phase} continuity failed: ${failures.join(", ")}`);
+  }
+  process.stdout.write(
+    `GREEN_CONTINUITY phase=${phase} agent=${expected.agentId} session=${expected.sessionId} parent=${expected.parentAgentId}\n`,
+  );
+}
+
+async function waitFor(
+  description: string,
+  probe: () => Promise<boolean>,
+  timeoutMs: number,
+): Promise<void> {
+  const started = Date.now();
+  let lastError = "";
+  while (Date.now() - started <= timeoutMs) {
+    try {
+      if (await probe()) return;
+      lastError = "";
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(1_000);
+  }
+  throw new Error(
+    `${description} timed out after ${timeoutMs}ms${lastError ? `: ${lastError}` : ""}`,
+  );
+}
+
+function addressResolved(result: Payload): boolean {
+  return (
+    result.ok === true &&
+    result.delivered !== false &&
+    !/Agent not found/i.test(String(result.error ?? ""))
+  );
+}
+
+async function main(): Promise<void> {
+  const entry = resolve(process.argv[2] ?? "dist/index.js");
+  if (!existsSync(entry)) throw new Error(`branch entry does not exist: ${entry}`);
+  if (!process.env.CMUX_SOCKET_PATH) {
+    throw new Error("CMUX_SOCKET_PATH must pin the real cmux instance");
+  }
+  const callerWorkspace = process.env.CMUX_WORKSPACE_ID;
+  if (!callerWorkspace) {
+    throw new Error("CMUX_WORKSPACE_ID is required; run from a cmux pane");
+  }
+
+  const surfaces = new Map<string, string>();
+  let client: Client | null = null;
+  try {
+    client = await connect(entry);
+    const parentResult = await rawCall(
+      client,
+      "spawn_agent",
+      {
+        repo: "cmuxlayer",
+        cli: "claude",
+        model: "opus",
+        role: "orchestrator",
+        placement: "left",
+        workspace: callerWorkspace,
+        force_new: true,
+        focus: false,
+        prompt:
+          "Issue #416 live acceptance parent fixture. Do not modify files and do not spawn agents. Wait for further instructions.",
+      },
+      120_000,
+    );
+    trackCreatedSurface(parentResult, callerWorkspace, surfaces);
+    if (parentResult.ok !== true) {
+      throw new Error(`spawn_agent failed: ${JSON.stringify(parentResult)}`);
+    }
+    const parent = requireSpawn(parentResult, "parent");
+    process.stdout.write(`spawned parent ${parent.agent_id} ${parent.surface_id}\n`);
+    await client.close();
+    client = null;
+
+    client = await connect(entry, {
+      workspace: parent.workspace_id,
+      surface: parent.surface_id,
+    });
+    const childResult = await rawCall(
+      client,
+      "spawn_agent",
+      {
+        repo: "cmuxlayer",
+        cli: "claude",
+        model: "opus",
+        role: "worker",
+        placement: "right",
+        workspace: parent.workspace_id,
+        force_new: true,
+        focus: false,
+        auto_revive: true,
+        parent_agent_id: parent.agent_id,
+        prompt:
+          "Issue #416 live acceptance fixture. Do not modify files and do not spawn agents. Immediately use AskUserQuestion with one question and two choices, then after the answer reply briefly and become idle.",
+      },
+      120_000,
+    );
+    trackCreatedSurface(childResult, parent.workspace_id, surfaces);
+    if (childResult.ok !== true) {
+      throw new Error(`spawn_agent failed: ${JSON.stringify(childResult)}`);
+    }
+    const child = requireSpawn(childResult, "child");
+    process.stdout.write(`spawned child ${child.agent_id} ${child.surface_id}\n`);
+
+    const initial = readDurableState(child.agent_id);
+    const sessionId = initial.cli_session_id;
+    if (typeof sessionId !== "string" || !sessionId) {
+      throw new Error(`child has no cli_session_id: ${JSON.stringify(initial)}`);
+    }
+    assertContinuity(initial, {
+      agentId: child.agent_id,
+      sessionId,
+      parentAgentId: parent.agent_id,
+    }, "spawn");
+
+    await waitFor(
+      "interactive overlay",
+      async () => {
+        const screen = await call(client!, "read_screen", {
+          surface: child.surface_id,
+          workspace: child.workspace_id,
+          lines: 80,
+        });
+        const parsed =
+          screen.parsed && typeof screen.parsed === "object"
+            ? screen.parsed
+            : screen;
+        return (
+          parsed.control_state === "interactive_overlay" ||
+          (Array.isArray(parsed.errors) &&
+            parsed.errors.includes("interactive_prompt"))
+        );
+      },
+      120_000,
+    );
+    process.stdout.write(`observed interactive_overlay ${child.agent_id}\n`);
+    assertContinuity(
+      readDurableState(child.agent_id),
+      { agentId: child.agent_id, sessionId, parentAgentId: parent.agent_id },
+      "overlay-frozen",
+    );
+
+    await call(client, "send_to", {
+      mode: "key",
+      surface: child.surface_id,
+      workspace: child.workspace_id,
+      key: "down",
+    });
+    await call(client, "send_to", {
+      mode: "key",
+      surface: child.surface_id,
+      workspace: child.workspace_id,
+      key: "return",
+    });
+    const afterOverlaySend = await rawCall(client, "send_to", {
+      mode: "agent",
+      agent_id: child.agent_id,
+      text: "Issue #416 addressability check after overlay; acknowledge briefly.",
+      allow_busy: true,
+    });
+    if (!addressResolved(afterOverlaySend)) {
+      throw new Error(
+        `original id failed after overlay: ${JSON.stringify(afterOverlaySend)}`,
+      );
+    }
+    process.stdout.write(`GREEN_ADDRESS phase=overlay agent=${child.agent_id}\n`);
+    assertContinuity(
+      readDurableState(child.agent_id),
+      { agentId: child.agent_id, sessionId, parentAgentId: parent.agent_id },
+      "overlay",
+    );
+
+    await waitFor(
+      "child idle after overlay",
+      async () => {
+        const record = readDurableState(child.agent_id);
+        return record.state === "idle" || record.state === "ready";
+      },
+      120_000,
+    );
+    process.stdout.write("waiting 35s across two idle sweep intervals\n");
+    await sleep(35_000);
+    const afterIdleSend = await rawCall(client, "send_to", {
+      mode: "agent",
+      agent_id: child.agent_id,
+      text: "Issue #416 addressability check after idle; acknowledge briefly.",
+      allow_busy: true,
+    });
+    if (!addressResolved(afterIdleSend)) {
+      throw new Error(`original id failed after idle: ${JSON.stringify(afterIdleSend)}`);
+    }
+    process.stdout.write(`GREEN_ADDRESS phase=idle agent=${child.agent_id}\n`);
+    assertContinuity(
+      readDurableState(child.agent_id),
+      { agentId: child.agent_id, sessionId, parentAgentId: parent.agent_id },
+      "idle",
+    );
+
+    await client.close();
+    client = null;
+    client = await connect(entry);
+    const afterRestartSend = await rawCall(client, "send_to", {
+      mode: "agent",
+      agent_id: child.agent_id,
+      text: "Issue #416 addressability check after cmuxlayer restart; acknowledge briefly.",
+      allow_busy: true,
+    });
+    if (!addressResolved(afterRestartSend)) {
+      throw new Error(
+        `original id failed after restart: ${JSON.stringify(afterRestartSend)}`,
+      );
+    }
+    process.stdout.write(`GREEN_ADDRESS phase=restart agent=${child.agent_id}\n`);
+    assertContinuity(
+      readDurableState(child.agent_id),
+      { agentId: child.agent_id, sessionId, parentAgentId: parent.agent_id },
+      "restart",
+    );
+
+    await call(client, "close_surface", {
+      surface: child.surface_id,
+      workspace: child.workspace_id,
+      force: true,
+    });
+    surfaces.delete(child.surface_id);
+    const deadSend = await rawCall(client, "send_to", {
+      mode: "agent",
+      agent_id: child.agent_id,
+      text: "This send must fail because the child surface is dead.",
+      allow_busy: true,
+    });
+    if (
+      deadSend.ok === true &&
+      deadSend.delivered !== false
+    ) {
+      throw new Error(`dead id falsely resolved: ${JSON.stringify(deadSend)}`);
+    }
+    process.stdout.write(
+      `GREEN_DEAD_NEGATIVE agent=${child.agent_id} receipt=${JSON.stringify(deadSend)}\n`,
+    );
+    process.stdout.write(`GREEN_ID_CHURN agent=${child.agent_id}\n`);
+  } finally {
+    let cleanupClient = client;
+    if (!cleanupClient && surfaces.size > 0) {
+      try {
+        cleanupClient = await connect(entry);
+      } catch {
+        // The exact surface refs remain in the failure output for manual cleanup.
+      }
+    }
+    if (cleanupClient) {
+      for (const [surface, workspace] of surfaces) {
+        try {
+          await rawCall(cleanupClient, "close_surface", {
+            surface,
+            workspace,
+            force: true,
+          });
+        } catch {
+          // Best-effort cleanup is scoped to exact surface refs created above.
+        }
+      }
+      await cleanupClient.close();
+    }
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `RED_ID_CHURN ${error instanceof Error ? error.stack : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -5,6 +5,7 @@ import type {
   CmuxSurface,
   ParsedControlPlaneState,
   ParsedScreenStatus,
+  SurfaceWorkingDirectorySource,
 } from "./types.js";
 import { inferRepoFromDirectory } from "./repo-workspace.js";
 
@@ -15,6 +16,7 @@ export interface DiscoveredAgent {
   surface_title: string;
   workspace_id?: string | null;
   current_directory?: string | null;
+  working_directory_source?: SurfaceWorkingDirectorySource;
   cli: CliType | "unknown";
   control_state: ParsedControlPlaneState;
   parsed_status: ParsedScreenStatus | null;
@@ -51,12 +53,19 @@ export function inferRepoFromTitle(title: string): string {
 }
 
 export function inferRepoFromDiscovery(
-  discovered: Pick<DiscoveredAgent, "current_directory" | "surface_title">,
+  discovered: Pick<
+    DiscoveredAgent,
+    "current_directory" | "working_directory_source" | "surface_title"
+  >,
 ): string {
+  const titleRepo = inferRepoFromTitle(discovered.surface_title);
+  const trustedCwd =
+    discovered.working_directory_source === "terminal_metadata" ||
+    discovered.working_directory_source === "surface";
   const cwd = discovered.current_directory?.trim();
-  return cwd
-    ? inferRepoFromDirectory(cwd)
-    : inferRepoFromTitle(discovered.surface_title);
+  return trustedCwd && cwd
+    ? inferRepoFromDirectory(cwd, titleRepo)
+    : titleRepo;
 }
 
 export function discoveredStatusToAgentState(
@@ -135,6 +144,7 @@ export class AgentDiscovery {
           surface.working_directory ??
           surface.requested_working_directory ??
           null,
+        working_directory_source: surface.working_directory_source,
         cli,
         control_state: parsed.control_state,
         parsed_status: parsed.status,
@@ -161,6 +171,7 @@ export class AgentDiscovery {
           surface.working_directory ??
           surface.requested_working_directory ??
           null,
+        working_directory_source: surface.working_directory_source,
         cli: "unknown",
         control_state: "unknown",
         parsed_status: null,

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -6,6 +6,7 @@ import type {
   ParsedControlPlaneState,
   ParsedScreenStatus,
 } from "./types.js";
+import { inferRepoFromDirectory } from "./repo-workspace.js";
 
 export interface DiscoveredAgent {
   surface_id: string;
@@ -13,6 +14,7 @@ export interface DiscoveredAgent {
   surface_uuid?: string | null;
   surface_title: string;
   workspace_id?: string | null;
+  current_directory?: string | null;
   cli: CliType | "unknown";
   control_state: ParsedControlPlaneState;
   parsed_status: ParsedScreenStatus | null;
@@ -46,6 +48,15 @@ export function inferRepoFromTitle(title: string): string {
   const stripped = stripKnownAgentSuffixes(title);
   if (!stripped) return "";
   return stripped.replace(/^[A-Z]/, (match) => match.toLowerCase());
+}
+
+export function inferRepoFromDiscovery(
+  discovered: Pick<DiscoveredAgent, "current_directory" | "surface_title">,
+): string {
+  const cwd = discovered.current_directory?.trim();
+  return cwd
+    ? inferRepoFromDirectory(cwd)
+    : inferRepoFromTitle(discovered.surface_title);
 }
 
 export function discoveredStatusToAgentState(
@@ -118,6 +129,12 @@ export class AgentDiscovery {
         surface_uuid: surface.id ?? null,
         surface_title: surface.title,
         workspace_id: workspaceId,
+        current_directory:
+          surface.current_directory ??
+          surface.cwd ??
+          surface.working_directory ??
+          surface.requested_working_directory ??
+          null,
         cli,
         control_state: parsed.control_state,
         parsed_status: parsed.status,
@@ -138,6 +155,12 @@ export class AgentDiscovery {
         surface_uuid: surface.id ?? null,
         surface_title: surface.title,
         workspace_id: workspaceId,
+        current_directory:
+          surface.current_directory ??
+          surface.cwd ??
+          surface.working_directory ??
+          surface.requested_working_directory ??
+          null,
         cli: "unknown",
         control_state: "unknown",
         parsed_status: null,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5342,13 +5342,31 @@ export class AgentEngine {
         newlySurfacelessAgentIds.add(finalized.agent_id);
       }
     }
-    this.enableStartupPurge({ retainAgentIds: newlySurfacelessAgentIds });
     const discovered = await discovery.scan(true);
     await this.registry.listMerged(discovery, {
       force: true,
       discovered,
       nonDestructive: true,
     });
+    for (const record of this.registry.list()) {
+      if (record.agent_id.startsWith("auto-")) continue;
+      const persistedUuid = record.surface_uuid?.trim().toLowerCase() ?? null;
+      const liveManagedSurface = discovered.some((entry) => {
+        if (!entry.has_agent || entry.read_error) return false;
+        const observedUuid = entry.surface_uuid?.trim().toLowerCase() ?? null;
+        const sameSurface = Boolean(
+          persistedUuid && observedUuid === persistedUuid,
+        );
+        return (
+          sameSurface &&
+          this.registry.canUseObservedBinding(record, entry.surface_uuid)
+        );
+      });
+      if (liveManagedSurface) {
+        newlySurfacelessAgentIds.add(record.agent_id);
+      }
+    }
+    this.enableStartupPurge({ retainAgentIds: newlySurfacelessAgentIds });
     // Missing legacy provenance is intentionally equivalent to "unknown".
     // Do not rewrite those records at boot: changing updated_at would distort
     // lifecycle age and ghost-eviction evidence.

--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -77,6 +77,7 @@ export function toObservedPublicAgent(
   return {
     agent_id: record.agent_id,
     repo: record.repo,
+    surface_provenance: record.surface_provenance ?? "unknown",
     model: observed(
       model,
       hasScreenModelObservation ? "screen" : "registry",

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -35,6 +35,7 @@ import {
 } from "./seat-identity.js";
 import { validateSurfaceIdentityBijection } from "./surface-topology.js";
 import { deriveCmuxObserverOwnerId } from "./cmux-observer-identity.js";
+import { inferRepoFromDirectory } from "./repo-workspace.js";
 
 export type SurfaceProvider = () => Promise<CmuxSurface[]>;
 
@@ -277,7 +278,9 @@ function inferRepairLauncher(
   if (titleLauncher) return titleLauncher;
 
   if (discovered.cli === "unknown") return null;
-  const repo = repairRepoFromTitle(discovered.surface_title);
+  const repo = discovered.current_directory?.trim()
+    ? inferRepoFromDirectory(discovered.current_directory)
+    : repairRepoFromTitle(discovered.surface_title);
   const suffix = suffixForCli(discovered.cli);
   if (!repo || !suffix) return null;
   return {
@@ -399,7 +402,10 @@ function patchForRepairCandidate(
     seat_role: candidate.seat.seat_role,
     seat_identity_status: candidate.seat.seat_identity_status,
     seat_identity_error: candidate.seat.seat_identity_error,
-    role: candidate.role,
+    role:
+      record.surface_provenance === "cmuxlayer_spawn" && record.role
+        ? record.role
+        : candidate.role,
   };
 
   for (const [key, value] of Object.entries(fields) as Array<
@@ -1083,18 +1089,33 @@ export class AgentRegistry {
         if (!liveRecord) {
           continue;
         }
+        const exactStableBinding = Boolean(
+          recordUuid &&
+            surfaceUuidKey(discoveredEntry.surface_uuid) === recordUuid,
+        );
+        if (
+          exactStableBinding &&
+          TERMINAL_STATES.has(liveRecord.state) &&
+          discoveredEntry.has_agent &&
+          discoveredEntry.control_state !== "shell"
+        ) {
+          liveRecord = this.syncManagedRecordLifecycleFromDiscovery(
+            liveRecord,
+            discoveredEntry,
+          );
+        }
       }
 
-      const discoveredReplacesStaleManagedRecord =
+      const discoveredReplacesUnprovenTerminalRecord =
         opts?.nonDestructive === true &&
         !isAutoRecord &&
         TERMINAL_STATES.has(record.state) &&
         discoveredEntry?.has_agent === true &&
-        discoveredEntry.read_error === false;
-      if (!discoveredReplacesStaleManagedRecord) {
-        if (discoveredEntry) {
-          seenSurfaces.add(discoveredEntry.surface_id);
-        }
+        discoveredEntry.read_error === false &&
+        (!recordUuid ||
+          surfaceUuidKey(discoveredEntry.surface_uuid) !== recordUuid);
+      if (discoveredEntry && !discoveredReplacesUnprovenTerminalRecord) {
+        seenSurfaces.add(discoveredEntry.surface_id);
       }
       merged.push({
         ...liveRecord,
@@ -1860,7 +1881,10 @@ export class AgentRegistry {
 
   repairFromDiscovery(
     discovered: DiscoveredAgent[],
-    opts?: { seatRegistry?: SeatRegistry | null },
+    opts?: {
+      seatRegistry?: SeatRegistry | null;
+      orphansOnly?: boolean;
+    },
   ): RegistryRepairSummary {
     if (
       !hasBijectiveDiscoveryIdentity(discovered) ||
@@ -1882,6 +1906,19 @@ export class AgentRegistry {
 
     for (const entry of discovered) {
       if (entry.read_error) continue;
+      if (opts?.orphansOnly) {
+        const surfaceRecords = [...this.agents.values()].filter(
+          (record) => record.surface_id === entry.surface_id,
+        );
+        const needsRepair =
+          surfaceRecords.length === 0 ||
+          surfaceRecords.some(
+            (record) =>
+              isAutoAgentId(record.agent_id) ||
+              isPendingAgentId(record.agent_id),
+          );
+        if (!needsRepair) continue;
+      }
       const candidate = this.repairCandidateForDiscovery(
         entry,
         opts?.seatRegistry,
@@ -1989,6 +2026,21 @@ export class AgentRegistry {
     );
 
     if (managedRecord) {
+      for (const duplicate of recordsForSurface) {
+        if (
+          !isAutoAgentId(duplicate.agent_id) ||
+          hasSurfaceUuidConflict(duplicate, discovered) ||
+          !this.canUseObservedBinding(duplicate, discovered.surface_uuid)
+        ) {
+          continue;
+        }
+        // This is positive identity evidence, not an absence inference: both
+        // rows carry the exact stable UUID observed on the live surface.
+        const removedAgentId = this.evictExplicit(duplicate.agent_id);
+        if (removedAgentId) {
+          evicted.add(removedAgentId);
+        }
+      }
       const updated = this.updateManagedSurfaceRegistration(
         managedRecord,
         discovered,
@@ -2007,12 +2059,21 @@ export class AgentRegistry {
     );
 
     for (const record of recordsForSurface) {
+      const isObservedAutoDuplicate =
+        isAutoAgentId(record.agent_id) &&
+        !hasSurfaceUuidConflict(record, discovered) &&
+        (this.canUseObservedBinding(record, discovered.surface_uuid) ||
+          (surfaceUuidKey(record.surface_uuid) === null &&
+            record.surface_id === discovered.surface_id &&
+            this.canMutateForObservedAbsence(record)));
       if (
-        isAutoAgentId(record.agent_id) ||
+        isObservedAutoDuplicate ||
         (isPendingAgentId(record.agent_id) &&
           !seatIsManagedOnAnotherLiveSurface)
       ) {
-        const removedAgentId = this.evict(record.agent_id);
+        const removedAgentId = isObservedAutoDuplicate
+          ? this.evictExplicit(record.agent_id)
+          : this.evict(record.agent_id);
         if (removedAgentId) {
           evicted.add(removedAgentId);
         }
@@ -2043,7 +2104,14 @@ export class AgentRegistry {
         : this.repairEntry(existingSeatRecord, discovered, candidate, "updated");
     }
 
-    const created = this.createRepairedRecord(discovered, candidate);
+    const continuityRecord = recordsForSurface.find((record) =>
+      isAutoAgentId(record.agent_id),
+    );
+    const created = this.createRepairedRecord(
+      discovered,
+      candidate,
+      continuityRecord,
+    );
     this.stateMgr.writeState(created);
     this.agents.set(created.agent_id, created);
     return this.repairEntry(created, discovered, candidate, "created");
@@ -2087,9 +2155,15 @@ export class AgentRegistry {
   private createRepairedRecord(
     discovered: DiscoveredAgent,
     candidate: RegistryRepairCandidate,
+    continuityRecord?: AgentRecord,
   ): AgentRecord {
     const now = new Date().toISOString();
     const state = discoveredStatusToAgentState(discovered.parsed_status);
+    const hasManagedContinuity = Boolean(
+      continuityRecord?.cli_session_id ||
+        continuityRecord?.parent_agent_id ||
+        continuityRecord?.surface_provenance === "cmuxlayer_spawn",
+    );
     return {
       agent_id: candidate.agentId,
       surface_id: discovered.surface_id,
@@ -2100,15 +2174,18 @@ export class AgentRegistry {
       repo: candidate.repo,
       model: discovered.model ?? "unknown",
       cli: candidate.cli,
-      cli_session_id: null,
-      cli_session_path: null,
+      cli_session_id: continuityRecord?.cli_session_id ?? null,
+      cli_session_path: continuityRecord?.cli_session_path ?? null,
+      surface_provenance:
+        continuityRecord?.surface_provenance ?? "unknown",
       launcher_name: candidate.launcherName,
       seat_id: candidate.seat.seat_id,
       seat_lane: candidate.seat.seat_lane,
       seat_role: candidate.seat.seat_role,
       seat_identity_status: candidate.seat.seat_identity_status,
       seat_identity_error: candidate.seat.seat_identity_error,
-      task_summary: "(resync-repaired)",
+      task_summary:
+        continuityRecord?.task_summary ?? "(resync-repaired)",
       pid: null,
       version: 1,
       created_at: now,
@@ -2117,17 +2194,24 @@ export class AgentRegistry {
         state === "error"
           ? "Repaired agent surface reported a frozen state"
           : null,
-      parent_agent_id: null,
-      spawn_depth: 0,
-      role: candidate.role,
-      auto_archive_on_done: false,
+      parent_agent_id: continuityRecord?.parent_agent_id ?? null,
+      spawn_depth: continuityRecord?.spawn_depth ?? 0,
+      role:
+        hasManagedContinuity && continuityRecord?.role
+          ? continuityRecord.role
+          : candidate.role,
+      authority: continuityRecord?.authority,
+      function: continuityRecord?.function,
+      placement: continuityRecord?.placement,
+      auto_archive_on_done:
+        continuityRecord?.auto_archive_on_done ?? false,
       deletion_intent: false,
       quality: "unknown",
       max_cost_per_agent: null,
       crash_recover: candidate.role === "orchestrator",
       respawn_attempts: 0,
       user_killed: false,
-      auto_revive: false,
+      auto_revive: continuityRecord?.auto_revive ?? false,
       revive_attempts: 0,
       revive_last_attempt_at: null,
       revive_next_attempt_at: null,
@@ -2139,7 +2223,7 @@ export class AgentRegistry {
       revive_previous_state: null,
       revive_consecutive_observations: 0,
       revive_notification_sent_at: null,
-      halt_escalation: true,
+      halt_escalation: continuityRecord?.halt_escalation ?? true,
       halt_episode_type: null,
       halt_episode_started_at: null,
       halt_episode_observations: 0,

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -278,8 +278,14 @@ function inferRepairLauncher(
   if (titleLauncher) return titleLauncher;
 
   if (discovered.cli === "unknown") return null;
-  const repo = discovered.current_directory?.trim()
-    ? inferRepoFromDirectory(discovered.current_directory)
+  const trustedCwd =
+    discovered.working_directory_source === "terminal_metadata" ||
+    discovered.working_directory_source === "surface";
+  const repo = trustedCwd && discovered.current_directory?.trim()
+    ? inferRepoFromDirectory(
+        discovered.current_directory,
+        repairRepoFromTitle(discovered.surface_title),
+      )
     : repairRepoFromTitle(discovered.surface_title);
   const suffix = suffixForCli(discovered.cli);
   if (!repo || !suffix) return null;
@@ -1096,8 +1102,12 @@ export class AgentRegistry {
         if (
           exactStableBinding &&
           TERMINAL_STATES.has(liveRecord.state) &&
+          liveRecord.state !== "done" &&
+          liveRecord.user_killed !== true &&
           discoveredEntry.has_agent &&
-          discoveredEntry.control_state !== "shell"
+          discoveredEntry.control_state !== "shell" &&
+          discoveredEntry.control_state !== "dead" &&
+          discoveredEntry.control_state !== "stale_surface"
         ) {
           liveRecord = this.syncManagedRecordLifecycleFromDiscovery(
             liveRecord,
@@ -2185,10 +2195,12 @@ export class AgentRegistry {
       seat_identity_status: candidate.seat.seat_identity_status,
       seat_identity_error: candidate.seat.seat_identity_error,
       task_summary:
-        continuityRecord?.task_summary ?? "(resync-repaired)",
+        continuityRecord?.task_summary === "(auto-discovered)"
+          ? "(resync-repaired)"
+          : (continuityRecord?.task_summary ?? "(resync-repaired)"),
       pid: null,
       version: 1,
-      created_at: now,
+      created_at: continuityRecord?.created_at ?? now,
       updated_at: now,
       error:
         state === "error"
@@ -2223,7 +2235,9 @@ export class AgentRegistry {
       revive_previous_state: null,
       revive_consecutive_observations: 0,
       revive_notification_sent_at: null,
-      halt_escalation: continuityRecord?.halt_escalation ?? true,
+      halt_escalation:
+        continuityRecord?.parent_agent_id != null &&
+        (continuityRecord.halt_escalation ?? true),
       halt_episode_type: null,
       halt_episode_started_at: null,
       halt_episode_observations: 0,

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -165,6 +165,7 @@ export interface PublicAgent {
 export interface ObservedPublicAgent {
   agent_id: string;
   repo: string;
+  surface_provenance: SurfaceProvenance;
   model: Observed<string | null>;
   state: Observed<AgentState | null>;
   session_id: Observed<string | null>;

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
 export function pathBaseName(path: string): string {
   const normalized = path.trim().replace(/\/+$/, "");
   const index = normalized.lastIndexOf("/");
@@ -40,8 +43,48 @@ function repoIdentityToken(input: string): string {
   return baseName;
 }
 
+function nearestGitRoot(path: string): string | null {
+  let cursor = resolve(path);
+  while (true) {
+    if (existsSync(join(cursor, ".git"))) return cursor;
+    const parent = dirname(cursor);
+    if (parent === cursor) return null;
+    cursor = parent;
+  }
+}
+
+function pathContainsRepoToken(path: string, repo: string): boolean {
+  return path
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => tokenMatchesRepo(segment, repo));
+}
+
+function worktreeRepoToken(path: string): string | null {
+  const segments = path.split("/").filter(Boolean);
+  const worktreesIndex = segments.findIndex(
+    (segment) => segment.toLowerCase() === ".worktrees",
+  );
+  if (worktreesIndex > 0) return segments[worktreesIndex - 1] ?? null;
+  const dotWtSegment = segments.find((segment) =>
+    segment.toLowerCase().endsWith(".wt"),
+  );
+  return dotWtSegment ? dotWtSegment.slice(0, -3) : null;
+}
+
 /** Derive a repository identity from a repo root or supported worktree path. */
-export function inferRepoFromDirectory(path: string): string {
+export function inferRepoFromDirectory(
+  path: string,
+  expectedRepo?: string,
+): string {
+  const gitRoot = nearestGitRoot(path);
+  if (gitRoot) return repoIdentityToken(gitRoot);
+  if (expectedRepo) {
+    if (pathContainsRepoToken(path, expectedRepo)) {
+      return repoIdentityToken(expectedRepo);
+    }
+    return worktreeRepoToken(path) ?? repoIdentityToken(expectedRepo);
+  }
   return repoIdentityToken(path);
 }
 

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -40,6 +40,11 @@ function repoIdentityToken(input: string): string {
   return baseName;
 }
 
+/** Derive a repository identity from a repo root or supported worktree path. */
+export function inferRepoFromDirectory(path: string): string {
+  return repoIdentityToken(path);
+}
+
 function tokenMatchesRepo(token: string, repo: string): boolean {
   const normalizedRepo = repoIdentityToken(repo).toLowerCase();
   const normalizedRepoNoHyphen = normalizedRepo.replace(/-/g, "");

--- a/src/server.ts
+++ b/src/server.ts
@@ -12753,13 +12753,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             discovery.invalidate();
             const discovered = await discovery.scan(true);
             const observedAtMs = Date.now();
-            if (
-              registry
-                .list()
-                .some((record) => record.agent_id.includes("-pending-"))
-            ) {
-              registry.repairFromDiscovery(discovered, { seatRegistry });
-            }
+            registry.repairFromDiscovery(discovered, {
+              seatRegistry,
+              orphansOnly: true,
+            });
             const merged = await registry.listMerged(discovery, {
               filter,
               force: true,

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -25,7 +25,7 @@ import {
 } from "./agent-types.js";
 import {
   discoveredStatusToAgentState,
-  inferRepoFromTitle,
+  inferRepoFromDiscovery,
   type DiscoveredAgent,
 } from "./agent-discovery.js";
 
@@ -642,7 +642,7 @@ export class StateManager {
       surface_provenance: "unknown",
       workspace_id: discovered.workspace_id ?? null,
       state: discoveredStatusToAgentState(discovered.parsed_status),
-      repo: inferRepoFromTitle(discovered.surface_title),
+      repo: inferRepoFromDiscovery(discovered),
       model: discovered.model ?? "unknown",
       cli: discovered.cli === "unknown" ? "claude" : discovered.cli,
       cli_session_id: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,13 @@ export interface CmuxWorkspace {
   current_directory?: string | null;
 }
 
+export type SurfaceWorkingDirectorySource =
+  | "terminal_metadata"
+  | "surface"
+  | "pane"
+  | "workspace_fallback"
+  | "unavailable";
+
 export interface CmuxSurface {
   id?: string;
   ref: string;
@@ -32,6 +39,8 @@ export interface CmuxSurface {
   cwd?: string | null;
   working_directory?: string | null;
   requested_working_directory?: string | null;
+  working_directory_source?: SurfaceWorkingDirectorySource;
+  working_directory_fallback?: boolean;
 }
 
 export interface CmuxPane {

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
-import { AgentDiscovery } from "../src/agent-discovery.js";
+import {
+  AgentDiscovery,
+  inferRepoFromDiscovery,
+} from "../src/agent-discovery.js";
 
 const deadCodexShellFixture = JSON.parse(
   readFileSync(
@@ -13,6 +16,62 @@ const deadCodexShellFixture = JSON.parse(
 ) as { lines_80: string };
 
 describe("AgentDiscovery", () => {
+  it("derives a repo root instead of a nested cwd basename", () => {
+    expect(
+      inferRepoFromDiscovery({
+        current_directory: "/Users/example/Gits/cmuxlayer/src",
+        working_directory_source: "surface",
+        surface_title: "cmuxlayerClaude",
+      }),
+    ).toBe("cmuxlayer");
+  });
+
+  it("ignores workspace fallback cwd when the title carries repo identity", () => {
+    expect(
+      inferRepoFromDiscovery({
+        current_directory: "/Users/example/Gits/unrelated-workspace",
+        working_directory_source: "workspace_fallback",
+        surface_title: "cmuxlayerClaude",
+      }),
+    ).toBe("cmuxlayer");
+  });
+
+  it("falls back to title when a trusted cwd has no recognizable repo root", () => {
+    expect(
+      inferRepoFromDiscovery({
+        current_directory: "/Users/example/scratch/misc",
+        working_directory_source: "surface",
+        surface_title: "cmuxlayerClaude",
+      }),
+    ).toBe("cmuxlayer");
+  });
+
+  it("retains the working-directory evidence source in discovery", async () => {
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => [
+        {
+          ref: "surface:cwd-source",
+          title: "cmuxlayerCodex",
+          type: "terminal",
+          index: 0,
+          selected: true,
+          current_directory: "/Users/example/Gits/cmuxlayer/src",
+          working_directory_source: "terminal_metadata",
+        },
+      ],
+      readScreen: async (surface) => ({
+        surface,
+        text: "codex> ",
+        lines: 1,
+        scrollback_used: false,
+      }),
+    });
+
+    await expect(discovery.scan(true)).resolves.toMatchObject([
+      { working_directory_source: "terminal_metadata" },
+    ]);
+  });
+
   it("keeps dead Codex identity while exposing the active shell control state", async () => {
     const discovery = new AgentDiscovery({
       listSurfaces: async () => [

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -51,6 +51,15 @@ describe("agent facade projections", () => {
     });
   });
 
+  it("exposes whether a listed agent was spawned or adopted", () => {
+    const projected = toObservedPublicAgent(
+      makeRecord({ surface_provenance: "cmuxlayer_spawn" }),
+      { derivedAtMs: 2_000 },
+    );
+
+    expect(projected.surface_provenance).toBe("cmuxlayer_spawn");
+  });
+
   it("projects a PublicAgent without leaking surface topology", () => {
     const projected = toPublicAgent(makeRecord());
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -2257,6 +2257,7 @@ describe("AgentRegistry", () => {
           id: "11111111-2222-4333-8444-555555555555",
           current_directory:
             "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+          working_directory_source: "surface",
         },
       ]);
       await registry.reconstitute();
@@ -2269,6 +2270,7 @@ describe("AgentRegistry", () => {
             surface_title: "zsh",
             current_directory:
               "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+            working_directory_source: "surface",
             cli: "claude",
           }),
         ],
@@ -2294,6 +2296,136 @@ describe("AgentRegistry", () => {
         role: "worker",
         auto_revive: true,
         halt_escalation: true,
+      });
+    });
+
+    it("does not resurrect completed, killed, dead, or stale managed records", async () => {
+      const cases = [
+        {
+          name: "completed",
+          state: "done" as const,
+          error: null,
+          user_killed: false,
+          control_state: "ready" as const,
+          parsed_status: "idle" as const,
+        },
+        {
+          name: "killed",
+          state: "error" as const,
+          error: "Killed by user",
+          user_killed: true,
+          control_state: "ready" as const,
+          parsed_status: "working" as const,
+        },
+        {
+          name: "dead",
+          state: "error" as const,
+          error: "agent crashed",
+          user_killed: false,
+          control_state: "dead" as const,
+          parsed_status: "idle" as const,
+        },
+        {
+          name: "stale",
+          state: "error" as const,
+          error: "stale surface",
+          user_killed: false,
+          control_state: "stale_surface" as const,
+          parsed_status: "idle" as const,
+        },
+      ];
+      const discoveries: DiscoveredAgent[] = [];
+      const surfaces: CmuxSurface[] = [];
+
+      for (const [index, testCase] of cases.entries()) {
+        const surfaceId = `surface:terminal-${testCase.name}`;
+        const surfaceUuid = `42100000-0000-4000-8000-00000000000${index}`;
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `cmuxlayerClaude-${testCase.name}`,
+            surface_id: surfaceId,
+            surface_uuid: surfaceUuid,
+            state: testCase.state,
+            error: testCase.error,
+            user_killed: testCase.user_killed,
+            task_done_detected_at:
+              testCase.state === "done"
+                ? "2026-08-14T18:00:00.000Z"
+                : undefined,
+          }),
+        );
+        surfaces.push({ ...makeSurface(surfaceId), id: surfaceUuid });
+        discoveries.push(
+          makeDiscovered({
+            surface_id: surfaceId,
+            surface_uuid: surfaceUuid,
+            control_state: testCase.control_state,
+            parsed_status: testCase.parsed_status,
+          }),
+        );
+      }
+
+      const registry = new AgentRegistry(stateMgr, async () => surfaces);
+      await registry.reconstitute();
+      await registry.listMerged(
+        {
+          scan: vi.fn().mockResolvedValue(discoveries),
+        } as unknown as AgentDiscovery,
+        { force: true },
+      );
+
+      for (const testCase of cases) {
+        expect(
+          stateMgr.readState(`cmuxlayerClaude-${testCase.name}`),
+        ).toMatchObject({
+          state: testCase.state,
+          error: testCase.error,
+          user_killed: testCase.user_killed,
+        });
+      }
+    });
+
+    it("repairs auto-discovery metadata without resetting lifecycle age", async () => {
+      const autoId = "auto-claude-42111111-2222-4333-8444-555555555555";
+      const createdAt = "2026-08-14T09:00:00.000Z";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: autoId,
+          surface_id: "surface:repair-metadata",
+          surface_uuid: "42111111-2222-4333-8444-555555555555",
+          repo: "cmuxlayer",
+          cli: "claude",
+          task_summary: "(auto-discovered)",
+          created_at: createdAt,
+          parent_agent_id: null,
+          halt_escalation: true,
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        {
+          ...makeSurface("surface:repair-metadata"),
+          id: "42111111-2222-4333-8444-555555555555",
+        },
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:repair-metadata",
+            surface_uuid: "42111111-2222-4333-8444-555555555555",
+            surface_title: "cmuxlayerClaude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+      const repaired = stateMgr.readState(result.repaired[0]!.agent_id);
+
+      expect(repaired).toMatchObject({
+        task_summary: "(resync-repaired)",
+        created_at: createdAt,
+        parent_agent_id: null,
+        halt_escalation: false,
       });
     });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -2230,6 +2230,138 @@ describe("AgentRegistry", () => {
       });
     });
 
+    it("repairs an orphan from its cwd without dropping managed lineage metadata", async () => {
+      const autoId = "auto-claude-11111111-2222-4333-8444-555555555555";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: autoId,
+          surface_id: "surface:416",
+          surface_uuid: "11111111-2222-4333-8444-555555555555",
+          workspace_id: "workspace:cmuxlayer",
+          repo: "zsh",
+          cli: "claude",
+          cli_session_id: "managed-session-416",
+          cli_session_path: "/durable/claude/managed-session-416.jsonl",
+          task_summary: "Fix stable agent identity",
+          parent_agent_id: "cmuxlayerCodex-parent",
+          spawn_depth: 2,
+          role: "worker",
+          auto_revive: true,
+          halt_escalation: true,
+        }),
+      );
+
+      const registry = new AgentRegistry(stateMgr, async () => [
+        {
+          ...makeSurface("surface:416"),
+          id: "11111111-2222-4333-8444-555555555555",
+          current_directory:
+            "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+        },
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:416",
+            surface_uuid: "11111111-2222-4333-8444-555555555555",
+            surface_title: "zsh",
+            current_directory:
+              "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.repaired).toEqual([
+        expect.objectContaining({
+          agent_id: "cmuxlayerLead",
+          repo: "cmuxlayer",
+          action: "created",
+        }),
+      ]);
+      expect(result.evicted).toEqual([autoId]);
+      expect(stateMgr.readState("cmuxlayerLead")).toMatchObject({
+        agent_id: "cmuxlayerLead",
+        repo: "cmuxlayer",
+        cli_session_id: "managed-session-416",
+        cli_session_path: "/durable/claude/managed-session-416.jsonl",
+        task_summary: "Fix stable agent identity",
+        parent_agent_id: "cmuxlayerCodex-parent",
+        spawn_depth: 2,
+        role: "worker",
+        auto_revive: true,
+        halt_escalation: true,
+      });
+    });
+
+    it("removes an auto duplicate when the same live surface still has its managed id", async () => {
+      const surfaceUuid = "21111111-2222-4333-8444-555555555555";
+      const managedId = "cmuxlayerClaude-managed";
+      const autoId = `auto-claude-${surfaceUuid}`;
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: managedId,
+          surface_id: "surface:duplicate",
+          surface_uuid: surfaceUuid,
+          repo: "cmuxlayer",
+          cli: "claude",
+          launcher_name: "cmuxlayerClaude",
+          surface_provenance: "cmuxlayer_spawn",
+          state: "working",
+          cli_session_id: "managed-session",
+          parent_agent_id: "cmuxlayerCodex-parent",
+          role: "worker",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: autoId,
+          surface_id: "surface:duplicate",
+          surface_uuid: surfaceUuid,
+          repo: "cmuxlayerClaude [surface:duplicate]",
+          cli: "claude",
+          state: "working",
+          cli_session_id: null,
+          parent_agent_id: null,
+          role: "orchestrator",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        { ...makeSurface("surface:duplicate"), id: surfaceUuid },
+      ]);
+      await registry.reconstitute();
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:duplicate",
+            surface_uuid: surfaceUuid,
+            surface_title: "cmuxlayerClaude",
+            cli: "claude",
+          }),
+        ],
+        { seatRegistry: REPAIR_SEATS },
+      );
+
+      expect(result.evicted).toEqual([autoId]);
+      expect(stateMgr.readState(autoId)).toBeNull();
+      expect(stateMgr.readState(managedId)).toMatchObject({
+        agent_id: managedId,
+        cli_session_id: "managed-session",
+        parent_agent_id: "cmuxlayerCodex-parent",
+        role: "worker",
+      });
+      expect(
+        registry
+          .list()
+          .filter((record) => record.surface_uuid === surfaceUuid)
+          .map((record) => record.agent_id),
+      ).toEqual([managedId]);
+    });
+
     it("keeps duplicate launcher-title surfaces on one canonical repaired registration", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2206,7 +2206,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          agent_id: "auto-codex-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+          agent_id: "cmuxlayerCodex",
         }),
       ]),
     );
@@ -6122,7 +6122,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.agents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          agent_id: `auto-codex-${secondUuid}`,
+          agent_id: "cmuxlayerCodex",
         }),
       ]),
     );
@@ -6133,6 +6133,33 @@ describe("agent lifecycle tool handlers", () => {
     const list = registeredTestTool(server, "list_agents") as any;
 
     expect(list.annotations?.readOnlyHint).toBe(false);
+  });
+
+  it("list_agents repairs discovered orphans even when no pending registration exists", async () => {
+    const stableUuid = "42111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:managed",
+        id: stableUuid,
+        workspace_ref: "workspace:1",
+        title: "cmuxlayerCodex",
+      },
+    ]);
+    routeClient.setScreenText("OpenAI Codex\nModel: gpt-5.6-sol\n\ncodex> ");
+    const record = makeServerAgentRecord({
+      agent_id: "managed-stable-sibling",
+      surface_id: "surface:managed",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+    const registry = testLifecycleEngine(server).getRegistry();
+    const repair = vi.spyOn(registry, "repairFromDiscovery");
+
+    await registeredTestTool(server, "list_agents").handler({}, {});
+
+    expect(repair).toHaveBeenCalledTimes(1);
   });
 
   it("list_agents publishes a tracked ready agent fallen back to shell as an unhealthy error", async () => {
@@ -6326,7 +6353,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.skipped_agents).toBeUndefined();
   });
 
-  it("send_to keeps registry repo ownership when a title contains a surface suffix", async () => {
+  it("send_to keeps repaired registry repo ownership when a title contains a surface suffix", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([
       {
@@ -6354,16 +6381,25 @@ describe("agent lifecycle tool handlers", () => {
       {},
       {} as any,
     );
-    expect(parseToolResult(listResult)).toMatchObject({
+    const listed = parseToolResult(listResult) as {
+      ok: boolean;
+      agents: Array<{ agent_id: string; repo: string }>;
+    };
+    expect(listed).toMatchObject({
       ok: true,
-      agents: [expect.objectContaining({ repo: "brainlayer" })],
+      agents: [
+        expect.objectContaining({
+          agent_id: "brainClaude",
+          repo: "brainlayer",
+        }),
+      ],
     });
     routeClient.client.send.mockClear();
     routeClient.sendCalls.length = 0;
 
     const result = await registeredTestTool(server, "send_to").handler(
       {
-        agent_id: record.agent_id,
+        agent_id: "brainClaude",
         text: "keep going",
         press_enter: false,
       },
@@ -6374,7 +6410,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(routeClient.sendCalls).toEqual([
       { surface: "surface:199", text: "keep going" },
     ]);
-    expect(testLifecycleEngine(server).getAgentState(record.agent_id)?.repo).toBe(
+    expect(testLifecycleEngine(server).getAgentState("brainClaude")?.repo).toBe(
       "brainlayer",
     );
   });

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -1769,7 +1769,7 @@ describe("Sidebar Sync", () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: agentId,
-        state: "done",
+        state: "error",
         surface_id: "surface:1025",
         surface_uuid: surfaceUuid,
         surface_provenance: "cmuxlayer_spawn",
@@ -1782,7 +1782,7 @@ describe("Sidebar Sync", () => {
         parent_agent_id: "cmuxlayerCodex-parent",
         spawn_depth: 1,
         role: "worker",
-        task_done_detected_at: "2026-08-14T18:00:00.000Z",
+        error: "interactive_prompt",
       }),
     );
     liveSurfaces = [
@@ -1793,6 +1793,7 @@ describe("Sidebar Sync", () => {
         workspace_ref: "workspace:cmuxlayer",
         current_directory:
           "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+        working_directory_source: "surface",
       },
     ];
     const overlay = readFileSync(

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -1763,6 +1763,102 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("keeps a managed id and its lineage when restart observes a live interactive overlay", async () => {
+    const agentId = "cmuxlayerClaude-cfc87803";
+    const surfaceUuid = "845F3804-D185-4C7D-90EC-48E78A6A65B3";
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: agentId,
+        state: "done",
+        surface_id: "surface:1025",
+        surface_uuid: surfaceUuid,
+        surface_provenance: "cmuxlayer_spawn",
+        workspace_id: "workspace:cmuxlayer",
+        repo: "cmuxlayer",
+        cli: "claude",
+        cli_session_id: "cfc87803-1111-4222-8333-444444444444",
+        cli_session_path: "/durable/claude/cfc87803.jsonl",
+        launcher_name: "cmuxlayerClaude",
+        parent_agent_id: "cmuxlayerCodex-parent",
+        spawn_depth: 1,
+        role: "worker",
+        task_done_detected_at: "2026-08-14T18:00:00.000Z",
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:1025"),
+        id: surfaceUuid,
+        title: "cmuxlayerClaude [surface:1025]",
+        workspace_ref: "workspace:cmuxlayer",
+        current_directory:
+          "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+      },
+    ];
+    const overlay = readFileSync(
+      new URL(
+        "./fixtures/painpoints/claude-ask-user-question-overlay.txt",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    mockClient.readScreen.mockResolvedValue({
+      surface: "surface:1025",
+      text: overlay,
+      lines: 30,
+      scrollback_used: false,
+    });
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => liveSurfaces,
+      readScreen: (surface, opts) => mockClient.readScreen(surface, opts),
+    });
+
+    await engine.initialize(discovery);
+    expect(
+      engine
+        .getRegistry()
+        .list()
+        .map((record) => ({ id: record.agent_id, state: record.state })),
+    ).toEqual([{ id: agentId, state: "error" }]);
+    await engine.runSweep();
+
+    expect(engine.getAgentState(agentId)).toMatchObject({
+      agent_id: agentId,
+      state: "error",
+      surface_uuid: surfaceUuid,
+      cli_session_id: "cfc87803-1111-4222-8333-444444444444",
+      cli_session_path: "/durable/claude/cfc87803.jsonl",
+      parent_agent_id: "cmuxlayerCodex-parent",
+      spawn_depth: 1,
+      role: "worker",
+    });
+    expect(
+      engine
+        .getRegistry()
+        .list()
+        .filter((record) => record.surface_uuid === surfaceUuid)
+        .map((record) => record.agent_id),
+    ).toEqual([agentId]);
+
+    mockClient.readScreen.mockResolvedValue({
+      surface: "surface:1025",
+      text:
+        "Claude Code\nWorking (1s)\nImplementing the requested follow-up after the overlay.",
+      lines: 30,
+      scrollback_used: false,
+    });
+    discovery.invalidate();
+    await engine.getRegistry().listMerged(discovery, { force: true });
+
+    expect(engine.getAgentState(agentId)).toMatchObject({
+      agent_id: agentId,
+      state: "idle",
+      cli_session_id: "cfc87803-1111-4222-8333-444444444444",
+      parent_agent_id: "cmuxlayerCodex-parent",
+      role: "worker",
+    });
+  });
+
   it("purges a preexisting surfaceless error when its ref is recycled at startup", async () => {
     stateMgr.writeState(
       makeRecord({


### PR DESCRIPTION
## Summary

- retain a managed agent ID during startup whenever discovery proves the same live pane by exact stable UUID
- reconcile terminal managed records from that live observation instead of minting an `auto-*` replacement
- repair discovered orphan rows on every `list_agents` refresh while preserving session, parent, role, provenance, and revive metadata
- derive repaired repository ownership from pane cwd, including worktrees
- add a repeatable real-cmux probe for overlay key driving, idle sweeps, process restart, lineage continuity, and a dead-agent negative

## Verification

- `bun run test -- --reporter=dot` — 2,666 passed, 1 skipped
- `bun run pre-pr` — 63 passed
- `CMUXLAYER_FORCE_INPROCESS=1` branch build via `bun run live:id-churn .../dist/index.js` — `GREEN_ID_CHURN`
  - original ID delivered after real `interactive_overlay` key driving
  - original ID delivered after 35 seconds / two idle sweep intervals
  - original ID delivered after a fresh in-process cmuxlayer startup
  - `cli_session_id` and `parent_agent_id` remained unchanged at each checkpoint
  - force-closed child returned `delivered:false` with stable-UUID-not-live evidence
- push hook reran the complete suite successfully

Closes #416

— cmuxlayerCodex-6e68ae63 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-6e68ae63","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0019d","ts":"2026-08-14T19:38:44Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core registry merge/repair and startup purge behavior; mis-binding could affect agent addressability or lifecycle, though tests and the live probe target issue #416 explicitly.
> 
> **Overview**
> **Managed agents stay on their canonical IDs** when discovery churn would previously mint `auto-*` replacements or drop lineage. Startup purge now retains records whose **stable surface UUID** still matches a live managed pane; `listMerged` can **reconcile lifecycle** for terminal managed rows when the same UUID is observed alive (e.g. interactive overlay → idle).
> 
> **Discovery repair** is broader and safer: `list_agents` always runs `repairFromDiscovery` with **`orphansOnly`**, repo inference uses **trusted pane cwd** (including worktrees) via `inferRepoFromDirectory`, repaired records **inherit session/parent/role/provenance** from auto duplicates, and duplicate auto rows are **evicted** when a managed id owns the surface. Completed/killed/dead/stale managed records are **not** resurrected without UUID proof.
> 
> Adds **`bun run live:id-churn`** — a real-cmux probe for overlay, idle sweeps, restart, continuity, and dead-agent negative — and exposes **`surface_provenance`** on observed agent listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68060e46fda266fc9d58c1f39183810958090da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve managed agent IDs and lineage across discovery churn and process restart
> - On startup, the purge step in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/421/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now retains agents whose persisted `surface_uuid` matches a live managed surface, preventing accidental removal during reconciliation.
> - `AgentRegistry.createRepairedRecord` in [agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/421/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) inherits prior managed lineage (`cli_session_id`, `parent_agent_id`, `role`, `created_at`, etc.) when continuity can be established, avoiding lifecycle resets on restart.
> - Auto-discovered duplicate records on an already-managed surface are now explicitly evicted during repair to prevent dual ownership.
> - `list_agents` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/421/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now always runs orphan repair (scoped to surfaces without a managed record), not only when pending IDs exist.
> - Discovery results now include `current_directory` and `working_directory_source`, and repo inference prefers trusted cwd evidence over title-only heuristics.
> - A live probe script ([scripts/run-live-id-churn-probe.ts](https://github.com/EtanHey/cmuxlayer/pull/421/files#diff-a4e9689273bb76a7c4b76b911ba1fc96ca95099452e77e165ce6cd2e68635fc8)) validates ID continuity across UI overlay, idle sweeps, and process restart against a real cmux instance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68060e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent identity continuity across discovery, restarts, and interactive overlays.
  * Preserved sessions, parent relationships, roles, repositories, and lifecycle state during recovery.
  * Prevented duplicate records and kept repaired agents addressable by canonical IDs.
  * Improved repository detection using trusted working-directory information.
  * Exposed surface provenance for clearer agent status details.

* **Tests**
  * Added coverage for orphan recovery, duplicate cleanup, restart handling, overlay detection, and post-repair messaging.
  * Added a live acceptance probe for identity continuity and agent addressability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->