### PR TITLE
fix: send_to v2 follow-ups from PR #441 review

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6255,23 +6255,31 @@ export class AgentEngine {
   }
 
   queueDelivery(input: {
+    delivery_id?: string;
     agent_id: string;
     text: string;
     press_enter: boolean;
     source_event: DeliveryEventType;
   }): AgentDeliveryReceipt {
+    const existing = input.delivery_id
+      ? this.deliveryReceipts.get(input.delivery_id)
+      : undefined;
     const receipt: AgentDeliveryReceipt = {
-      delivery_id: randomUUID(),
-      ...input,
+      delivery_id: input.delivery_id ?? existing?.delivery_id ?? randomUUID(),
+      agent_id: input.agent_id,
+      text: input.text,
+      press_enter: input.press_enter,
+      source_event: input.source_event,
       delivery_state: "queued",
       terminal: false,
-      created_at: new Date().toISOString(),
+      created_at: existing?.created_at ?? new Date().toISOString(),
       resolved_at: null,
-      retry_count: 0,
+      retry_count: existing?.retry_count ?? 0,
       submit_verified: null,
       error: null,
       submission_started_at: null,
       next_attempt_at: null,
+      verify_deadline_at: null,
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     try {
@@ -6295,21 +6303,24 @@ export class AgentEngine {
     delivery_state?: "queued" | "queued_followup";
   }): AgentDeliveryReceipt {
     const acceptedAt = new Date().toISOString();
+    const existing = this.deliveryReceipts.get(input.delivery_id);
+    const queuedFollowup =
+      (input.delivery_state ?? "queued") === "queued_followup";
     const receipt: AgentDeliveryReceipt = {
       ...input,
       delivery_state: input.delivery_state ?? "queued",
       terminal: false,
-      created_at: acceptedAt,
+      created_at: existing?.created_at ?? acceptedAt,
       resolved_at: null,
       submit_verified: null,
       error: null,
-      submission_started_at: acceptedAt,
+      submission_started_at: existing?.submission_started_at ?? acceptedAt,
       next_attempt_at: null,
       composer_accepted: true,
-      verify_deadline_at:
-        (input.delivery_state ?? "queued") === "queued_followup"
-          ? null
-          : new Date(Date.now() + this.deliveryVerifyDeadlineMs).toISOString(),
+      verify_deadline_at: queuedFollowup
+        ? null
+        : (existing?.verify_deadline_at ??
+          new Date(Date.now() + this.deliveryVerifyDeadlineMs).toISOString()),
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     try {
@@ -7816,11 +7827,7 @@ export class AgentEngine {
   markObservedPause(agentId: string, paused: boolean): AgentRecord | null {
     const agent = this.getAgentState(agentId);
     if (!agent) return null;
-    return this.persistPausedState(
-      agent,
-      paused,
-      new Date().toISOString(),
-    );
+    return this.persistPausedState(agent, paused, new Date().toISOString());
   }
 
   markAgentWorking(agentId: string): AgentRecord | null {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -582,6 +582,8 @@ export interface AgentEngineOptions {
   fleetWorkingNoProgressTimeoutMs?: number;
   /** Bound one queued terminal submission so lifecycle sweeps cannot hang forever. */
   deliverySubmitTimeoutMs?: number;
+  /** Bound one background verify observation so a hung reader cannot wedge later sweeps. */
+  deliveryVerifyTimeoutMs?: number;
   /** How long a pending_verify delivery may stay nonterminal before failed_confirmed. */
   deliveryVerifyDeadlineMs?: number;
   /**
@@ -1232,6 +1234,7 @@ export class AgentEngine {
   private deliveryDrainInFlight = false;
   private deliveryVerifyInFlight = false;
   private deliverySubmitTimeoutMs: number;
+  private deliveryVerifyTimeoutMs: number;
   private deliveryVerifyDeadlineMs: number;
   private deliveryTicketDir: string | null;
   private deliveryIssueFiler: DeliveryIssueFiler | null = null;
@@ -1256,6 +1259,10 @@ export class AgentEngine {
     this.deliverySubmitTimeoutMs = Math.max(
       1,
       opts?.deliverySubmitTimeoutMs ?? 30_000,
+    );
+    this.deliveryVerifyTimeoutMs = Math.max(
+      1,
+      opts?.deliveryVerifyTimeoutMs ?? this.deliverySubmitTimeoutMs,
     );
     this.deliveryVerifyDeadlineMs = Math.max(
       1,
@@ -6474,13 +6481,29 @@ export class AgentEngine {
           : Date.parse(receipt.created_at) + this.deliveryVerifyDeadlineMs;
         let observation: DeliveryVerifyObservation = { outcome: "pending" };
         if (this.deliveryVerifier) {
+          let timeout: ReturnType<typeof setTimeout> | null = null;
           try {
-            observation = await this.deliveryVerifier(receipt);
+            observation = await Promise.race([
+              this.deliveryVerifier(receipt),
+              new Promise<never>((_resolve, reject) => {
+                timeout = setTimeout(
+                  () =>
+                    reject(
+                      new Error(
+                        `Delivery verify timed out after ${this.deliveryVerifyTimeoutMs}ms`,
+                      ),
+                    ),
+                  this.deliveryVerifyTimeoutMs,
+                );
+              }),
+            ]);
           } catch (error) {
             observation = {
               outcome: "pending",
               reason: error instanceof Error ? error.message : String(error),
             };
+          } finally {
+            if (timeout) clearTimeout(timeout);
           }
         }
         if (observation.outcome === "delivered") {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -230,11 +230,18 @@ export interface AgentDeliveryReceipt {
   ticket_filed?: boolean;
   /** Consecutive verifier observations that the target agent is missing. */
   verify_miss_count?: number;
+  /** Last time background verify actually read the target surface. */
+  verify_last_attempt_at?: string | null;
 }
 
 export const DEFAULT_DELIVERY_VERIFY_DEADLINE_MS = 10 * 60 * 1000;
 export const DELIVERY_TARGET_GONE_CONFIRM_MISSES = 3;
 const DELIVERY_WAIT_POLL_MS = 100;
+
+export type DeliveryVerifySnapshot = {
+  text: string;
+  parsed?: unknown;
+};
 
 export type DeliveryVerifyObservation = {
   outcome: "pending" | "delivered" | "failed_confirmed";
@@ -245,7 +252,12 @@ export type DeliveryVerifyObservation = {
 
 type DeliveryVerifier = (
   receipt: AgentDeliveryReceipt,
+  snapshot?: DeliveryVerifySnapshot | null,
 ) => Promise<DeliveryVerifyObservation>;
+
+type DeliverySnapshotReader = (
+  receipt: AgentDeliveryReceipt,
+) => Promise<DeliveryVerifySnapshot | null>;
 
 type DeliveryIssueFiler = (ticket: DeliveryFailureTicket) => Promise<void>;
 
@@ -596,6 +608,8 @@ export interface AgentEngineOptions {
   deliveryIssueFiler?: DeliveryIssueFiler;
   /** Screen/transcript observer for pending deliveries. */
   deliveryVerifier?: DeliveryVerifier;
+  /** Optional per-sweep surface reader so many receipts share one snapshot. */
+  deliverySnapshotReader?: DeliverySnapshotReader;
   /** Base delay for same-surface CLI auto-revive retries. */
   autoReviveBackoffBaseMs?: number;
   /** Deterministic clock and per-class dwell controls for live-halt escalation. */
@@ -1231,6 +1245,7 @@ export class AgentEngine {
   private deliveryReceiptsPath: string;
   private deliverySubmitter: DeliverySubmitter | null = null;
   private deliveryVerifier: DeliveryVerifier | null = null;
+  private deliverySnapshotReader: DeliverySnapshotReader | null = null;
   private deliveryDrainInFlight = false;
   private deliveryVerifyInFlight = false;
   private deliverySubmitTimeoutMs: number;
@@ -1271,6 +1286,7 @@ export class AgentEngine {
     this.deliveryTicketDir = opts?.deliveryTicketDir ?? null;
     this.deliveryIssueFiler = opts?.deliveryIssueFiler ?? null;
     this.deliveryVerifier = opts?.deliveryVerifier ?? null;
+    this.deliverySnapshotReader = opts?.deliverySnapshotReader ?? null;
     this.autoReviveBackoffBaseMs = Math.max(
       0,
       opts?.autoReviveBackoffBaseMs ?? DEFAULT_AUTO_REVIVE_BACKOFF_BASE_MS,
@@ -6182,6 +6198,10 @@ export class AgentEngine {
     this.deliveryVerifier = verifier;
   }
 
+  setDeliverySnapshotReader(reader: DeliverySnapshotReader | null): void {
+    this.deliverySnapshotReader = reader;
+  }
+
   setDeliveryIssueFiler(filer: DeliveryIssueFiler | null): void {
     this.deliveryIssueFiler = filer;
   }
@@ -6468,6 +6488,7 @@ export class AgentEngine {
     if (this.deliveryVerifyInFlight || !this.deliveryVerifier) return;
     this.deliveryVerifyInFlight = true;
     try {
+      const snapshots = new Map<string, DeliveryVerifySnapshot | null>();
       for (const receipt of this.deliveryReceipts.values()) {
         const watching =
           receipt.delivery_state === "pending_verify" ||
@@ -6479,12 +6500,28 @@ export class AgentEngine {
         const deadlineMs = receipt.verify_deadline_at
           ? Date.parse(receipt.verify_deadline_at)
           : Date.parse(receipt.created_at) + this.deliveryVerifyDeadlineMs;
+        const now = Date.now();
+        const timedOut = deadlineApplies && now >= deadlineMs;
+        const skipRead = this.shouldSkipVerifyRead(receipt, now);
         let observation: DeliveryVerifyObservation = { outcome: "pending" };
-        if (this.deliveryVerifier) {
+        if (skipRead && !timedOut) continue;
+        if (!skipRead && this.deliveryVerifier) {
+          const agent = this.getAgentState(receipt.agent_id);
+          const snapshotKey = agent?.surface_id ?? receipt.agent_id;
+          let snapshot: DeliveryVerifySnapshot | null | undefined;
+          if (this.deliverySnapshotReader) {
+            if (!snapshots.has(snapshotKey)) {
+              snapshots.set(
+                snapshotKey,
+                await this.deliverySnapshotReader(receipt),
+              );
+            }
+            snapshot = snapshots.get(snapshotKey) ?? null;
+          }
           let timeout: ReturnType<typeof setTimeout> | null = null;
           try {
             observation = await Promise.race([
-              this.deliveryVerifier(receipt),
+              this.deliveryVerifier(receipt, snapshot),
               new Promise<never>((_resolve, reject) => {
                 timeout = setTimeout(
                   () =>
@@ -6505,6 +6542,8 @@ export class AgentEngine {
           } finally {
             if (timeout) clearTimeout(timeout);
           }
+          receipt.verify_last_attempt_at = new Date().toISOString();
+          this.persistDeliveryReceipts();
         }
         if (observation.outcome === "delivered") {
           receipt.delivery_state = "submitted";
@@ -6528,7 +6567,6 @@ export class AgentEngine {
           observation.reason === "target_gone" &&
           (receipt.verify_miss_count ?? 0) >=
             DELIVERY_TARGET_GONE_CONFIRM_MISSES;
-        const timedOut = deadlineApplies && Date.now() >= deadlineMs;
         if (
           observation.outcome === "failed_confirmed" ||
           confirmedGone ||
@@ -6550,6 +6588,36 @@ export class AgentEngine {
     } finally {
       this.deliveryVerifyInFlight = false;
     }
+  }
+
+  private verifyReadIntervalMs(
+    receipt: AgentDeliveryReceipt,
+    now: number,
+  ): number {
+    if (
+      receipt.delivery_state === "queued_followup" ||
+      !receipt.verify_deadline_at
+    ) {
+      const ageMs = Math.max(0, now - Date.parse(receipt.created_at));
+      const minutes = Math.floor(ageMs / 60_000);
+      return Math.min(60_000, 5_000 * 2 ** Math.min(minutes, 3));
+    }
+    const remaining = Math.max(0, Date.parse(receipt.verify_deadline_at) - now);
+    const created = Date.parse(receipt.created_at);
+    const total = Math.max(1, Date.parse(receipt.verify_deadline_at) - created);
+    const remainingRatio = remaining / total;
+    if (remainingRatio > 0.5) return 5_000;
+    if (remainingRatio > 0.2) return 15_000;
+    return 30_000;
+  }
+
+  private shouldSkipVerifyRead(
+    receipt: AgentDeliveryReceipt,
+    now: number,
+  ): boolean {
+    if (!receipt.verify_last_attempt_at) return false;
+    const since = now - Date.parse(receipt.verify_last_attempt_at);
+    return since > 0 && since < this.verifyReadIntervalMs(receipt, now);
   }
 
   private async fileConfirmedFailureTicket(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6446,7 +6446,7 @@ export class AgentEngine {
   async waitForDelivery(
     deliveryId: string,
     timeoutMs: number,
-  ): Promise<AgentDeliveryReceipt> {
+  ): Promise<AgentDeliveryReceipt & { timed_out?: boolean }> {
     const start = Date.now();
     const existing = this.getDeliveryReceipt(deliveryId);
     if (!existing) {
@@ -6455,33 +6455,32 @@ export class AgentEngine {
     if (existing.terminal) {
       return existing;
     }
-    return new Promise<AgentDeliveryReceipt>((resolve, reject) => {
-      const finish = (receipt: AgentDeliveryReceipt) => {
-        clearInterval(timer);
-        resolve(receipt);
-      };
-      const timer = setInterval(() => {
-        const elapsed = Date.now() - start;
-        const current = this.getDeliveryReceipt(deliveryId);
-        if (!current) {
+    return new Promise<AgentDeliveryReceipt & { timed_out?: boolean }>(
+      (resolve, reject) => {
+        const finish = (
+          receipt: AgentDeliveryReceipt & { timed_out?: boolean },
+        ) => {
           clearInterval(timer);
-          reject(new Error(`Delivery not found: ${deliveryId}`));
-          return;
-        }
-        if (current.terminal) {
-          finish(current);
-          return;
-        }
-        if (elapsed >= timeoutMs) {
-          clearInterval(timer);
-          reject(
-            new Error(
-              `Timed out after ${timeoutMs}ms waiting for delivery ${deliveryId}`,
-            ),
-          );
-        }
-      }, DELIVERY_WAIT_POLL_MS);
-    });
+          resolve(receipt);
+        };
+        const timer = setInterval(() => {
+          const elapsed = Date.now() - start;
+          const current = this.getDeliveryReceipt(deliveryId);
+          if (!current) {
+            clearInterval(timer);
+            reject(new Error(`Delivery not found: ${deliveryId}`));
+            return;
+          }
+          if (current.terminal) {
+            finish(current);
+            return;
+          }
+          if (elapsed >= timeoutMs) {
+            finish({ ...current, timed_out: true });
+          }
+        }, DELIVERY_WAIT_POLL_MS);
+      },
+    );
   }
 
   async verifyPendingDeliveries(): Promise<void> {

--- a/src/delivery-failure-tickets.ts
+++ b/src/delivery-failure-tickets.ts
@@ -84,7 +84,7 @@ export async function fileDeliveryFailureGithubIssue(
   const run =
     opts?.runner ??
     (async (file, args) => execFileAsync(file, args, { timeout: 15_000 }));
-  const marker = `cmuxlayer-delivery-failure:${ticket.signature}`;
+  const marker = `cmuxlayer-delivery-failure-${ticket.signature}`;
   const title = ticketTitle(ticket);
   const body = [
     marker,

--- a/src/delivery-failure-tickets.ts
+++ b/src/delivery-failure-tickets.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const DEFAULT_TICKET_DIR = join(homedir(), ".cmuxlayer", "tickets");
 const DEFAULT_REPO = "EtanHey/cmuxlayer";
+export const DELIVERY_TICKET_OCCURRENCE_CAP = 10;
 
 export interface DeliveryFailureTicket {
   signature: string;
@@ -55,7 +56,9 @@ export function writeDeliveryFailureTicket(
     ? {
         ...existing,
         occurrence_count: existing.occurrence_count + 1,
-        occurrences: [...existing.occurrences, ticket],
+        occurrences: [...existing.occurrences, ticket].slice(
+          -DELIVERY_TICKET_OCCURRENCE_CAP,
+        ),
       }
     : {
         signature: ticket.signature,

--- a/src/server.ts
+++ b/src/server.ts
@@ -586,6 +586,7 @@ const DeliveryOutputShape = {
   submit_attempted: z.boolean().optional(),
   submit_verified: z.boolean().nullable().optional(),
   delivery_id: z.string().optional(),
+  duplicate_of: z.string().optional(),
 };
 const DeliveryReceiptOutputSchema = z
   .object({

--- a/src/server.ts
+++ b/src/server.ts
@@ -14512,6 +14512,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (args.text === undefined) {
             throw new Error("send_to mode=agent requires text");
           }
+          args.text = sanitizeTerminalInput(args.text);
           assertInlineInputAllowed({
             tool: "send_to",
             arg: "text",

--- a/src/server.ts
+++ b/src/server.ts
@@ -10968,45 +10968,72 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : {}),
       };
     });
-    engine.setDeliveryVerifier(async (receipt: AgentDeliveryReceipt) => {
+    engine.setDeliverySnapshotReader(async (receipt: AgentDeliveryReceipt) => {
       const agent = engine.getAgentState(receipt.agent_id);
-      if (!agent) {
-        return { outcome: "pending" as const, reason: "target_gone" };
-      }
-      const snapshot = await readParsedSurface(
+      if (!agent) return null;
+      return readParsedSurface(
         agent.surface_id,
         agent.workspace_id ?? undefined,
       );
-      if (!snapshot?.text.trim()) {
-        return {
-          outcome: "pending" as const,
-          reason: "surface_read_unavailable",
-        };
-      }
-      const pending = screenShowsPendingInput(snapshot.text, receipt.text);
-      const queued = screenShowsQueuedAgentInput(snapshot.text, receipt.text);
-      const cursorQueuedFollowup = screenShowsQueuedCursorFollowup(
-        snapshot.text,
-        receipt.text,
-      );
-      const composer = extractComposerInputRegion(snapshot.text, receipt.text);
-      const cli = inferComposerCli(snapshot.text, snapshot.parsed);
-      if (queued || cursorQueuedFollowup || (cli === "cursor" && pending)) {
-        return { outcome: "pending" as const };
-      }
-      const composerCleared = composer !== null && composer.trim() === "";
-      const correlationTail = receipt.text
-        .trim()
-        .slice(-Math.min(80, receipt.text.trim().length));
-      const inTranscript =
-        correlationTail.length > 0 &&
-        normalizeTerminalText(snapshot.text).includes(correlationTail) &&
-        !pending;
-      if (composerCleared || inTranscript) {
-        return { outcome: "delivered" as const, submit_verified: true };
-      }
-      return { outcome: "pending" as const };
     });
+    engine.setDeliveryVerifier(
+      async (receipt: AgentDeliveryReceipt, snapshot) => {
+        const agent = engine.getAgentState(receipt.agent_id);
+        if (!agent) {
+          return { outcome: "pending" as const, reason: "target_gone" };
+        }
+        const resolvedSnapshot =
+          snapshot === undefined
+            ? await readParsedSurface(
+                agent.surface_id,
+                agent.workspace_id ?? undefined,
+              )
+            : snapshot;
+        if (!resolvedSnapshot?.text.trim()) {
+          return {
+            outcome: "pending" as const,
+            reason: "surface_read_unavailable",
+          };
+        }
+        const pending = screenShowsPendingInput(
+          resolvedSnapshot.text,
+          receipt.text,
+        );
+        const queued = screenShowsQueuedAgentInput(
+          resolvedSnapshot.text,
+          receipt.text,
+        );
+        const cursorQueuedFollowup = screenShowsQueuedCursorFollowup(
+          resolvedSnapshot.text,
+          receipt.text,
+        );
+        const composer = extractComposerInputRegion(
+          resolvedSnapshot.text,
+          receipt.text,
+        );
+        const cli = inferComposerCli(
+          resolvedSnapshot.text,
+          resolvedSnapshot.parsed as Parameters<typeof inferComposerCli>[1],
+        );
+        if (queued || cursorQueuedFollowup || (cli === "cursor" && pending)) {
+          return { outcome: "pending" as const };
+        }
+        const composerCleared = composer !== null && composer.trim() === "";
+        const correlationTail = receipt.text
+          .trim()
+          .slice(-Math.min(80, receipt.text.trim().length));
+        const inTranscript =
+          correlationTail.length > 0 &&
+          normalizeTerminalText(resolvedSnapshot.text).includes(
+            correlationTail,
+          ) &&
+          !pending;
+        if (composerCleared || inTranscript) {
+          return { outcome: "delivered" as const, submit_verified: true };
+        }
+        return { outcome: "pending" as const };
+      },
+    );
 
     // Reconstitute and discover live surfaces before the first sidebar paint.
     // The engine initializer is idempotent because daemon connections share a

--- a/src/server.ts
+++ b/src/server.ts
@@ -14660,9 +14660,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 continue;
               }
               const deliveryId = randomUUID();
+              engine.acceptPendingVerify({
+                delivery_id: deliveryId,
+                agent_id: agent.agent_id,
+                text: args.text,
+                press_enter: args.press_enter,
+                source_event: "send_to",
+                retry_count: 0,
+              });
               const livePaused = await observePausedTarget(agent);
               if (livePaused.paused) {
                 const queued = engine.queueDelivery({
+                  delivery_id: deliveryId,
                   agent_id: agent.agent_id,
                   text: args.text,
                   press_enter: args.press_enter,
@@ -14686,6 +14695,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               if (!args.allow_busy && agent.state === "working") {
                 const queued = engine.queueDelivery({
+                  delivery_id: deliveryId,
                   agent_id: agent.agent_id,
                   text: args.text,
                   press_enter: args.press_enter,
@@ -14886,9 +14896,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               data,
             );
           }
+          const deliveryId = randomUUID();
+          engine.acceptPendingVerify({
+            delivery_id: deliveryId,
+            agent_id: agentId,
+            text: args.text,
+            press_enter: args.press_enter,
+            source_event: "send_to",
+            retry_count: 0,
+          });
           const livePaused = await observePausedTarget(targetAgent);
           if (livePaused.paused) {
             const receipt = engine.queueDelivery({
+              delivery_id: deliveryId,
               agent_id: agentId,
               text: args.text,
               press_enter: args.press_enter,
@@ -14914,6 +14934,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           if (!args.allow_busy && targetAgent?.state === "working") {
             const receipt = engine.queueDelivery({
+              delivery_id: deliveryId,
               agent_id: agentId,
               text: args.text,
               press_enter: args.press_enter,
@@ -14936,7 +14957,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               data,
             );
           }
-          const deliveryId = randomUUID();
           let delivery: Awaited<ReturnType<typeof deliverAgentInput>>;
           try {
             delivery = await deliverAgentInput({

--- a/src/server.ts
+++ b/src/server.ts
@@ -663,6 +663,10 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       agent_id: z.string().optional(),
       results: z.array(z.record(z.unknown())).optional(),
       watch: z.record(z.unknown()).optional(),
+      delivery_id: z.string().optional(),
+      delivery_state: z.string().optional(),
+      terminal: z.boolean().optional(),
+      timed_out: z.boolean().optional(),
     })
     .passthrough(),
   control_health: z
@@ -12897,6 +12901,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               terminal: receipt.terminal,
               submit_verified: receipt.submit_verified,
               agent_id: receipt.agent_id,
+              ...(receipt.timed_out ? { timed_out: true } : {}),
             };
             return okFormatted(formatOk("wait_for", data), data);
           }

--- a/tests/delivery-failure-tickets.test.ts
+++ b/tests/delivery-failure-tickets.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  fileDeliveryFailureGithubIssue,
   writeDeliveryFailureTicket,
   type DeliveryFailureTicket,
 } from "../src/delivery-failure-tickets.js";
@@ -60,5 +61,23 @@ describe("delivery failure tickets", () => {
     expect(record.occurrences.at(-1)?.delivery_id).toBe(
       `delivery-${total - 1}`,
     );
+  });
+
+  it("uses a colon-free GitHub search marker", async () => {
+    const searches: string[] = [];
+    const ticket = makeTicket();
+    await fileDeliveryFailureGithubIssue(ticket, {
+      runner: async (_file, args) => {
+        const searchAt = args.indexOf("--search");
+        if (searchAt >= 0) {
+          searches.push(String(args[searchAt + 1]));
+        }
+        return { stdout: "[]", stderr: "" };
+      },
+    });
+
+    expect(searches).toHaveLength(1);
+    expect(searches[0]).toBe(`cmuxlayer-delivery-failure-${ticket.signature}`);
+    expect(searches[0]).not.toMatch(/:/);
   });
 });

--- a/tests/delivery-failure-tickets.test.ts
+++ b/tests/delivery-failure-tickets.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  writeDeliveryFailureTicket,
+  type DeliveryFailureTicket,
+} from "../src/delivery-failure-tickets.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-delivery-failure-tickets-test");
+
+function makeTicket(
+  overrides?: Partial<DeliveryFailureTicket>,
+): DeliveryFailureTicket {
+  return {
+    signature: "sigdeadbeef1234",
+    delivery_id: "delivery-1",
+    agent_id: "agent-1",
+    reason: "verify_deadline_elapsed",
+    cli: "cursor",
+    what_happened: "verify timed out",
+    what_fixed_it: "do not blind-retry",
+    evidence: { n: 1 },
+    observed_at: "2026-08-17T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("delivery failure tickets", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("caps stored occurrences to the last N while keeping the total count", () => {
+    const cap = 10;
+    const extra = 3;
+    const total = cap + extra;
+    let written = writeDeliveryFailureTicket(
+      makeTicket({ delivery_id: "delivery-0" }),
+      { dir: TEST_DIR },
+    );
+    for (let i = 1; i < total; i++) {
+      written = writeDeliveryFailureTicket(
+        makeTicket({ delivery_id: `delivery-${i}` }),
+        { dir: TEST_DIR },
+      );
+    }
+
+    const record = JSON.parse(
+      readFileSync(written.path, "utf8"),
+    ) as typeof written.record;
+    expect(record.occurrence_count).toBe(total);
+    expect(record.occurrences).toHaveLength(cap);
+    expect(record.occurrences[0]?.delivery_id).toBe(`delivery-${extra}`);
+    expect(record.occurrences.at(-1)?.delivery_id).toBe(
+      `delivery-${total - 1}`,
+    );
+  });
+});

--- a/tests/public-output-schema-stdio.test.ts
+++ b/tests/public-output-schema-stdio.test.ts
@@ -77,6 +77,7 @@ describe("public tool output schemas over stdio", () => {
           "title",
           "model",
           "agent_type",
+          "duplicate_of",
           "boot_prompt_delivered",
           "boot_prompt_receipt",
           "boot_prompt_bytes",
@@ -101,9 +102,12 @@ describe("public tool output schemas over stdio", () => {
       };
       for (const [toolName, fields] of Object.entries(declaredFields)) {
         const schema = tools.find((tool) => tool.name === toolName)
-          ?.outputSchema as { properties?: Record<string, unknown> } | undefined;
+          ?.outputSchema as
+          { properties?: Record<string, unknown> } | undefined;
         for (const field of fields) {
-          expect(schema?.properties, `${toolName}.${field}`).toHaveProperty(field);
+          expect(schema?.properties, `${toolName}.${field}`).toHaveProperty(
+            field,
+          );
         }
       }
 

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -950,4 +950,58 @@ describe("send_to v2 background verify", () => {
       engine.dispose();
     }
   });
+
+  it("times out a hung delivery verifier so later sweeps can still run", async () => {
+    let calls = 0;
+    const client = new FakeAgentSurfaceClient();
+    const stateMgr = new StateManager(TEST_DIR);
+    const engine = new AgentEngine(
+      stateMgr,
+      new AgentRegistry(stateMgr, async () => []),
+      client as any,
+      {
+        deliveryVerifyTimeoutMs: 50,
+        deliveryVerifier: async () => {
+          calls += 1;
+          if (calls === 1) {
+            return new Promise(() => {});
+          }
+          return { outcome: "delivered", submit_verified: true };
+        },
+      },
+    );
+    try {
+      engine.acceptPendingVerify({
+        delivery_id: "hung-1",
+        agent_id: "agent-1",
+        text: "hangs the verifier",
+        press_enter: true,
+        source_event: "send_to",
+        retry_count: 0,
+      });
+
+      let settled = false;
+      const first = engine.verifyPendingDeliveries().then(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(50);
+      await first;
+      expect(settled).toBe(true);
+      expect(engine.getDeliveryReceipt("hung-1")).toMatchObject({
+        delivery_state: "pending_verify",
+        terminal: false,
+      });
+
+      await engine.verifyPendingDeliveries();
+      expect(calls).toBe(2);
+      expect(engine.getDeliveryReceipt("hung-1")).toMatchObject({
+        delivery_id: "hung-1",
+        delivery_state: "submitted",
+        terminal: true,
+        submit_verified: true,
+      });
+    } finally {
+      engine.dispose();
+    }
+  });
 });

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -144,9 +144,14 @@ class FakeAgentSurfaceClient {
     };
   }
 
+  sendGate: Promise<void> | null = null;
+
   async send(surface: string, text: string) {
     if (surface !== this.surface) {
       throw new Error(`Unknown surface: ${surface}`);
+    }
+    if (this.sendGate) {
+      await this.sendGate;
     }
     this.sendCalls.push(text);
     this.pendingText += text;
@@ -463,6 +468,52 @@ describe("send_to v2 background verify", () => {
       terminal: true,
       submit_verified: true,
     });
+  });
+
+  it("registers the delivery before typing so concurrent identical sends return duplicate_of", async () => {
+    const client = new FakeAgentSurfaceClient();
+    let releaseSend!: () => void;
+    client.sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const args = {
+      agent_id: "agent-1",
+      text: "race me once",
+      press_enter: true,
+    };
+    const firstPromise = server._registeredTools.send_to.handler(
+      args,
+      {} as any,
+    );
+    for (let i = 0; i < 30; i++) {
+      await Promise.resolve();
+    }
+    const engine = server._registeredTools.interact._engine;
+    const inFlight = engine.listDeliveryReceipts();
+    expect(inFlight).toEqual([
+      expect.objectContaining({
+        text: "race me once",
+        delivery_state: "pending_verify",
+        terminal: false,
+      }),
+    ]);
+    expect(client.sendCalls).toEqual([]);
+
+    const second = parseResult(
+      await server._registeredTools.send_to.handler(args, {} as any),
+    );
+    releaseSend();
+    for (let elapsed = 0; elapsed < 10_000; elapsed += 100) {
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    const first = parseResult(await firstPromise);
+
+    expect(second.duplicate_of).toBe(inFlight[0].delivery_id);
+    expect(second.delivery_id).toBe(first.delivery_id);
+    expect(client.sendCalls).toEqual(["race me once"]);
   });
 
   it("returns the existing delivery_id with duplicate_of instead of typing again", async () => {

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -518,6 +518,28 @@ describe("send_to v2 background verify", () => {
     expect(client.sendCalls).toEqual(["race me once"]);
   });
 
+  it("stores sanitized text on the delivery receipt so verify matches the typed payload", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+    const raw = "hello\x07\x1b[31mworld";
+    const sanitized = "helloworld";
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: raw,
+        press_enter: true,
+      }),
+    );
+
+    const engine = server._registeredTools.interact._engine;
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      text: sanitized,
+    });
+    expect(client.sendCalls.join("")).toBe(sanitized);
+  });
+
   it("returns the existing delivery_id with duplicate_of instead of typing again", async () => {
     const client = new FakeAgentSurfaceClient();
     server = createVerifyServer(client);

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -48,6 +48,7 @@ class FakeAgentSurfaceClient {
   title = "brainlayerClaude";
   readonly sendCalls: string[] = [];
   readonly sendKeyCalls: string[] = [];
+  readScreenCalls = 0;
   cli: "claude" | "cursor" = "claude";
   requiredReturns = 99;
   /** Model Cursor's follow-ups box that needs a second Return ("enter send now"). */
@@ -190,6 +191,7 @@ class FakeAgentSurfaceClient {
     if (surface !== this.surface) {
       throw new Error(`Unknown surface: ${surface}`);
     }
+    this.readScreenCalls += 1;
     const tail = this.pendingText.slice(-160);
     const text =
       this.screenOverride ??
@@ -946,6 +948,71 @@ describe("send_to v2 background verify", () => {
       });
       expect(existsSync(ticketDir)).toBe(false);
       expect(filed).toHaveLength(0);
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("dedupes surface snapshots across pending deliveries in one verify sweep", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "first pending",
+        press_enter: true,
+      }),
+    );
+    parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "second pending",
+        press_enter: true,
+      }),
+    );
+
+    const engine = server._registeredTools.interact._engine;
+    expect(engine.listDeliveryReceipts()).toHaveLength(2);
+    client.readScreenCalls = 0;
+    await engine.verifyPendingDeliveries();
+    expect(client.readScreenCalls).toBe(1);
+  });
+
+  it("backs off verify reads as the deadline recedes", async () => {
+    let reads = 0;
+    const client = new FakeAgentSurfaceClient();
+    const stateMgr = new StateManager(TEST_DIR);
+    const engine = new AgentEngine(
+      stateMgr,
+      new AgentRegistry(stateMgr, async () => []),
+      client as any,
+      {
+        deliveryVerifyDeadlineMs: 10_000,
+        deliverySnapshotReader: async () => {
+          reads += 1;
+          return { text: "Claude Code\n> leftover\n" };
+        },
+        deliveryVerifier: async () => ({ outcome: "pending" }),
+      },
+    );
+    try {
+      engine.acceptPendingVerify({
+        delivery_id: "backoff-1",
+        agent_id: "agent-1",
+        text: "backoff pending",
+        press_enter: true,
+        source_event: "send_to",
+        retry_count: 0,
+      });
+
+      await engine.verifyPendingDeliveries();
+      expect(reads).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      await engine.verifyPendingDeliveries();
+      expect(reads).toBe(1);
     } finally {
       engine.dispose();
     }

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -646,6 +646,46 @@ describe("send_to v2 background verify", () => {
     expect(filed).toHaveLength(1);
   });
 
+  it("returns a nonterminal wait_for delivery receipt with timed_out instead of rejecting", async () => {
+    const client = new FakeAgentSurfaceClient();
+    server = createVerifyServer(client);
+    registerAgent(server);
+
+    const sent = parseResult(
+      await callTool(server, "send_to", {
+        agent_id: "agent-1",
+        text: "still waiting",
+        press_enter: true,
+      }),
+    );
+    expect(sent.delivery_state).toBe("pending_verify");
+
+    const waitPromise = server._registeredTools.wait_for.handler(
+      { delivery_id: sent.delivery_id, timeout_ms: 200 },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    const waited = await waitPromise;
+    const parsed = parseResult(waited);
+
+    expect(waited.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      delivery_id: sent.delivery_id,
+      delivery_state: "pending_verify",
+      terminal: false,
+      timed_out: true,
+    });
+    expect(
+      server._registeredTools.interact._engine.getDeliveryReceipt(
+        sent.delivery_id,
+      ),
+    ).toMatchObject({
+      delivery_state: "pending_verify",
+      terminal: false,
+    });
+  });
+
   it("lets wait_for accept a delivery_id and return the terminal receipt", async () => {
     const client = new FakeAgentSurfaceClient();
     server = createVerifyServer(client);


### PR DESCRIPTION
## Summary
- Close the concurrent-identical-sends window by registering `pending_verify` before typing, and timeout a hung `deliveryVerifier` so `deliveryVerifyInFlight` cannot wedge forever.
- Dedupe per-surface verify snapshots in one sweep and back off reads as the deadline recedes; `wait_for({delivery_id})` on timeout returns the nonterminal receipt with `timed_out` instead of a tool error.
- Cap ticket-file occurrences (last 10 + count), use a colon-free GitHub dedupe marker, store sanitized send_to text on the receipt, and declare `duplicate_of` on `DeliveryOutputShape`.

## Test plan
- [x] `bun run test` → 117 files, 2780 passed, 1 skipped
- [x] `bun run typecheck` → clean
- [ ] Live: concurrent identical `send_to` to a busy Cursor pane returns `duplicate_of` without a second type

— cmuxlayerCursor-8742cee0 (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"cmuxlayerCursor-8742cee0","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"8742cee0","ts":"2026-08-18T14:42:56Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the send_to delivery lifecycle and background verify loop (timeouts, backoff, shared snapshots); behavior is heavily covered by new tests but affects operator-facing MCP tools.
> 
> **Overview**
> Hardens **send_to v2** background delivery verification and closes races where two identical in-flight sends could both reach the terminal.
> 
> **send_to** now allocates a `delivery_id`, registers **`pending_verify` via `acceptPendingVerify` before any typing**, and reuses that id through queue/pause/busy paths so a concurrent identical request can return **`duplicate_of`**. Input is **sanitized before** it is stored on the receipt and sent, so verify correlates against what was actually typed.
> 
> **Background verify** gains an optional **`deliverySnapshotReader`** so one surface read is shared across receipts in a sweep, **`deliveryVerifyTimeoutMs`** so a hung verifier cannot block later sweeps, and **`verify_last_attempt_at`** with deadline-aware read backoff. The verifier callback can take a pre-read snapshot; the server wires reader + verifier separately.
> 
> **`wait_for({ delivery_id })`** on timeout returns the **nonterminal receipt with `timed_out: true`** instead of failing the tool; output schemas add `duplicate_of` and delivery wait fields.
> 
> **Delivery failure tickets** keep only the **last 10 occurrences** while incrementing total count, and GitHub dedupe uses a **colon-free** marker. Receipt **queue/accept** paths honor optional **`delivery_id`** and preserve timestamps on composer replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eefe94867d3e3a8b37bdf0f676037b2820ff555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix send_to v2 delivery verification with deduplication, backoff, and timeout handling
> - Pre-registers deliveries with a generated `deliveryId` before typing, enabling `duplicate_of` detection for concurrent identical `send_to` requests.
> - `waitForDelivery` now returns a nonterminal receipt with `timed_out: true` instead of throwing on timeout; the `wait_for` API response includes this flag.
> - Background verify deduplicates surface reads per sweep via a shared `deliverySnapshotReader`, and backs off read frequency based on delivery age and deadline proximity.
> - Verifier calls are wrapped in a `Promise.race` against `deliveryVerifyTimeoutMs` so hung verifiers don't block sweeps; `verify_last_attempt_at` is recorded to track backoff state.
> - Delivery failure ticket files now cap stored occurrences at 10 and fix a colon-in-marker bug that broke GitHub issue deduplication search.
> - Behavioral Change: `queueDelivery` accepts an optional `delivery_id` and preserves `created_at`/`retry_count` on re-queue, changing how concurrent sends are deduplicated.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5eefe94. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->