### PR TITLE
fix: remap stale surface refs and collect spawn_agent validation errors

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6357,8 +6357,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     /** Live cmux tab title for this surface when topology knows it. */
     title: string | null;
     stableSurfaceIdentity: string | null;
+    remapped_from?: string;
+    remapped_to?: string;
     assertCurrent: () => Promise<void>;
   };
+
+  const remapFields = (
+    route: RawSurfaceMutationRoute,
+  ): Pick<RawSurfaceMutationRoute, "remapped_from" | "remapped_to"> =>
+    route.remapped_from && route.remapped_to
+      ? {
+          remapped_from: route.remapped_from,
+          remapped_to: route.remapped_to,
+        }
+      : {};
 
   /**
    * Bind a caller-visible mutable ref to a stable UUID before terminal I/O.
@@ -6402,6 +6414,51 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const expectedUuid = capturedUuid ?? registryUuid;
     const topologyObserverEpoch = context.surfaceObserverEpoch;
     const topology = await collectSurfaceTopology();
+    const withSurfaceRemap = (
+      route: Omit<RawSurfaceMutationRoute, "remapped_from" | "remapped_to">,
+    ): RawSurfaceMutationRoute =>
+      route.surface !== requestedSurface
+        ? {
+            ...route,
+            remapped_from: requestedSurface,
+            remapped_to: route.surface,
+          }
+        : route;
+    const throwStaleSurfaceRef = (
+      snapshot: SurfaceTopologySnapshot | null,
+    ): never => {
+      const liveAgents: Array<{ agent_id: string; surface_id: string }> = [];
+      const seen = new Set<string>();
+      for (const record of stateMgr.listStates()) {
+        const uuid = record.surface_uuid?.trim();
+        const currentRef =
+          uuid && snapshot ? findSurfaceRefByUuid(snapshot, uuid) : null;
+        const liveRef =
+          currentRef ??
+          (snapshot?.workspaceBySurface.has(record.surface_id)
+            ? record.surface_id
+            : null);
+        if (!liveRef || seen.has(record.agent_id)) continue;
+        seen.add(record.agent_id);
+        liveAgents.push({ agent_id: record.agent_id, surface_id: liveRef });
+      }
+      if (liveAgents.length === 1) {
+        throw new Error(
+          `${requestedSurface} is stale; agent ${liveAgents[0].agent_id} is alive at ${liveAgents[0].surface_id} — use agent_id`,
+        );
+      }
+      if (liveAgents.length > 1) {
+        const listed = liveAgents
+          .map((agent) => `${agent.agent_id} at ${agent.surface_id}`)
+          .join(", ");
+        throw new Error(
+          `${requestedSurface} is stale; live managed agents: ${listed} — use agent_id`,
+        );
+      }
+      throw new Error(
+        `${requestedSurface} is stale; no live managed agent maps this ref`,
+      );
+    };
 
     if (topology?.complete === true) {
       const uuidTargetRef = findSurfaceRefByUuid(topology, requestedSurface);
@@ -6458,30 +6515,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
         };
-        return {
+        return withSurfaceRemap({
           surface: currentRef,
           workspace,
           title: topology.titleBySurface.get(currentRef) ?? null,
           stableSurfaceIdentity: stableUuid,
           assertCurrent,
-        };
+        });
       }
 
       if (
         topology.surfaceIdByRef.size > 0 ||
         topology.surfaceRefById.size > 0
       ) {
-        throw new Error(
-          `Fresh topology did not provide a stable surface UUID for ` +
-            `${requestedSurface}; refusing ${operation}.`,
-        );
+        throwStaleSurfaceRef(topology);
       }
 
       if (!topology.workspaceBySurface.has(requestedSurface)) {
-        throw new Error(
-          `Fresh topology does not contain ${requestedSurface}; refusing ${operation} ` +
-            `rather than trusting an absent mutable ref.`,
-        );
+        throwStaleSurfaceRef(topology);
       }
 
       const workspace =
@@ -8153,6 +8204,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               retry_count: record.retry_count,
             }),
             status: record.status,
+            ...remapFields(route),
           };
           return okFormatted(
             formatDelivery("send_input", {
@@ -8198,6 +8250,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const data = {
           ...identity,
           ...delivery,
+          ...remapFields(route),
         };
         return okFormatted(
           formatDelivery("send_input", {
@@ -8375,6 +8428,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ...identity,
           command: sanitizedCommand,
           ...delivery,
+          ...remapFields(route),
           boot_prompt_delivered: isBootPromptDelivered(bootPromptDelivery),
           boot_prompt_receipt: bootPromptDelivery,
           boot_prompt_bytes: bootPromptDelivery?.bytes,
@@ -8476,7 +8530,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             stableSurfaceIdentity: route.stableSurfaceIdentity,
           },
         );
-        const data = { surface: route.surface, key, ...delivery };
+        const data = {
+          surface: route.surface,
+          key,
+          ...delivery,
+          ...remapFields(route),
+        };
         return okFormatted(formatOk("send_key", data), data);
       } catch (e) {
         return err(e);
@@ -8540,12 +8599,64 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             topologyBeforeRead,
           );
         }
-        const { result, topology } = await readScreenSnapshot({
+        let result: ReadScreenSnapshot["result"];
+        let topology: ReadScreenSnapshot["topology"];
+        let screenRemap: Pick<
+          RawSurfaceMutationRoute,
+          "remapped_from" | "remapped_to"
+        > = {};
+        const snapshotOpts = {
           surface: args.surface,
           workspace: args.workspace,
           lines: args.lines,
           scrollback: args.scrollback,
-        });
+        };
+        try {
+          ({ result, topology } = await readScreenSnapshot(snapshotOpts));
+        } catch (readError) {
+          const route = await resolveRawSurfaceMutationRoute(
+            args.surface,
+            args.workspace,
+            "read_screen",
+          );
+          if (route.surface === args.surface) throw readError;
+          screenRemap = remapFields(route);
+          ({ result, topology } = await readScreenSnapshot({
+            ...snapshotOpts,
+            surface: route.surface,
+            workspace: route.workspace ?? args.workspace,
+          }));
+        }
+        const requestedIsLive =
+          topology?.workspaceBySurface.has(args.surface) === true ||
+          topology?.surfaceIdByRef.has(args.surface) === true;
+        if (
+          topology?.complete === true &&
+          !requestedIsLive &&
+          !screenRemap.remapped_from
+        ) {
+          const route = await resolveRawSurfaceMutationRoute(
+            args.surface,
+            args.workspace,
+            "read_screen",
+          );
+          screenRemap = remapFields(route);
+          if (route.surface !== args.surface) {
+            const remapped = await readScreenSnapshot({
+              ...snapshotOpts,
+              surface: route.surface,
+              workspace: route.workspace ?? args.workspace,
+            });
+            result = remapped.result;
+            topology = remapped.topology;
+            if (hasCodexRolloutCandidate) {
+              codexAgentBeforeRead = resolveCodexAgentForSurface(
+                route.surface,
+                topology,
+              );
+            }
+          }
+        }
         const title = topology?.titleBySurface.get(result.surface) ?? null;
         const { column, column_count } =
           topology?.topologyBySurface.get(result.surface) ??
@@ -8579,6 +8690,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             column_count,
             parsed,
             delivery: getSurfaceDelivery(result.surface),
+            ...screenRemap,
           };
           const formatted = formatReadScreen(
             result.surface,
@@ -8605,6 +8717,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             scrollback_used: result.scrollback_used,
             parsed,
             delivery: getSurfaceDelivery(result.surface),
+            ...screenRemap,
           };
           const formatted = formatReadScreen(
             result.surface,
@@ -8633,6 +8746,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           parsed,
           ...(screenPreview ? { screen_preview: screenPreview } : {}),
           delivery: getSurfaceDelivery(result.surface),
+          ...screenRemap,
         };
         const formatted = formatReadScreen(
           result.surface,
@@ -10869,20 +10983,54 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...(cwdReceipt ? { cwd_receipt: cwdReceipt } : {}),
             });
           }
-          requireValue(args.repo, "repo is required for type=agent");
-          requireValue(args.cli, "cli is required for type=agent");
-          if (
+          const spawnProblems: string[] = [];
+          if (!args.repo) {
+            spawnProblems.push("repo is required for type=agent");
+          }
+          if (!args.cli) {
+            spawnProblems.push("cli is required for type=agent");
+          }
+          const rolelessClaude =
             args.version === 1 &&
-            args.cli === "claude" &&
-            args.role === undefined
-          ) {
-            return err(
-              new Error(
-                'Claude spawns require an explicit job role; use either authority:"lead", role:"implementor" or authority:"worker", role:"reviewer"',
-              ),
-              { error_code: "ROLE_REQUIRED" },
+            (args.cli === "claude" || args.cli === undefined) &&
+            args.role === undefined;
+          if (rolelessClaude) {
+            spawnProblems.push(
+              'Claude spawns require an explicit job role; use either authority:"lead", role:"implementor" or authority:"worker", role:"reviewer"',
             );
           }
+          if (args.cli) {
+            try {
+              resolveSpawnModelPolicy(args.cli, args.model);
+            } catch (error) {
+              spawnProblems.push(
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+            try {
+              resolveSpawnEffort(args.cli, args.effort);
+            } catch (error) {
+              spawnProblems.push(
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+          }
+          if (spawnProblems.length > 0) {
+            const error_code =
+              spawnProblems.length === 1 &&
+              rolelessClaude &&
+              args.cli === "claude"
+                ? "ROLE_REQUIRED"
+                : spawnProblems.length > 1
+                  ? "INVALID_SPAWN_SPEC"
+                  : undefined;
+            return err(
+              new Error(spawnProblems.join("; ")),
+              error_code ? { error_code } : {},
+            );
+          }
+          requireValue(args.repo, "repo is required for type=agent");
+          requireValue(args.cli, "cli is required for type=agent");
           const normalizedRole = normalizeSpawnAxes({
             role: args.role,
             placement: args.placement,

--- a/src/server.ts
+++ b/src/server.ts
@@ -6426,6 +6426,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         : route;
     const throwStaleSurfaceRef = (
       snapshot: SurfaceTopologySnapshot | null,
+      diagnostic?: string,
     ): never => {
       const liveAgents: Array<{ agent_id: string; surface_id: string }> = [];
       const seen = new Set<string>();
@@ -6442,22 +6443,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         seen.add(record.agent_id);
         liveAgents.push({ agent_id: record.agent_id, surface_id: liveRef });
       }
-      if (liveAgents.length === 1) {
-        throw new Error(
-          `${requestedSurface} is stale; agent ${liveAgents[0].agent_id} is alive at ${liveAgents[0].surface_id} — use agent_id`,
-        );
-      }
-      if (liveAgents.length > 1) {
-        const listed = liveAgents
-          .map((agent) => `${agent.agent_id} at ${agent.surface_id}`)
-          .join(", ");
-        throw new Error(
-          `${requestedSurface} is stale; live managed agents: ${listed} — use agent_id`,
-        );
-      }
-      throw new Error(
-        `${requestedSurface} is stale; no live managed agent maps this ref`,
-      );
+      const occupancy =
+        liveAgents.length === 1
+          ? `${requestedSurface} is stale; agent ${liveAgents[0].agent_id} is alive at ${liveAgents[0].surface_id} — use agent_id`
+          : liveAgents.length > 1
+            ? `${requestedSurface} is stale; live managed agents: ${liveAgents
+                .map((agent) => `${agent.agent_id} at ${agent.surface_id}`)
+                .join(", ")} — use agent_id`
+            : `${requestedSurface} is stale; no live managed agent maps this ref`;
+      throw new Error(diagnostic ? `${occupancy} (${diagnostic})` : occupancy);
     };
 
     if (topology?.complete === true) {
@@ -6486,7 +6480,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       if (stableUuid) {
         const currentRef = findSurfaceRefByUuid(topology, stableUuid);
         if (!currentRef) {
-          throw new Error(
+          return throwStaleSurfaceRef(
+            topology,
             `Stable surface UUID ${stableUuid} captured for ${requestedSurface} ` +
               `is no longer live; refusing ${operation} rather than using a recycled ref.`,
           );
@@ -8626,6 +8621,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             surface: route.surface,
             workspace: route.workspace ?? args.workspace,
           }));
+          if (hasCodexRolloutCandidate) {
+            codexAgentBeforeRead = resolveCodexAgentForSurface(
+              route.surface,
+              topology,
+            );
+          }
         }
         const requestedIsLive =
           topology?.workspaceBySurface.has(args.surface) === true ||

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -9546,6 +9546,172 @@ codex>
     ]);
   });
 
+  it("raw send_to names a live agent when a captured UUID is no longer live", async () => {
+    const deadUuid = "11111111-2222-4333-8444-555555555555";
+    const liveUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:524",
+        id: deadUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "skillcreatorClaude",
+      surface_id: "surface:89",
+      surface_uuid: liveUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "skill-creator",
+      cli: "claude",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+    await registeredTestTool(server, "list_surfaces").handler({}, {} as any);
+    routeClient.setLiveSurfaces([
+      {
+        ref: "surface:89",
+        id: liveUuid,
+        workspace_ref: "workspace:1",
+        title: "skillcreatorClaude",
+      },
+    ]);
+    routeClient.client.send.mockClear();
+    routeClient.sendCalls.length = 0;
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "are you dead",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(
+      /surface:524 is stale; agent skillcreatorClaude is alive at surface:89 — use agent_id/i,
+    );
+    expect(parsed.error).not.toMatch(
+      /^Stable surface UUID .* is no longer live; refusing/i,
+    );
+    expect(routeClient.sendCalls).toEqual([]);
+  });
+
+  it("raw send_to says no live agent when a captured UUID is gone and none remain", async () => {
+    const deadUuid = "11111111-2222-4333-8444-555555555555";
+    const otherUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:524",
+        id: deadUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      lifecycleInitializer: async () => {},
+    });
+    await registeredTestTool(server, "list_surfaces").handler({}, {} as any);
+    routeClient.setLiveSurfaces([
+      {
+        ref: "surface:other",
+        id: otherUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    routeClient.client.send.mockClear();
+    routeClient.sendCalls.length = 0;
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "anyone there",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/surface:524 is stale/i);
+    expect(parsed.error).toMatch(/no live managed agent/i);
+    expect(parsed.error).not.toMatch(
+      /^Stable surface UUID .* is no longer live; refusing/i,
+    );
+    expect(routeClient.sendCalls).toEqual([]);
+  });
+
+  it("read_screen catch-path forward keeps Codex rollout enrichment", async () => {
+    const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+    const path = "/fixtures/codex/catch-path-forward.jsonl";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: surfaceUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    routeClient.setScreenText(
+      "gpt-5.4 high · 75% left · ~/Gits/cmuxlayer\nWorking (2s • esc to interrupt)",
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "codex-catch-path-forward",
+      surface_id: "surface:524",
+      surface_uuid: surfaceUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      cli: "codex",
+      cli_session_id: "session-catch",
+      cli_session_path: path,
+    });
+    const get = vi.fn().mockResolvedValue({
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+      observed_model_context_window: 258_400,
+    });
+    const server = await createUuidRouteServer(routeClient, record, {
+      codexRolloutFillProvider: { get },
+    });
+    const originalRead = routeClient.client.readScreen.getMockImplementation();
+    routeClient.client.readScreen.mockImplementation(
+      async (surface: string, opts?: { lines?: number }) => {
+        if (surface === "surface:524") {
+          throw new Error("surface:524 is gone");
+        }
+        if (!originalRead) {
+          throw new Error("missing readScreen implementation");
+        }
+        return originalRead(surface, opts);
+      },
+    );
+
+    const result = await registeredTestTool(server, "read_screen").handler(
+      { surface: "surface:524", parsed_only: true },
+      {},
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      surface: "surface:89",
+      remapped_from: "surface:524",
+      remapped_to: "surface:89",
+    });
+    expect(get).toHaveBeenCalledWith(path);
+    expect(parsed.parsed).toMatchObject({
+      agent_type: "codex",
+      token_count: 100_000,
+      context_window: 400_000,
+      context_pct: 25,
+    });
+  });
+
   it("raw send_to follows the captured UUID when the old ref is vacated", async () => {
     const originalUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -588,6 +588,29 @@ describe("lean spawn tool responses", () => {
     },
   );
 
+  it("rejects a spawn missing repo, cli, and role in one error that names all three", async () => {
+    const exec = makeLifecycleExec();
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const result = await spawn.handler(
+      { version: 1, type: "agent" },
+      {} as any,
+    );
+    const parsed = result.structuredContent as Record<string, unknown>;
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/repo/i);
+    expect(parsed.error).toMatch(/cli/i);
+    expect(parsed.error).toMatch(/role/i);
+    expect(
+      exec.mock.calls.some(
+        ([, args]) =>
+          args.includes("new-split") || args.includes("new-surface"),
+      ),
+    ).toBe(false);
+  });
+
   it("rejects roleless Claude before creating any surface and names both fixes", async () => {
     const exec = makeLifecycleExec();
     const server = createLifecycleServer(exec);
@@ -9328,6 +9351,201 @@ codex>
     expect(routeClient.sendCalls).toEqual([]);
   });
 
+  it("raw send_to forwards a stale ref to a live managed agent and reports remap fields", async () => {
+    const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: surfaceUuid,
+        workspace_ref: "workspace:1",
+        title: "skillcreatorClaude",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "skillcreatorClaude",
+      surface_id: "surface:524",
+      surface_uuid: surfaceUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "skill-creator",
+      cli: "claude",
+      task_summary: "live peer",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+    routeClient.client.send.mockClear();
+    routeClient.sendCalls.length = 0;
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "are you alive",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      surface: "surface:89",
+      remapped_from: "surface:524",
+      remapped_to: "surface:89",
+    });
+    expect(routeClient.sendCalls).toEqual([
+      { surface: "surface:89", text: "are you alive" },
+    ]);
+  });
+
+  it("read_screen forwards a stale ref to a live managed agent and reports remap fields", async () => {
+    const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: surfaceUuid,
+        workspace_ref: "workspace:1",
+        title: "skillcreatorClaude",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "skillcreatorClaude",
+      surface_id: "surface:524",
+      surface_uuid: surfaceUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "skill-creator",
+      cli: "claude",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+
+    const result = await registeredTestTool(server, "read_screen").handler(
+      { surface: "surface:524" },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      ok: true,
+      surface: "surface:89",
+      remapped_from: "surface:524",
+      remapped_to: "surface:89",
+    });
+  });
+
+  it("raw send_to on a stale ref with no mapped agent names that no live agent occupies it", async () => {
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      lifecycleInitializer: async () => {},
+    });
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "anyone there",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/surface:524 is stale/i);
+    expect(parsed.error).toMatch(/no live managed agent/i);
+    expect(parsed.error).not.toMatch(
+      /Fresh topology did not provide a stable surface UUID/i,
+    );
+    expect(routeClient.sendCalls).toEqual([]);
+  });
+
+  it("raw send_to on a stale ref names a live agent that already moved off that ref", async () => {
+    const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: surfaceUuid,
+        workspace_ref: "workspace:1",
+        title: "skillcreatorClaude",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "skillcreatorClaude",
+      surface_id: "surface:89",
+      surface_uuid: surfaceUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "skill-creator",
+      cli: "claude",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "are you dead",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(
+      /surface:524 is stale; agent skillcreatorClaude is alive at surface:89 — use agent_id/i,
+    );
+    expect(parsed.error).not.toMatch(
+      /Fresh topology did not provide a stable surface UUID/i,
+    );
+    expect(routeClient.sendCalls).toEqual([]);
+  });
+
+  it("raw send_to to an exact live ref is unchanged and has no remap fields", async () => {
+    const surfaceUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:89",
+        id: surfaceUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      lifecycleInitializer: async () => {},
+    });
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:89",
+        text: "exact ref",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.surface).toBe("surface:89");
+    expect(parsed).not.toHaveProperty("remapped_from");
+    expect(parsed).not.toHaveProperty("remapped_to");
+    expect(routeClient.sendCalls).toEqual([
+      { surface: "surface:89", text: "exact ref" },
+    ]);
+  });
+
   it("raw send_to follows the captured UUID when the old ref is vacated", async () => {
     const originalUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([
@@ -9484,7 +9702,9 @@ codex>
     );
 
     expect(result.isError).toBe(true);
-    expect(parseToolResult(result).error).toMatch(/fresh topology|not live/i);
+    expect(parseToolResult(result).error).toMatch(
+      /surface:missing is stale; no live managed agent/i,
+    );
     expect(routeClient.sendCalls).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- C5: `send_to` / `read_screen` on a stale surface ref now forward to the live managed agent (with `remapped_from` / `remapped_to`) instead of a bare topology UUID error that looked like agent death. When forwarding is impossible, the error names whether a live agent occupies the story and tells the caller to use `agent_id`.
- C6: `spawn_agent` collects missing/invalid `repo`, `cli`, `role`, and model/effort problems into one rejection instead of a four-error staircase.

## Test plan
- [x] `bun run test` — 2707 passed, 1 skipped
- [x] `bun run typecheck`
- [x] Stale ref + live agent (registry still on old surface_id) forwards with remap fields
- [x] Stale ref + no mapped agent errors with `no live managed agent`
- [x] Stale ref + agent already at the new surface names that agent and says use `agent_id`
- [x] Exact live-ref sends unchanged (no remap fields)
- [x] Spawn missing repo+cli+role returns one error naming all three
- [ ] Live MCP session check after merge (worker endpoint is open PR; lead owns merge)

— cmuxlayerCursor (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"a4c874e2","ts":"2026-08-17T19:48:39Z"} -->

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale surface refs by remapping to live agents and collect spawn_agent validation errors
> - Stale surface references are now remapped to the live managed agent instead of failing immediately; `send_input`, `send_command`, `send_key`, and `read_screen` return `remapped_from`/`remapped_to` fields when a remap occurs.
> - Stale-ref errors now enumerate live managed agents and suggest using `agent_id`, replacing prior generic error messages.
> - `read_screen` retries the snapshot against the remapped live surface on failure and preserves Codex rollout enrichment through the remap path.
> - `spawn_agent` validation now accumulates all issues (missing repo, missing cli, roleless Claude, invalid model policy, invalid effort) and returns a single aggregated error instead of failing on the first problem.
> - Behavioral Change: stale-ref error text has changed; tests expecting the old generic messages will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ab3745.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->