### PR TITLE
feat(release): receipts ledger, verify-only mode, tap-clone sync, contract gate visibility

### DIFF
--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -119,12 +119,29 @@ scrollback.
   `gates.contract_reason` on a skip), the tap push, and the tap-clone sync
   (`tap.clone_sync` = `synced` / `skipped` / `failed`, with before/after SHAs).
 - `release-verify.sh` records `verify.result`, `verify.mode`, tap-clone
-  divergence, and appends one **per-Mac install evidence** entry
-  (`{host, result, installed, mode, at}`) to `installs[]` — every Mac that runs
-  it appends its own entry, so the fleet-wide picture is one file.
+  divergence, and appends one **install evidence** entry
+  (`{host, result, installed, mode, at}`) to `installs[]`.
 - Every mutation also appends to an in-file `events[]` trail; writes are atomic
   (temp file + rename), and re-running `init` never drops existing install
   evidence.
+
+**The default ledger is per-Mac, not fleet-wide.** `~/.local/state/…` is local
+disk: four Macs running `release-verify.sh` produce four separate
+`release-<version>.json` files, each holding its own single `installs[]` entry.
+That is still a real improvement — four durable files beat four scrollbacks —
+but collecting them is on you.
+
+To aggregate a release into **one** file, point every Mac at shared storage:
+
+```bash
+export CMUXLAYER_RELEASE_RECEIPTS_DIR=/path/to/shared/release-receipts
+```
+
+The `installs[]` array and its `host` field exist for exactly that. One caveat
+before you do it: `release-receipt.mjs` does a read-modify-write with **no
+locking**, so two Macs verifying the same version at the same moment can drop
+one another's entry. Stagger them, or treat a shared ledger as best-effort
+until locking lands.
 
 Read one directly:
 

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -87,25 +87,128 @@ ID so distinct identities cannot collide after filename sanitization.
 One command does the whole pipeline:
 
 ```bash
-~/Gits/cmuxlayer/scripts/release.sh 0.3.0
+~/Gits/cmuxlayer/scripts/release.sh 0.4.44                     # asks once before pushing
+~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --yes               # no prompt
+~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --dry-run           # print every step, change nothing
+~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --require-contract  # a skipped real-cmux gate aborts
 ```
 
-It will: verify a clean tree + green build/tests, bump `package.json`, commit,
-push `main`, tag `vX.Y.Z`, then update the Homebrew formula's `url` + `sha256`
-in `~/Gits/homebrew-layers` and push the tap. Afterwards, run the verification
-helper with the released version:
+It will: verify a clean tree + green typecheck/tests, run the real-cmux
+contract gate, bump `package.json`, commit, push `main`, tag `vX.Y.Z`, update
+the Homebrew formula's `url` + `sha256` in `~/Gits/homebrew-layers`, push the
+tap, and **sync the tap clone Homebrew itself reads**. Afterwards, run the
+verification helper on **each** Mac:
 
 ```bash
-~/Gits/cmuxlayer/scripts/release-verify.sh 0.3.0
+~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.44                # sync clone → upgrade → assert
+~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.44 --verify-only  # assert only; never upgrades
 ```
 
-The helper fetches and hard-resets the tap clone Homebrew actually reads at
+### The release receipt (stop trusting scrollback)
+
+Both scripts write a durable **release receipt** through
+`scripts/release-receipt.mjs` instead of leaving the answer to "did this
+release actually gate, ship, and land on every Mac?" in four terminals'
+scrollback.
+
+- Location: `$CMUXLAYER_RELEASE_RECEIPTS_DIR`, defaulting to
+  `~/.local/state/cmuxlayer/release-receipts/release-<version>.json`.
+- `release.sh` records: version, tag, release commit SHA, timestamps,
+  tarball URL + `sha256`, each gate's result (`gates.typecheck`,
+  `gates.tests`, `gates.contract` — `pass` / `skip` / `fail`, with
+  `gates.contract_reason` on a skip), the tap push, and the tap-clone sync
+  (`tap.clone_sync` = `synced` / `skipped` / `failed`, with before/after SHAs).
+- `release-verify.sh` records `verify.result`, `verify.mode`, tap-clone
+  divergence, and appends one **per-Mac install evidence** entry
+  (`{host, result, installed, mode, at}`) to `installs[]` — every Mac that runs
+  it appends its own entry, so the fleet-wide picture is one file.
+- Every mutation also appends to an in-file `events[]` trail; writes are atomic
+  (temp file + rename), and re-running `init` never drops existing install
+  evidence.
+
+Read one directly:
+
+```bash
+node ~/Gits/cmuxlayer/scripts/release-receipt.mjs show 0.4.44
+node ~/Gits/cmuxlayer/scripts/release-receipt.mjs path 0.4.44
+```
+
+Receipt writes are never a gate: a failed receipt write warns and the release
+continues. `--dry-run` writes no receipt at all.
+
+### The real-cmux contract gate (#370)
+
+`release.sh` runs `bun run test:contract`. That lane **skips itself** when no
+live, non-production cmux socket is reachable — cmux grants
+`CMUX_SOCKET_CAPABILITY` only to processes started inside a pane, and the
+runner refuses the production socket outright (pin
+`/tmp/cmux-nightly.sock`, or set `CMUX_CONTRACT_ALLOW_PROD=1` to override).
+Those skips are why 0.4.17–0.4.19 shipped without the gate ever running.
+
+Now the skip is classified and written to the receipt as
+`gates.contract: skip` with its reason, and there are two ways to make it a
+hard gate:
+
+- `scripts/release.sh <version> --require-contract` — a skipped gate aborts the
+  release before anything is pushed;
+- `CMUX_CONTRACT_REQUIRE_LIVE=1 bun run test:contract` — the runner itself
+  turns a skip into `[contract] FAIL:` and a non-zero exit.
+
+`scripts/nightly-contract-run.sh` writes its own nightly receipt under
+`~/.local/state/cmux/contract-nightly-<date>.json`.
+
+**Running it green.** Open a shell *inside a cmux pane* (that is the only place
+`CMUX_SOCKET_CAPABILITY` is granted) and run the lane. Verified green on
+2026-08-18 from a pane on the live socket:
+
+```bash
+CMUX_CONTRACT_ALLOW_PROD=1 bun run test:contract
+# [contract] PASS system.ping shape on ~/.local/state/cmux/cmux-501.sock
+# [contract] PASS detached orphan pid=… denied with EPROTO
+# [contract] PASS list_surfaces/read_screen through dist daemon pid=…
+# [contract] PASS doctor --json healthy on isolated live stack
+# [contract] PASS graceful retire/autostart …
+# [contract] PASS real-cmux contract lane
+```
+
+The lane's live steps against the pinned cmux are read-only (`system.ping`,
+`list_surfaces`, `read_screen`); the daemon it retires and restarts is its own,
+under a temp `HOME` and a temp socket. Prefer the nightly pin
+(`CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock`) when nightly is up;
+`CMUX_CONTRACT_ALLOW_PROD=1` is the explicit override when it is not.
+
+### Verify-only mode (failures-ledger 10.5)
+
+`release-verify.sh --verify-only` (alias `--no-upgrade`) **asserts without
+mutating this Mac**: no `brew upgrade`, no `reset --hard` of Homebrew's tap
+clone. It fetches (remote refs only), reports how many commits brew's clone is
+behind `origin/main`, asserts `brew list --versions cmuxlayer`, and appends its
+install evidence. This exists because a "verification" that silently upgraded
+mid-fleet nearly broke an explicit operator hold on the v0.4.24 cut.
+
+The default (upgrading) mode is unchanged: it fetches and hard-resets the tap
+clone Homebrew actually reads at
 `$(brew --repository)/Library/Taps/etanhey/homebrew-layers` to `origin/main`,
 runs `brew upgrade etanhey/layers/cmuxlayer`, and fails unless
