### PR TITLE
fix(ci): the suite was green only on the maintainer's Mac (#490)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      # The suite spawns `bun` (tests/fleet-sidebar.test.ts) and release.sh
+      # shells out to `bun run`. Without it this job fails on toolchain, not code.
+      - uses: oven-sh/setup-bun@v2
 
       - run: npm install --no-package-lock
       - run: npm run typecheck

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,7 @@
 #   scripts/release.sh 0.3.0 --yes               # no confirmation prompt
 #   scripts/release.sh 0.3.0 --dry-run           # print every step, change nothing
 #   scripts/release.sh 0.3.0 --require-contract  # a skipped real-cmux gate aborts the release
+#   scripts/release.sh 0.3.0 --require-ci        # a non-green CI on HEAD aborts the release
 #
 # Steps: clean-tree + green build/tests gate → bump package.json → commit +
 # push main → tag vX.Y.Z + push tag → update formula url+sha256 in the
@@ -30,11 +31,14 @@ VERSION="${1:-}"
 YES=0
 DRY=0
 REQUIRE_CONTRACT=0
+REQUIRE_CI=0
+CI_CONCLUSION="unknown"
 for arg in "${@:2}"; do
   case "$arg" in
     --yes) YES=1 ;;
     --dry-run) DRY=1 ;;
     --require-contract) REQUIRE_CONTRACT=1 ;;
+    --require-ci) REQUIRE_CI=1 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -50,6 +54,16 @@ trap cleanup EXIT
 
 die() { echo "release: $*" >&2; exit 1; }
 run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
+
+# In-place sed that works on BSD *and* GNU. `sed -i ''` is BSD-only: GNU sed
+# reads the '' as the script and the expression as a filename, exits 2, and
+# takes this script down with it — which is why every Linux CI run of the
+# release-receipt tests failed while the same tests passed on a Mac.
+sed_inplace() {
+  local expression="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  sed -E "$expression" "$file" >"$tmp" && mv "$tmp" "$file"
+}
 
 # Receipt writes are never allowed to fail a release: the ledger records the
 # release, it does not gate it.
@@ -84,6 +98,29 @@ if [ "$DRY" -ne 1 ]; then
   receipt init "$VERSION"
   RECEIPT_PATH="$(node "$RECEIPT_CLI" path "$VERSION" 2>/dev/null || true)"
   receipt_record "gates.require_contract" "$([ "$REQUIRE_CONTRACT" -eq 1 ] && echo true || echo false)"
+fi
+
+# --- CI status of the commit being released (#490) -------------------------
+# Six tagged releases shipped while publish.yml failed on every single run and
+# cmuxlayer never reached npm at all. Nothing in the release said so. The receipt
+# now carries CI's verdict on the released commit, and the banner prints it, so
+# "the release looked clean" can never again mean "nobody opened the log".
+if [ "$DRY" -eq 1 ]; then
+  printf 'DRY  %s\n' "read CI status for HEAD"
+else
+  RELEASE_COMMIT="$(git rev-parse HEAD)"
+  # An unusable gh -- absent, unauthenticated, offline -- reads as unknown.
+  # Only a real `success` from a real run is allowed to look green.
+  CI_CONCLUSION="$(gh run list --commit "$RELEASE_COMMIT" --workflow ci.yml \
+    --limit 1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || true)"
+  [ -n "$CI_CONCLUSION" ] || CI_CONCLUSION="unknown"
+  receipt_record "gates.ci" "$CI_CONCLUSION"
+  if [ "$CI_CONCLUSION" != "success" ]; then
+    if [ "$REQUIRE_CI" -eq 1 ]; then
+      die "--require-ci: CI for $RELEASE_COMMIT is $CI_CONCLUSION, not success"
+    fi
+    echo "release: WARNING — CI for $RELEASE_COMMIT is $CI_CONCLUSION; recorded in the receipt"
+  fi
 fi
 
 echo "release: gating on typecheck + tests…"
@@ -159,7 +196,7 @@ if [ "$YES" -ne 1 ] && [ "$DRY" -ne 1 ]; then
 fi
 
 # --- bump + commit + tag (cmuxlayer) --------------------------------------
-run "sed -i '' -E 's/^(  \"version\": \")[^\"]+(\",)\$/\\1$VERSION\\2/' package.json"
+run "sed_inplace 's/^(  \"version\": \")[^\"]+(\",)\$/\\1$VERSION\\2/' package.json"
 run "git commit -aqm 'chore: release $TAG'"
 run "git push origin main"
 run "git tag -a '$TAG' -m 'cmuxlayer $TAG'"
@@ -189,8 +226,8 @@ receipt_record "artifact.url" "$URL"
 receipt_record "artifact.sha256" "$SHA"
 
 # --- bump formula (homebrew-layers) ---------------------------------------
-run "sed -i '' -E 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
-run "sed -i '' -E 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
+run "sed_inplace 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
+run "sed_inplace 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
 run "brew audit etanhey/layers/cmuxlayer || true"
 run "git -C '$TAP_DIR' commit -aqm 'cmuxlayer $TAG'"
 run "git -C '$TAP_DIR' push origin main"
@@ -246,6 +283,7 @@ fi
 cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
+CI: $CI_CONCLUSION (workflow ci.yml on the released commit)
 Receipt: $RECEIPT_LABEL
 Next (on EACH Mac — each run appends its own install evidence to the receipt):
   $REPO_DIR/scripts/release-verify.sh "$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,6 @@
 #   scripts/release.sh 0.3.0 --yes               # no confirmation prompt
 #   scripts/release.sh 0.3.0 --dry-run           # print every step, change nothing
 #   scripts/release.sh 0.3.0 --require-contract  # a skipped real-cmux gate aborts the release
-#   scripts/release.sh 0.3.0 --require-ci        # a non-green CI on HEAD aborts the release
 #
 # Steps: clean-tree + green build/tests gate → bump package.json → commit +
 # push main → tag vX.Y.Z + push tag → update formula url+sha256 in the
