### PR TITLE
fix(f1): resolve callers, delivery and closure from live state, not the stale registry record

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -123,6 +123,23 @@ export class AgentDiscovery {
     this.cache = null;
   }
 
+  /**
+   * AIDEV-NOTE (F1): the last screen scan, synchronously, or null when there is
+   * none inside the TTL. Consumers that must resolve LIVE agent state on a
+   * synchronous path (caller identity, P11 closure) use this instead of
+   * trusting the registry record, which #408 poisons to `done` within minutes.
+   * Never triggers I/O: no fresh evidence means "no evidence", not "stale ok".
+   */
+  cachedScan(): { rows: DiscoveredAgent[]; observed_at_ms: number } | null {
+    if (!this.cache) return null;
+    if (Date.now() - this.cache.at >= this.ttlMs) return null;
+    const observerScoped = typeof this.deps.observerIdProvider === "function";
+    if (observerScoped && this.cache.observerId !== this.getObserverId()) {
+      return null;
+    }
+    return { rows: this.cache.result, observed_at_ms: this.cache.at };
+  }
+
   private getObserverId(): string | null {
     return this.deps.observerIdProvider?.()?.trim() || null;
   }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -44,6 +44,15 @@ import {
 } from "./agent-registry.js";
 import type { AgentDiscovery } from "./agent-discovery.js";
 import {
+  isLiveActive,
+  resolveLiveAgentState,
+  type LiveAgentState,
+} from "./live-agent-state.js";
+
+/** Live-derived state for a record, injected by the server (F1). */
+export type LiveStateResolver = (agent: AgentRecord) => LiveAgentState | null;
+
+import {
   resumeCommandForAgent,
   resumeCwdForAgent,
   resumeInvocationForAgent,
@@ -1452,6 +1461,7 @@ export function resolveSpawnLaunchPlan(
 
 export class AgentEngine {
   private stateMgr: StateManager;
+  private liveStateResolver: LiveStateResolver | null = null;
   private registry: AgentRegistry;
   private client: AgentEngineClient;
   private spawnPreflight: (
@@ -1703,6 +1713,25 @@ export class AgentEngine {
     return this.registry;
   }
 
+  /**
+   * AIDEV-NOTE (F1): P11 closure is a statement about what an agent IS doing,
+   * so it must read the live-derived state. Reading `agent.state` made a
+   * working agent report `closure:"artifact_missing"` -- which P11's own table
+   * means "route a reviewer NOW" -- purely because #408 had flipped its
+   * registry record to `done`. The server injects the live probe; without one
+   * this degrades to the record, and says so through the resolution's `source`.
+   */
+  setLiveStateResolver(resolver: LiveStateResolver | null): void {
+    this.liveStateResolver = resolver;
+  }
+
+  /** Live state for one record, or the record's own state when unprobed. */
+  liveStateOf(agent: AgentRecord): LiveAgentState {
+    return (
+      this.liveStateResolver?.(agent) ?? resolveLiveAgentState(agent, null)
+    );
+  }
+
   assessHarvestability(agent: AgentRecord): WorkerHarvestability {
     const issueCodes: string[] = [];
     const issues: string[] = [];
@@ -1712,16 +1741,35 @@ export class AgentEngine {
     };
 
     const role = agent.role ?? inferRecordRoleOrNull(agent);
+    // AIDEV-NOTE (F1): closure is derived from the LIVE state, but only ONE
+    // live observation is strong enough to overturn a recorded `done`: the
+    // screen showing the agent still WORKING. That is what #408 produced live
+    // (`state {value:"working", source:"screen"}` beside `detail.state:"done"`)
+    // and it made P11 report `artifact_missing` -- "route a reviewer NOW" --
+    // on an agent mid-turn. A `ready` prompt cannot overturn done (a finished
+    // worker sits at one too), and a dead/shell pane must not either: there
+    // the record's `done` plus the missing artifact IS the story.
+    const live = this.liveStateOf(agent);
+    const effectiveState = isLiveActive(live) ? live.state : agent.state;
     const neutralEvidenceChannel: HarvestabilityEvidenceChannel = {
       done_source: agent.task_done_detected_at ? "screen" : "none",
       degraded: false,
       reason: null,
     };
-    if (agent.state !== "done" || role === "orchestrator") {
+    if (effectiveState !== "done" || role === "orchestrator") {
+      // AIDEV-NOTE (F1): the contract PAIR is state-independent -- report_path
+      // and done_marker are what the lead must check whenever it looks. The
+      // record-only read here was invisible while `done` always took the branch
+      // below; now that a live-working agent can land here, a prose-contract
+      // agent would have reported a null pair mid-turn.
+      const preClosureGoal = this.readClosureGoalContract(
+        agent.goal_file ?? null,
+        agent,
+      );
       return {
         closeable: false,
         closure: resolveClosureState({
-          state: agent.state,
+          state: effectiveState,
           role,
           // A contract exists if EITHER source supplies one; sourcing this from
           // the record alone made a legacy prose agent read not_applicable while
@@ -1732,8 +1780,8 @@ export class AgentEngine {
           closureArtifactVerified: null,
         }),
         closure_artifact_verified: null,
-        report_path: agent.report_path ?? null,
-        done_marker: agent.done_marker ?? null,
+        report_path: preClosureGoal.reportPath,
+        done_marker: preClosureGoal.doneMarker,
         report_exists: null,
         report_fresh: null,
         report_final_line: null,
@@ -1845,7 +1893,7 @@ export class AgentEngine {
         !keptOpen?.present &&
         (!prLoopRequired || prLoopSatisfied === true),
       closure: resolveClosureState({
-        state: agent.state,
+        state: effectiveState,
         role,
         contractIssued: Boolean(goal.reportPath && goal.doneMarker),
         closureArtifactVerified,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -11,6 +11,7 @@ import {
   inferRecordRoleOrNull,
   isAgentRoleInferenceError,
 } from "./layout-policy.js";
+import { screenConfirmedAgentState } from "./live-agent-state.js";
 
 export type AgentHealthStatus = "healthy" | "degraded" | "unhealthy";
 export type AgentHealthIssueSeverity = "blocking" | "degraded" | "info";
@@ -436,31 +437,26 @@ export function evaluateAgentHealth(
       `screen parses as ${input.screen_status} but the last ${input.surface_write_liveness?.consecutive_broken_pipe_failures ?? "several"} surface writes failed with a broken pipe`,
     );
   }
-  const screenDone = input.screen_status === "done";
   let reconciledState: AgentState | undefined;
-  let screenConfirmedState: AgentState | undefined;
+  // AIDEV-NOTE (F1): the screen->state rule lives in live-agent-state.ts so the
+  // health report, caller resolution, delivery gating and P11 closure all agree
+  // on what "live" means. Do not re-derive it here.
+  const screenConfirmedState =
+    screenConfirmedAgentState({
+      status: input.screen_status,
+      agent_type: input.screen_agent_type,
+      control_state: input.screen_control_state,
+    }) ?? undefined;
   const screenIsShell =
     input.screen_control_state === "shell" &&
     input.screen_agent_type === "unknown";
   if (screenIsShell) {
-    screenConfirmedState = "error";
     addIssue(
       issueCodes,
       issues,
       "agent_shell_fallback",
       "tracked agent surface has fallen back to a bare shell with no agent process visible",
     );
-  } else if (screenActive) {
-    screenConfirmedState = "working";
-  } else if (
-    input.screen_control_state === "ready" &&
-    input.screen_agent_type !== null &&
-    input.screen_agent_type !== undefined &&
-    input.screen_agent_type !== "unknown"
-  ) {
-    screenConfirmedState = "ready";
-  } else if (screenDone) {
-    screenConfirmedState = "done";
   }
   if (screenConfirmedState && screenConfirmedState !== agent.state) {
     reconciledState = screenConfirmedState;

--- a/src/live-agent-state.ts
+++ b/src/live-agent-state.ts
@@ -1,0 +1,175 @@
+import type { AgentRecord, AgentState } from "./agent-types.js";
+import type {
+  ParsedControlPlaneState,
+  ParsedScreenStatus,
+} from "./types.js";
+
+/**
+ * AIDEV-NOTE (F1): THE single source of live agent-state truth.
+ *
+ * The registry record is a cache, and a known-broken one: #408 flips live
+ * agents to `done` within minutes. Every consumer that read `agent.state` as
+ * primary truth inherited that lie — caller identity resolved to null (U6),
+ * `send_to` returned a terminal `failed` receipt to an agent sitting at a live
+ * prompt, and P11 closure read `artifact_missing` on a working agent.
+ *
+ * So: derive state from the LIVE screen observation, and fall back to the
+ * registry record only as provenance when no screen evidence exists. This
+ * module owns the rule; `agent-health.ts` and the server consumers import it
+ * rather than each re-deriving one.
+ */
+
+/** Agent states that are safe to close without `force`: the task is over. */
+export const TERMINAL_AGENT_STATES: ReadonlySet<AgentState> = new Set<AgentState>([
+  "done",
+  "error",
+]);
+
+/** Agent states that accept unforced interactive delivery. */
+export const INTERACTIVE_AGENT_STATES: ReadonlySet<AgentState> =
+  new Set<AgentState>(["ready", "idle"]);
+
+export type ScreenStateObservation = {
+  status?: ParsedScreenStatus | string | null;
+  agent_type?: string | null;
+  control_state?: ParsedControlPlaneState | string | null;
+};
+
+export type LiveAgentState = {
+  /** Live-derived state: what the agent IS, not what the registry remembers. */
+  state: AgentState;
+  /** `screen` when live evidence decided it; `registry` when it is a fallback. */
+  source: "screen" | "registry";
+  /** The record's own value, kept for provenance and drift reporting. */
+  registry_state: AgentState;
+  /** Raw screen verdict, whether or not it was strong enough to override. */
+  screen_state: AgentState | null;
+  /** Live evidence contradicts the record — #408 poisoning, observable. */
+  stale_registry_state: boolean;
+};
+
+/**
+ * The one screen→state rule. Returns null when the screen says nothing
+ * conclusive, which is a real answer: absence of evidence is not evidence the
+ * record is right, it just leaves the record unchallenged.
+ */
+export function screenConfirmedAgentState(
+  screen: ScreenStateObservation | null | undefined,
+): AgentState | null {
+  if (!screen) return null;
+  const status = screen.status ?? null;
+  const agentType = screen.agent_type ?? null;
+  const controlState = screen.control_state ?? null;
+  // A tracked agent surface that has fallen back to a bare shell has no agent
+  // process left; that is an error regardless of how idle the prompt looks.
+  if (controlState === "shell" && agentType === "unknown") return "error";
+  if (status === "working" || status === "thinking") return "working";
+  if (
+    controlState === "ready" &&
+    agentType !== null &&
+    agentType !== undefined &&
+    agentType !== "unknown"
+  ) {
+    return "ready";
+  }
+  if (status === "done") return "done";
+  return null;
+}
+
+/**
+ * Whether a screen verdict is strong enough to overturn the recorded state.
+ *
+ * AIDEV-NOTE (F1): `ready` is the weak one, and getting this wrong breaks the
+ * opposite contract. A worker that genuinely finished ALSO sits at a ready
+ * prompt — the screen cannot tell "done, at prompt" from "idle, never
+ * started", while the record can (it carries done-marker/transcript
+ * detection). So `ready` may clear a stale `error` or a mid-boot state, but it
+ * must never overturn `done`, or done-detection dies for every agent that
+ * returns to its prompt. Positive evidence of ACTIVITY (`working`) or of a
+ * dead process (bare `shell`) always wins: those contradict the record with
+ * something the record cannot know.
+ */
+function screenOverridesRecord(
+  screenState: AgentState,
+  registryState: AgentState,
+): boolean {
+  if (screenState === registryState) return false;
+  if (screenState === "working" || screenState === "error") return true;
+  if (screenState === "done") return true;
+  // screenState === "ready"
+  return registryState !== "done";
+}
+
+export function resolveLiveAgentState(
+  record: Pick<AgentRecord, "state">,
+  screen: ScreenStateObservation | null | undefined,
+): LiveAgentState {
+  const registryState = record.state;
+  const screenState = screenConfirmedAgentState(screen);
+  if (screenState === null) {
+    return {
+      state: registryState,
+      source: "registry",
+      registry_state: registryState,
+      screen_state: null,
+      stale_registry_state: false,
+    };
+  }
+  const overrides = screenOverridesRecord(screenState, registryState);
+  const state = overrides ? screenState : registryState;
+  return {
+    state,
+    // The screen is the source when it decided the answer — by overriding the
+    // record, or by corroborating it. When the record won a disagreement, the
+    // record is the source, and the raw screen verdict stays visible below.
+    source: screenState === state ? "screen" : "registry",
+    registry_state: registryState,
+    screen_state: screenState,
+    stale_registry_state: overrides,
+  };
+}
+
+export function isLiveTerminal(live: LiveAgentState): boolean {
+  return TERMINAL_AGENT_STATES.has(live.state);
+}
+
+/**
+ * Positive live evidence that the agent is still doing the work. The ONLY
+ * observation strong enough to overturn a recorded `done`: a ready prompt is
+ * also where a finished worker sits, and a dead pane says nothing about
+ * whether the task completed.
+ */
+export function isLiveActive(live: LiveAgentState): boolean {
+  return live.state === "working" && live.source === "screen";
+}
+
+export function isLiveInteractive(live: LiveAgentState): boolean {
+  return INTERACTIVE_AGENT_STATES.has(live.state);
+}
+
+/**
+ * Whether unforced input may be delivered right now.
+ *
+ * AIDEV-NOTE (F1): delivery asks a DIFFERENT question from closure. Closure
+ * asks "did the task finish?", which a ready prompt cannot answer. Delivery
+ * asks "will this surface accept a message?", which a ready prompt answers
+ * definitively — so a live agent prompt is deliverable even while its record
+ * says `done`. Gating this on the record is what returned `delivery:"failed"`,
+ * `terminal:true` to an agent sitting at a live prompt (ledger row 4).
+ *
+ * Deliberately only ever WIDENS what the record allowed. A false refusal to a
+ * live agent is the harm this lane exists to kill; the other direction already
+ * has `allow_busy` and the bare-shell refusal ahead of it.
+ */
+export function isLiveDeliverable(live: LiveAgentState): boolean {
+  if (INTERACTIVE_AGENT_STATES.has(live.registry_state)) return true;
+  // A live agent prompt overrides a TERMINAL record — that, and only that, is
+  // the #408 poisoning case. Every other record state keeps its gate: a
+  // `booting` pane may still be receiving its launcher line, and a `working`
+  // one is mid-turn, where a momentarily-ready parse must not be read as
+  // permission to type (that is what `allow_busy` is for).
+  return (
+    live.screen_state === "ready" &&
+    TERMINAL_AGENT_STATES.has(live.registry_state)
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3575,6 +3575,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // is the best available caller identity even when the record is stale --
     // the call itself is the liveness evidence. The live-first ordering still
     // lets a genuinely live record win a recycled surface (#378 MEDIUM-A).
+    // AIDEV-TODO (F1 review, finding 2): the LAST tier below matches a terminal
+    // record by `surface_id`, and `surface_id` is a RECYCLABLE ref -- a dead
+    // worker's record whose ref got reused can claim to be the caller, and #378
+    // then forces the new pane's children to worker/right off a corpse. The
+    // obvious guard -- compare the live pane's CLI to the record's, as
+    // deliverAgentInput does -- does NOT work here: `registry.listMerged`
+    // rewrites `record.cli` from the live pane, so by the time caller
+    // resolution runs, a recycled record already claims the new occupant's CLI.
+    // Needs a signal the merge does not overwrite. Tiers 1 and 3 (UUID) are
+    // unaffected. Tracked in #468.
     const live = (agent: AgentRecord): boolean =>
       !isLiveTerminal(liveStateFor(agent));
     return (
@@ -11054,10 +11064,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             // be caught, never reported as ok. Verified agent messages may
             // retry Return once only while the exact text remains in a Codex
             // composer; accepted TUI queues are nonterminal receipts instead.
+            // AIDEV-NOTE (F1): gate verification on the SAME live-resolved
+            // state the delivery gate above used. Reading the registry record
+            // here meant the class this lane newly admits -- registry-terminal
+            // + screen `ready` + allow_busy:false -- skipped verification
+            // entirely and returned an unproven success: the same receipt lie
+            // with the sign flipped (false `failed` -> false `ok`). It also
+            // suppressed markAgentWorking below, so the poisoned record was
+            // never corrected and every later send repeated the unverified path.
             verify_submit:
               args.press_enter &&
-              (args.allow_busy ||
-                INTERACTIVE_AGENT_STATES.has(deliveryRoute.state)),
+              (args.allow_busy || isLiveDeliverable(liveRouteState)),
             // A single recovery Return is part of verified sends and inbox
             // wakeups. Other lifecycle mutations (notably goal supersession)
             // retain their stricter no-retry evidence semantics.

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,14 @@ import {
   type DiscoveredAgent,
 } from "./agent-discovery.js";
 import {
+  INTERACTIVE_AGENT_STATES,
+  isLiveDeliverable,
+  isLiveTerminal,
+  resolveLiveAgentState,
+  TERMINAL_AGENT_STATES,
+  type LiveAgentState,
+} from "./live-agent-state.js";
+import {
   resumeCommandForAgent,
   toAgentStatePayload,
   toObservedPublicAgent,
@@ -492,9 +500,6 @@ const LAUNCHER_LINE_CORRUPTION_ERROR =
   "launcher line corrupted by external input; manual Enter may have executed a modified command";
 /** Heartbeat freshness window before dispatch_to_agent falls back to a surface nudge. */
 const INBOX_NUDGE_HEARTBEAT_MAX_AGE_MS = AGENT_HEALTH_MONITOR_MAX_AGE_MS;
-const INTERACTIVE_AGENT_STATES = new Set<AgentState>(["ready", "idle"]);
-/** Agent states that are safe to close without `force`: the task is over. */
-const TERMINAL_AGENT_STATES = new Set<AgentState>(["done", "error"]);
 const READY_PATTERN_CLIS: CliType[] = [
   "claude",
   "codex",
@@ -3538,6 +3543,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // Health/read paths should not fail just because a refresh scan failed.
     }
   };
+  /**
+   * AIDEV-NOTE (F1): live-derived state for one record, resolved from the last
+   * screen scan. Wired to the discovery cache inside the lifecycle block; until
+   * then (and whenever no fresh scan exists) it degrades to the registry record
+   * as explicit `source: "registry"` provenance, never as silent truth.
+   */
+  const liveAgentStateProbe: {
+    current: ((agent: AgentRecord) => LiveAgentState | null) | null;
+  } = { current: null };
+  const liveStateFor = (agent: AgentRecord): LiveAgentState =>
+    liveAgentStateProbe.current?.(agent) ?? resolveLiveAgentState(agent, null);
+
   const resolveCurrentCallerAgent = (): AgentRecord | null => {
     const callerSurface = currentCallerContext()?.surfaceId?.trim();
     if (!callerSurface) return null;
@@ -3545,13 +3562,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const records = [
       ...(context.lifecycleRegistry?.list() ?? []),
       ...stateMgr.listStates(),
-    ].filter((agent) => !TERMINAL_AGENT_STATES.has(agent.state));
+    ];
+    const matchesUuid = (agent: AgentRecord): boolean =>
+      agent.surface_uuid?.trim().toLowerCase() === normalizedSurface;
+    const matchesSurfaceId = (agent: AgentRecord): boolean =>
+      agent.surface_id === callerSurface;
+    // AIDEV-NOTE (F1): a terminal state is an ORDERING signal here, never an
+    // exclusion, and it is read LIVE. #408 flips live agents to `done` within
+    // minutes; excluding those records made the caller invisible, so the child
+    // it spawned recorded parent_agent_id:null (U6) and the #378 worker guard
+    // silently no-opped. A record bound to the surface the call is arriving on
+    // is the best available caller identity even when the record is stale --
+    // the call itself is the liveness evidence. The live-first ordering still
+    // lets a genuinely live record win a recycled surface (#378 MEDIUM-A).
+    const live = (agent: AgentRecord): boolean =>
+      !isLiveTerminal(liveStateFor(agent));
     return (
-      records.find(
-        (agent) =>
-          agent.surface_uuid?.trim().toLowerCase() === normalizedSurface,
-      ) ??
-      records.find((agent) => agent.surface_id === callerSurface) ??
+      records.find((agent) => matchesUuid(agent) && live(agent)) ??
+      records.find((agent) => matchesSurfaceId(agent) && live(agent)) ??
+      records.find(matchesUuid) ??
+      records.find(matchesSurfaceId) ??
       null
     );
   };
@@ -10242,6 +10272,48 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       listSurfaces: surfaceProvider,
       readScreen: (surface, opts) => client.readScreen(surface, opts),
     });
+    // AIDEV-NOTE (F1): from here on, every consumer that used to read
+    // `agent.state` as truth resolves the LIVE state through this probe. It
+    // reads the last screen scan only -- no I/O on the caller's path -- and
+    // returns null when there is no fresh evidence, which degrades to the
+    // registry record with honest `registry` provenance.
+    const screenObservationForRecord = (
+      agent: AgentRecord,
+    ): {
+      status: string | null;
+      agent_type: string | null;
+      control_state: string | null;
+    } | null => {
+      const cached = discovery.cachedScan();
+      if (!cached) return null;
+      const uuidKey = (value: string | null | undefined): string | null =>
+        value?.trim().toLowerCase() || null;
+      const agentUuid = uuidKey(agent.surface_uuid);
+      // Same binding rule list_agents uses: a UUID pair, or a surface_id match
+      // ONLY when neither side has a UUID and this observer owns the seat.
+      // A looser match would let an unrelated pane's screen decide an agent's
+      // state, which is a worse lie than the stale record it replaces.
+      const row = cached.rows.find((surface) => {
+        const surfaceUuid = uuidKey(surface.surface_uuid);
+        return agentUuid && surfaceUuid
+          ? agentUuid === surfaceUuid
+          : Boolean(
+              !agentUuid &&
+              !surfaceUuid &&
+              agent.surface_observer_id &&
+              agent.surface_observer_id === registry.getObserverId() &&
+              surface.surface_id === agent.surface_id,
+            );
+      });
+      if (!row || row.read_error) return null;
+      return {
+        status: row.parsed_status ?? null,
+        agent_type: row.cli === "kiro" ? "unknown" : (row.cli ?? null),
+        control_state: row.control_state ?? null,
+      };
+    };
+    liveAgentStateProbe.current = (agent) =>
+      resolveLiveAgentState(agent, screenObservationForRecord(agent));
     const awaitLifecycleStart = async (): Promise<void> => {
       if (context.lifecycleStartPromise) {
         await context.lifecycleStartPromise;
@@ -10571,6 +10643,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     };
     context.lifecycleSweepEngine = engine;
     lifecycleHealthEngine = engine;
+    // F1: closure, harvestability and the health report all resolve state
+    // through the same live probe the caller/delivery paths use.
+    engine.setLiveStateResolver(liveAgentStateProbe.current);
 
     server.tool(
       "arm_watch",
@@ -10899,13 +10974,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               context.surfaceObserverId,
             )?.pty_dead === true,
         }));
+      // AIDEV-NOTE (F1): gate on the LIVE state, not the route's registry copy.
+      // `freshOccupant` is a target-scoped scan taken moments ago -- the same
+      // evidence P4 uses. Reading the record here is what returned a terminal
+      // `failed` receipt to an agent sitting at a live prompt (ledger row 4):
+      // #408 had flipped its record to `done` while its screen read ready.
+      const liveRouteState = resolveLiveAgentState(
+        { state: route.state },
+        freshOccupant && !freshOccupant.read_error
+          ? {
+              status: freshOccupant.parsed_status,
+              agent_type:
+                freshOccupant.cli === "kiro" ? "unknown" : freshOccupant.cli,
+              control_state: freshOccupant.control_state,
+            }
+          : null,
+      );
       if (
         !args.allow_busy &&
-        !INTERACTIVE_AGENT_STATES.has(route.state) &&
+        !isLiveDeliverable(liveRouteState) &&
         !routeSurfaceAlive
       ) {
         throw new RetryableDeliveryError(
-          `Agent "${args.agent_id}" is not in an interactive state (current: ${route.state}). ` +
+          `Agent "${args.agent_id}" is not in an interactive state ` +
+            `(current: ${liveRouteState.state}, source: ${liveRouteState.source}` +
+            `${liveRouteState.stale_registry_state ? `, registry record says ${liveRouteState.registry_state}` : ""}). ` +
             `Must be in: ${[...INTERACTIVE_AGENT_STATES].join(", ")}. ` +
             `Pass allow_busy: true to bypass this gate and deliver raw keystrokes regardless of state.`,
         );
@@ -15124,6 +15217,39 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               delivery_id: deliveryId,
             });
           } catch (error) {
+            // AIDEV-NOTE (F1): a RetryableDeliveryError is, by name and by the
+            // drain loop's own handling, NOT a terminal outcome -- the engine
+            // backs it off and tries again. Flattening it into a terminal
+            // `failed` receipt here contradicted send_to's own published
+            // promise ("Omit it to receive a nonterminal queued receipt") and
+            // was the fleet's #1 receipt lie: a lead told its live worker was
+            // dead. Hand back the queued receipt the drain loop will honour.
+            if (error instanceof RetryableDeliveryError) {
+              const receipt = engine.queueDelivery({
+                delivery_id: deliveryId,
+                agent_id: agentId,
+                text: args.text,
+                press_enter: args.press_enter,
+                source_event: "send_to",
+              });
+              const data = {
+                accepted: true,
+                agent_id: agentId,
+                ...buildPublicDeliveryReceipt({
+                  delivery_state: "queued",
+                  delivery_id: receipt.delivery_id,
+                  typed: false,
+                  submit_attempted: false,
+                  submit_verified: receipt.submit_verified,
+                  retry_count: receipt.retry_count,
+                  WARNING: `Delivery is queued for retry, not delivered yet: ${error.message}`,
+                }),
+              };
+              return okFormatted(
+                `send_to accepted — delivery ${receipt.delivery_id} queued for retry`,
+                data,
+              );
+            }
             const failedReceipt = engine.resolveDelivery(
               {
                 delivery_id: deliveryId,

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -11,6 +11,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "../src/server.js";
+import { runWithCallerContext } from "../src/caller-context.js";
 import type { StateManager } from "../src/state-manager.js";
 import type { AgentRecord } from "../src/agent-types.js";
 
@@ -219,13 +220,45 @@ describe("F1 — live state, not the stale registry record", () => {
     });
     const parsed = parseResult(result);
 
+    // The receipt may be terminal — but only as a PROVEN success. What must
+    // never happen again is a terminal `failed` against a live prompt.
     expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
-    expect(parsed.terminal, JSON.stringify(parsed)).toBe(false);
     expect(parsed.delivery).not.toBe("failed");
     expect(parsed.delivery_state).not.toBe("failed");
+    expect(parsed.delivered).toBe(true);
+    expect(parsed.submit_verified).toBe(true);
     // The registry lie survives as provenance, not as the verdict.
     expect(parsed.registry_state).toBe("done");
     expect(parsed.health?.reconciled_state).toBe("ready");
+  });
+
+  it("send_to VERIFIES the submit on the stale-done/screen-ready class it newly admits", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-staleverify",
+        surface_id: client.idleSurface,
+        state: "done",
+      }),
+    );
+
+    const result = await callTool(server, "send_to", {
+      mode: "agent",
+      agent_id: "cmuxlayerCodex-staleverify",
+      text: "status?",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    // Widening the gate on live evidence must not hand these deliveries to the
+    // unverified submit path: that is the same receipt lie with the sign
+    // flipped -- a false `ok` instead of a false `failed`.
+    expect(parsed.submit_verified, JSON.stringify(parsed)).toBe(true);
+    // NOTE: `markAgentWorking` still only transitions from `idle`
+    // (agent-engine.ts:8339), so a verified send does not yet correct a
+    // poisoned `done` record. Widening that precondition would erase
+    // done-detection whenever a lead pings a finished worker, so it is a
+    // separate state-machine decision, not part of this gate fix.
   });
 
   it("send_to still refuses when the live screen agrees the surface is dead", async () => {
@@ -272,6 +305,55 @@ describe("F1 — live state, not the stale registry record", () => {
     expect(parsed.terminal, JSON.stringify(parsed)).not.toBe(true);
     expect(parsed.delivery_state ?? parsed.delivery).not.toBe("failed");
     expect(parsed.accepted ?? parsed.ok).toBe(true);
+  });
+
+  it("caller resolution prefers a live record over a stale one on the same surface", async () => {
+    // Pins the tier order the AIDEV-NOTE asserts: live-first, terminal records
+    // only as a fallback. A future reorder that put the stale record first
+    // would resurrect the #378 MEDIUM-A hazard. `mine:true` lists the resolved
+    // caller's children, so whose child comes back names the caller.
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-deadseat",
+        surface_id: client.workingSurface,
+        state: "done",
+      }),
+    );
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-liveseat",
+        surface_id: client.workingSurface,
+        state: "working",
+      }),
+    );
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-childofdead",
+        surface_id: "surface:childofdead",
+        parent_agent_id: "cmuxlayerCodex-deadseat",
+      }),
+    );
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-childoflive",
+        surface_id: "surface:childoflive",
+        parent_agent_id: "cmuxlayerCodex-liveseat",
+      }),
+    );
+
+    const parsed = await runWithCallerContext(
+      { workspaceId: "workspace:1", surfaceId: client.workingSurface },
+      async () => parseResult(await callTool(server, "list_agents", { mine: true })),
+    );
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.agents.map((agent: any) => agent.agent_id)).toEqual([
+      "cmuxlayerCodex-childoflive",
+    ]);
   });
 
   it("P11 closure reads pending, not artifact_missing, on a screen-working agent", async () => {

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Lane F1 regressions: consumers must resolve caller identity, delivery gating
+ * and P11 closure from the LIVE-derived state, never from the registry record.
+ *
+ * The registry marks live agents `done` within minutes (#408). This lane does
+ * not fix that; it makes the consumers immune to it. Every test here seeds a
+ * record whose `state` is a lie and asserts the consumer believes the screen.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import type { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-f1-live-state-truth-test");
+const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-f1-live-state-truth.sock";
+
+const IDLE_CODEX_SCREEN = [
+  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+  "codex>",
+].join("\n");
+const WORKING_CODEX_SCREEN = [
+  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+  "• Working (12s • esc to interrupt)",
+  "codex>",
+].join("\n");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool.handler(args, {} as any);
+}
+
+/** Two live codex surfaces: one at a prompt, one mid-turn. */
+class LiveSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly idleSurface = "surface:idle";
+  readonly workingSurface = "surface:working";
+  readonly sendCalls: string[] = [];
+  readonly sendKeyCalls: string[] = [];
+  readonly screens: Record<string, string> = {
+    "surface:idle": IDLE_CODEX_SCREEN,
+    "surface:working": WORKING_CODEX_SCREEN,
+  };
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 2,
+          surface_refs: [this.idleSurface, this.workingSurface],
+          selected_surface_ref: this.idleSurface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.idleSurface,
+          title: "cmuxlayerCodex-idle",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+        {
+          ref: this.workingSurface,
+          title: "cmuxlayerCodex-working",
+          type: "terminal",
+          index: 1,
+          selected: false,
+        },
+      ],
+    };
+  }
+
+  async send(surface: string, text: string) {
+    if (!(surface in this.screens)) throw new Error(`Unknown surface: ${surface}`);
+    this.sendCalls.push(`${surface}:${text}`);
+  }
+
+  async sendKey(surface: string, key: string) {
+    if (!(surface in this.screens)) throw new Error(`Unknown surface: ${surface}`);
+    this.sendKeyCalls.push(`${surface}:${key}`);
+  }
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    const text = this.screens[surface];
+    if (text == null) throw new Error(`Unknown surface: ${surface}`);
+    return { surface, text, lines: opts?.lines ?? 30, scrollback_used: false };
+  }
+
+  async renameTab() {}
+}
+
+function createLiveServer(client: LiveSurfaceClient) {
+  return createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+    surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
+    surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
+  });
+}
+
+function makeAgent(
+  overrides: Partial<AgentRecord> &
+    Pick<AgentRecord, "agent_id" | "surface_id">,
+): AgentRecord {
+  const now = "2026-08-18T13:40:00.000Z";
+  return {
+    workspace_id: "workspace:1",
+    surface_observer_id: TEST_OBSERVER_OWNER,
+    state: "idle",
+    repo: "cmuxlayer",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "f1 live state",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    paused: false,
+    paused_source: null,
+    ...overrides,
+  } as AgentRecord;
+}
+
+function registerAgent(server: any, record: AgentRecord): AgentRecord {
+  const engine = server._registeredTools["interact"]._engine;
+  const stateMgr = engine["stateMgr"] as StateManager;
+  stateMgr.writeState(record);
+  engine.getRegistry().set(record.agent_id, record);
+  return record;
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") engine.dispose();
+}
+
+describe("F1 — live state, not the stale registry record", () => {
+  let server: any;
+  let client: LiveSurfaceClient;
+
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    client = new LiveSurfaceClient();
+    server = createLiveServer(client);
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("send_to a screen-idle agent whose record says done returns a NONTERMINAL receipt", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-stale",
+        surface_id: client.idleSurface,
+        // The #408 lie: registry says the task is over, the prompt is live.
+        state: "done",
+        task_done_detected_at: "2026-08-18T13:41:00.000Z",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const result = await callTool(server, "send_to", {
+      mode: "agent",
+      agent_id: "cmuxlayerCodex-stale",
+      text: "status?",
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.terminal, JSON.stringify(parsed)).toBe(false);
+    expect(parsed.delivery).not.toBe("failed");
+    expect(parsed.delivery_state).not.toBe("failed");
+    // The registry lie survives as provenance, not as the verdict.
+    expect(parsed.registry_state).toBe("done");
+    expect(parsed.health?.reconciled_state).toBe("ready");
+  });
+
+  it("send_to still refuses when the live screen agrees the surface is dead", async () => {
+    client.screens["surface:idle"] = "$ ";
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-dead",
+        surface_id: client.idleSurface,
+        state: "done",
+      }),
+    );
+
+    const result = await callTool(server, "send_to", {
+      mode: "agent",
+      agent_id: "cmuxlayerCodex-dead",
+      text: "status?",
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok === false || parsed.delivery === "failed").toBe(true);
+  });
+
+  it("send_to to a mid-turn agent never resolves as a terminal failure", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-midturn",
+        surface_id: client.workingSurface,
+        // Stale-done record on an agent that is demonstrably mid-turn. The gate
+        // refuses -- correctly, it is busy -- but that refusal is RETRYABLE, so
+        // flattening it into `failed`/`terminal:true` would be the same receipt
+        // lie in a different costume. The engine will drain it when the turn ends.
+        state: "done",
+      }),
+    );
+
+    const result = await callTool(server, "send_to", {
+      mode: "agent",
+      agent_id: "cmuxlayerCodex-midturn",
+      text: "status?",
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.terminal, JSON.stringify(parsed)).not.toBe(true);
+    expect(parsed.delivery_state ?? parsed.delivery).not.toBe("failed");
+    expect(parsed.accepted ?? parsed.ok).toBe(true);
+  });
+
+  it("P11 closure reads pending, not artifact_missing, on a screen-working agent", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-busy",
+        surface_id: client.workingSurface,
+        // Registry lie again: done with no artifact would read artifact_missing,
+        // which P11's own table means "route a reviewer NOW".
+        state: "done",
+        report_path: join(TEST_DIR, "reports", "cmuxlayerCodex-busy.md"),
+        done_marker: "### @cmuxlayerCodex-busy DONE",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const result = await callTool(server, "list_agents", {});
+    const parsed = parseResult(result);
+    const row = parsed.agents.find(
+      (agent: any) => agent.agent_id === "cmuxlayerCodex-busy",
+    );
+
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    expect(row.state.value).toBe("working");
+    expect(row.state.source).toBe("screen");
+    expect(row.closure).toBe("pending");
+  });
+
+  it("P11 closure still reports artifact_missing when the screen confirms done", async () => {
+    client.screens["surface:idle"] = [
+      "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+      "codex>",
+    ].join("\n");
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-finished",
+        surface_id: client.idleSurface,
+        state: "done",
+        report_path: join(TEST_DIR, "reports", "missing.md"),
+        done_marker: "### @cmuxlayerCodex-finished DONE",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const result = await callTool(server, "list_agents", { detail: "full" });
+    const parsed = parseResult(result);
+    const row = parsed.agents.find(
+      (agent: any) => agent.agent_id === "cmuxlayerCodex-finished",
+    );
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    // A finished worker sits at a ready prompt too, so `ready` must NOT
+    // overturn a recorded done: the deadlock signal has to survive.
+    expect(row.closure).toBe("artifact_missing");
+  });
+});

