### PR TITLE
Fix Codex delivery truth across rotating prompts

### DIFF
--- a/docs/plans/2026-08-20-lane-500-codex-delivery.md
+++ b/docs/plans/2026-08-20-lane-500-codex-delivery.md
@@ -1,0 +1,58 @@
+# Lane 500 Codex Delivery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore lead-to-Codex delivery without weakening the human-draft guard, make key-submit receipts follow observed prompt transitions, and expose retry stalls without inventing a terminal failure.
+
+**Architecture:** Keep composer safety in `src/server.ts`, but classify Codex's rotating ghost placeholders through a documented placeholder pattern before the foreign-draft guard runs. Give key-mode verification a pre-key snapshot and accept an observed permission-prompt dismissal as positive evidence without treating post-key composer text as failure evidence. In `src/agent-engine.ts`, fingerprint retry snapshots and mark a still-queued receipt as needing attention after repeated byte-identical refusals.
+
+**Tech Stack:** TypeScript, Vitest, Bun, cmuxlayer MCP delivery engine.
+
+---
+
+### Task 1: Codex ghost placeholders versus human drafts
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/delivery-truth-t2.test.ts`
+
+1. Add an integration regression where a ready Codex pane displays `Ask Codex to do anything` and `send_to` must mutate the pane and return a submitted receipt.
+2. Run `bunx vitest run tests/delivery-truth-t2.test.ts` and capture the foreign-draft refusal.
+3. Add the narrow Codex placeholder classifier, preserving literal submitted-placeholder text as pending input.
+4. Re-run the focused test and confirm the existing half-typed-human-draft test remains green.
+
+### Task 2: Key-mode permission-prompt state transition
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/t2b-silent-failures.test.ts`
+
+1. Add a regression that starts on a Codex permission prompt, dispatches Return, then observes `control_state` become `busy` while a Codex placeholder remains visible.
+2. Run `bunx vitest run tests/t2b-silent-failures.test.ts` and capture the `composer_still_populated` failure.
+3. Capture a pre-key screen and verify submit by the permission prompt being dismissed; never emit `composer_still_populated` for key mode.
+4. Re-run the focused test and keep non-submit dispatch receipts unchanged.
+
+### Task 3: Byte-identical retry attention
+
+**Files:**
+- Modify: `src/agent-engine.ts`
+- Modify: `src/server.ts`
+- Test: `tests/agent-engine.test.ts`
+
+1. Add a fake-timer regression that repeatedly rejects a queued delivery on the same snapshot and expects a nonterminal `needs_attention` receipt after the configured attempt threshold.
+2. Run the focused AgentEngine test and capture the missing attention fields.
+3. Persist a snapshot fingerprint and unchanged count on retryable refusals; set a visible attention reason at the threshold while keeping `delivery_state:"queued"` and `terminal:false`.
+4. Expose the attention fields through `wait_for({delivery_id})` and detailed delivery listings.
+5. Re-run the focused test, then verify changed behavior still respects bounded retry timing without claiming delivery failure.
+
+### Task 4: Verification and reviewed PR handoff
+
+**Files:**
+- Modify: PR body and engine report only after evidence exists.
+
+1. Run all three focused suites, `bun run typecheck`, and `bun run test`.
+2. Inspect `git diff --check`, the full diff, and status.
+3. Run bounded local CodeRabbit review if available and address real findings.
+4. Use the sanctioned terminal surface to commit with the required identity trailer, push, create a ready PR, and request bot review.
+5. Read CI and review output, address blocking findings, and leave the PR open.
+6. Write the engine report and exact lead handoff line with the verified PR URL.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7231,26 +7231,26 @@ export class AgentEngine {
           Date.now() >= Date.parse(receipt.queue_deadline_at)
         ) {
           // AIDEV-NOTE (#500): an unchanged screen proves a retry stall, not
-          // that the payload failed. Freeze the queued receipt in an explicit
-          // attention state instead of converting missing outcome evidence
-          // into a terminal `failed_confirmed` verdict.
+          // that the payload failed. Keep the explicit attention state and
+          // start a fresh bounded retry epoch instead of either inventing a
+          // terminal verdict or freezing a receipt that still says `queued`.
+          // The existing capped backoff below keeps attempts slow, while a
+          // later-cleared composer can still recover and deliver the payload.
           if (receipt.needs_attention === true) {
-            if (receipt.next_attempt_at !== null) {
-              receipt.next_attempt_at = null;
-              this.persistDeliveryReceipts();
-            }
+            receipt.queue_deadline_at = null;
+            this.persistDeliveryReceipts();
+          } else {
+            const gateReason = receipt.error ?? "no gate reason recorded";
+            receipt.delivery_state = "failed_confirmed";
+            receipt.terminal = true;
+            receipt.submit_verified = false;
+            receipt.resolved_at = new Date().toISOString();
+            receipt.next_attempt_at = null;
+            receipt.error = `queue_deadline_elapsed after ${receipt.retry_count} retryable refusals; last gate reason: ${gateReason}`;
+            this.persistDeliveryReceipts();
+            this.appendDeliveryReceiptEventBestEffort(receipt);
             continue;
           }
-          const gateReason = receipt.error ?? "no gate reason recorded";
-          receipt.delivery_state = "failed_confirmed";
-          receipt.terminal = true;
-          receipt.submit_verified = false;
-          receipt.resolved_at = new Date().toISOString();
-          receipt.next_attempt_at = null;
-          receipt.error = `queue_deadline_elapsed after ${receipt.retry_count} retryable refusals; last gate reason: ${gateReason}`;
-          this.persistDeliveryReceipts();
-          this.appendDeliveryReceiptEventBestEffort(receipt);
-          continue;
         }
         if (
           receipt.next_attempt_at &&

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3,7 +3,7 @@
  * These 7 functions are the engine that MCP tools (and later the 2-tool facade) drive.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import {
   existsSync,
@@ -275,11 +275,20 @@ export interface AgentDeliveryReceipt {
   verify_miss_count?: number;
   /** Last time background verify actually read the target surface. */
   verify_last_attempt_at?: string | null;
+  /** A nonterminal retry stall that now requires a human to inspect the pane. */
+  needs_attention?: boolean;
+  /** Evidence-backed explanation for the attention state. */
+  attention_reason?: string | null;
+  /** Consecutive retryable refusals observed on the same byte-identical screen. */
+  unchanged_screen_retry_count?: number;
+  /** Internal digest for comparing retry snapshots without persisting screen text. */
+  retry_screen_fingerprint?: string | null;
 }
 
 export const DEFAULT_DELIVERY_VERIFY_DEADLINE_MS = 10 * 60 * 1000;
 export const DEFAULT_DELIVERY_QUEUE_DEADLINE_MS = 10 * 60 * 1000;
 export const DELIVERY_TARGET_GONE_CONFIRM_MISSES = 3;
+export const DELIVERY_UNCHANGED_SCREEN_ATTENTION_ATTEMPTS = 3;
 const DELIVERY_WAIT_POLL_MS = 100;
 
 export type DeliveryVerifySnapshot = {
@@ -6748,6 +6757,10 @@ export class AgentEngine {
       submission_started_at: null,
       next_attempt_at: null,
       verify_deadline_at: null,
+      needs_attention: false,
+      attention_reason: null,
+      unchanged_screen_retry_count: 0,
+      retry_screen_fingerprint: null,
     };
     this.deliveryReceipts.set(receipt.delivery_id, receipt);
     try {
@@ -7217,6 +7230,17 @@ export class AgentEngine {
           receipt.queue_deadline_at &&
           Date.now() >= Date.parse(receipt.queue_deadline_at)
         ) {
+          // AIDEV-NOTE (#500): an unchanged screen proves a retry stall, not
+          // that the payload failed. Freeze the queued receipt in an explicit
+          // attention state instead of converting missing outcome evidence
+          // into a terminal `failed_confirmed` verdict.
+          if (receipt.needs_attention === true) {
+            if (receipt.next_attempt_at !== null) {
+              receipt.next_attempt_at = null;
+              this.persistDeliveryReceipts();
+            }
+            continue;
+          }
           const gateReason = receipt.error ?? "no gate reason recorded";
           receipt.delivery_state = "failed_confirmed";
           receipt.terminal = true;
@@ -7259,6 +7283,10 @@ export class AgentEngine {
           receipt.retry_count += result.retry_count;
           receipt.error = null;
           receipt.next_attempt_at = null;
+          receipt.needs_attention = false;
+          receipt.attention_reason = null;
+          receipt.unchanged_screen_retry_count = 0;
+          receipt.retry_screen_fingerprint = null;
           if (
             result.delivery === "queued" ||
             result.delivery === "queued_followup"
@@ -7293,6 +7321,7 @@ export class AgentEngine {
           if (error instanceof RetryableDeliveryError) {
             receipt.submission_started_at = null;
             receipt.retry_count += 1;
+            await this.recordRetryScreenAttention(receipt);
             receipt.queue_deadline_at ??= new Date(
               Date.now() + this.deliveryQueueDeadlineMs,
             ).toISOString();
@@ -7321,6 +7350,40 @@ export class AgentEngine {
       }
     } finally {
       this.deliveryDrainInFlight = false;
+    }
+  }
+
+  private async recordRetryScreenAttention(
+    receipt: AgentDeliveryReceipt,
+  ): Promise<void> {
+    if (!this.deliverySnapshotReader) return;
+    const snapshot = await this.withDeliveryVerifyTimeout(
+      this.deliverySnapshotReader(receipt),
+      "Delivery retry snapshot read",
+    ).catch(() => null);
+    if (!snapshot) return;
+
+    const fingerprint = createHash("sha256")
+      .update(snapshot.text, "utf8")
+      .digest("hex");
+    if (receipt.retry_screen_fingerprint === fingerprint) {
+      receipt.unchanged_screen_retry_count =
+        (receipt.unchanged_screen_retry_count ?? 0) + 1;
+    } else {
+      receipt.retry_screen_fingerprint = fingerprint;
+      receipt.unchanged_screen_retry_count = 1;
+      receipt.needs_attention = false;
+      receipt.attention_reason = null;
+    }
+
+    if (
+      receipt.unchanged_screen_retry_count >=
+      DELIVERY_UNCHANGED_SCREEN_ATTENTION_ATTEMPTS
+    ) {
+      receipt.needs_attention = true;
+      receipt.attention_reason =
+        `Delivery remains queued after ${receipt.unchanged_screen_retry_count} ` +
+        "retryable refusals on a byte-identical target screen; human inspection required";
     }
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7321,6 +7321,11 @@ export class AgentEngine {
           if (error instanceof RetryableDeliveryError) {
             receipt.submission_started_at = null;
             receipt.retry_count += 1;
+            // The submitter proved that no mutation occurred. Persist that
+            // replay-safe boundary before the diagnostic snapshot awaits so a
+            // crash cannot resurrect the old "submission started" marker and
+            // terminalize a delivery that is safe to retry.
+            this.persistDeliveryReceipts();
             await this.recordRetryScreenAttention(receipt);
             receipt.queue_deadline_at ??= new Date(
               Date.now() + this.deliveryQueueDeadlineMs,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5386,6 +5386,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         submit_attempted: submitAttempted,
         submit_verified: verification.submit_verified,
         retry_count: 0,
+        ...(submitAttempted && verification.submit_verified === null
+          ? {
+              WARNING:
+                "SUBMIT NOT VERIFIED — the key was dispatched, but no " +
+                "observable prompt/composer transition confirmed submission. " +
+                "Do not treat ok:true as submission confirmation.",
+            }
+          : {}),
       });
       if (opts.source_event) {
         appendDeliveryEvent({

--- a/src/server.ts
+++ b/src/server.ts
@@ -2381,14 +2381,15 @@ function matchLegacyClaudePromptLine(
  * Codex renders empty-composer hints as dim text, but cmux read-screen exposes
  * only flattened terminal text here -- no cell styling survives the client
  * boundary. Keep the observed rotating hints in one anchored pattern so they
- * cannot be mistaken for arbitrary human prose. The variable-looking parts
- * cover Codex's documented placeholder forms rather than one release literal.
+ * cannot be mistaken for arbitrary human prose. These are exact rendered
+ * placeholders, not templates: expanding their variable-looking segments
+ * would swallow real drafts such as `Write tests for @server.ts`.
  *
  * Observed on 2026-08-20: `Implement {feature}`,
  * `Ask Codex to do anything`, and `Write tests for @filename`.
  */
 const CODEX_EMPTY_COMPOSER_PLACEHOLDER_RE =
-  /^(?:Implement \{[^{}\n]+\}|Ask Codex to do anything|Write tests for @[A-Za-z0-9_.-]+)$/;
+  /^(?:Implement \{feature\}|Ask Codex to do anything|Write tests for @filename)$/;
 
 function normalizeKnownPlaceholderComposerInput(
   cli: CliType | null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2385,7 +2385,7 @@ function matchLegacyClaudePromptLine(
  * anchored pattern so they cannot be mistaken for arbitrary human prose.
  * These are exact rendered placeholders, not templates: expanding their
  * variable-looking segments would swallow real drafts such as
- * `Write tests for @server.ts`. Richer style detection is tracked in #505.
+ * `Write tests for @server.ts`. Richer style detection is tracked in #504.
  *
  * Observed on 2026-08-20: `Implement {feature}`,
  * `Ask Codex to do anything`, and `Write tests for @filename`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -2378,12 +2378,14 @@ function matchLegacyClaudePromptLine(
 }
 
 /**
- * Codex renders empty-composer hints as dim text, but cmux read-screen exposes
- * only flattened terminal text here -- no cell styling survives the client
- * boundary. Keep the observed rotating hints in one anchored pattern so they
- * cannot be mistaken for arbitrary human prose. These are exact rendered
- * placeholders, not templates: expanding their variable-looking segments
- * would swallow real drafts such as `Write tests for @server.ts`.
+ * Codex renders empty-composer hints as dim text. The `surface.read_text`
+ * frame used by this path is flattened, but styling is available separately
+ * through `terminal.replay`'s `render_grid` capability. Until that richer
+ * frame is wired into delivery classification, keep the observed hints in one
+ * anchored pattern so they cannot be mistaken for arbitrary human prose.
+ * These are exact rendered placeholders, not templates: expanding their
+ * variable-looking segments would swallow real drafts such as
+ * `Write tests for @server.ts`. Richer style detection is tracked in #505.
  *
  * Observed on 2026-08-20: `Implement {feature}`,
  * `Ask Codex to do anything`, and `Write tests for @filename`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -535,7 +535,7 @@ const SendToArgsSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Key name for mode="key". Submit aliases (return, enter, KPEnter, ctrl-m, a raw CR) are normalized to "return" and verified: the receipt reports key_dispatched, and a submit that leaves the composer populated fails instead of returning ok.',
+      'Key name for mode="key". Submit aliases (return, enter, KPEnter, ctrl-m, a raw CR) are normalized to "return" and verified from observed prompt/composer transitions; unchanged composer contents alone are not treated as failure.',
     ),
   workspace: z.string().optional(),
   chunk_size: z.number().int().min(1).optional().default(200),
@@ -614,6 +614,8 @@ const DeliveryOutputShape = {
   submit_verified: z.boolean().nullable().optional(),
   delivery_id: z.string().optional(),
   duplicate_of: z.string().optional(),
+  needs_attention: z.boolean().optional(),
+  attention_reason: z.string().optional(),
 };
 const DeliveryReceiptOutputSchema = z
   .object({
@@ -909,6 +911,8 @@ export const DELIVERY_RECEIPT_VOCABULARY = [
   "submit_attempted",
   "submit_verified",
   "retry_count",
+  "needs_attention",
+  "attention_reason",
 ] as const;
 
 type PublicDeliveryState =
@@ -930,6 +934,8 @@ export interface PublicDeliveryReceipt {
   delivery_state?: PublicDeliveryState;
   delivery_id?: string;
   duplicate_of?: string;
+  needs_attention?: boolean;
+  attention_reason?: string;
   WARNING?: string;
 }
 
@@ -945,6 +951,8 @@ export function buildPublicDeliveryReceipt(input: {
   submit_attempted: boolean;
   submit_verified: boolean | null;
   retry_count: number;
+  needs_attention?: boolean;
+  attention_reason?: string | null;
   WARNING?: string;
 }): PublicDeliveryReceipt {
   const evidencedState =
@@ -973,6 +981,14 @@ export function buildPublicDeliveryReceipt(input: {
       ? { delivery: evidencedState, delivery_state: evidencedState }
       : {}),
     ...(input.delivery_id ? { delivery_id: input.delivery_id } : {}),
+    ...(input.needs_attention === true
+      ? {
+          needs_attention: true,
+          ...(input.attention_reason
+            ? { attention_reason: input.attention_reason }
+            : {}),
+        }
+      : {}),
     ...(warning ? { WARNING: warning } : {}),
   };
 }
@@ -1089,11 +1105,11 @@ type SubmitVerificationFailureReason =
 /**
  * Why a bare submit-key dispatch could not be confirmed. A key send carries no
  * text, so the text path's evidence (does the screen still show what we typed?)
- * does not apply; the composer region itself is the evidence.
+ * does not apply; prompt-state transitions and an emptied composer are the
+ * available positive evidence.
  */
 type SubmitKeyVerificationReason =
   | "surface_read_unavailable"
-  | "composer_still_populated"
   | "submit_evidence_absent";
 
 class SubmitVerificationError extends Error {
@@ -2361,6 +2377,19 @@ function matchLegacyClaudePromptLine(
   return match ? { input: match[1] ?? "" } : null;
 }
 
+/**
+ * Codex renders empty-composer hints as dim text, but cmux read-screen exposes
+ * only flattened terminal text here -- no cell styling survives the client
+ * boundary. Keep the observed rotating hints in one anchored pattern so they
+ * cannot be mistaken for arbitrary human prose. The variable-looking parts
+ * cover Codex's documented placeholder forms rather than one release literal.
+ *
+ * Observed on 2026-08-20: `Implement {feature}`,
+ * `Ask Codex to do anything`, and `Write tests for @filename`.
+ */
+const CODEX_EMPTY_COMPOSER_PLACEHOLDER_RE =
+  /^(?:Implement \{[^{}\n]+\}|Ask Codex to do anything|Write tests for @[A-Za-z0-9_.-]+)$/;
+
 function normalizeKnownPlaceholderComposerInput(
   cli: CliType | null,
   input: string,
@@ -2372,7 +2401,8 @@ function normalizeKnownPlaceholderComposerInput(
     .join("\n")
     .trim();
   if (
-    (cli === "codex" && withoutCursorBorders === "Implement {feature}") ||
+    (cli === "codex" &&
+      CODEX_EMPTY_COMPOSER_PLACEHOLDER_RE.test(withoutCursorBorders)) ||
     (cli === "cursor" &&
       (withoutCursorBorders === "Plan, search, build anything" ||
         CURSOR_FOLLOWUP_PLACEHOLDER_RE.test(withoutCursorBorders)))
@@ -5237,24 +5267,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   };
 
   /**
-   * AIDEV-NOTE (#484): a bare submit key used to return ok:true with
-   * submit_verified:null and no evidence of any kind -- the documented
-   * "type, then press Return" recovery reported success for a no-op and two
-   * leads silently stopped being able to talk to each other. A submit key now
-   * has to answer the only question that matters: did the composer let go of
-   * its contents? Positive evidence either way is reported; absence of
-   * evidence is reported as absence, never as success.
+   * AIDEV-NOTE (#484/#500): key mode writes no payload, so post-key composer
+   * contents cannot prove whether this key landed. Positive evidence comes
+   * from an observed state transition (especially permission_prompt being
+   * dismissed) or a composer that visibly clears; otherwise the result stays
+   * unknown rather than inventing `composer_still_populated`.
    */
   const verifySubmitKeyOutcome = async (opts: {
     surface: string;
     workspace?: string;
+    baseline: { text: string; parsed: ParsedScreenResult } | null;
   }): Promise<{
     submit_verified: boolean | null;
     submit_verification_reason: SubmitKeyVerificationReason | null;
   }> => {
     const startedAt = Date.now();
     let sawReadableScreen = false;
-    let composerStillPopulated = false;
 
     while (Date.now() - startedAt < SEND_KEY_SUBMIT_VERIFY_TIMEOUT_MS) {
       const snapshot = await readParsedSurface(opts.surface, opts.workspace);
@@ -5263,26 +5291,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         continue;
       }
       sawReadableScreen = true;
-      const composerInput = extractComposerInputRegion(snapshot.text);
-      composerStillPopulated =
-        composerInput !== null && composerInput.trim() !== "";
-
-      // AIDEV-NOTE (#484 review): a populated composer VETOES every other
-      // signal. A busy target is the reported scenario -- the recipient was
-      // working on its previous turn while the relayed message sat unsent in
-      // its composer -- so reading "working" as proof of submit reported
-      // submit_verified:true for a message still visible on screen. That is
-      // worse than the null it replaced: null admits ignorance, true asserts
-      // an observation contradicted by the pane. The text path already gets
-      // this right by gating the same status branch on !hasPendingSubmitEvidence.
-      if (composerStillPopulated) {
-        await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
-        continue;
+      if (
+        opts.baseline?.parsed.control_state === "permission_prompt" &&
+        snapshot.parsed.control_state !== "permission_prompt"
+      ) {
+        return { submit_verified: true, submit_verification_reason: null };
       }
-      if (composerInput !== null) {
+      const composerInput = extractComposerInputRegion(snapshot.text);
+      if (composerInput !== null && composerInput.trim() === "") {
         // The composer is readable and empty: it let go of its contents. This
-        // is the ONLY positive proof available to a key send. A "working"
-        // status deliberately does not count: the reported target was already
+        // is positive proof for a composer submit. A "working" status alone
+        // deliberately does not count: the reported target was already
         // working on its previous turn, so status cannot distinguish "my
         // submit started a turn" from "a turn was already running" -- and a
         // composer that renders boxed reads as unreadable here, so accepting
@@ -5296,14 +5315,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return {
         submit_verified: null,
         submit_verification_reason: "surface_read_unavailable",
-      };
-    }
-    if (composerStillPopulated) {
-      // The key reached the pane and the composer still holds its contents:
-      // that is a submit that did not land, not a submit we failed to observe.
-      return {
-        submit_verified: false,
-        submit_verification_reason: "composer_still_populated",
       };
     }
     return {
@@ -5346,6 +5357,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
       }
       const key = normalizeKeyName(opts.key);
+      const submitAttempted = isSubmitKey(key);
+      const submitBaseline =
+        submitAttempted && opts.verify_submit
+          ? await readParsedSurface(opts.surface, opts.workspace)
+          : null;
       // sendKeyWithRetry throws when nothing reached the pane, so reaching the
       // next line is the dispatch evidence the receipt was missing (#484).
       await sendKeyWithRetry(
@@ -5354,12 +5370,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         opts.workspace,
         opts.beforeMutation,
       );
-      const submitAttempted = isSubmitKey(key);
       const verification =
         submitAttempted && opts.verify_submit
           ? await verifySubmitKeyOutcome({
               surface: opts.surface,
               workspace: opts.workspace,
+              baseline: submitBaseline,
             })
           : { submit_verified: null, submit_verification_reason: null };
       const receipt = buildPublicDeliveryReceipt({
@@ -13678,6 +13694,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               terminal: receipt.terminal,
               submit_verified: receipt.submit_verified,
               agent_id: receipt.agent_id,
+              retry_count: receipt.retry_count,
+              ...(receipt.needs_attention === true
+                ? {
+                    needs_attention: true,
+                    attention_reason: receipt.attention_reason,
+                  }
+                : {}),
               ...(receipt.timed_out ? { timed_out: true } : {}),
             };
             return okFormatted(formatOk("wait_for", data), data);
@@ -14109,6 +14132,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     terminal: receipt.terminal,
                     created_at: receipt.created_at,
                     resolved_at: receipt.resolved_at,
+                    retry_count: receipt.retry_count,
+                    ...(receipt.needs_attention === true
+                      ? {
+                          needs_attention: true,
+                          attention_reason: receipt.attention_reason,
+                        }
+                      : {}),
                   })),
                 }
               : {}),
@@ -15002,6 +15032,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     submit_attempted: false,
                     submit_verified: duplicate.submit_verified,
                     retry_count: duplicate.retry_count,
+                    needs_attention: duplicate.needs_attention,
+                    attention_reason: duplicate.attention_reason,
                   }),
                   accepted: true,
                 });
@@ -15237,6 +15269,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 submit_attempted: false,
                 submit_verified: duplicate.submit_verified,
                 retry_count: duplicate.retry_count,
+                needs_attention: duplicate.needs_attention,
+                attention_reason: duplicate.attention_reason,
               }),
             };
             return okFormatted(

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -14097,6 +14097,66 @@ Session ID: ${sessionId}`,
       }
     });
 
+    it("surfaces repeated refusals on a byte-identical screen as nonterminal attention", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-20T07:30:00.000Z"));
+      try {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: "unchanged-composer-delivery",
+            state: "idle",
+            surface_id: "surface:42",
+          }),
+        );
+        liveSurfaces = [makeSurface("surface:42")];
+        await engine.getRegistry().reconstitute();
+        engine.setDeliverySnapshotReader(async () => ({
+          text: ">_ OpenAI Codex\n› a human draft remains here",
+        }));
+        engine.setDeliverySubmitter(async () => {
+          throw new RetryableDeliveryError(
+            "target composer already holds text this delivery did not write",
+          );
+        });
+        const receipt = engine.queueDelivery({
+          agent_id: "unchanged-composer-delivery",
+          text: "lead request",
+          press_enter: true,
+          source_event: "send_to",
+        });
+
+        for (let attempt = 1; attempt <= 3; attempt += 1) {
+          await engine.drainDeliveryQueue();
+          const current = engine.getDeliveryReceipt(receipt.delivery_id)!;
+          if (attempt < 3) {
+            expect(current.needs_attention).not.toBe(true);
+          }
+          vi.setSystemTime(Date.parse(current.next_attempt_at!));
+        }
+
+        const attention = engine.getDeliveryReceipt(receipt.delivery_id)!;
+        expect(attention).toMatchObject({
+          delivery_state: "queued",
+          terminal: false,
+          retry_count: 3,
+          unchanged_screen_retry_count: 3,
+          needs_attention: true,
+          attention_reason: expect.stringMatching(/3.*byte-identical/i),
+        });
+
+        vi.setSystemTime(Date.parse(attention.queue_deadline_at!) + 1);
+        await engine.drainDeliveryQueue();
+        expect(engine.getDeliveryReceipt(receipt.delivery_id)).toMatchObject({
+          delivery_state: "queued",
+          terminal: false,
+          needs_attention: true,
+          resolved_at: null,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("terminalizes a retryable requeue once its bounded queue lifetime elapses (#467)", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-11T18:00:00.000Z"));

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -14110,9 +14110,15 @@ Session ID: ${sessionId}`,
         );
         liveSurfaces = [makeSurface("surface:42")];
         await engine.getRegistry().reconstitute();
-        engine.setDeliverySnapshotReader(async () => ({
-          text: ">_ OpenAI Codex\n› a human draft remains here",
-        }));
+        engine.setDeliverySnapshotReader(async () => {
+          const persisted = JSON.parse(
+            readFileSync(join(TEST_DIR, "delivery-receipts.json"), "utf8"),
+          );
+          expect(persisted[0].submission_started_at).toBeNull();
+          return {
+            text: ">_ OpenAI Codex\n› a human draft remains here",
+          };
+        });
         engine.setDeliverySubmitter(async () => {
           throw new RetryableDeliveryError(
             "target composer already holds text this delivery did not write",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -14100,6 +14100,7 @@ Session ID: ${sessionId}`,
     it("surfaces repeated refusals on a byte-identical screen as nonterminal attention", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-08-20T07:30:00.000Z"));
+      let recovered = false;
       try {
         stateMgr.writeState(
           makeRecord({
@@ -14120,6 +14121,9 @@ Session ID: ${sessionId}`,
           };
         });
         engine.setDeliverySubmitter(async () => {
+          if (recovered) {
+            return { retry_count: 0, submit_verified: true };
+          }
           throw new RetryableDeliveryError(
             "target composer already holds text this delivery did not write",
           );
@@ -14152,11 +14156,23 @@ Session ID: ${sessionId}`,
 
         vi.setSystemTime(Date.parse(attention.queue_deadline_at!) + 1);
         await engine.drainDeliveryQueue();
-        expect(engine.getDeliveryReceipt(receipt.delivery_id)).toMatchObject({
+        const postDeadline = engine.getDeliveryReceipt(receipt.delivery_id)!;
+        expect(postDeadline).toMatchObject({
           delivery_state: "queued",
           terminal: false,
           needs_attention: true,
+          retry_count: 4,
           resolved_at: null,
+        });
+
+        recovered = true;
+        vi.setSystemTime(Date.parse(postDeadline.next_attempt_at!));
+        await engine.drainDeliveryQueue();
+        expect(engine.getDeliveryReceipt(receipt.delivery_id)).toMatchObject({
+          delivery_state: "submitted",
+          terminal: true,
+          needs_attention: false,
+          submit_verified: true,
         });
       } finally {
         vi.useRealTimers();

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -34,13 +34,16 @@ function parseToolResult(result: any) {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
-async function spawnReadyAgent(server: any) {
+async function spawnReadyAgent(
+  server: any,
+  cli: "claude" | "codex" = "claude",
+) {
   const spawn = server._registeredTools["spawn_agent"];
   const spawnResult = await spawn.handler(
     {
       repo: "brainlayer",
       model: "sonnet",
-      cli: "claude",
+      cli,
       workspace: "workspace:1",
       boot_prompt_timeout_ms: 100,
     },
@@ -209,6 +212,40 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     expect(mutatedPane(mockExec)).toBe(true);
     context.dispose();
   });
+
+  it("send_to delivers through a rotating Codex placeholder", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText =
+      ">_ OpenAI Codex\n› Implement {feature}\n" +
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer\n";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server, "codex");
+
+    screenText =
+      ">_ OpenAI Codex\n› Ask Codex to do anything\n" +
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools["send_to"].handler(
+      { agent_id: agentId, text: "fleet message", press_enter: true },
+      {} as any,
+    );
+
+    expect(parseToolResult(result)).toMatchObject({
+      ok: true,
+      delivered: true,
+      delivery_state: "submitted",
+    });
+    expect(mutatedPane(mockExec)).toBe(true);
+    context.dispose();
+  }, 20_000);
 });
 
 describe("T2 delivery truth — draft guard must not fire on chrome (B1)", () => {
@@ -405,6 +442,28 @@ describe("T2 delivery truth — unmissable non-delivery (#445)", () => {
         WARNING: pausedTargetWarning("registry"),
       }).WARNING,
     ).toBe(pausedTargetWarning("registry"));
+  });
+
+  it("keeps nonterminal retry attention visible in public receipts", async () => {
+    const { buildPublicDeliveryReceipt } = await loadServerModule();
+    expect(
+      buildPublicDeliveryReceipt({
+        delivery_state: "queued",
+        delivery_id: "d-attention",
+        typed: false,
+        submit_attempted: false,
+        submit_verified: null,
+        retry_count: 3,
+        needs_attention: true,
+        attention_reason:
+          "Delivery remains queued after 3 retryable refusals on a byte-identical target screen",
+      }),
+    ).toMatchObject({
+      delivery_state: "queued",
+      terminal: false,
+      needs_attention: true,
+      attention_reason: expect.stringMatching(/byte-identical/i),
+    });
   });
 });
 

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -246,6 +246,40 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     expect(mutatedPane(mockExec)).toBe(true);
     context.dispose();
   }, 20_000);
+
+  it("does not mistake a Codex-shaped human draft for a placeholder", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText =
+      ">_ OpenAI Codex\n› Implement {feature}\n" +
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer\n";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server, "codex");
+
+    screenText =
+      ">_ OpenAI Codex\n› Write tests for @server.ts\n" +
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools["send_to"].handler(
+      { agent_id: agentId, text: "fleet message", press_enter: true },
+      {} as any,
+    );
+
+    expect(parseToolResult(result)).toMatchObject({
+      delivered: false,
+      terminal: false,
+      delivery_state: "queued",
+    });
+    expect(mutatedPane(mockExec)).toBe(false);
+    context.dispose();
+  }, 20_000);
 });
 
 describe("T2 delivery truth — draft guard must not fire on chrome (B1)", () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -271,6 +271,8 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
     expect(data.ok).toBe(true);
     expect(data.submit_verified).toBeNull();
     expect(data.submit_verification_reason).toBe("submit_evidence_absent");
+    expect(data.WARNING).toMatch(/submit not verified/i);
+    expect(data.WARNING).toMatch(/do not treat.*submission confirmation/i);
   });
 
   it("does not treat unchanged working state as submit evidence", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -50,6 +50,18 @@ const WORKING_AND_CLEARED_CLAUDE_SCREEN =
 // unsent in its composer. Status and composer disagree, and the composer wins.
 const WORKING_AND_POPULATED_CLAUDE_SCREEN =
   "Claude Code\n✻ Working (3s · esc to interrupt)\n> lead: please pick up lane T4";
+const CODEX_PERMISSION_PROMPT_SCREEN = [
+  ">_ OpenAI Codex",
+  "Do you want to allow this command?",
+  "[y/n]",
+  "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+].join("\n");
+const CODEX_BUSY_AFTER_PERMISSION_SCREEN = [
+  ">_ OpenAI Codex",
+  "Working (3s • esc to interrupt)",
+  "› Review this repository",
+  "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+].join("\n");
 
 /**
  * Minimal cmux CLI mock. `screen` is a live box so a test can change what the
@@ -227,21 +239,41 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
     expect(data.submit_verification_reason).toBeNull();
   });
 
-  it("fails instead of returning ok:true when the composer still holds the unsent text", async () => {
-    // The exact #484 shape: a lead typed a message, it sat unsent, and the
-    // documented mode:"key" recovery reported success while the pane never moved.
+  it("verifies Return when a Codex permission prompt is dismissed", async () => {
+    let approved = false;
+    const exec = makeExec({
+      screen: () =>
+        approved
+          ? CODEX_BUSY_AFTER_PERMISSION_SCREEN
+          : CODEX_PERMISSION_PROMPT_SCREEN,
+      onSendKey: () => {
+        approved = true;
+      },
+    });
+
+    const result = await sendKey(makeServer(exec), "return");
+
+    const data = payload(result);
+    expect(result.isError).toBeUndefined();
+    expect(data.submit_verified).toBe(true);
+    expect(data.submit_verification_reason).toBeNull();
+  });
+
+  it("does not infer key failure from a composer that remains populated", async () => {
+    // The exact #484 shape: a lead typed a message and it sat unsent. Key mode
+    // did not write that payload, so unchanged contents are absence of evidence.
     const exec = makeExec({ screen: () => POPULATED_CLAUDE_SCREEN });
 
     const result = await sendKey(makeServer(exec), "return");
 
     const data = payload(result);
-    expect(result.isError).toBe(true);
-    expect(data.ok).toBe(false);
-    expect(data.submit_verified).toBe(false);
-    expect(data.submit_verification_reason).toBe("composer_still_populated");
+    expect(result.isError).toBeUndefined();
+    expect(data.ok).toBe(true);
+    expect(data.submit_verified).toBeNull();
+    expect(data.submit_verification_reason).toBe("submit_evidence_absent");
   });
 
-  it("lets a populated composer veto a working status instead of losing the race to it", async () => {
+  it("does not treat unchanged working state as submit evidence", async () => {
     // The reported target was BUSY: working on its previous turn while the
     // relayed message sat unsent. Reading "working" as proof of submit reported
     // submit_verified:true for a message still visible on screen — worse than
@@ -254,10 +286,10 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
     const result = await sendKey(makeServer(exec), "return");
 
     const data = payload(result);
-    expect(result.isError).toBe(true);
-    expect(data.ok).toBe(false);
-    expect(data.submit_verified).toBe(false);
-    expect(data.submit_verification_reason).toBe("composer_still_populated");
+    expect(result.isError).toBeUndefined();
+    expect(data.ok).toBe(true);
+    expect(data.submit_verified).toBeNull();
+    expect(data.submit_verification_reason).toBe("submit_evidence_absent");
   });
 
   it("will not treat a working status as proof when the composer cannot be read", async () => {


### PR DESCRIPTION
## Summary

- recognize Codex's observed rotating empty-composer placeholders without weakening the human half-typed draft refusal
- verify key submits from an observed `permission_prompt` transition instead of treating unrelated composer contents as failure evidence
- expose repeated byte-identical retry stalls as nonterminal `needs_attention` receipts while retaining slow recovery attempts

Fixes #500.

## Root cause and boundary

The delivery guard treated only the literal `Implement {feature}` as a Codex empty-composer placeholder. Codex rotates that ghost text, so `Ask Codex to do anything` was mistaken for a foreign human draft and rejected before mutation.

The `surface.read_text` frame used by this delivery path is flattened and does not carry cell styles. Styling is nevertheless reachable through a separate capability: `terminal.replay` exposes a `render_grid` with `faint` metadata. Wiring that richer frame into the mutation gate is tracked in #504; this P0 uses one anchored exact alternation for the documented observed list: `Implement {feature}`, `Ask Codex to do anything`, and `Write tests for @filename`. Arbitrary human prose still fails closed.

Key mode had a separate attribution bug: it writes no payload, so post-key composer contents cannot prove that the dispatched key failed. It now captures a pre-key screen and treats `permission_prompt -> non-permission_prompt` (or a visibly cleared composer) as positive evidence; an unchanged populated composer stays `submit_verified:null` rather than becoming a fabricated failure, with an explicit `SUBMIT NOT VERIFIED` warning so `ok:true` cannot be relayed as submission confirmation.

Finally, repeated retryable refusal on the same byte-identical screen had no explicit stalled state and could age into a terminal failure without outcome evidence. Receipts now fingerprint retry snapshots, surface `needs_attention` after three identical attempts, and remain queued/nonterminal. At the old deadline they start a fresh bounded retry epoch with the existing capped backoff, so a later-cleared pane can still recover and deliver.

## Failing-first evidence

- rotating placeholder regression: expected a submitted/delivered receipt for `Ask Codex to do anything`; received queued/not delivered before the classifier change
- permission transition regression: expected the Return receipt to verify after prompt dismissal; old logic returned an error from the still-populated composer path
- retry-stall regression: expected attention metadata after three identical snapshots; the fields did not exist before the engine change

Deleting each targeted behavior reopens a distinct regression: the rotating-placeholder test catches removal of classification, the existing and Codex-shaped human-draft tests catch an overbroad bypass, the permission test catches removal of baseline transition evidence, and the engine test catches removal of fingerprinting, the threshold, the nonterminal deadline rule, or post-deadline recovery.

## Verification

- `bunx vitest --configLoader runner run tests/delivery-truth-t2.test.ts tests/t2b-silent-failures.test.ts tests/agent-engine.test.ts` — 403 passed after review fixes
- `bun run typecheck` — passed
- current-head pre-push full suite — 137 files passed; 3,173 passed, 1 skipped
- `CMUX_CONTRACT_ALLOW_PROD=1 bun run test:contract` — passed live ping, ancestry denial, list/read through the isolated dist daemon, doctor health, and graceful isolated daemon retire/autostart
- `git diff --check` — passed

Local CodeRabbit was started before commit but produced only review heartbeats and did not complete within the three-minute bound; it was interrupted with no findings returned. Remote reviewers are requested below.

Macroscope identified two concrete gaps after the PR opened. Commit `b86ca58` narrows variable-looking placeholder text to the three exact observed strings (with a regression for `Write tests for @server.ts`) and persists the cleared retry marker before awaiting the diagnostic screen snapshot. Lead review then found that styling is available through `terminal.replay` and that the first attention implementation froze forever; commit `9bf980b` corrects the documentation, links #504, and proves a post-deadline receipt keeps retrying and delivers after recovery.

Codex review identified that an evidence-unknown submit-key receipt still lacked an unmissable warning. Commit `2987f7a` keeps the truthful unknown state and adds the explicit warning plus failing-first coverage.

— cmuxlayerCodex-3e917d92 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-3e917d92","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a01d66","ts":"2026-08-20T05:14:05Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex key-mode verification and surface repeated-refusal attention on delivery receipts
> - Replaces single-string placeholder matching with `CODEX_EMPTY_COMPOSER_PLACEHOLDER_RE` in `normalizeKnownPlaceholderComposerInput`, recognizing 'Ask Codex to do anything' and 'Write tests for @filename' as empty-composer placeholders rather than human drafts
> - Overhauls `verifySubmitKeyOutcome` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/503/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595): permission-prompt dismissal is now positive submit evidence, a still-populated composer is no longer a failure (`composer_still_populated` removed from `SubmitKeyVerificationReason`), and missing evidence yields `submit_verified:null` with reason `submit_evidence_absent` plus an explicit WARNING
> - Adds `recordRetryScreenAttention` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/503/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5): SHA-256 fingerprints the delivery screen on each retryable refusal, increments `unchanged_screen_retry_count` when the screen is byte-identical, and sets `needs_attention=true` with `attention_reason` after `DELIVERY_UNCHANGED_SCREEN_ATTENTION_ATTEMPTS` (3) consecutive identical refusals
> - Extends `AgentDeliveryReceipt`, `PublicDeliveryReceipt`, and `DeliveryOutputShape` with `needs_attention` and `attention_reason`; projects these fields through `wait_for`, `list_agents`, and duplicate-delivery responses
> - Behavioral Change: `drainDeliveryQueue` no longer terminalizes a receipt whose `queue_deadline_at` elapses when `needs_attention` is true — it clears the deadline and restarts a bounded retry epoch. The `SubmitKeyVerificationReason` type drops `composer_still_populated`; callers that switch on that discriminator will fail to compile. Key-mode sends that previously returned a hard error for a populated composer now return `ok:true` with `submit_verified:null` and a WARNING.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a3d8da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->