@@ -31,14 +30,11 @@ VERSION="${1:-}"
 YES=0
 DRY=0
 REQUIRE_CONTRACT=0
-REQUIRE_CI=0
-CI_CONCLUSION="unknown"
 for arg in "${@:2}"; do
   case "$arg" in
     --yes) YES=1 ;;
     --dry-run) DRY=1 ;;
     --require-contract) REQUIRE_CONTRACT=1 ;;
-    --require-ci) REQUIRE_CI=1 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -54,16 +50,6 @@ trap cleanup EXIT
 
 die() { echo "release: $*" >&2; exit 1; }
 run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
-
-# In-place sed that works on BSD *and* GNU. `sed -i ''` is BSD-only: GNU sed
-# reads the '' as the script and the expression as a filename, exits 2, and
-# takes this script down with it — which is why every Linux CI run of the
-# release-receipt tests failed while the same tests passed on a Mac.
-sed_inplace() {
-  local expression="$1" file="$2" tmp
-  tmp="$(mktemp)"
-  sed -E "$expression" "$file" >"$tmp" && mv "$tmp" "$file"
-}
 
 # Receipt writes are never allowed to fail a release: the ledger records the
 # release, it does not gate it.
@@ -98,29 +84,6 @@ if [ "$DRY" -ne 1 ]; then
   receipt init "$VERSION"
   RECEIPT_PATH="$(node "$RECEIPT_CLI" path "$VERSION" 2>/dev/null || true)"
   receipt_record "gates.require_contract" "$([ "$REQUIRE_CONTRACT" -eq 1 ] && echo true || echo false)"
-fi
-
-# --- CI status of the commit being released (#490) -------------------------
-# Six tagged releases shipped while publish.yml failed on every single run and
-# cmuxlayer never reached npm at all. Nothing in the release said so. The receipt
-# now carries CI's verdict on the released commit, and the banner prints it, so
-# "the release looked clean" can never again mean "nobody opened the log".
-if [ "$DRY" -eq 1 ]; then
-  printf 'DRY  %s\n' "read CI status for HEAD"
-else
-  RELEASE_COMMIT="$(git rev-parse HEAD)"
-  # An unusable gh -- absent, unauthenticated, offline -- reads as unknown.
-  # Only a real `success` from a real run is allowed to look green.
-  CI_CONCLUSION="$(gh run list --commit "$RELEASE_COMMIT" --workflow ci.yml \
-    --limit 1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || true)"
-  [ -n "$CI_CONCLUSION" ] || CI_CONCLUSION="unknown"
-  receipt_record "gates.ci" "$CI_CONCLUSION"
-  if [ "$CI_CONCLUSION" != "success" ]; then
-    if [ "$REQUIRE_CI" -eq 1 ]; then
-      die "--require-ci: CI for $RELEASE_COMMIT is $CI_CONCLUSION, not success"
-    fi
-    echo "release: WARNING — CI for $RELEASE_COMMIT is $CI_CONCLUSION; recorded in the receipt"
-  fi
 fi
 
 echo "release: gating on typecheck + tests…"
@@ -196,7 +159,7 @@ if [ "$YES" -ne 1 ] && [ "$DRY" -ne 1 ]; then
 fi
 
 # --- bump + commit + tag (cmuxlayer) --------------------------------------
-run "sed_inplace 's/^(  \"version\": \")[^\"]+(\",)\$/\\1$VERSION\\2/' package.json"
+run "sed -i '' -E 's/^(  \"version\": \")[^\"]+(\",)\$/\\1$VERSION\\2/' package.json"
 run "git commit -aqm 'chore: release $TAG'"
 run "git push origin main"
 run "git tag -a '$TAG' -m 'cmuxlayer $TAG'"
@@ -226,8 +189,8 @@ receipt_record "artifact.url" "$URL"
 receipt_record "artifact.sha256" "$SHA"
 
 # --- bump formula (homebrew-layers) ---------------------------------------
-run "sed_inplace 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
-run "sed_inplace 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
+run "sed -i '' -E 's|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/$TAG.tar.gz|' '$FORMULA'"
+run "sed -i '' -E 's|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"$SHA\"|' '$FORMULA'"
 run "brew audit etanhey/layers/cmuxlayer || true"
 run "git -C '$TAP_DIR' commit -aqm 'cmuxlayer $TAG'"
 run "git -C '$TAP_DIR' push origin main"
@@ -283,7 +246,6 @@ fi
 cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
-CI: $CI_CONCLUSION (workflow ci.yml on the released commit)
 Receipt: $RECEIPT_LABEL
 Next (on EACH Mac — each run appends its own install evidence to the receipt):
   $REPO_DIR/scripts/release-verify.sh "$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,6 +33,7 @@ DRY=0
 REQUIRE_CONTRACT=0
 REQUIRE_CI=0
 CI_CONCLUSION="unknown"
+CI_COMMIT_LABEL="HEAD"
 for arg in "${@:2}"; do
   case "$arg" in
     --yes) YES=1 ;;
@@ -59,10 +60,13 @@ run() { if [ "$DRY" -eq 1 ]; then printf 'DRY  %s\n' "$*"; else eval "$@"; fi; }
 # reads the '' as the script and the expression as a filename, exits 2, and
 # takes this script down with it — which is why every Linux CI run of the
 # release-receipt tests failed while the same tests passed on a Mac.
+# Writes back through the ORIGINAL file rather than mv-ing the tmpfile over it:
+# mv would hand the target the tmpfile's 0600 and owner, a mode change `sed -i`
+# never makes.
 sed_inplace() {
   local expression="$1" file="$2" tmp
   tmp="$(mktemp)"
-  sed -E "$expression" "$file" >"$tmp" && mv "$tmp" "$file"
+  sed -E "$expression" "$file" >"$tmp" && cat "$tmp" >"$file" && rm -f "$tmp"
 }
 
 # Receipt writes are never allowed to fail a release: the ledger records the