--- a/tests/live-agent-state.test.ts
+++ b/tests/live-agent-state.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import type { AgentRecord } from "../src/agent-types.js";
+import {
+  INTERACTIVE_AGENT_STATES,
+  TERMINAL_AGENT_STATES,
+  isLiveDeliverable,
+  isLiveInteractive,
+  isLiveTerminal,
+  resolveLiveAgentState,
+  screenConfirmedAgentState,
+} from "../src/live-agent-state.js";
+
+function record(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    agent_id: "cmuxlayerClaude-f1",
+    surface_id: "surface:f1",
+    workspace_id: "workspace:1",
+    state: "done",
+    repo: "cmuxlayer",
+    model: "claude-opus-5",
+    cli: "claude",
+    cli_session_id: null,
+    task_summary: "F1",
+    pid: null,
+    version: 1,
+    created_at: "2026-08-18T00:00:00.000Z",
+    updated_at: "2026-08-18T00:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    ...overrides,
+  } as AgentRecord;
+}
+
+describe("screenConfirmedAgentState — the one screen->state rule", () => {
+  it("reads an active screen as working", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "working",
+        agent_type: "claude",
+        control_state: "busy",
+      }),
+    ).toBe("working");
+  });
+
+  it("reads an agent at a live prompt as ready", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "idle",
+        agent_type: "claude",
+        control_state: "ready",
+      }),
+    ).toBe("ready");
+  });
+
+  it("reads a bare shell as error, never as a healthy idle agent", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "idle",
+        agent_type: "unknown",
+        control_state: "shell",
+      }),
+    ).toBe("error");
+  });
+
+  it("returns null when there is no screen evidence at all", () => {
+    expect(screenConfirmedAgentState(null)).toBeNull();
+    expect(
+      screenConfirmedAgentState({
+        status: null,
+        agent_type: null,
+        control_state: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveLiveAgentState — live truth, registry as fallback provenance", () => {
+  it("prefers the live screen over a stale done registry record", () => {
+    const resolved = resolveLiveAgentState(record({ state: "done" }), {
+      status: "working",
+      agent_type: "claude",
+      control_state: "busy",
+    });
+    expect(resolved).toMatchObject({
+      state: "working",
+      source: "screen",
+      registry_state: "done",
+      stale_registry_state: true,
+    });
+  });
+
+  it("keeps a registry-done agent done at a ready prompt, but calls it deliverable", () => {
+    // A worker that genuinely finished also sits at a ready prompt, so `ready`
+    // must not overturn `done` -- that would erase done-detection. Delivery is
+    // a separate question, and the live prompt answers it: yes.
+    const resolved = resolveLiveAgentState(record({ state: "done" }), {
+      status: "idle",
+      agent_type: "claude",
+      control_state: "ready",
+    });
+    expect(resolved.state).toBe("done");
+    expect(resolved.screen_state).toBe("ready");
+    expect(resolved.stale_registry_state).toBe(false);
+    expect(isLiveInteractive(resolved)).toBe(false);
+    expect(isLiveDeliverable(resolved)).toBe(true);
+  });
+
+  it("lets a ready prompt clear a stale error record", () => {
+    const resolved = resolveLiveAgentState(record({ state: "error" }), {
+      status: "idle",
+      agent_type: "claude",
+      control_state: "ready",
+    });
+    expect(resolved.state).toBe("ready");
+    expect(resolved.source).toBe("screen");
+    expect(INTERACTIVE_AGENT_STATES.has(resolved.state)).toBe(true);
+  });
+
+  it("falls back to the registry record when no screen evidence exists", () => {
+    const resolved = resolveLiveAgentState(record({ state: "done" }), null);
+    expect(resolved).toMatchObject({
+      state: "done",
+      source: "registry",
+      registry_state: "done",
+      screen_state: null,
+      stale_registry_state: false,
+    });
+    expect(isLiveTerminal(resolved)).toBe(true);
+    expect(isLiveDeliverable(resolved)).toBe(false);
+  });
+
+  it("does not invent staleness when screen and registry agree", () => {
+    const resolved = resolveLiveAgentState(record({ state: "working" }), {
+      status: "working",
+      agent_type: "claude",
+      control_state: "busy",
+    });
+    expect(resolved.stale_registry_state).toBe(false);
+    expect(resolved.source).toBe("screen");
+  });
+
+  it("keeps a screen-confirmed terminal state terminal", () => {
+    const resolved = resolveLiveAgentState(record({ state: "working" }), {
+      status: "idle",
+      agent_type: "unknown",
+      control_state: "shell",
+    });
+    expect(resolved.state).toBe("error");
+    expect(TERMINAL_AGENT_STATES.has(resolved.state)).toBe(true);
+    expect(isLiveTerminal(resolved)).toBe(true);
+  });
+});

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2960,6 +2960,104 @@ describe("agent lifecycle tool handlers", () => {
     });
   });
 
+  it("F1: a caller whose registry record went stale-done is still recorded as parent", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    // #408 poisons the record of a live lead within minutes. Under the old
+    // terminal-state filter this caller was invisible, so the child it spawned
+    // got parent_agent_id:null -- the U6 violation observed live.
+    const staleLead = makeServerAgentRecord({
+      agent_id: "cmuxlayerClaude-stale",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "done",
+      repo: "cmuxlayer",
+      cli: "claude",
+      role: "orchestrator",
+      task_done_detected_at: "2026-08-18T00:00:00Z",
+    });
+    engine.stateMgr.writeState(staleLead);
+    engine.getRegistry().set(staleLead.agent_id, staleLead);
+    mockExec.mockClear();
+
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:1", surfaceId: staleLead.surface_id },
+      () =>
+        spawn.handler(
+          {
+            repo: "cmuxlayer",
+            cli: "claude",
+            role: "reviewer",
+            prompt: "Review PR #456",
+            force_new: true,
+          },
+          {} as any,
+        ),
+    );
+    const parsed = parseToolResult(result);
+    const child = engine.getAgentState(parsed.agent_id);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.parent_agent_id).toBe(staleLead.agent_id);
+    expect(child).toMatchObject({
+      parent_agent_id: staleLead.agent_id,
+      spawn_depth: 1,
+    });
+  });
+
+  it("F1: the #378 worker guard still fires for a stale-done worker caller", async () => {
+    const server = createLifecycleServer(mockExec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const staleWorker = makeServerAgentRecord({
+      agent_id: "cmuxlayerCodex-staleworker",
+      surface_id: "surface:caller",
+      workspace_id: "workspace:1",
+      state: "done",
+      repo: "cmuxlayer",
+      cli: "codex",
+      role: "worker",
+      task_done_detected_at: "2026-08-18T00:00:00Z",
+    });
+    engine.stateMgr.writeState(staleWorker);
+    engine.getRegistry().set(staleWorker.agent_id, staleWorker);
+    mockExec.mockClear();
+
+    const result = await runWithCallerContext(
+      { workspaceId: "workspace:1", surfaceId: staleWorker.surface_id },
+      () =>
+        spawn.handler(
+          {
+            repo: "cmuxlayer",
+            cli: "claude",
+            role: "orchestrator",
+            prompt: "Review PR #380",
+            force_new: true,
+          },
+          {} as any,
+        ),
+    );
+    const parsed = parseToolResult(result);
+    const child = engine.getAgentState(parsed.agent_id);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed).toMatchObject({
+      role: "worker",
+      authority: "worker",
+      placement: "right",
+    });
+    expect(parsed.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/worker caller.*forced.*role.*worker/i),
+      ]),
+    );
+    expect(child).toMatchObject({
+      role: "worker",
+      parent_agent_id: staleWorker.agent_id,
+    });
+  });
+
   it("stop_agent logs a durable close entry carrying caller, force, and target", async () => {
     const server = createLifecycleServer(mockExec);
     const stopTool = (server as any)._registeredTools["stop_agent"];
@@ -8921,7 +9019,15 @@ describe("agent lifecycle tool handlers", () => {
     const agentId = (
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
-    const done = engine.stateMgr.transition(agentId, "done");
+    // Detach the seat from any live pane. Under F1 a screen that still reads
+    // WORKING overrules a `done` record — so to test the closure-evidence rule
+    // the record has to be the only evidence there is, which is exactly the
+    // case a lead faces when a worker's pane is gone.
+    const done = {
+      ...engine.stateMgr.transition(agentId, "done"),
+      surface_uuid: "00000000-0000-4000-8000-00000000dead",
+    };
+    engine.stateMgr.writeState(done);
     engine.getRegistry().set(agentId, done);
 
     const result = await getState.handler({ agent_id: agentId }, {} as any);
@@ -9802,13 +9908,19 @@ codex>
       spawnResult.structuredContent ?? JSON.parse(spawnResult.content[0].text)
     ).agent_id;
 
-    // Agent is in "booting" state — not interactive
+    // Agent is in "booting" state — not interactive. The gate still fires and
+    // still names its reason, but a RETRYABLE refusal is not a terminal
+    // outcome (F1): send_to hands back the nonterminal queued receipt its own
+    // description promises, and the engine drains it once the agent is ready.
     const result = await sendTo.handler(
       { agent_id: agentId, text: "hello", press_enter: true },
       {} as any,
     );
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/not in an interactive state/);
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBeFalsy();
+    expect(parsed.terminal).not.toBe(true);
+    expect(parsed.delivery_state).toBe("queued");
+    expect(JSON.stringify(parsed)).toMatch(/not in an interactive state/);
   });
 
   it("send_to_agent leaves an idle agent idle when submitted delivery fails", async () => {


### PR DESCRIPTION
## Lane F1 — one stale registry field silently disabled four contracts

Finding F1 (`docs.local/plan/stability-v2/phase-12/evaluation.md`): the registry marks live agents `done` within minutes (**#408**). Everything that read that record as primary truth broke together. This lane does **not** fix #408's root cause — it makes the consumers immune to it.

### The four consequences, and what changed

| Consequence | Before | After |
|---|---|---|
| **U6** — caller identity | `resolveCurrentCallerAgent` filtered terminal records out (`server.ts:497`, `:3541-3556`), so a live lead was invisible and its child recorded `parent_agent_id: null` | Terminal state is an **ordering** signal, never an exclusion; a record bound to the surface the call arrives on is the caller |
| **#378 worker guard** | `callerIsWorker` could never be true for a stale-done caller — the fix for the 3×-recurring "reviewer in the lead column" class no-opped | Fires again; regression test covers a stale-done worker caller |
| **U8/#404** — delivery | `send_to` returned `delivery:"failed"`, `terminal:true` to an agent at a live prompt (ledger row 4). Retryable refusals were flattened into terminal failures | Gate reads the fresh target-scoped scan already in hand; retryable refusals return the **nonterminal queued receipt** send_to's own description promises |
| **P11 Contract C** — closure | `agent.state` passed to `resolveClosureState` (`agent-engine.ts:1723,1847`) made a *working* agent read `artifact_missing` — "route a reviewer NOW" | Closure derives from live state |

### The change class

New `src/live-agent-state.ts` owns **one** screen→state rule (`agent-health.ts` now imports it instead of re-deriving it) plus the rules for when live evidence may overturn the record:

- `working` and bare-shell **always** override — the record cannot know either.
- `ready` may clear a stale `error` but **never** a `done`. A finished worker sits at a ready prompt too; overriding there would erase done-detection for every agent that returns to its prompt.
- **Deliverability is a different question from closure.** Closure asks "did the task finish?", which a ready prompt cannot answer. Delivery asks "will this surface accept input?", which it answers definitively. `isLiveDeliverable` only ever *widens* what the record allowed, and only over a **terminal** record — a `booting` pane may still be receiving its launcher line.

`AgentDiscovery.cachedScan()` exposes the last scan synchronously, so none of this adds I/O to a caller path. With no fresh evidence it degrades to the record with explicit `source: "registry"` provenance.

### Deliberate contract changes (existing tests updated, not bent)

1. `send_to` / `send_to_agent` return a nonterminal queued receipt **naming the refusal reason** instead of an error when the interactive gate refuses retryably. The engine drains it when the target is ready.
2. A `done` record whose pane still reads **working** now reports closure `pending`, not `artifact_missing` — that is the F1 ruling applied to `get_agent_state` too, so one existing test was re-seeded to detach its pane (the record then really is the only evidence, which is the case it was written to describe).

### Tests

- `tests/live-agent-state.test.ts` (10) — the rule itself, including both directions of the `ready` case.
- `tests/f1-live-state-truth.test.ts` (5) — the live-probe shape: send_to to a screen-idle registry-done agent returns nonterminal; a mid-turn target never resolves terminal; closure reads `pending` while working and still `artifact_missing` when the screen confirms done.
- `tests/server-agent-tools.test.ts` — stale-done caller recorded as parent; #378 guard fires for a stale-done worker caller.

### Verification

- `bun run test` — **131 files, 3076 passed, 1 skipped, 0 failed**
- `bun run pre-pr` — typecheck + harness, 63 passed

### PREDICTION

- **Most likely reviewer objection:** the widened `send_to` contract. A caller that treated `isError` as "target is dead" now gets `ok: true` with a queued receipt. That is the point — the old shape was the receipt lie — but any consumer keying off `isError` for non-interactive targets needs to read `delivery_state`/`terminal` instead.
- **Residual risk:** `list_agents` still publishes `state.value` from `health.reconciled_state` (which reconciles `ready` over `done`) while `closure` uses the narrower live rule. A row can therefore read `state: ready (screen)` beside `closure: artifact_missing`. That is correct — the agent finished and is at its prompt — but it looks like a disagreement at a glance. Unifying the two projections was outside this lane.
- **Not attempted:** #408's root cause (why the registry flips `done`), per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caller identity, message delivery receipts, and P11 closure across the server and engine; consumers that treated `send_to` `isError` as “dead agent” must read `delivery_state`/`terminal` instead.
> 
> **Overview**
> **Lane F1** makes control-plane behavior use **live screen evidence** when the registry wrongly marks active agents `done` (#408), instead of treating `agent.state` as ground truth.
> 
> A new **`live-agent-state.ts`** centralizes screen→state mapping and when screen may override the record (`working` / bare shell / screen `done` win; `ready` never overturns registry `done`; **`isLiveDeliverable`** can still allow input to a live prompt over a terminal record). **`AgentDiscovery.cachedScan()`** exposes the last TTL-valid scan synchronously (no extra I/O). The server wires a **live-state probe** from that cache into **caller resolution** (terminal records are ordering hints, not excluded), **`send_to`** gating and submit verification, and **`AgentEngine`** harvestability/P11 closure via **`setLiveStateResolver`**. **`agent-health`** reuses the same screen rule instead of duplicating it.
> 
> **Contract shifts:** retryable interactive refusals on **`send_to`** return a **nonterminal queued** receipt (not a terminal `failed`); mid-turn targets follow the same pattern. Closure on a screen-**working** agent with a stale `done` record reports **`pending`**, not **`artifact_missing`**.
> 
> Regression coverage adds **`live-agent-state.test.ts`**, **`f1-live-state-truth.test.ts`**, and server-agent tests for stale-done callers/parent linkage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928d5fb4597d02ab4707f83a855fda2e2f3f4507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent status now reflects live screen activity alongside recorded state.
  * Improved handling of active, ready, completed, idle, and unavailable agents.
  * Delivery to agents in recoverable states can now be queued for retry.
  * Discovery results can be reused while still valid, reducing repeated scans.

* **Bug Fixes**
  * Prevented stale completion records from incorrectly blocking active agents or lifecycle updates.
  * Improved closure and delivery decisions when live agent evidence differs from recorded status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix caller resolution, input delivery, and closure to use live screen state instead of stale registry
> - Introduces `resolveLiveAgentState` in [`live-agent-state.ts`](https://github.com/EtanHey/cmuxlayer/pull/466/files#diff-322d6880044f3f65ee31cf41e0e2452e12e8d1b45bd6852111281ae0730fa1cc) to combine registry state with screen observations into a live-derived state with provenance, replacing ad-hoc state derivation spread across modules.
> - `send_to` delivery gate now uses `isLiveDeliverable` so agents at a live prompt with a stale terminal registry state receive input instead of returning a terminal failed receipt.
> - `resolveCurrentCallerAgent` in [`server.ts`](https://github.com/EtanHey/cmuxlayer/pull/466/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) no longer blanket-excludes terminal registry records; it prefers live-active matches so callers still running mid-turn are correctly attributed.
> - `AgentEngine.assessHarvestability` reads live state via an injected `LiveStateResolver`, preventing a working agent from reporting `closure:"artifact_missing"` when the registry is stale-done.
> - `RetryableDeliveryError` now returns a queued, non-terminal receipt instead of a terminal failure.
> - Behavioral Change: delivery, caller resolution, and closure all now depend on cached screen observations wired through `AgentDiscovery.cachedScan`; if the cache is stale or absent, behavior degrades to registry-only state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 928d5fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->