### PR TITLE
feat(p11b): the boot prompt carries a pointer, not the contract

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -352,9 +352,11 @@ export interface SpawnAgentResult {
   /** P11/U10: engine-issued coordination contract, returned in the receipt. */
   report_path?: string;
   done_marker?: string;
-  /** Constraint 1: the footer's own byte cost, declared not buried (#424/#425). */
+  /** Constraint 1: the contract's own byte cost, declared not buried (#424/#425). */
   coordination_footer_bytes?: number;
-  /** Provenance: the footer is NOT injected yet, so the bytes were never sent. */
+  /** P11b: file the boot pointer points at, carrying mailbox + report contract. */
+  contract_path?: string;
+  /** Provenance: whether the contract actually reached the worker at boot. */
   coordination_footer_delivered?: boolean;
   coordination_footer_note?: string;
 }

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -206,7 +206,26 @@ export function renderBootContractFile(input: BootContractFileInput): string {
     "",
     "## Mailbox",
     "",
-    `Monitor your inbox: ${input.mailbox.monitor_command}`,
+    // AIDEV-NOTE (F5 / ledger #24): `tail -n0 -F` BLOCKS. Run in the
+    // foreground it is a self-deadlock -- the ledger recorded it happening
+    // twice to the same reviewer. Inline, there was no budget to qualify it;
+    // in the file there is, and the file is now the engine's own words under a
+    // pointer that says "Read and follow", which reads MORE imperative than
+    // the old "monitor with", not less. So the qualifier goes here, where it
+    // costs zero wire bytes.
+    //
+    // Deliberately qualified HERE and not in recommendedMonitorCommand: that
+    // function has other callers (receipts, nudges, tool descriptions) whose
+    // consumers expect the bare command, and changing monitor semantics for
+    // all of them inside a boot-delivery PR is the scope creep this lane is
+    // supposed to model against. Those callers are the F5 follow-up (#461).
+    // The canonical command stays a verbatim substring of the line below, so a
+    // consumer matching on it still matches.
+    "Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a",
+    "self-deadlock (ledger #24). Detach it, then return:",
+    "",
+    `    ${input.mailbox.monitor_command} &`,
+    "",
     `After each handled message run: ${input.mailbox.cursor_update_env}=<handled-message-id> ${input.mailbox.cursor_update_command}`,
     "",
   ];
@@ -273,4 +292,13 @@ export function writeBootContractFile(
  * number and concludes something the engine never did.
  */
 export const COORDINATION_CONTRACT_DELIVERED_NOTE =
-  "delivered_via_contract_file: the boot prompt is a one-line pointer at contract_path, which carries the mailbox contract AND report_path/done_marker. The pointer keeps boot delivery on the typed path (under the 500-char chunk threshold). Caveat: an agent that ignores the pointer never reads the contract -- detectable (the file is unread) rather than silent, but not eliminated.";
+  "delivered_via_contract_file: the boot prompt is a one-line pointer at contract_path, which carries the mailbox contract AND report_path/done_marker. The pointer keeps boot delivery under the 500-char chunk threshold, so it is not split. Caveat: an agent that ignores the pointer never reads the contract. That is OBSERVABLE IN PRINCIPLE -- the file is on disk unread, unlike a chunked boot prompt that never submitted -- but NO health or closure path checks it today; nothing here detects it for you. coordination_footer_bytes measures the inline one-line rendering, which is NOT what was sent: the wire carried a ~130-byte pointer and the contract lives in a file of a different size again.";
+
+/**
+ * Resume provenance (#462 item 2). The contract file is refreshed on resume --
+ * idempotent, since both strings derive from agent_id alone -- but no pointer
+ * is re-typed into the resuming pane. Reporting `delivered: true` here would be
+ * the undisclosed non-delivery this lane exists to eliminate.
+ */
+export const COORDINATION_CONTRACT_REFRESHED_NOT_REDELIVERED =
+  "refreshed_not_redelivered: the spawn contract file at contract_path was rewritten on resume (identical bytes -- both strings derive from agent_id alone), and report_path/done_marker are re-issued and re-persisted. The boot POINTER was NOT re-typed into the resuming pane: `--resume` restores the prior session, which already contains it, and typing into a pane mid-resume is a delivery-path change this did not make. If the resumed session did NOT restore its context, the LEAD must point the worker at contract_path.";

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, join } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
 import { agentDir, type InboxOpts } from "./inbox.js";
 
 // AIDEV-NOTE (P11 / U10): engine-issued coordination paths. Before this, the