-`brew list --versions cmuxlayer` prints exactly the released version. This
-explicit sync is required because that tap's `origin` can be the local
-`~/Gits/homebrew-layers` checkout while its `main` has no upstream tracking, so
-`brew update` alone does not guarantee a fast-forward.
+`brew list --versions cmuxlayer` prints exactly the released version.
+
+> ⚠️ `brew upgrade` deletes the running keg under every live MCP child, so
+> agents holding an old cmuxlayer child keep running deleted code until they
+> `/mcp reconnect cmuxlayer` (#371). "Deployed" is per-agent, not fleet-wide —
+> which is what the per-Mac `installs[]` evidence is for.
+
+### Why the tap clone must be synced explicitly (#371, failures-ledger 16)
+
+`release.sh` edits and pushes `~/Gits/homebrew-layers`, but brew reads its OWN
+clone under `$(brew --repository)/Library/Taps/etanhey/homebrew-layers`. That
+clone's `main` frequently has **no upstream tracking**, so `brew update` reports
+"Already up-to-date" while sitting commits behind and `git pull` fails with "no
+tracking information" — observed on both Macs after v0.4.26. Both `release.sh`
+(after the tap push) and `release-verify.sh` (default mode) therefore run an
+explicit `git -C <clone> fetch origin && git -C <clone> reset --hard origin/main`.
+In `release.sh` this step is **additive and non-fatal** — the release is already
+pushed by then, so a missing brew or missing clone is recorded as
+`tap.clone_sync: skipped` rather than failing the run.
 
 Manual equivalent, if you prefer:
 
@@ -208,5 +311,7 @@ explicit `workspace` only when you deliberately want a different one.
 | `~/.golems/config.yaml` → `mcpServers.cmuxlayer` | wires the launcher into the fleet |
 | `~/.golems/bin/cmuxlayer-mcp` | launcher: brew (default) vs live source (`CMUXLAYER_DEV=1`) |
 | `EtanHey/homebrew-layers` → `Formula/cmuxlayer.rb` | the brew formula (stable tag + `head`) |
-| `scripts/release.sh` | one-command release: bump → tag → formula bump → push |
-| `scripts/release-verify.sh` | sync Homebrew's tap clone → upgrade → assert installed version |
+| `scripts/release.sh` | one-command release: gate → bump → tag → formula bump → push → sync brew's tap clone → receipt |
+| `scripts/release-verify.sh` | sync Homebrew's tap clone → upgrade → assert installed version (`--verify-only` asserts without upgrading) |
+| `scripts/release-receipt.mjs` | the release receipts ledger (`CMUXLAYER_RELEASE_RECEIPTS_DIR`) |
+| `scripts/run-real-cmux-contract.ts` | the real-cmux contract lane (`CMUX_CONTRACT_REQUIRE_LIVE=1` makes a skip fatal) |

--- a/scripts/release-receipt.mjs
+++ b/scripts/release-receipt.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+//
+// Release receipts ledger — the durable record a release leaves behind, so
+// "did it actually ship, verify, and land on every Mac?" is answered by a file
+// instead of by terminal scrollback (failures-ledger rows 10.5 / 16, #371).
+//
+//   release-receipt.mjs init <version> [--commit SHA] [--host H]
+//   release-receipt.mjs record <version> <dotted.key> <value> [--json]
+//   release-receipt.mjs install <version> --result pass|fail --installed STR
+//                                          [--mode upgrade|verify-only] [--host H]
+//   release-receipt.mjs path <version>
+//   release-receipt.mjs show <version>
+//
+// Ledger dir: $CMUXLAYER_RELEASE_RECEIPTS_DIR, else
+// $HOME/.local/state/cmuxlayer/release-receipts. One JSON receipt per version;
+// every mutation appends to an in-file event trail and rewrites atomically.
+import { hostname } from "node:os";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCHEMA = "cmuxlayer.release-receipt/v1";
+
+function die(message) {
+  process.stderr.write(`release-receipt: ${message}\n`);
+  process.exit(2);
+}
+
+export function receiptsDir(env = process.env) {
+  if (env.CMUXLAYER_RELEASE_RECEIPTS_DIR) {
+    return env.CMUXLAYER_RELEASE_RECEIPTS_DIR;
+  }
+  const home = env.HOME;
+  if (!home) die("neither CMUXLAYER_RELEASE_RECEIPTS_DIR nor HOME is set");
+  return join(home, ".local", "state", "cmuxlayer", "release-receipts");
+}
+
+export function receiptPath(version, env = process.env) {
+  return join(receiptsDir(env), `release-${version}.json`);
+}
+
+function utcNow() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function defaultHost(env = process.env) {
+  return env.CMUXLAYER_RECEIPT_HOST || hostname().replace(/\..*$/, "");
+}
+
+function readReceipt(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function writeReceipt(path, receipt) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  receipt.updated_at = utcNow();
+  const tmp = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(receipt, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+function emptyReceipt(version, env) {
+  const now = utcNow();
+  return {
+    schema: SCHEMA,
+    version,
+    tag: `v${version}`,
+    host: defaultHost(env),
+    created_at: now,
+    updated_at: now,
+    commit: null,
+    gates: {},
+    artifact: {},
+    tap: {},
+    verify: {},
+    installs: [],
+    events: [],
+  };
+}
+
+/** Loads the receipt for `version`, creating the in-memory shape if absent. */
+export function loadOrCreate(version, env = process.env) {
+  const path = receiptPath(version, env);
+  return { path, receipt: readReceipt(path) ?? emptyReceipt(version, env) };
+}
+
+export function setDottedKey(target, dottedKey, value) {
+  const parts = dottedKey.split(".");
+  let cursor = target;
+  for (const part of parts.slice(0, -1)) {
+    if (typeof cursor[part] !== "object" || cursor[part] === null) {
+      cursor[part] = {};
+    }
+    cursor = cursor[part];
+  }
+  cursor[parts[parts.length - 1]] = value;
+  return target;
+}
+
+function flagValue(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (value === undefined) die(`${name} needs a value`);
+  return value;
+}
+
+function positionals(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      if (arg !== "--json") i += 1;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  if (!command) die("usage: release-receipt.mjs <init|record|install|path|show> …");
+
+  const args = positionals(rest);
+  const version = args[0];
+  if (!version) die(`${command} needs a version`);
+
+  if (command === "path") {
+    process.stdout.write(`${receiptPath(version)}\n`);
+    return;
+  }
+
+  if (command === "show") {
+    const { path, receipt } = loadOrCreate(version);
+    if (!readReceipt(path)) die(`no receipt for ${version} at ${path}`);
+    process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+    return;
+  }
+
+  const { path, receipt } = loadOrCreate(version);
+
+  if (command === "init") {
+    const commit = flagValue(rest, "--commit");
+    const host = flagValue(rest, "--host");
+    if (commit) receipt.commit = commit;
+    if (host) receipt.host = host;
+    receipt.events.push({ at: utcNow(), event: "init", key: null });
+    writeReceipt(path, receipt);
+    process.stdout.write(`${path}\n`);
+    return;
+  }
+
+  if (command === "record") {
+    const key = args[1];
+    const raw = args[2];
+    if (!key || raw === undefined) {
+      die("usage: release-receipt.mjs record <version> <dotted.key> <value> [--json]");
+    }
+    let value = raw;
+    if (rest.includes("--json")) {
+      try {
+        value = JSON.parse(raw);
+      } catch (error) {
+        die(`--json value is not valid JSON: ${error.message}`);
+      }
+    } else if (raw === "true" || raw === "false") {
+      value = raw === "true";
+    }
+    setDottedKey(receipt, key, value);
+    receipt.events.push({ at: utcNow(), event: "record", key, value });
+    writeReceipt(path, receipt);
+    return;
+  }
+
+  if (command === "install") {
+    const entry = {
+      host: flagValue(rest, "--host") ?? defaultHost(),
+      result: flagValue(rest, "--result") ?? "unknown",
+      installed: flagValue(rest, "--installed") ?? "",
+      mode: flagValue(rest, "--mode") ?? "upgrade",
+      at: utcNow(),
+    };
+    receipt.installs.push(entry);
+    receipt.events.push({ at: entry.at, event: "install", key: entry.host });
+    writeReceipt(path, receipt);
+    return;
+  }
+
+  die(`unknown command: ${command}`);
+}
+
+main(process.argv.slice(2));

--- a/scripts/release-receipt.mjs
+++ b/scripts/release-receipt.mjs
@@ -20,6 +20,21 @@ import { join } from "node:path";
 
 const SCHEMA = "cmuxlayer.release-receipt/v1";
 
+// `record` may only reach these top-level sections. The ledger's whole value is
+// that it cannot be corrupted by a stray key: structural fields (installs,
+// events, version, …) are owned by this file, never by a caller's dotted key.
+const RECORDABLE_ROOTS = new Set([
+  "gates",
+  "artifact",
+  "tap",
+  "verify",
+  "commit",
+  "pushed",
+  "previous_version",
+  "notes",
+]);
+const FORBIDDEN_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
 function die(message) {
   process.stderr.write(`release-receipt: ${message}\n`);
   process.exit(2);
@@ -55,6 +70,11 @@ function readReceipt(path) {
   }
 }
 
+// NOTE: read-modify-write with no locking. That is safe for the default
+// per-Mac ledger dir (one writer per file). If CMUXLAYER_RELEASE_RECEIPTS_DIR
+// is ever pointed at shared/synced storage, two Macs verifying at the same
+// moment can drop one another's installs[] entry — add locking before trusting
+// a shared ledger.
 function writeReceipt(path, receipt) {
   mkdirSync(join(path, ".."), { recursive: true });
   receipt.updated_at = utcNow();
@@ -86,6 +106,18 @@ function emptyReceipt(version, env) {
 export function loadOrCreate(version, env = process.env) {
   const path = receiptPath(version, env);
   return { path, receipt: readReceipt(path) ?? emptyReceipt(version, env) };
+}
+
+export function assertRecordableKey(dottedKey) {
+  const parts = dottedKey.split(".");
+  if (parts.some((part) => part === "" || FORBIDDEN_SEGMENTS.has(part))) {
+    die(`refusing unsafe key: ${dottedKey}`);
+  }
+  if (!RECORDABLE_ROOTS.has(parts[0])) {
+    die(
+      `refusing to record '${dottedKey}': only ${[...RECORDABLE_ROOTS].join(", ")} are writable`,
+    );
+  }
 }
 
 export function setDottedKey(target, dottedKey, value) {
@@ -126,7 +158,10 @@ function main(argv) {
   const [command, ...rest] = argv;
   if (!command) die("usage: release-receipt.mjs <init|record|install|path|show> …");
 
-  const args = positionals(rest);
+  // `record` takes its arguments strictly positionally so a value may start
+  // with "--"; every other command is flag-parsed.
+  const recordArgs = rest.filter((arg) => arg !== "--json");
+  const args = command === "record" ? recordArgs : positionals(rest);
   const version = args[0];
   if (!version) die(`${command} needs a version`);
 
@@ -156,11 +191,12 @@ function main(argv) {
   }
 
   if (command === "record") {
-    const key = args[1];
-    const raw = args[2];
+    const key = recordArgs[1];
+    const raw = recordArgs[2];
     if (!key || raw === undefined) {
       die("usage: release-receipt.mjs record <version> <dotted.key> <value> [--json]");
     }
+    assertRecordableKey(key);
     let value = raw;
     if (rest.includes("--json")) {
       try {

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -56,11 +56,13 @@ if [ "$VERIFY_ONLY" -eq 1 ]; then
 else
   git -C "$BREW_TAP_DIR" fetch origin
   git -C "$BREW_TAP_DIR" reset --hard origin/main
-  receipt_record "verify.tap_clone_behind" "0"
+  # measured after the sync, not asserted
+  receipt_record "verify.tap_clone_behind" \
+    "$(git -C "$BREW_TAP_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo unknown)"
   brew upgrade etanhey/layers/cmuxlayer
 fi
 
-INSTALLED="$(brew list --versions cmuxlayer)"
+INSTALLED="$(brew list --versions cmuxlayer || true)"
 if [ "$INSTALLED" = "cmuxlayer $VERSION" ]; then
   receipt_record "verify.result" "pass"
   receipt install "$VERSION" --result pass --installed "$INSTALLED" --mode "$MODE"

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -1,22 +1,72 @@
 #!/usr/bin/env bash
 # Sync the tap clone Homebrew actually reads, upgrade cmuxlayer, and verify it.
+#
+#   release-verify.sh 0.4.44                 # sync tap clone → upgrade → assert version
+#   release-verify.sh 0.4.44 --verify-only   # assert only: no upgrade, no reset --hard
+#   release-verify.sh 0.4.44 --no-upgrade    # alias of --verify-only (failures-ledger 10.5)
+#
+# Every run appends per-Mac install evidence to the release receipt, so a
+# release's fleet-wide state is a file, not four terminals' scrollback.
 set -euo pipefail
 
 die() { echo "release-verify: $*" >&2; exit 1; }
 
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RECEIPT_CLI="$REPO_DIR/scripts/release-receipt.mjs"
+
 VERSION="${1:-}"
-[ -n "$VERSION" ] || die "usage: release-verify.sh <X.Y.Z>"
+VERIFY_ONLY=0
+for arg in "${@:2}"; do
+  case "$arg" in
+    # --no-upgrade is the name failures-ledger row 10.5 asked for; keep both.
+    --verify-only|--no-upgrade) VERIFY_ONLY=1 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$VERSION" ] || die "usage: release-verify.sh <X.Y.Z> [--verify-only|--no-upgrade]"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver X.Y.Z, got '$VERSION'"
 command -v brew >/dev/null 2>&1 || die "brew is not installed"
 
+MODE="upgrade"
+[ "$VERIFY_ONLY" -eq 1 ] && MODE="verify-only"
+
+# Receipt writes never gate verification; they record it.
+receipt() { node "$RECEIPT_CLI" "$@" >/dev/null || echo "release-verify: receipt write failed: $*" >&2; }
+receipt_record() { receipt record "$VERSION" "$1" "$2"; }
+
+receipt init "$VERSION"
+receipt_record "verify.mode" "$MODE"
+
 BREW_TAP_DIR="$(brew --repository)/Library/Taps/etanhey/homebrew-layers"
 [ -d "$BREW_TAP_DIR/.git" ] || die "Homebrew tap clone not found at $BREW_TAP_DIR"
+receipt_record "verify.tap_clone" "$BREW_TAP_DIR"
 
-git -C "$BREW_TAP_DIR" fetch origin
-git -C "$BREW_TAP_DIR" reset --hard origin/main
-brew upgrade etanhey/layers/cmuxlayer
+if [ "$VERIFY_ONLY" -eq 1 ]; then
+  # Verify-only must never mutate this Mac: no reset --hard of brew's clone and
+  # no `brew upgrade` (failures-ledger row 10.5 — a "verification" that upgrades
+  # mid-fleet can break an explicit operator hold). Fetching only moves remote
+  # refs, so the divergence can still be reported as evidence.
+  git -C "$BREW_TAP_DIR" fetch origin
+  BEHIND="$(git -C "$BREW_TAP_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo unknown)"
+  receipt_record "verify.tap_clone_behind" "$BEHIND"
+  if [ "$BEHIND" != "0" ] && [ "$BEHIND" != "unknown" ]; then
+    echo "release-verify: NOTE — brew's tap clone is $BEHIND commit(s) behind origin/main (not synced in verify-only mode)"
+  fi
+else
+  git -C "$BREW_TAP_DIR" fetch origin
+  git -C "$BREW_TAP_DIR" reset --hard origin/main
+  receipt_record "verify.tap_clone_behind" "0"
+  brew upgrade etanhey/layers/cmuxlayer
+fi
 
 INSTALLED="$(brew list --versions cmuxlayer)"
-[ "$INSTALLED" = "cmuxlayer $VERSION" ] || die "expected cmuxlayer $VERSION, got '${INSTALLED:-not installed}'"
-
-echo "release-verify: cmuxlayer $VERSION is installed from the synced tap"
+if [ "$INSTALLED" = "cmuxlayer $VERSION" ]; then
+  receipt_record "verify.result" "pass"
+  receipt install "$VERSION" --result pass --installed "$INSTALLED" --mode "$MODE"
+  echo "release-verify: cmuxlayer $VERSION is installed ($MODE mode); evidence appended to $(node "$RECEIPT_CLI" path "$VERSION")"
+else
+  receipt_record "verify.result" "fail"
+  receipt install "$VERSION" --result fail --installed "${INSTALLED:-not installed}" --mode "$MODE"
+  die "expected cmuxlayer $VERSION, got '${INSTALLED:-not installed}'"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,15 @@ for arg in "${@:2}"; do
   esac
 done
 
+CONTRACT_LOG=""
+TMP=""
+cleanup() {
+  [ -n "$CONTRACT_LOG" ] && rm -f "$CONTRACT_LOG"
+  [ -n "$TMP" ] && rm -f "$TMP"
+  return 0
+}
+trap cleanup EXIT
+
 die() { echo "release: $*" >&2; exit 1; }
 run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
 
@@ -101,21 +110,23 @@ else
   fi
   CONTRACT_STATUS=${PIPESTATUS[0]}
   set -e
-  CONTRACT_LAST="$(awk 'NF { line = $0 } END { print line }' "$CONTRACT_LOG")"
-  rm -f "$CONTRACT_LOG"
 
+  # The verdict is SEARCHED for, never read off the tail: the runner's finally
+  # block prints cleanup warnings AFTER its PASS/SKIP marker, and stdout/stderr
+  # merge through one pipe — so the last line is not the lane's answer.
   CONTRACT_RESULT="fail"
-  CONTRACT_REASON="$CONTRACT_LAST"
+  CONTRACT_REASON="$(awk 'NF { line = $0 } END { print line }' "$CONTRACT_LOG")"
   if [ "$CONTRACT_STATUS" -eq 0 ]; then
-    case "$CONTRACT_LAST" in
-      "[contract] PASS real-cmux contract lane")
-        CONTRACT_RESULT="pass"; CONTRACT_REASON="" ;;
-      "[contract] SKIP: "*)
-        CONTRACT_RESULT="skip"; CONTRACT_REASON="${CONTRACT_LAST#\[contract\] SKIP: }" ;;
-      *)
-        CONTRACT_RESULT="unknown"
-        CONTRACT_REASON="contract lane exited zero without a final PASS or SKIP marker" ;;
-    esac
+    if grep -q '^\[contract\] PASS real-cmux contract lane$' "$CONTRACT_LOG"; then
+      CONTRACT_RESULT="pass"
+      CONTRACT_REASON=""
+    elif grep -q '^\[contract\] SKIP: ' "$CONTRACT_LOG"; then
+      CONTRACT_RESULT="skip"
+      CONTRACT_REASON="$(grep -m1 '^\[contract\] SKIP: ' "$CONTRACT_LOG" | sed -e 's/^\[contract\] SKIP: //')"
+    else
+      CONTRACT_RESULT="unknown"
+      CONTRACT_REASON="contract lane exited zero without a PASS or SKIP marker"
+    fi
   fi
   receipt_record "gates.contract" "$CONTRACT_RESULT"
   if [ -n "$CONTRACT_REASON" ]; then
@@ -124,14 +135,17 @@ else
 
   case "$CONTRACT_RESULT" in
     pass) ;;
-    skip)
+    skip|unknown)
+      # A zero exit is the lane saying it did not fail. Recording that and
+      # warning is what this script has always done; only --require-contract
+      # turns a non-pass into a stop.
       if [ "$REQUIRE_CONTRACT" -eq 1 ]; then
-        die "--require-contract: the real-cmux contract gate skipped ($CONTRACT_REASON)"
+        die "--require-contract: the real-cmux contract gate did not pass ($CONTRACT_RESULT: $CONTRACT_REASON)"
       fi
-      echo "release: WARNING — real-cmux contract gate SKIPPED ($CONTRACT_REASON); recorded in the receipt"
+      echo "release: WARNING — real-cmux contract gate $CONTRACT_RESULT ($CONTRACT_REASON); recorded in the receipt"
       ;;
     *)
