### PR TITLE
fix: stop echoing boot prompts as send_to title (#424)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -52,6 +52,8 @@ import {
   MAX_SPAWN_DEPTH,
   MAX_CHILDREN,
   MAX_RESPAWN_ATTEMPTS,
+  resolveBootPromptText,
+  summarizeTaskSummary,
   type AgentRoute,
   type AgentRecord,
   type AgentAuthority,
@@ -212,9 +214,7 @@ export class RetryableDeliveryError extends Error {
   }
 }
 
-type DeliverySubmitter = (
-  receipt: AgentDeliveryReceipt,
-) => Promise<{
+type DeliverySubmitter = (receipt: AgentDeliveryReceipt) => Promise<{
   retry_count: number;
   submit_verified: boolean | null;
   delivery?: "submitted" | "queued";
@@ -226,6 +226,7 @@ export interface SpawnAgentParams {
   effort?: string;
   cli: CliType;
   prompt: string;
+  boot_prompt_path?: string | null;
   boot_prompt_timeout_ms?: number;
   boot_prompt_pending?: boolean;
   workspace?: string;
@@ -276,7 +277,10 @@ export class AgentLaunchError extends Error {
     readonly launch_cause?: unknown,
     readonly launch_phase: "focus" | "launch" = "launch",
   ) {
-    super(message, launch_cause === undefined ? undefined : { cause: launch_cause });
+    super(
+      message,
+      launch_cause === undefined ? undefined : { cause: launch_cause },
+    );
     this.name = "AgentLaunchError";
   }
 }
@@ -1676,7 +1680,12 @@ export class AgentEngine {
     goalText: string | null,
     reportText: string | null,
   ): boolean {
-    return [agent.task_summary, goalText, reportText]
+    return [
+      resolveBootPromptText(agent),
+      agent.task_summary,
+      goalText,
+      reportText,
+    ]
       .filter(Boolean)
       .join("\n")
       .split(/\r?\n/)
@@ -2239,9 +2248,7 @@ export class AgentEngine {
     if (!requestedWorkspace || !surface.workspace) {
       return surface;
     }
-    if (
-      surface.workspace === requestedWorkspace
-    ) {
+    if (surface.workspace === requestedWorkspace) {
       return surface;
     }
     return {
@@ -2347,7 +2354,7 @@ export class AgentEngine {
       agent.launch_cwd?.trim() ||
       agent.worktree_path?.trim(),
     );
-    if (agent.task_summary.trim().length === 0 && !hasManagedLaunchContext) {
+    if (resolveBootPromptText(agent).length === 0 && !hasManagedLaunchContext) {
       return false;
     }
     return this.hasCustomSessionIdentityResolver || hasManagedLaunchContext;
@@ -2360,7 +2367,7 @@ export class AgentEngine {
     if (!agent.boot_prompt_pending) {
       return false;
     }
-    const prompt = agent.task_summary.trim();
+    const prompt = resolveBootPromptText(agent);
     if (!prompt) {
       return !this.isBootPromptPendingStale(agent);
     }
@@ -2535,7 +2542,7 @@ export class AgentEngine {
       this.harnessCwdForAgent(agent),
       {
         sinceMs,
-        expectedText: agent.task_summary,
+        expectedText: resolveBootPromptText(agent),
         ...(process.env.CMUXLAYER_HARNESS_HOME
           ? { home: process.env.CMUXLAYER_HARNESS_HOME }
           : {}),
@@ -2874,10 +2881,7 @@ export class AgentEngine {
       }
       if (resolvedSession) {
         try {
-          return this.finalizeCapturedSession(
-            captureAgent,
-            resolvedSession,
-          );
+          return this.finalizeCapturedSession(captureAgent, resolvedSession);
         } catch {
           return captureAgent;
         }
@@ -2886,9 +2890,8 @@ export class AgentEngine {
         !resolvingFirstConnect &&
         captureAgent.transcript_session_capture_deferred === true
       ) {
-        captureAgent = this.recordDeferredTranscriptCaptureFailure(
-          captureAgent,
-        );
+        captureAgent =
+          this.recordDeferredTranscriptCaptureFailure(captureAgent);
       }
     }
 
@@ -2921,10 +2924,7 @@ export class AgentEngine {
     const previousAttempts = Number.isFinite(
       agent.transcript_session_capture_attempts,
     )
-      ? Math.max(
-          0,
-          Math.trunc(agent.transcript_session_capture_attempts ?? 0),
-        )
+      ? Math.max(0, Math.trunc(agent.transcript_session_capture_attempts ?? 0))
       : 0;
     const attempts = Math.min(
       MAX_DEFERRED_TRANSCRIPT_CAPTURE_ATTEMPTS,
@@ -3238,9 +3238,9 @@ export class AgentEngine {
   ): AgentRecord {
     const hasEpisodeState = Boolean(
       agent.halt_episode_type ||
-        agent.halt_episode_started_at ||
-        agent.halt_notification_sent_at ||
-        agent.halt_notified_ancestor_id,
+      agent.halt_episode_started_at ||
+      agent.halt_notification_sent_at ||
+      agent.halt_notified_ancestor_id,
     );
     if (!hasEpisodeState && Object.keys(patch).length === 0) return agent;
     const updated = this.stateMgr.updateRecord(agent.agent_id, {
@@ -3310,8 +3310,8 @@ export class AgentEngine {
     ) {
       const hasProgressMemory = Boolean(
         agent.halt_last_active_at ||
-          agent.halt_last_progress_at_ms ||
-          agent.halt_last_progress_signature,
+        agent.halt_last_progress_at_ms ||
+        agent.halt_last_progress_signature,
       );
       return this.clearHaltEpisode(
         agent,
@@ -3331,9 +3331,8 @@ export class AgentEngine {
     );
     const screenActive =
       parsed.status === "working" || parsed.status === "thinking";
-    const blockingBackgroundWaitMs = this.blockingBackgroundWaitElapsedMs(
-      screenText,
-    );
+    const blockingBackgroundWaitMs =
+      this.blockingBackgroundWaitElapsedMs(screenText);
     let haltType: AgentHaltType | null = null;
     let episodeStartedAtMs = nowMs;
     if (
@@ -3546,7 +3545,8 @@ export class AgentEngine {
       auto_revive: true,
       revive_attempts: agent.revive_attempts ?? 0,
       revive_outcome: outcome,
-      verified_model: outcome === "revived" ? agent.parsed_model ?? null : null,
+      verified_model:
+        outcome === "revived" ? (agent.parsed_model ?? null) : null,
       manual_resume_command:
         outcome === "unrecoverable" && agent.cli_session_id
           ? buildRawResumeCommand(agent.cli, agent.repo, agent.cli_session_id)
@@ -3619,11 +3619,15 @@ export class AgentEngine {
         workspace: attempted.workspace_id ?? undefined,
       });
       const observerEpoch = this.captureSurfaceObserverEpoch();
-      const creating = this.stateMgr.transition(attempted.agent_id, "creating", {
-        error: null,
-        pid: null,
-        cli_session_id: sessionId,
-      });
+      const creating = this.stateMgr.transition(
+        attempted.agent_id,
+        "creating",
+        {
+          error: null,
+          pid: null,
+          cli_session_id: sessionId,
+        },
+      );
       this.registry.set(agent.agent_id, creating);
       const booting = this.stateMgr.transition(attempted.agent_id, "booting", {
         error: null,
@@ -3687,7 +3691,10 @@ export class AgentEngine {
       error: null,
     });
     this.registry.set(agent.agent_id, completed);
-    const notification = await this.dispatchCliExitOutcome(completed, "revived");
+    const notification = await this.dispatchCliExitOutcome(
+      completed,
+      "revived",
+    );
     completed = notification.record;
     this.appendAutoReviveCliExitEvent(
       completed,
@@ -3719,7 +3726,9 @@ export class AgentEngine {
       if ((agent.revive_attempts ?? 0) >= MAX_RESPAWN_ATTEMPTS) {
         await this.markAutoReviveUnrecoverable(
           agent,
-          agent.revive_last_error ?? agent.error ?? "readiness verification failed",
+          agent.revive_last_error ??
+            agent.error ??
+            "readiness verification failed",
         );
         continue;
       }
@@ -4166,7 +4175,7 @@ export class AgentEngine {
   }
 
   private extractNamedBlocker(agent: AgentRecord): string | null {
-    const text = [agent.error, agent.task_summary]
+    const text = [agent.error, resolveBootPromptText(agent), agent.task_summary]
       .filter((value): value is string => Boolean(value?.trim()))
       .join(" ");
     const match = text.match(
@@ -6159,9 +6168,10 @@ export class AgentEngine {
     // Job role is authoritative. The versioned tool rejects missing agent
     // axes; direct legacy engine callers default to worker without consulting
     // the selected harness.
-    const role = spawnParams.role !== undefined
-      ? inferAgentRole({ role: spawnParams.role })
-      : "worker";
+    const role =
+      spawnParams.role !== undefined
+        ? inferAgentRole({ role: spawnParams.role })
+        : "worker";
 
     this.spawnGuard.check(spawnParams.workspace);
 
@@ -6252,8 +6262,7 @@ export class AgentEngine {
       state: "booting",
       repo: spawnParams.repo,
       model: spawnParams.model ?? modelPolicy.effective_model,
-      effort:
-        spawnParams.cli === "codex" ? (effort ?? "high") : null,
+      effort: spawnParams.cli === "codex" ? (effort ?? "high") : null,
       cli: spawnParams.cli,
       cli_session_id: null,
       cli_session_path: null,
@@ -6263,7 +6272,11 @@ export class AgentEngine {
       seat_role: seatIdentity.seat_role,
       seat_identity_status: seatIdentity.seat_identity_status,
       seat_identity_error: seatIdentity.seat_identity_error,
-      task_summary: spawnParams.prompt,
+      task_summary: summarizeTaskSummary(
+        spawnParams.prompt,
+        spawnParams.boot_prompt_path,
+      ),
+      boot_prompt_text: spawnParams.prompt.trim() ? spawnParams.prompt : null,
       pid: null,
       version: 1,
       created_at: now,
@@ -6452,9 +6465,7 @@ export class AgentEngine {
       state: "booting",
       model: modelPolicy.effective_model,
       requested_model: modelPolicy.requested_model,
-      warnings: [
-        ...modelPolicy.warnings,
-      ],
+      warnings: [...modelPolicy.warnings],
       model_policy: modelPolicy,
       cwd: launchCwd ?? undefined,
       mcp_env: spawnParams.mcp_env,
@@ -6488,7 +6499,8 @@ export class AgentEngine {
       agent.cli_session_id,
       agent.launcher_name,
     );
-    const requestedWorkspace = opts?.workspace ?? agent.workspace_id ?? undefined;
+    const requestedWorkspace =
+      opts?.workspace ?? agent.workspace_id ?? undefined;
     this.spawnGuard.check(requestedWorkspace);
 
     let surface: CreatedAgentSurface | null = null;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -5,13 +5,7 @@
 import { randomUUID } from "node:crypto";
 
 export type AgentState =
-  | "creating"
-  | "booting"
-  | "ready"
-  | "working"
-  | "idle"
-  | "done"
-  | "error";
+  "creating" | "booting" | "ready" | "working" | "idle" | "done" | "error";
 
 export type CliType = "claude" | "codex" | "gemini" | "kiro" | "cursor";
 
@@ -24,14 +18,8 @@ export type SurfaceProvenance = "cmuxlayer_spawn" | "unknown";
 export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
 export type ObservationSource = "screen" | "registry" | "process";
 export type AgentReviveOutcome =
-  | "pending"
-  | "failed"
-  | "revived"
-  | "unrecoverable";
-export type AgentHaltType =
-  | "awaiting_input"
-  | "idle_without_done"
-  | "wedged";
+  "pending" | "failed" | "revived" | "unrecoverable";
+export type AgentHaltType = "awaiting_input" | "idle_without_done" | "wedged";
 
 export interface Observed<T> {
   value: T;
@@ -69,7 +57,17 @@ export interface AgentRecord {
   seat_role?: string | null;
   seat_identity_status?: SeatIdentityStatus;
   seat_identity_error?: string | null;
+  /**
+   * Short label for role inference, sidebar, and registry echoes.
+   * Never store the full boot brief here — that lives in `boot_prompt_text`.
+   */
   task_summary: string;
+  /**
+   * Full boot-prompt payload typed/verified on spawn. Delivery and session
+   * matching read this; legacy records may still have the full text only in
+   * `task_summary` until rewritten.
+   */
+  boot_prompt_text?: string | null;
   pid: number | null;
   version: number;
   created_at: string;
@@ -303,10 +301,7 @@ export interface AgentCliExitEvent {
 
 /** Which close/kill path emitted the event. */
 export type CloseEventPath =
-  | "close_surface"
-  | "stop_agent"
-  | "kill"
-  | "internal";
+  "close_surface" | "stop_agent" | "kill" | "internal";
 
 /**
  * Durable, attributed record of a surface close or agent kill/stop. Answers
@@ -501,4 +496,49 @@ export function generateAgentId(
     return `${golemName}-${sessionIdPrefix(sessionId)}`;
   }
   return `${golemName}-${randomUUID().slice(0, SESSION_ID_PREFIX_LENGTH)}`;
+}
+
+const TASK_SUMMARY_MAX_CHARS = 80;
+
+/**
+ * Build the short registry label for an agent. Prefer a boot-prompt filename
+ * when spawn used `boot_prompt_path`; otherwise the first non-empty line,
+ * capped. Never used as a response `title` — that is the live surface title.
+ */
+export function summarizeTaskSummary(
+  prompt: string,
+  bootPromptPath?: string | null,
+): string {
+  const pathLabel = bootPromptPath?.trim();
+  if (pathLabel) {
+    const base = pathLabel.split(/[\\/]/).pop()?.trim();
+    if (base) return base;
+  }
+  const firstLine =
+    prompt
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? "";
+  if (firstLine.length <= TASK_SUMMARY_MAX_CHARS) return firstLine;
+  return `${firstLine.slice(0, TASK_SUMMARY_MAX_CHARS - 1)}…`;
+}
+
+/** Full boot-prompt text for delivery/verification; falls back for legacy rows. */
+export function resolveBootPromptText(
+  agent: Pick<AgentRecord, "boot_prompt_text" | "task_summary">,
+): string {
+  const dedicated = agent.boot_prompt_text?.trim();
+  if (dedicated) return dedicated;
+  return agent.task_summary?.trim() ?? "";
+}
+
+/** Persist both fields when a boot prompt (or replacement mission) is known. */
+export function bootPromptRegistryFields(
+  promptText: string,
+  bootPromptPath?: string | null,
+): Pick<AgentRecord, "task_summary" | "boot_prompt_text"> {
+  return {
+    boot_prompt_text: promptText,
+    task_summary: summarizeTaskSummary(promptText, bootPromptPath),
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,6 +105,10 @@ import type {
   DeliveryTelemetryEvent,
 } from "./agent-types.js";
 import {
+  bootPromptRegistryFields,
+  summarizeTaskSummary,
+} from "./agent-types.js";
+import {
   formatListSurfaces,
   formatReadScreen,
   formatListAgents,
@@ -346,10 +350,7 @@ const QueryMonitorRegistryArgsSchema = {
 
 const WatchSpecArgsSchema = {
   owner: z.string().min(1).describe("Agent/seat notified by the watch"),
-  target: z
-    .string()
-    .min(1)
-    .describe("Absolute file path or public agent_id"),
+  target: z.string().min(1).describe("Absolute file path or public agent_id"),
   predicate: z
     .enum(WATCH_AGENT_PREDICATES)
     .optional()
@@ -602,7 +603,9 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       screen: z.record(z.unknown()).nullable().optional(),
       state_conflict: z.boolean().optional(),
       health: z.record(z.unknown()).optional(),
-      receipts: z.array(z.object({ ...DeliveryOutputShape }).passthrough()).optional(),
+      receipts: z
+        .array(z.object({ ...DeliveryOutputShape }).passthrough())
+        .optional(),
     })
     .passthrough(),
   read_screen: z
@@ -2006,10 +2009,7 @@ function formatToolValidationError(
       return `${path}: ${issue.message}`;
     })
     .join("; ");
-  const example =
-    toolName === "send_to"
-      ? ` ${SEND_TO_WORKING_EXAMPLE}`
-      : "";
+  const example = toolName === "send_to" ? ` ${SEND_TO_WORKING_EXAMPLE}` : "";
   return `${toolName} invalid arguments: ${details}.${example}`;
 }
 
@@ -2467,10 +2467,7 @@ function screenShowsQueuedAgentInput(
     return false;
   }
 
-  while (
-    index >= 0 &&
-    !stripCodexQueueGutter(lines[index] ?? "").trim()
-  ) {
+  while (index >= 0 && !stripCodexQueueGutter(lines[index] ?? "").trim()) {
     index -= 1;
   }
   const queueHeadingPattern =
@@ -2701,16 +2698,18 @@ export interface TargetIdentity {
   agent_type?: string;
 }
 
-// Best-effort, CHEAP target-agent identity for delivery responses (send_input /
-// send_command). Sourced from the in-memory state cache only — no extra socket
-// round-trip / read_screen per send. Unknown fields are omitted.
+// Best-effort target-agent identity for delivery responses (send_input /
+// send_command). `title` is the live cmux tab/surface title when known — never
+// the boot prompt / task_summary. Model/cli come from the in-memory registry.
 function resolveTargetIdentity(
   stateMgr: StateManager,
   surfaceRef: string,
+  surfaceTitle?: string | null,
 ): TargetIdentity {
   const identity: TargetIdentity = { surface: surfaceRef };
+  const title = surfaceTitle?.trim();
+  if (title) identity.title = title;
   const record = resolveLatestSurfaceAgentRecord(stateMgr, surfaceRef);
-  if (record?.task_summary) identity.title = record.task_summary;
   if (record?.model) identity.model = record.model;
   if (record?.cli) identity.agent_type = record.cli;
   return identity;
@@ -3774,7 +3773,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       };
     }
-    if (palette && typeof toolName === "string" && !palette.shouldRegister(toolName)) {
+    if (
+      palette &&
+      typeof toolName === "string" &&
+      !palette.shouldRegister(toolName)
+    ) {
       return palette.defer(toolName, args);
     }
     if (typeof toolName === "string") {
@@ -4622,11 +4625,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       } else {
         retryEligiblePendingSince = null;
       }
-      const retryObserveMs =
-        codexRetryEligiblePendingInput
-          ? Math.min(timeoutMs, CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS)
-          : opts.source_event === "spawn_agent" &&
-              !hasParsedAgentIdentity(snapshot.parsed)
+      const retryObserveMs = codexRetryEligiblePendingInput
+        ? Math.min(timeoutMs, CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS)
+        : opts.source_event === "spawn_agent" &&
+            !hasParsedAgentIdentity(snapshot.parsed)
           ? 0
           : Math.min(timeoutMs, SEND_INPUT_SAFE_RETRY_OBSERVE_MS);
 
@@ -4735,7 +4737,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     await opts.beforeMutation?.();
     if (opts.key !== undefined) {
       if (opts.chunks.length > 0 || opts.press_enter) {
-        throw new Error("Delivery engine key input is mutually exclusive with text submission");
+        throw new Error(
+          "Delivery engine key input is mutually exclusive with text submission",
+        );
       }
       const key = normalizeKeyName(opts.key);
       await sendKeyWithRetry(
@@ -4888,8 +4892,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 deliveryOutcome === "queued"
                   ? ("queued" as const)
                   : submit_verified === false
-                  ? ("failed" as const)
-                  : ("submitted" as const),
+                    ? ("failed" as const)
+                    : ("submitted" as const),
             }
           : {}),
       });
@@ -5573,10 +5577,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               throw readinessError;
             }
             if (
-              screenShowsPendingShellInput(
-                pendingScreen.text,
-                sanitizedCommand,
-              )
+              screenShowsPendingShellInput(pendingScreen.text, sanitizedCommand)
             ) {
               throw new LauncherReadinessError(
                 `launcher command remained pending after Return on ${opts.surface}`,
@@ -5607,11 +5608,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     timeout_ms?: number;
     onUpdateShellRelaunch?: () => Promise<void>;
     resolveRoute?: () => Promise<{ surface: string; workspace?: string }>;
-  }): Promise<PublicDeliveryReceipt & {
-    bytes: number;
-    prompt_text: string | null;
-    prompt_warning: string | null;
-  }> => {
+  }): Promise<
+    PublicDeliveryReceipt & {
+      bytes: number;
+      prompt_text: string | null;
+      prompt_warning: string | null;
+    }
+  > => {
     const bootPromptPath = getBootPromptPath(opts.boot_prompt_path);
     assertBootPromptMode(opts.prompt, bootPromptPath);
     if (
@@ -6351,6 +6354,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   type RawSurfaceMutationRoute = {
     surface: string;
     workspace?: string;
+    /** Live cmux tab title for this surface when topology knows it. */
+    title: string | null;
     stableSurfaceIdentity: string | null;
     assertCurrent: () => Promise<void>;
   };
@@ -6456,6 +6461,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return {
           surface: currentRef,
           workspace,
+          title: topology.titleBySurface.get(currentRef) ?? null,
           stableSurfaceIdentity: stableUuid,
           assertCurrent,
         };
@@ -6484,6 +6490,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return {
         surface: requestedSurface,
         workspace,
+        title: topology.titleBySurface.get(requestedSurface) ?? null,
         stableSurfaceIdentity: null,
         assertCurrent: async () => {
           const current = await collectSurfaceTopology();
@@ -6513,6 +6520,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     return {
       surface: requestedSurface,
       workspace: explicitWorkspace,
+      title: null,
       stableSurfaceIdentity: null,
       assertCurrent: async () => {},
     };
@@ -8129,7 +8137,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           };
           startBackgroundDelivery(record);
 
-          const identity = resolveTargetIdentity(stateMgr, route.surface);
+          const identity = resolveTargetIdentity(
+            stateMgr,
+            route.surface,
+            route.title,
+          );
           const data = {
             ...identity,
             ...buildPublicDeliveryReceipt({
@@ -8178,7 +8190,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           },
         );
 
-        const identity = resolveTargetIdentity(stateMgr, route.surface);
+        const identity = resolveTargetIdentity(
+          stateMgr,
+          route.surface,
+          route.title,
+        );
         const data = {
           ...identity,
           ...delivery,
@@ -8350,7 +8366,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           });
         }
 
-        const identity = resolveTargetIdentity(stateMgr, route.surface);
+        const identity = resolveTargetIdentity(
+          stateMgr,
+          route.surface,
+          route.title,
+        );
         const data = {
           ...identity,
           command: sanitizedCommand,
@@ -8711,10 +8731,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
-        const handlerName = args.action === "move" ? "move_surface" : "rename_tab";
+        const handlerName =
+          args.action === "move" ? "move_surface" : "rename_tab";
         const handler = toolHandlersByName.get(handlerName);
         if (!handler) {
-          throw new Error(`Internal surface adapter unavailable: ${handlerName}`);
+          throw new Error(
+            `Internal surface adapter unavailable: ${handlerName}`,
+          );
         }
         if (args.action === "rename" && !args.title) {
           throw new Error("update_surface action=rename requires title");
@@ -8881,7 +8904,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             throw new Error("close_surface scope=agent requires agent_id");
           }
           const handler = toolHandlersByName.get("stop_agent");
-          if (!handler) throw new Error("Internal agent close adapter unavailable");
+          if (!handler)
+            throw new Error("Internal agent close adapter unavailable");
           const result = await handler(
             { agent_id: args.agent_id, force: args.force },
             {},
@@ -9393,9 +9417,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery?: "submitted" | "queued";
           delivery_id?: string;
         } = { attempted: false, sent: false, reason: "" };
-        const acceptedRecord = context.lifecycleRegistry?.get(args.agent_id) ?? null;
-        const wakeIdleAgent =
-          monitor_alive && acceptedRecord?.state === "idle";
+        const acceptedRecord =
+          context.lifecycleRegistry?.get(args.agent_id) ?? null;
+        const wakeIdleAgent = monitor_alive && acceptedRecord?.state === "idle";
         if (args.nudge === "never") {
           nudge.reason = "nudge disabled by caller";
         } else if (monitor_alive && !wakeIdleAgent) {
@@ -9427,10 +9451,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 msg,
                 inboxPath(args.agent_id, inboxOpts),
               );
-              if (
-                record.state === "working" &&
-                context.lifecycleSweepEngine
-              ) {
+              if (record.state === "working" && context.lifecycleSweepEngine) {
                 const queued = context.lifecycleSweepEngine.queueDelivery({
                   agent_id: args.agent_id,
                   text: pointer,
@@ -10141,7 +10162,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               record.cli === "codex"
                 ? Boolean(
                     record.model?.trim() &&
-                      record.model.trim().toLowerCase() !== "codex",
+                    record.model.trim().toLowerCase() !== "codex",
                   )
                 : process.env.REPOGOLEM_ALLOW_MODEL === "1",
           },
@@ -10554,10 +10575,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe("Initial working directory for type=terminal"),
-        title: z
-          .string()
-          .optional()
-          .describe("Tab title for type=terminal"),
+        title: z.string().optional().describe("Tab title for type=terminal"),
         prompt: z
           .string()
           .optional()
@@ -10614,7 +10632,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         authority: z
           .enum(["lead", "worker"])
           .optional()
-          .describe("Authority axis, independent from job function and placement"),
+          .describe(
+            "Authority axis, independent from job function and placement",
+          ),
         auto_archive_on_done: z
           .boolean()
           .optional()
@@ -10714,9 +10734,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             await awaitLifecycleStart();
             const existing = engine.getAgentState(args.resume_agent_id);
             if (!existing) {
-              return err(
-                new Error(`Agent not found: ${args.resume_agent_id}`),
-              );
+              return err(new Error(`Agent not found: ${args.resume_agent_id}`));
             }
             const workspace = await canonicalWorkspaceRef(
               args.workspace ?? existing.workspace_id ?? undefined,
@@ -10753,7 +10771,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...result,
               role: inferRecordRoleOrNull(existing) ?? "worker",
               ...(focusRestoreWarning
-                ? { warning: focusRestoreWarning, warnings: [focusRestoreWarning] }
+                ? {
+                    warning: focusRestoreWarning,
+                    warnings: [focusRestoreWarning],
+                  }
                 : {}),
             };
             return buildSpawnToolReturn(
@@ -10783,12 +10804,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               "spawn_agent",
               createsWorkspace
                 ? callerWorkspace
-                : requestedWorkspace ?? callerWorkspace,
+                : (requestedWorkspace ?? callerWorkspace),
             );
             const workspace = createsWorkspace
               ? (await client.createWorkspace(requestedWorkspace!.slice(4)))
                   .workspace
-              : requestedWorkspace ?? callerWorkspace;
+              : (requestedWorkspace ?? callerWorkspace);
             const panes = await client.listPanes({ workspace });
             const placement = chooseAgentSpawnPlacement(
               panes.panes,
@@ -10894,9 +10915,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const effectiveParentAgentId = callerIsWorker
             ? callerAgent!.agent_id
             : (args.parent_agent_id ?? callerAgent?.agent_id);
-          const effectiveRole = callerIsWorker
-            ? "worker"
-            : normalizedRole.role;
+          const effectiveRole = callerIsWorker ? "worker" : normalizedRole.role;
           const workerCallerWarning = callerIsWorker
             ? `Worker caller ${callerAgent!.agent_id} forced child role to worker and recorded itself as parent; worker-spawned agents cannot claim orchestrator placement.`
             : undefined;
@@ -10946,7 +10965,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   workspace_id: agent.workspace_id ?? null,
                   state: agent.state,
                   role: inferRecordRoleOrNull(agent),
-                  task_summary: agent.task_summary,
+                  task_summary: summarizeTaskSummary(agent.task_summary),
                 }));
           const duplicateSpawnWarning =
             existingSameLaneAgents.length > 0
@@ -11025,6 +11044,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               effort: args.effort,
               cli: args.cli,
               prompt: spawnPrompt,
+              boot_prompt_path: bootPromptPath,
               boot_prompt_pending: true,
               workspace: spawnWorkspace,
               cwd: worktree.prepared?.path,
@@ -11168,7 +11188,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               await captureSpawnSessionBestEffort(result);
               if (bootPromptDelivery.prompt_text !== null) {
                 const updated = stateMgr.updateRecord(result.agent_id, {
-                  task_summary: bootPromptDelivery.prompt_text,
+                  ...bootPromptRegistryFields(
+                    bootPromptDelivery.prompt_text,
+                    bootPromptPath,
+                  ),
                   boot_prompt_pending: false,
                   prompt_delivered: bootPromptDelivery.submit_verified === true,
                   submit_verified: bootPromptDelivery.submit_verified,
@@ -11465,8 +11488,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         let mutationWorkspace: string | undefined;
         let surfaceCreated = false;
         let worktree:
-          | Awaited<ReturnType<typeof prepareSpawnWorktree>>
-          | undefined;
+          Awaited<ReturnType<typeof prepareSpawnWorktree>> | undefined;
         try {
           resolveSpawnModelPolicy(args.cli, args.model);
           assertBootPromptMode(args.prompt, null);
@@ -11568,7 +11590,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
             canonicalizeSpawnResult(result);
             const updated = stateMgr.updateRecord(result.agent_id, {
-              task_summary: bootPromptDelivery.prompt_text ?? args.prompt ?? "",
+              ...bootPromptRegistryFields(
+                bootPromptDelivery.prompt_text ?? args.prompt ?? "",
+              ),
               boot_prompt_pending: false,
             });
             registry.set(result.agent_id, updated);
@@ -11893,8 +11917,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 creation.append(
                   "agents",
                   identity,
-                  (left, right) =>
-                    left.surface_id === right.surface_id,
+                  (left, right) => left.surface_id === right.surface_id,
                 );
                 focusRestoreLease = await capturePostCreationFocus(
                   focusRestoreLease,
@@ -11961,8 +11984,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               activeSpawnIdentity.workspace_id =
                 result.workspace_id ?? workspace ?? null;
               const updated = stateMgr.updateRecord(result.agent_id, {
-                task_summary:
+                ...bootPromptRegistryFields(
                   bootPromptDelivery.prompt_text ?? agent.prompt ?? "",
+                ),
                 boot_prompt_pending: false,
                 prompt_delivered:
                   hasPrompt && bootPromptDelivery.submit_verified === true,
@@ -12022,7 +12046,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ...result,
                 role,
                 health,
-                boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
+                boot_prompt_delivered:
+                  isBootPromptDelivered(bootPromptDelivery),
                 boot_prompt_receipt: bootPromptDelivery,
                 boot_prompt_submit_verified:
                   bootPromptDelivery?.submit_verified ?? null,
@@ -12146,7 +12171,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
           }
           if (caught instanceof SurfaceGoneError) {
-            return err(caught, surfaceGonePayload(caught, failureIdentityPayload));
+            return err(
+              caught,
+              surfaceGonePayload(caught, failureIdentityPayload),
+            );
           }
           if (caught instanceof BootPromptTimeoutError) {
             return err(caught, {
@@ -12493,7 +12521,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     type ListAgentsCacheEntry = {
       topology_signature: string;
       derived_at: number;
-      agents: Array<ObservedPublicAgent & { health: AgentHealth }>;
+      agents: Array<
+        ObservedPublicAgent & {
+          surface_id: string;
+          send_via: "send_to";
+          health?: AgentHealth;
+        }
+      >;
       skipped_agents: Array<{ agent_id: string; error: string }>;
     };
     const listAgentsCache = new Map<string, ListAgentsCacheEntry>();
@@ -12515,7 +12549,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "list_agents",
-      "List live-derived agents; filter to children with mine/parent_agent_id and request full diagnostics with detail=full.",
+      "List live-derived agents; filter to children with mine/parent_agent_id. Default summary is lean (id, state, surface_id, send_via). Pass detail=full for health diagnostics and the full registry record.",
       {
         state: z
           .enum([
@@ -12547,7 +12581,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         detail: z
           .enum(["summary", "full"])
           .optional()
-          .default("summary"),
+          .default("summary")
+          .describe(
+            "summary (default): lean addressable rows. full: health diagnostics plus the full registry record.",
+          ),
         max_age_ms: z
           .number()
           .int()
@@ -12628,10 +12665,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     ? agentUuid === surfaceUuid
                     : Boolean(
                         !agentUuid &&
-                          !surfaceUuid &&
-                          agent.surface_observer_id &&
-                          agent.surface_observer_id === registry.getObserverId() &&
-                          surface.surface_id === agent.surface_id,
+                        !surfaceUuid &&
+                        agent.surface_observer_id &&
+                        agent.surface_observer_id ===
+                          registry.getObserverId() &&
+                        surface.surface_id === agent.surface_id,
                       );
                 });
                 const trustedScreenObservation =
@@ -12644,8 +12682,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     ...healthTopologyOverrides(agent, topology),
                     ...(trustedScreenObservation
                       ? {
-                          screen_status:
-                            trustedScreenObservation.parsed_status,
+                          screen_status: trustedScreenObservation.parsed_status,
                           screen_agent_type:
                             trustedScreenObservation.cli === "kiro"
                               ? "unknown"
@@ -12683,14 +12720,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       screenObservedAtMs: screenObservation?.observed_at_ms,
                       screenModel: screenObservation?.model,
                     }),
-                    health: {
-                      ...health,
-                      ...(screenObservation
-                        ? { screen_observation: screenObservation }
-                        : {}),
-                    },
+                    surface_id: agent.surface_id,
+                    send_via: "send_to" as const,
                     ...(args.detail === "full"
                       ? {
+                          health: {
+                            ...health,
+                            ...(screenObservation
+                              ? { screen_observation: screenObservation }
+                              : {}),
+                          },
                           detail: {
                             ...toAgentStatePayload(agent),
                             harvestability: engine.assessHarvestability(agent),
@@ -12726,9 +12765,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const entry: ListAgentsCacheEntry = {
             topology_signature: topologySignature,
             derived_at: Date.now(),
-            agents: agents as Array<
-              ObservedPublicAgent & { health: AgentHealth }
-            >,
+            agents: agents as ListAgentsCacheEntry["agents"],
             skipped_agents: skippedAgents,
           };
           listAgentsCache.set(cacheKey, entry);
@@ -12767,8 +12804,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : null;
             const scoped = merged.filter(
               (agent) =>
-                (!parentAgentId ||
-                  agent.parent_agent_id === parentAgentId) &&
+                (!parentAgentId || agent.parent_agent_id === parentAgentId) &&
                 (!requestedIds || requestedIds.has(agent.agent_id)),
             );
             return { merged: scoped, discovered, observedAtMs };
@@ -12786,18 +12822,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (isSurfaceEnumerationError(e)) {
             try {
               return await buildListAgentsResponse(
-                registry
-                  .list(filter)
-                  .filter((agent) => {
-                    const requestedIds = args.agent_ids
-                      ? new Set(args.agent_ids)
-                      : null;
-                    return (
-                      (!parentAgentId ||
-                        agent.parent_agent_id === parentAgentId) &&
-                      (!requestedIds || requestedIds.has(agent.agent_id))
-                    );
-                  }),
+                registry.list(filter).filter((agent) => {
+                  const requestedIds = args.agent_ids
+                    ? new Set(args.agent_ids)
+                    : null;
+                  return (
+                    (!parentAgentId ||
+                      agent.parent_agent_id === parentAgentId) &&
+                    (!requestedIds || requestedIds.has(agent.agent_id))
+                  );
+                }),
                 null,
                 listAgentsTopologySignature(null),
               );
@@ -13689,7 +13723,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const args = parsedArgs.data;
           const mode = args.mode ?? "agent";
           if (args.targeting && mode !== "agent") {
-            throw new Error("send_to.targeting is supported only in mode=agent");
+            throw new Error(
+              "send_to.targeting is supported only in mode=agent",
+            );
           }
           if (mode !== "agent") {
             const surface = args.surface ?? args.target;
@@ -13856,8 +13892,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             const resolvedTargets = Object.freeze(
               targetPlan
                 .filter(
-                  (entry): entry is TargetPlan & { agent: Readonly<AgentRecord> } =>
-                    entry.resolution === "resolved" && entry.agent !== undefined,
+                  (
+                    entry,
+                  ): entry is TargetPlan & { agent: Readonly<AgentRecord> } =>
+                    entry.resolution === "resolved" &&
+                    entry.agent !== undefined,
                 )
                 .map((entry) => entry.agent),
             );
@@ -13921,7 +13960,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               const deliveryId = randomUUID();
               if (!args.allow_busy && agent.state === "working") {
-              const queued = engine.queueDelivery({
+                const queued = engine.queueDelivery({
                   agent_id: agent.agent_id,
                   text: args.text,
                   press_enter: args.press_enter,
@@ -13962,19 +14001,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         retry_count: delivery.retry_count,
                       })
                     : delivery.delivery === "submitted"
-                    ? engine.resolveDelivery({
-                        delivery_id: deliveryId,
-                        agent_id: agent.agent_id,
-                        text: args.text,
-                        press_enter: args.press_enter,
-                        source_event: "send_to",
-                        delivery_state: "submitted",
-                        terminal: true,
-                        retry_count: delivery.retry_count,
-                        submit_verified: delivery.submit_verified,
-                        error: null,
-                      })
-                    : null;
+                      ? engine.resolveDelivery({
+                          delivery_id: deliveryId,
+                          agent_id: agent.agent_id,
+                          text: args.text,
+                          press_enter: args.press_enter,
+                          source_event: "send_to",
+                          delivery_state: "submitted",
+                          terminal: true,
+                          retry_count: delivery.retry_count,
+                          submit_verified: delivery.submit_verified,
+                          error: null,
+                        })
+                      : null;
                 mutableReceipts.push({
                   ...resolutionMetadata,
                   agent_id: agent.agent_id,
@@ -14004,7 +14043,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         : 0,
                     submit_verified:
                       error instanceof SubmitVerificationError ? false : null,
-                    error: error instanceof Error ? error.message : String(error),
+                    error:
+                      error instanceof Error ? error.message : String(error),
                   },
                   {
                     appendFailureEvent: !(
@@ -14020,11 +14060,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     delivery_id: failed.delivery_id,
                     typed:
                       error instanceof SubmitVerificationError
-                        ? error.receipt?.typed ?? true
+                        ? (error.receipt?.typed ?? true)
                         : false,
                     submit_attempted:
                       error instanceof SubmitVerificationError
-                        ? error.receipt?.submit_attempted ?? args.press_enter
+                        ? (error.receipt?.submit_attempted ?? args.press_enter)
                         : false,
                     submit_verified: failed.submit_verified,
                     retry_count: failed.retry_count,
@@ -14062,7 +14102,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             };
             if (resolvedTargets.length === 0) {
               return err(
-                new Error("send_to targeting resolved zero targets; refusing silent no-op"),
+                new Error(
+                  "send_to targeting resolved zero targets; refusing silent no-op",
+                ),
                 data,
               );
             }
@@ -14143,20 +14185,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 appendFailureEvent: !(error instanceof SubmitVerificationError),
               },
             );
-            failedReceiptPayload = { ...buildPublicDeliveryReceipt({
-              delivery_state: "failed",
-              delivery_id: failedReceipt.delivery_id,
-              typed:
-                error instanceof SubmitVerificationError
-                  ? error.receipt?.typed ?? true
-                  : false,
-              submit_attempted:
-                error instanceof SubmitVerificationError
-                  ? error.receipt?.submit_attempted ?? args.press_enter
-                  : false,
-              submit_verified: failedReceipt.submit_verified,
-              retry_count: failedReceipt.retry_count,
-            }) };
+            failedReceiptPayload = {
+              ...buildPublicDeliveryReceipt({
+                delivery_state: "failed",
+                delivery_id: failedReceipt.delivery_id,
+                typed:
+                  error instanceof SubmitVerificationError
+                    ? (error.receipt?.typed ?? true)
+                    : false,
+                submit_attempted:
+                  error instanceof SubmitVerificationError
+                    ? (error.receipt?.submit_attempted ?? args.press_enter)
+                    : false,
+                submit_verified: failedReceipt.submit_verified,
+                retry_count: failedReceipt.retry_count,
+              }),
+            };
             throw error;
           }
           const receipt =
@@ -14170,19 +14214,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   retry_count: delivery.retry_count,
                 })
               : delivery.delivery === "submitted"
-              ? engine.resolveDelivery({
-                  delivery_id: deliveryId,
-                  agent_id: agentId,
-                  text: args.text,
-                  press_enter: args.press_enter,
-                  source_event: "send_to",
-                  delivery_state: "submitted",
-                  terminal: true,
-                  retry_count: delivery.retry_count,
-                  submit_verified: delivery.submit_verified,
-                  error: null,
-                })
-              : null;
+                ? engine.resolveDelivery({
+                    delivery_id: deliveryId,
+                    agent_id: agentId,
+                    text: args.text,
+                    press_enter: args.press_enter,
+                    source_event: "send_to",
+                    delivery_state: "submitted",
+                    terminal: true,
+                    retry_count: delivery.retry_count,
+                    submit_verified: delivery.submit_verified,
+                    error: null,
+                  })
+                : null;
           // Preserve the already-terminal receipt if optional evidence
           // collection fails after the pane mutation has succeeded.
           const publicReceipt = buildPublicDeliveryReceipt({
@@ -14931,7 +14975,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 context_window: screenData?.context_window ?? null,
                 context_pct: screenData?.context_pct ?? null,
                 cost: screenData?.cost ?? null,
-                task_summary: agent.task_summary,
+                task_summary: summarizeTaskSummary(agent.task_summary),
                 spawn_depth: agent.spawn_depth,
                 created_at: agent.created_at,
                 quality: agent.quality,
@@ -14972,7 +15016,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     rawRegisterTool(
       "expand_palette",
       {
-        description: "Register the remaining Phase 5 tools for this MCP session.",
+        description:
+          "Register the remaining Phase 5 tools for this MCP session.",
         inputSchema: {},
         outputSchema: z
           .object({

--- a/tests/payload-slim.test.ts
+++ b/tests/payload-slim.test.ts
@@ -1,0 +1,276 @@
+/**
+ * #424 payload slim — response title must be the real tab title.
+ * TDD: fails until send path stops echoing task_summary/boot prompt as title
+ * and reports the same surface title list_surfaces already returns.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createServer,
+  createServerContext,
+  type CmuxServerContext,
+  type CreateServerOptions,
+} from "../src/server.js";
+import { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
+import {
+  bootPromptRegistryFields,
+  resolveBootPromptText,
+  summarizeTaskSummary,
+} from "../src/agent-types.js";
+import {
+  currentCallerContext,
+  runWithCallerContext,
+} from "../src/caller-context.js";
+
+const TEST_DIR = join(tmpdir(), `cmux-payload-slim-${process.pid}`);
+const REAL_TAB_TITLE = "cmuxlayerClaude [surface:82]";
+const BOOT_PROMPT = [
+  "# Lane: CURSOR RESUME — wrong flag, and it types a broken command into a live agent",
+  "",
+  "Reported by brainlayerClaude from Etan's screen, verified in code and against the live CLI.",
+  "",
+  "## Defect 1 — the flag is wrong",
+  "Full brief body that must never come back on send_to.",
+].join("\n");
+
+const serverContexts: CmuxServerContext[] = [];
+
+function createTrackedServer(opts: Omit<CreateServerOptions, "context">) {
+  const context = createServerContext({
+    ...opts,
+    sessionIdentityResolver: opts.sessionIdentityResolver ?? (() => null),
+    surfaceObserverOwnerIdProvider:
+      opts.surfaceObserverOwnerIdProvider ??
+      (() => "cmux:/tmp/cmuxlayer-payload-slim.sock"),
+    surfaceObserverEpochProvider:
+      opts.surfaceObserverEpochProvider ??
+      (() => "cmux:/tmp/cmuxlayer-payload-slim.sock@test"),
+  });
+  serverContexts.push(context);
+  const server = createServer({ ...opts, context });
+  const sendTo = (server as any)._registeredTools?.send_to;
+  if (sendTo?.handler) {
+    const handler = sendTo.handler.bind(sendTo);
+    sendTo.handler = (...handlerArgs: any[]) =>
+      currentCallerContext()
+        ? handler(...handlerArgs)
+        : runWithCallerContext({ workspaceId: "workspace:1" }, () =>
+            handler(...handlerArgs),
+          );
+  }
+  return server;
+}
+
+function makeSurfaceClient(title: string) {
+  const surface = {
+    ref: "surface:82",
+    id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    workspace_ref: "workspace:1",
+    title,
+  };
+  return {
+    currentSocketPath: vi.fn(() => "/tmp/cmuxlayer-payload-slim.sock"),
+    currentObserverTransportEpoch: vi.fn(() => "test"),
+    listWorkspaces: vi.fn().mockResolvedValue({
+      workspaces: [
+        {
+          ref: "workspace:1",
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    }),
+    listPanes: vi.fn().mockResolvedValue({
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: "pane:1",
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [surface.ref],
+          surface_ids: [surface.id],
+          selected_surface_ref: surface.ref,
+        },
+      ],
+    }),
+    listPaneSurfaces: vi.fn().mockResolvedValue({
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      pane_ref: "pane:1",
+      surfaces: [
+        {
+          ...surface,
+          type: "terminal",
+          index: 0,
+          selected: true,
+          pane_ref: "pane:1",
+        },
+      ],
+    }),
+    readScreen: vi.fn().mockResolvedValue({
+      surface: surface.ref,
+      text: "claude> ",
+      lines: 20,
+      scrollback_used: false,
+    }),
+    send: vi.fn().mockResolvedValue(undefined),
+    pasteText: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn().mockResolvedValue(undefined),
+    log: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    clearStatus: vi.fn().mockResolvedValue(undefined),
+    setProgress: vi.fn().mockResolvedValue(undefined),
+    clearProgress: vi.fn().mockResolvedValue(undefined),
+    newSplit: vi.fn(),
+    newSurface: vi.fn(),
+    selectWorkspace: vi.fn(),
+    closeSurface: vi.fn(),
+    notify: vi.fn(),
+    listStatus: vi.fn().mockResolvedValue([]),
+    identify: vi.fn().mockResolvedValue({}),
+  };
+}
+
+function seedBriefedAgent(stateDir: string): AgentRecord {
+  const fields = bootPromptRegistryFields(BOOT_PROMPT, "/tmp/brief.md");
+  const record: AgentRecord = {
+    agent_id: "cmuxlayerClaude-briefed",
+    surface_id: "surface:82",
+    surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    surface_observer_id: "cmux:/tmp/cmuxlayer-payload-slim.sock",
+    workspace_id: "workspace:1",
+    state: "idle",
+    repo: "cmuxlayer",
+    model: "claude-opus-5",
+    cli: "claude",
+    cli_session_id: null,
+    ...fields,
+    pid: null,
+    version: 1,
+    created_at: "2026-08-16T00:00:00Z",
+    updated_at: "2026-08-16T00:00:00Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "orchestrator",
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    boot_prompt_pending: false,
+  };
+  new StateManager(stateDir).writeState(record);
+  return record;
+}
+
+describe("payload slim #424", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(
+      serverContexts.map(
+        (context) => context.lifecycleStartPromise ?? Promise.resolve(),
+      ),
+    );
+    for (const context of serverContexts.splice(0)) {
+      context.dispose();
+    }
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("summarizeTaskSummary prefers boot_prompt_path basename and preserves full text separately", () => {
+    expect(summarizeTaskSummary(BOOT_PROMPT, "/tmp/docs/brief.md")).toBe(
+      "brief.md",
+    );
+    expect(summarizeTaskSummary(BOOT_PROMPT)).toBe(
+      "# Lane: CURSOR RESUME — wrong flag, and it types a broken command into a live a…",
+    );
+    const fields = bootPromptRegistryFields(BOOT_PROMPT, "/tmp/brief.md");
+    expect(fields.task_summary).toBe("brief.md");
+    expect(fields.boot_prompt_text).toBe(BOOT_PROMPT);
+    expect(resolveBootPromptText(fields)).toBe(BOOT_PROMPT);
+    expect(resolveBootPromptText({ task_summary: BOOT_PROMPT })).toBe(
+      BOOT_PROMPT,
+    );
+  });
+
+  it("send_to title equals list_surfaces title and never echoes the boot prompt", async () => {
+    const client = makeSurfaceClient(REAL_TAB_TITLE);
+    seedBriefedAgent(TEST_DIR);
+    const server = createTrackedServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    await serverContexts[serverContexts.length - 1]?.lifecycleStartPromise;
+
+    const listSurfaces = (server as any)._registeredTools["list_surfaces"];
+    const listed = await listSurfaces.handler({}, {} as any);
+    const listedData =
+      listed.structuredContent ?? JSON.parse(listed.content[0].text);
+    const listedSurface = (
+      listedData.surfaces as Array<Record<string, unknown>>
+    ).find((surface) => surface.ref === "surface:82");
+    expect(listedSurface?.title).toBe(REAL_TAB_TITLE);
+
+    const sendTo = (server as any)._registeredTools["send_to"];
+    const result = await sendTo.handler(
+      {
+        mode: "surface",
+        target: "surface:82",
+        text: "ping",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const data = result.structuredContent ?? JSON.parse(result.content[0].text);
+    const serialized = JSON.stringify({
+      data,
+      text: result.content?.[0]?.text ?? "",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(data.title).toBe(listedSurface?.title);
+    expect(data.title).toBe(REAL_TAB_TITLE);
+    expect(serialized).not.toContain(BOOT_PROMPT);
+    expect(serialized).not.toContain("Defect 1 — the flag is wrong");
+  });
+
+  it("list_agents summary omits health and includes send_via", async () => {
+    const client = makeSurfaceClient(REAL_TAB_TITLE);
+    seedBriefedAgent(TEST_DIR);
+    const server = createTrackedServer({
+      client: client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    await serverContexts[serverContexts.length - 1]?.lifecycleStartPromise;
+
+    const list = (server as any)._registeredTools["list_agents"];
+    const summary = await list.handler({}, {} as any);
+    const summaryData =
+      summary.structuredContent ?? JSON.parse(summary.content[0].text);
+    expect(summaryData.agents[0].agent_id).toBe("cmuxlayerClaude-briefed");
+    expect(summaryData.agents[0].surface_id).toBe("surface:82");
+    expect(summaryData.agents[0].send_via).toBe("send_to");
+    expect(summaryData.agents[0].health).toBeUndefined();
+    expect(JSON.stringify(summaryData)).not.toContain(BOOT_PROMPT);
+
+    const full = await list.handler({ detail: "full" }, {} as any);
+    const fullData = full.structuredContent ?? JSON.parse(full.content[0].text);
+    expect(fullData.agents[0].health).toBeDefined();
+    expect(fullData.agents[0].detail.boot_prompt_text).toBe(BOOT_PROMPT);
+    expect(fullData.agents[0].detail.task_summary).toBe("brief.md");
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -58,8 +58,7 @@ afterEach(async () => {
   if (originalLauncherRegistryPath === undefined) {
     delete process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
   } else {
-    process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH =
-      originalLauncherRegistryPath;
+    process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH = originalLauncherRegistryPath;
   }
   if (originalAllowModel === undefined) {
     delete process.env.REPOGOLEM_ALLOW_MODEL;
@@ -293,9 +292,11 @@ function createTrackedServer(
         const ownerId = testObserverOwnerId();
         if (!ownerId) return null;
         const transportEpoch = (
-          opts.client as {
-            currentObserverTransportEpoch?: () => string | null;
-          } | undefined
+          opts.client as
+            | {
+                currentObserverTransportEpoch?: () => string | null;
+              }
+            | undefined
         )?.currentObserverTransportEpoch?.();
         return `${ownerId}@${transportEpoch || "test"}`;
       }),
@@ -579,8 +580,9 @@ describe("lean spawn tool responses", () => {
       expect(result.structuredContent).toMatchObject({ ok: false });
       expect(result.structuredContent.error).toContain(`Invalid ${field}=`);
       expect(
-        exec.mock.calls.some(([, args]) =>
-          args.includes("new-split") || args.includes("new-surface"),
+        exec.mock.calls.some(
+          ([, args]) =>
+            args.includes("new-split") || args.includes("new-surface"),
         ),
       ).toBe(false);
     },
@@ -604,8 +606,9 @@ describe("lean spawn tool responses", () => {
       /use either .*authority.*lead.*role.*implementor.*or .*authority.*worker.*role.*reviewer/i,
     );
     expect(
-      exec.mock.calls.some(([, args]) =>
-        args.includes("new-split") || args.includes("new-surface"),
+      exec.mock.calls.some(
+        ([, args]) =>
+          args.includes("new-split") || args.includes("new-surface"),
       ),
     ).toBe(false);
   });
@@ -630,8 +633,9 @@ describe("lean spawn tool responses", () => {
       error_code: "ROLE_REQUIRED",
     });
     expect(
-      exec.mock.calls.some(([, args]) =>
-        args.includes("new-split") || args.includes("new-surface"),
+      exec.mock.calls.some(
+        ([, args]) =>
+          args.includes("new-split") || args.includes("new-surface"),
       ),
     ).toBe(false);
   });
@@ -670,7 +674,9 @@ describe("lean spawn tool responses", () => {
     ).toBe(true);
 
     const engine = (server as any)._registeredTools["interact"]._engine;
-    expect(engine.getAgentState(result.structuredContent.agent_id)).toMatchObject({
+    expect(
+      engine.getAgentState(result.structuredContent.agent_id),
+    ).toMatchObject({
       function: "reviewer",
       authority: "worker",
       placement: "right",
@@ -730,10 +736,13 @@ describe("lean spawn tool responses", () => {
     const result = await spawn.handler(args, {} as any);
 
     expect(result.structuredContent).toMatchObject({ ok: false });
-    expect(result.structuredContent.error).toMatch(/reviewer.*right|left.*reviewer/i);
+    expect(result.structuredContent.error).toMatch(
+      /reviewer.*right|left.*reviewer/i,
+    );
     expect(
-      exec.mock.calls.some(([, callArgs]) =>
-        callArgs.includes("new-split") || callArgs.includes("new-surface"),
+      exec.mock.calls.some(
+        ([, callArgs]) =>
+          callArgs.includes("new-split") || callArgs.includes("new-surface"),
       ),
     ).toBe(false);
   });
@@ -783,8 +792,7 @@ describe("lean spawn tool responses", () => {
     expect(
       exec.mock.calls.some(
         ([, callArgs]) =>
-          callArgs.includes("rename-tab") &&
-          callArgs.includes("P5 live probe"),
+          callArgs.includes("rename-tab") && callArgs.includes("P5 live probe"),
       ),
     ).toBe(true);
   });
@@ -892,7 +900,9 @@ describe("lean spawn tool responses", () => {
   });
 
   it("terminal new workspace refuses manual mode before creating workspace", async () => {
-    const baseExec = makeLifecycleExec({ createdWorkspace: "workspace:created" });
+    const baseExec = makeLifecycleExec({
+      createdWorkspace: "workspace:created",
+    });
     const exec = vi.fn().mockImplementation(async (cmd, args) => {
       if (Array.isArray(args) && args.includes("list-status")) {
         return {
@@ -966,7 +976,9 @@ describe("lean spawn tool responses", () => {
       role: "reviewer",
     });
     expect(result.structuredContent.agent_id).not.toContain("-pending-");
-    expect(engine.getAgentState(result.structuredContent.agent_id)).toMatchObject({
+    expect(
+      engine.getAgentState(result.structuredContent.agent_id),
+    ).toMatchObject({
       agent_id: result.structuredContent.agent_id,
       parent_agent_id: parent.agent_id,
       function: "reviewer",
@@ -1052,9 +1064,7 @@ describe("lean spawn tool responses", () => {
       {} as any,
     );
 
-    expect(manifests[0]?.tab_name).toBe(
-      "registeredClaude [surface:new]",
-    );
+    expect(manifests[0]?.tab_name).toBe("registeredClaude [surface:new]");
     expect(lifecycleInitializer).toHaveBeenCalledTimes(1);
     expect(lifecycleSurfaceProvider).not.toHaveBeenCalled();
     expect(context.stateDir).toBe(stateDir);
@@ -1225,8 +1235,9 @@ describe("lean spawn tool responses", () => {
     );
     expect(worktreeExec).not.toHaveBeenCalled();
     expect(
-      (exec as any).mock.calls.some(([, args]: [string, string[]]) =>
-        args.includes("new-split") || args.includes("new-surface"),
+      (exec as any).mock.calls.some(
+        ([, args]: [string, string[]]) =>
+          args.includes("new-split") || args.includes("new-surface"),
       ),
     ).toBe(false);
   });
@@ -1250,7 +1261,9 @@ describe("lean spawn tool responses", () => {
       'Codex effort "medium" cannot be used with cli "claude"',
     );
     expect(
-      mockExec.mock.calls.some(([, callArgs]) => callArgs.includes("new-split")),
+      mockExec.mock.calls.some(([, callArgs]) =>
+        callArgs.includes("new-split"),
+      ),
     ).toBe(false);
   });
 
@@ -1290,7 +1303,9 @@ describe("lean spawn tool responses", () => {
       );
     }
     expect(
-      mockExec.mock.calls.some(([, callArgs]) => callArgs.includes("new-split")),
+      mockExec.mock.calls.some(([, callArgs]) =>
+        callArgs.includes("new-split"),
+      ),
     ).toBe(false);
   });
 
@@ -1325,7 +1340,9 @@ describe("lean spawn tool responses", () => {
     );
     expect(worktreeExec).not.toHaveBeenCalled();
     expect(
-      mockExec.mock.calls.some(([, callArgs]) => callArgs.includes("new-split")),
+      mockExec.mock.calls.some(([, callArgs]) =>
+        callArgs.includes("new-split"),
+      ),
     ).toBe(false);
   });
 
@@ -1365,7 +1382,9 @@ describe("lean spawn tool responses", () => {
       ),
     ).toBe(false);
     expect(
-      mockExec.mock.calls.some(([, callArgs]) => callArgs.includes("new-split")),
+      mockExec.mock.calls.some(([, callArgs]) =>
+        callArgs.includes("new-split"),
+      ),
     ).toBe(false);
   });
 });
@@ -1476,8 +1495,7 @@ type UuidRouteSurface = {
 
 function makeUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
   let liveSurfaces = initialSurfaces;
-  let screenText =
-    "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ";
+  let screenText = "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ";
   const sendCalls: Array<{ surface: string; text: string }> = [];
   const pasteCalls: Array<{ surface: string; text: string }> = [];
   const surfacesForWorkspace = (workspace?: string) =>
@@ -1488,57 +1506,63 @@ function makeUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
     currentSocketPath: vi.fn(() => "/tmp/current.sock"),
     currentObserverTransportEpoch: vi.fn(() => "test:1"),
     listWorkspaces: vi.fn().mockImplementation(async () => ({
-      workspaces: [...new Set(liveSurfaces.map((surface) => surface.workspace_ref))].map(
-        (ref, index) => ({
-          ref,
-          title: ref,
-          index,
-          selected: index === 0,
-          pinned: false,
+      workspaces: [
+        ...new Set(liveSurfaces.map((surface) => surface.workspace_ref)),
+      ].map((ref, index) => ({
+        ref,
+        title: ref,
+        index,
+        selected: index === 0,
+        pinned: false,
+      })),
+    })),
+    listPanes: vi
+      .fn()
+      .mockImplementation(async (opts?: { workspace?: string }) => {
+        const surfaces = surfacesForWorkspace(opts?.workspace);
+        const surfaceIds = surfaces
+          .map((surface) => surface.id)
+          .filter((id): id is string => Boolean(id));
+        return {
+          workspace_ref: opts?.workspace,
+          window_ref: `window:${opts?.workspace ?? "1"}`,
+          panes:
+            surfaces.length === 0
+              ? []
+              : [
+                  {
+                    ref: `pane:${opts?.workspace ?? "1"}`,
+                    index: 0,
+                    focused: true,
+                    surface_count: surfaces.length,
+                    surface_refs: surfaces.map((surface) => surface.ref),
+                    ...(surfaceIds.length === surfaces.length
+                      ? { surface_ids: surfaceIds }
+                      : {}),
+                    selected_surface_ref: surfaces[0]?.ref,
+                  },
+                ],
+        };
+      }),
+    listPaneSurfaces: vi
+      .fn()
+      .mockImplementation(
+        async (opts?: { workspace?: string; pane?: string }) => ({
+          workspace_ref: opts?.workspace,
+          window_ref: `window:${opts?.workspace ?? "1"}`,
+          pane_ref: opts?.pane ?? `pane:${opts?.workspace ?? "1"}`,
+          surfaces: surfacesForWorkspace(opts?.workspace).map(
+            (surface, index) => ({
+              ...surface,
+              title: surface.title ?? "cmuxlayerCodex",
+              type: "terminal",
+              index,
+              selected: index === 0,
+              pane_ref: opts?.pane ?? `pane:${opts?.workspace ?? "1"}`,
+            }),
+          ),
         }),
       ),
-    })),
-    listPanes: vi.fn().mockImplementation(async (opts?: { workspace?: string }) => {
-      const surfaces = surfacesForWorkspace(opts?.workspace);
-      const surfaceIds = surfaces
-        .map((surface) => surface.id)
-        .filter((id): id is string => Boolean(id));
-      return {
-        workspace_ref: opts?.workspace,
-        window_ref: `window:${opts?.workspace ?? "1"}`,
-        panes:
-          surfaces.length === 0
-            ? []
-            : [
-                {
-                  ref: `pane:${opts?.workspace ?? "1"}`,
-                  index: 0,
-                  focused: true,
-                  surface_count: surfaces.length,
-                  surface_refs: surfaces.map((surface) => surface.ref),
-                  ...(surfaceIds.length === surfaces.length
-                    ? { surface_ids: surfaceIds }
-                    : {}),
-                  selected_surface_ref: surfaces[0]?.ref,
-                },
-              ],
-      };
-    }),
-    listPaneSurfaces: vi.fn().mockImplementation(
-      async (opts?: { workspace?: string; pane?: string }) => ({
-        workspace_ref: opts?.workspace,
-        window_ref: `window:${opts?.workspace ?? "1"}`,
-        pane_ref: opts?.pane ?? `pane:${opts?.workspace ?? "1"}`,
-        surfaces: surfacesForWorkspace(opts?.workspace).map((surface, index) => ({
-          ...surface,
-          title: surface.title ?? "cmuxlayerCodex",
-          type: "terminal",
-          index,
-          selected: index === 0,
-          pane_ref: opts?.pane ?? `pane:${opts?.workspace ?? "1"}`,
-        })),
-      }),
-    ),
     readScreen: vi.fn().mockImplementation(async (surface: string) => ({
       surface,
       text: screenText,
@@ -1563,13 +1587,17 @@ function makeUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
     newSurface: vi.fn(),
     selectWorkspace: vi.fn(),
     closeSurface: vi.fn().mockImplementation(async (surface: string) => {
-      liveSurfaces = liveSurfaces.filter((candidate) => candidate.ref !== surface);
+      liveSurfaces = liveSurfaces.filter(
+        (candidate) => candidate.ref !== surface,
+      );
     }),
-    moveSurface: vi.fn().mockImplementation(async (opts: { surface: string }) => ({
-      surface: opts.surface,
-      pane: null,
-      workspace: null,
-    })),
+    moveSurface: vi
+      .fn()
+      .mockImplementation(async (opts: { surface: string }) => ({
+        surface: opts.surface,
+        pane: null,
+        workspace: null,
+      })),
     renameTab: vi.fn().mockResolvedValue(undefined),
     notify: vi.fn(),
     listStatus: vi.fn().mockResolvedValue([]),
@@ -1657,8 +1685,11 @@ function makeBroadcastClient(
   } = {},
 ): BroadcastMockClient {
   const submittedSurfaces = new Set<string>();
-  const sendCalls: Array<{ surface: string; text: string; workspace?: string }> =
-    [];
+  const sendCalls: Array<{
+    surface: string;
+    text: string;
+    workspace?: string;
+  }> = [];
   const sendKeyCalls: Array<{
     surface: string;
     key: string;
@@ -1668,9 +1699,13 @@ function makeBroadcastClient(
     ...new Set(records.map((record) => record.workspace_id ?? "workspace:1")),
   ];
   const recordsForWorkspace = (workspace?: string) =>
-    records.filter((record) => (record.workspace_id ?? "workspace:1") === workspace);
+    records.filter(
+      (record) => (record.workspace_id ?? "workspace:1") === workspace,
+    );
   const screenFor = (surface: string): string => {
-    const record = records.find((candidate) => candidate.surface_id === surface);
+    const record = records.find(
+      (candidate) => candidate.surface_id === surface,
+    );
     if (submittedSurfaces.has(surface)) {
       return record?.cli === "claude"
         ? "Claude Code\nWorking\n"
@@ -1716,23 +1751,25 @@ function makeBroadcastClient(
         ],
       };
     }),
-    listPaneSurfaces: vi.fn().mockImplementation(async ({ workspace, pane }) => {
-      const workspaceRecords = recordsForWorkspace(workspace);
-      return {
-        workspace_ref: workspace,
-        window_ref: `window:${workspace}`,
-        pane_ref: pane ?? `pane:${workspace}`,
-        surfaces: workspaceRecords.map((record, index) => ({
-          ref: record.surface_id,
-          title: record.task_summary,
-          type: "terminal",
-          index,
-          selected: index === 0,
+    listPaneSurfaces: vi
+      .fn()
+      .mockImplementation(async ({ workspace, pane }) => {
+        const workspaceRecords = recordsForWorkspace(workspace);
+        return {
           workspace_ref: workspace,
+          window_ref: `window:${workspace}`,
           pane_ref: pane ?? `pane:${workspace}`,
-        })),
-      };
-    }),
+          surfaces: workspaceRecords.map((record, index) => ({
+            ref: record.surface_id,
+            title: record.task_summary,
+            type: "terminal",
+            index,
+            selected: index === 0,
+            workspace_ref: workspace,
+            pane_ref: pane ?? `pane:${workspace}`,
+          })),
+        };
+      }),
     readScreen: vi.fn().mockImplementation(async (surface) => ({
       surface,
       text: screenFor(surface),
@@ -1767,7 +1804,8 @@ function makeBroadcastClient(
         surface_ref: opts.callerSurface ?? process.env.CMUX_TAB_ID,
         workspace_ref: records.find(
           (record) =>
-            record.surface_id === (opts.callerSurface ?? process.env.CMUX_TAB_ID),
+            record.surface_id ===
+            (opts.callerSurface ?? process.env.CMUX_TAB_ID),
         )?.workspace_id,
       },
       focused: {
@@ -1828,7 +1866,10 @@ type TestToolResult = {
 };
 
 type RegisteredTestTool = {
-  handler(args: Record<string, unknown>, context: unknown): Promise<TestToolResult>;
+  handler(
+    args: Record<string, unknown>,
+    context: unknown,
+  ): Promise<TestToolResult>;
 };
 
 type TestLifecycleEngine = {
@@ -1846,7 +1887,10 @@ function registeredTestTool(server: unknown, name: string): RegisteredTestTool {
 }
 
 function testLifecycleEngine(server: unknown): TestLifecycleEngine {
-  const interact = registeredTestTool(server, "interact") as RegisteredTestTool & {
+  const interact = registeredTestTool(
+    server,
+    "interact",
+  ) as RegisteredTestTool & {
     _engine: TestLifecycleEngine;
   };
   return interact._engine;
@@ -2266,10 +2310,7 @@ describe("agent lifecycle tool handlers", () => {
     await serverContexts.at(-1)?.lifecycleStartPromise;
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
-    const result = await spawn.handler(
-      { resume_agent_id: agentId },
-      {} as any,
-    );
+    const result = await spawn.handler({ resume_agent_id: agentId }, {} as any);
     const parsed = parseToolResult(result) as Record<string, unknown>;
 
     expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
@@ -2331,11 +2372,7 @@ describe("agent lifecycle tool handlers", () => {
     });
     expect(exec).toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining([
-        "list-status",
-        "--workspace",
-        "workspace:1",
-      ]),
+      expect.arrayContaining(["list-status", "--workspace", "workspace:1"]),
     );
     expect(
       exec.mock.calls.some(
@@ -2352,9 +2389,7 @@ describe("agent lifecycle tool handlers", () => {
         modeReads += 1;
         return {
           stdout: JSON.stringify(
-            modeReads === 1
-              ? []
-              : [{ key: "mode.control", value: "manual" }],
+            modeReads === 1 ? [] : [{ key: "mode.control", value: "manual" }],
           ),
           stderr: "",
         };
@@ -2501,9 +2536,11 @@ describe("agent lifecycle tool handlers", () => {
       const calls: string[] = [];
       const mockClient = {
         createWorkspace: vi.fn(),
-        selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
-          calls.push(`select:${workspace}`);
-        }),
+        selectWorkspace: vi
+          .fn()
+          .mockImplementation(async (workspace: string) => {
+            calls.push(`select:${workspace}`);
+          }),
         listWorkspaces: vi.fn().mockResolvedValue({
           workspaces: [
             {
@@ -2654,7 +2691,9 @@ describe("agent lifecycle tool handlers", () => {
     const parsed = parseToolResult(result);
 
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toMatch(/workspace.*t3layer.*brainlayer|brainlayer.*workspace.*t3layer/i);
+    expect(parsed.error).toMatch(
+      /workspace.*t3layer.*brainlayer|brainlayer.*workspace.*t3layer/i,
+    );
     expect(
       exec.mock.calls.some(
         ([, args]) =>
@@ -2997,7 +3036,8 @@ describe("agent lifecycle tool handlers", () => {
       },
       {} as any,
     );
-    const first = firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
+    const first =
+      firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
     const engine = (server as any)._registeredTools["interact"]._engine;
     const registry = engine.getRegistry();
     const firstRecord = registry.get(first.agent_id);
@@ -3014,7 +3054,8 @@ describe("agent lifecycle tool handlers", () => {
       {} as any,
     );
     const second =
-      secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
+      secondResult.structuredContent ??
+      JSON.parse(secondResult.content[0].text);
 
     expect(second.ok).toBe(true);
     expect(second.warnings).toEqual(
@@ -3040,7 +3081,8 @@ describe("agent lifecycle tool handlers", () => {
       },
       {} as any,
     );
-    const first = firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
+    const first =
+      firstResult.structuredContent ?? JSON.parse(firstResult.content[0].text);
     const engine = (server as any)._registeredTools["interact"]._engine;
     const registry = engine.getRegistry();
     const firstRecord = registry.get(first.agent_id);
@@ -3058,7 +3100,8 @@ describe("agent lifecycle tool handlers", () => {
       {} as any,
     );
     const second =
-      secondResult.structuredContent ?? JSON.parse(secondResult.content[0].text);
+      secondResult.structuredContent ??
+      JSON.parse(secondResult.content[0].text);
 
     expect(second.ok).toBe(true);
     expect(second.warnings).not.toEqual(
@@ -3271,11 +3314,7 @@ describe("agent lifecycle tool handlers", () => {
     ).toBe(true);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining([
-        "paste-buffer",
-        "--surface",
-        "surface:moved",
-      ]),
+      expect.arrayContaining(["paste-buffer", "--surface", "surface:moved"]),
     );
   });
 
@@ -3323,10 +3362,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.error).toMatch(/boot prompt.*manual mode/i);
     expect(mockExec).not.toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining([
-        "send",
-        "must not type in manual mode",
-      ]),
+      expect.arrayContaining(["send", "must not type in manual mode"]),
     );
   });
 
@@ -3466,9 +3502,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(chunks.length).toBeGreaterThan(0);
     expect(chunks.every((chunk) => chunk.trim().length > 0)).toBe(true);
     expect(
-      chunks.every(
-        (chunk) => Buffer.byteLength(chunk, "utf-8") <= 16_000,
-      ),
+      chunks.every((chunk) => Buffer.byteLength(chunk, "utf-8") <= 16_000),
     ).toBe(true);
     expect(chunks.join("")).toContain(prompt);
     expect(chunks.join("")).toContain("cmuxlayer mailbox contract");
@@ -3599,10 +3633,7 @@ describe("agent lifecycle tool handlers", () => {
     const registryPath = join(TEST_DIR, "launchers.zsh");
     const worktreePath = join(repoRoot, ".worktrees", "registry-root");
     mkdirSync(repoRoot, { recursive: true });
-    writeFileSync(
-      registryPath,
-      `repoGolem skillcreator "${repoRoot}"\n`,
-    );
+    writeFileSync(registryPath, `repoGolem skillcreator "${repoRoot}"\n`);
     vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
     const worktreeExec = vi.fn().mockImplementation(async () => {
       mkdirSync(worktreePath, { recursive: true });
@@ -3718,8 +3749,9 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.error).toMatch(/Launcher registry miss.*wt-eval-scratch/s);
     expect(worktreeExec).not.toHaveBeenCalled();
     expect(
-      exec.mock.calls.some(([, args]) =>
-        args.includes("select-workspace") || args.includes("surface.focus"),
+      exec.mock.calls.some(
+        ([, args]) =>
+          args.includes("select-workspace") || args.includes("surface.focus"),
       ),
     ).toBe(false);
   });
@@ -3858,7 +3890,10 @@ describe("agent lifecycle tool handlers", () => {
     try {
       const gitsDir = join(TEST_DIR, "Gits");
       const repoRoot = join(TEST_DIR, ".config", "ralph-launch-failure");
-      const registryPath = join(TEST_DIR, "launchers-post-surface-rollback.zsh");
+      const registryPath = join(
+        TEST_DIR,
+        "launchers-post-surface-rollback.zsh",
+      );
       const worktreePath = join(repoRoot, ".worktrees", "post-surface-failure");
       mkdirSync(repoRoot, { recursive: true });
       writeFileSync(registryPath, `repoGolem ralph "${repoRoot}"\n`);
@@ -3969,10 +4004,7 @@ describe("agent lifecycle tool handlers", () => {
           return {
             stdout: JSON.stringify({
               surface: "surface:new",
-              text:
-                elapsed < 800
-                  ? "$ voicelayerCodex -s"
-                  : "codex> ",
+              text: elapsed < 800 ? "$ voicelayerCodex -s" : "codex> ",
               lines: 20,
               scrollback_used: false,
             }),
@@ -4248,7 +4280,12 @@ describe("agent lifecycle tool handlers", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    const worktreePath = join(gitsDir, "cmuxlayer", ".worktrees", "sterile-worker");
+    const worktreePath = join(
+      gitsDir,
+      "cmuxlayer",
+      ".worktrees",
+      "sterile-worker",
+    );
     expect(parsed.ok).toBe(true);
     expect(parsed.role).toBe("worker");
     expect(parsed.mcp_profile).toBe("sterile");
@@ -4269,7 +4306,12 @@ describe("agent lifecycle tool handlers", () => {
   it("new_worktree_split publishes its worktree cwd through the injected manifest writer", async () => {
     const gitsDir = join(TEST_DIR, "Gits");
     mkdirSync(join(gitsDir, "cmuxlayer"), { recursive: true });
-    const worktreePath = join(gitsDir, "cmuxlayer", ".worktrees", "manifest-worker");
+    const worktreePath = join(
+      gitsDir,
+      "cmuxlayer",
+      ".worktrees",
+      "manifest-worker",
+    );
     const worktreeExec = vi.fn().mockImplementation(async () => {
       mkdirSync(worktreePath, { recursive: true });
       return { stdout: "", stderr: "" };
@@ -4464,9 +4506,11 @@ describe("agent lifecycle tool handlers", () => {
       const calls: string[] = [];
       const mockClient = {
         createWorkspace: vi.fn(),
-        selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
-          calls.push(`select:${workspace}`);
-        }),
+        selectWorkspace: vi
+          .fn()
+          .mockImplementation(async (workspace: string) => {
+            calls.push(`select:${workspace}`);
+          }),
         listWorkspaces: vi.fn().mockResolvedValue({
           workspaces: [
             {
@@ -4850,10 +4894,9 @@ describe("agent lifecycle tool handlers", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text:
-              lastSentText.includes("file prompt body")
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/voicelayer\nWorking (1s • esc to interrupt)"
-                : lastSentText === ""
+            text: lastSentText.includes("file prompt body")
+              ? "gpt-5.5 xhigh · 99% left · ~/Gits/voicelayer\nWorking (1s • esc to interrupt)"
+              : lastSentText === ""
                 ? "$ "
                 : launcherReturnCount < 2
                   ? "$ voicelayerCodex -s"
@@ -4934,7 +4977,11 @@ describe("agent lifecycle tool handlers", () => {
           launcherSent = true;
           return { stdout: "{}", stderr: "" };
         }
-        if (launcherSent && args.includes("send-key") && args.includes("return")) {
+        if (
+          launcherSent &&
+          args.includes("send-key") &&
+          args.includes("return")
+        ) {
           launcherReturns += 1;
           return { stdout: "{}", stderr: "" };
         }
@@ -4970,9 +5017,7 @@ describe("agent lifecycle tool handlers", () => {
       expect(parsed.error).toContain(
         "launcher command remained pending after Return",
       );
-      expect(parsed.last_10_lines).toContain(
-        "bash-5.2$ voicelayerCodex -s",
-      );
+      expect(parsed.last_10_lines).toContain("bash-5.2$ voicelayerCodex -s");
       expect(launcherReturns).toBeGreaterThanOrEqual(1);
     } finally {
       vi.useRealTimers();
@@ -5055,12 +5100,11 @@ describe("agent lifecycle tool handlers", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text:
-              lastSentText.includes("file prompt body")
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/voicelayer\nWorking (1s • esc to interrupt)"
-                : lastSentText === ""
-                  ? "$ "
-                  : "$ voicelayerCodex -s\ncodex> ",
+            text: lastSentText.includes("file prompt body")
+              ? "gpt-5.5 xhigh · 99% left · ~/Gits/voicelayer\nWorking (1s • esc to interrupt)"
+              : lastSentText === ""
+                ? "$ "
+                : "$ voicelayerCodex -s\ncodex> ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -5107,7 +5151,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(promptDelivered).toBe(true);
   });
 
-  it("spawn_agent stores boot_prompt_path contents as task_summary after delivery", async () => {
+  it("spawn_agent stores boot_prompt_path contents as boot_prompt_text and a short task_summary", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
     const server = createLifecycleServer(mockExec);
@@ -5140,7 +5184,8 @@ describe("agent lifecycle tool handlers", () => {
     );
     const state =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
-    expect(state.task_summary).toBe("file prompt body");
+    expect(state.boot_prompt_text).toBe("file prompt body");
+    expect(state.task_summary).toBe("mandate.md");
   });
 
   it("spawn_agent rejects prompt and boot_prompt_path together", async () => {
@@ -5338,8 +5383,8 @@ describe("agent lifecycle tool handlers", () => {
 
       const state = engine.stateMgr
         .listStates()
-        .find((candidate: AgentRecord) =>
-          candidate.agent_id === parsed.agent_id
+        .find(
+          (candidate: AgentRecord) => candidate.agent_id === parsed.agent_id,
         );
       expect(state).toBeDefined();
       expect(state?.surface_id).toBe(parsed.surface_id);
@@ -5363,10 +5408,7 @@ describe("agent lifecycle tool handlers", () => {
           launcherSentAt ??= Date.now();
         }
         if (args.includes("read-screen")) {
-          if (
-            launcherSentAt !== null &&
-            Date.now() - launcherSentAt < 200
-          ) {
+          if (launcherSentAt !== null && Date.now() - launcherSentAt < 200) {
             throw new Error("EAGAIN: launcher screen not readable yet");
           }
           return {
@@ -5409,9 +5451,7 @@ describe("agent lifecycle tool handlers", () => {
       );
       expect(parsed.agent_id).toEqual(expect.any(String));
       expect(parsed.surface_id).toBe("surface:new");
-      expect(parsed.last_10_lines).toContain(
-        "agent launcher still starting",
-      );
+      expect(parsed.last_10_lines).toContain("agent launcher still starting");
     } finally {
       vi.useRealTimers();
     }
@@ -5750,7 +5790,8 @@ describe("agent lifecycle tool handlers", () => {
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(["booting", "ready"]).toContain(state.state);
     expect(state.error).toBeNull();
-    expect(state.task_summary).toBe("file prompt body");
+    expect(state.boot_prompt_text).toBe("file prompt body");
+    expect(state.task_summary).toBe("mandate.md");
     expect(state.boot_prompt_pending).toBe(true);
     expect(state.prompt_delivered).toBe(false);
     expect(state.submit_verified).toBeNull();
@@ -5828,10 +5869,12 @@ describe("agent lifecycle tool handlers", () => {
     const defaultResult = await spawn.handler(defaultArgs, {} as any);
     const optedOutResult = await spawn.handler(optedOutArgs, {} as any);
     const defaultId = (
-      defaultResult.structuredContent ?? JSON.parse(defaultResult.content[0].text)
+      defaultResult.structuredContent ??
+      JSON.parse(defaultResult.content[0].text)
     ).agent_id;
     const optedOutId = (
-      optedOutResult.structuredContent ?? JSON.parse(optedOutResult.content[0].text)
+      optedOutResult.structuredContent ??
+      JSON.parse(optedOutResult.content[0].text)
     ).agent_id;
     const defaultStateResult = await getState.handler(
       { agent_id: defaultId },
@@ -5902,7 +5945,9 @@ describe("agent lifecycle tool handlers", () => {
       state: "error",
       surface_id: "surface:dead-manual",
     });
-    expect(engine.getAgentState(record.agent_id)?.error).toMatch(/manual mode/i);
+    expect(engine.getAgentState(record.agent_id)?.error).toMatch(
+      /manual mode/i,
+    );
   });
 
   it("spawn_agent defaults crash_recover to true for orchestrators", async () => {
@@ -5911,12 +5956,12 @@ describe("agent lifecycle tool handlers", () => {
     const getState = (server as any)._registeredTools["get_agent_state"];
 
     const spawnArgs = spawn.inputSchema.parse({
-        repo: "brainlayer",
-        model: "sonnet",
-        cli: "claude",
-        role: "implementor",
-        authority: "lead",
-        prompt: "fix gap F",
+      repo: "brainlayer",
+      model: "sonnet",
+      cli: "claude",
+      role: "implementor",
+      authority: "lead",
+      prompt: "fix gap F",
     });
     const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
@@ -5939,11 +5984,11 @@ describe("agent lifecycle tool handlers", () => {
     const getState = (server as any)._registeredTools["get_agent_state"];
 
     const spawnArgs = spawn.inputSchema.parse({
-        repo: "cmuxlayer",
-        model: "gpt-5.4",
-        cli: "codex",
-        prompt: "fix gap F",
-        role: "worker",
+      repo: "cmuxlayer",
+      model: "gpt-5.4",
+      cli: "codex",
+      prompt: "fix gap F",
+      role: "worker",
     });
     const spawnResult = await spawn.handler(spawnArgs, {} as any);
     const agentId = (
@@ -6003,7 +6048,32 @@ describe("agent lifecycle tool handlers", () => {
       observed_at_ms: expect.any(Number),
     });
     expect(parsed.agents[0].resume_command).toBeUndefined();
-    expect(parsed.agents[0].surface_id).toBeUndefined();
+    expect(parsed.agents[0].surface_id).toBeDefined();
+    expect(parsed.agents[0].send_via).toBe("send_to");
+    expect(parsed.agents[0].health).toBeUndefined();
+  });
+
+  it("list_agents detail=full includes health diagnostics", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const list = (server as any)._registeredTools["list_agents"];
+
+    await spawn.handler(
+      {
+        repo: "brainlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "task 1",
+      },
+      {} as any,
+    );
+
+    const result = await list.handler(
+      { state: "working", detail: "full" },
+      {} as any,
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.agents[0].health).toMatchObject({
       status: "healthy",
       issue_codes: expect.arrayContaining([
@@ -6183,10 +6253,14 @@ describe("agent lifecycle tool handlers", () => {
     const server = await createUuidRouteServer(routeClient, record);
 
     const parsed = parseToolResult(
-      await registeredTestTool(server, "list_agents").handler({}, {}),
+      await registeredTestTool(server, "list_agents").handler(
+        { detail: "full" },
+        {},
+      ),
     );
     const corpse = parsed.agents.find(
-      (candidate: { agent_id: string }) => candidate.agent_id === "corpse-agent",
+      (candidate: { agent_id: string }) =>
+        candidate.agent_id === "corpse-agent",
     );
 
     expect(corpse.state).toMatchObject({ value: "error", source: "screen" });
@@ -6218,10 +6292,14 @@ describe("agent lifecycle tool handlers", () => {
     const server = await createUuidRouteServer(routeClient, record);
 
     const parsed = parseToolResult(
-      await registeredTestTool(server, "list_agents").handler({}, {}),
+      await registeredTestTool(server, "list_agents").handler(
+        { detail: "full" },
+        {},
+      ),
     );
     const live = parsed.agents.find(
-      (candidate: { agent_id: string }) => candidate.agent_id === "mirror-agent",
+      (candidate: { agent_id: string }) =>
+        candidate.agent_id === "mirror-agent",
     );
 
     expect(live.state).toMatchObject({ value: "ready", source: "screen" });
@@ -6457,7 +6535,9 @@ describe("agent lifecycle tool handlers", () => {
       rearm: vi.fn(),
     });
 
-    const parsed = parseToolResult(await list.handler({}, {} as any));
+    const parsed = parseToolResult(
+      await list.handler({ detail: "full" }, {} as any),
+    );
 
     expect(parsed.agents[0]?.health).toMatchObject({
       status: "unhealthy",
@@ -6764,7 +6844,8 @@ describe("agent lifecycle tool handlers", () => {
         role: "orchestrator",
       }),
     ];
-    const { server, sendCalls, sendKeyCalls } = await createBroadcastServer(records);
+    const { server, sendCalls, sendKeyCalls } =
+      await createBroadcastServer(records);
     const broadcast = (server as any)._registeredTools["broadcast"];
 
     const result = await broadcast.handler(
@@ -7354,7 +7435,9 @@ describe("agent lifecycle tool handlers", () => {
     const parsed = parseToolResult(result);
 
     expect(result.isError).toBe(true);
-    expect(parsed.error).toContain('Ambiguous agent_id prefix "cmuxlayerClaude"');
+    expect(parsed.error).toContain(
+      'Ambiguous agent_id prefix "cmuxlayerClaude"',
+    );
     expect(parsed.error).toContain("cmuxlayerClaude-11111111");
     expect(parsed.error).toContain("cmuxlayerClaude-22222222");
     expect(sendCalls).toHaveLength(0);
@@ -7455,7 +7538,9 @@ describe("agent lifecycle tool handlers", () => {
         expect.objectContaining({
           agent_id: "gatherer-fail",
           delivered: false,
-          error: expect.stringContaining("send failed for surface:gatherer-fail"),
+          error: expect.stringContaining(
+            "send failed for surface:gatherer-fail",
+          ),
         }),
       ]),
     });
@@ -7568,7 +7653,7 @@ describe("agent lifecycle tool handlers", () => {
       {} as any,
     );
 
-    const result = await list.handler({}, {} as any);
+    const result = await list.handler({ detail: "full" }, {} as any);
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
@@ -7583,9 +7668,7 @@ describe("agent lifecycle tool handlers", () => {
       },
       health: {
         status: "healthy",
-        issue_codes: expect.arrayContaining([
-          "registry_screen_disagreement",
-        ]),
+        issue_codes: expect.arrayContaining(["registry_screen_disagreement"]),
         issue_severities: {
           registry_screen_disagreement: "info",
         },
@@ -7625,7 +7708,10 @@ describe("agent lifecycle tool handlers", () => {
     );
 
     const parsed = parseToolResult(
-      await registeredTestTool(server, "list_agents").handler({}, {}),
+      await registeredTestTool(server, "list_agents").handler(
+        { detail: "full" },
+        {},
+      ),
     );
     const agent = (parsed.agents as Array<Record<string, any>>).find(
       (candidate) => candidate.agent_id === record.agent_id,
@@ -7637,7 +7723,7 @@ describe("agent lifecycle tool handlers", () => {
       source: "registry",
     });
     expect(agent?.health?.reconciled_state).toBeUndefined();
-    expect(agent?.health?.issue_codes).not.toContain(
+    expect(agent?.health?.issue_codes ?? []).not.toContain(
       "registry_screen_disagreement",
     );
   });
@@ -7666,7 +7752,10 @@ describe("agent lifecycle tool handlers", () => {
     );
 
     const parsed = parseToolResult(
-      await registeredTestTool(server, "list_agents").handler({}, {}),
+      await registeredTestTool(server, "list_agents").handler(
+        { detail: "full" },
+        {},
+      ),
     );
     const agent = (parsed.agents as Array<Record<string, any>>).find(
       (candidate) => candidate.agent_id === record.agent_id,
@@ -7678,7 +7767,7 @@ describe("agent lifecycle tool handlers", () => {
       source: "registry",
     });
     expect(agent?.health?.reconciled_state).toBeUndefined();
-    expect(agent?.health?.issue_codes).not.toContain(
+    expect(agent?.health?.issue_codes ?? []).not.toContain(
       "registry_screen_disagreement",
     );
   });
@@ -7714,15 +7803,17 @@ describe("agent lifecycle tool handlers", () => {
         workspace_ref: "workspace:new",
       },
     ]);
-    routeClient.client.readScreen.mockImplementation(async (surface: string) => ({
-      surface,
-      text:
-        surface === "surface:new"
-          ? "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)"
-          : "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ",
-      lines: 20,
-      scrollback_used: false,
-    }));
+    routeClient.client.readScreen.mockImplementation(
+      async (surface: string) => ({
+        surface,
+        text:
+          surface === "surface:new"
+            ? "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)"
+            : "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ",
+        lines: 20,
+        scrollback_used: false,
+      }),
+    );
 
     const parsed = parseToolResult(
       await registeredTestTool(server, "get_agent_state").handler(
@@ -7774,7 +7865,9 @@ describe("agent lifecycle tool handlers", () => {
 
     await sendInput.handler(sendArgs, {} as any);
     await sendInput.handler(sendArgs, {} as any);
-    const parsed = parseToolResult(await listAgents.handler({}, {} as any)) as {
+    const parsed = parseToolResult(
+      await listAgents.handler({ detail: "full" }, {} as any),
+    ) as {
       agents: Array<{ health: { status: string; issue_codes: string[] } }>;
     };
 
@@ -7929,19 +8022,16 @@ describe("agent lifecycle tool handlers", () => {
       report_path: reportPath,
       done_marker: "DONE_P7_HARVESTABILITY",
     });
-    expect(
-      (missing.health as { issue_codes: string[] }).issue_codes,
-    ).toContain("closure_without_artifact");
+    expect((missing.health as { issue_codes: string[] }).issue_codes).toContain(
+      "closure_without_artifact",
+    );
 
     writeFileSync(
       reportPath,
       "Status: COMPLETE\nDONE_P7_HARVESTABILITY\n",
       "utf8",
     );
-    const verifiedResult = await getState.handler(
-      { agent_id: agentId },
-      {},
-    );
+    const verifiedResult = await getState.handler({ agent_id: agentId }, {});
     const verified = parseToolResult(verifiedResult);
     expect(verified.harvestability).toMatchObject({
       closeable: true,
@@ -8254,9 +8344,9 @@ describe("agent lifecycle tool handlers", () => {
     expect(
       (parsed.harvestability as { issue_codes: string[] }).issue_codes,
     ).toContain("report_stale");
-    expect(
-      (parsed.health as { issue_codes: string[] }).issue_codes,
-    ).toContain("closure_without_artifact");
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "closure_without_artifact",
+    );
   });
 
   it("get_agent_state does not treat non-DONE terminal markers as closeable", async () => {
@@ -8298,9 +8388,9 @@ describe("agent lifecycle tool handlers", () => {
       closure_artifact_verified: false,
       done_marker: null,
     });
-    expect(
-      (parsed.health as { issue_codes: string[] }).issue_codes,
-    ).toContain("closure_without_artifact");
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "closure_without_artifact",
+    );
   });
 
   it("get_agent_state normalizes persisted legacy IC agents to workers that require closure artifacts", async () => {
@@ -8330,9 +8420,9 @@ describe("agent lifecycle tool handlers", () => {
       closeable: false,
       closure_artifact_verified: false,
     });
-    expect(
-      (parsed.health as { issue_codes: string[] }).issue_codes,
-    ).toContain("closure_without_artifact");
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "closure_without_artifact",
+    );
   });
 
   it("get_agent_state does not mark non-done workers unhealthy for missing completion evidence", async () => {
@@ -8422,9 +8512,9 @@ describe("agent lifecycle tool handlers", () => {
         complete: false,
       },
     });
-    expect(
-      (parsed.health as { issue_codes: string[] }).issue_codes,
-    ).toContain("kept_open_contract_incomplete");
+    expect((parsed.health as { issue_codes: string[] }).issue_codes).toContain(
+      "kept_open_contract_incomplete",
+    );
   });
 
   it("get_agent_state reports degraded evidence when done relies on screen fallback after harness read failure", async () => {
@@ -8935,12 +9025,7 @@ codex>
       });
       expect(mockExec).toHaveBeenCalledWith(
         "cmux",
-        expect.arrayContaining([
-          "send",
-          "--surface",
-          "surface:new",
-          "recover",
-        ]),
+        expect.arrayContaining(["send", "--surface", "surface:new", "recover"]),
       );
     },
   );
@@ -9080,8 +9165,7 @@ codex>
     });
     const server = await createUuidRouteServer(routeClient, record);
     const engine = testLifecycleEngine(server) as any;
-    const originalResolveAgentIoRoute =
-      engine.resolveAgentIoRoute.bind(engine);
+    const originalResolveAgentIoRoute = engine.resolveAgentIoRoute.bind(engine);
     let resolveCount = 0;
     vi.spyOn(engine, "resolveAgentIoRoute").mockImplementation(
       async (agentId: string) => {
@@ -9147,8 +9231,7 @@ codex>
     });
     const server = await createUuidRouteServer(routeClient, record);
     const engine = testLifecycleEngine(server) as any;
-    const originalResolveAgentIoRoute =
-      engine.resolveAgentIoRoute.bind(engine);
+    const originalResolveAgentIoRoute = engine.resolveAgentIoRoute.bind(engine);
     let resolveCount = 0;
     vi.spyOn(engine, "resolveAgentIoRoute").mockImplementation(
       async (agentId: string) => {
@@ -9239,7 +9322,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/ambiguous|recycled|multiple/i);
+    expect(parseToolResult(result).error).toMatch(
+      /ambiguous|recycled|multiple/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
   });
 
@@ -9321,7 +9406,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/explicit workspace|workspace:1/i);
+    expect(parseToolResult(result).error).toMatch(
+      /explicit workspace|workspace:1/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
   });
 
@@ -9363,18 +9450,10 @@ codex>
       await vi.advanceTimersByTimeAsync(1);
 
       expect(
-        tracker.observe(
-          "surface:230",
-          null,
-          "cmux:/tmp/observer-old.sock",
-        ),
+        tracker.observe("surface:230", null, "cmux:/tmp/observer-old.sock"),
       ).toMatchObject({ consecutive_broken_pipe_failures: 1 });
       expect(
-        tracker.observe(
-          "surface:230",
-          null,
-          "cmux:/tmp/observer-new.sock",
-        ),
+        tracker.observe("surface:230", null, "cmux:/tmp/observer-new.sock"),
       ).toBeNull();
     } finally {
       vi.useRealTimers();
@@ -9439,7 +9518,9 @@ codex>
       {} as any,
     );
     expect(parseToolResult(listed)).toMatchObject({
-      surfaces: [expect.objectContaining({ ref: "surface:230", id: staleUuid })],
+      surfaces: [
+        expect.objectContaining({ ref: "surface:230", id: staleUuid }),
+      ],
     });
     routeClient.setLiveSurfaces([
       {
@@ -9508,7 +9589,9 @@ codex>
       );
 
       expect(result.isError).toBe(true);
-      expect(parseToolResult(result).error).toMatch(/ambiguous|recycled|multiple/i);
+      expect(parseToolResult(result).error).toMatch(
+        /ambiguous|recycled|multiple/i,
+      );
       expect(routeClient.client.moveSurface).not.toHaveBeenCalled();
       expect(routeClient.client.renameTab).not.toHaveBeenCalled();
     },
@@ -9793,7 +9876,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/stable surface UUID.*not live/i);
+    expect(parseToolResult(result).error).toMatch(
+      /stable surface UUID.*not live/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
     expect(routeClient.client.send).not.toHaveBeenCalled();
   });
@@ -9844,7 +9929,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/stale|no longer maps|not live/i);
+    expect(parseToolResult(result).error).toMatch(
+      /stale|no longer maps|not live/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
     expect(routeClient.client.send).not.toHaveBeenCalled();
   });
@@ -9896,7 +9983,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/recycled|no longer occupies|identity/i);
+    expect(parseToolResult(result).error).toMatch(
+      /recycled|no longer occupies|identity/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
     expect(routeClient.client.send).not.toHaveBeenCalled();
   });
@@ -9926,8 +10015,7 @@ codex>
       server,
       observerId,
     );
-    const originalResolveAgentIoRoute =
-      engine.resolveAgentIoRoute.bind(engine);
+    const originalResolveAgentIoRoute = engine.resolveAgentIoRoute.bind(engine);
     let resolveCount = 0;
     const resolveAgentIoRoute = vi
       .spyOn(engine, "resolveAgentIoRoute")
@@ -10028,7 +10116,9 @@ codex>
       restartedRegistry,
       {} as any,
     );
-    expect(restartedEngine.getDeliveryReceipt(queued.delivery_id)).toMatchObject({
+    expect(
+      restartedEngine.getDeliveryReceipt(queued.delivery_id),
+    ).toMatchObject({
       delivery_id: queued.delivery_id,
       text: "hello",
       delivery_state: "queued",
@@ -10865,7 +10955,11 @@ codex>
 
   it("supersede_agent_goal updates registry metadata and delivers a file-backed goal", async () => {
     const goalPath = join(TEST_DIR, "mission.md");
-    writeFileSync(goalPath, "# Mission\n\nFinish the lifecycle repair.\n", "utf8");
+    writeFileSync(
+      goalPath,
+      "# Mission\n\nFinish the lifecycle repair.\n",
+      "utf8",
+    );
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const supersede = (server as any)._registeredTools["supersede_agent_goal"];
@@ -10917,7 +11011,10 @@ codex>
       ]),
     );
 
-    const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
     const state =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(state.task_summary).toBe("full baseline mission");
@@ -10926,7 +11023,11 @@ codex>
 
   it("supersede_agent_goal reports an unverified pane side effect without patching the registry", async () => {
     const goalPath = join(TEST_DIR, "queued-mission.md");
-    writeFileSync(goalPath, "# Queued mission\n\nReplace the active work.\n", "utf8");
+    writeFileSync(
+      goalPath,
+      "# Queued mission\n\nReplace the active work.\n",
+      "utf8",
+    );
     const baseExec = makeLifecycleExec();
     let goalWasWritten = false;
     const supersedeExec = vi.fn(async (cmd, args) => {
@@ -11016,7 +11117,11 @@ codex>
 
   it("supersede_agent_goal rejects a null submit receipt without patching an error-state agent", async () => {
     const goalPath = join(TEST_DIR, "unverified-error-state-mission.md");
-    writeFileSync(goalPath, "# Mission\n\nDo not record without proof.\n", "utf8");
+    writeFileSync(
+      goalPath,
+      "# Mission\n\nDo not record without proof.\n",
+      "utf8",
+    );
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const supersede = (server as any)._registeredTools["supersede_agent_goal"];
@@ -11127,7 +11232,11 @@ codex>
 
   it("supersede_agent_goal clears stale boot prompt metadata after delivery", async () => {
     const goalPath = join(TEST_DIR, "boot-pending-mission.md");
-    writeFileSync(goalPath, "# Mission\n\nReplace boot prompt state.\n", "utf8");
+    writeFileSync(
+      goalPath,
+      "# Mission\n\nReplace boot prompt state.\n",
+      "utf8",
+    );
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const supersede = (server as any)._registeredTools["supersede_agent_goal"];
@@ -11162,7 +11271,10 @@ codex>
     );
 
     expect(result.isError).toBeFalsy();
-    const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+    const stateResult = await getState.handler(
+      { agent_id: agentId },
+      {} as any,
+    );
     const state =
       stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
     expect(state.state).toBe("working");
@@ -11174,10 +11286,16 @@ codex>
     "supersede_agent_goal resets stale %s lifecycle metadata after delivery",
     async (terminalState) => {
       const goalPath = join(TEST_DIR, `reset-${terminalState}-mission.md`);
-      writeFileSync(goalPath, "# Mission\n\nReplace stale lifecycle state.\n", "utf8");
+      writeFileSync(
+        goalPath,
+        "# Mission\n\nReplace stale lifecycle state.\n",
+        "utf8",
+      );
       const server = createLifecycleServer(mockExec);
       const spawn = (server as any)._registeredTools["spawn_agent"];
-      const supersede = (server as any)._registeredTools["supersede_agent_goal"];
+      const supersede = (server as any)._registeredTools[
+        "supersede_agent_goal"
+      ];
       const getState = (server as any)._registeredTools["get_agent_state"];
 
       const spawnResult = await spawn.handler(
@@ -11225,9 +11343,13 @@ codex>
       expect(result.isError).toBeFalsy();
       expect(parsed.registry_state).toBe("working");
 
-      const stateResult = await getState.handler({ agent_id: agentId }, {} as any);
+      const stateResult = await getState.handler(
+        { agent_id: agentId },
+        {} as any,
+      );
       const state =
-        stateResult.structuredContent ?? JSON.parse(stateResult.content[0].text);
+        stateResult.structuredContent ??
+        JSON.parse(stateResult.content[0].text);
       expect(state.state).toBe("working");
       expect(state.task_summary).toBe("replacement mission");
       expect(state.goal_file).toBe(goalPath);
@@ -11239,15 +11361,21 @@ codex>
 
   it("supersede_agent_goal does not update registry metadata when delivery fails", async () => {
     const goalPath = join(TEST_DIR, "undelivered-mission.md");
-    writeFileSync(goalPath, "# Mission\n\nThis should not be recorded.\n", "utf8");
+    writeFileSync(
+      goalPath,
+      "# Mission\n\nThis should not be recorded.\n",
+      "utf8",
+    );
     const backingExec = makeLifecycleExec();
-    const failingExec: ExecFn = vi.fn().mockImplementation(async (cmd, args) => {
-      const text = String(args[args.length - 1] ?? "");
-      if (args.includes("send") && text.startsWith("/goal ")) {
-        throw new Error("send failed");
-      }
-      return backingExec(cmd, args);
-    });
+    const failingExec: ExecFn = vi
+      .fn()
+      .mockImplementation(async (cmd, args) => {
+        const text = String(args[args.length - 1] ?? "");
+        if (args.includes("send") && text.startsWith("/goal ")) {
+          throw new Error("send failed");
+        }
+        return backingExec(cmd, args);
+      });
     const server = createLifecycleServer(failingExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const supersede = (server as any)._registeredTools["supersede_agent_goal"];
@@ -11437,7 +11565,11 @@ codex>
     );
 
     expect(result.structuredContent).toMatchObject({ ok: true, results: [] });
-    expect(waitForAll).toHaveBeenCalledWith([child.agent_id], "done", undefined);
+    expect(waitForAll).toHaveBeenCalledWith(
+      [child.agent_id],
+      "done",
+      undefined,
+    );
   });
 
   it("wait_for returns an error for an unknown agent_id", async () => {
@@ -11666,7 +11798,8 @@ codex>
         context_pct: 25,
       });
     } finally {
-      if (previousFlag === undefined) delete process.env.CMUXLAYER_HARNESS_JSONL;
+      if (previousFlag === undefined)
+        delete process.env.CMUXLAYER_HARNESS_JSONL;
       else process.env.CMUXLAYER_HARNESS_JSONL = previousFlag;
       if (previousHome === undefined) delete process.env.CMUXLAYER_HARNESS_HOME;
       else process.env.CMUXLAYER_HARNESS_HOME = previousHome;
@@ -11975,9 +12108,9 @@ codex>
       context_window: 400_000,
       context_pct: 20,
     });
-    expect(testLifecycleEngine(server).getAgentState(record.agent_id)).not.toHaveProperty(
-      "token_count",
-    );
+    expect(
+      testLifecycleEngine(server).getAgentState(record.agent_id),
+    ).not.toHaveProperty("token_count");
   });
 
   it("get_agent_state never reads a Codex rollout for a UUID-less record", async () => {
@@ -12289,7 +12422,11 @@ codex>
     vi.useFakeTimers();
     try {
       const pending = registeredTestTool(server, "my_agents").handler({}, {});
-      for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+      for (
+        let index = 0;
+        index < 50 && get.mock.calls.length === 0;
+        index += 1
+      ) {
         await Promise.resolve();
       }
       expect(get).toHaveBeenCalledTimes(1);
@@ -12446,10 +12583,7 @@ codex>
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const myAgents = (server as any)._registeredTools["my_agents"];
 
-    await spawn.handler(
-      { repo: "voicelayer", cli: "claude" },
-      {} as any,
-    );
+    await spawn.handler({ repo: "voicelayer", cli: "claude" }, {} as any);
     await spawn.handler(
       {
         repo: "brainlayer",
@@ -12543,11 +12677,13 @@ codex>
     const engine = testLifecycleEngine(server) as any;
     const registry = engine.getRegistry();
     const originalListMerged = registry.listMerged.bind(registry);
-    vi.spyOn(registry, "listMerged").mockImplementation(async (...args: any[]) => {
-      const merged = await originalListMerged(...args);
-      routeClient.setLiveSurfaces(movedSurfaces);
-      return merged;
-    });
+    vi.spyOn(registry, "listMerged").mockImplementation(
+      async (...args: any[]) => {
+        const merged = await originalListMerged(...args);
+        routeClient.setLiveSurfaces(movedSurfaces);
+        return merged;
+      },
+    );
     routeClient.client.readScreen.mockImplementation(
       async (surface: string) => ({
         surface,
@@ -12575,10 +12711,10 @@ codex>
       surface_id: "surface:new",
       state: "working",
     });
-    expect(routeClient.client.readScreen).toHaveBeenCalledWith(
-      "surface:new",
-      { lines: 20, workspace: "workspace:new" },
-    );
+    expect(routeClient.client.readScreen).toHaveBeenCalledWith("surface:new", {
+      lines: 20,
+      workspace: "workspace:new",
+    });
     expect(routeClient.client.readScreen).not.toHaveBeenCalledWith(
       "surface:old",
       expect.anything(),
@@ -13344,9 +13480,7 @@ describe("auto-focus discipline (focus target before split, restore after render
 
         expect(result.structuredContent.ok).toBe(true);
         expect(result.structuredContent.surface_id).toBe("surface:new");
-        const created = calls.findIndex((args) =>
-          args.includes("new-surface"),
-        );
+        const created = calls.findIndex((args) => args.includes("new-surface"));
         const focusedCreated = focusSurfaceIdx(calls, "surface:new");
         const firstCreatedRead = calls.findIndex(
           (args, index) =>
@@ -13464,7 +13598,9 @@ describe("auto-focus discipline (focus target before split, restore after render
       expect(result.structuredContent.error).toMatch(/focus.*surface:new/i);
       expect(result.structuredContent.agent_id).toEqual(expect.any(String));
       expect(result.structuredContent.surface_id).toBe("surface:new");
-      expect(result.structuredContent.error).not.toMatch(/readiness|timed out/i);
+      expect(result.structuredContent.error).not.toMatch(
+        /readiness|timed out/i,
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3081,7 +3081,65 @@ describe("tool handler integration", () => {
       max_cost_per_agent: null,
     });
 
-    const mockExec = vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" });
+    const mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:95"],
+                surface_ids: ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"],
+                selected_surface_ref: "surface:95",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:95",
+                id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                title: "BL-LEAD",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "{}", stderr: "" };
+    });
     const server = createServer({
       exec: mockExec,
       stateDir,
@@ -3214,6 +3272,62 @@ describe("tool handler integration", () => {
     });
 
     const mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: true,
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:1",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:positive"],
+                surface_ids: ["cccccccc-cccc-4ccc-8ccc-cccccccccccc"],
+                selected_surface_ref: "surface:positive",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:1",
+            surfaces: [
+              {
+                ref: "surface:positive",
+                id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                title: "cmuxlayerCodex positive",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({


### PR DESCRIPTION
## Summary
- Split `task_summary` (short label) from `boot_prompt_text` (full boot payload used for delivery/verification). Truncating `task_summary` in place would break boot-prompt submit verification.
- `send_to` / `send_input` / `send_command` response `title` is now the **live cmux surface title** (same value `list_surfaces` reports) — never the boot prompt, never a truncated summary.
- Lean `list_agents` default: omit health; include `surface_id` + `send_via: "send_to"`. Health/full registry stay behind `detail=full`.

### `task_summary` / `boot_prompt_text` reader map
| Reader | Field |
|---|---|
| Boot delivery / pending-prompt screen check (`agent-engine`) | `boot_prompt_text` via `resolveBootPromptText` |
| Session identity `expectedText` (`agent-engine`) | `boot_prompt_text` |
| PR-loop / blocker text scan (`agent-engine`) | both (`boot_prompt_text` + `task_summary`) |
| Role inference title (`server` broadcast) | short `task_summary` |
| Duplicate-spawn warning / `my_agents` echo | short `task_summary` (summarized on echo for legacy rows) |
| Response `title` on send paths | **live surface title from topology** — not either field |
| Auto-discovered / resync markers (`agent-health`) | short `task_summary` sentinel strings |

## Measure (representative payloads)
| Call | Before | After |
|---|---:|---:|
| `send_to` structured response | ~3922 B (brief-as-title) | ~275 B (real tab title) |
| `list_agents` ×11 agents | ~51272 B (health + brief noise) | ~5887 B (lean summary) |

## Test plan
- [x] `bunx vitest run` — 2677 passed, 1 skipped
- [x] RED→GREEN: `send_to` title equals `list_surfaces` title; never contains boot prompt
- [x] Spawn with `boot_prompt_path` stores full text in `boot_prompt_text`, basename in `task_summary`
- [x] Receipt fields (`delivery` / `delivery_state` / `terminal` / `submit_*`) unchanged

Closes #424


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop echoing boot prompt text as the agent title in `send_to` responses
> - Separates the full boot prompt (`boot_prompt_text`) from a short registry label (`task_summary`) in `AgentRecord`; `task_summary` now stores the filename basename or first 80 chars of the prompt, not the full text.
> - Adds `resolveBootPromptText` and `summarizeTaskSummary` helpers in [agent-types.ts](https://github.com/EtanHey/cmuxlayer/pull/428/files#diff-efd9180892738f786d25ac95f9c9adf7070aa3bc8d56cf1c7d726435f977c6d9) to canonically access boot prompt content and build short labels.
> - `resolveTargetIdentity` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/428/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now sets `title` from the live cmux tab surface title instead of inferring it from `task_summary`, so `send_to` receipts never echo boot prompt content as the title.
> - `list_agents` in summary mode drops health diagnostics and always includes `surface_id` and `send_via: "send_to"`; health is only returned in `detail='full'` mode.
> - Behavioral Change: existing agents without `boot_prompt_text` fall back to trimmed `task_summary` via `resolveBootPromptText`; newly spawned agents will store full and short forms separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f65dcfd. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->