### PR TITLE
fix(t1b): one resolution per list_agents row, and artifact_missing needs observed done (#488)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1734,7 +1734,19 @@ export class AgentEngine {
     );
   }
 
-  assessHarvestability(agent: AgentRecord): WorkerHarvestability {
+  /**
+   * AIDEV-NOTE (T1b/#488): `live` is how a caller that ALREADY has a screen
+   * observation hands it in, so one response cannot resolve `closure` from one
+   * evidence source and `state` from another. `list_agents` takes a fresh scan
+   * on every call and then rendered closure off `cachedScan()`, which returns
+   * null once that scan is 2000ms old -- so the same row said `working` and
+   * `artifact_missing`, and flapped as the cache aged. Callers without an
+   * observation keep the injected probe; there is no new screen read here.
+   */
+  assessHarvestability(
+    agent: AgentRecord,
+    opts?: { live?: LiveAgentState | null },
+  ): WorkerHarvestability {
     const issueCodes: string[] = [];
     const issues: string[] = [];
     const addIssue = (code: string, message: string): void => {
@@ -1751,7 +1763,7 @@ export class AgentEngine {
     // on an agent mid-turn. A `ready` prompt cannot overturn done (a finished
     // worker sits at one too), and a dead/shell pane must not either: there
     // the record's `done` plus the missing artifact IS the story.
-    const live = this.liveStateOf(agent);
+    const live = opts?.live ?? this.liveStateOf(agent);
     const effectiveState = isLiveActive(live) ? live.state : agent.state;
     const neutralEvidenceChannel: HarvestabilityEvidenceChannel = {
       done_source: agent.task_done_detected_at ? "screen" : "none",
@@ -1780,6 +1792,8 @@ export class AgentEngine {
             Boolean(agent.report_path && agent.done_marker) ||
             Boolean(agent.goal_file),
           closureArtifactVerified: null,
+          // Unreachable as a deadlock claim: this branch is not `done`.
+          doneEvidence: false,
         }),
         closure_artifact_verified: null,
         report_path: preClosureGoal.reportPath,
@@ -1825,6 +1839,17 @@ export class AgentEngine {
       reportText !== null &&
       reportFresh === true &&
       reportFinalLine === goal.doneMarker;
+    // AIDEV-NOTE (T1b/#488): the POSITIVE done evidence `artifact_missing`
+    // now requires. `evidence_channel.done_source` is already the engine's
+    // answer to "what saw this agent finish" -- `screen` from
+    // task_done_detected_at, `transcript` from the harness JSONL -- and a
+    // screen that itself reads `done` counts. `none` means the only thing
+    // claiming done is the record, which #408 writes without observing
+    // anything.
+    const doneEvidence =
+      evidenceChannel.done_source !== "none" ||
+      live.screen_state === "done" ||
+      closureArtifactVerified;
     const keptOpen = reportText
       ? this.extractKeptOpenContract(reportText)
       : null;
@@ -1899,6 +1924,7 @@ export class AgentEngine {
         role,
         contractIssued: Boolean(goal.reportPath && goal.doneMarker),
         closureArtifactVerified,
+        doneEvidence,
       }),
       closure_artifact_verified: closureArtifactVerified,
       report_path: goal.reportPath,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5751,7 +5751,19 @@ export class AgentEngine {
       // text in hand, closure resolves from THAT rather than from the discovery
       // cache, which may be cold on this path too. No new read: when there is
       // no screen text, the injected probe is used exactly as before.
-      const sweepScreenText = taskDoneResult.screenText;
+      // The done-detection pass returns early for a record already at `done`
+      // -- exactly #488's shape -- so its screen text is absent precisely when
+      // closure needs it. `readSweepScreen` memoizes on `sweepCtx`, which the
+      // health input below reuses for this same agent, so this shares that
+      // read rather than adding one.
+      let sweepScreenText = taskDoneResult.screenText;
+      if (sweepScreenText === undefined) {
+        try {
+          sweepScreenText = (await this.readSweepScreen(agent, sweepCtx)).text;
+        } catch {
+          // No screen is no evidence; the injected probe answers as before.
+        }
+      }
       const harvestability = this.assessHarvestability(agent, {
         live:
           sweepScreenText === undefined

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1847,9 +1847,7 @@ export class AgentEngine {
     // claiming done is the record, which #408 writes without observing
     // anything.
     const doneEvidence =
-      evidenceChannel.done_source !== "none" ||
-      live.screen_state === "done" ||
-      closureArtifactVerified;
+      evidenceChannel.done_source !== "none" || live.screen_state === "done";
     const keptOpen = reportText
       ? this.extractKeptOpenContract(reportText)
       : null;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5744,7 +5744,20 @@ export class AgentEngine {
         this.clearAgentLifecycleMemory(initialAgentId);
         continue;
       }
-      const harvestability = this.assessHarvestability(agent);
+      // AIDEV-NOTE (T1b/#488): the sweep is the third emitter -- its
+      // harvestability feeds the health input, the sidebar row's `report=` and
+      // the done notification, beside a state derived from the screen it reads
+      // below. When the done-detection pass already has this agent's screen
+      // text in hand, closure resolves from THAT rather than from the discovery
+      // cache, which may be cold on this path too. No new read: when there is
+      // no screen text, the injected probe is used exactly as before.
+      const sweepScreenText = taskDoneResult.screenText;
+      const harvestability = this.assessHarvestability(agent, {
+        live:
+          sweepScreenText === undefined
+            ? null
+            : resolveLiveAgentState(agent, parseScreen(sweepScreenText)),
+      });
       const healthScreenContexts = new Map<string, SweepAgentContext>();
       let screenCurrentAction: string | null = null;
       const healthScreenContextFor = (

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -121,8 +121,15 @@ export function coordinationFooterBytes(contract: CoordinationContract): number 
  * into one falsey value, the same hazard `paused` shipped with in v0.4.41 and
  * that v0.4.42 fixed by attaching provenance (types.ts pauseHonestyFields).
  *
- * Invariant: `artifact_missing` is reachable ONLY from state "done", so it is
- * an actionable deadlock signal on its own -- no cross-referencing required.
+ * Invariant: `artifact_missing` is reachable ONLY from state "done" AND from
+ * POSITIVE done evidence, so it is an actionable deadlock signal on its own --
+ * no cross-referencing required.
+ *
+ * AIDEV-NOTE (T1b/#488): the second half of that invariant is the fix. A bare
+ * registry flip to `done` (#408 does this within minutes, with nothing having
+ * observed a done) used to be enough, so healthy mid-work children -- one of
+ * them two minutes old -- rendered the "route a reviewer NOW" signal. Absence
+ * of done evidence is `pending`, never a deadlock claim.
  */
 export type ClosureState =
   | "verified"
@@ -135,13 +142,20 @@ export function resolveClosureState(input: {
   role?: string | null;
   contractIssued: boolean;
   closureArtifactVerified: boolean | null;
+  /**
+   * Something OBSERVED this agent finish: a done marker on screen
+   * (`task_done_detected_at`), a harness transcript that ended, or a verified
+   * report. Required -- not optional -- so every call site has to say which
+   * evidence it has rather than inheriting the record's word for it.
+   */
+  doneEvidence: boolean;
 }): ClosureState {
   if (!input.contractIssued) return "not_applicable";
   if (input.role === "orchestrator") return "not_applicable";
   if (input.state !== "done") return "pending";
-  return input.closureArtifactVerified === true
-    ? "verified"
-    : "artifact_missing";
+  // A verified artifact IS positive done evidence, so it is checked first.
+  if (input.closureArtifactVerified === true) return "verified";
+  return input.doneEvidence ? "artifact_missing" : "pending";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server.ts
+++ b/src/server.ts
@@ -7212,6 +7212,56 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
       : parsed;
 
+  /**
+   * AIDEV-NOTE (T1b/#488): ONE screen observation for a response that emits
+   * `closure` and `state`/health together. `list_agents` threads its own scan;
+   * `get_agent_state` and `wait_for` have no scan, so they read the surface ONCE
+   * here and hand the same observation to both consumers -- the health block via
+   * the screen_* overrides it already accepts (which stop it re-reading), and
+   * closure via `assessHarvestability(agent, { live })`. Without this, closure
+   * fell back to `cachedScan()`, null past 2000ms, and the same response could
+   * say `working` and `artifact_missing` at once. Read count is unchanged: the
+   * read moves out of the health call, it is not added to it.
+   */
+  const observeAgentOnce = async (
+    agent: AgentRecord,
+    topology: SurfaceTopologySnapshot | null,
+  ): Promise<{
+    screenOverrides: AgentHealthInputOverrides;
+    live: LiveAgentState;
+  }> => {
+    const binding = resolveAuthorizedAgentSurfaceBinding(agent, topology);
+    if (!binding) {
+      // No authorized surface is no evidence -- the same answer the health path
+      // reaches on its own, and `resolveLiveAgentState` records it as
+      // `source: "registry"` rather than passing the record off as observed.
+      return { screenOverrides: {}, live: resolveLiveAgentState(agent, null) };
+    }
+    const parsed = await readParsedSurface(
+      binding.surfaceRef,
+      binding.workspaceId ?? undefined,
+      { agent },
+    );
+    return {
+      screenOverrides: {
+        screen_status: parsed?.parsed.status ?? null,
+        screen_agent_type: parsed?.parsed.agent_type ?? null,
+        screen_control_state: parsed?.parsed.control_state ?? null,
+        screen_actions: parsed?.parsed.actions ?? null,
+      },
+      live: resolveLiveAgentState(
+        agent,
+        parsed
+          ? {
+              status: parsed.parsed.status,
+              agent_type: parsed.parsed.agent_type,
+              control_state: parsed.parsed.control_state,
+            }
+          : null,
+      ),
+    };
+  };
+
   const evaluateServerAgentHealth = async (
     agent: AgentRecord,
     overrides?: AgentHealthInputOverrides,
@@ -13255,11 +13305,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 const resultAgent = result.agent
                   ? engine.getAgentState(result.agent.agent_id)
                   : null;
+                // T1b (#488): one observation feeds this reply's health block
+                // AND its closure, so the two cannot contradict each other.
+                const observed = resultAgent
+                  ? await observeAgentOnce(resultAgent, topology)
+                  : null;
                 const health = resultAgent
                   ? await evaluateServerAgentHealth(
                       resultAgent,
                       {
                         ...healthTopologyOverrides(resultAgent, topology),
+                        ...(observed?.screenOverrides ?? {}),
                       },
                       topology,
                     )
@@ -13270,7 +13326,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 // with no new carrier (#414: a carrier without a reader is not
                 // a carrier).
                 const harvest = resultAgent
-                  ? engine.assessHarvestability(resultAgent)
+                  ? engine.assessHarvestability(resultAgent, {
+                      live: observed?.live ?? null,
+                    })
                   : null;
                 return {
                   ...result,
@@ -13440,7 +13498,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!state)
             return err(new Error(`Agent not found: ${args.agent_id}`));
           const topology = await collectSurfaceTopology();
-          const harvestability = engine.assessHarvestability(state);
+          // T1b (#488): the screen this response reports on is the screen its
+          // closure is resolved from. Read once, used by both.
+          const observed = await observeAgentOnce(state, topology);
+          const harvestability = engine.assessHarvestability(state, {
+            live: observed.live,
+          });
           const authorizedBinding = resolveAuthorizedAgentSurfaceBinding(
             state,
             topology,
@@ -13450,6 +13513,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               state,
               {
                 ...healthTopologyOverrides(state, topology),
+                ...observed.screenOverrides,
                 harvestability,
               },
               topology,

--- a/src/server.ts
+++ b/src/server.ts
@@ -13690,6 +13690,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   topology,
                 );
                 const reconciledState = health.reconciled_state ?? agent.state;
+                // AIDEV-NOTE (T1b/#488): ONE observation per row. `closure`
+                // used to re-resolve live state through the discovery cache
+                // (`cachedScan()`, null past 2000ms) while `state` right above
+                // used THIS call's own scan -- so a cold cache made one row
+                // read `working` and `artifact_missing` at the same time, and
+                // flap as the cache aged. Same evidence, resolved once, passed
+                // to both. Costs zero extra screen reads: the scan already
+                // happened at the top of this call.
+                const rowLiveState = resolveLiveAgentState(
+                  agent,
+                  trustedScreenObservation
+                    ? {
+                        status: trustedScreenObservation.parsed_status,
+                        agent_type:
+                          trustedScreenObservation.cli === "kiro"
+                            ? "unknown"
+                            : trustedScreenObservation.cli,
+                        control_state: trustedScreenObservation.control_state,
+                      }
+                    : null,
+                );
+                const rowHarvestability = engine.assessHarvestability(agent, {
+                  live: rowLiveState,
+                });
                 const screenObservation = trustedScreenObservation
                   ? {
                       observed_at_ms: liveDiscovery!.observed_at_ms,
@@ -13732,7 +13756,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     // deadlocked child (done, no artifact -> act) from a busy one
                     // (pending -> wait) WITHOUT a second full-detail call. A bare
                     // boolean made both of those `false`; that was the S3 bug.
-                    closure: engine.assessHarvestability(agent).closure,
+                    closure: rowHarvestability.closure,
                     ...(args.detail === "full"
                       ? {
                           health: {
@@ -13743,7 +13767,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           },
                           detail: {
                             ...toAgentStatePayload(agent),
-                            harvestability: engine.assessHarvestability(agent),
+                            harvestability: rowHarvestability,
                           },
                         }
                       : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -13310,16 +13310,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 const observed = resultAgent
                   ? await observeAgentOnce(resultAgent, topology)
                   : null;
-                const health = resultAgent
-                  ? await evaluateServerAgentHealth(
-                      resultAgent,
-                      {
-                        ...healthTopologyOverrides(resultAgent, topology),
-                        ...(observed?.screenOverrides ?? {}),
-                      },
-                      topology,
-                    )
-                  : undefined;
                 // P11 Contract B: a lead that BLOCKS on its children gets the
                 // closure state in the reply it was already waiting for -- the
                 // completion signal surfaces where the parent actually looks,
@@ -13330,6 +13320,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       live: observed?.live ?? null,
                     })
                   : null;
+                const health = resultAgent
+                  ? await evaluateServerAgentHealth(
+                      resultAgent,
+                      {
+                        ...healthTopologyOverrides(resultAgent, topology),
+                        ...(observed?.screenOverrides ?? {}),
+                        ...(harvest ? { harvestability: harvest } : {}),
+                      },
+                      topology,
+                    )
+                  : undefined;
                 return {
                   ...result,
                   health,
@@ -13733,6 +13734,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   observedSurface && !observedSurface.read_error
                     ? observedSurface
                     : null;
+                // AIDEV-NOTE (T1b/#488): ONE observation per row. `closure`
+                // used to re-resolve live state through the discovery cache
+                // (`cachedScan()`, null past 2000ms) while `state` below used
+                // THIS call's own scan -- so a cold cache made one row read
+                // `working` and `artifact_missing` at the same time, and flap
+                // as the cache aged. Same evidence, resolved once, passed to
+                // the health block AND to closure. Costs zero extra screen
+                // reads: the scan already happened at the top of this call.
+                const rowLiveState = resolveLiveAgentState(
+                  agent,
+                  trustedScreenObservation
+                    ? {
+                        status: trustedScreenObservation.parsed_status,
+                        agent_type:
+                          trustedScreenObservation.cli === "kiro"
+                            ? "unknown"
+                            : trustedScreenObservation.cli,
+                        control_state: trustedScreenObservation.control_state,
+                      }
+                    : null,
+                );
+                const rowHarvestability = engine.assessHarvestability(agent, {
+                  live: rowLiveState,
+                });
                 const health = await evaluateServerAgentHealth(
                   agent,
                   {
@@ -13750,34 +13775,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                             trustedScreenObservation.actions ?? [],
                         }
                       : {}),
+                    // Without this the health block re-derived harvestability
+                    // through the probe (buildAgentHealthInput's
+                    // `deps.assessHarvestability`), putting a THIRD resolution
+                    // in the same row: `closure_without_artifact` could fire
+                    // beside `closure: "pending"`.
+                    harvestability: rowHarvestability,
                   },
                   topology,
                 );
                 const reconciledState = health.reconciled_state ?? agent.state;
-                // AIDEV-NOTE (T1b/#488): ONE observation per row. `closure`
-                // used to re-resolve live state through the discovery cache
-                // (`cachedScan()`, null past 2000ms) while `state` right above
-                // used THIS call's own scan -- so a cold cache made one row
-                // read `working` and `artifact_missing` at the same time, and
-                // flap as the cache aged. Same evidence, resolved once, passed
-                // to both. Costs zero extra screen reads: the scan already
-                // happened at the top of this call.
-                const rowLiveState = resolveLiveAgentState(
-                  agent,
-                  trustedScreenObservation
-                    ? {
-                        status: trustedScreenObservation.parsed_status,
-                        agent_type:
-                          trustedScreenObservation.cli === "kiro"
-                            ? "unknown"
-                            : trustedScreenObservation.cli,
-                        control_state: trustedScreenObservation.control_state,
-                      }
-                    : null,
-                );
-                const rowHarvestability = engine.assessHarvestability(agent, {
-                  live: rowLiveState,
-                });
                 const screenObservation = trustedScreenObservation
                   ? {
                       observed_at_ms: liveDiscovery!.observed_at_ms,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3247,6 +3247,50 @@ describe("AgentEngine", () => {
       }
     });
 
+    // T1b (#488): the sweep is the third emitter of closure -- its assessment
+    // feeds the health input, this row's `report=`/`health=` text and the done
+    // notification, beside a state it derives from the screen it reads. It used
+    // to take closure from the discovery-cache probe, which is cold on this
+    // path too, so a live-working agent whose record #408 had flipped rendered
+    // the blocking `closure_without_artifact` here as well.
+    it("sweep row closure follows the screen it read, at no extra read", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "worker-sweep-live-closure",
+          state: "done",
+          surface_id: "surface:sweep-live-closure",
+          workspace_id: "workspace:brainlayer",
+          cli: "codex",
+          role: "worker",
+          task_done_detected_at: "2026-05-25T12:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:sweep-live-closure"),
+          workspace_ref: "workspace:brainlayer",
+        },
+      ];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:sweep-live-closure",
+        text: "codex\n• Working (12s • esc to interrupt)\ncodex> ",
+        lines: 80,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockClear();
+
+      await engine.runSweep();
+
+      const row = (mockClient.setStatus as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[1] as string | undefined;
+      expect(row, JSON.stringify((mockClient.setStatus as any).mock.calls)).toBeTruthy();
+      expect(row).not.toContain("closure_without_artifact");
+      // The pre-read shares `sweepCtx` with the health input's own read, so
+      // resolving closure from the screen costs nothing extra.
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(1);
+    });
+
     it("does not rewrite TASK_DONE candidate metadata while the sweep stamps liveness", async () => {
       vi.useFakeTimers();
       try {

--- a/tests/coordination-paths.test.ts
+++ b/tests/coordination-paths.test.ts
@@ -112,7 +112,11 @@ describe("P11 boot footer (Constraint 1: <=2 short lines, bytes declared)", () =
 });
 
 describe("P11 closure state (Constraint 3: no bare boolean at default detail)", () => {
-  const issued = { contractIssued: true };
+  // T1b (#488): `observed` is a done that something actually SAW -- a done
+  // marker on screen, a finished transcript. `unobserved` is the bare registry
+  // flip #408 writes on live agents, which must never claim a deadlock.
+  const issued = { contractIssued: true, doneEvidence: true };
+  const unobserved = { contractIssued: true, doneEvidence: false };
 
   it("done + verified artifact => verified", () => {
     expect(
@@ -124,7 +128,7 @@ describe("P11 closure state (Constraint 3: no bare boolean at default detail)", 
     ).toBe("verified");
   });
 
-  it("S3 SIGNATURE: done + no artifact => artifact_missing, NOT pending", () => {
+  it("S3 SIGNATURE: done + done evidence + no artifact => artifact_missing, NOT pending", () => {
     expect(
       resolveClosureState({
         ...issued,
@@ -132,6 +136,26 @@ describe("P11 closure state (Constraint 3: no bare boolean at default detail)", 
         closureArtifactVerified: false,
       }),
     ).toBe("artifact_missing");
+  });
+
+  it("T1b: done with NO done evidence => pending, never artifact_missing", () => {
+    const closure = resolveClosureState({
+      ...unobserved,
+      state: "done",
+      closureArtifactVerified: false,
+    });
+    expect(closure).toBe("pending");
+    expect(closure).not.toBe("artifact_missing");
+  });
+
+  it("T1b: a verified artifact IS done evidence, so it still reads verified", () => {
+    expect(
+      resolveClosureState({
+        ...unobserved,
+        state: "done",
+        closureArtifactVerified: true,
+      }),
+    ).toBe("verified");
   });
 
   it("still working => pending, and NEVER artifact_missing", () => {
@@ -165,6 +189,7 @@ describe("P11 closure state (Constraint 3: no bare boolean at default detail)", 
     expect(
       resolveClosureState({
         contractIssued: false,
+        doneEvidence: true,
         state: "done",
         closureArtifactVerified: null,
       }),

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -382,7 +382,7 @@ describe("F1 — live state, not the stale registry record", () => {
     expect(row.closure).toBe("pending");
   });
 
-  it("P11 closure still reports artifact_missing when the screen confirms done", async () => {
+  it("P11 closure still reports artifact_missing when a done was OBSERVED", async () => {
     client.screens["surface:idle"] = [
       "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
       "codex>",
@@ -393,6 +393,10 @@ describe("F1 — live state, not the stale registry record", () => {
         agent_id: "cmuxlayerCodex-finished",
         surface_id: client.idleSurface,
         state: "done",
+        // T1b (#488): the record alone is no longer enough to claim a deadlock
+        // -- #408 writes `done` on live agents without anything observing one.
+        // This agent's done WAS observed, so the signal must survive.
+        task_done_detected_at: "2026-08-18T13:41:00.000Z",
         report_path: join(TEST_DIR, "reports", "missing.md"),
         done_marker: "### @cmuxlayerCodex-finished DONE",
       } as Partial<AgentRecord> as any),

--- a/tests/t1b-closure-probe-divergence.test.ts
+++ b/tests/t1b-closure-probe-divergence.test.ts
@@ -441,6 +441,36 @@ describe("T1b (#488) — closure and state resolve from ONE observation", () => 
     expect(parsed.health.issue_codes).toContain("closure_without_artifact");
   });
 
+  it("detail:full health carries the SAME resolution, not a third one", async () => {
+    // The health block re-derived harvestability through the probe, so a cold
+    // cache could fire the blocking `closure_without_artifact` issue on the
+    // very row whose `closure` reads `pending` -- the divergence moved one
+    // field over.
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-health",
+        surface_id: client.workingSurface,
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "health.md"),
+        done_marker: "DONE_T1B_HEALTH",
+      } as Partial<AgentRecord> as any),
+    );
+
+    await callTool(server, "list_agents", {});
+    poisonProbeCold(server);
+
+    const parsed = parseResult(
+      await callTool(server, "list_agents", { detail: "full" }),
+    );
+    const row = rowFor(parsed, "cmuxlayerCodex-t1b-health");
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    expect(row.closure).toBe("pending");
+    expect(row.detail.harvestability.closure).toBe("pending");
+    expect(row.health.issue_codes).not.toContain("closure_without_artifact");
+  });
+
   it("three consecutive calls for an unchanged agent do not flap the closure", async () => {
     registerAgent(
       server,

--- a/tests/t1b-closure-probe-divergence.test.ts
+++ b/tests/t1b-closure-probe-divergence.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Lane T1b (#488): ONE resolution per `list_agents` response.
+ *
+ * `closure` used to derive from the discovery-cache probe (null once the cache
+ * is 2000ms old) while the SAME row's `state` derived from the live scan the
+ * call had just taken. Cache warm, the two agreed; cache cold, one row said
+ * `state: working` and `closure: artifact_missing` -- "route a reviewer NOW"
+ * against an agent mid-turn -- and the field flapped as the cache aged.
+ *
+ * These tests drive the divergence directly: the probe is poisoned to its
+ * COLD shape (registry fallback) while the response's own scan sees the live
+ * screen. Closure must follow the scan, not the cold probe.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/server.js";
+import { resolveLiveAgentState } from "../src/live-agent-state.js";
+import type { StateManager } from "../src/state-manager.js";
+import type { AgentRecord } from "../src/agent-types.js";
+
+const TEST_DIR = join(tmpdir(), "cmux-t1b-closure-probe-divergence-test");
+const TEST_OBSERVER_OWNER = "cmux:/tmp/cmux-t1b-closure-probe.sock";
+
+const READY_CODEX_SCREEN = [
+  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+  "codex>",
+].join("\n");
+const WORKING_CODEX_SCREEN = [
+  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+  "• Working (12s • esc to interrupt)",
+  "codex>",
+].join("\n");
+
+function parseResult(result: any): any {
+  return result.structuredContent ?? JSON.parse(result.content[0].text);
+}
+
+async function callTool(
+  server: any,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const tool = server._registeredTools[name];
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool.handler(args, {} as any);
+}
+
+class LiveSurfaceClient {
+  readonly workspace = "workspace:1";
+  readonly pane = "pane:1";
+  readonly readySurface = "surface:ready";
+  readonly workingSurface = "surface:working";
+  readonly screens: Record<string, string> = {
+    "surface:ready": READY_CODEX_SCREEN,
+    "surface:working": WORKING_CODEX_SCREEN,
+  };
+
+  async listWorkspaces() {
+    return {
+      workspaces: [
+        {
+          ref: this.workspace,
+          title: "Main",
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    };
+  }
+
+  async listPanes() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      panes: [
+        {
+          ref: this.pane,
+          index: 0,
+          focused: true,
+          surface_count: 2,
+          surface_refs: [this.readySurface, this.workingSurface],
+          selected_surface_ref: this.readySurface,
+        },
+      ],
+    };
+  }
+
+  async listPaneSurfaces() {
+    return {
+      workspace_ref: this.workspace,
+      window_ref: "window:1",
+      pane_ref: this.pane,
+      surfaces: [
+        {
+          ref: this.readySurface,
+          title: "cmuxlayerCodex-ready",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+        {
+          ref: this.workingSurface,
+          title: "cmuxlayerCodex-working",
+          type: "terminal",
+          index: 1,
+          selected: false,
+        },
+      ],
+    };
+  }
+
+  async send() {}
+  async sendKey() {}
+
+  readScreenCalls = 0;
+
+  async readScreen(surface: string, opts?: { lines?: number }) {
+    const text = this.screens[surface];
+    if (text == null) throw new Error(`Unknown surface: ${surface}`);
+    this.readScreenCalls += 1;
+    return { surface, text, lines: opts?.lines ?? 30, scrollback_used: false };
+  }
+
+  async renameTab() {}
+}
+
+function createLiveServer(client: LiveSurfaceClient) {
+  return createServer({
+    client: client as any,
+    stateDir: TEST_DIR,
+    disableSpawnPreflight: true,
+    surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
+    surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
+  });
+}
+
+function makeAgent(
+  overrides: Partial<AgentRecord> &
+    Pick<AgentRecord, "agent_id" | "surface_id">,
+): AgentRecord {
+  const now = "2026-08-19T13:40:00.000Z";
+  return {
+    workspace_id: "workspace:1",
+    surface_observer_id: TEST_OBSERVER_OWNER,
+    state: "idle",
+    repo: "cmuxlayer",
+    model: "gpt-5.5",
+    cli: "codex",
+    cli_session_id: null,
+    task_summary: "t1b closure divergence",
+    pid: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "worker",
+    task_done_candidate_at: null,
+    task_done_detected_at: null,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: false,
+    respawn_attempts: 0,
+    user_killed: false,
+    paused: false,
+    paused_source: null,
+    ...overrides,
+  } as AgentRecord;
+}
+
+function testEngine(server: any) {
+  return server._registeredTools["interact"]._engine;
+}
+
+function registerAgent(server: any, record: AgentRecord): AgentRecord {
+  const engine = testEngine(server);
+  const stateMgr = engine["stateMgr"] as StateManager;
+  stateMgr.writeState(record);
+  engine.getRegistry().set(record.agent_id, record);
+  return record;
+}
+
+/** The cold-cache probe: `cachedScan()` returned null, so no screen evidence. */
+function poisonProbeCold(server: any): void {
+  testEngine(server).setLiveStateResolver((agent: AgentRecord) =>
+    resolveLiveAgentState(agent, null),
+  );
+}
+
+function rowFor(parsed: any, agentId: string): any {
+  return parsed.agents.find((agent: any) => agent.agent_id === agentId);
+}
+
+function disposeServer(server: any) {
+  const engine = server?._registeredTools?.interact?._engine;
+  if (engine && typeof engine.dispose === "function") engine.dispose();
+}
+
+describe("T1b (#488) — closure and state resolve from ONE observation", () => {
+  let server: any;
+  let client: LiveSurfaceClient;
+
+  beforeEach(async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    client = new LiveSurfaceClient();
+    server = createLiveServer(client);
+  });
+
+  afterEach(() => {
+    disposeServer(server);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("working screen + COLD closure probe reads pending, never artifact_missing", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-busy",
+        surface_id: client.workingSurface,
+        // #408's lie plus real prior done evidence: even THAT must not outrank
+        // a screen this same response read as mid-turn.
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "busy.md"),
+        done_marker: "DONE_T1B_BUSY",
+      } as Partial<AgentRecord> as any),
+    );
+
+    // First call warms lifecycle start (which installs the real probe).
+    await callTool(server, "list_agents", {});
+    poisonProbeCold(server);
+
+    const parsed = parseResult(await callTool(server, "list_agents", {}));
+    const row = rowFor(parsed, "cmuxlayerCodex-t1b-busy");
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    expect(row.state.value).toBe("working");
+    expect(row.state.source).toBe("screen");
+    expect(row.closure).toBe("pending");
+  });
+
+  it("ready screen + stale-done record with NO done evidence reads pending", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-flip",
+        surface_id: client.readySurface,
+        // The bare #408 record flip: `done` with nothing that ever observed a
+        // done. `artifact_missing` from this alone is the false deadlock.
+        state: "done",
+        task_done_detected_at: null,
+        report_path: join(TEST_DIR, "reports", "flip.md"),
+        done_marker: "DONE_T1B_FLIP",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const parsed = parseResult(await callTool(server, "list_agents", {}));
+    const row = rowFor(parsed, "cmuxlayerCodex-t1b-flip");
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    expect(row.closure).toBe("pending");
+    expect(row.closure).not.toBe("artifact_missing");
+  });
+
+  it("the deadlock signal SURVIVES: done evidence + missing report is artifact_missing", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-deadlocked",
+        surface_id: client.readySurface,
+        state: "done",
+        // Positive done evidence: the sweep observed the done, then no report.
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "never-written.md"),
+        done_marker: "DONE_T1B_DEADLOCK",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const parsed = parseResult(await callTool(server, "list_agents", {}));
+    const row = rowFor(parsed, "cmuxlayerCodex-t1b-deadlocked");
+    expect(row, JSON.stringify(parsed)).toBeTruthy();
+    expect(row.closure).toBe("artifact_missing");
+  });
+
+  it("costs ZERO extra screen reads: one scan per call, both fields off it (#425)", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-cost",
+        surface_id: client.workingSurface,
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "cost.md"),
+        done_marker: "DONE_T1B_COST",
+      } as Partial<AgentRecord> as any),
+    );
+
+    await callTool(server, "list_agents", {});
+    const before = client.readScreenCalls;
+    const parsed = parseResult(await callTool(server, "list_agents", {}));
+    const reads = client.readScreenCalls - before;
+
+    // Two surfaces exist, so one scan is two reads. Threading that scan into
+    // closure adds none: the alternative -- forcing fresh evidence on the
+    // closure path -- would have added one read per row per call.
+    expect(rowFor(parsed, "cmuxlayerCodex-t1b-cost")?.closure).toBe("pending");
+    expect(reads).toBe(Object.keys(client.screens).length);
+  });
+
+  it("three consecutive calls for an unchanged agent do not flap the closure", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-flap",
+        surface_id: client.workingSurface,
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "flap.md"),
+        done_marker: "DONE_T1B_FLAP",
+      } as Partial<AgentRecord> as any),
+    );
+
+    // The reported flap (`db1ff995`, working→done→working in 17s) is the probe
+    // cache expiring between calls while nothing about the agent changed.
+    const first = parseResult(await callTool(server, "list_agents", {}));
+    poisonProbeCold(server);
+    const second = parseResult(await callTool(server, "list_agents", {}));
+    const third = parseResult(await callTool(server, "list_agents", {}));
+
+    const closures = [first, second, third].map(
+      (parsed) => rowFor(parsed, "cmuxlayerCodex-t1b-flap")?.closure,
+    );
+    expect(closures, JSON.stringify(closures)).toEqual([
+      "pending",
+      "pending",
+      "pending",
+    ]);
+  });
+});

--- a/tests/t1b-closure-probe-divergence.test.ts
+++ b/tests/t1b-closure-probe-divergence.test.ts
@@ -311,6 +311,103 @@ describe("T1b (#488) — closure and state resolve from ONE observation", () => 
     expect(reads).toBe(Object.keys(client.screens).length);
   });
 
+  it("get_agent_state does not render artifact_missing beside a working screen", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-getstate",
+        surface_id: client.workingSurface,
+        // The residual shape the reviewer reproduced: a done that WAS once
+        // observed, on an agent that is demonstrably working again.
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "getstate.md"),
+        done_marker: "DONE_T1B_GETSTATE",
+      } as Partial<AgentRecord> as any),
+    );
+
+    await callTool(server, "list_agents", {});
+    poisonProbeCold(server);
+
+    const parsed = parseResult(
+      await callTool(server, "get_agent_state", {
+        agent_id: "cmuxlayerCodex-t1b-getstate",
+      }),
+    );
+    expect(parsed.health?.reconciled_state, JSON.stringify(parsed)).toBe(
+      "working",
+    );
+    expect(parsed.harvestability.closure).toBe("pending");
+  });
+
+  it("wait_for does not render artifact_missing beside a working screen", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-waitfor",
+        surface_id: client.workingSurface,
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "waitfor.md"),
+        done_marker: "DONE_T1B_WAITFOR",
+      } as Partial<AgentRecord> as any),
+    );
+
+    await callTool(server, "list_agents", {});
+    poisonProbeCold(server);
+
+    const parsed = parseResult(
+      await callTool(server, "wait_for", {
+        ids: ["cmuxlayerCodex-t1b-waitfor"],
+        target_state: "done",
+        timeout_ms: 2000,
+      }),
+    );
+    const result = parsed.results[0];
+    expect(result.health?.reconciled_state, JSON.stringify(parsed)).toBe(
+      "working",
+    );
+    expect(result.closure).toBe("pending");
+  });
+
+  it("the deadlock signal survives on ALL THREE emitters, not just list_agents", async () => {
+    // The false-negative the reviewer named: narrowing `artifact_missing` must
+    // not silence the case it exists for. Done evidence, ready prompt, report
+    // never written -- every path that emits closure must still say so.
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-realdeadlock",
+        surface_id: client.readySurface,
+        state: "done",
+        task_done_detected_at: "2026-08-19T13:41:00.000Z",
+        report_path: join(TEST_DIR, "reports", "real-deadlock.md"),
+        done_marker: "DONE_T1B_REALDEADLOCK",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const listed = parseResult(await callTool(server, "list_agents", {}));
+    const state = parseResult(
+      await callTool(server, "get_agent_state", {
+        agent_id: "cmuxlayerCodex-t1b-realdeadlock",
+      }),
+    );
+    const waited = parseResult(
+      await callTool(server, "wait_for", {
+        ids: ["cmuxlayerCodex-t1b-realdeadlock"],
+        target_state: "done",
+        timeout_ms: 2000,
+      }),
+    );
+
+    expect(
+      rowFor(listed, "cmuxlayerCodex-t1b-realdeadlock")?.closure,
+      JSON.stringify(listed),
+    ).toBe("artifact_missing");
+    expect(state.harvestability.closure).toBe("artifact_missing");
+    expect(waited.results[0].closure).toBe("artifact_missing");
+  });
+
   it("three consecutive calls for an unchanged agent do not flap the closure", async () => {
     registerAgent(
       server,

--- a/tests/t1b-closure-probe-divergence.test.ts
+++ b/tests/t1b-closure-probe-divergence.test.ts
@@ -408,6 +408,39 @@ describe("T1b (#488) — closure and state resolve from ONE observation", () => 
     expect(waited.results[0].closure).toBe("artifact_missing");
   });
 
+  it("narrowing artifact_missing silences the CLAIM, not the evidence: health still flags it", async () => {
+    // The reviewer's named false-negative: a worker that finished without a
+    // recognized done marker looks identical to a #408 flip. Closure withholds
+    // the deadlock CLAIM there -- but `closure_artifact_verified:false` and the
+    // blocking `closure_without_artifact` health issue still render, so the
+    // population is auditable rather than invisible. This is the post-merge
+    // signal to watch: records at `done` with `closure:"pending"` and
+    // `done_source:"none"`.
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-t1b-unobserved",
+        surface_id: client.readySurface,
+        state: "done",
+        task_done_detected_at: null,
+        report_path: join(TEST_DIR, "reports", "unobserved.md"),
+        done_marker: "DONE_T1B_UNOBSERVED",
+      } as Partial<AgentRecord> as any),
+    );
+
+    const parsed = parseResult(
+      await callTool(server, "get_agent_state", {
+        agent_id: "cmuxlayerCodex-t1b-unobserved",
+      }),
+    );
+    expect(parsed.harvestability.closure, JSON.stringify(parsed)).toBe(
+      "pending",
+    );
+    expect(parsed.harvestability.closure_artifact_verified).toBe(false);
+    expect(parsed.harvestability.evidence_channel.done_source).toBe("none");
+    expect(parsed.health.issue_codes).toContain("closure_without_artifact");
+  });
+
   it("three consecutive calls for an unchanged agent do not flap the closure", async () => {
     registerAgent(
       server,


### PR DESCRIPTION
Closes #488. Round 2 — reviewer verdict was ITERATE; all three asks addressed below.

## The defect
`list_agents` takes a fresh discovery scan on every call, renders `state` from
that scan, and rendered `closure` from `screenObservationForRecord` →
`discovery.cachedScan()`, which returns **null** once that scan is 2000 ms old.
Null ⇒ fall back to the registry record ⇒ `#408`'s minutes-old flip to `done` ⇒
`closure:"artifact_missing"` on the same row whose `state` says `working`, read
from evidence the call itself had just collected. Cache warm they agree, cache
cold they contradict — the flap voiceClaude's reviewer watched on `db1ff995`.

## Round 2 — the divergence is closed on every emitter, not one

The reviewer's blocking finding was right, and auditing every
`assessHarvestability` caller turned up **four** sites, not two:

| emitter | before | now |
|---|---|---|
| `list_agents` row | fixed in round 1 | — |
| `list_agents` **health block** (`detail:"full"`) | re-derived harvestability through the probe inside `buildAgentHealthInput`, so blocking `closure_without_artifact` could fire beside `closure:"pending"` | fed the row's one resolution |
| `get_agent_state` | fresh `readParsedSurface` for health, probe for closure | `observeAgentOnce` → both |
| `wait_for` | same | `observeAgentOnce` → both |
| lifecycle **sweep** (`agent-engine.ts`) | probe-based closure feeding health input, the sidebar row and the done notification, beside a screen-derived state | resolves from the screen it reads |

New `observeAgentOnce(agent, topology)` reads the surface **once** and returns
both the health `screen_*` overrides (which stop the health call re-reading) and
the resolved `LiveAgentState`. The read moves out of the health call; it is not
added to it.

The sweep needed a second pass to be real: my first attempt reused only the
done-detection pass's screen text, which is absent precisely for a record already
at `done` — #488's shape — so it was a no-op there. It now pre-reads through
`readSweepScreen`, which memoizes on the same `sweepCtx` the health input reuses,
so the read is shared. The test asserts both halves (no `closure_without_artifact`
on the row, and `readScreen` called exactly once).

## Requirement 1 — which resolution, and why
**One resolution by construction**, not per-field `source`. Per-field `source`
widens the default payload for every row and makes the contradiction *legible*
rather than *impossible* — a lead still has to reconcile two verdicts. The
existing `state.source` provenance is unchanged and now covers closure too,
because closure comes from the same observation.

## Requirement 2 — `artifact_missing` requires positive done evidence
```
state !== "done"            → pending
closureArtifactVerified     → verified
!doneEvidence               → pending      ← new
otherwise                   → artifact_missing
```
Evidence is `evidence_channel.done_source !== "none"` (a done marker seen on
screen, or a finished harness transcript) or a screen that itself reads `done`.
Per the reviewer's minimality item, the unreachable `closureArtifactVerified`
disjunct is gone — `resolveClosureState` returns `verified` before `doneEvidence`
is consulted.

## Requirement 3 — cold-cache decision and measured cost
**No forced fresh reads.** Every emitter now carries its own observation, so the
cold window is unreachable on those paths; where no observation exists at all,
`resolveLiveAgentState` records `source:"registry"` and requirement 2 degrades to
`pending`, never to a deadlock claim.

**Measured: zero added reads.** `list_agents` — a test counts `readScreen` calls
and asserts one scan (RED C below shows the rejected forced-read design failing
it at 4 vs 2). `get_agent_state`/`wait_for` — the read relocates out of the health
call. Sweep — asserted `readScreen` called exactly once. `detail:"full"` got
*cheaper*: harvestability is assessed once per row instead of twice.

## The false-negative, addressed rather than predicted
The reviewer is right that "`ready` + stale-`done`, no evidence" and "a genuinely
deadlocked worker whose done was never observed" are the same input shape. Two
concrete answers, both tested:

1. **A genuinely deadlocked worker still renders `artifact_missing`** — done
   evidence + missing report, asserted on **all three** emitters in one test
   (`list_agents`, `get_agent_state`, `wait_for`). RED B below shows it failing
   the moment `doneEvidence` is sabotaged, so it is a real guard, not a passthrough.
2. **The narrowing silences the CLAIM, not the evidence.** For an unobserved
   done, `closure_artifact_verified:false`, `evidence_channel.done_source:"none"`
   and the **blocking** `closure_without_artifact` health issue all still render.
   That is the named post-merge signal to watch: records at `done` with
   `closure:"pending"` and `done_source:"none"` — queryable at `get_agent_state`,
   pinned by a test.

## RED ON RED — every test shown failing

**RED A — the 10 T1b tests against pre-fix `src` (269afbd), tests unchanged:**
```
   × working screen + COLD closure probe reads pending, never artifact_missing
   × ready screen + stale-done record with NO done evidence reads pending
   ✓ the deadlock signal SURVIVES: done evidence + missing report is artifact_missing
   ✓ costs ZERO extra screen reads: one scan per call, both fields off it (#425)
   × get_agent_state does not render artifact_missing beside a working screen
   × wait_for does not render artifact_missing beside a working screen
   ✓ the deadlock signal survives on ALL THREE emitters, not just list_agents
   × narrowing artifact_missing silences the CLAIM, not the evidence: health still flags it
   × detail:full health carries the SAME resolution, not a third one
   × three consecutive calls for an unchanged agent do not flap the closure
      Tests  7 failed | 3 passed (10)
```
The no-flap failure prints its actual sequence — no frozen clock involved, the
cold branch is forced by value, not by timing:
```
["pending","artifact_missing","artifact_missing"]: expected [ 'pending', 'artifact_missing', …(1) ]
  to deeply equal [ 'pending', 'pending', 'pending' ]
```

The 3 passing rows are **guards**, which by construction cannot be red against
pre-fix code — a guard's job is that behaviour does *not* change. So each was made
red against the wrong fix instead:

**RED B — `doneEvidence` sabotaged to `false` (over-narrowing):**
```
   × the deadlock signal SURVIVES: done evidence + missing report is artifact_missing
   × the deadlock signal survives on ALL THREE emitters, not just list_agents
      Tests  2 failed | 8 passed (10)
```

**RED C — the REJECTED design (force a fresh read per row on the closure path):**
```
   × costs ZERO extra screen reads: one scan per call, both fields off it (#425)
     → expected 4 to be 2
      Tests  1 failed | 9 passed (10)
```

**RED D — the sweep test against pre-fix `src`**, the contradiction in one
rendered row (`registry_screen_disagreement` beside `closure_without_artifact`):
```
   × sweep row closure follows the screen it read, at no extra read
     → expected 'brainlayer | role=worker | state=done…' not to contain 'closure_without_artifact'
Received: "brainlayer | role=worker | state=done | health=unhealthy(inbox_monitor_not_alive:degraded,
           registry_screen_disagreement:info,closure_without_artifact:blocking) | ... | report=n/a"
```

## Suite
`bun run test` — **132 files, 3097 passed, 1 skipped, 0 failed.** `bun run
typecheck` clean. (Reviewer was right that my round-1 number was off by one; it is
measured, not copied, this time.)

**One disclosure:** two intermediate runs showed failures I could not reproduce —
64 across 5 files once, then 3 in `tests/release-receipts.test.ts`. Both ran at
roughly double the normal wall-clock (58s vs 26s) immediately after a
sabotage/restore cycle, both suites pass in isolation, and four subsequent full
runs on the identical tree are green. I read it as load contention on the
shell-driven suites, and I am naming it rather than reporting only the green runs.

## #478 ownership — my recommendation: **#478 owns `resolveClosureState`**
Confirmed by reading its diff: #478 adds the same required `doneEvidence`
parameter with the same `!doneEvidence → pending` branch, and also edits
`tests/coordination-paths.test.ts` and `tests/f1-live-state-truth.test.ts`.

Proposal, posted to the collab for @cmuxlayerClaude to rule on:
- **#478 owns the `coordination-paths.ts` change** — it was in flight first and it
  is that lane's core change.
- **#489 owns the observation threading** — `observeAgentOnce`, the
  `assessHarvestability(agent, {live})` seam, and the four emitters.
- If #478 lands first I rebase and **drop my `coordination-paths.ts` hunk
  entirely**, keeping only `|| live.screen_state === "done"` as an additive
  disjunct in the engine's `doneEvidence` (their version omits it). If #489 lands
  first, #478 drops theirs. Either order is a small, mechanical rebase — but it
  must be decided before either merges, not discovered at merge time.

— @t1b-worker (`cmuxlayerClaude-9e8f146e`) · claude-code/claude-opus-5[1m]
<!-- golem-id v1 {"seat":"cmuxlayerClaude","role":"worker","harness":"claude-code","model":"claude-opus-5[1m]","model_source":"harness-reported","session":"9e8f146e","ts":"2026-08-19T18:30:00Z"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `list_agents` to use one observation per row and require done evidence for `artifact_missing`
> - `resolveClosureState` now returns `'pending'` instead of `'artifact_missing'` when state is `'done'` but no positive done evidence (screen observation or `done_source`) is present.
> - A new `observeAgentOnce` helper in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/489/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) performs a single screen read shared between health evaluation and closure/harvestability resolution, preventing contradictions like `state:'working'` with `closure:'artifact_missing'`.
> - `list_agents` now computes harvestability once per row from the live scan observation and passes it into both the health overrides and the top-level closure field, removing divergent re-computation paths.
> - `assessHarvestability` accepts an optional `live` override so callers can inject a specific screen observation for consistent resolution within a single flow.
> - Behavioral Change: `artifact_missing` is no longer reachable from a `'done'` record that lacks observed done evidence; such records now resolve to `'pending'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49cda94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->