-      die "real-cmux contract gate did not pass: $CONTRACT_REASON" ;;
+      die "real-cmux contract gate failed: $CONTRACT_REASON" ;;
   esac
 fi
 
@@ -162,7 +176,6 @@ if [ "$DRY" -eq 1 ]; then
   SHA="<sha256-of-$TAG>"
 else
   TMP="$(mktemp)"
-  trap 'rm -f "$TMP"' EXIT
   # GitHub may take a moment to generate the tag tarball.
   for i in 1 2 3 4 5; do
     if curl -fsSL "$URL" -o "$TMP"; then break; fi
@@ -224,10 +237,16 @@ else
   fi
 fi
 
+if [ "$DRY" -eq 1 ]; then
+  RECEIPT_LABEL="<dry-run: no receipt written>"
+else
+  RECEIPT_LABEL="${RECEIPT_PATH:-<receipt unavailable — is node installed? see warnings above>}"
+fi
+
 cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
-Receipt: ${RECEIPT_PATH:-<dry-run: no receipt written>}
+Receipt: $RECEIPT_LABEL
 Next (on EACH Mac — each run appends its own install evidence to the receipt):
   $REPO_DIR/scripts/release-verify.sh "$VERSION"
   $REPO_DIR/scripts/release-verify.sh "$VERSION" --verify-only   # never upgrades

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,13 +2,19 @@
 #
 # Cut a cmuxlayer release and bump the Homebrew formula, in one go.
 #
-#   scripts/release.sh 0.3.0            # full release (asks once before pushing)
-#   scripts/release.sh 0.3.0 --yes      # no confirmation prompt
-#   scripts/release.sh 0.3.0 --dry-run  # print every step, change nothing
+#   scripts/release.sh 0.3.0                     # full release (asks once before pushing)
+#   scripts/release.sh 0.3.0 --yes               # no confirmation prompt
+#   scripts/release.sh 0.3.0 --dry-run           # print every step, change nothing
+#   scripts/release.sh 0.3.0 --require-contract  # a skipped real-cmux gate aborts the release
 #
 # Steps: clean-tree + green build/tests gate → bump package.json → commit +
 # push main → tag vX.Y.Z + push tag → update formula url+sha256 in the
