### PR TITLE
fix: recover corrupted launcher lines instead of wedging spawn (#434)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2506,10 +2506,10 @@ function screenShowsQueuedAgentInput(
 
 export type PendingLauncherLineKind = "exact" | "corrupted" | "empty" | "other";
 
-function readPendingShellInput(
+function inspectPendingShellInput(
   screenText: string,
   submittedText: string,
-): string | null {
+): { pending: string; outputBelowPrompt: boolean } | null {
   const trimmed = submittedText.trim();
   if (!trimmed) {
     return null;
@@ -2552,23 +2552,25 @@ function readPendingShellInput(
     lines[activePromptIndex] ?? "",
     promptOptions,
   );
-  return [prompt?.input ?? "", ...lines.slice(activePromptIndex + 1, end)]
-    .join("")
-    .trimEnd();
+  const below = lines.slice(activePromptIndex + 1, end);
+  return {
+    pending: [prompt?.input ?? "", ...below].join("").trimEnd(),
+    outputBelowPrompt: below.some((line) => line.trim().length > 0),
+  };
 }
 
 export function screenShowsPendingShellInput(
   screenText: string,
   submittedText: string,
 ): boolean {
-  const pending = readPendingShellInput(screenText, submittedText);
-  if (pending === null) {
+  const inspected = inspectPendingShellInput(screenText, submittedText);
+  if (inspected === null) {
     return false;
   }
   const trimmed = submittedText.trim();
   return (
-    pending === trimmed ||
-    pending.replace(/\s+/g, "") === trimmed.replace(/\s+/g, "")
+    inspected.pending === trimmed ||
+    inspected.pending.replace(/\s+/g, "") === trimmed.replace(/\s+/g, "")
   );
 }
 
@@ -2576,11 +2578,11 @@ export function classifyPendingLauncherLine(
   screenText: string,
   submittedText: string,
 ): PendingLauncherLineKind {
-  const pending = readPendingShellInput(screenText, submittedText);
-  if (pending === null) {
+  const inspected = inspectPendingShellInput(screenText, submittedText);
+  if (inspected === null) {
     return "other";
   }
-  const compactPending = pending.replace(/\s+/g, "");
+  const compactPending = inspected.pending.replace(/\s+/g, "");
   const compactSubmitted = submittedText.trim().replace(/\s+/g, "");
   if (!compactPending) {
     return "empty";
@@ -2588,10 +2590,12 @@ export function classifyPendingLauncherLine(
   if (compactPending === compactSubmitted) {
     return "exact";
   }
-  if (compactSubmitted && compactPending.includes(compactSubmitted)) {
-    return "corrupted";
+  // Output below the prompt is boot/history, not pending input. Only a
+  // single non-exact prompt line is recoverable corruption.
+  if (inspected.outputBelowPrompt) {
+    return "other";
   }
-  return "other";
+  return "corrupted";
 }
 
 function parseRawSubmitEvidenceMetrics(
@@ -5621,41 +5625,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           await clearAndVerifyFreshShellPrompt();
           await typeLauncherCommand(false);
         };
-        try {
-          const delivery = await typeLauncherCommand(true);
-          if (delivery.submit_verified !== true) {
-            // The command can clear from the shell without proving the launcher
-            // accepted it. Probe once to consume transient ready evidence, then
-            // let boot-prompt readiness own update/relaunch monitoring.
-            await probeAgentLaunchReadyOnce({
-              surface: opts.surface,
-              workspace: opts.workspace,
-            });
-          }
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          if (!/Enter submit could not be verified/.test(message)) {
-            throw error;
-          }
-          let pendingKind: PendingLauncherLineKind = "other";
-          try {
-            const pendingScreen = await readLauncherScreen();
-            pendingKind = classifyPendingLauncherLine(
-              pendingScreen.text,
-              sanitizedCommand,
-            );
-          } catch (readError) {
-            if (isSurfaceGoneReadFailure(readError, opts.surface)) {
-              throw new SurfaceGoneError(opts.surface, readError);
-            }
-          }
-          if (pendingKind === "corrupted") {
-            await recoverCorruptedLauncherLine();
-          }
-          // The command can remain visible in shell history while the launcher is
-          // already booting. Readiness detection is the authoritative launch check.
-          // An empty prompt after human Enter is treated as already submitted.
+        const confirmReadyThenRecoverIfCorrupted = async (): Promise<void> => {
+          // Readiness is the authoritative launch check. Only recover a
+          // corrupted pending line after that check fails — otherwise ctrl-u
+          // can land in a healthy booting pane.
           try {
             await waitForAgentLaunchReady({
               surface: opts.surface,
@@ -5666,11 +5639,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           } catch (readinessError) {
             let pendingScreen;
             try {
-              pendingScreen = await client.readScreen(opts.surface, {
-                workspace: opts.workspace,
-                lines: 80,
-                scrollback: false,
-              });
+              pendingScreen = await readLauncherScreen();
             } catch (readError) {
               if (isSurfaceGoneReadFailure(readError, opts.surface)) {
                 throw new SurfaceGoneError(opts.surface, readError);
@@ -5683,10 +5652,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 sanitizedCommand,
               ) === "corrupted"
             ) {
-              throw new LauncherReadinessError(
-                LAUNCHER_LINE_CORRUPTION_ERROR,
-                tailLines(pendingScreen.text, 10),
-              );
+              await recoverCorruptedLauncherLine();
+              await waitForAgentLaunchReady({
+                surface: opts.surface,
+                workspace: opts.workspace,
+                timeout_ms: opts.timeout_ms,
+                onUpdateShellRelaunch: relaunchOriginalCommand,
+              });
+              return;
             }
             if (
               screenShowsPendingShellInput(pendingScreen.text, sanitizedCommand)
@@ -5698,6 +5671,46 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
             throw readinessError;
           }
+        };
+        try {
+          const delivery = await typeLauncherCommand(true);
+          if (delivery.submit_verified === true) {
+            return;
+          }
+          // The command can clear from the shell without proving the launcher
+          // accepted it. Probe once to consume transient ready evidence, then
+          // let boot-prompt readiness own update/relaunch monitoring.
+          await probeAgentLaunchReadyOnce({
+            surface: opts.surface,
+            workspace: opts.workspace,
+          });
+          // Interleaved corruption never throws: the exact command is gone, so
+          // verify is advisory. Recover only that single-line case here; other
+          // screens (Codex update menus, boot output) belong to boot-prompt wait.
+          let pendingScreen;
+          try {
+            pendingScreen = await readLauncherScreen();
+          } catch (readError) {
+            if (isSurfaceGoneReadFailure(readError, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, readError);
+            }
+            return;
+          }
+          if (
+            classifyPendingLauncherLine(
+              pendingScreen.text,
+              sanitizedCommand,
+            ) === "corrupted"
+          ) {
+            await confirmReadyThenRecoverIfCorrupted();
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (!/Enter submit could not be verified/.test(message)) {
+            throw error;
+          }
+          await confirmReadyThenRecoverIfCorrupted();
         }
       },
       {

--- a/src/server.ts
+++ b/src/server.ts
@@ -463,6 +463,9 @@ function bootPromptUpdateMaxMs(): number {
 const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
+const LAUNCHER_LINE_CORRUPTION_RECOVERY_ATTEMPTS = 2;
+const LAUNCHER_LINE_CORRUPTION_ERROR =
+  "launcher line corrupted by external input; manual Enter may have executed a modified command";
 /** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
 const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = AGENT_HEALTH_MONITOR_MAX_AGE_MS;
 const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
@@ -2501,13 +2504,15 @@ function screenShowsQueuedAgentInput(
   return visiblePrefix.length > 0 && submitted.startsWith(visiblePrefix);
 }
 
-export function screenShowsPendingShellInput(
+export type PendingLauncherLineKind = "exact" | "corrupted" | "empty" | "other";
+
+function readPendingShellInput(
   screenText: string,
   submittedText: string,
-): boolean {
+): string | null {
   const trimmed = submittedText.trim();
   if (!trimmed) {
-    return false;
+    return null;
   }
 
   const lines = normalizeTerminalText(screenText).split("\n");
@@ -2516,7 +2521,6 @@ export function screenShowsPendingShellInput(
     end -= 1;
   }
 
-  const compactSubmitted = trimmed.replace(/\s+/g, "");
   const promptOptions = {
     allowRootInput: isLauncherShellCommand(trimmed),
   };
@@ -2534,29 +2538,60 @@ export function screenShowsPendingShellInput(
       // launcher command; ordinary output such as "Building... 62%" is not a
       // trustworthy prompt anchor.
       if (!strictPrompt && !promptOptions.allowRootInput) {
-        return false;
+        return null;
       }
       activePromptIndex = index;
       break;
     }
   }
   if (activePromptIndex < 0) {
-    return false;
+    return null;
   }
 
   const prompt = matchShellPromptLine(
     lines[activePromptIndex] ?? "",
     promptOptions,
   );
-  const pending = [
-    prompt?.input ?? "",
-    ...lines.slice(activePromptIndex + 1, end),
-  ]
+  return [prompt?.input ?? "", ...lines.slice(activePromptIndex + 1, end)]
     .join("")
     .trimEnd();
+}
+
+export function screenShowsPendingShellInput(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  const pending = readPendingShellInput(screenText, submittedText);
+  if (pending === null) {
+    return false;
+  }
+  const trimmed = submittedText.trim();
   return (
-    pending === trimmed || pending.replace(/\s+/g, "") === compactSubmitted
+    pending === trimmed ||
+    pending.replace(/\s+/g, "") === trimmed.replace(/\s+/g, "")
   );
+}
+
+export function classifyPendingLauncherLine(
+  screenText: string,
+  submittedText: string,
+): PendingLauncherLineKind {
+  const pending = readPendingShellInput(screenText, submittedText);
+  if (pending === null) {
+    return "other";
+  }
+  const compactPending = pending.replace(/\s+/g, "");
+  const compactSubmitted = submittedText.trim().replace(/\s+/g, "");
+  if (!compactPending) {
+    return "empty";
+  }
+  if (compactPending === compactSubmitted) {
+    return "exact";
+  }
+  if (compactSubmitted && compactPending.includes(compactSubmitted)) {
+    return "corrupted";
+  }
+  return "other";
 }
 
 function parseRawSubmitEvidenceMetrics(
@@ -5430,14 +5465,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     await withSurfaceWrite(
       opts.surface,
       async () => {
+        const readLauncherScreen = () =>
+          client.readScreen(opts.surface, {
+            workspace: opts.workspace,
+            lines: 80,
+            scrollback: false,
+          });
         const submitPendingLauncherCommand = async (): Promise<boolean> => {
-          const readLauncherScreen = () =>
-            client.readScreen(opts.surface, {
-              workspace: opts.workspace,
-              lines: 80,
-              scrollback: false,
-            });
-
           let screen;
           try {
             screen = await readLauncherScreen();
@@ -5485,13 +5519,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             }
           }
         };
-        const clearAndVerifyFreshShellPrompt = async (): Promise<void> => {
+        const clearAndVerifyFreshShellPrompt = async (
+          key: "ctrl-c" | "ctrl-u" = "ctrl-c",
+        ): Promise<void> => {
           await opts.assertSurfaceBindingCurrent?.();
           await executeDeliveryEngine({
             surface: opts.surface,
             workspace: opts.workspace,
             chunks: [],
-            key: "ctrl-c",
+            key,
             chunk_size: 0,
             chunk_delay_ms: 0,
             press_enter: false,
@@ -5505,6 +5541,76 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             require_fresh_shell_prompt: true,
           });
         };
+        const typeLauncherCommand = async (verifySubmit: boolean) =>
+          executeDeliveryEngine({
+            surface: opts.surface,
+            workspace: opts.workspace,
+            chunks,
+            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
+            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
+            press_enter: true,
+            source_event: "spawn_agent",
+            verify_submit: verifySubmit,
+            submit_verify_timeout_ms: verifySubmit
+              ? SEND_INPUT_RECOVERY_ENTER_DELAY_MS
+              : undefined,
+            beforeMutation: opts.assertSurfaceBindingCurrent,
+          });
+        const recoverCorruptedLauncherLine = async (): Promise<void> => {
+          for (
+            let attempt = 0;
+            attempt < LAUNCHER_LINE_CORRUPTION_RECOVERY_ATTEMPTS;
+            attempt += 1
+          ) {
+            await clearAndVerifyFreshShellPrompt("ctrl-u");
+            try {
+              const recovered = await typeLauncherCommand(true);
+              if (recovered.submit_verified === true) {
+                return;
+              }
+            } catch (recoveryError) {
+              const recoveryMessage =
+                recoveryError instanceof Error
+                  ? recoveryError.message
+                  : String(recoveryError);
+              if (!/Enter submit could not be verified/.test(recoveryMessage)) {
+                throw recoveryError;
+              }
+            }
+            let recoveredScreen;
+            try {
+              recoveredScreen = await readLauncherScreen();
+            } catch (readError) {
+              if (isSurfaceGoneReadFailure(readError, opts.surface)) {
+                throw new SurfaceGoneError(opts.surface, readError);
+              }
+              throw readError;
+            }
+            const recoveredKind = classifyPendingLauncherLine(
+              recoveredScreen.text,
+              sanitizedCommand,
+            );
+            if (recoveredKind !== "corrupted") {
+              return;
+            }
+          }
+          let failedScreen;
+          try {
+            failedScreen = await readLauncherScreen();
+          } catch (readError) {
+            if (isSurfaceGoneReadFailure(readError, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, readError);
+            }
+            throw new LauncherReadinessError(
+              LAUNCHER_LINE_CORRUPTION_ERROR,
+              [],
+            );
+          }
+          throw new LauncherReadinessError(
+            LAUNCHER_LINE_CORRUPTION_ERROR,
+            tailLines(failedScreen.text, 10),
+          );
+        };
         if (opts.relaunch) {
           if (await submitPendingLauncherCommand()) {
             return;
@@ -5513,31 +5619,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         const relaunchOriginalCommand = async (): Promise<void> => {
           await clearAndVerifyFreshShellPrompt();
-          await executeDeliveryEngine({
-            surface: opts.surface,
-            workspace: opts.workspace,
-            chunks,
-            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-            press_enter: true,
-            source_event: "spawn_agent",
-            verify_submit: false,
-            beforeMutation: opts.assertSurfaceBindingCurrent,
-          });
+          await typeLauncherCommand(false);
         };
         try {
-          const delivery = await executeDeliveryEngine({
-            surface: opts.surface,
-            workspace: opts.workspace,
-            chunks,
-            chunk_size: SEND_INPUT_CHUNK_THRESHOLD,
-            chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
-            press_enter: true,
-            source_event: "spawn_agent",
-            verify_submit: true,
-            submit_verify_timeout_ms: SEND_INPUT_RECOVERY_ENTER_DELAY_MS,
-            beforeMutation: opts.assertSurfaceBindingCurrent,
-          });
+          const delivery = await typeLauncherCommand(true);
           if (delivery.submit_verified !== true) {
             // The command can clear from the shell without proving the launcher
             // accepted it. Probe once to consume transient ready evidence, then
@@ -5553,8 +5638,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!/Enter submit could not be verified/.test(message)) {
             throw error;
           }
+          let pendingKind: PendingLauncherLineKind = "other";
+          try {
+            const pendingScreen = await readLauncherScreen();
+            pendingKind = classifyPendingLauncherLine(
+              pendingScreen.text,
+              sanitizedCommand,
+            );
+          } catch (readError) {
+            if (isSurfaceGoneReadFailure(readError, opts.surface)) {
+              throw new SurfaceGoneError(opts.surface, readError);
+            }
+          }
+          if (pendingKind === "corrupted") {
+            await recoverCorruptedLauncherLine();
+          }
           // The command can remain visible in shell history while the launcher is
           // already booting. Readiness detection is the authoritative launch check.
+          // An empty prompt after human Enter is treated as already submitted.
           try {
             await waitForAgentLaunchReady({
               surface: opts.surface,
@@ -5575,6 +5676,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 throw new SurfaceGoneError(opts.surface, readError);
               }
               throw readinessError;
+            }
+            if (
+              classifyPendingLauncherLine(
+                pendingScreen.text,
+                sanitizedCommand,
+              ) === "corrupted"
+            ) {
+              throw new LauncherReadinessError(
+                LAUNCHER_LINE_CORRUPTION_ERROR,
+                tailLines(pendingScreen.text, 10),
+              );
             }
             if (
               screenShowsPendingShellInput(pendingScreen.text, sanitizedCommand)

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5024,6 +5024,242 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("spawn_agent recovers a human-prefixed launcher line with ctrl-u then retypes", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "";
+    let humanPrefix = "ng ";
+    let launched = false;
+    let ctrlUCount = 0;
+    let typedLaunches = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        typedLaunches += 1;
+        composer += `${humanPrefix}${command}`;
+        humanPrefix = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `$ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 5_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(ctrlUCount).toBeLessThanOrEqual(2);
+    expect(typedLaunches).toBeGreaterThanOrEqual(2);
+    expect(launched).toBe(true);
+  }, 10_000);
+
+  it("spawn_agent does not ctrl-u a clean pending launcher line", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "";
+    let launched = false;
+    let ctrlUCount = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        composer += command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `$ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 5_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBe(0);
+    expect(launched).toBe(true);
+  }, 10_000);
+
+  it("spawn_agent treats an empty prompt after human Enter as already submitted", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let launched = false;
+    let ctrlUCount = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        launched = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched ? "cursor> \nWorking (1s • esc to interrupt)" : "$ ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 5_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBe(0);
+  }, 10_000);
+
+  it("spawn_agent errors when launcher-line corruption recovery is exhausted", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "";
+    let ctrlUCount = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        composer = `ng ${command}`;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: `$ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 5_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      "launcher line corrupted by external input; manual Enter may have executed a modified command",
+    );
+    expect(ctrlUCount).toBe(2);
+    const getState = (server as any)._registeredTools["get_agent_state"];
+    const state = parseToolResult(
+      await getState.handler({ agent_id: parsed.agent_id }, {} as any),
+    );
+    expect(state.state).toBe("error");
+    expect(String(state.error)).toContain(
+      "launcher line corrupted by external input",
+    );
+    const list = (server as any)._registeredTools["list_agents"];
+    const listed = parseToolResult(
+      await list.handler({ state: "error" }, {} as any),
+    );
+    const listedAgent = (
+      listed.agents as Array<{
+        agent_id?: string;
+        state?: { value?: string };
+      }>
+    ).find((agent) => agent.agent_id === parsed.agent_id);
+    expect(listedAgent?.state?.value).toBe("error");
+  }, 10_000);
+
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5075,7 +5075,7 @@ describe("agent lifecycle tool handlers", () => {
         {
           repo: "voicelayer",
           cli: "cursor",
-          boot_prompt_timeout_ms: 5_000,
+          boot_prompt_timeout_ms: 400,
         },
         {} as any,
       ),
@@ -5228,7 +5228,7 @@ describe("agent lifecycle tool handlers", () => {
         {
           repo: "voicelayer",
           cli: "cursor",
-          boot_prompt_timeout_ms: 5_000,
+          boot_prompt_timeout_ms: 400,
         },
         {} as any,
       ),
@@ -5258,6 +5258,126 @@ describe("agent lifecycle tool handlers", () => {
       }>
     ).find((agent) => agent.agent_id === parsed.agent_id);
     expect(listedAgent?.state?.value).toBe("error");
+  }, 10_000);
+
+  it("spawn_agent does not ctrl-u a healthy booting pane with echoed launcher output", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let sent = false;
+    let ctrlUCount = 0;
+    let readyReads = 0;
+    const bootScreen = [
+      "etanheyman ~  $ voicelayerCursor -s",
+      "[4] 55084",
+      "Starting Cursor Agent...",
+    ].join("\n");
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        sent = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        if (sent) {
+          readyReads += 1;
+        }
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text:
+              sent && readyReads > 2
+                ? "cursor> \nWorking (1s • esc to interrupt)"
+                : sent
+                  ? bootScreen
+                  : "$ ",
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 5_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBe(0);
+  }, 10_000);
+
+  it("spawn_agent recovers interleaved human characters inside the launcher command", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "";
+    let launched = false;
+    let ctrlUCount = 0;
+    let typedLaunches = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        typedLaunches += 1;
+        composer = typedLaunches === 1 ? "voicelayerCurng sor -s" : command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `$ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 400,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(ctrlUCount).toBeLessThanOrEqual(2);
+    expect(typedLaunches).toBeGreaterThanOrEqual(2);
+    expect(launched).toBe(true);
   }, 10_000);
 
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -752,6 +752,35 @@ describe("input delivery batching helpers", () => {
       ).toBe(expected);
     },
   );
+
+  it.each([
+    {
+      label: "boot output below an echoed launcher",
+      screen:
+        "etanheyman ~  $ brainlayerCursor -s\n[4] 55084\nStarting Cursor Agent...",
+      expected: "other",
+    },
+    {
+      label: "interleaved human characters inside the command",
+      screen: "etanheyman ~  $ brainlayerCurng sor -s",
+      expected: "corrupted",
+    },
+    {
+      label: "truncated pending launcher line",
+      screen: "etanheyman ~  $ brainlayerCursor -",
+      expected: "corrupted",
+    },
+  ])(
+    "classifies a $label as $expected",
+    async ({ screen, expected }) => {
+      const { classifyPendingLauncherLine } =
+        await loadInputDeliveryTestModule();
+
+      expect(
+        classifyPendingLauncherLine(screen, "brainlayerCursor -s"),
+      ).toBe(expected);
+    },
+  );
 });
 
 describe("tool registration", () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -37,6 +37,10 @@ type InputDeliveryTestModule = typeof import("../src/server.js") & {
     screenText: string,
     submittedText: string,
   ) => boolean;
+  classifyPendingLauncherLine: (
+    screenText: string,
+    submittedText: string,
+  ) => "exact" | "corrupted" | "empty" | "other";
 };
 
 const openServers = new Set<ReturnType<typeof createServerImpl>>();
@@ -713,6 +717,39 @@ describe("input delivery batching helpers", () => {
         await loadInputDeliveryTestModule();
 
       expect(screenShowsPendingShellInput(screen, submittedText)).toBe(false);
+    },
+  );
+
+  it.each([
+    {
+      label: "prefix",
+      screen: "$ ng brainlayerCursor -s",
+      expected: "corrupted",
+    },
+    {
+      label: "suffix",
+      screen: "$ brainlayerCursor -s xx",
+      expected: "corrupted",
+    },
+    {
+      label: "clean line",
+      screen: "$ brainlayerCursor -s",
+      expected: "exact",
+    },
+    {
+      label: "empty line after human Enter already submitted",
+      screen: "$ brainlayerCursor -s\n$ ",
+      expected: "empty",
+    },
+  ])(
+    "classifies a $label pending launcher line",
+    async ({ screen, expected }) => {
+      const { classifyPendingLauncherLine } =
+        await loadInputDeliveryTestModule();
+
+      expect(
+        classifyPendingLauncherLine(screen, "brainlayerCursor -s"),
+      ).toBe(expected);
     },
   );
 });


### PR DESCRIPTION
## Summary
- When a pending launcher line contains the command plus foreign keystrokes (prefix/suffix), clear with ctrl-u, re-verify a fresh prompt, retype, and resubmit. Bound to 2 attempts; reuse the existing clear-and-verify path.
- If recovery is exhausted, spawn transitions to `error` with `launcher line corrupted by external input; manual Enter may have executed a modified command` instead of sitting in `booting` until a human presses Enter.
- Empty prompt after human Enter is treated as already submitted and checked via the existing launcher-running readiness path. Clean pending lines are unchanged.

Fixes #434 (recovery + surfacing only; does not remove the focus requirement).

## Test plan
- [x] `bun run test` — 2709 passed, 1 skipped
- [x] Detection fixtures: prefix `ng brainlayerCursor -s`, suffix `brainlayerCursor -s xx`, clean line, empty line after human Enter
- [x] spawn_agent recovers a human-prefixed line with ctrl-u (≤2 attempts)
- [x] Exhausted recovery marks the agent `error` and surfaces it on `list_agents` / `get_agent_state`

— cmuxlayerCursor (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"a46c1b0c","ts":"2026-08-17T19:48:03Z"} -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher command delivery when shell input is corrupted or includes unexpected text.
  * Automatically clears and retries affected commands, with verification after each attempt.
  * Reports a specific launcher-readiness error when recovery cannot be completed.
  * Correctly handles clean commands and empty prompts after manual submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix corrupted launcher lines in `spawn_agent` by recovering with ctrl-u and retrying
> - Adds `classifyPendingLauncherLine` to detect whether a pending launcher line is exact, empty, corrupted (non-empty mismatch with no output below prompt), or other.
> - When a corrupted launcher line is detected, the `spawn_agent` handler sends ctrl-u to clear it and retypes the command, retrying up to `LAUNCHER_LINE_CORRUPTION_RECOVERY_ATTEMPTS` times before throwing a `LauncherReadinessError`.
> - Skips ctrl-u when there is output below the prompt (e.g. boot or history output) to avoid disrupting a healthy booting pane.
> - Treats an empty prompt after a manual Enter as already submitted rather than stalling.
> - Adds `inspectPendingShellInput` as a shared helper used by both `screenShowsPendingShellInput` and the new classification logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d2c0e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->