### PR TITLE
fix: send_to v2 background verify and Cursor queued_followup

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -201,7 +201,12 @@ import {
 type ProcessLiveness = "alive" | "gone" | "unknown";
 
 export type AgentDeliveryState =
-  "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
+  | "submitted"
+  | "queued"
+  | "queued_followup"
+  | "failed"
+  | "pending_verify"
+  | "failed_confirmed";
 
 export interface AgentDeliveryReceipt {
   delivery_id: string;
@@ -254,7 +259,7 @@ export class RetryableDeliveryError extends Error {
 type DeliverySubmitter = (receipt: AgentDeliveryReceipt) => Promise<{
   retry_count: number;
   submit_verified: boolean | null;
-  delivery?: "submitted" | "queued" | "pending_verify";
+  delivery?: "submitted" | "queued" | "queued_followup" | "pending_verify";
 }>;
 
 export interface SpawnAgentParams {
@@ -6225,11 +6230,12 @@ export class AgentEngine {
     press_enter: boolean;
     source_event: DeliveryEventType;
     retry_count: number;
+    delivery_state?: "queued" | "queued_followup";
   }): AgentDeliveryReceipt {
     const acceptedAt = new Date().toISOString();
     const receipt: AgentDeliveryReceipt = {
       ...input,
-      delivery_state: "queued",
+      delivery_state: input.delivery_state ?? "queued",
       terminal: false,
       created_at: acceptedAt,
       resolved_at: null,
@@ -6294,7 +6300,8 @@ export class AgentEngine {
     for (const receipt of this.deliveryReceipts.values()) {
       if (
         (receipt.delivery_state === "pending_verify" ||
-          receipt.delivery_state === "queued") &&
+          receipt.delivery_state === "queued" ||
+          receipt.delivery_state === "queued_followup") &&
         receipt.agent_id === input.agent_id &&
         receipt.text === input.text &&
         receipt.press_enter === input.press_enter
@@ -6383,6 +6390,7 @@ export class AgentEngine {
       for (const receipt of this.deliveryReceipts.values()) {
         const watching =
           receipt.delivery_state === "pending_verify" ||
+          receipt.delivery_state === "queued_followup" ||
           (receipt.delivery_state === "queued" &&
             receipt.composer_accepted === true);
         if (!watching || receipt.terminal) continue;
@@ -6449,7 +6457,7 @@ export class AgentEngine {
       cli: agent?.cli ?? null,
       what_happened: `Delivery ${receipt.delivery_id} to ${receipt.agent_id} reached failed_confirmed (${reason}) after background verify.`,
       what_fixed_it:
-        "Do not blind-retry. Identical send_to while pending_verify/queued returns duplicate_of. Query wait_for({delivery_id}) or list_agents detail=full.",
+        "Do not blind-retry. Identical send_to while pending_verify/queued/queued_followup returns duplicate_of. Query wait_for({delivery_id}) or list_agents detail=full.",
       evidence: {
         receipt,
         observation,
@@ -6524,8 +6532,11 @@ export class AgentEngine {
           receipt.retry_count += result.retry_count;
           receipt.error = null;
           receipt.next_attempt_at = null;
-          if (result.delivery === "queued") {
-            receipt.delivery_state = "queued";
+          if (
+            result.delivery === "queued" ||
+            result.delivery === "queued_followup"
+          ) {
+            receipt.delivery_state = result.delivery;
             receipt.terminal = false;
             receipt.resolved_at = null;
             receipt.submit_verified = null;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6404,7 +6404,7 @@ export class AgentEngine {
   }
 
   async verifyPendingDeliveries(): Promise<void> {
-    if (this.deliveryVerifyInFlight) return;
+    if (this.deliveryVerifyInFlight || !this.deliveryVerifier) return;
     this.deliveryVerifyInFlight = true;
     try {
       for (const receipt of this.deliveryReceipts.values()) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -47,9 +47,7 @@ import type {
   ParsedScreenStatus,
 } from "./types.js";
 import {
-  defaultDeliveryTicketDir,
   deliveryFailureSignature,
-  fileDeliveryFailureGithubIssue,
   writeDeliveryFailureTicket,
   type DeliveryFailureTicket,
 } from "./delivery-failure-tickets.js";
@@ -230,9 +228,12 @@ export interface AgentDeliveryReceipt {
   /** Hard deadline for background verify; ISO timestamp. */
   verify_deadline_at?: string | null;
   ticket_filed?: boolean;
+  /** Consecutive verifier observations that the target agent is missing. */
+  verify_miss_count?: number;
 }
 
 export const DEFAULT_DELIVERY_VERIFY_DEADLINE_MS = 10 * 60 * 1000;
+export const DELIVERY_TARGET_GONE_CONFIRM_MISSES = 3;
 const DELIVERY_WAIT_POLL_MS = 100;
 
 export type DeliveryVerifyObservation = {
@@ -583,7 +584,11 @@ export interface AgentEngineOptions {
   deliverySubmitTimeoutMs?: number;
   /** How long a pending_verify delivery may stay nonterminal before failed_confirmed. */
   deliveryVerifyDeadlineMs?: number;
-  /** Local evidence-ticket directory; defaults to ~/.cmuxlayer/tickets. */
+  /**
+   * Local evidence-ticket directory. Omitted/null disables tickets so bare
+   * construction never writes ~/.cmuxlayer/tickets or calls gh. Production
+   * entrypoints inject the directory and filer.
+   */
   deliveryTicketDir?: string;
   /** Optional GitHub/local ticket sink invoked once per failure signature. */
   deliveryIssueFiler?: DeliveryIssueFiler;
@@ -1228,7 +1233,7 @@ export class AgentEngine {
   private deliveryVerifyInFlight = false;
   private deliverySubmitTimeoutMs: number;
   private deliveryVerifyDeadlineMs: number;
-  private deliveryTicketDir: string;
+  private deliveryTicketDir: string | null;
   private deliveryIssueFiler: DeliveryIssueFiler | null = null;
   private autoReviveBackoffBaseMs: number;
   private haltNow: () => number;
@@ -1256,8 +1261,7 @@ export class AgentEngine {
       1,
       opts?.deliveryVerifyDeadlineMs ?? DEFAULT_DELIVERY_VERIFY_DEADLINE_MS,
     );
-    this.deliveryTicketDir =
-      opts?.deliveryTicketDir ?? defaultDeliveryTicketDir();
+    this.deliveryTicketDir = opts?.deliveryTicketDir ?? null;
     this.deliveryIssueFiler = opts?.deliveryIssueFiler ?? null;
     this.deliveryVerifier = opts?.deliveryVerifier ?? null;
     this.autoReviveBackoffBaseMs = Math.max(
@@ -6138,7 +6142,7 @@ export class AgentEngine {
         readFileSync(this.deliveryReceiptsPath, "utf8"),
       );
       if (!Array.isArray(parsed)) return;
-      let repairedUncertainReceipt = false;
+      let repairedReceipts = false;
       for (const candidate of parsed) {
         if (
           candidate &&
@@ -6160,12 +6164,27 @@ export class AgentEngine {
             receipt.resolved_at = new Date().toISOString();
             receipt.error =
               "Delivery outcome uncertain after process restart; refusing automatic replay";
-            repairedUncertainReceipt = true;
+            repairedReceipts = true;
+          }
+          const deadlineWatched =
+            receipt.delivery_state === "pending_verify" ||
+            (receipt.delivery_state === "queued" &&
+              receipt.composer_accepted === true);
+          if (
+            deadlineWatched &&
+            !receipt.terminal &&
+            (receipt.verify_deadline_at == null ||
+              receipt.verify_deadline_at === "")
+          ) {
+            receipt.verify_deadline_at = new Date(
+              Date.now() + this.deliveryVerifyDeadlineMs,
+            ).toISOString();
+            repairedReceipts = true;
           }
           this.deliveryReceipts.set(receipt.delivery_id, receipt);
         }
       }
-      if (repairedUncertainReceipt) {
+      if (repairedReceipts) {
         try {
           this.persistDeliveryReceipts();
         } catch {
@@ -6244,9 +6263,10 @@ export class AgentEngine {
       submission_started_at: acceptedAt,
       next_attempt_at: null,
       composer_accepted: true,
-      verify_deadline_at: new Date(
-        Date.now() + this.deliveryVerifyDeadlineMs,
-      ).toISOString(),
+      verify_deadline_at:
+        (input.delivery_state ?? "queued") === "queued_followup"
+          ? null
+          : new Date(Date.now() + this.deliveryVerifyDeadlineMs).toISOString(),
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     try {
@@ -6394,6 +6414,7 @@ export class AgentEngine {
           (receipt.delivery_state === "queued" &&
             receipt.composer_accepted === true);
         if (!watching || receipt.terminal) continue;
+        const deadlineApplies = receipt.delivery_state !== "queued_followup";
         const deadlineMs = receipt.verify_deadline_at
           ? Date.parse(receipt.verify_deadline_at)
           : Date.parse(receipt.created_at) + this.deliveryVerifyDeadlineMs;
@@ -6408,18 +6429,34 @@ export class AgentEngine {
             };
           }
         }
-        const timedOut = Date.now() >= deadlineMs;
         if (observation.outcome === "delivered") {
           receipt.delivery_state = "submitted";
           receipt.terminal = true;
           receipt.resolved_at = new Date().toISOString();
           receipt.submit_verified = observation.submit_verified ?? true;
           receipt.error = null;
+          receipt.verify_miss_count = 0;
           this.persistDeliveryReceipts();
           this.appendDeliveryReceiptEventBestEffort(receipt);
           continue;
         }
-        if (observation.outcome === "failed_confirmed" || timedOut) {
+        if (observation.reason === "target_gone") {
+          receipt.verify_miss_count = (receipt.verify_miss_count ?? 0) + 1;
+          this.persistDeliveryReceipts();
+        } else if ((receipt.verify_miss_count ?? 0) > 0) {
+          receipt.verify_miss_count = 0;
+          this.persistDeliveryReceipts();
+        }
+        const confirmedGone =
+          observation.reason === "target_gone" &&
+          (receipt.verify_miss_count ?? 0) >=
+            DELIVERY_TARGET_GONE_CONFIRM_MISSES;
+        const timedOut = deadlineApplies && Date.now() >= deadlineMs;
+        if (
+          observation.outcome === "failed_confirmed" ||
+          confirmedGone ||
+          timedOut
+        ) {
           const reason =
             observation.reason ??
             (timedOut ? "verify_deadline_elapsed" : "failed_confirmed");
@@ -6444,6 +6481,8 @@ export class AgentEngine {
     observation: DeliveryVerifyObservation,
   ): Promise<void> {
     if (receipt.ticket_filed) return;
+    const ticketDir = this.deliveryTicketDir;
+    if (!ticketDir) return;
     const agent = this.getAgentState(receipt.agent_id);
     const signature = deliveryFailureSignature({
       reason,
@@ -6467,18 +6506,14 @@ export class AgentEngine {
       observed_at: new Date().toISOString(),
     };
     const written = writeDeliveryFailureTicket(ticket, {
-      dir: this.deliveryTicketDir,
+      dir: ticketDir,
     });
     receipt.ticket_filed = true;
     this.persistDeliveryReceipts();
     if (!written.created) return;
-    const filer =
-      this.deliveryIssueFiler ??
-      (async (nextTicket) => {
-        await fileDeliveryFailureGithubIssue(nextTicket);
-      });
+    if (!this.deliveryIssueFiler) return;
     try {
-      await filer(ticket);
+      await this.deliveryIssueFiler(ticket);
     } catch {
       // Local ticket is authoritative; GitHub is best-effort.
     }
@@ -6541,9 +6576,13 @@ export class AgentEngine {
             receipt.resolved_at = null;
             receipt.submit_verified = null;
             receipt.composer_accepted = true;
-            receipt.verify_deadline_at ??= new Date(
-              Date.now() + this.deliveryVerifyDeadlineMs,
-            ).toISOString();
+            if (result.delivery === "queued") {
+              receipt.verify_deadline_at ??= new Date(
+                Date.now() + this.deliveryVerifyDeadlineMs,
+              ).toISOString();
+            } else {
+              receipt.verify_deadline_at = null;
+            }
           } else if (result.delivery === "pending_verify") {
             receipt.delivery_state = "pending_verify";
             receipt.terminal = false;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -47,6 +47,13 @@ import type {
   ParsedScreenStatus,
 } from "./types.js";
 import {
+  defaultDeliveryTicketDir,
+  deliveryFailureSignature,
+  fileDeliveryFailureGithubIssue,
+  writeDeliveryFailureTicket,
+  type DeliveryFailureTicket,
+} from "./delivery-failure-tickets.js";
+import {
   generateAgentId,
   isCrashRecoveryEligible,
   isCrashRecoveryExhausted,
@@ -193,7 +200,8 @@ import {
 
 type ProcessLiveness = "alive" | "gone" | "unknown";
 
-export type AgentDeliveryState = "submitted" | "queued" | "failed";
+export type AgentDeliveryState =
+  "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
 
 export interface AgentDeliveryReceipt {
   delivery_id: string;
@@ -214,7 +222,26 @@ export interface AgentDeliveryReceipt {
   next_attempt_at?: string | null;
   /** The receiving TUI visibly accepted this into its own queue; never replay it. */
   composer_accepted?: boolean;
+  /** Hard deadline for background verify; ISO timestamp. */
+  verify_deadline_at?: string | null;
+  ticket_filed?: boolean;
 }
+
+export const DEFAULT_DELIVERY_VERIFY_DEADLINE_MS = 10 * 60 * 1000;
+const DELIVERY_WAIT_POLL_MS = 100;
+
+export type DeliveryVerifyObservation = {
+  outcome: "pending" | "delivered" | "failed_confirmed";
+  submit_verified?: boolean | null;
+  reason?: string;
+  evidence?: Record<string, unknown>;
+};
+
+type DeliveryVerifier = (
+  receipt: AgentDeliveryReceipt,
+) => Promise<DeliveryVerifyObservation>;
+
+type DeliveryIssueFiler = (ticket: DeliveryFailureTicket) => Promise<void>;
 
 /** A known pre-mutation delivery rejection that is safe to retry. */
 export class RetryableDeliveryError extends Error {
@@ -227,7 +254,7 @@ export class RetryableDeliveryError extends Error {
 type DeliverySubmitter = (receipt: AgentDeliveryReceipt) => Promise<{
   retry_count: number;
   submit_verified: boolean | null;
-  delivery?: "submitted" | "queued";
+  delivery?: "submitted" | "queued" | "pending_verify";
 }>;
 
 export interface SpawnAgentParams {
@@ -549,6 +576,14 @@ export interface AgentEngineOptions {
   fleetWorkingNoProgressTimeoutMs?: number;
   /** Bound one queued terminal submission so lifecycle sweeps cannot hang forever. */
   deliverySubmitTimeoutMs?: number;
+  /** How long a pending_verify delivery may stay nonterminal before failed_confirmed. */
+  deliveryVerifyDeadlineMs?: number;
+  /** Local evidence-ticket directory; defaults to ~/.cmuxlayer/tickets. */
+  deliveryTicketDir?: string;
+  /** Optional GitHub/local ticket sink invoked once per failure signature. */
+  deliveryIssueFiler?: DeliveryIssueFiler;
+  /** Screen/transcript observer for pending deliveries. */
+  deliveryVerifier?: DeliveryVerifier;
   /** Base delay for same-surface CLI auto-revive retries. */
   autoReviveBackoffBaseMs?: number;
   /** Deterministic clock and per-class dwell controls for live-halt escalation. */
@@ -1183,8 +1218,13 @@ export class AgentEngine {
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
   private deliveryReceiptsPath: string;
   private deliverySubmitter: DeliverySubmitter | null = null;
+  private deliveryVerifier: DeliveryVerifier | null = null;
   private deliveryDrainInFlight = false;
+  private deliveryVerifyInFlight = false;
   private deliverySubmitTimeoutMs: number;
+  private deliveryVerifyDeadlineMs: number;
+  private deliveryTicketDir: string;
+  private deliveryIssueFiler: DeliveryIssueFiler | null = null;
   private autoReviveBackoffBaseMs: number;
   private haltNow: () => number;
   private haltAwaitingInputDwellMs: number;
@@ -1207,6 +1247,14 @@ export class AgentEngine {
       1,
       opts?.deliverySubmitTimeoutMs ?? 30_000,
     );
+    this.deliveryVerifyDeadlineMs = Math.max(
+      1,
+      opts?.deliveryVerifyDeadlineMs ?? DEFAULT_DELIVERY_VERIFY_DEADLINE_MS,
+    );
+    this.deliveryTicketDir =
+      opts?.deliveryTicketDir ?? defaultDeliveryTicketDir();
+    this.deliveryIssueFiler = opts?.deliveryIssueFiler ?? null;
+    this.deliveryVerifier = opts?.deliveryVerifier ?? null;
     this.autoReviveBackoffBaseMs = Math.max(
       0,
       opts?.autoReviveBackoffBaseMs ?? DEFAULT_AUTO_REVIVE_BACKOFF_BASE_MS,
@@ -3083,7 +3131,10 @@ export class AgentEngine {
         // silence and then retrying the identical broken command.
         const rejection = this.detectResumeRejection(agent, screen.text);
         if (rejection) {
-          const settled = this.stateMgr.updateRecord(agent.agent_id, settlement);
+          const settled = this.stateMgr.updateRecord(
+            agent.agent_id,
+            settlement,
+          );
           this.registry.set(agent.agent_id, settled);
           return this.recordAutoReviveResumeFailure(settled, rejection);
         }
@@ -6061,10 +6112,19 @@ export class AgentEngine {
   async runSweep(): Promise<void> {
     await this.runLifecycleMutation(() => this.runSweepOnce());
     await this.drainDeliveryQueue();
+    await this.verifyPendingDeliveries();
   }
 
   setDeliverySubmitter(submitter: DeliverySubmitter | null): void {
     this.deliverySubmitter = submitter;
+  }
+
+  setDeliveryVerifier(verifier: DeliveryVerifier | null): void {
+    this.deliveryVerifier = verifier;
+  }
+
+  setDeliveryIssueFiler(filer: DeliveryIssueFiler | null): void {
+    this.deliveryIssueFiler = filer;
   }
 
   private loadDeliveryReceipts(): void {
@@ -6178,6 +6238,9 @@ export class AgentEngine {
       submission_started_at: acceptedAt,
       next_attempt_at: null,
       composer_accepted: true,
+      verify_deadline_at: new Date(
+        Date.now() + this.deliveryVerifyDeadlineMs,
+      ).toISOString(),
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     try {
@@ -6202,7 +6265,11 @@ export class AgentEngine {
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     this.persistDeliveryReceipts();
-    if (receipt.delivery_state === "failed" && opts?.appendFailureEvent) {
+    if (
+      (receipt.delivery_state === "failed" ||
+        receipt.delivery_state === "failed_confirmed") &&
+      opts?.appendFailureEvent
+    ) {
       this.appendDeliveryReceiptEventBestEffort(receipt);
     }
     return { ...receipt };
@@ -6211,6 +6278,202 @@ export class AgentEngine {
   getDeliveryReceipt(deliveryId: string): AgentDeliveryReceipt | null {
     const receipt = this.deliveryReceipts.get(deliveryId);
     return receipt ? { ...receipt } : null;
+  }
+
+  listDeliveryReceipts(): AgentDeliveryReceipt[] {
+    return [...this.deliveryReceipts.values()].map((receipt) => ({
+      ...receipt,
+    }));
+  }
+
+  findOpenDuplicate(input: {
+    agent_id: string;
+    text: string;
+    press_enter: boolean;
+  }): AgentDeliveryReceipt | null {
+    for (const receipt of this.deliveryReceipts.values()) {
+      if (
+        (receipt.delivery_state === "pending_verify" ||
+          receipt.delivery_state === "queued") &&
+        receipt.agent_id === input.agent_id &&
+        receipt.text === input.text &&
+        receipt.press_enter === input.press_enter
+      ) {
+        return { ...receipt };
+      }
+    }
+    return null;
+  }
+
+  acceptPendingVerify(input: {
+    delivery_id: string;
+    agent_id: string;
+    text: string;
+    press_enter: boolean;
+    source_event: DeliveryEventType;
+    retry_count: number;
+    created_at?: string;
+  }): AgentDeliveryReceipt {
+    const now = new Date().toISOString();
+    const existing = this.deliveryReceipts.get(input.delivery_id);
+    const receipt: AgentDeliveryReceipt = {
+      ...input,
+      delivery_state: "pending_verify",
+      terminal: false,
+      created_at: input.created_at ?? existing?.created_at ?? now,
+      resolved_at: null,
+      submit_verified: null,
+      error: null,
+      submission_started_at: existing?.submission_started_at ?? now,
+      next_attempt_at: null,
+      verify_deadline_at:
+        existing?.verify_deadline_at ??
+        new Date(Date.now() + this.deliveryVerifyDeadlineMs).toISOString(),
+    };
+    this.deliveryReceipts.set(receipt.delivery_id, receipt);
+    this.persistDeliveryReceipts();
+    return { ...receipt };
+  }
+
+  async waitForDelivery(
+    deliveryId: string,
+    timeoutMs: number,
+  ): Promise<AgentDeliveryReceipt> {
+    const start = Date.now();
+    const existing = this.getDeliveryReceipt(deliveryId);
+    if (!existing) {
+      throw new Error(`Delivery not found: ${deliveryId}`);
+    }
+    if (existing.terminal) {
+      return existing;
+    }
+    return new Promise<AgentDeliveryReceipt>((resolve, reject) => {
+      const finish = (receipt: AgentDeliveryReceipt) => {
+        clearInterval(timer);
+        resolve(receipt);
+      };
+      const timer = setInterval(() => {
+        const elapsed = Date.now() - start;
+        const current = this.getDeliveryReceipt(deliveryId);
+        if (!current) {
+          clearInterval(timer);
+          reject(new Error(`Delivery not found: ${deliveryId}`));
+          return;
+        }
+        if (current.terminal) {
+          finish(current);
+          return;
+        }
+        if (elapsed >= timeoutMs) {
+          clearInterval(timer);
+          reject(
+            new Error(
+              `Timed out after ${timeoutMs}ms waiting for delivery ${deliveryId}`,
+            ),
+          );
+        }
+      }, DELIVERY_WAIT_POLL_MS);
+    });
+  }
+
+  async verifyPendingDeliveries(): Promise<void> {
+    if (this.deliveryVerifyInFlight) return;
+    this.deliveryVerifyInFlight = true;
+    try {
+      for (const receipt of this.deliveryReceipts.values()) {
+        const watching =
+          receipt.delivery_state === "pending_verify" ||
+          (receipt.delivery_state === "queued" &&
+            receipt.composer_accepted === true);
+        if (!watching || receipt.terminal) continue;
+        const deadlineMs = receipt.verify_deadline_at
+          ? Date.parse(receipt.verify_deadline_at)
+          : Date.parse(receipt.created_at) + this.deliveryVerifyDeadlineMs;
+        let observation: DeliveryVerifyObservation = { outcome: "pending" };
+        if (this.deliveryVerifier) {
+          try {
+            observation = await this.deliveryVerifier(receipt);
+          } catch (error) {
+            observation = {
+              outcome: "pending",
+              reason: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }
+        const timedOut = Date.now() >= deadlineMs;
+        if (observation.outcome === "delivered") {
+          receipt.delivery_state = "submitted";
+          receipt.terminal = true;
+          receipt.resolved_at = new Date().toISOString();
+          receipt.submit_verified = observation.submit_verified ?? true;
+          receipt.error = null;
+          this.persistDeliveryReceipts();
+          this.appendDeliveryReceiptEventBestEffort(receipt);
+          continue;
+        }
+        if (observation.outcome === "failed_confirmed" || timedOut) {
+          const reason =
+            observation.reason ??
+            (timedOut ? "verify_deadline_elapsed" : "failed_confirmed");
+          receipt.delivery_state = "failed_confirmed";
+          receipt.terminal = true;
+          receipt.resolved_at = new Date().toISOString();
+          receipt.submit_verified = false;
+          receipt.error = reason;
+          this.persistDeliveryReceipts();
+          this.appendDeliveryReceiptEventBestEffort(receipt);
+          await this.fileConfirmedFailureTicket(receipt, reason, observation);
+        }
+      }
+    } finally {
+      this.deliveryVerifyInFlight = false;
+    }
+  }
+
+  private async fileConfirmedFailureTicket(
+    receipt: AgentDeliveryReceipt,
+    reason: string,
+    observation: DeliveryVerifyObservation,
+  ): Promise<void> {
+    if (receipt.ticket_filed) return;
+    const agent = this.getAgentState(receipt.agent_id);
+    const signature = deliveryFailureSignature({
+      reason,
+      cli: agent?.cli ?? null,
+    });
+    const ticket: DeliveryFailureTicket = {
+      signature,
+      delivery_id: receipt.delivery_id,
+      agent_id: receipt.agent_id,
+      reason,
+      cli: agent?.cli ?? null,
+      what_happened: `Delivery ${receipt.delivery_id} to ${receipt.agent_id} reached failed_confirmed (${reason}) after background verify.`,
+      what_fixed_it:
+        "Do not blind-retry. Identical send_to while pending_verify/queued returns duplicate_of. Query wait_for({delivery_id}) or list_agents detail=full.",
+      evidence: {
+        receipt,
+        observation,
+        target_state: agent?.state ?? null,
+        surface_id: agent?.surface_id ?? null,
+      },
+      observed_at: new Date().toISOString(),
+    };
+    const written = writeDeliveryFailureTicket(ticket, {
+      dir: this.deliveryTicketDir,
+    });
+    receipt.ticket_filed = true;
+    this.persistDeliveryReceipts();
+    if (!written.created) return;
+    const filer =
+      this.deliveryIssueFiler ??
+      (async (nextTicket) => {
+        await fileDeliveryFailureGithubIssue(nextTicket);
+      });
+    try {
+      await filer(ticket);
+    } catch {
+      // Local ticket is authoritative; GitHub is best-effort.
+    }
   }
 
   async drainDeliveryQueue(): Promise<void> {
@@ -6267,6 +6530,17 @@ export class AgentEngine {
             receipt.resolved_at = null;
             receipt.submit_verified = null;
             receipt.composer_accepted = true;
+            receipt.verify_deadline_at ??= new Date(
+              Date.now() + this.deliveryVerifyDeadlineMs,
+            ).toISOString();
+          } else if (result.delivery === "pending_verify") {
+            receipt.delivery_state = "pending_verify";
+            receipt.terminal = false;
+            receipt.resolved_at = null;
+            receipt.submit_verified = null;
+            receipt.verify_deadline_at ??= new Date(
+              Date.now() + this.deliveryVerifyDeadlineMs,
+            ).toISOString();
           } else {
             receipt.delivery_state = "submitted";
             receipt.terminal = true;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -279,7 +279,12 @@ export interface DeliveryTelemetryEvent {
   delivery_id?: string;
   /** Nonterminal acceptance or terminal resolution. */
   delivery_state?:
-    "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
+    | "submitted"
+    | "queued"
+    | "queued_followup"
+    | "failed"
+    | "pending_verify"
+    | "failed_confirmed";
   target_agent?: string;
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -278,7 +278,8 @@ export interface DeliveryTelemetryEvent {
   /** Stable receipt identity for agent-routed delivery state transitions. */
   delivery_id?: string;
   /** Nonterminal acceptance or terminal resolution. */
-  delivery_state?: "submitted" | "queued" | "failed";
+  delivery_state?:
+    "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
   target_agent?: string;
 }
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -9,6 +9,10 @@ import type { AgentRoute } from "./agent-types.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
 import {
+  defaultDeliveryTicketDir,
+  fileDeliveryFailureGithubIssue,
+} from "./delivery-failure-tickets.js";
+import {
   defaultMonitorRegistryPath,
   httpNotifyMonitorDeadman,
 } from "./monitor-registry.js";
@@ -400,6 +404,16 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         }),
         fleetSidebarPublisher:
           opts.fleetSidebarPublisher ?? new FleetSidebarPublisher(),
+        deliveryTicketDir:
+          process.env.VITEST === "true" || process.env.NODE_ENV === "test"
+            ? undefined
+            : defaultDeliveryTicketDir(),
+        deliveryIssueFiler:
+          process.env.VITEST === "true" || process.env.NODE_ENV === "test"
+            ? undefined
+            : async (ticket) => {
+                await fileDeliveryFailureGithubIssue(ticket);
+              },
       },
     );
   }
@@ -451,7 +465,10 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         ...(workspace ? { workspace } : {}),
         ...(priorFocus
           ? {
-              on_surface_created: ({ surface, workspace: createdWorkspace }) => {
+              on_surface_created: ({
+                surface,
+                workspace: createdWorkspace,
+              }) => {
                 createdFocus = createdWorkspace
                   ? { workspace: createdWorkspace, surface }
                   : null;
@@ -675,9 +692,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     }
   }
 
-  private async currentFocusTargetBestEffort(): Promise<
-    AppServerFocusTarget | null
-  > {
+  private async currentFocusTargetBestEffort(): Promise<AppServerFocusTarget | null> {
     try {
       const focused = (await this.client.identify()).focused;
       const workspace = focused?.workspace_ref?.trim();

--- a/src/delivery-failure-tickets.ts
+++ b/src/delivery-failure-tickets.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TICKET_DIR = join(homedir(), ".cmuxlayer", "tickets");
+const DEFAULT_REPO = "EtanHey/cmuxlayer";
+
+export interface DeliveryFailureTicket {
+  signature: string;
+  delivery_id: string;
+  agent_id: string;
+  reason: string;
+  cli?: string | null;
+  what_happened: string;
+  what_fixed_it: string;
+  evidence: Record<string, unknown>;
+  observed_at: string;
+}
+
+export interface DeliveryTicketRecord {
+  signature: string;
+  title: string;
+  occurrence_count: number;
+  occurrences: DeliveryFailureTicket[];
+  github_issue_url?: string;
+}
+
+export function deliveryFailureSignature(input: {
+  reason: string;
+  cli?: string | null;
+}): string {
+  const normalized = `${input.cli ?? "unknown"}:${input.reason}`;
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+export function defaultDeliveryTicketDir(): string {
+  return DEFAULT_TICKET_DIR;
+}
+
+export function writeDeliveryFailureTicket(
+  ticket: DeliveryFailureTicket,
+  opts?: { dir?: string },
+): { path: string; created: boolean; record: DeliveryTicketRecord } {
+  const dir = opts?.dir ?? DEFAULT_TICKET_DIR;
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${ticket.signature}.json`);
+  const existing = existsSync(path)
+    ? (JSON.parse(readFileSync(path, "utf8")) as DeliveryTicketRecord)
+    : null;
+  const record: DeliveryTicketRecord = existing
+    ? {
+        ...existing,
+        occurrence_count: existing.occurrence_count + 1,
+        occurrences: [...existing.occurrences, ticket],
+      }
+    : {
+        signature: ticket.signature,
+        title: ticketTitle(ticket),
+        occurrence_count: 1,
+        occurrences: [ticket],
+      };
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+  return { path, created: !existing, record };
+}
+
+export async function fileDeliveryFailureGithubIssue(
+  ticket: DeliveryFailureTicket,
+  opts?: {
+    repo?: string;
+    runner?: (
+      file: string,
+      args: string[],
+    ) => Promise<{ stdout: string; stderr: string }>;
+  },
+): Promise<string | null> {
+  const repo = opts?.repo ?? DEFAULT_REPO;
+  const run =
+    opts?.runner ??
+    (async (file, args) => execFileAsync(file, args, { timeout: 15_000 }));
+  const marker = `cmuxlayer-delivery-failure:${ticket.signature}`;
+  const title = ticketTitle(ticket);
+  const body = [
+    marker,
+    "",
+    ticket.what_happened,
+    "",
+    ticket.what_fixed_it,
+    "",
+    "```json",
+    JSON.stringify(ticket.evidence, null, 2),
+    "```",
+  ].join("\n");
+  try {
+    const listed = await run("gh", [
+      "issue",
+      "list",
+      "--repo",
+      repo,
+      "--search",
+      marker,
+      "--state",
+      "all",
+      "--json",
+      "number,url,title",
+    ]);
+    const issues = JSON.parse(listed.stdout || "[]") as Array<{
+      number: number;
+      url: string;
+    }>;
+    if (issues[0]?.number) {
+      await run("gh", [
+        "issue",
+        "comment",
+        String(issues[0].number),
+        "--repo",
+        repo,
+        "--body",
+        body,
+      ]);
+      return issues[0].url ?? null;
+    }
+    const created = await run("gh", [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+      "--body",
+      body,
+    ]);
+    return created.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function ticketTitle(ticket: DeliveryFailureTicket): string {
+  return `delivery failure: ${ticket.reason} (${ticket.cli ?? "unknown"})`;
+}

--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -35,6 +35,10 @@ const CLAUDE_ACTIVE_RE =
 
 const CURSOR_ACTIVE_RE =
   /(?:^|\n)[^\S\r\n]*(?:(?:[⠀-⣿]+|⬢|⬡|•)[^\S\r\n]*)?(?:Calling|Editing|Reading|Writing|Searching|Planning|Running|Generating|Thinking|Waiting)\b(?:\.\.\.|…)?(?:[^\S\r\n]+[0-9][0-9,]*(?:\.[0-9]+)?[km]?[^\S\r\n]+tokens\b|[^\S\r\n]*(?=\r?(?:\n|$)))/i;
+export const CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE =
+  /follow-ups?(?:\s*·\s*enter send now|\s*─[\s\S]{0,300}?enter send now)/i;
+export const CURSOR_FOLLOWUP_PLACEHOLDER_RE =
+  /^\s*(?:→\s*)?Add a follow-up(?:\s|$)/im;
 const CURSOR_READY_RE = new RegExp(
   [
     String.raw`cursor>`,
@@ -55,11 +59,11 @@ const CODEX_READY_RE = new RegExp(
   ].join("|"),
   "im",
 );
-const CODEX_ACTIVE_RE = /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b|Working\s*\(/i;
+const CODEX_ACTIVE_RE =
+  /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b|Working\s*\(/i;
 const GEMINI_ACTIVE_RE =
   /(?:^|\n)\s*(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?\s*$/im;
-const GEMINI_ACTIVE_LINE_RE =
-  /^(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?$/i;
+const GEMINI_ACTIVE_LINE_RE = /^(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?$/i;
 const GEMINI_READY_PROMPT_LINE_RE = /^>\s*$/;
 
 export const CLI_READY_PATTERNS: Record<CliType, ReadyPattern> = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -447,6 +447,9 @@ const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 // recovery so fleet fan-out does not inherit the general 5s timeout.
 const BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS = 1_000;
 const CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS = 250;
+const CURSOR_FOLLOWUP_RETRY_OBSERVE_MS = 250;
+const CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE = /follow-ups?\s*·\s*enter send now/i;
+const CURSOR_FOLLOWUP_PLACEHOLDER_RE = /^Add a follow-up$/i;
 const SEND_INPUT_SAFE_RETRY_OBSERVE_MS = 2500;
 const SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS = 300;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
@@ -554,6 +557,7 @@ const DeliveryOutputShape = {
     .enum([
       "submitted",
       "queued",
+      "queued_followup",
       "failed",
       "pending_verify",
       "failed_confirmed",
@@ -563,6 +567,7 @@ const DeliveryOutputShape = {
     .enum([
       "submitted",
       "queued",
+      "queued_followup",
       "failed",
       "pending_verify",
       "failed_confirmed",
@@ -855,7 +860,12 @@ export const DELIVERY_RECEIPT_VOCABULARY = [
 ] as const;
 
 type PublicDeliveryState =
-  "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
+  | "submitted"
+  | "queued"
+  | "queued_followup"
+  | "failed"
+  | "pending_verify"
+  | "failed_confirmed";
 
 export interface PublicDeliveryReceipt {
   delivered: boolean;
@@ -885,6 +895,7 @@ export function buildPublicDeliveryReceipt(input: {
 }): PublicDeliveryReceipt {
   const evidencedState =
     input.delivery_state === "queued" ||
+    input.delivery_state === "queued_followup" ||
     input.delivery_state === "failed" ||
     input.delivery_state === "pending_verify" ||
     input.delivery_state === "failed_confirmed"
@@ -2192,6 +2203,7 @@ function isComposerFooterOrChromeLine(line: string): boolean {
     /^\/ commands\b/i.test(trimmed) ||
     /^(?:Auto|Agent)(?:\s*·|$)/i.test(trimmed) ||
     /^ctrl\+c to stop\b/i.test(trimmed) ||
+    CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE.test(trimmed) ||
     /^bypass permissions on\b/i.test(trimmed) ||
     /^⬡\s+Idle\b/i.test(trimmed) ||
     /^v20\d{2}\.\d{2}\.\d{2}-[a-f0-9]+$/i.test(trimmed)
@@ -2232,7 +2244,8 @@ function normalizeKnownPlaceholderComposerInput(
   if (
     (cli === "codex" && withoutCursorBorders === "Implement {feature}") ||
     (cli === "cursor" &&
-      withoutCursorBorders === "Plan, search, build anything")
+      (withoutCursorBorders === "Plan, search, build anything" ||
+        CURSOR_FOLLOWUP_PLACEHOLDER_RE.test(withoutCursorBorders)))
   ) {
     if (withoutCursorBorders === submittedText?.trim()) {
       return input;
@@ -2527,6 +2540,41 @@ function screenShowsQueuedAgentInput(
   );
   const submitted = compactQueueCorrelationText(submittedText.trim());
   return visiblePrefix.length > 0 && submitted.startsWith(visiblePrefix);
+}
+
+function screenShowsCursorFollowupNeedsEnter(screenText: string): boolean {
+  return (
+    inferComposerCli(screenText) === "cursor" &&
+    CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE.test(normalizeTerminalText(screenText))
+  );
+}
+
+function screenShowsQueuedCursorFollowup(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  if (inferComposerCli(screenText) !== "cursor") {
+    return false;
+  }
+  if (screenShowsPendingInput(screenText, submittedText)) {
+    return false;
+  }
+  const trimmed = submittedText.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const tail = trimmed.slice(-Math.min(80, trimmed.length));
+  const composer = extractComposerInputRegion(screenText, submittedText);
+  if (composer === null || composer.trim() !== "") {
+    return false;
+  }
+  if (!normalizeTerminalText(screenText).includes(tail)) {
+    return false;
+  }
+  return (
+    /→\s*Add a follow-up/i.test(screenText) ||
+    /ctrl\+c to stop/i.test(screenText)
+  );
 }
 
 export type PendingLauncherLineKind = "exact" | "corrupted" | "empty" | "other";
@@ -4546,7 +4594,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verified: boolean | null;
     submit_verification_reason: SubmitVerificationFailureReason | null;
     retry_count: number;
-    delivery: "submitted" | "queued" | "pending_verify";
+    delivery: "submitted" | "queued" | "queued_followup" | "pending_verify";
   }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
@@ -4626,6 +4674,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery: "queued",
         };
       }
+      if (
+        (opts.source_event === "send_to" ||
+          opts.source_event === "dispatch_nudge") &&
+        screenShowsQueuedCursorFollowup(snapshot.text, opts.text)
+      ) {
+        return {
+          submit_verified: null,
+          submit_verification_reason: null,
+          retry_count: retryCount,
+          delivery: "queued_followup",
+        };
+      }
       const screenCli = inferComposerCli(snapshot.text, snapshot.parsed);
       const cursorShowsSubmittedResponse =
         screenCli === "cursor" &&
@@ -4687,20 +4747,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           opts.source_event === "dispatch_nudge") &&
         hasPendingSubmitEvidence &&
         screenCli === "codex";
+      const cursorFollowupRetryEligiblePendingInput =
+        opts.allow_recovery_enter_retry !== false &&
+        (opts.source_event === "send_to" ||
+          opts.source_event === "dispatch_nudge") &&
+        hasPendingSubmitEvidence &&
+        screenCli === "cursor" &&
+        screenShowsCursorFollowupNeedsEnter(snapshot.text);
       const retryEligiblePendingInput =
-        spawnRetryEligiblePendingInput || codexRetryEligiblePendingInput;
+        spawnRetryEligiblePendingInput ||
+        codexRetryEligiblePendingInput ||
+        cursorFollowupRetryEligiblePendingInput;
       lastRetryEligiblePendingInput = retryEligiblePendingInput;
       if (retryEligiblePendingInput) {
         retryEligiblePendingSince ??= Date.now();
       } else {
         retryEligiblePendingSince = null;
       }
-      const retryObserveMs = codexRetryEligiblePendingInput
-        ? Math.min(timeoutMs, CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS)
-        : opts.source_event === "spawn_agent" &&
-            !hasParsedAgentIdentity(snapshot.parsed)
-          ? 0
-          : Math.min(timeoutMs, SEND_INPUT_SAFE_RETRY_OBSERVE_MS);
+      const retryObserveMs = cursorFollowupRetryEligiblePendingInput
+        ? Math.min(timeoutMs, CURSOR_FOLLOWUP_RETRY_OBSERVE_MS)
+        : codexRetryEligiblePendingInput
+          ? Math.min(timeoutMs, CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS)
+          : opts.source_event === "spawn_agent" &&
+              !hasParsedAgentIdentity(snapshot.parsed)
+            ? 0
+            : Math.min(timeoutMs, SEND_INPUT_SAFE_RETRY_OBSERVE_MS);
 
       // Pending input is ambiguous: the first Return may have been missed, or
       // it may have landed while a slow agent has not repainted the composer
@@ -4890,7 +4961,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let submit_verification_reason: SubmitVerificationFailureReason | null =
       null;
     let retry_count = 0;
-    let deliveryOutcome: "submitted" | "queued" | "pending_verify" =
+    let deliveryOutcome:
+      "submitted" | "queued" | "queued_followup" | "pending_verify" =
       "submitted";
 
     if (opts.press_enter) {
@@ -4951,7 +5023,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       submit_verification_reason = verification.submit_verification_reason;
       retry_count = verification.retry_count;
       deliveryOutcome = verification.delivery;
-      if (deliveryOutcome === "pending_verify") {
+      if (
+        deliveryOutcome === "pending_verify" ||
+        deliveryOutcome === "queued_followup"
+      ) {
         submit_verified = null;
         submit_verification_reason = null;
       }
@@ -4980,11 +5055,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               delivery_state:
                 deliveryOutcome === "queued"
                   ? ("queued" as const)
-                  : deliveryOutcome === "pending_verify"
-                    ? ("pending_verify" as const)
-                    : submit_verified === false
-                      ? ("failed" as const)
-                      : ("submitted" as const),
+                  : deliveryOutcome === "queued_followup"
+                    ? ("queued_followup" as const)
+                    : deliveryOutcome === "pending_verify"
+                      ? ("pending_verify" as const)
+                      : submit_verified === false
+                        ? ("failed" as const)
+                        : ("submitted" as const),
             }
           : {}),
       });
@@ -4994,11 +5071,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       delivery_state:
         deliveryOutcome === "queued"
           ? "queued"
-          : deliveryOutcome === "pending_verify"
-            ? "pending_verify"
-            : submit_verified === true
-              ? "submitted"
-              : undefined,
+          : deliveryOutcome === "queued_followup"
+            ? "queued_followup"
+            : deliveryOutcome === "pending_verify"
+              ? "pending_verify"
+              : submit_verified === true
+                ? "submitted"
+                : undefined,
       delivery_id: opts.delivery_id,
       typed: bytes > 0,
       submit_attempted: Boolean(opts.press_enter),
@@ -5009,6 +5088,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (
       submit_verified === false &&
       deliveryOutcome !== "queued" &&
+      deliveryOutcome !== "queued_followup" &&
       deliveryOutcome !== "pending_verify"
     ) {
       const timeoutMs =
@@ -10786,6 +10866,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         submit_verified: delivery.submit_verified,
         ...(delivery.delivery === "submitted" ||
         delivery.delivery === "queued" ||
+        delivery.delivery === "queued_followup" ||
         delivery.delivery === "pending_verify"
           ? { delivery: delivery.delivery }
           : {}),
@@ -10808,9 +10889,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       const pending = screenShowsPendingInput(snapshot.text, receipt.text);
       const queued = screenShowsQueuedAgentInput(snapshot.text, receipt.text);
+      const cursorQueuedFollowup = screenShowsQueuedCursorFollowup(
+        snapshot.text,
+        receipt.text,
+      );
       const composer = extractComposerInputRegion(snapshot.text, receipt.text);
       const cli = inferComposerCli(snapshot.text, snapshot.parsed);
-      if (queued || (cli === "cursor" && pending)) {
+      if (queued || cursorQueuedFollowup || (cli === "cursor" && pending)) {
         return { outcome: "pending" as const };
       }
       const composerCleared = composer !== null && composer.trim() === "";
@@ -14434,7 +14519,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   delivery_id: deliveryId,
                 });
                 const accepted =
-                  delivery.delivery === "queued"
+                  delivery.delivery === "queued" ||
+                  delivery.delivery === "queued_followup"
                     ? engine.acceptComposerQueue({
                         delivery_id: deliveryId,
                         agent_id: agent.agent_id,
@@ -14442,6 +14528,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         press_enter: args.press_enter,
                         source_event: "send_to",
                         retry_count: delivery.retry_count,
+                        delivery_state: delivery.delivery,
                       })
                     : delivery.delivery === "pending_verify"
                       ? engine.acceptPendingVerify({
@@ -14680,7 +14767,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             throw error;
           }
           const receipt =
-            delivery.delivery === "queued"
+            delivery.delivery === "queued" ||
+            delivery.delivery === "queued_followup"
               ? engine.acceptComposerQueue({
                   delivery_id: deliveryId,
                   agent_id: agentId,
@@ -14688,6 +14776,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   press_enter: args.press_enter,
                   source_event: "send_to",
                   retry_count: delivery.retry_count,
+                  delivery_state: delivery.delivery,
                 })
               : delivery.delivery === "pending_verify"
                 ? engine.acceptPendingVerify({

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,7 +54,11 @@ import {
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
-import type { DeliveryFailureTicket } from "./delivery-failure-tickets.js";
+import {
+  defaultDeliveryTicketDir,
+  fileDeliveryFailureGithubIssue,
+  type DeliveryFailureTicket,
+} from "./delivery-failure-tickets.js";
 import {
   deregisterMonitor,
   queryMonitorRegistryForGates,
@@ -189,6 +193,8 @@ import { normalizeKeyName } from "./key-names.js";
 import { currentCallerContext, type CallerContext } from "./caller-context.js";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
+  CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE,
+  CURSOR_FOLLOWUP_PLACEHOLDER_RE,
   matchReadyPattern,
   screenHasActiveAgentMarker,
   screenHasReadyAgentIdentity,
@@ -448,8 +454,6 @@ const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
 const BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS = 1_000;
 const CODEX_PENDING_COMPOSER_RETRY_OBSERVE_MS = 250;
 const CURSOR_FOLLOWUP_RETRY_OBSERVE_MS = 250;
-const CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE = /follow-ups?\s*·\s*enter send now/i;
-const CURSOR_FOLLOWUP_PLACEHOLDER_RE = /^Add a follow-up$/i;
 const SEND_INPUT_SAFE_RETRY_OBSERVE_MS = 2500;
 const SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS = 300;
 const BOOT_PROMPT_TIMEOUT_MS = 60_000;
@@ -2572,7 +2576,7 @@ function screenShowsQueuedCursorFollowup(
     return false;
   }
   return (
-    /→\s*Add a follow-up/i.test(screenText) ||
+    CURSOR_FOLLOWUP_PLACEHOLDER_RE.test(screenText) ||
     /ctrl\+c to stop/i.test(screenText)
   );
 }
@@ -3008,9 +3012,12 @@ export interface CreateServerOptions {
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
   /** Background send_to verify deadline; defaults to 10 minutes. */
   deliveryVerifyDeadlineMs?: number;
-  /** Local evidence tickets for failed_confirmed deliveries. */
+  /**
+   * Local evidence tickets for failed_confirmed deliveries. Omitted in tests;
+   * production createServer injects ~/.cmuxlayer/tickets when not VITEST/NODE_ENV=test.
+   */
   deliveryTicketDir?: string;
-  /** Optional GitHub/local ticket sink (tests inject a recorder). */
+  /** Optional GitHub/local ticket sink (tests inject a recorder; production injects gh). */
   deliveryIssueFiler?: (ticket: DeliveryFailureTicket) => Promise<void>;
 }
 
@@ -10145,6 +10152,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       });
     };
+    const testProcess =
+      process.env.VITEST === "true" || process.env.NODE_ENV === "test";
     const engine =
       context.lifecycleSweepEngine ??
       new AgentEngine(
@@ -10375,8 +10384,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           seatRegistryPath: opts?.seatRegistryPath,
           fleetSidebarPublisher: opts?.fleetSidebarPublisher,
           deliveryVerifyDeadlineMs: opts?.deliveryVerifyDeadlineMs,
-          deliveryTicketDir: opts?.deliveryTicketDir,
-          deliveryIssueFiler: opts?.deliveryIssueFiler,
+          deliveryTicketDir:
+            opts?.deliveryTicketDir ??
+            (testProcess ? undefined : defaultDeliveryTicketDir()),
+          deliveryIssueFiler:
+            opts?.deliveryIssueFiler ??
+            (testProcess
+              ? undefined
+              : async (ticket) => {
+                  await fileDeliveryFailureGithubIssue(ticket);
+                }),
         },
       );
     lifecycleSeatManifestPublisher = async (input) => {
@@ -10875,7 +10892,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     engine.setDeliveryVerifier(async (receipt: AgentDeliveryReceipt) => {
       const agent = engine.getAgentState(receipt.agent_id);
       if (!agent) {
-        return { outcome: "failed_confirmed" as const, reason: "target_gone" };
+        return { outcome: "pending" as const, reason: "target_gone" };
       }
       const snapshot = await readParsedSurface(
         agent.surface_id,
@@ -10906,11 +10923,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         correlationTail.length > 0 &&
         normalizeTerminalText(snapshot.text).includes(correlationTail) &&
         !pending;
-      if (
-        composerCleared ||
-        inTranscript ||
-        (!pending && isSubmitVerifiedStatus(snapshot.parsed.status))
-      ) {
+      if (composerCleared || inTranscript) {
         return { outcome: "delivered" as const, submit_verified: true };
       }
       return { outcome: "pending" as const };

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,10 +49,12 @@ import {
   RetryableDeliveryError,
   buildLaunchCommand,
   resolveSweepTiming,
+  type AgentDeliveryReceipt,
   type AgentLifecycleEvent,
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
+import type { DeliveryFailureTicket } from "./delivery-failure-tickets.js";
 import {
   deregisterMonitor,
   queryMonitorRegistryForGates,
@@ -548,8 +550,24 @@ const BaseOutputShape = {
 };
 const DeliveryOutputShape = {
   delivered: z.boolean().optional(),
-  delivery: z.enum(["submitted", "queued", "failed"]).optional(),
-  delivery_state: z.enum(["submitted", "queued", "failed"]).optional(),
+  delivery: z
+    .enum([
+      "submitted",
+      "queued",
+      "failed",
+      "pending_verify",
+      "failed_confirmed",
+    ])
+    .optional(),
+  delivery_state: z
+    .enum([
+      "submitted",
+      "queued",
+      "failed",
+      "pending_verify",
+      "failed_confirmed",
+    ])
+    .optional(),
   terminal: z.boolean().optional(),
   typed: z.boolean().optional(),
   submit_attempted: z.boolean().optional(),
@@ -836,7 +854,8 @@ export const DELIVERY_RECEIPT_VOCABULARY = [
   "retry_count",
 ] as const;
 
-type PublicDeliveryState = "submitted" | "queued" | "failed";
+type PublicDeliveryState =
+  "submitted" | "queued" | "failed" | "pending_verify" | "failed_confirmed";
 
 export interface PublicDeliveryReceipt {
   delivered: boolean;
@@ -848,6 +867,7 @@ export interface PublicDeliveryReceipt {
   delivery?: PublicDeliveryState;
   delivery_state?: PublicDeliveryState;
   delivery_id?: string;
+  duplicate_of?: string;
 }
 
 /**
@@ -864,13 +884,18 @@ export function buildPublicDeliveryReceipt(input: {
   retry_count: number;
 }): PublicDeliveryReceipt {
   const evidencedState =
-    input.delivery_state === "queued" || input.delivery_state === "failed"
+    input.delivery_state === "queued" ||
+    input.delivery_state === "failed" ||
+    input.delivery_state === "pending_verify" ||
+    input.delivery_state === "failed_confirmed"
       ? input.delivery_state
       : input.delivery_state === "submitted" && input.submit_verified === true
         ? "submitted"
         : undefined;
   const terminal =
-    evidencedState === "submitted" || evidencedState === "failed";
+    evidencedState === "submitted" ||
+    evidencedState === "failed" ||
+    evidencedState === "failed_confirmed";
   return {
     delivered: evidencedState === "submitted",
     terminal,
@@ -2933,6 +2958,12 @@ export interface CreateServerOptions {
   seatManifestNow?: () => string;
   /** Publish the opt-in generated fleet.swift from reconciled lifecycle state. */
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
+  /** Background send_to verify deadline; defaults to 10 minutes. */
+  deliveryVerifyDeadlineMs?: number;
+  /** Local evidence tickets for failed_confirmed deliveries. */
+  deliveryTicketDir?: string;
+  /** Optional GitHub/local ticket sink (tests inject a recorder). */
+  deliveryIssueFiler?: (ticket: DeliveryFailureTicket) => Promise<void>;
 }
 
 type CmuxLayerClient = CmuxClient | CmuxSocketClient;
@@ -4515,7 +4546,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verified: boolean | null;
     submit_verification_reason: SubmitVerificationFailureReason | null;
     retry_count: number;
-    delivery: "submitted" | "queued";
+    delivery: "submitted" | "queued" | "pending_verify";
   }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
@@ -4712,7 +4743,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           submit_verified: false,
           submit_verification_reason: "input_still_pending",
           retry_count: retryCount,
-          delivery: "submitted",
+          delivery:
+            opts.source_event === "send_to" ||
+            opts.source_event === "dispatch_nudge"
+              ? "pending_verify"
+              : "submitted",
         };
       }
 
@@ -4746,6 +4781,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : opts.require_working_status
               ? "working_status_not_observed"
               : "submit_evidence_absent";
+    const allowPendingVerify =
+      opts.source_event === "send_to" || opts.source_event === "dispatch_nudge";
+    if (allowPendingVerify && submitVerified === false) {
+      return {
+        submit_verified: null,
+        submit_verification_reason: null,
+        retry_count: retryCount,
+        delivery: "pending_verify",
+      };
+    }
     return {
       submit_verified: submitVerified,
       submit_verification_reason: failureReason,
@@ -4845,7 +4890,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let submit_verification_reason: SubmitVerificationFailureReason | null =
       null;
     let retry_count = 0;
-    let deliveryOutcome: "submitted" | "queued" = "submitted";
+    let deliveryOutcome: "submitted" | "queued" | "pending_verify" =
+      "submitted";
 
     if (opts.press_enter) {
       let cursorResponseBaseline: readonly string[] | null = null;
@@ -4905,6 +4951,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       submit_verification_reason = verification.submit_verification_reason;
       retry_count = verification.retry_count;
       deliveryOutcome = verification.delivery;
+      if (deliveryOutcome === "pending_verify") {
+        submit_verified = null;
+        submit_verification_reason = null;
+      }
     }
 
     await maybeRenameTask({
@@ -4930,9 +4980,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               delivery_state:
                 deliveryOutcome === "queued"
                   ? ("queued" as const)
-                  : submit_verified === false
-                    ? ("failed" as const)
-                    : ("submitted" as const),
+                  : deliveryOutcome === "pending_verify"
+                    ? ("pending_verify" as const)
+                    : submit_verified === false
+                      ? ("failed" as const)
+                      : ("submitted" as const),
             }
           : {}),
       });
@@ -4942,9 +4994,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       delivery_state:
         deliveryOutcome === "queued"
           ? "queued"
-          : submit_verified === true
-            ? "submitted"
-            : undefined,
+          : deliveryOutcome === "pending_verify"
+            ? "pending_verify"
+            : submit_verified === true
+              ? "submitted"
+              : undefined,
       delivery_id: opts.delivery_id,
       typed: bytes > 0,
       submit_attempted: Boolean(opts.press_enter),
@@ -4952,7 +5006,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       retry_count,
     });
 
-    if (submit_verified === false && deliveryOutcome !== "queued") {
+    if (
+      submit_verified === false &&
+      deliveryOutcome !== "queued" &&
+      deliveryOutcome !== "pending_verify"
+    ) {
       const timeoutMs =
         opts.submit_verify_timeout_ms ?? SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS;
       throw new SubmitVerificationError(
@@ -10236,6 +10294,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           seatRegistry,
           seatRegistryPath: opts?.seatRegistryPath,
           fleetSidebarPublisher: opts?.fleetSidebarPublisher,
+          deliveryVerifyDeadlineMs: opts?.deliveryVerifyDeadlineMs,
+          deliveryTicketDir: opts?.deliveryTicketDir,
+          deliveryIssueFiler: opts?.deliveryIssueFiler,
         },
       );
     lifecycleSeatManifestPublisher = async (input) => {
@@ -10723,10 +10784,51 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return {
         retry_count: delivery.retry_count,
         submit_verified: delivery.submit_verified,
-        ...(delivery.delivery === "submitted" || delivery.delivery === "queued"
+        ...(delivery.delivery === "submitted" ||
+        delivery.delivery === "queued" ||
+        delivery.delivery === "pending_verify"
           ? { delivery: delivery.delivery }
           : {}),
       };
+    });
+    engine.setDeliveryVerifier(async (receipt: AgentDeliveryReceipt) => {
+      const agent = engine.getAgentState(receipt.agent_id);
+      if (!agent) {
+        return { outcome: "failed_confirmed" as const, reason: "target_gone" };
+      }
+      const snapshot = await readParsedSurface(
+        agent.surface_id,
+        agent.workspace_id ?? undefined,
+      );
+      if (!snapshot?.text.trim()) {
+        return {
+          outcome: "pending" as const,
+          reason: "surface_read_unavailable",
+        };
+      }
+      const pending = screenShowsPendingInput(snapshot.text, receipt.text);
+      const queued = screenShowsQueuedAgentInput(snapshot.text, receipt.text);
+      const composer = extractComposerInputRegion(snapshot.text, receipt.text);
+      const cli = inferComposerCli(snapshot.text, snapshot.parsed);
+      if (queued || (cli === "cursor" && pending)) {
+        return { outcome: "pending" as const };
+      }
+      const composerCleared = composer !== null && composer.trim() === "";
+      const correlationTail = receipt.text
+        .trim()
+        .slice(-Math.min(80, receipt.text.trim().length));
+      const inTranscript =
+        correlationTail.length > 0 &&
+        normalizeTerminalText(snapshot.text).includes(correlationTail) &&
+        !pending;
+      if (
+        composerCleared ||
+        inTranscript ||
+        (!pending && isSubmitVerifiedStatus(snapshot.parsed.status))
+      ) {
+        return { outcome: "delivered" as const, submit_verified: true };
+      }
+      return { outcome: "pending" as const };
     });
 
     // Reconstitute and discover live surfaces before the first sidebar paint.
@@ -12487,6 +12589,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe("Single agent ID from spawn_agent"),
+        delivery_id: z
+          .string()
+          .optional()
+          .describe(
+            "Wait for a send_to delivery_id to reach a terminal outcome",
+          ),
         ids: z
           .array(z.string())
           .min(1)
@@ -12514,9 +12622,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           if (args.watch) {
-            if (args.agent_id || args.ids || args.mine) {
+            if (args.agent_id || args.ids || args.mine || args.delivery_id) {
               throw new Error(
-                "wait_for watch is mutually exclusive with agent_id, ids, and mine",
+                "wait_for watch is mutually exclusive with agent_id, ids, mine, and delivery_id",
               );
             }
             const result = await engine.waitForWatch(
@@ -12530,6 +12638,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }),
               result,
             );
+          }
+          if (args.delivery_id) {
+            if (args.agent_id || args.ids || args.mine) {
+              throw new Error(
+                "wait_for delivery_id is mutually exclusive with agent_id, ids, and mine",
+              );
+            }
+            const receipt = await engine.waitForDelivery(
+              args.delivery_id,
+              args.timeout_ms,
+            );
+            const data = {
+              delivery_id: receipt.delivery_id,
+              delivery_state: receipt.delivery_state,
+              terminal: receipt.terminal,
+              submit_verified: receipt.submit_verified,
+              agent_id: receipt.agent_id,
+            };
+            return okFormatted(formatOk("wait_for", data), data);
           }
           const targetState = args.target_state ?? "done";
           if (args.mine && (args.agent_id || args.ids)) {
@@ -12601,7 +12728,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
           }
           if (!args.agent_id) {
-            throw new Error("wait_for requires agent_id or ids");
+            throw new Error("wait_for requires agent_id, ids, or delivery_id");
           }
           const result = await engine.waitFor(
             args.agent_id,
@@ -12916,6 +13043,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             count: entry.agents.length,
             ...(entry.skipped_agents.length > 0
               ? { skipped_agents: entry.skipped_agents }
+              : {}),
+            ...(args.detail === "full"
+              ? {
+                  deliveries: engine.listDeliveryReceipts().map((receipt) => ({
+                    delivery_id: receipt.delivery_id,
+                    agent_id: receipt.agent_id,
+                    delivery_state: receipt.delivery_state,
+                    terminal: receipt.terminal,
+                    created_at: receipt.created_at,
+                    resolved_at: receipt.resolved_at,
+                  })),
+                }
               : {}),
           };
           const formatted = formatListAgents(
@@ -14240,6 +14379,28 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 });
                 continue;
               }
+              const duplicate = engine.findOpenDuplicate({
+                agent_id: agent.agent_id,
+                text: args.text,
+                press_enter: args.press_enter,
+              });
+              if (duplicate) {
+                mutableReceipts.push({
+                  ...resolutionMetadata,
+                  agent_id: agent.agent_id,
+                  duplicate_of: duplicate.delivery_id,
+                  ...buildPublicDeliveryReceipt({
+                    delivery_state: duplicate.delivery_state,
+                    delivery_id: duplicate.delivery_id,
+                    typed: false,
+                    submit_attempted: false,
+                    submit_verified: duplicate.submit_verified,
+                    retry_count: duplicate.retry_count,
+                  }),
+                  accepted: true,
+                });
+                continue;
+              }
               const deliveryId = randomUUID();
               if (!args.allow_busy && agent.state === "working") {
                 const queued = engine.queueDelivery({
@@ -14282,20 +14443,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         source_event: "send_to",
                         retry_count: delivery.retry_count,
                       })
-                    : delivery.delivery === "submitted"
-                      ? engine.resolveDelivery({
+                    : delivery.delivery === "pending_verify"
+                      ? engine.acceptPendingVerify({
                           delivery_id: deliveryId,
                           agent_id: agent.agent_id,
                           text: args.text,
                           press_enter: args.press_enter,
                           source_event: "send_to",
-                          delivery_state: "submitted",
-                          terminal: true,
                           retry_count: delivery.retry_count,
-                          submit_verified: delivery.submit_verified,
-                          error: null,
                         })
-                      : null;
+                      : delivery.delivery === "submitted"
+                        ? engine.resolveDelivery({
+                            delivery_id: deliveryId,
+                            agent_id: agent.agent_id,
+                            text: args.text,
+                            press_enter: args.press_enter,
+                            source_event: "send_to",
+                            delivery_state: "submitted",
+                            terminal: true,
+                            retry_count: delivery.retry_count,
+                            submit_verified: delivery.submit_verified,
+                            error: null,
+                          })
+                        : null;
                 mutableReceipts.push({
                   ...resolutionMetadata,
                   agent_id: agent.agent_id,
@@ -14408,6 +14578,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             cli: targetAgent?.cli,
             allowLongInline: args.allow_long_inline,
           });
+          const duplicate = engine.findOpenDuplicate({
+            agent_id: agentId,
+            text: args.text,
+            press_enter: args.press_enter,
+          });
+          if (duplicate) {
+            const data = {
+              accepted: true,
+              agent_id: agentId,
+              duplicate_of: duplicate.delivery_id,
+              ...buildPublicDeliveryReceipt({
+                delivery_state: duplicate.delivery_state,
+                delivery_id: duplicate.delivery_id,
+                typed: false,
+                submit_attempted: false,
+                submit_verified: duplicate.submit_verified,
+                retry_count: duplicate.retry_count,
+              }),
+            };
+            return okFormatted(
+              `send_to duplicate_of ${duplicate.delivery_id}`,
+              data,
+            );
+          }
           if (!args.allow_busy && targetAgent?.state === "working") {
             const receipt = engine.queueDelivery({
               agent_id: agentId,
@@ -14495,20 +14689,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   source_event: "send_to",
                   retry_count: delivery.retry_count,
                 })
-              : delivery.delivery === "submitted"
-                ? engine.resolveDelivery({
+              : delivery.delivery === "pending_verify"
+                ? engine.acceptPendingVerify({
                     delivery_id: deliveryId,
                     agent_id: agentId,
                     text: args.text,
                     press_enter: args.press_enter,
                     source_event: "send_to",
-                    delivery_state: "submitted",
-                    terminal: true,
                     retry_count: delivery.retry_count,
-                    submit_verified: delivery.submit_verified,
-                    error: null,
                   })
-                : null;
+                : delivery.delivery === "submitted"
+                  ? engine.resolveDelivery({
+                      delivery_id: deliveryId,
+                      agent_id: agentId,
+                      text: args.text,
+                      press_enter: args.press_enter,
+                      source_event: "send_to",
+                      delivery_state: "submitted",
+                      terminal: true,
+                      retry_count: delivery.retry_count,
+                      submit_verified: delivery.submit_verified,
+                      error: null,
+                    })
+                  : null;
           // Preserve the already-terminal receipt if optional evidence
           // collection fails after the pane mutation has succeeded.
           const publicReceipt = buildPublicDeliveryReceipt({

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -553,7 +553,10 @@ function createReliabilityServer(client: FakeClaudeSurfaceClient) {
   return server;
 }
 
-function registerAgent(server: any, overrides?: Partial<AgentRecord>): AgentRecord {
+function registerAgent(
+  server: any,
+  overrides?: Partial<AgentRecord>,
+): AgentRecord {
   const engine = server._registeredTools["interact"]._engine;
   const stateMgr = engine["stateMgr"];
   const registry = engine.getRegistry();
@@ -664,9 +667,9 @@ describe("enter reliability", () => {
           event.retry_count === 1,
       ),
     ).toBe(true);
-    expect(
-      events.some((event) => event.event_type === "press_enter"),
-    ).toBe(true);
+    expect(events.some((event) => event.event_type === "press_enter")).toBe(
+      true,
+    );
   }, 10_000);
 
   it("verifies a cleared idle composer without waiting for working status", async () => {
@@ -682,12 +685,16 @@ describe("enter reliability", () => {
       press_enter: true,
     });
     const parsed = parseResult(result);
-    const events = readEventLog().filter((event) => event.event_type === "send_to");
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_to",
+    );
 
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
     expect(parsed.retry_count).toBe(0);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
     expect(events).toHaveLength(1);
     expect(events[0]?.submit_verified).toBe(true);
     expect(events[0]?.retry_count).toBe(0);
@@ -699,26 +706,26 @@ describe("enter reliability", () => {
   ] as const)(
     "does not press Enter twice when a submitted %s still shows accepted input",
     async (_name, cli) => {
-    const client = new FakeSlowClearingAgentClient();
-    client.cli = cli;
-    client.clearAfterReads = 35;
-    server = createReliabilityServer(client);
-    registerAgent(server, { cli });
+      const client = new FakeSlowClearingAgentClient();
+      client.cli = cli;
+      client.clearAfterReads = 35;
+      server = createReliabilityServer(client);
+      registerAgent(server, { cli });
 
-    const result = await callTool(server, "send_to", {
-      agent_id: "agent-1",
-      text: "slow first token",
-      press_enter: true,
-    });
-    const parsed = parseResult(result);
+      const result = await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "slow first token",
+        press_enter: true,
+      });
+      const parsed = parseResult(result);
 
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
-      1,
-    );
-    expect(client.duplicateSubmits).toBe(0);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.submit_verified).toBe(true);
-    expect(parsed.retry_count).toBe(0);
+      expect(
+        client.sendKeyCalls.filter((key) => key === "return"),
+      ).toHaveLength(1);
+      expect(client.duplicateSubmits).toBe(0);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.submit_verified).toBe(true);
+      expect(parsed.retry_count).toBe(0);
     },
   );
 
@@ -736,18 +743,20 @@ describe("enter reliability", () => {
     const parsed = parseResult(result);
     const events = readEventLog();
 
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
-    expect(parsed.submit_verification_reason).toBe("input_still_pending");
-    expect(parsed.retry_safe).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
     expect(
       events.some(
         (event) =>
           event.event_type === "send_to" &&
-          event.submit_verified === false &&
+          event.delivery_state === "pending_verify" &&
           event.retry_count === 0,
       ),
     ).toBe(true);
@@ -771,7 +780,9 @@ describe("enter reliability", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
     expect(parsed.retry_count).toBe(0);
-    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(1);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
     expect(
       events.some(
         (event) =>
@@ -808,8 +819,8 @@ describe("enter reliability", () => {
     ["unavailable reads", "throw", "surface_read_unavailable"],
     ["blank screens", "blank", "surface_screen_empty"],
   ] as const)(
-    "fails closed only after a full verification window of %s and returns a non-retry-safe reason",
-    async (_name, mode, expectedReason) => {
+    "returns pending_verify after a full verification window of %s instead of a terminal fail",
+    async (_name, mode, _expectedReason) => {
       const client = new FakeUnavailableVerificationScreenClient(mode);
       client.requiredReturns = 1;
       server = createReliabilityServer(client);
@@ -837,11 +848,11 @@ describe("enter reliability", () => {
       const result = await resultPromise;
       const parsed = parseResult(result);
 
-      expect(result.isError).toBe(true);
-      expect(parsed.ok).toBe(false);
-      expect(parsed.submit_verified).toBe(false);
-      expect(parsed.submit_verification_reason).toBe(expectedReason);
-      expect(parsed.retry_safe).toBe(false);
+      expect(result.isError).not.toBe(true);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.delivery_state).toBe("pending_verify");
+      expect(parsed.terminal).toBe(false);
+      expect(parsed.submit_verified).toBeNull();
       expect(
         client.sendKeyCalls.filter((key) => key === "return"),
       ).toHaveLength(1);
@@ -987,19 +998,23 @@ describe("enter reliability", () => {
       allow_busy: true,
     });
     const parsed = parseResult(result);
-    const events = readEventLog().filter((event) => event.event_type === "send_to");
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_to",
+    );
 
     expect(followUp).toHaveLength(541);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(1);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       2,
     );
     expect(client.sendCalls.join("")).toBe(followUp);
     expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBe(false);
+    expect(events[0]?.delivery_state).toBe("pending_verify");
     expect(events[0]?.retry_count).toBe(1);
   }, 10_000);
 
@@ -1186,8 +1201,9 @@ describe("enter reliability", () => {
     const result = await resultPromise;
     const parsed = parseResult(result);
 
-    expect(result.isError).toBe(true);
-    expect(parsed.submit_verified).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.submit_verified).toBeNull();
     expect(settledAt).not.toBeNull();
     expect(settledAt! - startedAt).toBeLessThanOrEqual(1000);
     expect(client.postReturnScreenReadAttempts).toBeGreaterThanOrEqual(2);
@@ -1204,7 +1220,9 @@ describe("enter reliability", () => {
     client.queuedCodexReadsAfterReturn = 1;
     server = createReliabilityServer(client);
     registerAgent(server, { state: "ready", cli: "codex" });
-    const followUp = "Probe E queued follow-up evidence ".repeat(20).slice(0, 541);
+    const followUp = "Probe E queued follow-up evidence "
+      .repeat(20)
+      .slice(0, 541);
     const tail = followUp.slice(-80);
 
     const result = await callToolInTimerSteps(server, "send_to", {
@@ -1213,7 +1231,9 @@ describe("enter reliability", () => {
       press_enter: true,
     });
     const parsed = parseResult(result);
-    const events = readEventLog().filter((event) => event.event_type === "send_to");
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_to",
+    );
     const queuedScreen = client.screenReads.find((screen) =>
       screen.includes("Messages to be submitted after next tool call"),
     );
@@ -1322,7 +1342,9 @@ describe("enter reliability", () => {
     client.decorateQueuedCodexChrome = true;
     server = createReliabilityServer(client);
     registerAgent(server, { state: "ready", cli: "codex" });
-    const followUp = "decorated correlated queue payload ".repeat(18).slice(0, 541);
+    const followUp = "decorated correlated queue payload "
+      .repeat(18)
+      .slice(0, 541);
 
     const result = await callToolInTimerSteps(server, "send_to", {
       agent_id: "agent-1",
@@ -1363,9 +1385,9 @@ describe("enter reliability", () => {
     });
     const parsed = parseResult(result);
 
-    expect(client.screenReads.some((screen) => screen.includes("another sender"))).toBe(
-      true,
-    );
+    expect(
+      client.screenReads.some((screen) => screen.includes("another sender")),
+    ).toBe(true);
     expect(result.isError).not.toBe(true);
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
@@ -1385,21 +1407,21 @@ describe("enter reliability", () => {
       press_enter: true,
     });
     const parsed = parseResult(result);
-    const events = readEventLog().filter((event) => event.event_type === "send_to");
-
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
-    expect(parsed.submit_verification_reason).toBe(
-      "surface_read_unavailable",
+    const events = readEventLog().filter(
+      (event) => event.event_type === "send_to",
     );
-    expect(parsed.retry_safe).toBe(false);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
     expect(events).toHaveLength(1);
-    expect(events[0]?.submit_verified).toBe(false);
+    expect(events[0]?.delivery_state).toBe("pending_verify");
     expect(events[0]?.retry_count).toBe(0);
   }, 10_000);
 
@@ -1490,16 +1512,18 @@ describe("enter reliability", () => {
     expect(client.screenReads.at(-1)).toBe(
       CURSOR_PR343_V2_IMMEDIATE_WORKING_RESPONSE_SCREEN,
     );
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
   }, 10_000);
 
-  it("fails closed for retained-composer Cursor evidence when the baseline is unavailable", async () => {
+  it("keeps retained-composer Cursor evidence pending_verify when the baseline is unavailable", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
     client.cli = "cursor";
@@ -1520,9 +1544,11 @@ describe("enter reliability", () => {
     expect(client.screenReads.at(-1)).toBe(
       CURSOR_PR343_LIVE_ACCEPTED_RESPONSE_SCREEN,
     );
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
@@ -1618,9 +1644,11 @@ describe("enter reliability", () => {
 
     expect(client.screenReads.at(-1)).toContain("⬡ Running...");
     expect(client.screenReads.at(-1)).not.toContain("Thought for");
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).toBe(false);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
@@ -1649,9 +1677,9 @@ describe("enter reliability", () => {
       registerAgent(server, { state: "ready", cli });
 
       expect(screen).toContain(placeholder);
-      expect(
-        __submitEvidenceTestHooks.extractComposerInputRegion(screen),
-      ).toBe("");
+      expect(__submitEvidenceTestHooks.extractComposerInputRegion(screen)).toBe(
+        "",
+      );
 
       const result = await callToolInTimerSteps(server, "send_to", {
         agent_id: "agent-1",
@@ -1788,8 +1816,7 @@ describe("enter reliability", () => {
     expect(events).toHaveLength(2);
     expect(
       events.every(
-        (event) =>
-          event.submit_verified === true && event.retry_count === 0,
+        (event) => event.submit_verified === true && event.retry_count === 0,
       ),
     ).toBe(true);
   }, 10_000);

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from "vitest";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
   CLI_READY_PATTERNS,
+  CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE,
+  CURSOR_FOLLOWUP_PLACEHOLDER_RE,
   lineStartsWithCliInputPrompt,
   matchReadyPattern,
   screenHasActiveAgentMarker,
@@ -75,6 +77,33 @@ describe("CLI_INPUT_PROMPT_PREFIXES", () => {
     expect(Object.keys(CLI_INPUT_PROMPT_PREFIXES).sort()).toEqual(
       Object.keys(CLI_READY_PATTERNS).sort(),
     );
+  });
+
+  it("matches Cursor follow-up placeholder with or without the arrow prefix", () => {
+    expect(CURSOR_FOLLOWUP_PLACEHOLDER_RE.test("Add a follow-up")).toBe(true);
+    expect(CURSOR_FOLLOWUP_PLACEHOLDER_RE.test("→ Add a follow-up")).toBe(true);
+    expect(CURSOR_FOLLOWUP_PLACEHOLDER_RE.test("→Add a follow-up")).toBe(true);
+    expect(
+      CURSOR_FOLLOWUP_PLACEHOLDER_RE.test(
+        "Cursor Agent\nWorking\n→ Add a follow-up\nctrl+c to stop",
+      ),
+    ).toBe(true);
+    expect(
+      CURSOR_FOLLOWUP_PLACEHOLDER_RE.test(
+        "  → Add a follow-up                                                         ctrl+c to stop ",
+      ),
+    ).toBe(true);
+    expect(
+      CURSOR_FOLLOWUP_PLACEHOLDER_RE.test("please Add a follow-up later"),
+    ).toBe(false);
+    expect(
+      CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE.test("follow-ups · enter send now"),
+    ).toBe(true);
+    expect(
+      CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE.test(
+        "┌─ follow-ups ─────────────────────────────────────────┐\n │ +5 more lines · enter send now · ↑ select/edit · esc cancel",
+      ),
+    ).toBe(true);
   });
 
   it("does not treat an empty ready prompt as typed composer text", () => {
@@ -232,7 +261,11 @@ gpt-5.5 xhigh · ~/Gits/brainlayer
   });
 
   it("does not treat bare active Codex status lines as ready", () => {
-    for (const marker of ["Working", "Waiting for command approval", "Thinking"]) {
+    for (const marker of [
+      "Working",
+      "Waiting for command approval",
+      "Thinking",
+    ]) {
       const screen = [
         "gpt-5.5 xhigh · 70% left · ~/Gits/cmuxlayer",
         marker,

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -37,9 +37,13 @@ class FakeAgentSurfaceClient {
   readonly sendKeyCalls: string[] = [];
   cli: "claude" | "cursor" = "claude";
   requiredReturns = 99;
+  /** Model Cursor's follow-ups box that needs a second Return ("enter send now"). */
+  cursorFollowUpBox = false;
   private pendingText = "";
   private returnCount = 0;
   private transcriptTail: string | null = null;
+  private followUps: string[] = [];
+  private followUpNeedsEnter = false;
 
   async log() {}
   async setStatus() {}
@@ -62,6 +66,11 @@ class FakeAgentSurfaceClient {
 
   clearComposer(transcriptText?: string): void {
     this.pendingText = "";
+    this.followUpNeedsEnter = false;
+    if (this.followUps.length > 0) {
+      this.transcriptTail = this.followUps.join("\n");
+      this.followUps = [];
+    }
     this.transcriptTail = transcriptText ?? this.transcriptTail;
   }
 
@@ -69,6 +78,8 @@ class FakeAgentSurfaceClient {
     this.pendingText = "";
     this.returnCount = 0;
     this.transcriptTail = null;
+    this.followUps = [];
+    this.followUpNeedsEnter = false;
   }
 
   async listWorkspaces() {
@@ -140,6 +151,16 @@ class FakeAgentSurfaceClient {
       return;
     }
     this.returnCount += 1;
+    if (this.cursorFollowUpBox && this.cli === "cursor") {
+      if (this.returnCount === 1) {
+        this.followUpNeedsEnter = true;
+        return;
+      }
+      this.followUps.push(this.pendingText);
+      this.pendingText = "";
+      this.followUpNeedsEnter = false;
+      return;
+    }
     if (this.returnCount >= this.requiredReturns) {
       this.transcriptTail = this.pendingText;
       this.pendingText = "";
@@ -155,10 +176,21 @@ class FakeAgentSurfaceClient {
       this.cli === "cursor"
         ? [
             "Cursor Agent",
-            "Auto",
+            this.followUpNeedsEnter || this.followUps.length > 0
+              ? "Working"
+              : "Auto",
             "~/Gits/cmuxlayer · main",
             this.transcriptTail ? `  ${this.transcriptTail}` : "",
-            `→ ${tail}`,
+            ...this.followUps.map((item) => `  ${item}`),
+            this.followUpNeedsEnter ? "follow-ups · enter send now" : "",
+            this.pendingText
+              ? `→ ${tail}`
+              : this.followUps.length > 0 || this.followUpNeedsEnter
+                ? "→ Add a follow-up"
+                : `→ ${tail}`,
+            this.followUps.length > 0 || this.followUpNeedsEnter
+              ? "ctrl+c to stop"
+              : "",
           ]
             .filter((line) => line !== "")
             .join("\n")
@@ -279,10 +311,11 @@ describe("send_to v2 background verify", () => {
     });
   });
 
-  it("treats cursor composer text as queued-as-followup, not a terminal fail", async () => {
+  it("presses Cursor's follow-up Return and receipts queued_followup once the composer is consumed", async () => {
     const client = new FakeAgentSurfaceClient();
     client.cli = "cursor";
     client.title = "cmuxlayerCursor";
+    client.cursorFollowUpBox = true;
     server = createVerifyServer(client);
     registerAgent(server, { cli: "cursor" });
 
@@ -292,11 +325,104 @@ describe("send_to v2 background verify", () => {
       press_enter: true,
     });
     const parsed = parseResult(result);
+    const finalScreen = await client.readScreen(client.surface);
 
     expect(result.isError).not.toBe(true);
-    expect(parsed.delivery_state).toBe("pending_verify");
-    expect(parsed.terminal).toBe(false);
-    expect(parsed.submit_verified).toBeNull();
+    expect(parsed).toMatchObject({
+      ok: true,
+      delivery_id: expect.any(String),
+      delivery_state: "queued_followup",
+      delivery: "queued_followup",
+      terminal: false,
+      delivered: false,
+      submit_verified: null,
+    });
+    expect(
+      client.sendKeyCalls.filter((key) => key === "return").length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(finalScreen.text).toContain("→ Add a follow-up");
+    expect(finalScreen.text).toContain("busy cursor follow-up");
+    expect(finalScreen.text).not.toContain("enter send now");
+    expect(finalScreen.text).not.toMatch(/^→ busy cursor follow-up$/m);
+    const engine = server._registeredTools.interact._engine;
+    expect(engine.getDeliveryReceipt(parsed.delivery_id)).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      delivery_state: "queued_followup",
+      terminal: false,
+      composer_accepted: true,
+    });
+  });
+
+  it("returns duplicate_of for an identical send while queued_followup is in flight", async () => {
+    const client = new FakeAgentSurfaceClient();
+    client.cli = "cursor";
+    client.title = "cmuxlayerCursor";
+    client.cursorFollowUpBox = true;
+    server = createVerifyServer(client);
+    registerAgent(server, { cli: "cursor" });
+
+    const first = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "do not double-queue",
+        press_enter: true,
+      }),
+    );
+    expect(first.delivery_state).toBe("queued_followup");
+    const typedAfterFirst = client.sendCalls.length;
+    const returnsAfterFirst = client.sendKeyCalls.filter(
+      (key) => key === "return",
+    ).length;
+
+    const second = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "do not double-queue",
+        press_enter: true,
+      }),
+    );
+
+    expect(second.delivery_id).toBe(first.delivery_id);
+    expect(second.duplicate_of).toBe(first.delivery_id);
+    expect(second.delivery_state).toBe("queued_followup");
+    expect(client.sendCalls.length).toBe(typedAfterFirst);
+    expect(client.sendKeyCalls.filter((key) => key === "return").length).toBe(
+      returnsAfterFirst,
+    );
+  });
+
+  it("promotes queued_followup to submitted when the follow-up flushes at turn end", async () => {
+    const client = new FakeAgentSurfaceClient();
+    client.cli = "cursor";
+    client.title = "cmuxlayerCursor";
+    client.cursorFollowUpBox = true;
+    server = createVerifyServer(client);
+    registerAgent(server, { cli: "cursor" });
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "delivers at turn end",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("queued_followup");
+
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_state: "queued_followup",
+      terminal: false,
+    });
+
+    client.clearComposer("delivers at turn end");
+    await engine.verifyPendingDeliveries();
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_id: sent.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+      submit_verified: true,
+    });
   });
 
   it("promotes a pending_verify delivery to submitted once the composer clears", async () => {

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -10,8 +10,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "../src/server.js";
 import type { AgentRecord } from "../src/agent-types.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { StateManager } from "../src/state-manager.js";
 import { defaultDeliveryTicketDir } from "../src/delivery-failure-tickets.js";
-import { DELIVERY_TARGET_GONE_CONFIRM_MISSES } from "../src/agent-engine.js";
+import {
+  AgentEngine,
+  DELIVERY_TARGET_GONE_CONFIRM_MISSES,
+} from "../src/agent-engine.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-send-to-v2-verify-test");
 const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-send-to-v2-verify-test.sock";
@@ -835,5 +840,63 @@ describe("send_to v2 background verify", () => {
     });
     expect(existsSync(ticketDir)).toBe(false);
     expect(filed).toHaveLength(0);
+  });
+
+  it("does not advance or deadline-fail watched receipts when deliveryVerifier is null", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const filed: unknown[] = [];
+    writeFileSync(
+      join(TEST_DIR, "delivery-receipts.json"),
+      `${JSON.stringify([
+        {
+          delivery_id: "orphan-1",
+          agent_id: "agent-1",
+          text: "app-server has no verifier",
+          press_enter: true,
+          source_event: "send_to",
+          delivery_state: "pending_verify",
+          terminal: false,
+          created_at: "2026-08-17T19:00:00.000Z",
+          resolved_at: null,
+          retry_count: 0,
+          submit_verified: null,
+          error: null,
+          verify_deadline_at: "2026-08-17T19:50:00.000Z",
+        },
+      ])}\n`,
+    );
+    const client = new FakeAgentSurfaceClient();
+    const stateMgr = new StateManager(TEST_DIR);
+    const engine = new AgentEngine(
+      stateMgr,
+      new AgentRegistry(stateMgr, async () => []),
+      client as any,
+      {
+        deliveryTicketDir: ticketDir,
+        deliveryIssueFiler: async (ticket) => {
+          filed.push(ticket);
+        },
+      },
+    );
+    try {
+      expect(engine.getDeliveryReceipt("orphan-1")).toMatchObject({
+        delivery_state: "pending_verify",
+        terminal: false,
+        verify_deadline_at: "2026-08-17T19:50:00.000Z",
+      });
+
+      await engine.verifyPendingDeliveries();
+
+      expect(engine.getDeliveryReceipt("orphan-1")).toMatchObject({
+        delivery_id: "orphan-1",
+        delivery_state: "pending_verify",
+        terminal: false,
+        error: null,
+      });
+      expect(existsSync(ticketDir)).toBe(false);
+      expect(filed).toHaveLength(0);
+    } finally {
+      engine.dispose();
+    }
   });
 });

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -1,0 +1,514 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-send-to-v2-verify-test");
+const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-send-to-v2-verify-test.sock";
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+  const resultPromise = tool.handler(args, {} as any);
+  for (let elapsed = 0; elapsed < 10_000; elapsed += 100) {
+    await vi.advanceTimersByTimeAsync(100);
+  }
+  return resultPromise;
+}
+
+class FakeAgentSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly surface = "surface:agent";
+  title = "brainlayerClaude";
+  readonly sendCalls: string[] = [];
+  readonly sendKeyCalls: string[] = [];
+  cli: "claude" | "cursor" = "claude";
+  requiredReturns = 99;
+  private pendingText = "";
+  private returnCount = 0;
+  private transcriptTail: string | null = null;
+
+  async log() {}
+  async setStatus() {}
+  async setStatuses() {
+    return true;
+  }
+  async clearStatus() {}
+  async listSurfaces() {
+    return {
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          workspace_ref: this.workspace,
+        },
+      ],
+    };
+  }
+
+  clearComposer(transcriptText?: string): void {
+    this.pendingText = "";
+    this.transcriptTail = transcriptText ?? this.transcriptTail;
+  }
+
+  resetTypedInput(): void {
+    this.pendingText = "";
+    this.returnCount = 0;
+    this.transcriptTail = null;
+  }
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 1,
+          surface_refs: [this.surface],
+          selected_surface_ref: this.surface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.surface,
+          title: this.title,
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+    this.sendCalls.push(text);
+    this.pendingText += text;
+  }
+
+  async pasteText(surface: string, text: string) {
+    await this.send(surface, text);
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+    this.sendKeyCalls.push(key);
+    if (key !== "return" || !this.pendingText) {
+      return;
+    }
+    this.returnCount += 1;
+    if (this.returnCount >= this.requiredReturns) {
+      this.transcriptTail = this.pendingText;
+      this.pendingText = "";
+    }
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    if (surface !== this.surface) {
+      throw new Error(`Unknown surface: ${surface}`);
+    }
+    const tail = this.pendingText.slice(-160);
+    const text =
+      this.cli === "cursor"
+        ? [
+            "Cursor Agent",
+            "Auto",
+            "~/Gits/cmuxlayer · main",
+            this.transcriptTail ? `  ${this.transcriptTail}` : "",
+            `→ ${tail}`,
+          ]
+            .filter((line) => line !== "")
+            .join("\n")
+        : `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
+    return {
+      surface,
+      text,
+      lines: opts?.lines ?? 30,
+      scrollback_used: false,
+    };
+  }
+
+  async renameTab(_surface: string, _title: string) {}
+}
+
+function createVerifyServer(
+  client: FakeAgentSurfaceClient,
+  extras?: {
+    deliveryVerifyDeadlineMs?: number;
+    deliveryTicketDir?: string;
+    deliveryIssueFiler?: (ticket: unknown) => Promise<void>;
+  },
+) {
+  const server = createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+    surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
+    surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
+    ...extras,
+  });
+  const engine = (server as any)._registeredTools.interact._engine;
+  engine.dispose();
+  return server;
+}
+
+function registerAgent(
+  server: any,
+  overrides?: Partial<AgentRecord>,
+): AgentRecord {
+  const engine = server._registeredTools.interact._engine;
+  const now = "2026-08-17T20:00:00Z";
+  const record: AgentRecord = {
+    agent_id: "agent-1",
+    surface_id: "surface:agent",
+    surface_observer_id: TEST_OBSERVER_OWNER,
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "cmuxlayer",
+    model: "sonnet",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "send_to v2 verify",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  };
+  engine.stateMgr.writeState(record);
+  engine.getRegistry().set(record.agent_id, record);
+  return record;
+}
+
+describe("send_to v2 background verify", () => {
+  let server: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date("2026-08-17T20:00:00.000Z") });
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    server = null;
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("returns pending_verify instead of terminal failed when the sync window expires without submit evidence", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "still pending",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      delivery_id: expect.any(String),
+      delivery_state: "pending_verify",
+      delivery: "pending_verify",
+      terminal: false,
+      delivered: false,
+      submit_verified: null,
+    });
+    const engine = server._registeredTools.interact._engine;
+    expect(engine.getDeliveryReceipt(parsed.delivery_id)).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      delivery_state: "pending_verify",
+      terminal: false,
+    });
+  });
+
+  it("treats cursor composer text as queued-as-followup, not a terminal fail", async () => {
+    const client = new FakeAgentSurfaceClient();
+    client.cli = "cursor";
+    client.title = "cmuxlayerCursor";
+    server = createVerifyServer(client);
+    registerAgent(server, { cli: "cursor" });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "busy cursor follow-up",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.terminal).toBe(false);
+    expect(parsed.submit_verified).toBeNull();
+  });
+
+  it("promotes a pending_verify delivery to submitted once the composer clears", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const sent = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "lands later",
+      press_enter: true,
+    });
+    const parsed = parseResult(sent);
+    expect(parsed.delivery_state).toBe("pending_verify");
+
+    client.clearComposer("lands later");
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(parsed.delivery_id)).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+      submit_verified: true,
+    });
+  });
+
+  it("returns the existing delivery_id with duplicate_of instead of typing again", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const first = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "do not double-type",
+        press_enter: true,
+      }),
+    );
+    expect(first.delivery_state).toBe("pending_verify");
+    const typedAfterFirst = client.sendCalls.length;
+
+    const second = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "do not double-type",
+        press_enter: true,
+      }),
+    );
+
+    expect(second.delivery_id).toBe(first.delivery_id);
+    expect(second.duplicate_of).toBe(first.delivery_id);
+    expect(second.delivery_state).toBe("pending_verify");
+    expect(client.sendCalls.length).toBe(typedAfterFirst);
+  });
+
+  it("suppresses an identical send while the engine queue still holds the first delivery", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server, { state: "working" });
+
+    const first = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "queued once",
+        press_enter: true,
+      }),
+    );
+    expect(first.delivery_state).toBe("queued");
+
+    const second = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "queued once",
+        press_enter: true,
+      }),
+    );
+
+    expect(second.delivery_id).toBe(first.delivery_id);
+    expect(second.duplicate_of).toBe(first.delivery_id);
+    expect(client.sendCalls).toEqual([]);
+  });
+
+  it("confirms failure after the verify deadline and writes a local evidence ticket", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const filed: unknown[] = [];
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client, {
+      deliveryVerifyDeadlineMs: 1_000,
+      deliveryTicketDir: ticketDir,
+      deliveryIssueFiler: async (ticket) => {
+        filed.push(ticket);
+      },
+    });
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "never lands",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("pending_verify");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_id: sent.delivery_id,
+      delivery_state: "failed_confirmed",
+      terminal: true,
+    });
+    expect(existsSync(ticketDir)).toBe(true);
+    expect(readdirSync(ticketDir).length).toBeGreaterThan(0);
+    expect(filed).toHaveLength(1);
+  });
+
+  it("dedupes evidence tickets by failure signature", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const filed: unknown[] = [];
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client, {
+      deliveryVerifyDeadlineMs: 1_000,
+      deliveryTicketDir: ticketDir,
+      deliveryIssueFiler: async (ticket) => {
+        filed.push(ticket);
+      },
+    });
+    registerAgent(server);
+
+    parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "first miss",
+        press_enter: true,
+      }),
+    );
+    client.resetTypedInput();
+    parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "second miss",
+        press_enter: true,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await server._registeredTools.interact._engine.verifyPendingDeliveries();
+
+    expect(readdirSync(ticketDir)).toHaveLength(1);
+    expect(filed).toHaveLength(1);
+  });
+
+  it("lets wait_for accept a delivery_id and return the terminal receipt", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "wait for me",
+        press_enter: true,
+      }),
+    );
+    client.clearComposer("wait for me");
+
+    const waitPromise = server._registeredTools.wait_for.handler(
+      { delivery_id: sent.delivery_id, timeout_ms: 5_000 },
+      {} as any,
+    );
+    const verifyPromise =
+      server._registeredTools.interact._engine.verifyPendingDeliveries();
+    await vi.advanceTimersByTimeAsync(200);
+    await verifyPromise;
+    const waited = parseResult(await waitPromise);
+
+    expect(waited).toMatchObject({
+      ok: true,
+      delivery_id: sent.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+    });
+  });
+
+  it("exposes deliveries on list_agents detail=full", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "list me",
+        press_enter: true,
+      }),
+    );
+
+    const listed = parseResult(
+      await callTool(server, "list_agents", { detail: "full" }),
+    );
+    expect(listed.deliveries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          delivery_id: sent.delivery_id,
+          agent_id: "agent-1",
+          delivery_state: "pending_verify",
+          terminal: false,
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "../src/server.js";
 import type { AgentRecord } from "../src/agent-types.js";
+import { defaultDeliveryTicketDir } from "../src/delivery-failure-tickets.js";
+import { DELIVERY_TARGET_GONE_CONFIRM_MISSES } from "../src/agent-engine.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-send-to-v2-verify-test");
 const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-send-to-v2-verify-test.sock";
@@ -39,6 +47,7 @@ class FakeAgentSurfaceClient {
   requiredReturns = 99;
   /** Model Cursor's follow-ups box that needs a second Return ("enter send now"). */
   cursorFollowUpBox = false;
+  screenOverride: string | null = null;
   private pendingText = "";
   private returnCount = 0;
   private transcriptTail: string | null = null;
@@ -173,7 +182,8 @@ class FakeAgentSurfaceClient {
     }
     const tail = this.pendingText.slice(-160);
     const text =
-      this.cli === "cursor"
+      this.screenOverride ??
+      (this.cli === "cursor"
         ? [
             "Cursor Agent",
             this.followUpNeedsEnter || this.followUps.length > 0
@@ -194,7 +204,7 @@ class FakeAgentSurfaceClient {
           ]
             .filter((line) => line !== "")
             .join("\n")
-        : `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`;
+        : `Claude Code\n> ${tail}\nCLAUDE_COUNTER:1\n`);
     return {
       surface,
       text,
@@ -636,5 +646,194 @@ describe("send_to v2 background verify", () => {
         }),
       ]),
     );
+  });
+
+  it("does not fail queued_followup after the verify deadline or file a ticket", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const filed: unknown[] = [];
+    const client = new FakeAgentSurfaceClient();
+    client.cli = "cursor";
+    client.title = "cmuxlayerCursor";
+    client.cursorFollowUpBox = true;
+    server = createVerifyServer(client, {
+      deliveryVerifyDeadlineMs: 1_000,
+      deliveryTicketDir: ticketDir,
+      deliveryIssueFiler: async (ticket) => {
+        filed.push(ticket);
+      },
+    });
+    registerAgent(server, { cli: "cursor" });
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "composer already consumed",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("queued_followup");
+
+    await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_id: sent.delivery_id,
+      delivery_state: "queued_followup",
+      terminal: false,
+    });
+    expect(existsSync(ticketDir)).toBe(false);
+    expect(filed).toHaveLength(0);
+  });
+
+  it("does not promote pending_verify to submitted on working status without composer or transcript evidence", async () => {
+    const client = new FakeAgentSurfaceClient();
+    client.cli = "cursor";
+    client.title = "cmuxlayerCursor";
+    server = createVerifyServer(client);
+    registerAgent(server, { cli: "cursor" });
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "do not promote on working status",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("pending_verify");
+
+    client.screenOverride = [
+      "Cursor Agent",
+      "⬡ Running...",
+      "~/Gits/cmuxlayer · main",
+      "→ leftover truncated follow-up",
+    ].join("\n");
+
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_id: sent.delivery_id,
+      delivery_state: "pending_verify",
+      terminal: false,
+    });
+  });
+
+  it("does not write home tickets or call gh from a bare createServer failure", async () => {
+    const homeTickets = defaultDeliveryTicketDir();
+    const before = existsSync(homeTickets) ? readdirSync(homeTickets) : null;
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client, {
+      deliveryVerifyDeadlineMs: 1_000,
+    });
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "no default tickets",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("pending_verify");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const engine = server._registeredTools.interact._engine;
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_state: "failed_confirmed",
+      terminal: true,
+    });
+    const after = existsSync(homeTickets) ? readdirSync(homeTickets) : null;
+    expect(after).toEqual(before);
+  });
+
+  it("waits for consecutive target_gone misses before failed_confirmed", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client, {
+      deliveryTicketDir: ticketDir,
+      deliveryIssueFiler: async () => {},
+    });
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "target may flicker",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("pending_verify");
+
+    const engine = server._registeredTools.interact._engine;
+    engine.getRegistry().remove("agent-1");
+
+    for (let miss = 1; miss < DELIVERY_TARGET_GONE_CONFIRM_MISSES; miss += 1) {
+      await engine.verifyPendingDeliveries();
+      expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+        delivery_state: "pending_verify",
+        terminal: false,
+        verify_miss_count: miss,
+      });
+    }
+
+    await engine.verifyPendingDeliveries();
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_state: "failed_confirmed",
+      terminal: true,
+      error: "target_gone",
+    });
+  });
+
+  it("backfills verify_deadline_at from load time so historical queued receipts do not immediately fail", async () => {
+    const ticketDir = join(TEST_DIR, "tickets");
+    const filed: unknown[] = [];
+    writeFileSync(
+      join(TEST_DIR, "delivery-receipts.json"),
+      `${JSON.stringify([
+        {
+          delivery_id: "hist-1",
+          agent_id: "agent-1",
+          text: "historical queued payload",
+          press_enter: true,
+          source_event: "send_to",
+          delivery_state: "queued",
+          terminal: false,
+          created_at: "2026-08-17T19:00:00.000Z",
+          resolved_at: null,
+          retry_count: 0,
+          submit_verified: null,
+          error: null,
+          composer_accepted: true,
+        },
+      ])}\n`,
+    );
+    const client = new FakeAgentSurfaceClient();
+    client.screenOverride = [
+      "Claude Code",
+      "> leftover that is not the payload",
+    ].join("\n");
+    server = createVerifyServer(client, {
+      deliveryTicketDir: ticketDir,
+      deliveryIssueFiler: async (ticket) => {
+        filed.push(ticket);
+      },
+    });
+    registerAgent(server);
+
+    const engine = server._registeredTools.interact._engine;
+    const loaded = engine.getDeliveryReceipt("hist-1");
+    expect(loaded.verify_deadline_at).toBe("2026-08-17T20:10:00.000Z");
+
+    await engine.verifyPendingDeliveries();
+    expect(engine.getDeliveryReceipt("hist-1")).toMatchObject({
+      delivery_id: "hist-1",
+      delivery_state: "queued",
+      terminal: false,
+    });
+    expect(existsSync(ticketDir)).toBe(false);
+    expect(filed).toHaveLength(0);
   });
 });

--- a/tests/verified-relay.test.ts
+++ b/tests/verified-relay.test.ts
@@ -188,7 +188,7 @@ describe("verified relay", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("send_to a frozen terminal returns an error instead of ok:true (short relay)", async () => {
+  it("send_to a frozen terminal returns pending_verify instead of a false terminal fail (short relay)", async () => {
     const client = new FrozenClaudeSurfaceClient();
     server = createRelayServer(client);
     registerAgent(server);
@@ -200,11 +200,18 @@ describe("verified relay", () => {
     });
     const parsed = parseResult(result);
 
-    // A relay that cannot confirm the input landed must NOT report success.
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).not.toBe(true);
-    expect(
-      client.sendKeyCalls.filter((key) => key === "return").length,
-    ).toBe(1);
+    // A relay that cannot confirm the input landed must not report delivered.
+    // Timeout-without-evidence is nonterminal pending_verify, not a false fail.
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      delivered: false,
+      terminal: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+    });
+    expect(client.sendKeyCalls.filter((key) => key === "return").length).toBe(
+      1,
+    );
   }, 10_000);
 });


### PR DESCRIPTION
## Summary
- `send_to` no longer receipts a terminal `failed` when the sync window expires without submit evidence. That false-fail was the #1 duplicate-delivery driver (#432, live specimens 4c2c4f00 / ff5ab3a6): callers retried, and the original text still landed at turn end.
- Timeout-without-evidence now returns `delivery_state: "pending_verify"` (`ok: true`, `submit_verified: null`, nonterminal). A background verifier on the sweep promotes to existing `submitted` (success) or `failed_confirmed` (hard 10 min deadline for **uncertain** states only).
- **Busy Cursor follow-ups:** when the screen shows follow-up chrome with the typed text still in the composer, the engine presses that Return itself, verifies the composer was consumed into Cursor's queue, and receipts `delivery_state: "queued_followup"` (delivers at turn end). Never a false `failed`, never leaving the Return to a human.
- **`queued_followup` does not inherit the 10-minute failure deadline.** Composer-consumed evidence means keep waiting (or, if the target is gone for 3 consecutive misses, `failed_confirmed`). Deadline timeout never files a ticket for `queued_followup`.
- Confirmed failures write a local ticket only when production entrypoints inject `deliveryTicketDir` / `deliveryIssueFiler` (not in bare `AgentEngine`, not when `VITEST=true` or `NODE_ENV=test`).
- Identical `send_to` (`agent_id` + `text` + `press_enter`) while `pending_verify`, `queued`, or `queued_followup` returns the existing `delivery_id` with `duplicate_of` instead of typing again.
- `wait_for({ delivery_id })` waits until terminal. `list_agents detail=full` includes a top-level `deliveries` array. Nine-tool surface otherwise unchanged; `send_command` / `send_input` / boot stay fail-closed.

## Round 3 (64d30de) — what this commit actually contains
Must-fix from rounds 1–2:
1. `queued_followup` excluded from `verify_deadline_elapsed` → `failed_confirmed` + ticket
2. Verifier no longer promotes on working/thinking status alone (composer-cleared or transcript tail required)
3. Ticket dir + `gh` filer default **off**; `createServer` / app-server inject only outside test processes
4. `target_gone` needs 3 consecutive misses before `failed_confirmed`
5. `loadDeliveryReceipts` backfills missing `verify_deadline_at` to **now + deadline**, not `created_at + deadline`

Also in this commit:
- Cursor follow-up chrome regexes moved to `src/pattern-registry.ts`
- Placeholder matches optional `→` prefix and same-line trailing chrome (`ctrl+c to stop`)
- `enter send now` matches both the one-line fake (`follow-ups · enter send now`) and the live boxed UI (`┌─ follow-ups` … later line `enter send now`)

**Not in this diff (should-fix 6–8 still open):** in-flight receipt registered only after typing; no timeout around `deliveryVerifier`; no per-surface `read_screen` dedup/backoff.

Human-typed text already in the composer: filed separately as https://github.com/EtanHey/cmuxlayer/issues/442 (not a #441 blocker).

## Design choices
- **Success vocabulary stays `submitted`.** Did not rename to `delivered`. Boolean `delivered: true` still means the existing success receipt. New states are `pending_verify`, `queued_followup`, and `failed_confirmed`. Immediate confirmed fails (safety gate, send-key throw) stay `failed`.
- **`queued_followup` is Cursor's native queue, not the engine-side `queued` wait.** Engine-side `queued` still means "do not type yet, agent.state is working and allow_busy is false." `queued_followup` means the text was typed, the follow-up Return was pressed, and Cursor will flush it at turn end.
- **Extra Return is gated on follow-up chrome**, not every busy Cursor composer. Blind extra-Enter on the main working composer is the #263 duplicate-submit class; this only finishes the follow-ups box the lead had to press by hand.

## Live probe (`CMUXLAYER_FORCE_INPROCESS=1`) — placeholder / arrow

Ran against real Cursor panes (not fakes). Extracted composer by stripping `CLI_INPUT_PROMPT_PREFIXES.cursor` (`→` / `cursor>`).

**surface:139 `cmuxlayerCursor` (this worker, empty follow-up composer):**
```
  → Add a follow-up                                                         ctrl+c to stop
composer guess: prefix=→  composer="Add a follow-up                                                         ctrl+c to stop "
placeholder vs full screen: true
placeholder vs composer: true
placeholder vs raw line: true
composer is exactly "Add a follow-up": false
```
The arrow **does** survive on the live composer line, and `ctrl+c to stop` is **same-line trailing chrome**, not a separate footer. Anchored `/^Add a follow-up$/i` misses both. Current registry regex matches.

**surface:152 `brainlayerCursor` (busy, boxed follow-ups with payload in composer):**
```
 ┌─ follow-ups ─────────────────────────────────────────────────────────────────────────┐
 │ ○ Read and execute this goal file until complete:                                    │
 │ +5 more lines · enter send now · ↑ select/edit · esc cancel                          │
 └──────────────────────────────────────────────────────────────────────────────────────┘
  → Read and execute this goal file until complete: ...
enter-send-now: true
placeholder vs full screen: false
```
`follow-ups` and `enter send now` are **not** on one `·`-joined line. The old `/follow-ups?\s*·\s*enter send now/i` misses this box; the registry regex matches the boxed form.

This probe verifies chrome/placeholder latching, **not** a full `send_to` → `queued_followup` → turn-end `submitted` roundtrip on a live pane.

## Test plan
- [x] `bun run test` — 115 files, 2740 passed, 1 skipped
- [x] `bun run typecheck`
- [x] Contract tests in `tests/send-to-v2-background-verify.test.ts` (pending_verify, queued_followup Return, no deadline fail, no working-status promotion, no default tickets, target_gone ×3, deadline backfill, duplicate_of, wait_for, list_agents)
- [x] Pattern-registry tests for arrow placeholder + boxed `enter send now`
- [x] Live in-process probe of placeholder/arrow/box chrome (evidence above)
- [ ] Live daemon/client session: `send_to` a busy Cursor pane, confirm `queued_followup`, then `wait_for({delivery_id})` after turn end

— cmuxlayerCursor-11c3aa25 (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor-11c3aa25","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"11c3aa25","ts":"2026-08-17T21:17:43Z"} -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add background verification and `queued_followup` state to `send_to` v2 delivery
> - Introduces `pending_verify`, `queued_followup`, and `failed_confirmed` delivery states so `send_to`/`dispatch_nudge` can defer confirmation to a background verifier instead of failing closed immediately.
> - Adds `verifyPendingDeliveries` background loop in `AgentEngine` that polls delivery state via a configurable `DeliveryVerifier`, transitions receipts to `submitted` on evidence, and to `failed_confirmed` after deadline or repeated target-gone misses.
> - Confirmed failures are persisted as local tickets via `writeDeliveryFailureTicket` and optionally mirrored to GitHub via the `gh` CLI using `fileDeliveryFailureGithubIssue`.
> - Detects Cursor follow-up UI state using two new regexes (`CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE`, `CURSOR_FOLLOWUP_PLACEHOLDER_RE`) to classify deliveries as `queued_followup` when the follow-up has been accepted by Cursor.
> - Adds `wait_for` support for `delivery_id` and exposes deliveries in `list_agents` full-detail responses; deduplication via `findOpenDuplicate` prevents duplicate in-flight sends.
> - Behavioral Change: verification failures for `send_to`/`dispatch_nudge` no longer throw `SubmitVerificationError` — they return non-terminal `pending_verify` receipts and are resolved asynchronously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d980c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `send_to`/`dispatch_nudge` receipt semantics and adds async verification that can mark deliveries `failed_confirmed` and file tickets; mitigated by duplicate suppression, conservative promotion rules, and test-only defaults for ticket I/O.
> 
> **Overview**
> **`send_to` v2** stops treating “no submit evidence within the sync window” as a terminal `failed` receipt. For `send_to` and `dispatch_nudge`, ambiguous outcomes now return **`pending_verify`** (`ok: true`, nonterminal, `submit_verified: null`) so callers do not blind-retry into duplicate deliveries.
> 
> A **background verifier** runs on each lifecycle sweep (`verifyPendingDeliveries`), using screen/transcript evidence to promote receipts to **`submitted`** or **`failed_confirmed`** (10-minute deadline for uncertain states, **not** for **`queued_followup`**). **`target_gone`** requires three consecutive misses before hard failure.
> 
> **Cursor follow-ups:** new pattern-registry chrome detection plus submit-verify logic can press the follow-up “enter send now” Return, then receipt **`queued_followup`** when the composer is consumed into Cursor’s queue (distinct from engine-side **`queued`** while `working`).
> 
> **Operator surface:** identical in-flight sends return **`duplicate_of`**; **`wait_for({ delivery_id })`** blocks until terminal; **`list_agents detail=full`** exposes deliveries. Confirmed failures can write deduped local tickets and optional **`gh`** issues when production injects ticket dir/filer (disabled in tests and bare `AgentEngine`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d980c543013bd737bebd39d3e060ffb16332457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->