-# homebrew-layers tap → push tap → tell you to run release verification.
+# homebrew-layers tap → push tap → sync the tap clone Homebrew itself reads →
+# tell you to run release verification.
+#
+# Every step writes into a durable release receipt (see scripts/release-receipt.mjs)
+# so "did this release actually gate, ship, and land?" is answered by a file and
+# not by terminal scrollback.
 #
 # See docs/releases-and-brew.md.
 set -euo pipefail
@@ -17,14 +23,18 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TAP_DIR="${CMUXLAYER_TAP_DIR:-$HOME/Gits/homebrew-layers}"
 FORMULA="$TAP_DIR/Formula/cmuxlayer.rb"
 TARBALL_URL_BASE="https://github.com/EtanHey/cmuxlayer/archive/refs/tags"
+RECEIPT_CLI="$REPO_DIR/scripts/release-receipt.mjs"
+BREW_TAP_CLONE_SUFFIX="Library/Taps/etanhey/homebrew-layers"
 
 VERSION="${1:-}"
 YES=0
 DRY=0
+REQUIRE_CONTRACT=0
 for arg in "${@:2}"; do
   case "$arg" in
     --yes) YES=1 ;;
     --dry-run) DRY=1 ;;
+    --require-contract) REQUIRE_CONTRACT=1 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -32,7 +42,18 @@ done
 die() { echo "release: $*" >&2; exit 1; }
 run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
 
-[ -n "$VERSION" ] || die "usage: release.sh <X.Y.Z> [--yes] [--dry-run]"
+# Receipt writes are never allowed to fail a release: the ledger records the
+# release, it does not gate it.
+receipt() {
+  if [ "$DRY" -eq 1 ]; then
+    printf 'DRY  receipt %s\n' "$*"
+    return 0
+  fi
+  node "$RECEIPT_CLI" "$@" >/dev/null || echo "release: receipt write failed: $*" >&2
+}
+receipt_record() { receipt record "$VERSION" "$1" "$2"; }
+
+[ -n "$VERSION" ] || die "usage: release.sh <X.Y.Z> [--yes] [--dry-run] [--require-contract]"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver X.Y.Z, got '$VERSION'"
 [ -f "$FORMULA" ] || die "formula not found at $FORMULA (set CMUXLAYER_TAP_DIR)"
 
@@ -48,14 +69,75 @@ if [ "$DRY" -ne 1 ]; then
   git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists"
 fi
 
+# --- open the receipt ------------------------------------------------------
+RECEIPT_PATH=""
+if [ "$DRY" -ne 1 ]; then
+  receipt init "$VERSION"
+  RECEIPT_PATH="$(node "$RECEIPT_CLI" path "$VERSION" 2>/dev/null || true)"
+  receipt_record "gates.require_contract" "$([ "$REQUIRE_CONTRACT" -eq 1 ] && echo true || echo false)"
+fi
+
 echo "release: gating on typecheck + tests…"
 run "bun run typecheck"
+receipt_record "gates.typecheck" "pass"
 run "env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test"
-echo "release: gating on real-cmux contracts (warn-only skip when no live CMUX_SOCKET_PATH is reachable)…"
-run "bun run test:contract"
+receipt_record "gates.tests" "pass"
+
+# --- real-cmux contract gate (#370) ---------------------------------------
+# The lane skips itself when no live non-production cmux socket is reachable.
+# A skip used to vanish into scrollback — three releases shipped without the
+# gate ever running. It is now classified and written to the receipt, and
+# --require-contract turns a skip into a hard stop.
+echo "release: gating on real-cmux contracts (skip is recorded; --require-contract makes it fatal)…"
+if [ "$DRY" -eq 1 ]; then
+  printf 'DRY  %s\n' "bun run test:contract"
+else
+  CONTRACT_LOG="$(mktemp)"
+  set +e
+  if [ "$REQUIRE_CONTRACT" -eq 1 ]; then
+    CMUX_CONTRACT_REQUIRE_LIVE=1 bun run test:contract 2>&1 | tee "$CONTRACT_LOG"
+  else
+    bun run test:contract 2>&1 | tee "$CONTRACT_LOG"
+  fi
+  CONTRACT_STATUS=${PIPESTATUS[0]}
+  set -e
+  CONTRACT_LAST="$(awk 'NF { line = $0 } END { print line }' "$CONTRACT_LOG")"
+  rm -f "$CONTRACT_LOG"
+
+  CONTRACT_RESULT="fail"
+  CONTRACT_REASON="$CONTRACT_LAST"
+  if [ "$CONTRACT_STATUS" -eq 0 ]; then
+    case "$CONTRACT_LAST" in
+      "[contract] PASS real-cmux contract lane")
+        CONTRACT_RESULT="pass"; CONTRACT_REASON="" ;;
+      "[contract] SKIP: "*)
+        CONTRACT_RESULT="skip"; CONTRACT_REASON="${CONTRACT_LAST#\[contract\] SKIP: }" ;;
+      *)
+        CONTRACT_RESULT="unknown"
+        CONTRACT_REASON="contract lane exited zero without a final PASS or SKIP marker" ;;
+    esac
+  fi
+  receipt_record "gates.contract" "$CONTRACT_RESULT"
+  if [ -n "$CONTRACT_REASON" ]; then
+    receipt_record "gates.contract_reason" "$CONTRACT_REASON"
+  fi
+
+  case "$CONTRACT_RESULT" in
+    pass) ;;
+    skip)
+      if [ "$REQUIRE_CONTRACT" -eq 1 ]; then
+        die "--require-contract: the real-cmux contract gate skipped ($CONTRACT_REASON)"
+      fi
+      echo "release: WARNING — real-cmux contract gate SKIPPED ($CONTRACT_REASON); recorded in the receipt"
+      ;;
+    *)
+      die "real-cmux contract gate did not pass: $CONTRACT_REASON" ;;
+  esac
+fi
 
 CURRENT="$(grep -E '^  "version":' package.json | head -1 | sed -E 's/.*"version": "([^"]+)".*/\1/')"
 echo "release: $CURRENT → $VERSION"
+receipt_record "previous_version" "$CURRENT"
 
 if [ "$YES" -ne 1 ] && [ "$DRY" -ne 1 ]; then
   read -r -p "Release $TAG and push to cmuxlayer + homebrew-layers? [y/N] " ans
@@ -68,6 +150,10 @@ run "git commit -aqm 'chore: release $TAG'"
 run "git push origin main"
 run "git tag -a '$TAG' -m 'cmuxlayer $TAG'"
 run "git push origin '$TAG'"
+if [ "$DRY" -ne 1 ]; then
+  receipt_record "commit" "$(git rev-parse HEAD)"
+  receipt_record "pushed" "true"
+fi
 
 # --- compute tarball sha256 -----------------------------------------------
 URL="$TARBALL_URL_BASE/$TAG.tar.gz"
@@ -86,6 +172,8 @@ else
   [ -n "$SHA" ] || die "could not compute sha256 for $URL"
 fi
 echo "release: $TAG sha256 = $SHA"
+receipt_record "artifact.url" "$URL"
+receipt_record "artifact.sha256" "$SHA"
 
 # --- bump formula (homebrew-layers) ---------------------------------------
 run "sed -i '' -E 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
@@ -93,12 +181,56 @@ run "sed -i '' -E 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
 run "brew audit etanhey/layers/cmuxlayer || true"
 run "git -C '$TAP_DIR' commit -aqm 'cmuxlayer $TAG'"
 run "git -C '$TAP_DIR' push origin main"
+receipt_record "tap.source_dir" "$TAP_DIR"
+receipt_record "tap.pushed" "true"
+
+# --- sync the tap clone Homebrew actually reads (#371, ledger row 16) ------
+# Pushing ~/Gits/homebrew-layers is not the end of the release: brew reads its
+# OWN clone under $(brew --repository), whose main often has no upstream
+# tracking, so `brew update` can report "already up-to-date" while sitting
+# commits behind. Syncing it here is additive — a failure is recorded, never
+# fatal, because the release itself is already pushed by this point.
+if [ "$DRY" -eq 1 ]; then
+  printf 'DRY  %s\n' "sync brew tap clone under \$(brew --repository)/$BREW_TAP_CLONE_SUFFIX"
+else
+  BREW_TAP_CLONE=""
+  if command -v brew >/dev/null 2>&1; then
+    BREW_TAP_CLONE="$(brew --repository)/$BREW_TAP_CLONE_SUFFIX"
+  fi
+  if [ -z "$BREW_TAP_CLONE" ]; then
+    receipt_record "tap.clone_sync" "skipped"
+    receipt_record "tap.clone_reason" "brew is not installed on this Mac"
+    echo "release: brew not installed — skipping tap-clone sync (recorded)"
+  elif [ ! -d "$BREW_TAP_CLONE/.git" ]; then
+    receipt_record "tap.clone_path" "$BREW_TAP_CLONE"
+    receipt_record "tap.clone_sync" "skipped"
+    receipt_record "tap.clone_reason" "no Homebrew tap clone at $BREW_TAP_CLONE (brew tap etanhey/layers)"
+    echo "release: no brew tap clone at $BREW_TAP_CLONE — skipping sync (recorded)"
+  else
+    receipt_record "tap.clone_path" "$BREW_TAP_CLONE"
+    CLONE_BEFORE="$(git -C "$BREW_TAP_CLONE" rev-parse HEAD 2>/dev/null || echo unknown)"
+    receipt_record "tap.clone_before" "$CLONE_BEFORE"
+    if git -C "$BREW_TAP_CLONE" fetch origin && \
+       git -C "$BREW_TAP_CLONE" reset --hard origin/main >/dev/null; then
+      CLONE_AFTER="$(git -C "$BREW_TAP_CLONE" rev-parse HEAD 2>/dev/null || echo unknown)"
+      receipt_record "tap.clone_after" "$CLONE_AFTER"
+      receipt_record "tap.clone_sync" "synced"
+      echo "release: brew tap clone synced $CLONE_BEFORE → $CLONE_AFTER"
+    else
+      receipt_record "tap.clone_sync" "failed"
+      receipt_record "tap.clone_reason" "fetch/reset failed in $BREW_TAP_CLONE"
+      echo "release: WARNING — could not sync $BREW_TAP_CLONE; run release-verify.sh to sync it"
+    fi
+  fi
+fi
 
 cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
-Next:
+Receipt: ${RECEIPT_PATH:-<dry-run: no receipt written>}
+Next (on EACH Mac — each run appends its own install evidence to the receipt):
   $REPO_DIR/scripts/release-verify.sh "$VERSION"
+  $REPO_DIR/scripts/release-verify.sh "$VERSION" --verify-only   # never upgrades
 
 # Outbox-semantics releases only (see docs/releases-and-brew.md "Pre-deploy hygiene"):
 #   if this release changes outbox dedup-id derivation or the delivery gate,

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -887,6 +887,24 @@ async function addPidReceiptToSet(
   }
 }
 
+/**
+ * #370: three releases shipped while this lane silently skipped itself. When
+ * CMUX_CONTRACT_REQUIRE_LIVE=1 the lane is a hard gate — a skip becomes a
+ * failure instead of a zero exit nobody reads.
+ */
+export function requiresLiveContract(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CMUX_CONTRACT_REQUIRE_LIVE === "1";
+}
+
+function reportSkip(reason: string): void {
+  if (requiresLiveContract()) {
+    throw new Error(
+      `CMUX_CONTRACT_REQUIRE_LIVE=1 demands a live contract run, but the lane skipped: ${reason}`,
+    );
+  }
+  console.warn(`[contract] SKIP: ${reason}`);
+}
+
 async function runContractSteps(
   setActiveStep: (step: string) => void,
 ): Promise<void> {
@@ -896,7 +914,7 @@ async function runContractSteps(
   if (requestedPin) {
     const productionGuard = await classifyProductionPin(requestedPin);
     if (productionGuard.kind === "skip") {
-      console.warn(`[contract] SKIP: ${productionGuard.reason}`);
+      reportSkip(productionGuard.reason);
       return;
     }
   }
@@ -905,7 +923,7 @@ async function runContractSteps(
     : null;
   const classification = classifyLivePin(requestedSocket, preflight);
   if (classification.kind === "skip") {
-    console.warn(`[contract] SKIP: ${classification.reason}`);
+    reportSkip(classification.reason);
     return;
   }
   assertPingShape(preflight?.result);

--- a/tests/pre-pr-scripts.test.ts
+++ b/tests/pre-pr-scripts.test.ts
@@ -49,10 +49,13 @@ describe("pre-PR script ladder", () => {
     const hermeticGate = release.indexOf(
       'run "env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test"',
     );
-    const contractGate = release.indexOf('run "bun run test:contract"');
+    const contractGate = release.indexOf('bun run test:contract 2>&1 | tee');
 
     expect(hermeticGate).toBeGreaterThan(-1);
     expect(contractGate).toBeGreaterThan(hermeticGate);
+    // The lane's outcome is classified into the receipt instead of scrolling by (#370).
+    expect(release).toContain('receipt_record "gates.contract"');
+    expect(release).toContain("--require-contract");
   });
 
   it("removes ambient cmux socket pins from the pre-push regression gate", () => {

--- a/tests/real-cmux-contract-runner.test.ts
+++ b/tests/real-cmux-contract-runner.test.ts
@@ -71,6 +71,33 @@ describe("real cmux contract runner helpers", () => {
     );
   });
 
+  it("turns a skip into a hard failure under CMUX_CONTRACT_REQUIRE_LIVE=1 (#370)", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        join(process.cwd(), "scripts", "run-real-cmux-contract.ts"),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          CMUX_SOCKET_PATH: "",
+          CMUX_CONTRACT_REQUIRE_LIVE: "1",
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("[contract] FAIL:");
+    expect(output).toContain("CMUX_CONTRACT_REQUIRE_LIVE=1");
+    expect(output).not.toContain("[contract] SKIP:");
+  });
+
   it("accepts only the live system.ping response shape", () => {
     expect(() => assertPingShape({ pong: true })).not.toThrow();
     expect(() => assertPingShape({ pong: false })).toThrow(/pong: true/);

--- a/tests/release-receipts.test.ts
+++ b/tests/release-receipts.test.ts
@@ -69,10 +69,11 @@ type Fixture = {
  */
 function makeReleaseFixture(
   opts: {
-    installedVersion?: string;
+    installedVersion?: string | null;
     contractOutput?: string;
     withBrew?: boolean;
     withBrewTapClone?: boolean;
+    withNode?: boolean;
   } = {},
 ): Fixture {
   const {
@@ -80,6 +81,7 @@ function makeReleaseFixture(
     contractOutput = "[contract] PASS real-cmux contract lane",
     withBrew = true,
     withBrewTapClone = true,
+    withNode = true,
   } = opts;
 
   const root = makeRoot("cmuxlayer-release-receipts-");
@@ -146,7 +148,7 @@ case "\${args[0]:-}" in
       v*) exit 1 ;;
       *) echo "1111111111111111111111111111111111111111" ;;
     esac ;;
-  rev-list) echo 0 ;;
+  rev-list) echo "\${STUB_BEHIND:-0}" ;;
   *) exit 0 ;;
 esac
 `,
@@ -158,6 +160,7 @@ esac
 printf 'bun %s\\n' "$*" >>"$STUB_LOG"
 if [ "\${2:-}" = "test:contract" ]; then
   printf '%s\\n' "$STUB_CONTRACT_OUTPUT"
+  exit "\${STUB_CONTRACT_EXIT:-0}"
 fi
 exit 0
 `,
@@ -194,10 +197,24 @@ exit 0
 printf 'brew %s\\n' "$*" >>"$STUB_LOG"
 case "\${1:-}" in
   --repository) printf '%s\\n' "$STUB_BREW_REPO" ;;
-  list) printf 'cmuxlayer %s\\n' "$STUB_INSTALLED_VERSION" ;;
+  list)
+    # real brew exits 1 when the formula is not installed
+    [ -z "$STUB_INSTALLED_VERSION" ] && exit 1
+    printf 'cmuxlayer %s\\n' "$STUB_INSTALLED_VERSION" ;;
   *) : ;;
 esac
 exit 0