@@ -108,13 +112,21 @@ fi
 if [ "$DRY" -eq 1 ]; then
   printf 'DRY  %s\n' "read CI status for HEAD"
 else
+  # `gh run list --commit` needs the FULL sha; an abbreviated one matches nothing
+  # and would read as `unknown`. Never loosen this to a short sha.
   RELEASE_COMMIT="$(git rev-parse HEAD)"
+  CI_COMMIT_LABEL="$RELEASE_COMMIT"
   # An unusable gh -- absent, unauthenticated, offline -- reads as unknown.
   # Only a real `success` from a real run is allowed to look green.
   CI_CONCLUSION="$(gh run list --commit "$RELEASE_COMMIT" --workflow ci.yml \
     --limit 1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || true)"
   [ -n "$CI_CONCLUSION" ] || CI_CONCLUSION="unknown"
   receipt_record "gates.ci" "$CI_CONCLUSION"
+  # Name the commit the verdict is ABOUT. The read happens before the version
+  # bump, so this is the commit the release was cut from -- not the tag's commit.
+  # In the one file whose purpose is that a release cannot look cleaner than it
+  # is, "which commit" cannot be left to inference.
+  receipt_record "gates.ci_commit" "$RELEASE_COMMIT"
   if [ "$CI_CONCLUSION" != "success" ]; then
     if [ "$REQUIRE_CI" -eq 1 ]; then
       die "--require-ci: CI for $RELEASE_COMMIT is $CI_CONCLUSION, not success"
@@ -283,7 +295,7 @@ fi
 cat <<EOF
 
 release: done — cmuxlayer $TAG is tagged and the formula is bumped.
-CI: $CI_CONCLUSION (workflow ci.yml on the released commit)
+CI: $CI_CONCLUSION (ci.yml on $CI_COMMIT_LABEL — the commit this release was cut from)
 Receipt: $RECEIPT_LABEL
 Next (on EACH Mac — each run appends its own install evidence to the receipt):
   $REPO_DIR/scripts/release-verify.sh "$VERSION"

--- a/src/seat-identity.ts
+++ b/src/seat-identity.ts
@@ -112,7 +112,16 @@ export function parseSeatRegistryConfig(raw: string): SeatRegistry {
   );
 }
 
-export function defaultSeatRegistryPath(): string {
+/**
+ * The seat registry is a MACHINE file: it says which seats this operator runs.
+ * `CMUXLAYER_SEAT_REGISTRY_PATH` lets a caller — a test, a sandbox, a second
+ * fleet — state its own registry instead of inheriting whatever the host has.
+ */
+export function defaultSeatRegistryPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.CMUXLAYER_SEAT_REGISTRY_PATH?.trim();
+  if (override) return override;
   return join(homedir(), ".golems", "config.yaml");
 }
 

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * One temp root per suite RUN, removed when the run ends.
+ *
+ * See tests/vitest.setup.ts for why. Isolating per run — not per worker — is
+ * exactly right: within a run vitest never executes one test file twice at once,
+ * so the fixed fixture names only collide ACROSS runs.
+ */
+const root = join("/tmp", `cmuxlayer-vitest-${process.pid}`);
+
+export function setup(): void {
+  mkdirSync(root, { recursive: true });
+  process.env.CMUXLAYER_TEST_TMP_ROOT = root;
+}
+
+export function teardown(): void {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -23,12 +23,16 @@ const SERVERS = new Set<{
   sockets: Set<net.Socket>;
 }>();
 
+// This hook compiles the whole project so the live daemon under test is the
+// real build. That is a minute's work on a loaded CI runner and ~3s on a warm
+// Mac -- vitest's 10s hook default made the file pass locally and time out in
+// CI, which is the same green-only-on-one-machine failure this lane exists for.
 beforeAll(() => {
   execFileSync(resolve("node_modules", ".bin", "tsc"), ["-p", "tsconfig.json"], {
     cwd: process.cwd(),
     stdio: "pipe",
   });
-});
+}, 300_000);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/tests/pre-pr-scripts.test.ts
+++ b/tests/pre-pr-scripts.test.ts
@@ -124,3 +124,22 @@ describe("pre-PR script ladder", () => {
     expect(script).toContain("exec bun run pre-pr");
   });
 });
+
+describe("release scripts run where CI runs", () => {
+  // `sed -i ''` is BSD-only. GNU sed reads the '' as the script and the real
+  // expression as a filename, exits 2, and takes release.sh down with it — the
+  // reason every Linux run of the release-receipt tests failed while the same
+  // tests passed on the maintainer's Mac.
+  it("keeps release scripts free of the BSD-only in-place sed form", () => {
+    for (const script of ["release.sh", "release-verify.sh"]) {
+      const code = readFileSync(join(repoRoot, "scripts", script), "utf8")
+        .split("\n")
+        .filter((line) => !/^\s*#/.test(line))
+        .join("\n");
+
+      expect(code, `${script} uses BSD-only sed -i ''`).not.toMatch(
+        /sed\s+-i\s+(''|"")/,
+      );
+    }
+  });
+});

--- a/tests/ram-watchdog-warn-only.test.ts
+++ b/tests/ram-watchdog-warn-only.test.ts
@@ -176,7 +176,9 @@ done
   writeFileSync(join(root, "fixtures/memsize.fixture"), "1048576\n");
 }
 
