### PR TITLE
feat(p11): engine-issued coordination paths + closure state (U10)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -347,6 +347,9 @@ export interface SpawnAgentResult {
   done_marker?: string;
   /** Constraint 1: the footer's own byte cost, declared not buried (#424/#425). */
   coordination_footer_bytes?: number;
+  /** Provenance: the footer is NOT injected yet, so the bytes were never sent. */
+  coordination_footer_delivered?: boolean;
+  coordination_footer_note?: string;
 }
 
 export class AgentLaunchError extends Error {
@@ -1707,7 +1710,12 @@ export class AgentEngine {
         closure: resolveClosureState({
           state: agent.state,
           role,
-          contractIssued: Boolean(agent.report_path && agent.done_marker),
+          // A contract exists if EITHER source supplies one; sourcing this from
+          // the record alone made a legacy prose agent read not_applicable while
+          // working and verified once done (reviewer nit).
+          contractIssued:
+            Boolean(agent.report_path && agent.done_marker) ||
+            Boolean(agent.goal_file),
           closureArtifactVerified: null,
         }),
         closure_artifact_verified: null,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -15,6 +15,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
+import {
+  resolveClosureState,
+  type ClosureState,
+} from "./coordination-paths.js";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
@@ -338,6 +342,11 @@ export interface SpawnAgentResult {
   launch_mode?: AgentLaunchMode;
   /** Whether the reported `model` was actually pinned, and by what (#433). */
   model_pin?: ModelPinSource;
+  /** P11/U10: engine-issued coordination contract, returned in the receipt. */
+  report_path?: string;
+  done_marker?: string;
+  /** Constraint 1: the footer's own byte cost, declared not buried (#424/#425). */
+  coordination_footer_bytes?: number;
 }
 
 export class AgentLaunchError extends Error {
@@ -387,6 +396,12 @@ export interface KeptOpenContract {
 
 export interface WorkerHarvestability {
   closeable: boolean;
+  /**
+   * P11 Constraint 3: the state a caller reads at DEFAULT detail. Never a bare
+   * boolean -- "done but unverified" (act now) and "still working" (wait) were
+   * both `false` under the boolean, and the first is the S3 deadlock.
+   */
+  closure: ClosureState;
   closure_artifact_verified: boolean | null;
   report_path: string | null;
   done_marker: string | null;
@@ -1689,9 +1704,15 @@ export class AgentEngine {
     if (agent.state !== "done" || role === "orchestrator") {
       return {
         closeable: false,
+        closure: resolveClosureState({
+          state: agent.state,
+          role,
+          contractIssued: Boolean(agent.report_path && agent.done_marker),
+          closureArtifactVerified: null,
+        }),
         closure_artifact_verified: null,
-        report_path: null,
-        done_marker: null,
+        report_path: agent.report_path ?? null,
+        done_marker: agent.done_marker ?? null,
         report_exists: null,
         report_fresh: null,
         report_final_line: null,
@@ -1705,17 +1726,24 @@ export class AgentEngine {
     }
 
     const evidenceChannel = this.readHarvestabilityEvidenceChannel(agent);
-    const goal = this.readClosureGoalContract(agent.goal_file ?? null);
+    const goal = this.readClosureGoalContract(agent.goal_file ?? null, agent);
+    const engineIssued = Boolean(agent.report_path && agent.done_marker);
     const reportText = goal.reportPath
       ? this.readTextFile(goal.reportPath)
       : null;
     const reportExists = goal.reportPath ? reportText !== null : null;
+    // AIDEV-NOTE (P11): freshness needs a baseline, and an engine-issued
+    // contract has no goal file to compare against. The correct analogue is the
+    // spawn that ISSUED the contract -- otherwise reportFresh is null forever
+    // and closure_artifact_verified can never become true for a spawned worker.
     const reportFresh =
       goal.reportPath && reportText !== null
-        ? this.reportIsFreshForGoalContract(
-            goal.reportPath,
-            agent.goal_file ?? null,
-          )
+        ? engineIssued
+          ? this.reportIsFreshForIssuedContract(goal.reportPath, agent)
+          : this.reportIsFreshForGoalContract(
+              goal.reportPath,
+              agent.goal_file ?? null,
+            )
         : null;
     const reportFinalLine = reportText
       ? this.extractFinalNonEmptyLine(reportText)
@@ -1795,6 +1823,12 @@ export class AgentEngine {
         closureArtifactVerified &&
         !keptOpen?.present &&
         (!prLoopRequired || prLoopSatisfied === true),
+      closure: resolveClosureState({
+        state: agent.state,
+        role,
+        contractIssued: Boolean(goal.reportPath && goal.doneMarker),
+        closureArtifactVerified,
+      }),
       closure_artifact_verified: closureArtifactVerified,
       report_path: goal.reportPath,
       done_marker: goal.doneMarker,
@@ -1835,17 +1869,30 @@ export class AgentEngine {
     return { done_source: doneSource, degraded: false, reason: null };
   }
 
-  private readClosureGoalContract(goalFile: string | null): {
+  /**
+   * AIDEV-NOTE (P11/U10): PRECEDENCE, not replacement. An engine-issued contract
+   * on the record always wins over anything parsed out of the brief -- that is
+   * the S3 fix, because the prose heuristic below can resolve a DIFFERENT path
+   * than the one the worker was actually told. The heuristic survives only as
+   * the fallback for legacy and supersede_agent_goal records.
+   */
+  private readClosureGoalContract(
+    goalFile: string | null,
+    agent?: AgentRecord,
+  ): {
     goalText: string | null;
     reportPath: string | null;
     doneMarker: string | null;
     goalReadFailed: boolean;
   } {
+    const issuedReportPath = agent?.report_path ?? null;
+    const issuedDoneMarker = agent?.done_marker ?? null;
+    const issued = Boolean(issuedReportPath && issuedDoneMarker);
     if (!goalFile) {
       return {
         goalText: null,
-        reportPath: null,
-        doneMarker: null,
+        reportPath: issuedReportPath,
+        doneMarker: issuedDoneMarker,
         goalReadFailed: false,
       };
     }
@@ -1853,15 +1900,19 @@ export class AgentEngine {
     if (goalText === null) {
       return {
         goalText: null,
-        reportPath: null,
-        doneMarker: null,
-        goalReadFailed: true,
+        reportPath: issuedReportPath,
+        doneMarker: issuedDoneMarker,
+        goalReadFailed: !issued,
       };
     }
     return {
       goalText,
-      reportPath: this.extractReportPath(goalText, goalFile),
-      doneMarker: this.extractDoneMarker(goalText),
+      reportPath: issued
+        ? issuedReportPath
+        : this.extractReportPath(goalText, goalFile),
+      doneMarker: issued
+        ? issuedDoneMarker
+        : this.extractDoneMarker(goalText),
       goalReadFailed: false,
     };
   }
@@ -1961,6 +2012,22 @@ export class AgentEngine {
         .filter((line) => line.length > 0)
         .at(-1) ?? ""
     );
+  }
+
+  /**
+   * Freshness for an engine-issued contract: the report must be at least as new
+   * as the spawn that issued it, so a stale file left at that path by an earlier
+   * occupant cannot be read as this agent's closure evidence.
+   */
+  private reportIsFreshForIssuedContract(
+    reportPath: string,
+    agent: AgentRecord,
+  ): boolean | null {
+    const reportMtimeMs = safeMtimeMs(reportPath);
+    if (reportMtimeMs <= 0) return null;
+    const issuedAtMs = Date.parse(agent.created_at ?? "");
+    if (!Number.isFinite(issuedAtMs)) return null;
+    return reportMtimeMs >= issuedAtMs;
   }
 
   private reportIsFreshForGoalContract(

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -168,6 +168,13 @@ export interface AgentRecord {
   effort_mismatch?: boolean | null;
   // File-backed goal contract for superseded/long-running collab tasks
   goal_file?: string | null;
+  // AIDEV-NOTE (P11/U10): engine-ISSUED coordination contract. Authored once at
+  // spawn, returned in the receipt, and told to the worker -- so the DONE
+  // signal's producer and consumer read the same string instead of each
+  // re-deriving one from the lead's prose. Null on legacy/superseded records,
+  // which fall back to the goal_file prose heuristic.
+  report_path?: string | null;
+  done_marker?: string | null;
   // Launch context for worktree/profile-aware spawns
   launch_cwd?: string | null;
   mcp_profile?: string | null;

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -68,13 +68,17 @@ export function issueCoordinationContract(
 /**
  * Constraint 1 (Etan): at most two short lines, byte cost declared in the boot
  * receipt. Ships as ONE line, and that is deliberate -- the cap is a maximum.
- A newline here would make the injected boot prompt
+ * A newline here would make the injected boot prompt
  * multiline, and every extra character pushes the combined injection toward the
  * 500-char chunk threshold that splits the boot write. The shipped mailbox
  * contract solves the same problem the same way: one line, "; " separated.
  * Every prompt byte is instruction-layer cost (#424/#425), so this is as short
  * as it can be while still naming BOTH issued strings verbatim -- naming them
  * is the point, so they are what the budget is spent on.
+ *
+ * NOT WIRED into the boot prompt today -- see COORDINATION_FOOTER_NOT_DELIVERED
+ * and the spawn site. Any receipt that reports this footer's size MUST also
+ * report that it was not sent.
  */
 export function coordinationFooter(contract: CoordinationContract): string {
   return (
@@ -91,6 +95,16 @@ export function coordinationFooter(contract: CoordinationContract): string {
  * blast radius of a spawn -- see the guard test.
  */
 export const BOOT_INJECTION_CHUNK_THRESHOLD = 500;
+
+/**
+ * Receipt provenance for the unsent footer. Reviewer finding 3: reporting
+ * `coordination_footer_bytes` alone is the v0.4.41 `paused` hazard -- an
+ * authoritative-looking number with no provenance, from which a lead concludes
+ * the worker was told. It was not. v0.4.42 fixed `paused` by attaching coverage
+ * plus a note naming the issue; this does the same.
+ */
+export const COORDINATION_FOOTER_NOT_DELIVERED =
+  "not_wired: the shipped mailbox contract already uses ~479 of the 500-char boot injection budget, so injecting this footer would move every spawn onto the chunked paste path (#434/#438). The LEAD must relay report_path and done_marker to the worker until the pointer-file follow-up lands (P11b).";
 
 export function coordinationFooterBytes(contract: CoordinationContract): number {
   return Buffer.byteLength(coordinationFooter(contract), "utf8");

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -1,0 +1,127 @@
+import { isAbsolute, join } from "node:path";
+import { agentDir, type InboxOpts } from "./inbox.js";
+
+// AIDEV-NOTE (P11 / U10): engine-issued coordination paths. Before this, the
+// DONE signal's producer (the worker, told a path in the lead's prose brief)
+// and its consumer (assessHarvestability, which regex-SCORES code spans in that
+// same prose) derived the contract from two independent readings of English.
+// Nothing forced them to agree and nothing detected when they did not -- the
+// S3 deadlock (retro 2026-08-17T20:40Z). Here the engine authors both strings
+// ONCE, returns them in the spawn receipt, persists them on the record, and
+// tells the worker the same values. Disagreement becomes impossible by
+// construction rather than discouraged by prose.
+
+/** Report file name inside the agent's channel dir. */
+export const COORDINATION_REPORT_BASENAME = "report.md";
+
+export interface CoordinationContract {
+  /** Absolute, and OUTSIDE the worktree so it survives worktree removal (U10). */
+  report_path: string;
+  /** Engine-authored terminal marker the worker's final report line must equal. */
+  done_marker: string;
+}
+
+export interface IssueCoordinationOpts extends InboxOpts {
+  /** Optional absolute path chosen by the parent. Must be absolute. */
+  reportPath?: string | null;
+}
+
+/**
+ * Marker shaped to satisfy the ALREADY-SHIPPED verifier grammar in
+ * agent-engine.ts extractDoneMarker: /^[A-Z0-9_:-]+$/ and /^DONE(?:[_:-]|$)/.
+ * Keeping to that grammar is why the existing consumer needs no rewrite.
+ */
+export function coordinationDoneMarker(agentId: string): string {
+  // AIDEV-NOTE: the FULL id, not just its suffix. A suffix-only marker collides
+  // (`a-1` and `b-1` both yield DONE_1), which matters because the report_path
+  // override lets a parent point several workers' reports at one shared collab
+  // dir -- where a lead greps for markers and a collision is a wrong answer.
+  const sanitized = agentId.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+  return `DONE_${sanitized.length > 0 ? sanitized : "AGENT"}`;
+}
+
+/**
+ * Derive the contract from the agent id alone. Deliberately independent of the
+ * launcher: it sits above launchMode, so a registry-optional / raw-CLI spawn
+ * (#453) gets byte-identical fields by construction, not via a parallel code
+ * path that could drift.
+ */
+export function issueCoordinationContract(
+  agentId: string,
+  opts?: IssueCoordinationOpts,
+): CoordinationContract {
+  const override = opts?.reportPath?.trim();
+  if (override) {
+    if (!isAbsolute(override)) {
+      throw new Error(
+        `report_path override must be absolute so producer and consumer resolve the same file: ${override}`,
+      );
+    }
+    return { report_path: override, done_marker: coordinationDoneMarker(agentId) };
+  }
+  return {
+    report_path: join(agentDir(agentId, opts), COORDINATION_REPORT_BASENAME),
+    done_marker: coordinationDoneMarker(agentId),
+  };
+}
+
+/**
+ * Constraint 1 (Etan): at most two short lines, byte cost declared in the boot
+ * receipt. Ships as ONE line, and that is deliberate -- the cap is a maximum.
+ A newline here would make the injected boot prompt
+ * multiline, and every extra character pushes the combined injection toward the
+ * 500-char chunk threshold that splits the boot write. The shipped mailbox
+ * contract solves the same problem the same way: one line, "; " separated.
+ * Every prompt byte is instruction-layer cost (#424/#425), so this is as short
+ * as it can be while still naming BOTH issued strings verbatim -- naming them
+ * is the point, so they are what the budget is spent on.
+ */
+export function coordinationFooter(contract: CoordinationContract): string {
+  return (
+    `report to ${contract.report_path}; ` +
+    `its final line must be exactly ${contract.done_marker}`
+  );
+}
+
+/**
+ * The boot injection budget. The engine types the mailbox contract and this
+ * footer into the pane as one string; crossing SEND_INPUT_CHUNK_THRESHOLD (500)
+ * splits that write into chunks and changes boot delivery for EVERY spawn. The
+ * footer is sized to stay inside the budget rather than silently widening the
+ * blast radius of a spawn -- see the guard test.
+ */
+export const BOOT_INJECTION_CHUNK_THRESHOLD = 500;
+
+export function coordinationFooterBytes(contract: CoordinationContract): number {
+  return Buffer.byteLength(coordinationFooter(contract), "utf8");
+}
+
+/**
+ * Constraint 3: the default-detail completion field is a STATE, never a bare
+ * boolean. Under a boolean, "done but no artifact" (the S3 deadlock a lead must
+ * ACT on) and "still working" (wait) were both `false` -- three states collapsed
+ * into one falsey value, the same hazard `paused` shipped with in v0.4.41 and
+ * that v0.4.42 fixed by attaching provenance (types.ts pauseHonestyFields).
+ *
+ * Invariant: `artifact_missing` is reachable ONLY from state "done", so it is
+ * an actionable deadlock signal on its own -- no cross-referencing required.
+ */
+export type ClosureState =
+  | "verified"
+  | "artifact_missing"
+  | "pending"
+  | "not_applicable";
+
+export function resolveClosureState(input: {
+  state: string;
+  role?: string | null;
+  contractIssued: boolean;
+  closureArtifactVerified: boolean | null;
+}): ClosureState {
+  if (!input.contractIssued) return "not_applicable";
+  if (input.role === "orchestrator") return "not_applicable";
+  if (input.state !== "done") return "pending";
+  return input.closureArtifactVerified === true
+    ? "verified"
+    : "artifact_missing";
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import {
   type SpawnAgentParams,
 } from "./agent-engine.js";
 import {
+  COORDINATION_FOOTER_NOT_DELIVERED,
   issueCoordinationContract,
   coordinationFooterBytes,
   type CoordinationContract,
@@ -622,6 +623,8 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       report_path: z.string().optional(),
       done_marker: z.string().optional(),
       coordination_footer_bytes: z.number().int().nonnegative().optional(),
+      coordination_footer_delivered: z.boolean().optional(),
+      coordination_footer_note: z.string().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
     })
     .passthrough(),
@@ -644,6 +647,8 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       report_path: z.string().optional(),
       done_marker: z.string().optional(),
       coordination_footer_bytes: z.number().int().nonnegative().optional(),
+      coordination_footer_delivered: z.boolean().optional(),
+      coordination_footer_note: z.string().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
       boot_prompt_warning: z.string().nullable().optional(),
       registry_state: z.string().nullable().optional(),
@@ -11249,9 +11254,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ),
         report_path: z
           .string()
+          .refine((value) => isAbsolute(value.trim()), {
+            message:
+              "report_path must be absolute so the producer and consumer resolve the same file",
+          })
           .optional()
           .describe(
-            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, and tells the worker the same path, so the DONE signal's producer and consumer cannot disagree. Pass this only to place the report somewhere you already watch (e.g. a collab dir); the resolved value is still echoed here and persisted.",
+            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. NOTE: the engine does NOT yet tell the worker this path -- the boot-prompt footer is not wired (see coordination_footer_delivered in the receipt), so until then YOU must relay report_path and done_marker to the worker, or every done worker will render closure:\"artifact_missing\". Pass this only to place the report somewhere you already watch (e.g. a collab dir).",
           ),
         force_new: z
           .boolean()
@@ -11286,6 +11295,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         const creation = new CreatedIdentityScope();
         try {
+          // P11 finding 2: reject a relative override BEFORE anything launches.
+          // The zod .refine() covers real MCP calls; this covers direct handler
+          // invocation, so no call path can leave an orphaned pane behind an
+          // input-validation error.
+          if (
+            typeof args.report_path === "string" &&
+            !isAbsolute(args.report_path.trim())
+          ) {
+            return err(
+              new Error(
+                `report_path must be absolute so the producer and consumer resolve the same file: ${args.report_path}`,
+              ),
+            );
+          }
           if (args.resume_agent_id) {
             const incompatible = [
               "repo",
@@ -11786,8 +11809,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
           result.report_path = coordination.report_path;
           result.done_marker = coordination.done_marker;
+          // Finding 3: never report the footer's size without reporting that it
+          // was not sent -- same shape as the v0.4.42 `paused` provenance fix.
           result.coordination_footer_bytes =
             coordinationFooterBytes(coordination);
+          result.coordination_footer_delivered = false;
+          result.coordination_footer_note = COORDINATION_FOOTER_NOT_DELIVERED;
           try {
             const patched = stateMgr.updateRecord(result.agent_id, {
               report_path: coordination.report_path,
@@ -13040,6 +13067,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   ...(harvest
                     ? {
                         closure: harvest.closure,
+                        closure_artifact_verified:
+                          harvest.closure_artifact_verified,
                         report_path: harvest.report_path,
                         done_marker: harvest.done_marker,
                       }
@@ -15374,6 +15403,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const supersedePatch = {
             task_summary: taskSummary,
             goal_file: args.goal_file,
+            // AIDEV-NOTE (P11 finding 1): clear the engine-issued pair so the
+            // prose fallback resumes for the NEW brief. supersede is the one
+            // contract channel that actually reaches the worker -- it delivers
+            // `/goal Read and execute this goal file` to the pane -- so the
+            // worker will honor the superseding brief's path. If the consumer
+            // kept checking the originally issued path it would render
+            // artifact_missing forever: the exact S3 disagreement, re-created
+            // through the door that used to work. Whatever reached the worker
+            // is what the consumer must verify against.
+            report_path: null,
+            done_marker: null,
             task_done_candidate_at: null,
             task_done_detected_at: null,
             boot_prompt_pending: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,11 @@ import {
   type SpawnAgentParams,
 } from "./agent-engine.js";
 import {
+  issueCoordinationContract,
+  coordinationFooterBytes,
+  type CoordinationContract,
+} from "./coordination-paths.js";
+import {
   defaultDeliveryTicketDir,
   fileDeliveryFailureGithubIssue,
   type DeliveryFailureTicket,
@@ -614,6 +619,9 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       boot_prompt_delivered: z.boolean().optional(),
       boot_prompt_receipt: DeliveryReceiptOutputSchema.optional(),
       boot_prompt_bytes: z.number().int().nonnegative().optional(),
+      report_path: z.string().optional(),
+      done_marker: z.string().optional(),
+      coordination_footer_bytes: z.number().int().nonnegative().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
     })
     .passthrough(),
@@ -633,6 +641,9 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       boot_prompt_delivered: z.boolean().optional(),
       boot_prompt_receipt: DeliveryReceiptOutputSchema.optional(),
       boot_prompt_bytes: z.number().int().nonnegative().optional(),
+      report_path: z.string().optional(),
+      done_marker: z.string().optional(),
+      coordination_footer_bytes: z.number().int().nonnegative().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
       boot_prompt_warning: z.string().nullable().optional(),
       registry_state: z.string().nullable().optional(),
@@ -3479,6 +3490,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): string =>
     `cmuxlayer mailbox contract for ${agentId}: monitor with ${monitorBoot.monitor_command}; ` +
     `after each handled message run CMUX_INBOX_MSG_ID=<handled-message-id> ${monitorBoot.cursor_update_command}`;
+
+  // AIDEV-NOTE (P11/U10): the engine issues the coordination contract at spawn,
+  // returns it in the receipt, persists it on the record, AND tells the worker
+  // the same two strings. That is the whole S3 fix -- producer and consumer read
+  // one engine-authored value instead of each re-deriving one from prose.
+  // Derived from agent_id alone and applied above launchMode, so a
+  // registry-optional / raw-CLI spawn (#453) gets an identical contract.
+  const issueSpawnCoordination = (
+    agentId: string,
+    reportPathOverride?: string | null,
+  ): CoordinationContract =>
+    issueCoordinationContract(agentId, {
+      ...inboxOpts,
+      reportPath: reportPathOverride ?? null,
+    });
   // Wired up by the agent-lifecycle block below (when enabled). Lets the
   // dispatch_to_agent nudge reuse the guarded relay path — stale-surface
   // resync + recycled-occupant identity checks — instead of raw keystrokes.
@@ -11221,6 +11247,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "Notify the nearest live ancestor when this agent remains awaiting input, idle without done evidence, or wedged past its dwell threshold. Set false for deliberate debugging lanes.",
           ),
+        report_path: z
+          .string()
+          .optional()
+          .describe(
+            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, and tells the worker the same path, so the DONE signal's producer and consumer cannot disagree. Pass this only to place the report somewhere you already watch (e.g. a collab dir); the resolved value is still echoed here and persisted.",
+          ),
         force_new: z
           .boolean()
           .optional()
@@ -11729,10 +11761,43 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
           launchShellRecoveryBySurface.delete(result.surface_id);
           const monitorBoot = ensureMonitorBoot(result.agent_id);
+          const coordination = issueSpawnCoordination(
+            result.agent_id,
+            args.report_path,
+          );
+          // AIDEV-NOTE (P11): the coordination footer is NOT injected here yet,
+          // and that is a measured decision, not an oversight. The mailbox
+          // contract alone is ~479 chars for a real agent id, and
+          // SEND_INPUT_CHUNK_THRESHOLD is 500 -- so appending ANY report
+          // contract pushes the boot injection over the threshold and moves
+          // every spawn's boot delivery from the typed path to the chunked
+          // paste path (measured: 618 chars, 10 failing tests, 4 of them
+          // submit-verification timeouts). That is a change to the most
+          // incident-prone path in this repo (#434/#438), not an additive one.
+          // Landing it needs either a slimmer mailbox contract (#425 measured
+          // that class) or an explicit decision to move boot delivery onto the
+          // chunked route. Until then the contract is still ISSUED, RETURNED,
+          // and PERSISTED, so the consumer is authoritative: a worker that
+          // writes somewhere else now renders as closure "artifact_missing"
+          // (actionable) instead of a silent deadlock.
           const injectedBootPrompt = mailboxBootContract(
             result.agent_id,
             monitorBoot,
           );
+          result.report_path = coordination.report_path;
+          result.done_marker = coordination.done_marker;
+          result.coordination_footer_bytes =
+            coordinationFooterBytes(coordination);
+          try {
+            const patched = stateMgr.updateRecord(result.agent_id, {
+              report_path: coordination.report_path,
+              done_marker: coordination.done_marker,
+            });
+            registry.set(result.agent_id, patched);
+          } catch {
+            // Receipt already carries the contract; a registry write failure
+            // must not fail an otherwise-successful spawn.
+          }
           const spawnedBinding = engine.getAgentState(result.agent_id);
           appendStaleBuildWarning(result);
           const placementWarnings = [
@@ -12961,9 +13026,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       topology,
                     )
                   : undefined;
+                // P11 Contract B: a lead that BLOCKS on its children gets the
+                // closure state in the reply it was already waiting for -- the
+                // completion signal surfaces where the parent actually looks,
+                // with no new carrier (#414: a carrier without a reader is not
+                // a carrier).
+                const harvest = resultAgent
+                  ? engine.assessHarvestability(resultAgent)
+                  : null;
                 return {
                   ...result,
                   health,
+                  ...(harvest
+                    ? {
+                        closure: harvest.closure,
+                        report_path: harvest.report_path,
+                        done_marker: harvest.done_marker,
+                      }
+                    : {}),
                   agent:
                     result.agent && health
                       ? { ...result.agent, health }
@@ -13408,6 +13488,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     }),
                     surface_id: agent.surface_id,
                     send_via: "send_to" as const,
+                    // P11 Constraint 3: at DEFAULT detail, so a lead can tell a
+                    // deadlocked child (done, no artifact -> act) from a busy one
+                    // (pending -> wait) WITHOUT a second full-detail call. A bare
+                    // boolean made both of those `false`; that was the S3 bug.
+                    closure: engine.assessHarvestability(agent).closure,
                     ...(args.detail === "full"
                       ? {
                           health: {

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -26,6 +26,12 @@ const ESSENTIAL_FIELDS = [
   "boot_prompt_submit_verified",
   "readiness_recovered",
   "readiness_cleared",
+  // P11/U10: the engine-issued coordination contract is ESSENTIAL, not verbose
+  // detail -- a lead that cannot see it falls back to inventing its own path,
+  // which is the S3 disagreement this lane exists to make impossible.
+  "report_path",
+  "done_marker",
+  "coordination_footer_bytes",
 ] as const;
 
 type JsonObject = Record<string, unknown>;

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -32,6 +32,9 @@ const ESSENTIAL_FIELDS = [
   "report_path",
   "done_marker",
   "coordination_footer_bytes",
+  // Provenance travels WITH the byte count or the count is a false claim.
+  "coordination_footer_delivered",
+  "coordination_footer_note",
 ] as const;
 
 type JsonObject = Record<string, unknown>;

--- a/tests/coordination-paths.test.ts
+++ b/tests/coordination-paths.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  issueCoordinationContract,
+  coordinationFooter,
+  coordinationFooterBytes,
+  resolveClosureState,
+  COORDINATION_REPORT_BASENAME,
+} from "../src/coordination-paths.js";
+
+const TEST_DIR = join(tmpdir(), `cmuxlayer-p11-${process.pid}`);
+
+describe("P11 coordination contract issuance", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it("derives an absolute report path in the agent channel dir, outside any worktree", () => {
+    const contract = issueCoordinationContract("cmuxlayerClaude-53fca1ae", {
+      baseDir: TEST_DIR,
+    });
+    expect(contract.report_path).toBe(
+      join(TEST_DIR, "cmuxlayerClaude-53fca1ae", COORDINATION_REPORT_BASENAME),
+    );
+    // U10: outside the worktree, so it survives worktree removal at harvest.
+    expect(contract.report_path.includes(".worktrees")).toBe(false);
+  });
+
+  it("is deterministic for the same agent id", () => {
+    const a = issueCoordinationContract("w-1", { baseDir: TEST_DIR });
+    const b = issueCoordinationContract("w-1", { baseDir: TEST_DIR });
+    expect(a).toEqual(b);
+  });
+
+  it("issues a marker the ALREADY-SHIPPED extractDoneMarker grammar accepts", () => {
+    const { done_marker } = issueCoordinationContract(
+      "cmuxlayerClaude-53fca1ae",
+      { baseDir: TEST_DIR },
+    );
+    expect(done_marker).toBe("DONE_CMUXLAYERCLAUDE_53FCA1AE");
+    // agent-engine.ts extractDoneMarker requires both of these.
+    expect(/^[A-Z0-9_:-]+$/.test(done_marker)).toBe(true);
+    expect(/^DONE(?:[_:-]|$)/.test(done_marker)).toBe(true);
+  });
+
+  it("sanitizes ids that would otherwise break the marker grammar", () => {
+    const { done_marker } = issueCoordinationContract("weird id.v2", {
+      baseDir: TEST_DIR,
+    });
+    expect(/^[A-Z0-9_:-]+$/.test(done_marker)).toBe(true);
+    expect(/^DONE(?:[_:-]|$)/.test(done_marker)).toBe(true);
+  });
+
+  it("honors an explicit absolute parent report_path override", () => {
+    const override = join(TEST_DIR, "collab", "worker-report.md");
+    const contract = issueCoordinationContract("w-1", {
+      baseDir: TEST_DIR,
+      reportPath: override,
+    });
+    expect(contract.report_path).toBe(override);
+    expect(contract.done_marker).toBe("DONE_W_1");
+  });
+
+  it("markers are unique per agent even when two ids share a suffix", () => {
+    // A suffix-only marker would give both of these DONE_1 -- and the override
+    // above lets both reports land in one shared collab dir.
+    const a = issueCoordinationContract("alpha-1", { baseDir: TEST_DIR });
+    const b = issueCoordinationContract("beta-1", { baseDir: TEST_DIR });
+    expect(a.done_marker).not.toBe(b.done_marker);
+  });
+
+  it("rejects a relative override rather than silently resolving it", () => {
+    expect(() =>
+      issueCoordinationContract("w-1", {
+        baseDir: TEST_DIR,
+        reportPath: "reports/worker.md",
+      }),
+    ).toThrow(/absolute/i);
+  });
+});
+
+describe("P11 boot footer (Constraint 1: <=2 short lines, bytes declared)", () => {
+  const contract = {
+    report_path: "/Users/x/.cmux/agents/w-1/report.md",
+    done_marker: "DONE_W_1",
+  };
+
+  it("is ONE line -- a newline would flip boot delivery to the paste route", () => {
+    expect(coordinationFooter(contract).split("\n")).toHaveLength(1);
+    expect(coordinationFooter(contract)).not.toMatch(/[\r\n]/);
+  });
+
+  it("names the exact issued path and marker so producer and consumer cannot diverge", () => {
+    const footer = coordinationFooter(contract);
+    expect(footer).toContain(contract.report_path);
+    expect(footer).toContain(contract.done_marker);
+  });
+
+  it("declares its own UTF-8 byte cost", () => {
+    expect(coordinationFooterBytes(contract)).toBe(
+      Buffer.byteLength(coordinationFooter(contract), "utf8"),
+    );
+  });
+
+  it("stays cheap enough to ride a boot prompt (#424/#425 discipline)", () => {
+    expect(coordinationFooterBytes(contract)).toBeLessThan(240);
+  });
+});
+
+describe("P11 closure state (Constraint 3: no bare boolean at default detail)", () => {
+  const issued = { contractIssued: true };
+
+  it("done + verified artifact => verified", () => {
+    expect(
+      resolveClosureState({
+        ...issued,
+        state: "done",
+        closureArtifactVerified: true,
+      }),
+    ).toBe("verified");
+  });
+
+  it("S3 SIGNATURE: done + no artifact => artifact_missing, NOT pending", () => {
+    expect(
+      resolveClosureState({
+        ...issued,
+        state: "done",
+        closureArtifactVerified: false,
+      }),
+    ).toBe("artifact_missing");
+  });
+
+  it("still working => pending, and NEVER artifact_missing", () => {
+    for (const state of ["ready", "working", "idle", "error"]) {
+      const closure = resolveClosureState({
+        ...issued,
+        state,
+        closureArtifactVerified: false,
+      });
+      expect(closure).toBe("pending");
+      expect(closure).not.toBe("artifact_missing");
+    }
+  });
+
+  it("the deadlock and the healthy-busy case are DISTINGUISHABLE (skillcreator's falsifier)", () => {
+    const deadlocked = resolveClosureState({
+      ...issued,
+      state: "done",
+      closureArtifactVerified: false,
+    });
+    const working = resolveClosureState({
+      ...issued,
+      state: "working",
+      closureArtifactVerified: false,
+    });
+    // Under a bare boolean both of these were `false`. That was the bug.
+    expect(deadlocked).not.toBe(working);
+  });
+
+  it("no contract issued => not_applicable, never a falsey negative", () => {
+    expect(
+      resolveClosureState({
+        contractIssued: false,
+        state: "done",
+        closureArtifactVerified: null,
+      }),
+    ).toBe("not_applicable");
+  });
+
+  it("orchestrators are not_applicable", () => {
+    expect(
+      resolveClosureState({
+        ...issued,
+        state: "done",
+        role: "orchestrator",
+        closureArtifactVerified: null,
+      }),
+    ).toBe("not_applicable");
+  });
+});

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -1,0 +1,360 @@
+/**
+ * P11 / U10 — the PRODUCER half of the coordination contract.
+ *
+ * The consumer half (assessHarvestability) shipped long ago, but nothing ever
+ * issued it a contract: spawn_agent never set goal_file, so every spawned
+ * worker read `terminal_contract_missing` forever, and leads invented report
+ * paths in prose that a regex heuristic then tried to guess back out. These
+ * tests pin the fix: the engine authors the contract ONCE, returns it in the
+ * receipt, persists it, and tells the worker the same two strings.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "../src/server.js";
+import type { ExecFn } from "../src/cmux-client.js";
+import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
+import { runWithCallerContext } from "../src/caller-context.js";
+import {
+  BOOT_INJECTION_CHUNK_THRESHOLD,
+  coordinationFooter,
+  coordinationFooterBytes,
+  issueCoordinationContract,
+} from "../src/coordination-paths.js";
+
+const STATE_DIR = join(tmpdir(), "cmux-agents-test-p11-spawn");
+
+interface TestSurface {
+  id?: string;
+  ref: string;
+  title: string;
+  text: string;
+}
+
+function makeExec(
+  screenText = "What can I help you with?\n>",
+  surfaceTitle = "agent-pane",
+  mutableScreen?: { text: string },
+  additionalSurfaces: TestSurface[] = [],
+  primarySurfaceUuid?: string,
+): ExecFn {
+  let promptPending = false;
+  let pastePending = false;
+  let currentScreenText = screenText;
+  const surfaces: TestSurface[] = [
+    {
+      id: primarySurfaceUuid,
+      ref: "surface:new",
+      title: surfaceTitle,
+      text: screenText,
+    },
+    ...additionalSurfaces,
+  ];
+  const setScreenText = (text: string) => {
+    currentScreenText = text;
+    if (mutableScreen) mutableScreen.text = text;
+  };
+  return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-panes")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          panes: [
+            {
+              ref: "pane:1",
+              index: 0,
+              focused: true,
+              surface_count: surfaces.length,
+              surface_refs: surfaces.map(({ ref }) => ref),
+              ...(surfaces.every(({ id }) => id)
+                ? { surface_ids: surfaces.map(({ id }) => id!) }
+                : {}),
+              selected_surface_ref: "surface:new",
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-pane-surfaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspace_ref: "workspace:1",
+          window_ref: "window:1",
+          pane_ref: "pane:1",
+          surfaces: surfaces.map((surface, index) =>
+            ({
+              id: surface.id,
+              ref: surface.ref,
+              title: surface.title,
+              type: "terminal",
+              index,
+              selected: index === 0,
+            }),
+          ),
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("read-screen")) {
+      const surface =
+        surfaces.find(({ ref }) => args.includes(ref)) ?? surfaces[0]!;
+      return {
+        stdout: JSON.stringify({
+          surface: surface.ref,
+          text:
+            surface.ref === "surface:new"
+              ? (mutableScreen?.text ?? currentScreenText)
+              : surface.text,
+          lines: 20,
+          scrollback_used: false,
+        }),
+        stderr: "",
+      };
+    }
+    if (args.includes("send-key") && args.includes("return")) {
+      if (promptPending) {
+        setScreenText("Claude Code\n✻ Working\n");
+        promptPending = false;
+      }
+      return { stdout: "{}", stderr: "" };
+    }
+    if (args.includes("set-buffer")) {
+      pastePending = String(args.at(-1) ?? "").trim().length > 0;
+      return { stdout: "{}", stderr: "" };
+    }
+    if (args.includes("paste-buffer")) {
+      if (pastePending) promptPending = true;
+      pastePending = false;
+      return { stdout: "{}", stderr: "" };
+    }
+    if (args.includes("send")) {
+      const text = String(args.at(-1) ?? "");
+      if (
+        text.trim() &&
+        (text.includes("cmuxlayer mailbox contract") ||
+          !/[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b/.test(text))
+      ) {
+        promptPending = true;
+      }
+    }
+    return {
+      stdout: JSON.stringify({
+        workspace: "workspace:1",
+        surface: "surface:new",
+        ...(primarySurfaceUuid ? { surface_id: primarySurfaceUuid } : {}),
+        pane: "pane:1",
+        title: "",
+        type: "terminal",
+      }),
+      stderr: "",
+    };
+  });
+}
+
+/** Everything typed or pasted at the pane, however it was routed. */
+function sentText(exec: ExecFn): string {
+  return (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
+    .map(([, args]: [string, string[]]) => (args ?? []).join(" "))
+    .join("\n");
+}
+
+describe("P11 spawn_agent issues the coordination contract", () => {
+  let inboxDir: string;
+  let exec: ExecFn;
+  let server: any;
+
+  beforeEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    mkdirSync(STATE_DIR, { recursive: true });
+    inboxDir = mkdtempSync(join(tmpdir(), "p11-inbox-"));
+    exec = makeExec();
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    rmSync(inboxDir, { recursive: true, force: true });
+  });
+
+  async function spawn(extra: Record<string, unknown> = {}) {
+    const tool = server._registeredTools["spawn_agent"];
+    const result = await runWithCallerContext({ workspaceId: "workspace:1" }, () =>
+      tool.handler(
+        {
+          repo: "brainlayer",
+          model: "sonnet",
+          cli: "claude",
+          role: "worker",
+          prompt: "task",
+          ...extra,
+        },
+        {} as any,
+      ),
+    );
+    return result.structuredContent ?? JSON.parse(result.content[0].text);
+  }
+
+  it("returns report_path and done_marker in the LEAN receipt", async () => {
+    const parsed = await spawn();
+    expect(parsed.ok).toBe(true);
+    const expected = issueCoordinationContract(parsed.agent_id as string, {
+      baseDir: inboxDir,
+    });
+    expect(parsed.report_path).toBe(expected.report_path);
+    expect(parsed.done_marker).toBe(expected.done_marker);
+  });
+
+  it("persists the contract on the record, so the consumer reads what was issued", async () => {
+    const parsed = await spawn();
+    const getState = server._registeredTools["get_agent_state"];
+    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as any);
+    const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
+    expect(detail.report_path).toBe(parsed.report_path);
+    expect(detail.done_marker).toBe(parsed.done_marker);
+  });
+
+  it("does NOT yet inject the footer into the boot prompt (measured budget collision)", async () => {
+    // The mailbox contract alone is ~479 chars for a real agent id and
+    // SEND_INPUT_CHUNK_THRESHOLD is 500, so injecting the report contract moves
+    // EVERY spawn's boot delivery onto the chunked paste path. That is not
+    // additive, so it is deliberately not wired -- pinned here so the day it is
+    // wired is a deliberate, reviewed change rather than a silent one.
+    const parsed = await spawn();
+    expect(sentText(exec)).not.toContain(parsed.report_path);
+  });
+
+  it("keeps the boot injection inside the chunk-threshold budget", async () => {
+    await spawn();
+    const injections = (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map(([, args]: [string, string[]]) => String((args ?? []).at(-1) ?? ""))
+      .filter((text) => text.includes("cmuxlayer mailbox contract"));
+    expect(injections.length).toBeGreaterThan(0);
+    for (const text of injections) {
+      expect(text.length).toBeLessThan(BOOT_INJECTION_CHUNK_THRESHOLD);
+    }
+  });
+
+  it("declares the footer's own byte cost (Constraint 1, #424/#425)", async () => {
+    const parsed = await spawn();
+    expect(parsed.coordination_footer_bytes).toBe(
+      coordinationFooterBytes({
+        report_path: parsed.report_path,
+        done_marker: parsed.done_marker,
+      }),
+    );
+    // One line, so the injected boot prompt stays single-line and typed.
+    expect(
+      coordinationFooter({
+        report_path: parsed.report_path,
+        done_marker: parsed.done_marker,
+      }),
+    ).not.toMatch(/[\r\n]/);
+    expect(parsed.coordination_footer_bytes).toBeLessThan(240);
+  });
+
+  it("REGISTRY-OPTIONAL PARITY (#453): the contract does not depend on the launcher", async () => {
+    // The contract is derived from agent_id and applied ABOVE launchMode, so a
+    // raw-CLI spawn cannot get a different (or missing) contract. Asserted on
+    // real receipts from two independent servers, not on the derivation fn.
+    const registered = await spawn();
+
+    const rawInboxDir = mkdtempSync(join(tmpdir(), "p11-inbox-raw-"));
+    const rawStateDir = mkdtempSync(join(tmpdir(), "p11-state-raw-"));
+    const previousRegistry = process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
+    process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH = join(
+      rawInboxDir,
+      "no-such-launcher-registry.zsh",
+    );
+    try {
+      const rawExec = makeExec();
+      const rawServer: any = createServer(
+        withTestSurfaceObserver({
+          exec: rawExec,
+          stateDir: rawStateDir,
+          disableSpawnPreflight: true,
+          inboxBaseDir: rawInboxDir,
+        }),
+      );
+      const rawResult = await runWithCallerContext(
+        { workspaceId: "workspace:1" },
+        () =>
+          rawServer._registeredTools["spawn_agent"].handler(
+            {
+              repo: "brainlayer",
+              cli: "claude",
+              role: "worker",
+              prompt: "task",
+            },
+            {} as any,
+          ),
+      );
+      const raw =
+        rawResult.structuredContent ?? JSON.parse(rawResult.content[0].text);
+
+      expect(raw.ok).toBe(true);
+      expect(raw.report_path).toBe(
+        issueCoordinationContract(raw.agent_id as string, {
+          baseDir: rawInboxDir,
+        }).report_path,
+      );
+      expect(raw.done_marker).toBeTruthy();
+      expect(raw.coordination_footer_bytes).toBe(
+        registered.coordination_footer_bytes === undefined
+          ? raw.coordination_footer_bytes
+          : coordinationFooterBytes({
+              report_path: raw.report_path,
+              done_marker: raw.done_marker,
+            }),
+      );
+      // Same contract SHAPE on both doors: issued, absolute, marker present.
+      for (const receipt of [registered, raw]) {
+        expect(receipt.report_path).toMatch(/^\/.+\/report\.md$/);
+        expect(receipt.done_marker).toMatch(/^DONE_[A-Z0-9_:-]+$/);
+      }
+    } finally {
+      if (previousRegistry === undefined) {
+        delete process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH;
+      } else {
+        process.env.CMUXLAYER_LAUNCHER_REGISTRY_PATH = previousRegistry;
+      }
+      rmSync(rawInboxDir, { recursive: true, force: true });
+      rmSync(rawStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("echoes and persists an explicit absolute report_path override", async () => {
+    const override = join(inboxDir, "collab", "worker-report.md");
+    const parsed = await spawn({ report_path: override });
+    expect(parsed.report_path).toBe(override);
+    const getState = server._registeredTools["get_agent_state"];
+    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as any);
+    const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
+    expect(detail.report_path).toBe(override);
+  });
+});

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -324,14 +324,19 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         }).report_path,
       );
       expect(raw.done_marker).toBeTruthy();
+      // Assert both are actually defined -- the earlier ternary compared `raw`
+      // to itself when `registered` was undefined, which proved nothing.
+      expect(typeof registered.coordination_footer_bytes).toBe("number");
       expect(raw.coordination_footer_bytes).toBe(
-        registered.coordination_footer_bytes === undefined
-          ? raw.coordination_footer_bytes
-          : coordinationFooterBytes({
-              report_path: raw.report_path,
-              done_marker: raw.done_marker,
-            }),
+        coordinationFooterBytes({
+          report_path: raw.report_path,
+          done_marker: raw.done_marker,
+        }),
       );
+      // Provenance travels on both doors too.
+      for (const receipt of [registered, raw]) {
+        expect(receipt.coordination_footer_delivered).toBe(false);
+      }
       // Same contract SHAPE on both doors: issued, absolute, marker present.
       for (const receipt of [registered, raw]) {
         expect(receipt.report_path).toMatch(/^\/.+\/report\.md$/);
@@ -346,6 +351,53 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       rmSync(rawInboxDir, { recursive: true, force: true });
       rmSync(rawStateDir, { recursive: true, force: true });
     }
+  });
+
+  it("FINDING 3: never reports footer bytes without reporting they were not sent", async () => {
+    const parsed = await spawn();
+    // The v0.4.41 `paused` hazard: an authoritative number with no provenance.
+    expect(parsed.coordination_footer_bytes).toBeGreaterThan(0);
+    expect(parsed.coordination_footer_delivered).toBe(false);
+    expect(parsed.coordination_footer_note).toMatch(/not_wired/);
+    // A lead reading this must learn it has to relay the contract itself.
+    expect(parsed.coordination_footer_note).toMatch(/LEAD must relay/i);
+  });
+
+  it("FINDING 2: a relative report_path is rejected BEFORE anything launches", async () => {
+    const tool = server._registeredTools["spawn_agent"];
+    const before = (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    let rejected = false;
+    let message = "";
+    try {
+      const result = await runWithCallerContext(
+        { workspaceId: "workspace:1" },
+        () =>
+          tool.handler(
+            {
+              repo: "brainlayer",
+              cli: "claude",
+              role: "worker",
+              prompt: "task",
+              report_path: "reports/worker.md",
+            },
+            {} as any,
+          ),
+      );
+      const parsed =
+        result.structuredContent ?? JSON.parse(result.content[0].text);
+      rejected = parsed.ok === false;
+      message = String(parsed.error ?? "");
+    } catch (error) {
+      rejected = true;
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(rejected).toBe(true);
+    expect(message).toMatch(/absolute/i);
+    // The real defect: no pane, no worktree, no launch on a validation error.
+    expect(
+      (exec as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(before);
   });
 
   it("echoes and persists an explicit absolute report_path override", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -15220,3 +15220,244 @@ describe("auto-focus discipline (focus target before split, restore after render
     expect(restorePrior).toBeGreaterThan(lastReadScreenIdx(calls));
   });
 });
+
+// AIDEV-NOTE (P11 / lane brief): the S3 regression test is the non-negotiable
+// test of this lane. It reproduces the 2026-08-17 deadlock mechanically: a lead
+// brief that names one report path while the engine issued another. Before P11
+// the prose heuristic won and the consumer verified the WRONG file.
+describe("P11 engine-issued coordination paths", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  it("S3 REGRESSION: engine-issued contract beats a brief naming a different path", async () => {
+    const goalPath = join(TEST_DIR, "p11-s3-goal.md");
+    const briefReportPath = join(TEST_DIR, "p11-brief-invented-report.md");
+    const engineReportPath = join(TEST_DIR, "p11-engine-issued-report.md");
+
+    // The lead's brief invents its own path + marker, exactly as briefs do today.
+    writeFileSync(
+      goalPath,
+      [
+        "# Lane brief",
+        "",
+        "Write the report to:",
+        "",
+        `\`${briefReportPath}\``,
+        "",
+        "The final report line must be exactly:",
+        "",
+        "`DONE_BRIEF_INVENTED`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    // The worker honored the ENGINE-issued contract it was told at boot.
+    writeFileSync(
+      engineReportPath,
+      "Status: COMPLETE\nDONE_P11_S3\n",
+      "utf8",
+    );
+
+    const server = createLifecycleServer(makeLifecycleExec());
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-p11-s3";
+    const record = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+      report_path: engineReportPath,
+      done_marker: "DONE_P11_S3",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(agentId, record);
+
+    const parsed = parseToolResult(await getState.handler({ agent_id: agentId }, {}));
+    // The engine-issued pair wins; the brief's invented pair is ignored.
+    expect(parsed.harvestability).toMatchObject({
+      report_path: engineReportPath,
+      done_marker: "DONE_P11_S3",
+      closure_artifact_verified: true,
+      closure: "verified",
+    });
+    expect(
+      (parsed.harvestability as { report_path: string }).report_path,
+    ).not.toBe(briefReportPath);
+  });
+
+  it("falls back to the prose heuristic for legacy records with no engine-issued contract", async () => {
+    const goalPath = join(TEST_DIR, "p11-legacy-goal.md");
+    const reportPath = join(TEST_DIR, "p11-legacy-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Legacy brief",
+        "",
+        "Write the report to:",
+        "",
+        `\`${reportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`DONE_LEGACY_PROSE`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_LEGACY_PROSE\n", "utf8");
+
+    const server = createLifecycleServer(makeLifecycleExec());
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-p11-legacy";
+    const record = makeServerAgentRecord({
+      agent_id: agentId,
+      goal_file: goalPath,
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(agentId, record);
+
+    const parsed = parseToolResult(await getState.handler({ agent_id: agentId }, {}));
+    expect(parsed.harvestability).toMatchObject({
+      report_path: reportPath,
+      done_marker: "DONE_LEGACY_PROSE",
+      closure_artifact_verified: true,
+      closure: "verified",
+    });
+  });
+
+  it("done child with no written report reads artifact_missing, not pending", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const getState = registeredTestTool(server, "get_agent_state");
+    const engine = testLifecycleEngine(server);
+    const agentId = "codex-golems-p11-deadlocked";
+    const record = makeServerAgentRecord({
+      agent_id: agentId,
+      state: "done",
+      report_path: join(TEST_DIR, "p11-never-written.md"),
+      done_marker: "DONE_P11_DEADLOCK",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(agentId, record);
+
+    const parsed = parseToolResult(await getState.handler({ agent_id: agentId }, {}));
+    expect(parsed.harvestability).toMatchObject({
+      closure: "artifact_missing",
+      closure_artifact_verified: false,
+    });
+    expect(
+      (parsed.harvestability as { issue_codes: string[] }).issue_codes,
+    ).toContain("report_missing");
+  });
+});
+
+// AIDEV-NOTE (P11 Constraint 3): skillcreator's falsifier, from the #727 lane.
+// An implementor sat DONE with an open PR and no marker while its lead waited
+// on that marker. Under a bare boolean that pane and a busy pane were BOTH
+// `false`. These tests pin that they are distinguishable at DEFAULT detail.
+describe("P11 closure state at default list_agents detail", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  async function listDefault(server: unknown) {
+    const list = registeredTestTool(server, "list_agents");
+    const parsed = parseToolResult(await list.handler({}, {}));
+    return (parsed.agents ?? []) as Array<Record<string, unknown>>;
+  }
+
+  it("a deadlocked child and a working child are DISTINGUISHABLE without detail:full", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const engine = testLifecycleEngine(server);
+
+    const deadlocked = makeServerAgentRecord({
+      agent_id: "codex-golems-p11-done-no-artifact",
+      state: "done",
+      report_path: join(TEST_DIR, "p11-list-never-written.md"),
+      done_marker: "DONE_P11_LIST_DEADLOCK",
+    });
+    const working = makeServerAgentRecord({
+      agent_id: "codex-golems-p11-still-working",
+      state: "working",
+      task_done_detected_at: null,
+      report_path: join(TEST_DIR, "p11-list-working.md"),
+      done_marker: "DONE_P11_LIST_WORKING",
+    });
+    for (const record of [deadlocked, working]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+
+    const agents = await listDefault(server);
+    const byId = new Map(agents.map((a) => [a.agent_id as string, a]));
+    expect(byId.get(deadlocked.agent_id)?.closure).toBe("artifact_missing");
+    expect(byId.get(working.agent_id)?.closure).toBe("pending");
+    // The whole point of Constraint 3.
+    expect(byId.get(deadlocked.agent_id)?.closure).not.toBe(
+      byId.get(working.agent_id)?.closure,
+    );
+  });
+
+  it("a child that wrote its report reads verified at default detail", async () => {
+    const reportPath = join(TEST_DIR, "p11-list-verified.md");
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_P11_LIST_OK\n", "utf8");
+    const server = createLifecycleServer(makeLifecycleExec());
+    const engine = testLifecycleEngine(server);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-golems-p11-list-verified",
+      state: "done",
+      report_path: reportPath,
+      done_marker: "DONE_P11_LIST_OK",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+
+    const agents = await listDefault(server);
+    expect(agents.find((a) => a.agent_id === record.agent_id)?.closure).toBe(
+      "verified",
+    );
+  });
+
+  it("a stale report left by an earlier occupant is NOT read as this agent's closure", async () => {
+    // The issued path is stable per agent_id, so a resumed/recycled id could
+    // otherwise inherit an old report and read `verified` without doing work.
+    const reportPath = join(TEST_DIR, "p11-list-stale.md");
+    writeFileSync(reportPath, "Status: COMPLETE\nDONE_P11_LIST_STALE\n", "utf8");
+    const stale = new Date("2026-07-05T05:00:00.000Z");
+    utimesSync(reportPath, stale, stale);
+
+    const server = createLifecycleServer(makeLifecycleExec());
+    const engine = testLifecycleEngine(server);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-golems-p11-list-stale",
+      state: "done",
+      created_at: "2026-07-05T07:00:00.000Z",
+      report_path: reportPath,
+      done_marker: "DONE_P11_LIST_STALE",
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+
+    const agents = await listDefault(server);
+    expect(agents.find((a) => a.agent_id === record.agent_id)?.closure).toBe(
+      "artifact_missing",
+    );
+  });
+
+  it("a contract-less spawn is not_applicable, never a falsey negative", async () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const engine = testLifecycleEngine(server);
+    const record = makeServerAgentRecord({
+      agent_id: "codex-golems-p11-no-contract",
+      state: "done",
+      goal_file: null,
+    });
+    engine.stateMgr.writeState(record);
+    engine.getRegistry().set(record.agent_id, record);
+
+    const agents = await listDefault(server);
+    expect(agents.find((a) => a.agent_id === record.agent_id)?.closure).toBe(
+      "not_applicable",
+    );
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -15285,6 +15285,77 @@ describe("P11 engine-issued coordination paths", () => {
     ).not.toBe(briefReportPath);
   });
 
+  it("FINDING 1: supersede_agent_goal clears the issued pair so the NEW brief wins", async () => {
+    // supersede is the one contract channel that actually reaches the worker --
+    // it delivers `/goal Read and execute this goal file` to the pane. If the
+    // consumer kept verifying the ORIGINALLY issued path, a superseded worker
+    // would render artifact_missing forever: the S3 disagreement re-created
+    // through the door that used to work.
+    const goalPath = join(TEST_DIR, "p11-supersede-goal.md");
+    const supersededReportPath = join(TEST_DIR, "p11-supersede-report.md");
+    writeFileSync(
+      goalPath,
+      [
+        "# Superseding brief",
+        "",
+        "Write the report to:",
+        "",
+        `\`${supersededReportPath}\``,
+        "",
+        "Final line:",
+        "",
+        "`DONE_P11_SUPERSEDED`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = registeredTestTool(server, "spawn_agent");
+    const supersede = registeredTestTool(server, "supersede_agent_goal");
+    const getState = registeredTestTool(server, "get_agent_state");
+
+    const spawned = parseToolResult(
+      await spawn.handler(
+        { repo: "brainlayer", model: "gpt-5.5", cli: "codex", role: "worker" },
+        {},
+      ),
+    );
+    const agentId = spawned.agent_id as string;
+    // Spawned after P11, so it carries an engine-issued pair.
+    expect(spawned.report_path).toBeTruthy();
+
+    const engine = testLifecycleEngine(server);
+    const registry = engine.getRegistry();
+    registry.set(agentId, engine.stateMgr.transition(agentId, "ready"));
+    registry.set(agentId, engine.stateMgr.transition(agentId, "working"));
+
+    const superseded = parseToolResult(
+      await supersede.handler({ agent_id: agentId, goal_file: goalPath }, {}),
+    );
+    expect(superseded.ok).toBe(true);
+
+    // The record must stop pinning the now-stale issued pair.
+    const after = engine.getAgentState(agentId);
+    expect(after?.report_path ?? null).toBeNull();
+    expect(after?.done_marker ?? null).toBeNull();
+
+    // And the consumer verifies against the brief the worker actually got.
+    writeFileSync(
+      supersededReportPath,
+      "Status: COMPLETE\nDONE_P11_SUPERSEDED\n",
+      "utf8",
+    );
+    registry.set(agentId, engine.stateMgr.transition(agentId, "done"));
+    const parsed = parseToolResult(
+      await getState.handler({ agent_id: agentId }, {}),
+    );
+    expect(parsed.harvestability).toMatchObject({
+      report_path: supersededReportPath,
+      done_marker: "DONE_P11_SUPERSEDED",
+    });
+  });
+
   it("falls back to the prose heuristic for legacy records with no engine-issued contract", async () => {
     const goalPath = join(TEST_DIR, "p11-legacy-goal.md");
     const reportPath = join(TEST_DIR, "p11-legacy-report.md");


### PR DESCRIPTION
## What this fixes

The S3 deadlock specimen (retro collab, @skillcreatorClaude 2026-08-17T20:40Z): a worker announced done on screen, its lead waited for a disk marker, and *"the signal's producer and its consumer disagree about what counts as done, and nothing detects that disagreement."*

Here is that failure in code:

- **The consumer half was already shipped and correct.** `assessHarvestability` (`agent-engine.ts:1673`) computes `report_path` / `done_marker` / `closure_artifact_verified` and surfaces in `get_agent`, `list_agents detail:"full"`, and `wait_for` health.
- **The producer half did not exist.** `grep -n goal_file src/*.ts` shows `goal_file` is written by exactly one tool — `supersede_agent_goal`. `spawn_agent` never set it. So **every spawned worker carried `goal_file: null` and read `terminal_contract_missing` forever** — the entire consumer half was dead code on the spawn path.
- **Where a contract did exist, it was guessed from prose.** `extractReportPath` (`:1885`) regex-*scores* markdown code spans in the brief and takes the top scorer; `extractDoneMarker` (`:1945`) scrapes the last `DONE*`-shaped span. Reword the brief and the consumer resolves a different string than the producer wrote.

Note on the spec: `final-understanding-v2.md` has **no section labelled "P11"** (`grep -n P11` returns nothing). The contract is there as **U10 ENGINE-ISSUED COORDINATION**. Label mismatch, not a missing section.

## Contract A — engine-issued, not lead-invented

`spawn_agent` derives, returns, and persists one engine-authored pair:

| field | value |
|---|---|
| `report_path` | `~/.cmux/agents/<agent_id>/report.md` — absolute, **outside the worktree** per U10, so it survives worktree removal at harvest |
| `done_marker` | `DONE_<AGENT_ID>` — shaped to satisfy the **already-shipped** `extractDoneMarker` grammar, so the existing verifier needs no rewrite |

`readClosureGoalContract` now **prefers** the record fields and keeps the prose heuristic as the fallback — precedence, not replacement, so legacy and `supersede_agent_goal` agents are unchanged. Derivation depends only on `agent_id` and sits above `launchMode`, so **registry-optional spawns (#453) get an identical contract by construction**, not via a second code path that could drift.

## Contract C — no bare boolean at default detail (Constraint 3)

@skillcreatorClaude's amendment, and it was right. Under a boolean, three states collapse into one `false` — and the middle one is the bug this retro exists for:

| child | lead must | bare boolean |
|---|---|---|
| done, artifact written | close the pane | `true` |
| **done, no artifact** | **route a reviewer NOW** | `false` |
| still working | wait | `false` |

Ships as `closure: "verified" | "artifact_missing" | "pending" | "not_applicable"` at **default** `list_agents` detail, with `artifact_missing` reachable **only** from `state === "done"` — so it is an actionable signal on its own. Same epistemics as the v0.4.42 `paused` fix (`types.ts` `pauseHonestyFields`): a falsey value is never load-bearing without its provenance.

## Not landed, and why (measured)

**The boot-prompt footer is built and tested but not wired.** Constraint 1 asked for a ≤2-line footer with bytes counted in the boot receipt. Implementing it surfaced a number the design did not anticipate:

- `SEND_INPUT_CHUNK_THRESHOLD` is **500** chars.
- The **already-shipped mailbox contract alone is ~479 chars** for a real agent id — 96% of the budget, before P11 adds anything.
- With the footer, the injection measured **618 chars** and the suite went **10 red across 3 files — four of them submit-verification timeouts**, not assertion churn.

So injecting the contract does not add a line to a prompt; it **moves every spawn's boot delivery from the typed path onto the chunked paste path** — the most incident-prone path in this repo (#434 readiness window, #438). That is not additive, and the brief said additive. Shortening the prose does not rescue it: ~21 chars remain.

**Consequence, stated plainly:** this PR gives **detection**, not yet **prevention by construction**. Because the consumer is now authoritative on the issued path, a worker that writes elsewhere renders as `closure: "artifact_missing"` — actionable — instead of silent deadlock. Telling the worker needs a decision that is not mine: **slim the mailbox contract (#425 already measured this exact class of payload waste), or explicitly accept chunked boot delivery for every spawn.** A guard test pins the current budget so the day it is crossed is a reviewed change.

## PREDICTION

- **Will hold:** the S3 regression (engine-issued beats a brief naming a different path) and the `artifact_missing` vs `pending` distinction are the load-bearing behaviors and are directly tested. Registry-optional parity is asserted on real receipts from two servers, not on the derivation function.
- **Most likely reviewer objection:** shipping `coordinationFooter` unwired. I judged a silent change to spawn boot delivery worse than a declared gap; if the reviewer disagrees, wiring it is a one-line change plus the delivery-route decision above.
- **Riskiest change:** `readClosureGoalContract` precedence. Legacy records are covered by an explicit fallback test, but any record carrying *both* a `goal_file` and engine-issued fields now resolves to the engine's — which is the intent, and is exactly what the S3 test pins.
- **Discovered mid-implementation, both caught by tests:** (1) suffix-only markers collide (`a-1`/`b-1` → `DONE_1`), which matters because the override lets several workers report into one shared collab dir — switched to the full id; (2) an engine-issued contract has no goal file, so the old freshness check could never pass and `closure` could never reach `verified` for a spawned worker — added a freshness baseline against the spawn that issued the contract, which also blocks a stale report left at that path by an earlier occupant.
- **Verified:** `bun run test` → 123 files, **2942 passed, 1 skipped, 0 failed**; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spawn receipts, agent records, harvestability precedence, and default API shapes (`closure`); boot contract is still not auto-delivered to workers, so behavior depends on leads relaying paths until follow-up.
> 
> **Overview**
> Fixes the S3-style deadlock where workers and `assessHarvestability` could disagree on report location/marker because each side inferred them from prose.
> 
> **Engine-issued contract at spawn:** `spawn_agent` derives `report_path` and `done_marker` (new `coordination-paths.ts`), persists them on the agent record, and returns them in lean spawn receipts. Optional absolute `report_path` override is validated before launch. `supersede_agent_goal` clears the issued pair so the new brief’s prose heuristic applies again.
> 
> **Consumer alignment:** `readClosureGoalContract` prefers record-issued paths over goal-file regex extraction; report freshness for issued contracts compares mtime to `created_at` so stale files at a recycled path don’t verify. Harvestability adds **`closure`** (`verified` | `artifact_missing` | `pending` | `not_applicable`) at default `list_agents` and in `wait_for` replies—so “done, no artifact” is actionable vs “still working.”
> 
> **Not wired yet:** A boot-prompt coordination footer is built and byte-counted in the receipt with explicit `coordination_footer_delivered: false` and a note that the lead must relay the contract until boot budget allows injection (~479/500 chars today).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b51884e22f9064fbe48c1b68b8dbe26a0046c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add engine-issued coordination contracts to `spawn_agent` with closure state tracking
> - Introduces [coordination-paths.ts](https://github.com/EtanHey/cmuxlayer/pull/454/files#diff-e9755eeba4a0e2b38c0755d707183f4db575afa048b0020a2c7bf74fd4e5e8b4), a new module that issues deterministic report/done-marker pairs per spawned agent, computes `ClosureState` (verified, artifact_missing, pending, not_applicable), and sizes the not-yet-delivered footer.
> - `spawn_agent` now issues a coordination contract after launch, persists `report_path` and `done_marker` to the agent registry record, and returns footer provenance fields (`coordination_footer_bytes`, `coordination_footer_delivered=false`, `coordination_footer_note`) in the response.
> - `assessHarvestability` prefers engine-issued `report_path`/`done_marker` over goal-file heuristics and uses spawn time (`created_at`) as the freshness baseline for issued contracts.
> - `supersede_agent_goal` clears `report_path` and `done_marker` so subsequent verification falls back to the new brief's contract.
> - `list_agents` at default detail now surfaces a `closure` state per agent; `wait_for` includes `closure` and `closure_artifact_verified`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b51884.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spawned agents now receive consistent report locations and completion markers.
  - Spawn responses include coordination details and footer size information.
  - Supports optional absolute report-path overrides.
  - `wait_for` and `list_agents` now show report paths, completion markers, and closure status.
- **Improvements**
  - Reports remain trackable even when expected goal files are unavailable.
  - Closure states distinguish verified, missing, pending, and not-applicable results.
- **Tests**
  - Added coverage for coordination contracts, path validation, report freshness, and closure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->