### PR TITLE
fix: survive keystrokes during spawn shell-readiness wait (#434)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -128,6 +128,7 @@ import {
   launcherFailureFromShell,
   matchShellPromptLine,
   matchesShellPrompt,
+  pendingShellPromptInput,
 } from "./shell-prompt.js";
 import {
   CreatedIdentityScope,
@@ -462,6 +463,8 @@ function bootPromptUpdateMaxMs(): number {
 }
 const LAUNCH_SHELL_READY_TIMEOUT_MS = 10_000;
 const LAUNCH_SHELL_READY_POLL_MS = 100;
+const LAUNCH_SHELL_JUNK_CLEAR_INTERVAL_MS = 2_500;
+const LAUNCH_SHELL_JUNK_CLEAR_MAX = 3;
 const LAUNCH_SUBMIT_READY_TIMEOUT_MS = 15_000;
 const LAUNCHER_LINE_CORRUPTION_RECOVERY_ATTEMPTS = 2;
 const LAUNCHER_LINE_CORRUPTION_ERROR =
@@ -1010,6 +1013,7 @@ class BootPromptTimeoutError extends Error {
   constructor(
     message: string,
     readonly last_10_lines: string[],
+    readonly pending_input_observed = false,
   ) {
     super(message);
     this.name = "BootPromptTimeoutError";
@@ -3283,6 +3287,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const activeSurfaceWrites = context.activeSurfaceWrites;
   const originalLaunchCommandsBySurface =
     context.originalLaunchCommandsBySurface;
+  const launchShellRecoveryBySurface = new Map<
+    string,
+    { recovered: true; cleared: string[] }
+  >();
   const surfaceWriteLiveness = context.surfaceWriteLiveness;
   const surfaceWriteLivenessCandidates = context.surfaceWriteLivenessCandidates;
   const surfacePtyDeadSince = context.surfacePtyDeadSince;
@@ -5257,10 +5265,35 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     workspace?: string;
     timeout_ms?: number;
     require_fresh_shell_prompt?: boolean;
-  }): Promise<void> => {
+    stableSurfaceIdentity?: string | null;
+    assertSurfaceBindingCurrent?: () => Promise<void>;
+  }): Promise<{ recovered: boolean; cleared: string[] }> => {
     const timeoutMs = opts.timeout_ms ?? LAUNCH_SHELL_READY_TIMEOUT_MS;
     const start = Date.now();
     let lastText = "";
+    const cleared: string[] = [];
+    let clears = 0;
+    let lastClearAt = 0;
+    let lastClearKey: "ctrl-u" | "ctrl-c" | null = null;
+    let pendingInputObserved = false;
+
+    const screenShowsAgentReady = (text: string): boolean =>
+      READY_PATTERN_CLIS.some((cli) => matchReadyPattern(cli, text).matched);
+
+    const sendClearKey = async (key: "ctrl-u" | "ctrl-c"): Promise<void> => {
+      await executeDeliveryEngine({
+        surface: opts.surface,
+        workspace: opts.workspace,
+        chunks: [],
+        key,
+        chunk_size: 0,
+        chunk_delay_ms: 0,
+        press_enter: false,
+        source_event: "send_key",
+        stableSurfaceIdentity: opts.stableSurfaceIdentity,
+        beforeMutation: opts.assertSurfaceBindingCurrent,
+      });
+    };
 
     while (Date.now() - start < timeoutMs) {
       try {
@@ -5270,14 +5303,34 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           scrollback: false,
         });
         lastText = screen.text;
-        if (
-          matchesShellPrompt(screen.text) ||
-          (!opts.require_fresh_shell_prompt &&
-            READY_PATTERN_CLIS.some(
-              (cli) => matchReadyPattern(cli, screen.text).matched,
-            ))
-        ) {
-          return;
+        const agentReady = screenShowsAgentReady(screen.text);
+        if (!opts.require_fresh_shell_prompt && agentReady) {
+          return { recovered: cleared.length > 0, cleared };
+        }
+        if (matchesShellPrompt(screen.text)) {
+          return { recovered: cleared.length > 0, cleared };
+        }
+        const pending = agentReady
+          ? null
+          : pendingShellPromptInput(screen.text);
+        if (pending) {
+          pendingInputObserved = true;
+          if (lastClearKey === "ctrl-u") {
+            await sendClearKey("ctrl-c");
+            lastClearKey = "ctrl-c";
+          } else if (
+            clears < LAUNCH_SHELL_JUNK_CLEAR_MAX &&
+            (clears === 0 ||
+              Date.now() - lastClearAt >= LAUNCH_SHELL_JUNK_CLEAR_INTERVAL_MS)
+          ) {
+            await sendClearKey("ctrl-u");
+            if (!cleared.includes(pending)) {
+              cleared.push(pending);
+            }
+            clears += 1;
+            lastClearAt = Date.now();
+            lastClearKey = "ctrl-u";
+          }
         }
       } catch (error) {
         if (isSurfaceGoneReadFailure(error, opts.surface)) {
@@ -5296,6 +5349,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     throw new BootPromptTimeoutError(
       `Timed out after ${timeoutMs}ms waiting for shell readiness on ${opts.surface}`,
       tailLines(lastText, 10),
+      pendingInputObserved,
     );
   };
 
@@ -5459,11 +5513,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         : [sanitizedCommand];
 
     if (!opts.relaunch) {
-      await waitForLaunchShellReady({
+      const shellRecovery = await waitForLaunchShellReady({
         surface: opts.surface,
         workspace: opts.workspace,
         timeout_ms: opts.timeout_ms,
+        stableSurfaceIdentity: opts.stableSurfaceIdentity,
+        assertSurfaceBindingCurrent: opts.assertSurfaceBindingCurrent,
       });
+      if (shellRecovery.recovered) {
+        launchShellRecoveryBySurface.set(opts.surface, {
+          recovered: true,
+          cleared: shellRecovery.cleared,
+        });
+      }
     }
     await opts.assertSurfaceBindingCurrent?.();
     await withSurfaceWrite(
@@ -5543,6 +5605,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             workspace: opts.workspace,
             timeout_ms: opts.timeout_ms,
             require_fresh_shell_prompt: true,
+            stableSurfaceIdentity: opts.stableSurfaceIdentity,
+            assertSurfaceBindingCurrent: opts.assertSurfaceBindingCurrent,
           });
         };
         const typeLauncherCommand = async (verifySubmit: boolean) =>
@@ -11353,7 +11417,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (
               e instanceof AgentLaunchError &&
               e.launch_phase === "launch" &&
-              e.launch_cause instanceof LauncherReadinessError
+              (e.launch_cause instanceof LauncherReadinessError ||
+                (e.launch_cause instanceof BootPromptTimeoutError &&
+                  e.launch_cause.pending_input_observed))
             ) {
               await cleanupFailedLauncherArtifacts(
                 e,
@@ -11407,6 +11473,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.surface_id,
           );
           originalLaunchCommandsBySurface.delete(result.surface_id);
+          const launchShellRecovery = launchShellRecoveryBySurface.get(
+            result.surface_id,
+          );
+          launchShellRecoveryBySurface.delete(result.surface_id);
           const monitorBoot = ensureMonitorBoot(result.agent_id);
           const injectedBootPrompt = mailboxBootContract(
             result.agent_id,
@@ -11654,6 +11724,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             boot_prompt_bytes: bootPromptDelivery?.bytes,
             boot_prompt_submit_verified:
               bootPromptDelivery?.submit_verified ?? null,
+            ...(launchShellRecovery?.recovered
+              ? {
+                  readiness_recovered: true,
+                  readiness_cleared: launchShellRecovery.cleared,
+                }
+              : {}),
           };
           return buildSpawnToolReturn(
             {
@@ -11829,6 +11905,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.surface_id,
           );
           originalLaunchCommandsBySurface.delete(result.surface_id);
+          const launchShellRecovery = launchShellRecoveryBySurface.get(
+            result.surface_id,
+          );
+          launchShellRecoveryBySurface.delete(result.surface_id);
           appendStaleBuildWarning(result);
           if (targetResolution.warnings.length > 0) {
             result.warnings = [
@@ -11915,6 +11995,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             boot_prompt_bytes: bootPromptDelivery?.bytes,
             boot_prompt_submit_verified:
               bootPromptDelivery?.submit_verified ?? null,
+            ...(launchShellRecovery?.recovered
+              ? {
+                  readiness_recovered: true,
+                  readiness_cleared: launchShellRecovery.cleared,
+                }
+              : {}),
           };
           return buildSpawnToolReturn(
             {
@@ -12216,6 +12302,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               result.surface_id,
             );
             originalLaunchCommandsBySurface.delete(result.surface_id);
+            const launchShellRecovery = launchShellRecoveryBySurface.get(
+              result.surface_id,
+            );
+            launchShellRecoveryBySurface.delete(result.surface_id);
             const monitorBoot = ensureMonitorBoot(result.agent_id);
             const injectedBootPrompt = mailboxBootContract(
               result.agent_id,
@@ -12314,6 +12404,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               boot_prompt_receipt: bootPromptDelivery,
               boot_prompt_submit_verified:
                 bootPromptDelivery?.submit_verified ?? null,
+              ...(launchShellRecovery?.recovered
+                ? {
+                    readiness_recovered: true,
+                    readiness_cleared: launchShellRecovery.cleared,
+                  }
+                : {}),
             });
             leanSpawnedAgents.push(
               shapeSpawnResponse({
@@ -12325,6 +12421,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 boot_prompt_receipt: bootPromptDelivery,
                 boot_prompt_submit_verified:
                   bootPromptDelivery?.submit_verified ?? null,
+                ...(launchShellRecovery?.recovered
+                  ? {
+                      readiness_recovered: true,
+                      readiness_cleared: launchShellRecovery.cleared,
+                    }
+                  : {}),
               }),
             );
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2973,6 +2973,10 @@ export interface CmuxServerContext {
   activeDeliveryBySurface: Map<string, string>;
   activeSurfaceWrites: Map<string, string>;
   originalLaunchCommandsBySurface: Map<string, string>;
+  launchShellRecoveryBySurface: Map<
+    string,
+    { recovered: true; cleared: string[] }
+  >;
   surfaceWriteLivenessCandidates: Set<string>;
   surfacePtyDeadSince: Map<string, number>;
   readScreenInflight: Map<string, Promise<ReadScreenSnapshot>>;
@@ -3114,6 +3118,7 @@ export function createServerContext(
     activeDeliveryBySurface: new Map(),
     activeSurfaceWrites: new Map(),
     originalLaunchCommandsBySurface: new Map(),
+    launchShellRecoveryBySurface: new Map(),
     surfaceWriteLivenessCandidates: new Set(),
     surfacePtyDeadSince: new Map(),
     readScreenInflight: new Map(),
@@ -3166,6 +3171,7 @@ export function createServerContext(
       context.lifecycleAgentInputDeliverer = null;
       context.lifecycleAgentInputDelivererReadyListeners.clear();
       context.originalLaunchCommandsBySurface.clear();
+      context.launchShellRecoveryBySurface.clear();
       context.capturedSurfaceUuidByRef.clear();
       context.ambiguousCapturedSurfaceRefs.clear();
       context.capturedSurfaceObserverEpoch = null;
@@ -3287,10 +3293,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const activeSurfaceWrites = context.activeSurfaceWrites;
   const originalLaunchCommandsBySurface =
     context.originalLaunchCommandsBySurface;
-  const launchShellRecoveryBySurface = new Map<
-    string,
-    { recovered: true; cleared: string[] }
-  >();
+  const launchShellRecoveryBySurface = context.launchShellRecoveryBySurface;
   const surfaceWriteLiveness = context.surfaceWriteLiveness;
   const surfaceWriteLivenessCandidates = context.surfaceWriteLivenessCandidates;
   const surfacePtyDeadSince = context.surfacePtyDeadSince;
@@ -10261,6 +10264,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               });
             } catch (error) {
               originalLaunchCommandsBySurface.delete(surface);
+              launchShellRecoveryBySurface.delete(surface);
               throw error;
             }
           },

--- a/src/shell-prompt.ts
+++ b/src/shell-prompt.ts
@@ -11,19 +11,14 @@ export function matchShellPromptLine(
   if (barePrompt && barePrompt[1] !== "#") {
     return { input: barePrompt[2] ?? "" };
   }
-  if (
-    barePrompt?.[1] === "#" &&
-    (!barePrompt[2] || opts?.allowRootInput)
-  ) {
+  if (barePrompt?.[1] === "#" && (!barePrompt[2] || opts?.allowRootInput)) {
     return { input: barePrompt[2] ?? "" };
   }
 
   if (!opts?.strict) {
     // Preserve the app-server's established readiness contract while still
     // exposing text after the decorated terminator to pending-input checks.
-    const decoratedPrompt = normalized.match(
-      /^.+?[$%#](?:\s+(.*))?$/u,
-    );
+    const decoratedPrompt = normalized.match(/^.+?[$%#](?:\s+(.*))?$/u);
     if (decoratedPrompt) {
       return { input: decoratedPrompt[1] ?? "" };
     }
@@ -42,6 +37,20 @@ export function matchesShellPrompt(text: string): boolean {
   return matchesShellPromptWithOptions(text, false);
 }
 
+/** Pending text on the last shell prompt line, or null when the line is empty/unrecognized. */
+export function pendingShellPromptInput(text: string): string | null {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  let end = lines.length;
+  while (end > 0 && !lines[end - 1]?.trim()) {
+    end -= 1;
+  }
+  if (end === 0) {
+    return null;
+  }
+  const input = matchShellPromptLine(lines[end - 1] ?? "")?.input.trim() ?? "";
+  return input.length > 0 ? input : null;
+}
+
 export function matchesShellPromptStrict(text: string): boolean {
   return matchesShellPromptWithOptions(text, true);
 }
@@ -53,9 +62,7 @@ function matchesShellPromptWithOptions(text: string, strict: boolean): boolean {
     end -= 1;
   }
   const prompt =
-    end > 0
-      ? matchShellPromptLine(lines[end - 1] ?? "", { strict })
-      : null;
+    end > 0 ? matchShellPromptLine(lines[end - 1] ?? "", { strict }) : null;
   return prompt?.input.trim() === "";
 }
 

--- a/src/shell-prompt.ts
+++ b/src/shell-prompt.ts
@@ -48,7 +48,16 @@ export function pendingShellPromptInput(text: string): string | null {
     return null;
   }
   const input = matchShellPromptLine(lines[end - 1] ?? "")?.input.trim() ?? "";
-  return input.length > 0 ? input : null;
+  if (input.length === 0) {
+    return null;
+  }
+  const decorated = (lines[end - 1] ?? "")
+    .trimEnd()
+    .match(/^(.+?)([$%#])(?:\s+(.*))?$/u);
+  if (decorated && /\d$/.test(decorated[1] ?? "")) {
+    return null;
+  }
+  return input;
 }
 
 export function matchesShellPromptStrict(text: string): boolean {

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -24,6 +24,8 @@ const ESSENTIAL_FIELDS = [
   "boot_prompt_delivered",
   "boot_prompt_receipt",
   "boot_prompt_submit_verified",
+  "readiness_recovered",
+  "readiness_cleared",
 ] as const;
 
 type JsonObject = Record<string, unknown>;
@@ -56,8 +58,9 @@ function leanHealth(value: unknown): JsonObject | undefined {
   const severities = record(health.issue_severities) ?? {};
   const realIndexes = codeEntries
     .map(({ code, index }) => ({ code, index, severity: severities[code] }))
-    .filter(({ code, severity }) =>
-      !(FRESH_SPAWN_INFO_CODES.has(code) && severity === "info"),
+    .filter(
+      ({ code, severity }) =>
+        !(FRESH_SPAWN_INFO_CODES.has(code) && severity === "info"),
     );
 
   if (

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5403,6 +5403,384 @@ describe("agent lifecycle tool handlers", () => {
     expect(launched).toBe(true);
   }, 10_000);
 
+  it("spawn_agent clears junk on the shell-readiness prompt before typing the launcher", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "wenfnng";
+    let launched = false;
+    let ctrlUCount = 0;
+    let typedLaunches = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        typedLaunches += 1;
+        composer = command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `etanheyman ~  $ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(ctrlUCount).toBeLessThanOrEqual(3);
+    expect(typedLaunches).toBe(1);
+    expect(launched).toBe(true);
+    expect(parsed.readiness_recovered).toBe(true);
+    expect(parsed.readiness_cleared).toEqual(
+      expect.arrayContaining(["wenfnng"]),
+    );
+  }, 10_000);
+
+  it("spawn_agent ctrl-u during readiness prevents human Enter from executing typed garbage", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "sjnfjdnsf";
+    let launched = false;
+    let ctrlUCount = 0;
+    let reads = 0;
+    const executed: string[] = [];
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        composer = command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() && composer.trim() !== command) {
+          executed.push(composer.trim());
+          composer = "";
+        } else if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        reads += 1;
+        if (
+          reads > 4 &&
+          composer.trim() &&
+          composer.trim() !== command &&
+          !executed.includes(composer.trim())
+        ) {
+          executed.push(composer.trim());
+          composer = "";
+        }
+        const screen = launched
+          ? "cursor> \nWorking (1s • esc to interrupt)"
+          : executed.length > 0 && composer.trim() === ""
+            ? `zsh: command not found: ${executed[0]}\netanheyman ~  $ `
+            : `etanheyman ~  $ ${composer}`;
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: screen,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(executed).toEqual([]);
+    expect(launched).toBe(true);
+    expect(parsed.readiness_recovered).toBe(true);
+    expect(parsed.readiness_cleared).toEqual(
+      expect.arrayContaining(["sjnfjdnsf"]),
+    );
+  }, 10_000);
+
+  it("spawn_agent does not claim a clean boot after clearing readiness junk", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "";
+    let launched = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        composer = command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `$ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(launched).toBe(true);
+    expect(parsed.readiness_recovered).toBeUndefined();
+    expect(parsed.readiness_cleared).toBeUndefined();
+  }, 10_000);
+
+  it("spawn_agent recovers junk in both the readiness window and the typed launcher line", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "wenfnng";
+    let launched = false;
+    let ctrlUCount = 0;
+    let typedLaunches = 0;
+    let humanPrefix = "ng ";
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        typedLaunches += 1;
+        composer = `${humanPrefix}${command}`;
+        humanPrefix = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `etanheyman ~  $ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(2);
+    expect(typedLaunches).toBeGreaterThanOrEqual(2);
+    expect(launched).toBe(true);
+    expect(parsed.readiness_recovered).toBe(true);
+    expect(parsed.readiness_cleared).toEqual(
+      expect.arrayContaining(["wenfnng"]),
+    );
+  }, 10_000);
+
+  it("spawn_agent falls back to ctrl-c when readiness junk survives ctrl-u", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let composer = "gjrbgjbrgjrbgjrbgjrgbjrgbjrgbjrgb";
+    let launched = false;
+    let ctrlUCount = 0;
+    let ctrlCCount = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && text === command) {
+        composer = command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-c")) {
+        ctrlCCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `etanheyman ~  $ ${composer}`,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const parsed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(parsed.ok).toBe(true);
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(ctrlCCount).toBeGreaterThanOrEqual(1);
+    expect(launched).toBe(true);
+    expect(parsed.readiness_recovered).toBe(true);
+  }, 10_000);
+
+  it("spawn_agent closes a junk shell that never becomes ready after bounded clears", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseExec = makeLifecycleExec({ surfaceUuid: "surface-uuid:new" });
+      let ctrlUCount = 0;
+      const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+        if (args.includes("send-key") && args.includes("ctrl-u")) {
+          ctrlUCount += 1;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (args.includes("read-screen")) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "etanheyman ~  $ wenfnng",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(cmd, args);
+      });
+      const server = createLifecycleServer(exec);
+      const spawn = (server as any)._registeredTools["spawn_agent"];
+      const resultPromise = spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 8_000,
+        },
+        {} as any,
+      );
+      await vi.advanceTimersByTimeAsync(9_000);
+      const parsed = parseToolResult(await resultPromise);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("waiting for shell readiness");
+      expect(parsed.last_10_lines).toEqual(
+        expect.arrayContaining(["etanheyman ~  $ wenfnng"]),
+      );
+      expect(ctrlUCount).toBe(3);
+      expect(exec).toHaveBeenCalledWith(
+        "cmux",
+        expect.arrayContaining(["close-surface", "surface-uuid:new"]),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 10_000);
+
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5781,6 +5781,109 @@ describe("agent lifecycle tool handlers", () => {
     }
   }, 10_000);
 
+  it("spawn_agent does not reuse a failed spawn's readiness_recovered on a recycled surface id", async () => {
+    const command = "voicelayerCursor -s";
+    const baseExec = makeLifecycleExec();
+    let spawnCount = 0;
+    let composer = "";
+    let sentLauncher = false;
+    let launched = false;
+    let ctrlUCount = 0;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("new-split")) {
+        spawnCount += 1;
+        composer = spawnCount === 1 ? "wenfnng" : "";
+        sentLauncher = false;
+        launched = false;
+      }
+      if (args.includes("send") && text === command) {
+        sentLauncher = true;
+        composer = command;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("ctrl-u")) {
+        ctrlUCount += 1;
+        composer = "";
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (spawnCount > 1 && composer.trim() === command) {
+          launched = true;
+          composer = "";
+        }
+        return { stdout: "{}", stderr: "" };
+      }
+      if (args.includes("read-screen")) {
+        const screen =
+          spawnCount === 1 && sentLauncher
+            ? "zsh: command not found: voicelayerCursor\n$ "
+            : launched
+              ? "cursor> \nWorking (1s • esc to interrupt)"
+              : `etanheyman ~  $ ${composer}`;
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: screen,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      const result = await baseExec(cmd, args);
+      if (
+        typeof result.stdout === "string" &&
+        result.stdout.includes("surface:")
+      ) {
+        return {
+          ...result,
+          stdout: result.stdout.replace(/surface:new-\d+/g, "surface:new"),
+        };
+      }
+      return result;
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    const failed = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+    expect(failed.ok).toBe(false);
+    expect(failed.surface_id).toBe("surface:new");
+    expect(ctrlUCount).toBeGreaterThanOrEqual(1);
+    expect(String(failed.error)).toMatch(
+      /Launcher exited before reaching readiness/,
+    );
+    const context = serverContexts.at(-1)!;
+    expect(context.launchShellRecoveryBySurface.size).toBe(0);
+    expect(context.originalLaunchCommandsBySurface.size).toBe(0);
+
+    const reused = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "voicelayer",
+          cli: "cursor",
+          boot_prompt_timeout_ms: 2_000,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(reused.ok).toBe(true);
+    expect(reused.surface_id).toBe("surface:new");
+    expect(launched).toBe(true);
+    expect(reused.readiness_recovered).toBeUndefined();
+    expect(reused.readiness_cleared).toBeUndefined();
+  }, 15_000);
+
   it("spawn_agent treats launch submit verification as advisory when readiness appears with shell history", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");

--- a/tests/shell-prompt.test.ts
+++ b/tests/shell-prompt.test.ts
@@ -3,6 +3,7 @@ import {
   launcherFailureFromShell,
   matchShellPromptLine,
   matchesShellPrompt,
+  pendingShellPromptInput,
 } from "../src/shell-prompt.js";
 
 describe("shell prompt recognition", () => {
@@ -85,5 +86,21 @@ describe("shell prompt recognition", () => {
     expect(matchShellPromptLine(screen.split("\n").at(-1) ?? "")).toEqual({
       input: junk,
     });
+    expect(pendingShellPromptInput(screen)).toBe(junk);
   });
+
+  it.each([
+    ["[oh-my-zsh] 50% of plugins loaded", "of plugins loaded"],
+    ["Downloading nvm... 45% complete", "complete"],
+    [
+      "receiving objects:  72% (720/1000), 1.2 MiB | 400 KiB/s",
+      "(720/1000), 1.2 MiB | 400 KiB/s",
+    ],
+  ])(
+    "does not treat digit-prefixed progress %j as pending shell input",
+    (line, decoratedTrap) => {
+      expect(matchShellPromptLine(line)?.input.trim()).toBe(decoratedTrap);
+      expect(pendingShellPromptInput(line)).toBeNull();
+    },
+  );
 });

--- a/tests/shell-prompt.test.ts
+++ b/tests/shell-prompt.test.ts
@@ -44,7 +44,9 @@ describe("shell prompt recognition", () => {
     expect(
       launcherFailureFromShell("zsh: command not found: cmuxlayerCodex\n$ "),
     ).toBe("zsh: command not found: cmuxlayerCodex");
-    expect(launcherFailureFromShell("build failed earlier\nsummary\n$ ")).toBeNull();
+    expect(
+      launcherFailureFromShell("build failed earlier\nsummary\n$ "),
+    ).toBeNull();
     expect(launcherFailureFromShell("error: cached warning\n$ ")).toBeNull();
   });
 
@@ -54,11 +56,14 @@ describe("shell prompt recognition", () => {
     "Context left: 12%",
     "Total cost: $",
     "issue #",
-  ])("does not treat a loose readiness suffix as launcher-exit evidence: %s", (line) => {
-    expect(
-      launcherFailureFromShell(`zsh: command not found: pyenv\n${line}`),
-    ).toBeNull();
-  });
+  ])(
+    "does not treat a loose readiness suffix as launcher-exit evidence: %s",
+    (line) => {
+      expect(
+        launcherFailureFromShell(`zsh: command not found: pyenv\n${line}`),
+      ).toBeNull();
+    },
+  );
 
   it.each([
     ["➜  cmuxlayer git:(main) $ ralphCodex -s", "ralphCodex -s"],
@@ -66,5 +71,19 @@ describe("shell prompt recognition", () => {
     ["[etan@mac cmuxlayer]$ ralphCodex -s", "ralphCodex -s"],
   ])("captures pending input from decorated prompt %s", (line, input) => {
     expect(matchShellPromptLine(line)).toEqual({ input });
+  });
+
+  it.each([
+    [" ngff%\netanheyman ~  $ wenfnng", "wenfnng"],
+    [
+      "rbgjrbgjrbgjrb%\netanheyman ~  $ gjrbgjbrgjrbgjrbgjrgbjrgbjrgbjrgb",
+      "gjrbgjbrgjrbgjrbgjrgbjrgbjrgbjrgb",
+    ],
+    ["etanheyman ~  $ sjnfjdnsf", "sjnfjdnsf"],
+  ])("exposes pending junk on live-probe prompt %j", (screen, junk) => {
+    expect(matchesShellPrompt(screen)).toBe(false);
+    expect(matchShellPromptLine(screen.split("\n").at(-1) ?? "")).toEqual({
+      input: junk,
+    });
   });
 });

--- a/tests/spawn-response.test.ts
+++ b/tests/spawn-response.test.ts
@@ -29,7 +29,12 @@ describe("spawn response shaping", () => {
           "inbox_monitor_not_alive",
           "registry_screen_disagreement",
         ],
-        issues: ["missing session", "cannot resume", "monitor booting", "screen ahead"],
+        issues: [
+          "missing session",
+          "cannot resume",
+          "monitor booting",
+          "screen ahead",
+        ],
         issue_severities: {
           missing_cli_session_id: "info",
           non_resumable: "info",
@@ -48,7 +53,10 @@ describe("spawn response shaping", () => {
       ...base,
       health: {
         status: "degraded",
-        issue_codes: ["missing_cli_session_id", "missing_managed_lead_agent_id"],
+        issue_codes: [
+          "missing_cli_session_id",
+          "missing_managed_lead_agent_id",
+        ],
         issues: ["missing session", "lead is missing"],
         issue_severities: {
           missing_cli_session_id: "info",
@@ -134,10 +142,23 @@ describe("spawn response shaping", () => {
     expect(shapeSpawnResponse(full, true)).toBe(full);
   });
 
+  it("keeps readiness recovery evidence in the lean spawn receipt", () => {
+    const shaped = shapeSpawnResponse({
+      ...base,
+      readiness_recovered: true,
+      readiness_cleared: ["wenfnng"],
+    });
+
+    expect(shaped.readiness_recovered).toBe(true);
+    expect(shaped.readiness_cleared).toEqual(["wenfnng"]);
+  });
+
   it("uses the same lean payload for text and structured content", () => {
     const result = buildSpawnToolReturn({ ...base, retry_count: 0 });
 
-    expect(JSON.parse(result.content[0]!.text)).toEqual(result.structuredContent);
+    expect(JSON.parse(result.content[0]!.text)).toEqual(
+      result.structuredContent,
+    );
     expect(result.structuredContent.retry_count).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- During `waitForLaunchShellReady`, pending input on a visible shell prompt is now cleared (ctrl-u, ctrl-c fallback; at most 3 clears, ~2.5s apart) so human keystrokes cannot stall the 10s readiness wait or be executed as a shell command before the launcher runs.
- A spawn that only became ready after that recovery reports `readiness_recovered: true` plus `readiness_cleared` on the lean receipt. An untouched clean boot omits those fields.
- Junk in both windows (readiness wait, then typed launcher line) still ends with a clean submitted launcher: this path hands off to the existing #438 recovery.
- If readiness still times out after observed junk, the loud error keeps screen evidence and the failed surface is closed via the existing #397 `cleanupFailedLauncherArtifacts` path. Generic never-ready shells (no prompt at all) stay forensics-keep, as the existing launch-timeout test requires.

Closes the remaining #434 window documented on v0.4.39 live probes (`etanheyman ~  $ wenfnng` / `sjnfjdnsf` executed as `zsh: command not found`).

## Test plan
- [x] Failing tests first, then green: readiness junk clear, Enter-does-not-execute-garbage, two-window handoff, ctrl-c fallback, `readiness_recovered` lean receipt, junk-timeout close, generic never-ready still kept
- [x] `bun run test` — 2733 passed, 1 skipped
- [x] `bun run typecheck` — clean
- [ ] Live probe: type during spawn shell-readiness wait; launcher should still submit; receipt should show `readiness_recovered`

— cmuxlayerCursor-515f0fb5 (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor-515f0fb5","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"e7b19902","ts":"2026-08-17T20:35:34Z"} -->

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keystrokes during spawn shell-readiness wait by clearing pending input with ctrl-u/ctrl-c
> - `waitForLaunchShellReady` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/440/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now detects pending input on the shell prompt using the new `pendingShellPromptInput` function and sends ctrl-u (escalating to ctrl-c) to clear junk before typing the launcher, bounded by `LAUNCH_SHELL_JUNK_CLEAR_MAX` (3) attempts spaced `LAUNCH_SHELL_JUNK_CLEAR_INTERVAL_MS` (2500ms) apart.
> - The function now returns `{ recovered: boolean; cleared: string[] }` instead of `void`; spawn responses include `readiness_recovered` and `readiness_cleared` fields when junk was cleared.
> - `BootPromptTimeoutError` gains a `pending_input_observed` flag; when set, the server runs `cleanupFailedLauncherArtifacts` on timeout.
> - `pendingShellPromptInput` is a new export in [shell-prompt.ts](https://github.com/EtanHey/cmuxlayer/pull/440/files#diff-8906643eb8e405dd1c0186c957d64fa4f4f05ac1fc7ce6e630b56a05224f8b94) that reads the last non-empty prompt line and returns any typed-but-not-submitted input.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f6c19da. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved launcher startup recovery when stale, corrupted, or accidental shell input is detected.
  - Prevented unintended execution of leftover terminal input during launches.
  - Added bounded cleanup and fallback handling for unrecoverable launch shells.
  - Launch responses now indicate whether recovery occurred and which input was cleared.

- **Tests**
  - Added coverage for recovery scenarios, clean launches, failed cleanup, and recycled surfaces.
  - Expanded validation of shell-input detection and recovery details in launch responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->