-describe("cmux RAM watchdog warn-only regression", () => {
+// Each case runs a real bash script through spawnSync; vitest's 5s default is
+// the wrong budget for that and flakes under full-suite load.
+describe("cmux RAM watchdog warn-only regression", { timeout: 30_000 }, () => {
   it("turns a watchdog memory breach into notification/snapshot work without SIGKILLing cmux", () => {
     const root = makeRoot("cmux-watchdog-vitest-");
     const logDir = join(root, "logs");

--- a/tests/release-receipts.test.ts
+++ b/tests/release-receipts.test.ts
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -456,9 +457,28 @@ describe("release.sh receipts", { timeout: 30_000 }, () => {
     const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
 
     expect(result.status).toBe(0);
-    expect(readReceipt(fixture, "0.4.1").gates.ci).toBe("success");
+    const receipt = readReceipt(fixture, "0.4.1");
+    expect(receipt.gates.ci).toBe("success");
+    // The verdict names the commit it is ABOUT. The read happens before the
+    // version bump, so it is the commit the release was cut from, not the tag's.
+    expect(receipt.gates.ci_commit).toBe("1".repeat(40));
+    // `gh run list --commit` matches nothing on an abbreviated sha, so a short
+    // one would silently read as "unknown". Keep the full form.
     expect(result.log).toContain(`gh run list --commit ${"1".repeat(40)}`);
-    expect(result.stdout).toContain("CI: success");
+    expect(result.stdout).toContain(
+      `CI: success (ci.yml on ${"1".repeat(40)} — the commit this release was cut from)`,
+    );
+  });
+
+  it("bumps package.json without changing its file mode", () => {
+    const fixture = makeReleaseFixture();
+    const manifest = join(fixture.repoDir, "package.json");
+    chmodSync(manifest, 0o640);
+
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(statSync(manifest).mode & 0o777).toBe(0o640);
   });
 
   it("never lets a release read as clean while its CI is red", () => {

--- a/tests/release-receipts.test.ts
+++ b/tests/release-receipts.test.ts
@@ -74,6 +74,8 @@ function makeReleaseFixture(
     withBrew?: boolean;
     withBrewTapClone?: boolean;
     withNode?: boolean;
+    /** What the stubbed `gh` reports for the released commit; "" = no gh. */
+    ciConclusion?: string;
   } = {},
 ): Fixture {
   const {
@@ -82,6 +84,7 @@ function makeReleaseFixture(
     withBrew = true,
     withBrewTapClone = true,
     withNode = true,
+    ciConclusion = "success",
   } = opts;
 
   const root = makeRoot("cmuxlayer-release-receipts-");
@@ -208,6 +211,17 @@ exit 0
     );
   }
 
+  writeExecutable(
+    join(binDir, "gh"),
+    `#!/usr/bin/env bash
+printf 'gh %s\\n' "$*" >>"$STUB_LOG"
+# An unusable gh (absent, unauthenticated, offline) must read as "unknown",
+# never as "clean" -- so this stub fails the way the real one does.
+[ -n "$STUB_CI_CONCLUSION" ] || exit 1
+printf '%s\\n' "$STUB_CI_CONCLUSION"
+`,
+  );
+
   if (!withNode) {
     writeExecutable(
       join(binDir, "node"),
@@ -227,6 +241,7 @@ exit 127
     STUB_BREW_REPO: brewRepo,
     STUB_INSTALLED_VERSION: installedVersion ?? "",
     STUB_CONTRACT_OUTPUT: contractOutput,
+    STUB_CI_CONCLUSION: ciConclusion,
     CMUXLAYER_TAP_DIR: tapDir,
     CMUXLAYER_RELEASE_RECEIPTS_DIR: receiptsDir,
     CMUXLAYER_RECEIPT_HOST: "test-mac",
@@ -409,7 +424,9 @@ describe("release receipt ledger CLI", () => {
   });
 });
 
-describe("release.sh receipts", () => {
+// These run the real release scripts end to end through stubbed binaries, so
+// vitest's 5s default is the wrong budget and flakes under full-suite load.
+describe("release.sh receipts", { timeout: 30_000 }, () => {
   it("writes a release receipt with version, sha256, commit and gate results", () => {
     const fixture = makeReleaseFixture();
     const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
@@ -430,6 +447,51 @@ describe("release.sh receipts", () => {
     expect(result.stdout).toContain(
       join(fixture.receiptsDir, "release-0.4.1.json"),
     );
+  });
+
+  // #490: publish.yml failed on 105 consecutive runs and cmuxlayer never reached
+  // npm, because a release's own receipt said nothing about CI. It does now.
+  it("records the CI verdict for the commit being released", () => {
+    const fixture = makeReleaseFixture();
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(readReceipt(fixture, "0.4.1").gates.ci).toBe("success");
+    expect(result.log).toContain(`gh run list --commit ${"1".repeat(40)}`);
+    expect(result.stdout).toContain("CI: success");
+  });
+
+  it("never lets a release read as clean while its CI is red", () => {
+    const fixture = makeReleaseFixture({ ciConclusion: "failure" });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(readReceipt(fixture, "0.4.1").gates.ci).toBe("failure");
+    expect(result.stdout).toContain("WARNING");
+    expect(result.stdout).toContain("CI: failure");
+  });
+
+  it("records an unusable gh as unknown rather than as a pass", () => {
+    const fixture = makeReleaseFixture({ ciConclusion: "" });
+    const result = runScript(fixture, "release.sh", ["0.4.1", "--yes"]);
+
+    expect(result.status).toBe(0);
+    expect(readReceipt(fixture, "0.4.1").gates.ci).toBe("unknown");
+    expect(result.stdout).toContain("WARNING");
+  });
+
+  it("refuses to release on a non-green CI under --require-ci", () => {
+    const fixture = makeReleaseFixture({ ciConclusion: "failure" });
+    const result = runScript(fixture, "release.sh", [
+      "0.4.1",
+      "--yes",
+      "--require-ci",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    // The die message, not `unknown flag: --require-ci`.
+    expect(result.stderr).toContain("release: --require-ci");
+    expect(result.log).not.toContain("git push origin main");
   });
 
   it("preserves the happy-path release commands (receipts stay additive)", () => {
@@ -595,7 +657,7 @@ describe("release.sh receipts", () => {
   });
 });
 
-describe("release-verify.sh", () => {
+describe("release-verify.sh", { timeout: 30_000 }, () => {
   it("verify-only never upgrades and never resets Homebrew's tap clone", () => {
     const fixture = makeReleaseFixture({ installedVersion: "0.4.1" });
     const result = runScript(fixture, "release-verify.sh", [

--- a/tests/seat-identity.test.ts
+++ b/tests/seat-identity.test.ts
@@ -1,6 +1,11 @@
+import { existsSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   assertSeatIdentity,
+  defaultSeatRegistryPath,
+  loadSeatRegistryFromConfig,
   type SeatRegistry,
 } from "../src/seat-identity.js";
 
@@ -102,5 +107,29 @@ describe("seat identity uniqueness", () => {
       seat_identity_error:
         "ambiguous seat registry repo match for repo=cmuxlayer launcher=staleCodex: cmuxlayerLead, cmuxlayerWorker",
     });
+  });
+});
+
+describe("seat registry source", () => {
+  it("lets the caller point the seat registry away from the machine's ~/.golems", () => {
+    const pinned = join(tmpdir(), "cmuxlayer-seat-registry-fixture.yaml");
+
+    expect(
+      defaultSeatRegistryPath({ CMUXLAYER_SEAT_REGISTRY_PATH: pinned }),
+    ).toBe(pinned);
+    expect(defaultSeatRegistryPath({})).toBe(
+      join(homedir(), ".golems", "config.yaml"),
+    );
+  });
+
+  // The suite once asserted `brainClaude` — a seat that exists only in the
+  // maintainer's ~/.golems/config.yaml. It was green on that Mac and red on
+  // every CI runner for days. Tests state their own registry or get none.
+  it("never resolves the seat registry from the machine running the suite", () => {
+    const pinned = defaultSeatRegistryPath();
+
+    expect(pinned).not.toBe(join(homedir(), ".golems", "config.yaml"));
+    expect(existsSync(pinned)).toBe(false);
+    expect(loadSeatRegistryFromConfig()).toBeNull();
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7537,7 +7537,19 @@ describe("agent lifecycle tool handlers", () => {
       cli_session_id: "claude-session",
       task_summary: "(auto-discovered)",
     });
-    const server = await createUuidRouteServer(routeClient, record);
+    // The repaired id is the SEAT, not the launcher, so this test states the
+    // seat registry it repairs against. Reading the host's ~/.golems/config.yaml
+    // instead is what made this assertion green on one Mac and red in CI.
+    const server = await createUuidRouteServer(routeClient, record, {
+      seatRegistry: {
+        brainClaude: {
+          repo: "brainlayer",
+          lane: "brainlayer",
+          role: "lead",
+          launchers: { claude: "brainlayerClaude" },
+        },
+      },
+    });
     const listResult = await registeredTestTool(server, "list_agents").handler(
       {},
       {} as any,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -315,7 +315,16 @@ async function runWithFakeTimers<T>(
   let elapsed = 0;
   let idleTurns = 0;
   const maxIdleTurns = 10_000;
-  while (!settled && elapsed < advanceMs && idleTurns < maxIdleTurns) {
+  // AIDEV-NOTE: advanceMs is how much SIMULATED time the operation is expected
+  // to need. It used to be the loop's only stop condition, which made it a
+  // machine budget rather than a semantic one: a turn that advances the clock
+  // without the handler progressing still spends it, and a loaded CI runner
+  // interleaves more of those than a warm laptop. Calls that are green here
+  // failed in CI at `elapsed=3000, idleTurns=0` — out of simulated budget, not
+  // stuck. Allow a generous multiple; idleTurns is what actually catches an
+  // operation that never progresses, and it is unaffected by machine speed.
+  const fakeTimeBudget = Math.max(advanceMs * 10, 30_000);
+  while (!settled && elapsed < fakeTimeBudget && idleTurns < maxIdleTurns) {
     // A handler can cross real I/O/event-loop boundaries before scheduling its
     // next poll. Do not spend its fake-time budget until that timer exists.
     await new Promise<void>((resolve) => REAL_SET_IMMEDIATE(resolve));
@@ -327,7 +336,7 @@ async function runWithFakeTimers<T>(
       idleTurns += 1;
       continue;
     }
-    const step = Math.min(50, advanceMs - elapsed);
+    const step = Math.min(50, fakeTimeBudget - elapsed);
     await advanceTimers(step);
     elapsed += step;
     idleTurns = 0;

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // The release script bumps package.json before its pre-push Vitest rerun.
@@ -14,3 +15,25 @@ process.env.CMUXLAYER_SEAT_REGISTRY_PATH = join(
   "fixtures",
   "no-seat-registry-on-this-machine.yaml",
 );
+
+// AIDEV-NOTE: 63 test files build fixtures at a FIXED name under os.tmpdir()
+// (`cmux-agents-test-engine`, `cmux-agents-test-registry`, …) and rmSync that
+// path in afterEach. Two suite runs on one machine — two worktrees, or a fleet
+// worker testing beside the maintainer — then share those directories and tear
+// each other's down mid-test: ENOTEMPTY, plus assertions that quietly read
+// another run's state. Measured on one file, run twice at once: 91 and 103
+// failures without this, 0 and 0 with it. One temp root per RUN makes every one
+// of those fixed names unique per run without touching 63 files.
+//
+// The root goes under /tmp, not under macOS's `/var/folders/…/T` default: unix
+// socket paths cap at ~104 bytes and several suites bind sockets inside a temp
+// dir, so a deeper root breaks them. /tmp/cmuxlayer-vitest-<pid> is HALF the
+// length of the macOS default — this buys socket headroom rather than spending it.
+// tests/global-setup.ts creates this root and removes it when the run ends.
+const root =
+  process.env.CMUXLAYER_TEST_TMP_ROOT?.trim() ||
+  join("/tmp", `cmuxlayer-vitest-${process.ppid}`);
+mkdirSync(root, { recursive: true });
+process.env.TMPDIR = root;
+process.env.TMP = root;
+process.env.TEMP = root;

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,3 +1,16 @@
+import { join } from "node:path";
+
 // The release script bumps package.json before its pre-push Vitest rerun.
 // Keep unit tests from comparing that temporary version with the host brew tree.
 process.env.CMUXLAYER_DEV = "1";
+
+// AIDEV-NOTE: the seat registry (~/.golems/config.yaml) names the seats THIS
+// operator runs. A test that reads it asserts against the host's fleet, so it
+// passes on one Mac and fails everywhere else — which is exactly how a
+// `brainClaude` assertion stayed green locally while CI was red for six days.
+// Pin it at a path that cannot exist: tests state their own registry or get none.
+process.env.CMUXLAYER_SEAT_REGISTRY_PATH = join(
+  __dirname,
+  "fixtures",
+  "no-seat-registry-on-this-machine.yaml",
+);

--- a/tests/workflow-toolchain.test.ts
+++ b/tests/workflow-toolchain.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(__dirname, "..");
+const workflowDir = join(repoRoot, ".github", "workflows");
+
+interface Job {
+  label: string;
+  source: string;
+}
+
+/** Every job, across every workflow, that runs the cmuxlayer test suite. */
+function suiteJobs(): Job[] {
+  const jobs: Job[] = [];
+
+  for (const file of readdirSync(workflowDir)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const lines = readFileSync(join(workflowDir, file), "utf8").split("\n");
+
+    let name: string | null = null;
+    let body: string[] = [];
+    const flush = () => {
+      if (name) jobs.push({ label: `${file}:${name}`, source: body.join("\n") });
+      name = null;
+      body = [];
+    };
+
+    for (const line of lines) {
+      const header = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+      if (header) {
+        flush();
+        name = header[1];
+        continue;
+      }
+      if (name) body.push(line);
+    }
+    flush();
+  }
+
+  return jobs.filter(({ source }) =>
+    /^\s*-?\s*run:.*\b(npm|bun) (run )?test\b/m.test(source),
+  );
+}
+
+/**
+ * AIDEV-NOTE: publish.yml ran the suite on setup-node alone for 105 releases.
+ * The suite spawns `bun` (tests/fleet-sidebar.test.ts) and release.sh shells out
+ * to `bun run`, so a bun-less runner fails on missing toolchain rather than on
+ * anything about the code. Nobody read the log, so cmuxlayer never reached npm.
+ */
+describe("workflow toolchain matches what the suite spawns", () => {
+  it("finds the jobs that run the suite", () => {
+    expect(suiteJobs().map((job) => job.label)).toContain("publish.yml:publish");
+  });
+
+  it("gives every suite-running job the bun the tests spawn", () => {
+    for (const { label, source } of suiteJobs()) {
+      expect(source, `${label} runs the suite without installing bun`).toContain(
+        "oven-sh/setup-bun",
+      );
+    }
+  });
+
+  it("never runs the suite on a node older than package.json engines", () => {
+    const engines: string = JSON.parse(
+      readFileSync(join(repoRoot, "package.json"), "utf8"),
+    ).engines.node;
+    const minimumMajor = Number(engines.replace(/[^0-9.]/g, "").split(".")[0]);
+
+    for (const { label, source } of suiteJobs()) {
+      for (const [, version] of source.matchAll(/node-version:\s*'?"?(\d+)/g)) {
+        expect(
+          Number(version),
+          `${label} pins node ${version} but engines require ${engines}`,
+        ).toBeGreaterThanOrEqual(minimumMajor);
+      }
+    }
+  });
+});

--- a/tests/workflow-toolchain.test.ts
+++ b/tests/workflow-toolchain.test.ts
@@ -38,9 +38,10 @@ function suiteJobs(): Job[] {
     flush();
   }
 
-  return jobs.filter(({ source }) =>
-    /^\s*-?\s*run:.*\b(npm|bun) (run )?test\b/m.test(source),
-  );
+  // Match the job BODY, not the `run:` line: `run: |` with the invocation on the
+  // next line is the ordinary Actions idiom, and a filter anchored to `run:`
+  // walks straight past it — along with composite and reusable workflows.
+  return jobs.filter(({ source }) => /\b(npm|bun) (run )?test\b/.test(source));
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, "**/.worktrees/**"],
+    globalSetup: ["./tests/global-setup.ts"],
     setupFiles: ["./tests/vitest.setup.ts"],
   },
 });


### PR DESCRIPTION
Refs #490 — deliberately not `Closes`. #490's third ask is the npm decision, which is Etan's and is now blocked account-side (npm is restricting token bypass of 2FA/security-key). A deferred ask is an open ask, so the issue stays open on that one point; the other three asks are done here.

## The finding is bigger than the report

voiceClaude reported 6 failed publish runs. Verified from this seat:

| Claim | Reality |
|---|---|
| publish.yml failed 6 runs | **105 runs, 105 failures — it has never once succeeded** (back to v0.2.0, 2026-06-20) |
| the suite is green, CI is the problem | **ci.yml has been red on `main` and on every PR since 2026-08-15 13:21Z**; last green `main` run was 2026-08-13T18:00Z |
| tests may lean on a live cmux | **No test needs a live cmux.** The full suite passes with an empty HOME (so no socket path is even reachable) and every `CMUX_*` unset |

Roughly two sprints of PRs merged against a gate that was red on GitHub the whole time. The stderr in the log (`SurfaceEnumerationError`, `AgentDiscovery` TypeErrors) is deliberate error-path noise, exactly as the reporter suspected — none of it is a cause.

## Classification (the brief's a/b/c)

**(b) Real bug the local environment was masking — `scripts/release.sh` is macOS-only.**
`sed -i ''` is BSD-only. GNU sed reads the `''` as the script and the expression as a *filename*, exits 2, and `set -e` takes the release down with it. Proven, not deduced — with GNU sed first on PATH:

```
before: Tests   9 failed | 22 passed (31)
after:  Tests  31 passed (31)
```

9 is exactly the release-receipts failure count in CI. Fixed with a `sed_inplace` helper (tmpfile + mv) that works on both seds.

**(b) Ambient-state masking — the suite read the maintainer's seat registry.**
`send_to keeps repaired registry repo ownership…` asserted `agent_id: "brainClaude"`. That id is not derivable from the fixture; it comes from `~/.golems/config.yaml` on one Mac (`seatRegistry.brainClaude.repo: brainlayer`). Everywhere else the repair yields `brainlayerClaude`. Three changes, so the class cannot recur:

- `CMUXLAYER_SEAT_REGISTRY_PATH` override on `defaultSeatRegistryPath()`, symmetric with the existing `CMUXLAYER_LAUNCHER_REGISTRY_PATH`
- `tests/vitest.setup.ts` pins it at a path that cannot exist — tests state their own registry or get none
- the test carries its own registry fixture, so the assertion still means something

**(c) CI-only artifact — publish.yml lacked the toolchain the suite spawns.**
The suite spawns `bun` (`tests/fleet-sidebar.test.ts`) and `release.sh` shells out to `bun run`, but publish.yml set up node only. It also pinned node 20 against `engines: ">=22.15"`. Added `oven-sh/setup-bun@v2`, moved to node 22, and added `tests/workflow-toolchain.test.ts`, which matches the job body — `run: |` with the invocation on the next line is the ordinary Actions idiom and an anchor on the `run:` line walks straight past it, as the reviewer demonstrated. It is a lint over the workflow files in this repo, not a guarantee about every possible job shape.

**Nothing was quarantined and nothing was skipped** (#370's lesson): there was no environment-dependent test to quarantine. The count the brief asked for is **0 tests require a live cmux**, and **1 test in 3085 depended on ambient `$HOME`** — now 0.

## What the first CI run then found, which no local run could

I predicted green. CI came back red on `tests/live-topology-restart.test.ts`, and it was right to. That file compiles the whole project in a `beforeAll` so the daemon under test is the real build — under vitest's **10s hook default**, which is ~3s of work on a warm Mac and well over 10s on a loaded runner. The budget, not the code, was what made the result depend on the machine. Budgets now match the work: 300s for the build hook, 30s for the release-script describes and the RAM-watchdog cases that spawn real `bash`.

## The flake was not a flake

Chasing the remaining intermittent reds turned up something worth its own paragraph. **63 test files build fixtures at a fixed name under the temp dir** (`cmux-agents-test-engine`, `cmux-agents-test-registry`, …) and `rmSync` that path in `afterEach`. Two suite runs on one machine — two worktrees, or a fleet worker testing beside you — share those directories and tear each other's down mid-test. Measured on `tests/agent-engine.test.ts`, run twice concurrently:

| | run A | run B |
|---|---|---|
| before | **91 failed** (40 ENOTEMPTY) | **103 failed** (51 ENOTEMPTY) |
| after | 0 failed | 0 failed |

That is the fleet's daily working condition. Every local green here has been part luck and every local red part noise — including the pre-push hook everyone treats as the merge gate, and it explains what @t1b-worker independently reported in the collab. A `globalSetup` now gives each **run** its own temp root and removes it at the end. Per run, not per worker: within a run vitest never executes one file twice at once, so the fixed names only collide *across* runs. The root sits under `/tmp` rather than macOS's `/var/folders/…/T`, which is half the length — several suites bind unix sockets inside a temp dir and those cap at ~104 bytes, so a deeper root breaks them. I know because my first attempt did exactly that and broke four socket suites.

## P10: release receipts carry CI status

Small enough to implement, so it is here. `release.sh` reads CI's verdict for the commit being released, writes `gates.ci` into the receipt, and prints `CI: <conclusion>` in the done banner. An unusable `gh` — absent, unauthenticated, offline — records `unknown`, never `success`. `--require-ci` makes a non-green CI fatal, mirroring `--require-contract`. Four new tests cover success / failure / unknown / refusal.

## npm — your call, not mine

**`gh secret list` on this repo returns nothing: there are zero Actions secrets, so `NPM_TOKEN` does not exist.** The earliest publish failures (e.g. 2026-06-29) are `npm error code ENEEDAUTH` with the suite passing — this workflow could never have published, before any test ever broke it. This PR makes its test step honest; it does **not** make it able to publish.

| Option | Consequence |
|---|---|
| **Publish for real** — add `NPM_TOKEN`, or configure npm trusted publishing, which the existing `id-token: write` + `--provenance` already anticipate | `cmuxlayer` becomes installable from npm as well as the tap. First publish of a 0.4.x package that has never existed on the registry; the name is currently unclaimed, so squatting risk ends. |
| **Remove publish.yml** | The Homebrew tap stays the only channel — which is what has actually shipped for 105 releases. Nothing user-visible changes, and one permanently-red workflow stops training everyone to ignore red. |
| **Gate it** — keep the workflow, guard on the secret (`if: secrets.NPM_TOKEN != ''`) | The workflow reads green-or-skipped instead of red, and turns real the moment a token is added. Costs a skipped job that says "not configured" rather than "broken". |

My read, for what it is worth: option 3 if you intend to publish eventually, option 2 if you do not. But this is a distribution decision and it is yours.

## PREDICTION

- **CI on this PR goes green.** Held back a notch from my first prediction, which was wrong: CI found a hook-budget failure my machine could not reproduce, and that is the entire lesson of this lane. What I can say is that the local shape now matches CI's much more closely — clean checkout, `npm install --no-package-lock`, node 22, GNU sed, empty HOME, no `CMUX_*` — and gives 132 files / 3094 passed / 1 skipped, with the two timing classes CI actually tripped on now budgeted for a slow runner rather than a warm laptop.
- **publish.yml still fails on the next tag — at `npm publish`, not at `npm test`.** It will get past typecheck/test/build and die on ENEEDAUTH until the npm decision above is made. Predicting it rather than letting it surprise you.
- **Least confident:** the workflow-toolchain test splits jobs with a hand-rolled YAML scan, not a parser. It is correct for the three workflows here, but a job that runs the suite through a composite action or a reusable workflow would slip past it. I took that over adding a YAML dependency to a three-workflow repo.
- **Still open, deliberately not fixed here:** the 63 fixed fixture names are isolated per run, not made unique in themselves. That is the right small change; renaming 63 files is a lane, not a hunk. If a future test ever runs the same file twice *within* one run, the collision returns.

## Review round (#494 ITERATE → addressed)

Both blockers and all three should-fixes are closed at `9391bf3`.

| # | Finding | Status |
|---|---|---|
| 1 | Land a green CI run | **Done** — [32290588061](https://github.com/EtanHey/cmuxlayer/actions/runs/32290588061) on `528a28d`: `test`, both `launcher-parity` legs, `build-site` all pass. First green CI in this repo since 2026-08-14 |
| 2 | `Closes #490` → `Refs #490` | **Done** — see the top of this body |
| 3 | Widen `suiteJobs()` past the `run:` line | **Done** — matches the job body. Reproduced the reviewer's probe (bun-less, node 18, `run: \|`): fails both assertions now, passed before |
| 4 | `gates.ci` names the commit it read | **Done** — receipt carries `gates.ci_commit`, banner says "on `<sha>` — the commit this release was cut from". Moving the read after the bump was the alternative and is worse: CI has not run on that commit, so it would always read `unknown` |
| 5 | `sed_inplace` preserving file mode | **Done** — writes back through the original file. Red-on-red: package.json at 0640 came out 0600 under the `mv` form |

Two corrections from the review folded in above: the publish span is **v0.2.0 / 2026-06-20**, not v0.2.5 / 2026-06-25; and the pre-fix GNU-sed failure count is **14** across `release-receipts` + `pre-pr-scripts` — my "9" counted only `release-receipts`, which is what CI showed before this branch added the portability lint.

The reviewer also explained the anomaly I could not: the `scripts/release.sh` revert was their pre-fix copy written into this worktree during red-on-red, swept up by my concurrent `git commit -a`. Nothing reached origin. My report has been corrected — it is not an unexplained mutation.

— cmuxlayerClaude-c7a1a82a (worker) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"cmuxlayerClaude-c7a1a82a","role":"worker","harness":"claude-code","model":"claude-opus-5","model_source":"session-jsonl","session":"d61407f5","ts":"2026-08-19T19:12:00Z"} -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release tooling can check continuous integration status and optionally block releases when checks fail.
  * Seat registry locations can be customized through an environment setting.

* **Bug Fixes**
  * Improved release script portability across operating systems.
  * Enhanced test isolation to prevent interference from local machine configuration.

* **Tests**
  * Added coverage for CI-aware releases, configurable seat registries, workflow toolchains, and release script portability.
  * Increased timeouts for longer-running integration and release tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and global test env (temp dirs, seat registry); behavior changes are mostly CI/test isolation, but a mistaken `--require-ci` or receipt/CI wiring could block or mislabel releases.
> 
> **Overview**
> Fixes **#490**: the suite and publish workflow were effectively green only on one Mac while Linux CI and npm publish stayed broken.
> 
> **Publish workflow** bumps Node to **22**, adds **`oven-sh/setup-bun@v2`**, and adds **`tests/workflow-toolchain.test.ts`** so jobs that run tests install bun and meet `engines.node`.
> 
> **`scripts/release.sh`** replaces BSD-only `sed -i ''` with portable **`sed_inplace`**, queries **`gh`** for **`ci.yml`** on the release commit (receipt fields **`gates.ci`** / **`gates.ci_commit`**, optional **`--require-ci`**), and surfaces CI in the done banner.
> 
> **Test hermeticity**: **`CMUXLAYER_SEAT_REGISTRY_PATH`** on **`defaultSeatRegistryPath()`**, global pin in **`vitest.setup.ts`**, per-run temp root via **`global-setup.ts`** and **`TMPDIR`**. Longer timeouts for compile-heavy and shell-spawn tests; fake-timer budget fix in **`server.test.ts`**.
> 
> **Coverage** adds CI/release receipt tests, seat-registry override tests, and a lint banning BSD `sed -i ''` in release scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2976ce67161635595236ec011de828a7ce3654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI to run on Node 22 with Bun and isolate tests from host config
> - Updates the publish workflow from Node 20 to Node 22 and adds `oven-sh/setup-bun` so the test suite and `release.sh` have Bun available, matching the maintainer's local environment.
> - Adds a per-run temp root via [tests/global-setup.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-a9f8e507c1cbc8c53302d037e01991ce78517f1ac3ca248134a6a1f42d86fd79) and [vitest.config.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92), and pins `CMUXLAYER_SEAT_REGISTRY_PATH` to a non-existent fixtures path in [tests/vitest.setup.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-93eb310abfe57eda4f26a00fb18fb508e2df0f4d0b8fe0270928ec62c2da7068) so tests no longer read the operator's `~/.golems/config.yaml`.
> - Teaches [scripts/release.sh](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389) a `--require-ci` flag that queries `gh run list` for the HEAD commit's CI conclusion and aborts on non-green status; adds a portable `sed_inplace` helper to avoid BSD/GNU `sed -i` discrepancies.
> - Increases timeouts in several test files (`live-topology-restart`, `ram-watchdog-warn-only`, `server`, release receipt suites) to reduce flakiness on slower machines.
> - Adds guard tests in [tests/workflow-toolchain.test.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-b39a12185515c19f7e9e5599616f865c17f8dc2051413e789cc91976892948a9) and [tests/pre-pr-scripts.test.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-85e90b49d31bf726c30302c0bea5dee1da315806081b12f76b3bd05caacfeabf) to enforce Bun setup and ban BSD-only `sed -i` in release scripts.
> - Behavioral Change: `defaultSeatRegistryPath` in [src/seat-identity.ts](https://github.com/EtanHey/cmuxlayer/pull/494/files#diff-b6c64d3457c6a287dafbab4a484e243e0f3964aa9930249306339512fa433b86) now honors `CMUXLAYER_SEAT_REGISTRY_PATH`; unset, it still defaults to `~/.golems/config.yaml`. Release scripts now record `gates.ci` and `gates.ci_commit` in the receipt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc2976c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
