### PR TITLE
fix: disclose harness-only coverage on inferred paused=false

### DIFF
--- a/src/agent-facade.ts
+++ b/src/agent-facade.ts
@@ -7,7 +7,7 @@ import type {
   ObservedPublicAgent,
   PublicAgent,
 } from "./agent-types.js";
-import type { PauseSource } from "./types.js";
+import { pauseHonestyFields, type PauseSource } from "./types.js";
 import { buildResumeCommand } from "./agent-command.js";
 
 export type AgentStatePayload = AgentRecord & {
@@ -78,6 +78,9 @@ export function toObservedPublicAgent(
   const model = hasScreenModelObservation
     ? (opts.screenModel ?? null)
     : (record.model ?? null);
+  const pausedSource = (opts.pausedSource ??
+    record.paused_source ??
+    "inferred") as PauseSource;
   return {
     agent_id: record.agent_id,
     repo: record.repo,
@@ -119,13 +122,12 @@ export function toObservedPublicAgent(
     ),
     paused: {
       value: opts.paused ?? record.paused === true,
-      source: (opts.pausedSource ??
-        record.paused_source ??
-        "inferred") as PauseSource,
+      source: pausedSource,
       observed_at_ms:
         opts.paused !== undefined
           ? (opts.screenObservedAtMs ?? derivedAtMs)
           : registryObservedAtMs,
+      ...pauseHonestyFields(pausedSource),
     },
     ...(resumeCommand ? { resume_command: resumeCommand } : {}),
   };

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -3,7 +3,11 @@
  * Every field is a primitive (string | number | null).
  */
 import { randomUUID } from "node:crypto";
-import type { ParsedControlPlaneState, PauseSource } from "./types.js";
+import type {
+  ParsedControlPlaneState,
+  PauseCoverage,
+  PauseSource,
+} from "./types.js";
 
 export type AgentState =
   "creating" | "booting" | "ready" | "working" | "idle" | "done" | "error";
@@ -192,6 +196,8 @@ export interface ObservedPublicAgent {
     value: boolean;
     source: PauseSource;
     observed_at_ms: number;
+    coverage?: PauseCoverage;
+    note?: string;
   };
 }
 

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -4,6 +4,7 @@ import type {
   ParsedScreenResult,
   ParsedScreenStatus,
 } from "./types.js";
+import { pauseHonestyFields } from "./types.js";
 import type { CliType } from "./agent-types.js";
 // AIDEV-NOTE: Single source of truth for per-model context windows lives in
 // harness-session.ts (MODEL_WINDOW_RULES). screen-parser delegates versioned lookups to it
@@ -1723,6 +1724,7 @@ export function parseScreen(text: string): ParsedScreenResult {
 
   const status = inferStatus(normalized, doneSignal, errors, agentType);
   const cliUpdateState = parseCliUpdateState(normalized, agentType);
+  const honesty = pauseHonestyFields("inferred");
   const result: ParsedScreenResult = {
     agent_type: agentType,
     status,
@@ -1738,6 +1740,12 @@ export function parseScreen(text: string): ParsedScreenResult {
     cost,
     paused: screenShowsPaused(normalized),
     paused_source: "inferred",
+    ...(honesty.coverage
+      ? {
+          paused_coverage: honesty.coverage,
+          paused_note: honesty.note,
+        }
+      : {}),
   };
 
   if (cliUpdateState !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,23 @@ export type ParsedControlPlaneState =
   | "stale_surface"
   | "poisoned_registry";
 export type PauseSource = "cmux-reported" | "inferred";
+/** Pause forms the detector can actually see. UI pause is not among them today. */
+export type PauseCoverage = "harness_only";
+
+export const HARNESS_ONLY_PAUSE_NOTE =
+  "cmux-UI pause not detectable; see #447";
+
+/** Caveat attached to inferred pause so value:false is not read as authoritative. */
+export function pauseHonestyFields(source: PauseSource): {
+  coverage?: PauseCoverage;
+  note?: string;
+} {
+  if (source === "cmux-reported") return {};
+  return {
+    coverage: "harness_only",
+    note: HARNESS_ONLY_PAUSE_NOTE,
+  };
+}
 
 export interface ParsedScreenResult {
   agent_type: ParsedScreenAgentType;
@@ -173,6 +190,9 @@ export interface ParsedScreenResult {
   /** Visible pause chrome. Absent cmux field means this is always inferred. */
   paused: boolean;
   paused_source: PauseSource;
+  /** Present while source is inferred; omitted once a cmux-reported pause exists. */
+  paused_coverage?: PauseCoverage;
+  paused_note?: string;
 }
 
 export interface CmuxStatusEntry {

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -74,7 +74,43 @@ describe("agent facade projections", () => {
       value: true,
       source: "inferred",
       observed_at_ms: 2_000,
+      coverage: "harness_only",
+      note: "cmux-UI pause not detectable; see #447",
     });
+  });
+
+  it("keeps value false on a clean agent and names the uncovered cmux-UI case", () => {
+    const projected = toObservedPublicAgent(makeRecord(), {
+      derivedAtMs: 2_000,
+    });
+
+    expect(projected.paused.value).toBe(false);
+    expect(projected.paused).toEqual({
+      value: false,
+      source: "inferred",
+      observed_at_ms: 2_000,
+      coverage: "harness_only",
+      note: "cmux-UI pause not detectable; see #447",
+    });
+  });
+
+  it("omits the harness-only pause caveat when a cmux-reported source exists", () => {
+    const projected = toObservedPublicAgent(
+      makeRecord({ paused: false, paused_source: "cmux-reported" }),
+      {
+        derivedAtMs: 2_000,
+        paused: false,
+        pausedSource: "cmux-reported",
+      },
+    );
+
+    expect(projected.paused).toEqual({
+      value: false,
+      source: "cmux-reported",
+      observed_at_ms: 2_000,
+    });
+    expect(projected.paused).not.toHaveProperty("coverage");
+    expect(projected.paused).not.toHaveProperty("note");
   });
 
   it("exposes whether a listed agent was spawned or adopted", () => {

--- a/tests/paused-visibility.test.ts
+++ b/tests/paused-visibility.test.ts
@@ -223,8 +223,33 @@ describe("paused pane visibility", () => {
       paused: {
         value: true,
         source: "inferred",
+        coverage: "harness_only",
+        note: "cmux-UI pause not detectable; see #447",
       },
     });
+  });
+
+  it("list_agents summary rows keep boolean false and name harness-only coverage on a clean agent", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "agent-idle",
+        surface_id: "surface:idle",
+      }),
+    );
+    const result = await callTool(server, "list_agents", {});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agents[0]).toMatchObject({
+      agent_id: "agent-idle",
+      paused: {
+        value: false,
+        source: "inferred",
+        coverage: "harness_only",
+        note: "cmux-UI pause not detectable; see #447",
+      },
+    });
+    expect(typeof parsed.agents[0].paused.value).toBe("boolean");
   });
 
   it("read_screen parsed output includes paused with inferred source", async () => {
@@ -243,7 +268,32 @@ describe("paused pane visibility", () => {
     expect(parsed.parsed).toMatchObject({
       paused: true,
       paused_source: "inferred",
+      paused_coverage: "harness_only",
+      paused_note: "cmux-UI pause not detectable; see #447",
     });
+    expect(typeof parsed.parsed.paused).toBe("boolean");
+  });
+
+  it("read_screen parsed output names harness-only coverage on a clean idle pane", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "agent-idle",
+        surface_id: "surface:idle",
+      }),
+    );
+    const result = await callTool(server, "read_screen", {
+      surface: "surface:idle",
+      parsed_only: true,
+    });
+    const parsed = parseResult(result);
+    expect(parsed.parsed).toMatchObject({
+      paused: false,
+      paused_source: "inferred",
+      paused_coverage: "harness_only",
+      paused_note: "cmux-UI pause not detectable; see #447",
+    });
+    expect(typeof parsed.parsed.paused).toBe("boolean");
   });
 
   it("send_to a paused target queues with an unmissable warning and never submitted", async () => {

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -1897,6 +1897,8 @@ Model: gemini-2.5-pro
 
       expect(parsed.paused).toBe(true);
       expect(parsed.paused_source).toBe("inferred");
+      expect(parsed.paused_coverage).toBe("harness_only");
+      expect(parsed.paused_note).toBe("cmux-UI pause not detectable; see #447");
     });
 
     it("marks zsh: suspended in the footer as inferred paused", () => {
@@ -1929,6 +1931,9 @@ Model: gemini-2.5-pro
       );
 
       expect(parsed.paused).toBe(false);
+      expect(parsed.paused_source).toBe("inferred");
+      expect(parsed.paused_coverage).toBe("harness_only");
+      expect(parsed.paused_note).toBe("cmux-UI pause not detectable; see #447");
     });
 
     it("does not treat Claude plan-mode ⏸ footer as paused", () => {


### PR DESCRIPTION
## Summary
- v0.4.41 rendered `paused:{value:false, source:"inferred"}` on every agent as if the detector could see the cmux-UI pause. It cannot.
- Keep `value` as a boolean. Add `coverage:"harness_only"` and `note:"cmux-UI pause not detectable; see #447"` on list_agents summary rows, and `paused_coverage` / `paused_note` on read_screen parsed output, whenever the source is inferred.
- Those caveat fields are omitted when `source` is `cmux-reported`, so a future cmux-visible pause can drop the honesty warning without a type change.

Related to #447. This is an interim honesty fix — do not close the issue.

## Consumers (boolean reads kept)
- `src/format.ts` reads `a.paused?.value` as a boolean for the list_agents pretty mark.
- Engine, discovery, registry, and send_to live-pause checks read `parsed.paused` / `agent.paused` as booleans.
- No Swift/sidebar consumers of the nested `{value, source}` object. Additive fields only; no boolean type change.

## Test plan
- [x] Clean agent: list_agents `paused.value === false` plus coverage/note
- [x] `cmux-reported` source omits coverage/note
- [x] read_screen parsed keeps `paused` boolean and adds harness-only caveat
- [x] `bun run test` — 116 files, 2776 passed, 1 skipped
- [x] `bun run typecheck`

— cmuxlayerCursor (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"b5c1434e","ts":"2026-08-18T14:26:59Z"} -->

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disclose harness-only pause coverage on inferred `paused=false` state
> - Adds a `pauseHonestyFields` utility in [types.ts](https://github.com/EtanHey/cmuxlayer/pull/448/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) that returns `coverage: 'harness_only'` and a descriptive `note` when the pause source is `'inferred'`, and empty fields when `'cmux-reported'`.
> - [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/448/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) now includes `paused_coverage` and `paused_note` in `ParsedScreenResult` for inferred pause states, even when `paused` is `false`.
> - [agent-facade.ts](https://github.com/EtanHey/cmuxlayer/pull/448/files#diff-21529243acfc8d7743920399222a1c7fb45242bf7f4a3759b7be3344ffe98a61) spreads honesty metadata into the `paused` field of `ObservedPublicAgent` when the pause source is inferred.
> - Behavioral Change: Clients consuming `list_agents` or `read_screen` outputs will now see additional `coverage` and `note` fields on inferred pause states where previously only a boolean was returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efd8764.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->