+`,
+    );
+  }
+
+  if (!withNode) {
+    writeExecutable(
+      join(binDir, "node"),
+      `#!/usr/bin/env bash
+printf 'node %s\\n' "$*" >>"$STUB_LOG"
+echo "bash: node: command not found" >&2
+exit 127
 `,
     );
   }
@@ -208,7 +225,7 @@ exit 0
     HOME: root,
     STUB_LOG: stubLog,
     STUB_BREW_REPO: brewRepo,
-    STUB_INSTALLED_VERSION: installedVersion,
+    STUB_INSTALLED_VERSION: installedVersion ?? "",
     STUB_CONTRACT_OUTPUT: contractOutput,
     CMUXLAYER_TAP_DIR: tapDir,
     CMUXLAYER_RELEASE_RECEIPTS_DIR: receiptsDir,
@@ -449,6 +466,82 @@ describe("release.sh receipts", () => {
     expect(receipt.gates.contract_reason).toContain("CMUX_SOCKET_PATH");
   });
 
+  it("classifies a PASS that is followed by cleanup output on stderr", () => {
+    // The runner's finally block prints "[contract] cleanup warning …" AFTER
+    // its PASS marker, so the lane's verdict is never reliably the last line.
+    const fixture = makeReleaseFixture({
+      contractOutput: [
+        "[contract] PASS real-cmux contract lane",
+        "[contract] cleanup warning for pid 4242: kill ESRCH",
+      ].join("\n"),
+    });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(readReceipt(fixture, "0.4.1").gates.contract).toBe("pass");
+    expect(result.log).toContain("git push origin main");
+  });
+
+  it("classifies a SKIP that is followed by cleanup output", () => {
+    const fixture = makeReleaseFixture({
+      contractOutput: [
+        "[contract] SKIP: refusing production cmux socket /x.sock",
+        "[contract] cleanup warning reading daemon pid receipt: EACCES",
+      ].join("\n"),
+    });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.gates.contract).toBe("skip");
+    expect(receipt.gates.contract_reason).toContain("production cmux socket");
+  });
+
+  it("warns and records — never aborts — on an unrecognised zero-exit lane", () => {
+    const fixture = makeReleaseFixture({
+      contractOutput: "some unrecognised runner chatter",
+    });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("WARNING");
+    expect(readReceipt(fixture, "0.4.1").gates.contract).toBe("unknown");
+    expect(result.log).toContain("git push origin main");
+  });
+
+  it("still aborts when the contract lane exits non-zero", () => {
+    const fixture = makeReleaseFixture({
+      contractOutput: "[contract] FAIL: doctor --json unhealthy",
+    });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"], {
+      STUB_CONTRACT_EXIT: "1",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.log).not.toContain("git push origin main");
+  });
+
+  it("refuses an unrecognised lane under --require-contract", () => {
+    const fixture = makeReleaseFixture({ contractOutput: "chatter only" });
+    const result = runScript(fixture, "release.sh", [
+      "0.4.1",
+      "--yes",
+      "--require-contract",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.log).not.toContain("git push origin main");
+  });
+
+  it("never claims a dry-run in the banner when the receipt could not be written", () => {
+    const fixture = makeReleaseFixture({ withNode: false });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain("dry-run");
+    expect(result.stdout).toContain("receipt unavailable");
+  });
+
   it("refuses to release on a skipped contract gate under --require-contract", () => {
     const fixture = makeReleaseFixture({
       contractOutput: "[contract] SKIP: no live cmux socket",
@@ -573,6 +666,68 @@ describe("release-verify.sh", () => {
       installed: "cmuxlayer 0.4.0",
     });
   });
+
+  it("records evidence when cmuxlayer is not installed on this Mac at all", () => {
+    const fixture = makeReleaseFixture({ installedVersion: null });
+    const result = runScript(fixture, "release-verify.sh", [
+      "0.4.1",
+      "--verify-only",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.verify.result).toBe("fail");
+    expect(receipt.installs[0]).toMatchObject({
+      result: "fail",
+      installed: "not installed",
+    });
+  });
+
+  it("measures how far brew's clone was behind instead of asserting zero", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
+    const result = runScript(fixture, "release-verify.sh", ["0.4.1"], {
+      STUB_BEHIND: "3",
+    });
+
+    expect(result.status).toBe(0);
+    // measured after the reset, so the stub's post-sync answer wins
+    expect(readReceipt(fixture, "0.4.1").verify.tap_clone_behind).toBe("3");
+  });
+});
+
+describe("release receipt ledger hardening", () => {
+  it("refuses prototype-polluting and structural keys", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const env = { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir };
+    runReceipt(["init", "0.9.1"], env);
+
+    for (const key of ["__proto__.polluted", "installs", "events", "version"]) {
+      const result = runReceipt(["record", "0.9.1", key, "x"], env);
+      expect(result.status, `expected ${key} to be refused`).not.toBe(0);
+    }
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(Array.isArray(receipt.installs)).toBe(true);
+    expect(receipt.version).toBe("0.9.1");
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it("keeps a recorded value that starts with dashes", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const env = { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir };
+    runReceipt(["init", "0.9.1"], env);
+    runReceipt(
+      ["record", "0.9.1", "gates.contract_reason", "--require-contract said no"],
+      env,
+    );
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(receipt.gates.contract_reason).toBe("--require-contract said no");
+  });
 });
 
 describe("docs/releases-and-brew.md tracks the shipped release path", () => {
@@ -588,6 +743,12 @@ describe("docs/releases-and-brew.md tracks the shipped release path", () => {
   it("documents verify-only and the release-side tap-clone sync", () => {
     expect(doc()).toContain("--verify-only");
     expect(doc()).toContain("Library/Taps/etanhey/homebrew-layers");
+  });
+
+  it("tells the truth about the per-Mac ledger and how to aggregate it", () => {
+    expect(doc()).toContain("per-Mac");
+    expect(doc()).not.toContain("so the fleet-wide picture is one file");
+    expect(doc()).toContain("shared");
   });
 
   it("documents the contract gate's require mode", () => {

--- a/tests/release-receipts.test.ts
+++ b/tests/release-receipts.test.ts
@@ -1,0 +1,597 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(__dirname, "..");
+const receiptCli = join(repoRoot, "scripts", "release-receipt.mjs");
+
+const tmpRoots: string[] = [];
+
+afterEach(() => {
+  while (tmpRoots.length > 0) {
+    const root = tmpRoots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tmpRoots.push(root);
+  return root;
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+function runReceipt(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [receiptCli, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+type Fixture = {
+  root: string;
+  repoDir: string;
+  tapDir: string;
+  brewRepo: string;
+  brewTapClone: string;
+  receiptsDir: string;
+  stubLog: string;
+  env: NodeJS.ProcessEnv;
+};
+
+/**
+ * Builds a sandbox with stubbed `git`/`brew`/`bun`/`curl`/`shasum` so the real
+ * release scripts can be executed end-to-end without touching the network, the
+ * live tap, or Homebrew.
+ */
+function makeReleaseFixture(
+  opts: {
+    installedVersion?: string;
+    contractOutput?: string;
+    withBrew?: boolean;
+    withBrewTapClone?: boolean;
+  } = {},
+): Fixture {
+  const {
+    installedVersion = "0.4.1",
+    contractOutput = "[contract] PASS real-cmux contract lane",
+    withBrew = true,
+    withBrewTapClone = true,
+  } = opts;
+
+  const root = makeRoot("cmuxlayer-release-receipts-");
+  const repoDir = join(root, "repo");
+  const scriptsDir = join(repoDir, "scripts");
+  const binDir = join(root, "bin");
+  const tapDir = join(root, "tap");
+  const brewRepo = join(root, "brew-repo");
+  const brewTapClone = join(
+    brewRepo,
+    "Library",
+    "Taps",
+    "etanhey",
+    "homebrew-layers",
+  );
+  const receiptsDir = join(root, "receipts");
+  const stubLog = join(root, "stub.log");
+
+  mkdirSync(scriptsDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(tapDir, "Formula"), { recursive: true });
+  if (withBrewTapClone)
+    mkdirSync(join(brewTapClone, ".git"), { recursive: true });
+
+  for (const script of [
+    "release.sh",
+    "release-verify.sh",
+    "release-receipt.mjs",
+  ]) {
+    const source = join(repoRoot, "scripts", script);
+    if (existsSync(source)) {
+      copyFileSync(source, join(scriptsDir, script));
+      chmodSync(join(scriptsDir, script), 0o755);
+    }
+  }
+
+  writeFileSync(
+    join(repoDir, "package.json"),
+    `{\n  "version": "0.4.0",\n  "name": "cmuxlayer"\n}\n`,
+  );
+  writeFileSync(
+    join(tapDir, "Formula", "cmuxlayer.rb"),
+    [
+      "class Cmuxlayer < Formula",
+      '  url "https://github.com/EtanHey/cmuxlayer/archive/refs/tags/v0.4.0.tar.gz"',
+      `  sha256 "${"0".repeat(64)}"`,
+      "end",
+      "",
+    ].join("\n"),
+  );
+
+  writeExecutable(
+    join(binDir, "git"),
+    `#!/usr/bin/env bash
+printf 'git %s\\n' "$*" >>"$STUB_LOG"
+args=("$@")
+if [ "\${args[0]:-}" = "-C" ]; then args=("\${args[@]:2}"); fi
+case "\${args[0]:-}" in
+  branch) echo main ;;
+  diff) exit 0 ;;
+  fetch) exit 0 ;;
+  rev-parse)
+    case "\${args[1]:-}" in
+      v*) exit 1 ;;
+      *) echo "1111111111111111111111111111111111111111" ;;
+    esac ;;
+  rev-list) echo 0 ;;
+  *) exit 0 ;;
+esac
+`,
+  );
+
+  writeExecutable(
+    join(binDir, "bun"),
+    `#!/usr/bin/env bash
+printf 'bun %s\\n' "$*" >>"$STUB_LOG"
+if [ "\${2:-}" = "test:contract" ]; then
+  printf '%s\\n' "$STUB_CONTRACT_OUTPUT"
+fi
+exit 0
+`,
+  );
+
+  writeExecutable(
+    join(binDir, "curl"),
+    `#!/usr/bin/env bash
+printf 'curl %s\\n' "$*" >>"$STUB_LOG"
+out=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out="$a"; fi
+  prev="$a"
+done
+[ -n "$out" ] && printf 'tarball\\n' >"$out"
+exit 0
+`,
+  );
+
+  writeExecutable(
+    join(binDir, "shasum"),
+    `#!/usr/bin/env bash
+printf 'shasum %s\\n' "$*" >>"$STUB_LOG"
+printf '%s  -\\n' "${"a".repeat(64)}"
+exit 0
+`,
+  );
+
+  if (withBrew) {
+    writeExecutable(
+      join(binDir, "brew"),
+      `#!/usr/bin/env bash
+printf 'brew %s\\n' "$*" >>"$STUB_LOG"
+case "\${1:-}" in
+  --repository) printf '%s\\n' "$STUB_BREW_REPO" ;;
+  list) printf 'cmuxlayer %s\\n' "$STUB_INSTALLED_VERSION" ;;
+  *) : ;;
+esac
+exit 0
+`,
+    );
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    HOME: root,
+    STUB_LOG: stubLog,
+    STUB_BREW_REPO: brewRepo,
+    STUB_INSTALLED_VERSION: installedVersion,
+    STUB_CONTRACT_OUTPUT: contractOutput,
+    CMUXLAYER_TAP_DIR: tapDir,
+    CMUXLAYER_RELEASE_RECEIPTS_DIR: receiptsDir,
+    CMUXLAYER_RECEIPT_HOST: "test-mac",
+  };
+
+  return {
+    root,
+    repoDir,
+    tapDir,
+    brewRepo,
+    brewTapClone,
+    receiptsDir,
+    stubLog,
+    env,
+  };
+}
+
+function runScript(
+  fixture: Fixture,
+  script: string,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+) {
+  const result = spawnSync(
+    "bash",
+    [join(fixture.repoDir, "scripts", script), ...args],
+    {
+      cwd: fixture.repoDir,
+      encoding: "utf8",
+      env: { ...fixture.env, ...extraEnv },
+    },
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    log: existsSync(fixture.stubLog)
+      ? readFileSync(fixture.stubLog, "utf8")
+      : "",
+  };
+}
+
+function readReceipt(fixture: Fixture, version: string): any {
+  const path = join(fixture.receiptsDir, `release-${version}.json`);
+  expect(existsSync(path), `expected receipt at ${path}`).toBe(true);
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("release receipt ledger CLI", () => {
+  it("initialises a receipt carrying version, tag, commit and timestamp", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const init = runReceipt(
+      ["init", "0.9.1", "--commit", "abc1234", "--host", "test-mac"],
+      { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir },
+    );
+
+    expect(init.stderr).toBe("");
+    expect(init.status).toBe(0);
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(receipt.version).toBe("0.9.1");
+    expect(receipt.tag).toBe("v0.9.1");
+    expect(receipt.commit).toBe("abc1234");
+    expect(receipt.host).toBe("test-mac");
+    expect(receipt.created_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    );
+    expect(receipt.installs).toEqual([]);
+  });
+
+  it("records nested keys and keeps an append-only event trail", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const env = { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir };
+    runReceipt(["init", "0.9.1"], env);
+    runReceipt(["record", "0.9.1", "gates.contract", "pass"], env);
+    runReceipt(["record", "0.9.1", "artifact.sha256", "deadbeef"], env);
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(receipt.gates.contract).toBe("pass");
+    expect(receipt.artifact.sha256).toBe("deadbeef");
+    expect(
+      receipt.events
+        .filter((e: any) => e.event === "record")
+        .map((e: any) => e.key),
+    ).toEqual([
+      "gates.contract",
+      "artifact.sha256",
+    ]);
+  });
+
+  it("appends per-Mac install evidence without dropping other Macs", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const env = { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir };
+    runReceipt(["init", "0.9.1"], env);
+    runReceipt(
+      [
+        "install",
+        "0.9.1",
+        "--host",
+        "m1",
+        "--result",
+        "pass",
+        "--installed",
+        "cmuxlayer 0.9.1",
+        "--mode",
+        "upgrade",
+      ],
+      env,
+    );
+    runReceipt(
+      [
+        "install",
+        "0.9.1",
+        "--host",
+        "m4",
+        "--result",
+        "fail",
+        "--installed",
+        "cmuxlayer 0.9.0",
+        "--mode",
+        "verify-only",
+      ],
+      env,
+    );
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(receipt.installs).toHaveLength(2);
+    expect(receipt.installs[0]).toMatchObject({
+      host: "m1",
+      result: "pass",
+      mode: "upgrade",
+    });
+    expect(receipt.installs[1]).toMatchObject({
+      host: "m4",
+      result: "fail",
+      mode: "verify-only",
+    });
+    expect(receipt.installs[1].at).toMatch(/Z$/);
+  });
+
+  it("re-initialising an existing receipt preserves prior install evidence", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const env = { CMUXLAYER_RELEASE_RECEIPTS_DIR: dir };
+    runReceipt(["init", "0.9.1"], env);
+    runReceipt(
+      [
+        "install",
+        "0.9.1",
+        "--host",
+        "m1",
+        "--result",
+        "pass",
+        "--installed",
+        "cmuxlayer 0.9.1",
+      ],
+      env,
+    );
+    runReceipt(["init", "0.9.1"], env);
+
+    const receipt = JSON.parse(
+      readFileSync(join(dir, "release-0.9.1.json"), "utf8"),
+    );
+    expect(receipt.installs).toHaveLength(1);
+  });
+
+  it("prints the receipt path so shell callers never guess it", () => {
+    const dir = makeRoot("cmuxlayer-receipt-cli-");
+    const result = runReceipt(["path", "0.9.1"], {
+      CMUXLAYER_RELEASE_RECEIPTS_DIR: dir,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(join(dir, "release-0.9.1.json"));
+  });
+});
+
+describe("release.sh receipts", () => {
+  it("writes a release receipt with version, sha256, commit and gate results", () => {
+    const fixture = makeReleaseFixture();
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.stderr).not.toMatch(/release: /);
+    expect(result.status).toBe(0);
+
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.version).toBe("0.4.1");
+    expect(receipt.tag).toBe("v0.4.1");
+    expect(receipt.commit).toBe("1".repeat(40));
+    expect(receipt.created_at).toMatch(/Z$/);
+    expect(receipt.artifact.sha256).toBe("a".repeat(64));
+    expect(receipt.artifact.url).toContain("v0.4.1.tar.gz");
+    expect(receipt.gates.typecheck).toBe("pass");
+    expect(receipt.gates.tests).toBe("pass");
+    expect(receipt.gates.contract).toBe("pass");
+    expect(result.stdout).toContain(
+      join(fixture.receiptsDir, "release-0.4.1.json"),
+    );
+  });
+
+  it("preserves the happy-path release commands (receipts stay additive)", () => {
+    const fixture = makeReleaseFixture();
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(result.log).toContain("git commit -aqm chore: release v0.4.1");
+    expect(result.log).toContain("git push origin main");
+    expect(result.log).toContain("git tag -a v0.4.1 -m cmuxlayer v0.4.1");
+    expect(result.log).toContain("git push origin v0.4.1");
+    expect(result.log).toContain("brew audit etanhey/layers/cmuxlayer");
+    expect(
+      readFileSync(join(fixture.repoDir, "package.json"), "utf8"),
+    ).toContain('"version": "0.4.1"');
+    const formula = readFileSync(
+      join(fixture.tapDir, "Formula", "cmuxlayer.rb"),
+      "utf8",
+    );
+    expect(formula).toContain("v0.4.1.tar.gz");
+    expect(formula).toContain(`sha256 "${"a".repeat(64)}"`);
+  });
+
+  it("records a skipped contract gate instead of losing it to scrollback", () => {
+    const fixture = makeReleaseFixture({
+      contractOutput:
+        "[contract] SKIP: CMUX_SOCKET_PATH is not set to a live cmux socket",
+    });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.gates.contract).toBe("skip");
+    expect(receipt.gates.contract_reason).toContain("CMUX_SOCKET_PATH");
+  });
+
+  it("refuses to release on a skipped contract gate under --require-contract", () => {
+    const fixture = makeReleaseFixture({
+      contractOutput: "[contract] SKIP: no live cmux socket",
+    });
+    const result = runScript(fixture, "release.sh", [
+      "0.4.1",
+      "--yes",
+      "--require-contract",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("contract");
+    expect(result.log).not.toContain("git push origin main");
+  });
+
+  it("syncs the tap clone Homebrew actually reads and records the receipt", () => {
+    const fixture = makeReleaseFixture();
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(result.log).toContain(`git -C ${fixture.brewTapClone} fetch origin`);
+    expect(result.log).toContain(
+      `git -C ${fixture.brewTapClone} reset --hard origin/main`,
+    );
+
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.tap.clone_path).toBe(fixture.brewTapClone);
+    expect(receipt.tap.clone_sync).toBe("synced");
+    expect(receipt.tap.clone_after).toBe("1".repeat(40));
+    expect(receipt.tap.pushed).toBe(true);
+  });
+
+  it("records a skipped tap-clone sync when Homebrew's clone is absent", () => {
+    const fixture = makeReleaseFixture({ withBrewTapClone: false });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.tap.clone_sync).toBe("skipped");
+    expect(receipt.tap.clone_reason).toBeTruthy();
+  });
+
+  it("writes no receipt in --dry-run", () => {
+    const fixture = makeReleaseFixture();
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--dry-run"]);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(fixture.receiptsDir, "release-0.4.1.json"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("release-verify.sh", () => {
+  it("verify-only never upgrades and never resets Homebrew's tap clone", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
+    const result = runScript(fixture, "release-verify.sh", [
+      "0.4.1",
+      "--verify-only",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.log).not.toContain("brew upgrade");
+    expect(result.log).not.toContain("reset --hard");
+    expect(result.log).toContain("brew list --versions cmuxlayer");
+  });
+
+  it("accepts --no-upgrade as the ledger-10.5 alias for verify-only", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
+    const result = runScript(fixture, "release-verify.sh", [
+      "0.4.1",
+      "--no-upgrade",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.log).not.toContain("brew upgrade");
+  });
+
+  it("records per-Mac install evidence into the release receipt", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
+    const result = runScript(fixture, "release-verify.sh", [
+      "0.4.1",
+      "--verify-only",
+    ]);
+
+    expect(result.status).toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.verify.result).toBe("pass");
+    expect(receipt.verify.mode).toBe("verify-only");
+    expect(receipt.installs).toHaveLength(1);
+    expect(receipt.installs[0]).toMatchObject({
+      host: "test-mac",
+      result: "pass",
+      installed: "cmuxlayer 0.4.1",
+      mode: "verify-only",
+    });
+  });
+
+  it("still upgrades in the default mode", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
+    const result = runScript(fixture, "release-verify.sh", ["0.4.1"]);
+
+    expect(result.status).toBe(0);
+    expect(result.log).toContain("brew upgrade etanhey/layers/cmuxlayer");
+    expect(result.log).toContain("reset --hard origin/main");
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.installs[0].mode).toBe("upgrade");
+  });
+
+  it("records failing install evidence when the wrong version is installed", () => {
+    const fixture = makeReleaseFixture({ installedVersion: "0.4.0" });
+    const result = runScript(fixture, "release-verify.sh", [
+      "0.4.1",
+      "--verify-only",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.verify.result).toBe("fail");
+    expect(receipt.installs[0]).toMatchObject({
+      result: "fail",
+      installed: "cmuxlayer 0.4.0",
+    });
+  });
+});
+
+describe("docs/releases-and-brew.md tracks the shipped release path", () => {
+  const doc = () =>
+    readFileSync(join(repoRoot, "docs", "releases-and-brew.md"), "utf8");
+
+  it("documents the receipts ledger and where it lands", () => {
+    expect(doc()).toContain("release receipt");
+    expect(doc()).toContain("CMUXLAYER_RELEASE_RECEIPTS_DIR");
+    expect(doc()).toContain("scripts/release-receipt.mjs");
+  });
+
+  it("documents verify-only and the release-side tap-clone sync", () => {
+    expect(doc()).toContain("--verify-only");
+    expect(doc()).toContain("Library/Taps/etanhey/homebrew-layers");
+  });
+
+  it("documents the contract gate's require mode", () => {
+    expect(doc()).toContain("--require-contract");
+    expect(doc()).toContain("CMUX_CONTRACT_REQUIRE_LIVE");
+  });
+});


### PR DESCRIPTION
Lane P10 — release receipts. Closes the release-path gaps behind #371, #370, and failures-ledger rows 10.5 and 16.

A release used to be auditable only through terminal scrollback: whether the contract gate actually ran, whether brew's own tap clone got synced, and which Macs actually ended up on the new version all lived in four terminals' history. This makes each of those a durable file.

**Scope honesty (corrected in round 2):** the ledger is **per-Mac by default**, not fleet-wide. `~/.local/state/cmuxlayer/release-receipts/` is local disk, so four Macs produce four `release-<version>.json` files that you still have to go collect. Aggregating a release into one file requires pointing `CMUXLAYER_RELEASE_RECEIPTS_DIR` at shared storage — now documented, along with the fact that `release-receipt.mjs` does an unlocked read-modify-write, so concurrent verifies on shared storage can drop an entry.

## What's in the diff

**1. Receipts ledger — `scripts/release-receipt.mjs` (new)**
Per-version JSON receipt under `$CMUXLAYER_RELEASE_RECEIPTS_DIR` (default `~/.local/state/cmuxlayer/release-receipts/release-<version>.json`). Atomic writes (temp + rename), append-only `events[]` trail, `installs[]` per-Mac evidence that a re-`init` never drops. `init` / `record <dotted.key> <value>` / `install` / `path` / `show`.

`release.sh` records version, tag, release commit SHA, timestamps, tarball url + sha256, `gates.typecheck` / `gates.tests` / `gates.contract` (+ `gates.contract_reason`), tap push, and tap-clone sync. Receipt writes warn and never gate a release; `--dry-run` writes nothing. `record` refuses prototype-polluting and structural keys and parses its value positionally, so a reason lifted from a log may start with `--`.

**2. `release-verify.sh --verify-only` (alias `--no-upgrade`) — ledger row 10.5**
Asserts without mutating the Mac: no `brew upgrade`, no `reset --hard` of brew's clone. Fetches (remote refs only), reports how many commits the clone is behind, asserts `brew list --versions`. Default upgrading mode is unchanged. Both modes append per-Mac install evidence (`{host, result, installed, mode, at}`) to the receipt.

**3. Tap-clone sync in `release.sh` — #371 / ledger row 16**
After the tap push, `release.sh` now runs `git -C "$(brew --repository)/Library/Taps/etanhey/homebrew-layers" fetch origin && … reset --hard origin/main` and records before/after SHAs. Additive and non-fatal by design — the release is already pushed by that point, so a missing brew or missing clone is recorded as `tap.clone_sync: skipped` rather than failing.

**4. Contract gate visibility — #370**
`release.sh` classifies the lane's PASS/SKIP/FAIL and writes it to the receipt instead of letting a skip scroll by (the reason 0.4.17–0.4.19 shipped ungated), plus `--require-contract` to abort before anything is pushed. `run-real-cmux-contract.ts` gains `CMUX_CONTRACT_REQUIRE_LIVE=1`, which turns a skip into `[contract] FAIL:` + non-zero exit. Default behaviour unchanged.

**5. Docs (non-code deliverable)** — `docs/releases-and-brew.md` rewritten to match the shipped path: receipts, verify-only, the release-side tap-clone sync and why it is needed, the contract gate's require modes, and how to run the lane green.

## Evidence

- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` → **118 files, 2805 passed, 1 skipped**.
- `bun run typecheck` → clean. Pre-push regression harness (`scripts/run_tests.sh`) → exit 0.
- New `tests/release-receipts.test.ts` (20 tests) executes the **real** `release.sh` / `release-verify.sh` end-to-end against stubbed `git`/`brew`/`bun`/`curl`/`shasum` in a sandbox — including a happy-path assertion that the existing release commands (bump, commit, push, tag, formula sed, `brew audit`) are unchanged.
- **#370 run green from inside a cmux pane**, on this machine, today:
  ```
  CMUX_CONTRACT_ALLOW_PROD=1 CMUX_CONTRACT_REQUIRE_LIVE=1 tsx scripts/run-real-cmux-contract.ts   # exit 0
  [contract] PASS system.ping shape on ~/.local/state/cmux/cmux-501.sock
  [contract] PASS detached orphan pid=32372 denied with EPROTO
  [contract] PASS list_surfaces/read_screen through dist daemon pid=32438
  [contract] PASS doctor --json healthy on isolated live stack
  [contract] PASS graceful retire/autostart 32438 -> 33092
  [contract] PASS real-cmux contract lane
  ```
  Its live steps against the pinned cmux are read-only (`system.ping`, `list_surfaces`, `read_screen`); the daemon it retires and restarts is its own, under a temp `HOME` and temp socket.