@@ -76,9 +77,12 @@ export function issueCoordinationContract(
  * as it can be while still naming BOTH issued strings verbatim -- naming them
  * is the point, so they are what the budget is spent on.
  *
- * NOT WIRED into the boot prompt today -- see COORDINATION_FOOTER_NOT_DELIVERED
- * and the spawn site. Any receipt that reports this footer's size MUST also
- * report that it was not sent.
+ * P11b: the contract now reaches the worker through the spawn contract FILE,
+ * not this inline footer. This stays as the canonical one-line rendering of the
+ * two issued strings (and as the receipt's byte measure); the inline injection
+ * it was sized for is only reachable via CMUXLAYER_BOOT_CONTRACT=inline, where
+ * it is still NOT sent. Any receipt reporting this size MUST also report how
+ * (or whether) the contract was delivered.
  */
 export function coordinationFooter(contract: CoordinationContract): string {
   return (
@@ -104,7 +108,7 @@ export const BOOT_INJECTION_CHUNK_THRESHOLD = 500;
  * plus a note naming the issue; this does the same.
  */
 export const COORDINATION_FOOTER_NOT_DELIVERED =
-  "not_wired: the shipped mailbox contract already uses ~479 of the 500-char boot injection budget, so injecting this footer would move every spawn onto the chunked paste path (#434/#438). The LEAD must relay report_path and done_marker to the worker until the pointer-file follow-up lands (P11b).";
+  "not_wired: boot delivery fell back to the pre-P11b INLINE mailbox contract (CMUXLAYER_BOOT_CONTRACT=inline, or the contract file could not be written). Inline, the mailbox contract already uses ~479 of the 500-char boot injection budget, so the report contract cannot ride with it without moving every spawn onto the chunked paste path (#434/#438). The LEAD must relay report_path and done_marker to this worker.";
 
 export function coordinationFooterBytes(contract: CoordinationContract): number {
   return Buffer.byteLength(coordinationFooter(contract), "utf8");
@@ -139,3 +143,134 @@ export function resolveClosureState(input: {
     ? "verified"
     : "artifact_missing";
 }
+
+// ---------------------------------------------------------------------------
+// P11b: the boot prompt carries a POINTER, not the contract.
+//
+// The mailbox contract is ~479 characters of instructions riding the most
+// incident-prone delivery path in this repo. At 500 characters
+// (SEND_INPUT_CHUNK_THRESHOLD) boot delivery leaves the typed path for the
+// chunked paste path (#434/#438), so ANY addition -- the #454 report contract
+// included -- was unshippable. That is the fleet's own pointer-brief law
+// (payload in a file, one line on the wire) being violated by the engine.
+//
+// So: the engine WRITES the contract to a file at spawn, and the boot prompt
+// points at it. One extra read before the agent's first turn, and an agent
+// that ignores the pointer never learns its contract -- but a contract file
+// that was never read is OBSERVABLE, whereas a chunked boot prompt that never
+// submitted is silent today. This trades a silent failure for a visible one;
+// it does not eliminate failure.
+// ---------------------------------------------------------------------------
+
+/** Contract file name inside the agent's channel dir (next to inbox.jsonl). */
+export const COORDINATION_CONTRACT_BASENAME = "contract.md";
+
+/**
+ * Absolute path of the spawn contract file. In the channel dir, NOT the
+ * worktree, for the same reason report_path is (U10): it must survive worktree
+ * removal, and the agent's channel dir is the one directory the engine already
+ * guarantees exists for every managed agent.
+ */
+export function coordinationContractPath(
+  agentId: string,
+  opts?: InboxOpts,
+): string {
+  return join(agentDir(agentId, opts), COORDINATION_CONTRACT_BASENAME);
+}
+
+/** Mailbox half of the contract, as the boot prompt used to carry it inline. */
+export interface MailboxContractFields {
+  monitor_command: string;
+  cursor_update_command: string;
+  cursor_update_env: string;
+}
+
+export interface BootContractFileInput {
+  agentId: string;
+  mailbox: MailboxContractFields;
+  /** #454's issued contract. Omitted only where the spawn path issues none. */
+  coordination?: CoordinationContract | null;
+}
+
+/**
+ * The file's body. Every string here is ENGINE-AUTHORED and identical to what
+ * the receipt reports -- the P11 invariant. Prose is kept minimal because the
+ * agent pays for it in context, but unlike the boot prompt this budget is not
+ * bounded by a keystroke threshold.
+ */
+export function renderBootContractFile(input: BootContractFileInput): string {
+  const lines = [
+    `# cmuxlayer contract for ${input.agentId}`,
+    "",
+    "Engine-issued at spawn. Do not re-derive these strings; use them verbatim.",
+    "",
+    "## Mailbox",
+    "",
+    `Monitor your inbox: ${input.mailbox.monitor_command}`,
+    `After each handled message run: ${input.mailbox.cursor_update_env}=<handled-message-id> ${input.mailbox.cursor_update_command}`,
+    "",
+  ];
+  if (input.coordination) {
+    lines.push(
+      "## Report",
+      "",
+      `Write your report to: ${input.coordination.report_path}`,
+      `Its final line must be exactly: ${input.coordination.done_marker}`,
+      "",
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Discriminator kept in the wire line on purpose. Boot injection and launcher
+ * keystrokes land on the same surface, and both the engine's own delivery
+ * bookkeeping and the session-identity stripper need to tell them apart from
+ * the text alone -- a bare `Read and follow <path>` is indistinguishable from a
+ * caller's pointer brief.
+ */
+export const BOOT_CONTRACT_POINTER_PREFIX = "cmuxlayer contract for";
+
+export function bootContractPointer(
+  agentId: string,
+  contractPath: string,
+): string {
+  return `${BOOT_CONTRACT_POINTER_PREFIX} ${agentId}: Read and follow ${contractPath}`;
+}
+
+/**
+ * Escape hatch for the migration step the brief allows. Default is the pointer;
+ * `CMUXLAYER_BOOT_CONTRACT=inline` restores the pre-P11b inline mailbox
+ * contract (which, being ~479 chars, still carries NO report contract -- the
+ * inline mode is the old behaviour exactly, budget collision included).
+ */
+export type BootContractMode = "pointer" | "inline";
+
+export function bootContractMode(
+  env: NodeJS.ProcessEnv = process.env,
+): BootContractMode {
+  return env.CMUXLAYER_BOOT_CONTRACT?.trim().toLowerCase() === "inline"
+    ? "inline"
+    : "pointer";
+}
+
+/** Write the contract file, returning its absolute path and exact contents. */
+export function writeBootContractFile(
+  input: BootContractFileInput,
+  opts?: InboxOpts,
+): { path: string; content: string } {
+  const path = coordinationContractPath(input.agentId, opts);
+  const content = renderBootContractFile(input);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+  return { path, content };
+}
+
+/**
+ * Pointer-mode provenance, the counterpart to COORDINATION_FOOTER_NOT_DELIVERED.
+ * Finding 3 again: a receipt that reports the contract's byte cost must also
+ * report HOW it reached the worker, or a lead reads an authoritative-looking
+ * number and concludes something the engine never did.
+ */
+export const COORDINATION_CONTRACT_DELIVERED_NOTE =
+  "delivered_via_contract_file: the boot prompt is a one-line pointer at contract_path, which carries the mailbox contract AND report_path/done_marker. The pointer keeps boot delivery on the typed path (under the 500-char chunk threshold). Caveat: an agent that ignores the pointer never reads the contract -- detectable (the file is unread) rather than silent, but not eliminated.";

--- a/src/harness-session.ts
+++ b/src/harness-session.ts
@@ -596,8 +596,25 @@ function normalizePromptText(value: string): string {
   return normalizeText(value.replace(/<\/?\s*user_query\s*>/gi, " "));
 }
 
+/**
+ * P11b: the boot injection is now a one-line pointer at the spawn contract
+ * file. Session identity matches a recorded prompt against the caller's text,
+ * so whatever the engine appended must be strippable -- both the pointer form
+ * and the pre-P11b inline form (still reachable via CMUXLAYER_BOOT_CONTRACT
+ * =inline, and present in every session recorded before this shipped).
+ */
+function stripManagedContractPointer(normalized: string): string | null {
+  const match = normalized.match(
+    /^(.*?) cmuxlayer contract for ([A-Za-z0-9_-]+): Read and follow (\/.+\/([A-Za-z0-9_-]+)\/contract\.md)$/,
+  );
+  if (!match || match[2] !== match[4]) return null;
+  return match[1]!.trim();
+}
+
 function stripManagedMailboxContract(value: string): string {
   const normalized = normalizePromptText(value);
+  const pointerStripped = stripManagedContractPointer(normalized);
+  if (pointerStripped !== null) return pointerStripped;
   const match = normalized.match(
     /^(.*?) cmuxlayer mailbox contract for ([A-Za-z0-9_-]+): monitor with tail -n0 -F (\/.+\/([A-Za-z0-9_-]+)\/inbox\.jsonl); after each handled message run CMUX_INBOX_MSG_ID=<handled-message-id> (.+)$/,
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ import {
 } from "./agent-engine.js";
 import {
   COORDINATION_CONTRACT_DELIVERED_NOTE,
+  COORDINATION_CONTRACT_REFRESHED_NOT_REDELIVERED,
   COORDINATION_FOOTER_NOT_DELIVERED,
   bootContractMode,
   bootContractPointer,
@@ -11423,6 +11424,53 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               result.surface_id,
               result.workspace_id ?? workspace,
             );
+            // AIDEV-NOTE (P11b / #462 item 2): resume used to return NO
+            // contract at all -- no report_path, no done_marker, no contract
+            // file -- so the crash-recovery case this repo exists for was the
+            // one case where a lead could not even SEE where its worker should
+            // report. The contract is derived from agent_id alone, so what is
+            // issued here is byte-identical to what the original spawn issued;
+            // refreshing the file is idempotent and restores it if the channel
+            // dir was reaped between the crash and the resume.
+            //
+            // What is deliberately NOT done: re-injecting the pointer as
+            // keystrokes into a resuming pane. `claude --resume` restores the
+            // prior session, so the original pointer message is already in the
+            // agent's context, and typing into a pane mid-resume is a change to
+            // the most incident-prone path in this repo -- the exact thing this
+            // PR exists to move work OFF. That sliver stays open on #462.
+            const resumeMonitorBoot = ensureMonitorBoot(result.agent_id);
+            const resumeCoordination = issueSpawnCoordination(
+              result.agent_id,
+              args.report_path,
+            );
+            const resumeContract = buildBootContractInjection(
+              result.agent_id,
+              resumeMonitorBoot,
+              resumeCoordination,
+            );
+            result.report_path = resumeCoordination.report_path;
+            result.done_marker = resumeCoordination.done_marker;
+            result.contract_path = resumeContract.contract_path ?? undefined;
+            result.coordination_footer_bytes =
+              coordinationFooterBytes(resumeCoordination);
+            // Provenance, same rule as the spawn path: the file is refreshed,
+            // but nothing was re-delivered to the pane on this call. Saying
+            // `true` here would be the claim this PR's own thesis forbids.
+            result.coordination_footer_delivered = false;
+            result.coordination_footer_note = resumeContract.contract_path
+              ? COORDINATION_CONTRACT_REFRESHED_NOT_REDELIVERED
+              : COORDINATION_FOOTER_NOT_DELIVERED;
+            try {
+              const patched = stateMgr.updateRecord(result.agent_id, {
+                report_path: resumeCoordination.report_path,
+                done_marker: resumeCoordination.done_marker,
+              });
+              registry.set(result.agent_id, patched);
+            } catch {
+              // Receipt already carries the contract; a registry write failure
+              // must not fail an otherwise-successful resume.
+            }
             const resumed = {
               version: 1,
               type: "agent",

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,9 +55,13 @@ import {
   type SpawnAgentParams,
 } from "./agent-engine.js";
 import {
+  COORDINATION_CONTRACT_DELIVERED_NOTE,
   COORDINATION_FOOTER_NOT_DELIVERED,
+  bootContractMode,
+  bootContractPointer,
   issueCoordinationContract,
   coordinationFooterBytes,
+  writeBootContractFile,
   type CoordinationContract,
 } from "./coordination-paths.js";
 import {
@@ -627,6 +631,7 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       report_path: z.string().optional(),
       done_marker: z.string().optional(),
       coordination_footer_bytes: z.number().int().nonnegative().optional(),
+      contract_path: z.string().optional(),
       coordination_footer_delivered: z.boolean().optional(),
       coordination_footer_note: z.string().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
@@ -651,6 +656,7 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       report_path: z.string().optional(),
       done_marker: z.string().optional(),
       coordination_footer_bytes: z.number().int().nonnegative().optional(),
+      contract_path: z.string().optional(),
       coordination_footer_delivered: z.boolean().optional(),
       coordination_footer_note: z.string().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
@@ -3499,6 +3505,45 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): string =>
     `cmuxlayer mailbox contract for ${agentId}: monitor with ${monitorBoot.monitor_command}; ` +
     `after each handled message run CMUX_INBOX_MSG_ID=<handled-message-id> ${monitorBoot.cursor_update_command}`;
+
+  // AIDEV-NOTE (P11b): the boot prompt carries a POINTER, not the contract.
+  // Inline, the mailbox contract alone is ~479 chars against a 500-char chunk
+  // threshold, so #454's report contract could not be added without moving
+  // EVERY spawn's boot delivery onto the chunked paste path (#434/#438). The
+  // contract now lives in a file the engine writes at spawn; the wire carries
+  // one short line. See coordination-paths.ts for the honest cost.
+  const buildBootContractInjection = (
+    agentId: string,
+    monitorBoot: MonitorBootResult,
+    coordination: CoordinationContract | null,
+  ): { text: string; contract_path: string | null } => {
+    if (bootContractMode() === "inline") {
+      return { text: mailboxBootContract(agentId, monitorBoot), contract_path: null };
+    }
+    try {
+      const written = writeBootContractFile(
+        {
+          agentId,
+          mailbox: {
+            monitor_command: monitorBoot.monitor_command,
+            cursor_update_command: monitorBoot.cursor_update_command,
+            cursor_update_env: monitorBoot.cursor_update_env,
+          },
+          coordination,
+        },
+        inboxOpts,
+      );
+      return {
+        text: bootContractPointer(agentId, written.path),
+        contract_path: written.path,
+      };
+    } catch {
+      // A contract-file write failure must not fail an otherwise-successful
+      // spawn. Fall back to the pre-P11b inline mailbox contract: the worker
+      // loses the report half (exactly as before P11b), not its mailbox.
+      return { text: mailboxBootContract(agentId, monitorBoot), contract_path: null };
+    }
+  };
 
   // AIDEV-NOTE (P11/U10): the engine issues the coordination contract at spawn,
   // returns it in the receipt, persists it on the record, AND tells the worker
@@ -11264,7 +11309,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           })
           .optional()
           .describe(
-            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. NOTE: the engine does NOT yet tell the worker this path -- the boot-prompt footer is not wired (see coordination_footer_delivered in the receipt), so until then YOU must relay report_path and done_marker to the worker, or every done worker will render closure:\"artifact_missing\". Pass this only to place the report somewhere you already watch (e.g. a collab dir).",
+            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. The engine also WRITES both strings to the spawn contract file (`contract_path`) and points the boot prompt at it, so the worker is told; check `coordination_footer_delivered` -- if false the contract file could not be written and YOU must relay report_path and done_marker, or a done worker renders closure:\"artifact_missing\". Pass this only to place the report somewhere you already watch (e.g. a collab dir).",
           ),
         force_new: z
           .boolean()
@@ -11792,33 +11837,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             result.agent_id,
             args.report_path,
           );
-          // AIDEV-NOTE (P11): the coordination footer is NOT injected here yet,
-          // and that is a measured decision, not an oversight. The mailbox
-          // contract alone is ~479 chars for a real agent id, and
-          // SEND_INPUT_CHUNK_THRESHOLD is 500 -- so appending ANY report
-          // contract pushes the boot injection over the threshold and moves
-          // every spawn's boot delivery from the typed path to the chunked
-          // paste path (measured: 618 chars, 10 failing tests, 4 of them
-          // submit-verification timeouts). That is a change to the most
-          // incident-prone path in this repo (#434/#438), not an additive one.
-          // Landing it needs either a slimmer mailbox contract (#425 measured
-          // that class) or an explicit decision to move boot delivery onto the
-          // chunked route. Until then the contract is still ISSUED, RETURNED,
-          // and PERSISTED, so the consumer is authoritative: a worker that
-          // writes somewhere else now renders as closure "artifact_missing"
-          // (actionable) instead of a silent deadlock.
-          const injectedBootPrompt = mailboxBootContract(
+          // AIDEV-NOTE (P11b): P11 could not deliver this contract -- inline,
+          // the mailbox contract alone was ~479 chars against a 500-char chunk
+          // threshold, so appending the report contract (measured 618 chars)
+          // moved every spawn onto the chunked paste path (#434/#438). The
+          // contract now goes to a file and the wire carries one short line, so
+          // the worker is finally TOLD the same two strings the receipt reports.
+          const bootContract = buildBootContractInjection(
             result.agent_id,
             monitorBoot,
+            coordination,
           );
+          const injectedBootPrompt = bootContract.text;
           result.report_path = coordination.report_path;
           result.done_marker = coordination.done_marker;
-          // Finding 3: never report the footer's size without reporting that it
-          // was not sent -- same shape as the v0.4.42 `paused` provenance fix.
+          // Finding 3: never report the contract's size without reporting how
+          // (or whether) it reached the worker -- the v0.4.42 `paused`
+          // provenance fix, applied to both outcomes of the fallback above.
           result.coordination_footer_bytes =
             coordinationFooterBytes(coordination);
-          result.coordination_footer_delivered = false;
-          result.coordination_footer_note = COORDINATION_FOOTER_NOT_DELIVERED;
+          result.contract_path = bootContract.contract_path ?? undefined;
+          result.coordination_footer_delivered =
+            bootContract.contract_path !== null;
+          result.coordination_footer_note = bootContract.contract_path
+            ? COORDINATION_CONTRACT_DELIVERED_NOTE
+            : COORDINATION_FOOTER_NOT_DELIVERED;
           try {
             const patched = stateMgr.updateRecord(result.agent_id, {
               report_path: coordination.report_path,
@@ -12654,10 +12697,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
             launchShellRecoveryBySurface.delete(result.surface_id);
             const monitorBoot = ensureMonitorBoot(result.agent_id);
-            const injectedBootPrompt = mailboxBootContract(
+            // P11b: pointer form here too, so no spawn path keeps the ~479-char
+            // inline contract on the wire. `null` because this batch path never
+            // issued a coordination contract (P11 wired spawn_agent only), so
+            // the file carries the mailbox half alone -- exactly what this path
+            // delivered before, now via the pointer.
+            const injectedBootPrompt = buildBootContractInjection(
               result.agent_id,
               monitorBoot,
-            );
+              null,
+            ).text;
             const spawnedBinding = engine.getAgentState(result.agent_id);
             appendStaleBuildWarning(result);
             let bootPromptDelivery:

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -32,6 +32,9 @@ const ESSENTIAL_FIELDS = [
   "report_path",
   "done_marker",
   "coordination_footer_bytes",
+  // P11b: the file the boot pointer points at. A lead that cannot see it cannot
+  // check whether the worker was actually told -- the whole point of the trade.
+  "contract_path",
   // Provenance travels WITH the byte count or the count is a false claim.
   "coordination_footer_delivered",
   "coordination_footer_note",

--- a/tests/harness-session.test.ts
+++ b/tests/harness-session.test.ts
@@ -678,6 +678,59 @@ describe("findLatestHarnessSessionIdentity (cwd → real session id)", () => {
     }
   });
 
+  it("P11b — Codex: matches a managed prompt with the appended contract POINTER", () => {
+    // Session identity matches a recorded prompt against the caller's text, so
+    // whatever the engine appended must be strippable. P11b changed what it
+    // appends; if the stripper does not follow, every managed Codex spawn stops
+    // resolving its session -- silently.
+    const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-pointer-prompt-"));
+    const cwd = "/Users/e/Gits/cmuxlayer";
+    const root = join(localHome, ".codex", "sessions", "2026", "08", "18");
+    mkdirSync(root, { recursive: true });
+    const file = join(root, "rollout-pointer.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "pointer-session", cwd },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text:
+                  "Repair the agent automatically.\n\n" +
+                  "cmuxlayer contract for cmuxlayerCodex-abcd1234: Read and follow /Users/e/.cmux/agents/cmuxlayerCodex-abcd1234/contract.md",
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    try {
+      expect(
+        findLatestHarnessSessionIdentity("codex", cwd, {
+          home: localHome,
+          expectedText: "Repair the agent automatically.",
+        })?.session_id,
+      ).toBe("pointer-session");
+      expect(
+        findLatestHarnessSessionIdentity("codex", cwd, {
+          home: localHome,
+          expectedText: "Different task.",
+        }),
+      ).toBeNull();
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
+  });
+
   it("Codex: matches a managed mailbox contract with a custom inbox base dir", () => {
     const localHome = mkdtempSync(join(tmpdir(), "cmux-harness-custom-inbox-"));
     const cwd = "/Users/e/Gits/cmuxlayer";

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -172,7 +172,7 @@ function makeExec(
       const text = String(args.at(-1) ?? "");
       if (
         text.trim() &&
-        (text.includes("cmuxlayer mailbox contract") ||
+        (text.includes("cmuxlayer contract for") ||
           !/[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b/.test(text))
       ) {
         promptPending = true;

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -9,7 +9,7 @@
  * receipt, persists it, and tells the worker the same two strings.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -18,10 +18,13 @@ import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
 import { runWithCallerContext } from "../src/caller-context.js";
 import {
   BOOT_INJECTION_CHUNK_THRESHOLD,
+  bootContractPointer,
+  coordinationContractPath,
   coordinationFooter,
   coordinationFooterBytes,
   issueCoordinationContract,
 } from "../src/coordination-paths.js";
+import { recommendedMonitorCommand } from "../src/inbox.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-p11-spawn");
 
@@ -150,7 +153,7 @@ function makeExec(
       const text = String(args.at(-1) ?? "");
       if (
         text.trim() &&
-        (text.includes("cmuxlayer mailbox contract") ||
+        (text.includes("cmuxlayer contract for") ||
           !/[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b/.test(text))
       ) {
         promptPending = true;
@@ -239,24 +242,97 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(detail.done_marker).toBe(parsed.done_marker);
   });
 
-  it("does NOT yet inject the footer into the boot prompt (measured budget collision)", async () => {
-    // The mailbox contract alone is ~479 chars for a real agent id and
-    // SEND_INPUT_CHUNK_THRESHOLD is 500, so injecting the report contract moves
-    // EVERY spawn's boot delivery onto the chunked paste path. That is not
-    // additive, so it is deliberately not wired -- pinned here so the day it is
-    // wired is a deliberate, reviewed change rather than a silent one.
+  // -------------------------------------------------------------------------
+  // P11b: the boot prompt carries a POINTER, not the contract.
+  // -------------------------------------------------------------------------
+
+  it("P11b: the contract file exists and carries the mailbox contract AND the issued report contract", async () => {
     const parsed = await spawn();
-    expect(sentText(exec)).not.toContain(parsed.report_path);
+    expect(parsed.contract_path).toBe(
+      coordinationContractPath(parsed.agent_id as string, {
+        baseDir: inboxDir,
+      }),
+    );
+    const file = readFileSync(parsed.contract_path, "utf8");
+    // Mailbox half -- the ~479 chars that used to ride the wire.
+    expect(file).toContain(recommendedMonitorCommand(parsed.agent_id, {
+      baseDir: inboxDir,
+    }));
+    expect(file).toContain("CMUX_INBOX_MSG_ID=<handled-message-id>");
+    expect(file).toContain(`cmuxlayer inbox-cursor '${parsed.agent_id}'`);
+    // Report half -- the #454-issued contract that never fit inline. Byte-equal
+    // to the receipt, which is the whole P11 invariant.
+    expect(file).toContain(parsed.report_path);
+    expect(file).toContain(parsed.done_marker);
   });
 
-  it("keeps the boot injection inside the chunk-threshold budget", async () => {
+  it("P11b: the boot prompt is a one-line pointer, and it points at the file", async () => {
+    const parsed = await spawn();
+    const injection = bootContractPointer(
+      parsed.agent_id as string,
+      parsed.contract_path as string,
+    );
+    expect(injection).not.toMatch(/[\r\n]/);
+    expect(sentText(exec)).toContain(injection);
+    // The instructions themselves are NOT on the wire any more.
+    expect(sentText(exec)).not.toContain("monitor with tail -n0 -F");
+  });
+
+  it("P11b: the composed boot prompt stays under SEND_INPUT_CHUNK_THRESHOLD for a real-length agent id", async () => {
+    // This is the regression that took the suite 10 red at 618 chars. Asserted
+    // on the delivered text, not on the injection alone: what crosses the
+    // threshold is caller prompt + injection joined, and that is what splits.
     await spawn();
-    const injections = (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
+    const deliveries = (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
       .map(([, args]: [string, string[]]) => String((args ?? []).at(-1) ?? ""))
-      .filter((text) => text.includes("cmuxlayer mailbox contract"));
-    expect(injections.length).toBeGreaterThan(0);
-    for (const text of injections) {
+      .filter((text) => text.includes("cmuxlayer contract for"));
+    expect(deliveries.length).toBeGreaterThan(0);
+    for (const text of deliveries) {
       expect(text.length).toBeLessThan(BOOT_INJECTION_CHUNK_THRESHOLD);
+    }
+
+    // And on the pure function, for an agent id at the long end of the real
+    // range -- the spawned id is short, so it alone would not catch a widening.
+    const longId = "cmuxlayerClaude-d2fc302f";
+    const longPointer = bootContractPointer(
+      longId,
+      coordinationContractPath(longId, {
+        baseDir: "/Users/someone-with-a-long-name/.cmux/agents",
+      }),
+    );
+    expect(longPointer.length).toBeLessThan(BOOT_INJECTION_CHUNK_THRESHOLD);
+  });
+
+  it("P11b: boot delivery is not SPLIT -- the whole composed prompt lands in one write", async () => {
+    // Splitting is the hazard, not pasting: the composed boot prompt (caller
+    // text + injection, newline-joined) has always gone through the composer
+    // paste, but at 618 chars it CHUNKED, and multi-chunk boot delivery is the
+    // most incident-prone route in this repo (#434/#438). So assert one write
+    // carrying BOTH halves -- two writes would mean the split came back.
+    await spawn();
+    const writes = (exec as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([, args]: [string, string[]]) =>
+        (args ?? []).some((arg) => String(arg).includes("cmuxlayer contract for")),
+      )
+      .map(([, args]: [string, string[]]) => String((args ?? []).at(-1) ?? ""));
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("task");
+    expect(writes[0]!.length).toBeLessThan(BOOT_INJECTION_CHUNK_THRESHOLD);
+  });
+
+  it("P11b: CMUXLAYER_BOOT_CONTRACT=inline restores the pre-P11b inline contract", async () => {
+    process.env.CMUXLAYER_BOOT_CONTRACT = "inline";
+    try {
+      const parsed = await spawn();
+      expect(sentText(exec)).toContain("cmuxlayer mailbox contract for");
+      expect(parsed.contract_path).toBeUndefined();
+      // Provenance follows the mode: inline cannot carry the report contract,
+      // so the receipt must say so rather than claiming delivery.
+      expect(parsed.coordination_footer_delivered).toBe(false);
+      expect(parsed.coordination_footer_note).toMatch(/not_wired/);
+      expect(sentText(exec)).not.toContain(parsed.report_path);
+    } finally {
+      delete process.env.CMUXLAYER_BOOT_CONTRACT;
     }
   });
 
@@ -333,9 +409,13 @@ describe("P11 spawn_agent issues the coordination contract", () => {
           done_marker: raw.done_marker,
         }),
       );
-      // Provenance travels on both doors too.
+      // P11b: provenance travels on both doors, and both now actually DELIVER
+      // the contract -- the pointer file is written above launchMode, so a
+      // raw-CLI spawn cannot end up as the one door that tells its worker
+      // nothing.
       for (const receipt of [registered, raw]) {
-        expect(receipt.coordination_footer_delivered).toBe(false);
+        expect(receipt.coordination_footer_delivered).toBe(true);
+        expect(receipt.contract_path).toMatch(/^\/.+\/contract\.md$/);
       }
       // Same contract SHAPE on both doors: issued, absolute, marker present.
       for (const receipt of [registered, raw]) {
@@ -353,14 +433,19 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     }
   });
 
-  it("FINDING 3: never reports footer bytes without reporting they were not sent", async () => {
+  it("FINDING 3: never reports contract bytes without reporting how they were sent", async () => {
     const parsed = await spawn();
     // The v0.4.41 `paused` hazard: an authoritative number with no provenance.
+    // P11b keeps the rule and flips the answer -- the note must now say the
+    // contract went via the file, and must not oversell it.
     expect(parsed.coordination_footer_bytes).toBeGreaterThan(0);
-    expect(parsed.coordination_footer_delivered).toBe(false);
-    expect(parsed.coordination_footer_note).toMatch(/not_wired/);
-    // A lead reading this must learn it has to relay the contract itself.
-    expect(parsed.coordination_footer_note).toMatch(/LEAD must relay/i);
+    expect(parsed.coordination_footer_delivered).toBe(true);
+    expect(parsed.coordination_footer_note).toMatch(
+      /delivered_via_contract_file/,
+    );
+    expect(parsed.coordination_footer_note).not.toMatch(/not_wired/);
+    // The honest cost is stated in the receipt, not just the PR body.
+    expect(parsed.coordination_footer_note).toMatch(/ignores the pointer/i);
   });
 
   it("FINDING 2: a relative report_path is rejected BEFORE anything launches", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -9,7 +9,13 @@
  * receipt, persists it, and tells the worker the same two strings.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -320,6 +326,66 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(writes[0]!.length).toBeLessThan(BOOT_INJECTION_CHUNK_THRESHOLD);
   });
 
+  it("P11b R4: an unwritable contract file falls back to inline WITHOUT emitting a dangling pointer", async () => {
+    // The adversarial case: if the write fails, the boot prompt must not point
+    // at a file that does not exist. The inline-mode test reaches the same
+    // OUTCOME by a different route, so this branch needs its own pin -- a
+    // regression that emitted the pointer before the write, or let the throw
+    // escape and fail the spawn, would otherwise stay green.
+    const blockedBase = join(tmpdir(), `p11b-blocked-${process.pid}-inbox`);
+    rmSync(blockedBase, { recursive: true, force: true });
+    // A FILE where the base dir should be: every channel-dir mkdir under it
+    // fails, so the contract write cannot succeed.
+    writeFileSync(blockedBase, "not a directory");
+    const blockedExec = makeExec();
+    const blockedStateDir = mkdtempSync(join(tmpdir(), "p11b-blocked-state-"));
+    const blockedServer: any = createServer(
+      withTestSurfaceObserver({
+        exec: blockedExec,
+        stateDir: blockedStateDir,
+        disableSpawnPreflight: true,
+        inboxBaseDir: blockedBase,
+      }),
+    );
+    try {
+      const parsed = await runWithCallerContext(
+        { workspaceId: "workspace:1" },
+        async () => {
+          const result = await blockedServer._registeredTools[
+            "spawn_agent"
+          ].handler(
+            {
+              repo: "brainlayer",
+              model: "sonnet",
+              cli: "claude",
+              role: "worker",
+              prompt: "task",
+            },
+            {} as any,
+          );
+          return result.structuredContent ?? JSON.parse(result.content[0].text);
+        },
+      );
+
+      // The spawn still succeeds -- a contract-file failure is not a spawn
+      // failure.
+      expect(parsed.ok).toBe(true);
+      expect(parsed.contract_path).toBeUndefined();
+      // No dangling pointer on the wire, and the mailbox contract still got
+      // through: the worker loses the report half, not its inbox.
+      const wire = sentText(blockedExec);
+      expect(wire).not.toContain("Read and follow");
+      expect(wire).toContain("cmuxlayer mailbox contract for");
+      // And the receipt says the lead must relay.
+      expect(parsed.coordination_footer_delivered).toBe(false);
+      expect(parsed.coordination_footer_note).toMatch(/not_wired/);
+      expect(parsed.coordination_footer_note).toMatch(/LEAD must relay/i);
+    } finally {
+      rmSync(blockedBase, { recursive: true, force: true });
+      rmSync(blockedStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("P11b: CMUXLAYER_BOOT_CONTRACT=inline restores the pre-P11b inline contract", async () => {
     process.env.CMUXLAYER_BOOT_CONTRACT = "inline";
     try {
@@ -444,8 +510,14 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       /delivered_via_contract_file/,
     );
     expect(parsed.coordination_footer_note).not.toMatch(/not_wired/);
-    // The honest cost is stated in the receipt, not just the PR body.
+    // The honest cost is stated in the receipt, not just the PR body -- and
+    // stated at the strength the build actually provides: nothing detects an
+    // unread contract file today, so the note must not claim it does.
     expect(parsed.coordination_footer_note).toMatch(/ignores the pointer/i);
+    expect(parsed.coordination_footer_note).toMatch(/observable in principle/i);
+    // R3: the byte count describes the UNSENT inline rendering, and must say so
+    // rather than reading as a measure of what went on the wire.
+    expect(parsed.coordination_footer_note).toMatch(/NOT what was sent/i);
   });
 
   it("FINDING 2: a relative report_path is rejected BEFORE anything launches", async () => {

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -88,7 +88,7 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
       const text = String(args.at(-1) ?? "");
       if (
         text.trim() &&
-        (text.includes("cmuxlayer mailbox contract") || !/Codex\b/.test(text))
+        (text.includes("cmuxlayer contract for") || !/Codex\b/.test(text))
       ) {
         promptPending = true;
       }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -30,6 +30,10 @@ import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { ParsedScreenResult } from "../src/types.js";
 import type { SeatManifest } from "../src/seat-manifest.js";
 import { AgentRegistry } from "../src/agent-registry.js";
+import {
+  coordinationContractPath,
+  issueCoordinationContract,
+} from "../src/coordination-paths.js";
 import { AgentEngine } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import {
@@ -2344,6 +2348,74 @@ describe("agent lifecycle tool handlers", () => {
       surface_id: "surface:new",
     });
     expect(spawn.inputSchema.shape.resume_agent_id).toBeDefined();
+  });
+
+  it("P11b/#462: resume issues, persists, and REFRESHES the contract -- and says it was not re-delivered", async () => {
+    // Before this, resume returned no contract at all: no report_path, no
+    // done_marker, no contract file. The crash-recovery case this repo exists
+    // for was the one case where a lead could not even see where its worker
+    // should report.
+    const agentId = "cmuxlayerCodex-stable-resume-contract";
+    const resumeInboxDir = mkdtempSync(join(tmpdir(), "p11b-resume-inbox-"));
+    const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeServerAgentRecord({
+        agent_id: agentId,
+        repo: "brainlayer",
+        cli: "codex",
+        state: "done",
+        surface_id: "surface:old",
+        cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      }),
+    );
+    const exec = makeLifecycleExec();
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      inboxBaseDir: resumeInboxDir,
+    });
+    await serverContexts.at(-1)?.lifecycleStartPromise;
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    try {
+      const result = await spawn.handler({ resume_agent_id: agentId }, {} as any);
+      const parsed = parseToolResult(result) as Record<string, any>;
+      expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+      expect(parsed.resumed).toBe(true);
+
+      // Byte-identical to what the original spawn issued -- both strings derive
+      // from agent_id alone, which is why refreshing is safe and idempotent.
+      const expected = issueCoordinationContract(agentId, {
+        baseDir: resumeInboxDir,
+      });
+      expect(parsed.report_path).toBe(expected.report_path);
+      expect(parsed.done_marker).toBe(expected.done_marker);
+      expect(parsed.contract_path).toBe(
+        coordinationContractPath(agentId, { baseDir: resumeInboxDir }),
+      );
+      const file = readFileSync(parsed.contract_path, "utf8");
+      expect(file).toContain(expected.report_path);
+      expect(file).toContain(expected.done_marker);
+
+      // The honest half: nothing was typed into the resuming pane, and the
+      // receipt must say so rather than inheriting the spawn path's `true`.
+      expect(parsed.coordination_footer_delivered).toBe(false);
+      expect(parsed.coordination_footer_note).toMatch(
+        /refreshed_not_redelivered/,
+      );
+
+      // Persisted, so the closure consumer reads what resume issued.
+      const stateTool = (server as any)._registeredTools["get_agent_state"];
+      const detail = parseToolResult(
+        await stateTool.handler({ agent_id: agentId }, {} as any),
+      ) as Record<string, unknown>;
+      expect(detail.report_path).toBe(expected.report_path);
+      expect(detail.done_marker).toBe(expected.done_marker);
+    } finally {
+      rmSync(resumeInboxDir, { recursive: true, force: true });
+    }
   });
 
   it("spawn_agent accepts placement as the canonical role-placement argument", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -3528,7 +3528,7 @@ describe("agent lifecycle tool handlers", () => {
       chunks.every((chunk) => Buffer.byteLength(chunk, "utf-8") <= 16_000),
     ).toBe(true);
     expect(chunks.join("")).toContain(prompt);
-    expect(chunks.join("")).toContain("cmuxlayer mailbox contract");
+    expect(chunks.join("")).toContain("cmuxlayer contract for");
     expect(chunks.join("")).toContain("\n\n");
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1346,7 +1346,7 @@ describe("tool handler integration", () => {
       newSurface: vi.fn(),
       focusSurface: vi.fn().mockResolvedValue(undefined),
       send: vi.fn().mockImplementation(async (surface: string, text: string) => {
-        if (text.includes("cmuxlayer mailbox contract")) {
+        if (text.includes("cmuxlayer contract for")) {
           pendingBootContracts.add(surface);
         } else {
           launchedSurfaces.add(surface);
@@ -1354,7 +1354,7 @@ describe("tool handler integration", () => {
       }),
       pasteText: vi.fn().mockImplementation(
         async (surface: string, text: string) => {
-          if (text.includes("cmuxlayer mailbox contract")) {
+          if (text.includes("cmuxlayer contract for")) {
             pendingBootContracts.add(surface);
           }
         },
@@ -8482,7 +8482,7 @@ describe("tool handler integration", () => {
           sentTexts.push(text);
           if (
             text.includes("cmuxlayerCodex") &&
-            !text.includes("cmuxlayer mailbox contract")
+            !text.includes("cmuxlayer contract for")
           ) {
             if (launcherSends === 0) {
               delete process.env.REPOGOLEM_ALLOW_MODEL;
@@ -8570,7 +8570,7 @@ describe("tool handler integration", () => {
           sentTexts.filter(
             (text) =>
               text.includes("cmuxlayerCodex") &&
-              !text.includes("cmuxlayer mailbox contract"),
+              !text.includes("cmuxlayer contract for"),
           ),
         ).toEqual([fixture.launcher_command, fixture.launcher_command]);
         expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(1);
@@ -8784,7 +8784,7 @@ describe("tool handler integration", () => {
           if (launcherSendAttempts === 1) {
             throw new Error("socket closed before receiving response");
           }
-        } else if (text.includes("cmuxlayer mailbox contract")) {
+        } else if (text.includes("cmuxlayer contract for")) {
           composer += text;
         }
         return { stdout: "{}", stderr: "" };
@@ -8801,7 +8801,7 @@ describe("tool handler integration", () => {
             ? fixture.screen
             : submitted === fixture.launcher_command
               ? "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›"
-              : submitted?.includes("cmuxlayer mailbox contract")
+              : submitted?.includes("cmuxlayer contract for")
                 ? "OpenAI Codex\nWorking (1s - esc to interrupt)"
               : composer
                 ? `etanheyman ~/Gits/brainlayer [main] $ ${composer}`
@@ -8841,7 +8841,7 @@ describe("tool handler integration", () => {
       );
 
       expect(submittedCommands[0]).toBe(fixture.launcher_command);
-      expect(submittedCommands[1]).toContain("cmuxlayer mailbox contract");
+      expect(submittedCommands[1]).toContain("cmuxlayer contract for");
       expect(submittedCommands).not.toContain(fixture.corrupted_command);
       expect(launcherSendAttempts).toBe(1);
     } finally {
@@ -8955,7 +8955,7 @@ describe("tool handler integration", () => {
             launcherWriteBecameAmbiguous = true;
             throw new Error(fixture.replay.transport_error);
           }
-        } else if (text.includes("cmuxlayer mailbox contract")) {
+        } else if (text.includes("cmuxlayer contract for")) {
           composer += text;
         }
         return { stdout: "{}", stderr: "" };
@@ -8967,7 +8967,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("read-screen")) {
         let text = fixture.replay.stale_probe_screen;
-        if (submittedCommands.at(-1)?.includes("cmuxlayer mailbox contract")) {
+        if (submittedCommands.at(-1)?.includes("cmuxlayer contract for")) {
           text = "OpenAI Codex\nWorking (1s - esc to interrupt)";
         } else if (submittedCommands.length > 0) {
           text = "OpenAI Codex\nmodel: gpt-5.6-sol xhigh\n\n›";
@@ -9031,7 +9031,7 @@ describe("tool handler integration", () => {
       );
       if (probe === "delayed-visible") {
         expect(submittedCommands[0]).toBe(fixture.launcher_command);
-        expect(submittedCommands[1]).toContain("cmuxlayer mailbox contract");
+        expect(submittedCommands[1]).toContain("cmuxlayer contract for");
       } else {
         expect(submittedCommands).toEqual([]);
       }
@@ -9143,7 +9143,7 @@ describe("tool handler integration", () => {
         sentTexts.push(text);
         if (
           text.includes("cmuxlayerCodex") &&
-          !text.includes("cmuxlayer mailbox contract")
+          !text.includes("cmuxlayer contract for")
         ) {
           launcherSends += 1;
         } else if (text.includes(prompt)) {
@@ -9332,7 +9332,7 @@ describe("tool handler integration", () => {
         sentTexts.push(text);
         if (
           text.includes("cmuxlayerCodex") &&
-          !text.includes("cmuxlayer mailbox contract")
+          !text.includes("cmuxlayer contract for")
         ) {
           launcherSent = true;
         } else if (text.includes(prompt)) {

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -28,7 +29,7 @@ function makeExec(): ExecFn {
       const text = String(args[args.length - 1] ?? "");
       if (/Codex/.test(text)) activeCli = "codex";
       if (/Claude/.test(text)) activeCli = "claude";
-      if (text.includes("cmuxlayer mailbox contract")) bootTextSent = true;
+      if (text.includes("cmuxlayer contract for")) bootTextSent = true;
     }
     if (args.includes("list-workspaces")) {
       return {
@@ -216,11 +217,16 @@ describe("spawn monitor boot", () => {
       status: "bootstrapped",
       cursor_update_env: "CMUX_INBOX_MSG_ID",
     });
+    // P11b: the wire carries a POINTER; the concrete mailbox and cursor
+    // commands live in the contract file it points at. Both halves asserted --
+    // a pointer at a file that lacks the commands tells the worker nothing.
     const deliveredText = deliveredInput(exec);
     expect(deliveredText).toContain(parsed.agent_id);
-    expect(deliveredText).toContain(parsed.monitor_boot.monitor_command);
-    expect(deliveredText).toContain(parsed.monitor_boot.cursor_update_command);
-    expect(deliveredText).toContain("CMUX_INBOX_MSG_ID");
+    expect(deliveredText).toContain(parsed.contract_path);
+    const contractFile = readFileSync(parsed.contract_path, "utf8");
+    expect(contractFile).toContain(parsed.monitor_boot.monitor_command);
+    expect(contractFile).toContain(parsed.monitor_boot.cursor_update_command);
+    expect(contractFile).toContain("CMUX_INBOX_MSG_ID");
     expect(monitorAlive(parsed.agent_id, 1_000, { baseDir: inboxDir })).toBe(
       false,
     );

--- a/tests/spawn-workspace.test.ts
+++ b/tests/spawn-workspace.test.ts
@@ -274,8 +274,8 @@ describe("workspace spawn tools", () => {
     let launcherSends = 0;
     const normalSend = client.send.getMockImplementation()!;
     client.send.mockImplementation(async (surface: string, text: string) => {
-      if (!text.includes("cmuxlayer mailbox contract")) launcherSends += 1;
-      if (launcherSends === 2 && !text.includes("cmuxlayer mailbox contract")) {
+      if (!text.includes("cmuxlayer contract for")) launcherSends += 1;
+      if (launcherSends === 2 && !text.includes("cmuxlayer contract for")) {
         throw new Error("second launcher send failed");
       }
       await normalSend(surface, text);


### PR DESCRIPTION
## Lane P11b — the boot prompt carries a pointer, not a contract

### The problem #454 measured and refused to ship

Every spawn's boot prompt carried the mailbox contract inline: **~479 characters** for a
real-length agent id, against a `SEND_INPUT_CHUNK_THRESHOLD` of **500**. Appending #454's
report contract measured **618 characters** and took the suite **10 red across 3 files, four of
them submit-verification timeouts** — because crossing 500 moves every spawn's boot delivery onto
the chunked paste path, the most incident-prone path in this repo (#434, #438).

So #454 shipped a contract that was *issued, returned, and persisted* but **never told to the
worker**. Leads had to relay `report_path` / `done_marker` by hand, and a worker that wasn't
relayed rendered as closure `artifact_missing`.

The shape of the bug: ~479 characters of **instructions** riding the most fragile delivery path we
have — the fleet's own pointer-brief law (payload in a file, one line on the wire) being violated
by the engine, while every skill doc instructs agents to obey it.

### What this does

**The engine writes the contract to a file at spawn; the boot prompt points at it.**

1. `coordination-paths.ts` gains the contract file — path, renderer, writer, and the pointer
   line. Composed with the existing module, not a parallel mechanism: the file is written into the
   agent's channel dir (`<channel>/contract.md`, next to `inbox.jsonl` and `report.md`), so
   it survives worktree removal for the same U10 reason `report_path` does.
2. The file carries **both halves**: the mailbox/cursor instructions that used to ride the wire,
   **and** the #454-issued `report_path` / `done_marker` — byte-identical to the receipt, which
   is the whole P11 invariant.
3. The boot prompt becomes one line: `cmuxlayer contract for <id>: Read and follow <abs-path>`.
   The `cmuxlayer contract for` prefix is deliberate, not decoration — boot injection and
   launcher keystrokes land on the same surface, and the session-identity stripper in
   `harness-session.ts` has to tell them apart from the text alone.
4. **Migration flag:** `CMUXLAYER_BOOT_CONTRACT=inline` restores the pre-P11b inline contract
   exactly, budget collision included (so inline still carries no report contract, and the receipt
   still says `not_wired`). Default is the pointer.
5. `harness-session.ts`: the stripper handles the pointer form **and** the inline form. Sessions
   recorded before this shipped still carry the inline text, and a stripper that only knew the new
   form would silently stop resolving them.

### Receipt changes

- `contract_path` — new, in the LEAN receipt allowlist. A lead that can't see the file can't
  check whether the worker was actually told, which is the whole point of the trade.
- `coordination_footer_delivered` — now `true`, with `coordination_footer_note` replaced by
  `delivered_via_contract_file: …`. Same Finding-3 rule as before (never a byte count without
  provenance), opposite answer.
- On a contract-file write failure the spawn does **not** fail: it falls back to the pre-P11b
  inline contract, and the receipt reports `delivered: false` + `not_wired` so the lead knows
  to relay by hand. The `report_path` tool description now says this instead of the old
  unconditional "you must relay".

### The honest cost

One extra read before the agent's first turn, and **an agent that ignores the pointer never learns
its contract.** That is acceptable *because it is detectable* — a contract file that was never read
is observable, whereas a chunked boot prompt that never submitted is silent today. This trades a
silent failure for a visible one. **It does not eliminate failure.** That caveat is in the receipt
note itself, not only here, and a test pins it there.

### Green criteria — verified, not asserted

Baseline on `main` (`4a88b43`) measured this session, **not** taken from the brief (the brief
said 123 files / 2942 passed; that was stale):

| | Baseline (main) | This branch |
|---|---|---|
| `bun run test` | 129 files, 3059 passed, 1 skipped, **0 failed** | 129 files, **3065 passed**, 1 skipped, **0 failed** (at 187389d; was 3063 at 10a0bdd) |
| `bun run typecheck` | clean | clean |

New tests:
- **Composed boot prompt under the threshold** — asserted on the *delivered* text (caller prompt +
  injection joined, which is what actually splits), plus on the pure pointer function for a
  long real-format agent id (`cmuxlayerClaude-d2fc302f` under a long home path), because the
  test-spawned id is short and would not catch a widening on its own. This is the regression that
  went red at 618.
- **Contract file exists and contains both halves** — the monitor command, the
  `CMUX_INBOX_MSG_ID` cursor update, and the issued `report_path` / `done_marker`.
- **The instructions are off the wire** — the delivered text contains the pointer and no longer
  contains `monitor with tail -n0 -F`.
- **Boot delivery is not split** — exactly one write carries both the caller prompt and the
  injection. (Precise claim: the composed boot prompt already went through the composer *paste* on
  `main`, because caller text + injection is multiline by construction. What changed at 618 was
  that it **chunked**. Multi-chunk boot delivery is the hazard; the test pins one write, not zero
  pastes.)
- **Inline mode** still produces the old contract, no `contract_path`, and `not_wired`
  provenance.
- **Pointer stripping** in `harness-session`, alongside the retained inline-form test.

**No spawn path moved onto chunked delivery.** Both spawn sites now send a ~130-char pointer
instead of a ~479-char contract, so every path moved *further from* the threshold, not toward it.

### Review iteration (187389d) — both required items addressed

**R2 · the contract file authored the ledger-#24 deadlock.** Fixed here, per the lead. The file said
`Monitor your inbox: tail -n0 -F <path>` — a blocking foreground watch, arriving under a pointer
that says *"Read and follow"*, which reads more imperative than the old "monitor with", not less.
The renderer now emits it backgrounded with an explicit *"it blocks, and holding a turn open on it
is a self-deadlock (ledger #24)"* line. This costs zero wire budget: the file is the one place the
instruction is no longer squeezed by a 500-char threshold.

Deliberately **not** changed in `recommendedMonitorCommand` — its other callers (receipts, nudges,
tool descriptions) expect the bare command, and changing monitor semantics for all of them inside a
delivery-path PR is the scope creep this lane is supposed to model against. **Those callers remain
open on #461.** The canonical command is still a verbatim substring of the emitted line, so any
consumer matching on it still matches.

**R1 · resume parity — wired, not deferred.** The reviewer was right that this is the case the repo
exists for. `spawn(resume_agent_id)` returned **no contract at all**, so crash recovery was the one
path where a lead could not even see where its worker should report. Resume now issues, persists, and
refreshes the contract. The refresh is byte-identical and idempotent — both strings derive from
`agent_id` alone — and it restores the file if the channel dir was reaped between the crash and the
resume.

**What resume deliberately does not do, and #462 stays open on it:** it does not re-type the pointer
into a resuming pane. `--resume` restores the prior session, which already contains the original
pointer message, and typing into a pane mid-resume is a change to the most incident-prone path in
this repo — precisely what this PR exists to move work *off*. The receipt reports
`coordination_footer_delivered: false` with a `refreshed_not_redelivered` note naming what a lead
must do if the resumed session did not restore its context. Pinned by a test.

**Also taken from the non-blocking half:**
- **R4** — the fallback branch now has its own test (unwritable channel dir): the spawn still
  succeeds, **no dangling pointer reaches the wire**, and the mailbox contract still gets through
  inline. The reviewer was right that the inline-mode test reached the same outcome by a different
  route and would not have caught a regression here.
- **R5 + R3** — the delivered note no longer claims detection the build does not provide. It now
  reads *"observable in principle … NO health or closure path checks it today; nothing here detects
  it for you"*, and states that `coordination_footer_bytes` measures the **unsent** inline
  rendering, not what went on the wire. Both pinned by assertions. Filed with **R6** as **#470**.
- **R7** is the lead's to settle in the brief template; the report's final line is the engine-issued
  marker, which is the P11 invariant working as intended.

I also caught myself citing a non-existent issue number in the receipt note during this iteration
(`#463`, which is actually the F9 delivery-enum issue). Verified against `gh issue list` and
removed rather than shipped.

### Scoped out, stated rather than hidden

`spawn_agents` (the batch path) never issued a coordination contract — P11 wired `spawn_agent`
only. It gets the pointer form (so no path keeps the long inline contract), but its file carries the
mailbox half alone: exactly what that path delivered before, now via the pointer. It also does not
report `contract_path`. Issuing, persisting, and reporting there touches that path's receipt schema
and closure semantics — **tracked on #470**, not folded silently into a delivery-path PR.

**#462 remains open** on the resume half this PR does not deliver: re-delivering the pointer to a
resuming pane. Item 1 (file-carried contracts) and the issuance/persistence half of item 2 land here;
do not close #462 on this merge.

### Test-hygiene finding, unrelated to this PR

`~/.cmux/agents` currently holds **111,769** directories — `tests/server-agent-tools.test.ts`
creates servers without an `inboxBaseDir`, so every run leaks real channel dirs for its synthetic
agents. Pre-existing and out of scope here (my new tests all use temp dirs), but worth a lane.

### Not merging

Worker lane. Reviewer posts ready-to-merge to the retro collab; `cmuxlayerClaude` merges.

— cmuxlayerClaude (worker) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"cmuxlayerClaude","role":"worker","harness":"claude-code","model":"claude-opus-5","model_source":"session-jsonl","session":"c71a81d0","ts":"2026-08-18T18:55:08Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deliver boot contract via file pointer instead of inline text in spawn_agent
> - Instead of embedding the ~479-char mailbox contract inline in the boot prompt, `spawn_agent` now writes a `contract.md` file to the agent's channel directory and injects a single-line pointer (e.g. `cmuxlayer contract for <agentId>: Read and follow /.../<agentId>/contract.md`).
> - Adds `writeBootContractFile`, `bootContractPointer`, and `bootContractMode` to [coordination-paths.ts](https://github.com/EtanHey/cmuxlayer/pull/469/files#diff-e9755eeba4a0e2b38c0755d707183f4db575afa048b0020a2c7bf74fd4e5e8b4); a `buildBootContractInjection` helper in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/469/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) handles pointer vs. inline fallback logic.
> - Resume re-issues and refreshes the contract file but explicitly marks `coordination_footer_delivered: false` with a `COORDINATION_CONTRACT_REFRESHED_NOT_REDELIVERED` note.
> - `contract_path` is added to spawn/send tool output schemas and to the essential fields list in [spawn-response.ts](https://github.com/EtanHey/cmuxlayer/pull/469/files#diff-8e32bbd194555438af0bcd530b415445a30a3fa1c3eb8ef3a2a05d9204d01445).
> - Set `CMUXLAYER_BOOT_CONTRACT=inline` to revert to legacy inline delivery; if the file write fails, the engine falls back to inline without emitting a dangling pointer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 187389d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->