## PREDICTION (round 1, kept for the record — and where it was wrong)

- Correct: the happy path is behaviour-preserving on the bump/commit/tag/push/formula commands, and `gates.contract: skip` on a pane-less Mac is the intended visible outcome.
- Correct but not contested: I predicted pushback on the non-fatal tap-clone sync and on `--verify-only` still running `git fetch origin`. The reviewer agreed with both calls.
- **Missed the actual weakest area.** The classifier read the *last line* of a merged stdout/stderr pipe, while the runner's `finally` block prints cleanup warnings **after** its PASS marker — so a passing lane could be classified `unknown` and abort a release. My own round-1 note about the lane's daemons being "noisy neighbours" was circling that instability without connecting it to the new parsing, and the fixture fed the classifier a single clean line, so the suite's green was silent on it.
- Also missed: the "fleet-wide picture is one file" claim, which the default per-Mac ledger dir does not support.

## Round 2 — review response

**§1 BLOCKER (fixed).** The verdict is now *searched* for (`grep -q '^\[contract\] PASS real-cmux contract lane$'`, else `grep -q '^\[contract\] SKIP: '` capturing that line as the reason), never read off the tail. An unrecognised-but-zero-exit lane now **warns and records `gates.contract: unknown`** instead of `die`-ing — a zero exit is the lane saying it did not fail, and this script has always tolerated that. A genuinely non-zero lane still aborts, and `--require-contract` still stops on any non-pass. Four new tests: PASS followed by a cleanup warning, SKIP followed by a cleanup warning, the previously uncovered `unknown` branch, and a non-zero FAIL.

**§3 BLOCKER (fixed).** Doc and PR body now state the per-Mac truth, document `CMUXLAYER_RELEASE_RECEIPTS_DIR=<shared path>` as the aggregation opt-in, and carry the no-locking caveat (also commented in `release-receipt.mjs`).

**§4 (taken).** `INSTALLED="$(brew list --versions cmuxlayer || true)"` — `brew list` exits 1 when the formula is not installed, so `set -e` was killing the script before recording the single most valuable entry a fleet install ledger can hold. Test added: a Mac with cmuxlayer absent now records `{result: fail, installed: "not installed"}`.

**§5 (taken).** Distinct banner message when the receipt could not be written (no more `<dry-run>` on a real release), with a test that runs `release.sh` under a node-less `PATH`; a single cleanup trap covering both temp files; `record` key/value hardening; and `verify.tap_clone_behind` measured after the sync rather than asserted as `"0"`. The `reset --hard` choice and the tap's `main` assumption stay as flagged-on-the-record.

**§2 — lead ruling.** The default stays non-fatal in this PR, exactly as shipped: `#370`'s root cause is environmental, and defaulting `--require-contract` on would break releases from any Mac without a live nightly pane. @cmuxlayerClaude is filing the default-flip as a follow-up issue. So: #370's failure mode is now **auditable, not yet prevented**, on the default path — that is the deliberate state of this PR, not an oversight.

**Gates after round 2:** `bun run typecheck` clean; `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bun run test` → 118 files, **2816 passed**, 1 skipped; pre-push regression harness exit 0.

— EtanHey's cmuxlayerClaude (worker) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"cmuxlayerClaude","role":"worker","harness":"claude-code","model":"claude-opus-5","model_source":"session-harness","session":"7eda6376"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-facing release and Homebrew verification scripts (including optional `reset --hard` on the tap clone and `brew upgrade` in default verify mode); default release behavior stays permissive on contract skips unless `--require-contract` is used.
> 
> **Overview**
> Replaces release/verify auditability from terminal scrollback with **durable per-version JSON receipts** (`release-receipt.mjs`), wired into `release.sh` and `release-verify.sh` (warn-only writes; `--dry-run` skips receipts).
> 
> **`release.sh`** now records gate outcomes (including **classified** real-cmux contract pass/skip/fail from log markers, not the last line), artifact/tap metadata, and an **optional hard stop** via `--require-contract` / `CMUX_CONTRACT_REQUIRE_LIVE=1`. After the tap push it **syncs Homebrew’s local tap clone** (`fetch` + `reset --hard origin/main`), recorded as non-fatal `tap.clone_sync`.
> 
> **`release-verify.sh`** adds **`--verify-only` / `--no-upgrade`**: fetch + version assert without `brew upgrade` or resetting the tap clone; both modes append per-Mac **`installs[]`** evidence to the receipt.
> 
> **`run-real-cmux-contract.ts`**: skips become failures when `CMUX_CONTRACT_REQUIRE_LIVE=1`. Docs and sandbox e2e tests cover the new release path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975937158267cfd57507b4b3fc1722834d1b968f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release receipts ledger, verify-only mode, tap-clone sync, and contract gate to release scripts
> - Introduces [`scripts/release-receipt.mjs`](https://github.com/EtanHey/cmuxlayer/pull/451/files#diff-eb3e39bf90e7786925b3c0fecbb4a8763288e496d8b43801c571af1386ae61f3), a CLI that writes atomic per-version JSON receipts capturing gates, artifacts, tap sync data, and per-Mac install evidence under `~/.local/state/cmuxlayer/release-receipts`.
> - Updates [`scripts/release.sh`](https://github.com/EtanHey/cmuxlayer/pull/451/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389) to initialize and populate receipts throughout the release process, adds `--require-contract` to make a skipped/unknown real-cmux contract gate fatal, and performs an explicit non-fatal sync of Homebrew's tap clone after pushing.
> - Updates [`scripts/release-verify.sh`](https://github.com/EtanHey/cmuxlayer/pull/451/files#diff-0361eb8bb3c02e45c57619eeac55e5f0388deb60ff9c6e3bb7e9a318cd39d124) with a `--verify-only` flag that runs assertions without mutating the system (no `brew upgrade`, no `git reset --hard`), and records tap clone divergence and verification evidence into the receipt.
> - Adds `requiresLiveContract`/`reportSkip` to [`scripts/run-real-cmux-contract.ts`](https://github.com/EtanHey/cmuxlayer/pull/451/files#diff-d69c2f6c09a7869995df79e531fec9361348264ae911f5b3e2e4138e7e75f98b) so that conditions previously logged as SKIP now exit non-zero when `CMUX_CONTRACT_REQUIRE_LIVE=1`.
> - `--dry-run` mode in `release.sh` suppresses all receipt writes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9759371.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->