### PR TITLE
fix(boot): stop declaring Codex ready mid-launch, stop certifying unobserved submits

### DIFF
--- a/src/pattern-registry.ts
+++ b/src/pattern-registry.ts
@@ -22,7 +22,7 @@ export interface PatternMatch {
 
 export const CLI_INPUT_PROMPT_PREFIXES: Record<CliType, readonly string[]> = {
   claude: ["❯"],
-  codex: ["codex>", "›", "❯"],
+  codex: ["codex>", "›", "»", "❯"],
   cursor: ["cursor>", "→"],
   gemini: ["gemini>"],
   kiro: ["kiro>"],
@@ -54,13 +54,15 @@ const CURSOR_READY_RE = new RegExp(
 const CODEX_READY_RE = new RegExp(
   [
     String.raw`codex>`,
-    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[^\n]+`,
-    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)[^\n]*\b(?:Model|model)\s*:?\s*gpt-\d[\w.-]*(?:\s+\w+)?\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)\s*›[^\n]*(?:\n|$)`,
+    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)\s*(?:›|»)[^\n]*(?:\n|$)[\s\S]*\bgpt-\d[\w.-]*(?:\s+\w+)?\s*·[^\n]+`,
+    String.raw`^(?![\s\S]*(?:Working \(|•\s*(?:Working|Waiting|Thinking)))[\s\S]*(?:^|\n)[^\n]*\bOpenAI\s+Codex\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)[^\n]*\b(?:Model|model)\s*:?\s*gpt-\d[\w.-]*(?:\s+\w+)?\b[^\n]*(?:\n|$)[\s\S]*(?:^|\n)\s*(?:›|»)[^\n]*(?:\n|$)`,
   ].join("|"),
   "im",
 );
 const CODEX_ACTIVE_RE =
   /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b|Working\s*\(/i;
+const CODEX_UNSTABLE_LAUNCH_RE =
+  /(?:^|\n).*Starting MCP servers\b|\bmodel\s*:\s*loading\b/i;
 const GEMINI_ACTIVE_RE =
   /(?:^|\n)\s*(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?\s*$/im;
 const GEMINI_ACTIVE_LINE_RE = /^(?:✦\s*)?(?:Working|Thinking)(?:\.\.\.|…)?$/i;
@@ -106,7 +108,9 @@ export function matchReadyPattern(
     matched:
       entry.pattern.test(screenContent) &&
       (cli !== "claude" || !CLAUDE_ACTIVE_RE.test(screenContent)) &&
-      (cli !== "codex" || !CODEX_ACTIVE_RE.test(screenContent)) &&
+      (cli !== "codex" ||
+        (!CODEX_ACTIVE_RE.test(screenContent) &&
+          !CODEX_UNSTABLE_LAUNCH_RE.test(screenContent))) &&
       (cli !== "gemini" ||
         !hasGeminiActiveMarkerAfterLastPrompt(screenContent)) &&
       (cli !== "cursor" || !CURSOR_ACTIVE_RE.test(screenContent)),

--- a/src/server.ts
+++ b/src/server.ts
@@ -446,6 +446,10 @@ const SEND_INPUT_RETRY_DELAY_MS = 25;
 const SEND_INPUT_ENTER_DELAY_MS = 50;
 const SEND_INPUT_RECOVERY_ENTER_DELAY_MS = 150;
 const DEFAULT_SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS = 5000;
+// Pre-Return correlation is a safety gate, not the full submit-verification
+// window. Keep it independently bounded so a surface that never paints typed
+// composer text cannot hold an entire spawn on the 5s verification timeout.
+const BOOT_PAYLOAD_OBSERVE_TIMEOUT_MS = 250;
 function parsePositiveIntegerMs(
   value: string | undefined,
   fallback: number,
@@ -2175,6 +2179,17 @@ function readyPatternCandidates(cli?: CliType): CliType[] {
   return cli ? [cli] : READY_PATTERN_CLIS;
 }
 
+function requiredBootReadyObservations(
+  cli: CliType,
+  screenText: string,
+): number {
+  const registryRequirement = matchReadyPattern(cli, screenText).consecutive;
+  if (cli !== "codex" || /(?:^|\n)\s*codex>(?:\s|$)/im.test(screenText)) {
+    return registryRequirement;
+  }
+  return Math.max(2, registryRequirement);
+}
+
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -2345,10 +2360,14 @@ function isComposerFooterOrChromeLine(line: string): boolean {
     /^[✻✢✳✶]\s+Cogitated\s+for\s+\d+s\b/i.test(trimmed) ||
     /^CLAUDE_COUNTER:/i.test(trimmed) ||
     /^gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?\s*[·•]\s*/i.test(trimmed) ||
+    /^gpt-[0-9][0-9a-z.-]*(?:\s+\w+)?$/i.test(trimmed) ||
     /^\d+(?:\.\d+)?%\s+(?:context\s+)?left\b/i.test(trimmed) ||
     /^\/ commands\b/i.test(trimmed) ||
     /^(?:Auto|Agent)(?:\s*·|$)/i.test(trimmed) ||
     /^ctrl\+c to stop\b/i.test(trimmed) ||
+    /\btab to queue message\b.*\b\d+(?:\.\d+)?%\s+context left\b/i.test(
+      trimmed,
+    ) ||
     CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE.test(trimmed) ||
     /^bypass permissions on\b/i.test(trimmed) ||
     /^⬡\s+Idle\b/i.test(trimmed) ||
@@ -2437,7 +2456,21 @@ function extractComposerInputRegion(
     }
 
     const inputLines = [match.input];
-    for (const line of lines.slice(index + 1, end)) {
+    const remainingLines = lines.slice(index + 1, end);
+    for (const [offset, line] of remainingLines.entries()) {
+      if (!line.trim()) {
+        const nextContentLine = remainingLines
+          .slice(offset + 1)
+          .find((candidate) => candidate.trim());
+        if (
+          nextContentLine === undefined ||
+          isComposerFooterOrChromeLine(nextContentLine)
+        ) {
+          break;
+        }
+        inputLines.push("");
+        continue;
+      }
       if (isComposerFooterOrChromeLine(line)) {
         break;
       }
@@ -2458,7 +2491,21 @@ function extractComposerInputRegion(
     }
 
     const inputLines = [match.input];
-    for (const line of lines.slice(index + 1, end)) {
+    const remainingLines = lines.slice(index + 1, end);
+    for (const [offset, line] of remainingLines.entries()) {
+      if (!line.trim()) {
+        const nextContentLine = remainingLines
+          .slice(offset + 1)
+          .find((candidate) => candidate.trim());
+        if (
+          nextContentLine === undefined ||
+          isComposerFooterOrChromeLine(nextContentLine)
+        ) {
+          break;
+        }
+        inputLines.push("");
+        continue;
+      }
       if (isComposerFooterOrChromeLine(line)) {
         break;
       }
@@ -2489,14 +2536,55 @@ function screenShowsPendingInput(
     return false;
   }
 
-  const tail = trimmed.slice(-Math.min(80, trimmed.length));
-  const compactTail = tail.replace(/\s+/g, "");
   const composerInput = extractComposerInputRegion(screenText, submittedText);
+  if (composerInput === null) {
+    return false;
+  }
+  const normalizedComposer = normalizeTerminalText(composerInput).trim();
+  const visibleTail = trimmed.slice(-Math.min(80, trimmed.length));
+  const compactVisibleTail = visibleTail.replace(/\s+/g, "");
   return (
-    composerInput !== null &&
-    (composerInput.includes(tail) ||
-      (compactTail.length > 0 &&
-        composerInput.replace(/\s+/g, "").includes(compactTail)))
+    normalizedComposer.includes(visibleTail) ||
+    (compactVisibleTail.length > 0 &&
+      normalizedComposer.replace(/\s+/g, "").includes(compactVisibleTail))
+  );
+}
+
+function screenShowsCompletePendingInput(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  const trimmed = normalizeTerminalText(submittedText).trim();
+  if (!trimmed) {
+    return false;
+  }
+  const composerInput = extractComposerInputRegion(screenText, submittedText);
+  if (composerInput === null) {
+    return false;
+  }
+  const normalizedComposer = normalizeTerminalText(composerInput).trim();
+  const compactSubmitted = trimmed.replace(/\s+/g, "");
+  return (
+    normalizedComposer.includes(trimmed) ||
+    (compactSubmitted.length > 0 &&
+      normalizedComposer.replace(/\s+/g, "").includes(compactSubmitted))
+  );
+}
+
+function screenContainsCompleteSubmittedText(
+  screenText: string,
+  submittedText: string,
+): boolean {
+  const trimmed = normalizeTerminalText(submittedText).trim();
+  if (!trimmed) {
+    return false;
+  }
+  const normalizedScreen = normalizeTerminalText(screenText);
+  const compactSubmitted = trimmed.replace(/\s+/g, "");
+  return (
+    normalizedScreen.includes(trimmed) ||
+    (compactSubmitted.length > 0 &&
+      normalizedScreen.replace(/\s+/g, "").includes(compactSubmitted))
   );
 }
 
@@ -2934,10 +3022,23 @@ function parseRawSubmitEvidenceMetrics(
   return { tokenCount, cost };
 }
 
+function parseSubmitEvidenceMetrics(
+  screenText: string,
+  parsed: ParsedScreenResult = parseScreen(screenText),
+): RawSubmitEvidenceMetrics {
+  const raw = parseRawSubmitEvidenceMetrics(screenText);
+  return {
+    tokenCount: raw.tokenCount ?? parsed.token_count,
+    cost: raw.cost ?? parsed.cost,
+  };
+}
+
 export const __submitEvidenceTestHooks = {
   extractComposerInputRegion,
   screenShowsPendingInput,
+  screenShowsCompletePendingInput,
   composerHoldsForeignDraft,
+  requiredBootReadyObservations,
 };
 
 function hasRawSubmitEvidenceIncrease(
@@ -4962,6 +5063,40 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
   };
 
+  const waitForCompletePayloadInComposer = async (opts: {
+    surface: string;
+    workspace?: string;
+    text: string;
+    timeout_ms: number;
+    beforeRead?: () => Promise<void>;
+  }): Promise<{
+    screenText: string;
+    metrics: RawSubmitEvidenceMetrics;
+  } | null> => {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < opts.timeout_ms) {
+      await opts.beforeRead?.();
+      const snapshot = await readParsedSurface(opts.surface, opts.workspace, {
+        throwOnSurfaceGone: true,
+      });
+      if (
+        snapshot &&
+        screenShowsCompletePendingInput(snapshot.text, opts.text)
+      ) {
+        return {
+          screenText: snapshot.text,
+          metrics: parseSubmitEvidenceMetrics(snapshot.text, snapshot.parsed),
+        };
+      }
+      const remaining = opts.timeout_ms - (Date.now() - startedAt);
+      if (remaining <= 0) {
+        break;
+      }
+      await delay(Math.min(SEND_INPUT_SUBMIT_VERIFY_POLL_MS, remaining));
+    }
+    return null;
+  };
+
   const verifySubmitAfterEnter = async (opts: {
     surface: string;
     workspace?: string;
@@ -4971,9 +5106,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     source_agent?: string | null;
     verify_submit: boolean;
     require_working_status?: boolean;
+    require_attributable_submit_evidence?: boolean;
     allow_recovery_enter_retry?: boolean;
     timeout_ms?: number;
     cursor_response_baseline: readonly string[] | null;
+    pre_type_screen?: string | null;
+    pre_return_screen?: string | null;
+    pre_return_metrics?: RawSubmitEvidenceMetrics | null;
     beforeMutation?: () => Promise<void>;
   }): Promise<{
     submit_verified: boolean | null;
@@ -5010,14 +5149,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let sawReadableScreen = false;
     let sawBlankScreen = false;
     let lastBootConsumptionRefuted = false;
-    const screenIncludesSubmittedText = (screenText: string): boolean => {
-      const trimmed = opts.text.trim();
-      if (!trimmed) {
-        return false;
-      }
-      const tail = trimmed.slice(-Math.min(80, trimmed.length));
-      return normalizeTerminalText(screenText).includes(tail);
-    };
+    const screenIncludesSubmittedText = (screenText: string): boolean =>
+      screenContainsCompleteSubmittedText(screenText, opts.text);
 
     while (Date.now() - startedAt < timeoutMs) {
       await opts.beforeMutation?.();
@@ -5036,7 +5169,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       sawReadableScreen = true;
 
-      const hasPendingInput = screenShowsPendingInput(snapshot.text, opts.text);
+      const hasPendingInput =
+        opts.require_attributable_submit_evidence === true
+          ? screenShowsCompletePendingInput(snapshot.text, opts.text)
+          : screenShowsPendingInput(snapshot.text, opts.text);
       const hasQueuedAgentInput = screenShowsQueuedAgentInput(
         snapshot.text,
         opts.text,
@@ -5096,10 +5232,46 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         hasPendingInput && !cursorShowsSubmittedResponse;
       lastHasPendingSubmitEvidence = hasPendingSubmitEvidence;
       const composerInput = extractComposerInputRegion(snapshot.text);
+      const preReturnComposerInput =
+        opts.pre_return_screen === null || opts.pre_return_screen === undefined
+          ? null
+          : extractComposerInputRegion(opts.pre_return_screen);
+      const bootFrameAdvanced =
+        opts.require_attributable_submit_evidence === true &&
+        opts.pre_return_screen !== null &&
+        opts.pre_return_screen !== undefined &&
+        normalizeTerminalText(snapshot.text) !==
+          normalizeTerminalText(opts.pre_return_screen);
+      const bootComposerAdvanced =
+        opts.require_attributable_submit_evidence === true &&
+        preReturnComposerInput !== null &&
+        composerInput !== null &&
+        normalizeTerminalText(composerInput) !==
+          normalizeTerminalText(preReturnComposerInput);
+      const bootFrameIsMonotonic =
+        bootComposerAdvanced &&
+        (opts.pre_type_screen === null ||
+          opts.pre_type_screen === undefined ||
+          normalizeTerminalText(snapshot.text) !==
+            normalizeTerminalText(opts.pre_type_screen));
+      const bootHasTokenOrCostDelta =
+        opts.require_attributable_submit_evidence === true &&
+        hasRawSubmitEvidenceIncrease(
+          parseSubmitEvidenceMetrics(snapshot.text, snapshot.parsed),
+          opts.pre_return_metrics,
+        );
+      const bootHasTranscriptEcho =
+        opts.require_attributable_submit_evidence === true &&
+        bootFrameAdvanced &&
+        !hasPendingSubmitEvidence &&
+        screenIncludesSubmittedText(snapshot.text);
       if (
         !hasPendingSubmitEvidence &&
         !bootConsumptionRefuted &&
-        (isSubmitVerifiedStatus(snapshot.parsed.status) ||
+        ((opts.require_attributable_submit_evidence !== true &&
+          isSubmitVerifiedStatus(snapshot.parsed.status)) ||
+          bootHasTokenOrCostDelta ||
+          bootHasTranscriptEcho ||
           cursorShowsSubmittedResponse)
       ) {
         return {
@@ -5114,6 +5286,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         composerInput.trim() === "" &&
         !hasPendingSubmitEvidence &&
         !bootConsumptionRefuted &&
+        (opts.require_attributable_submit_evidence !== true ||
+          bootFrameIsMonotonic) &&
         screenHasAnyAgentIdentity(snapshot.text, snapshot.parsed);
       if (hasClearedAgentComposer) {
         sawClearedComposerEvidence = true;
@@ -5144,7 +5318,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       const codexRetryEligiblePendingInput =
         opts.allow_recovery_enter_retry !== false &&
         (opts.source_event === "send_to" ||
-          opts.source_event === "dispatch_nudge") &&
+          opts.source_event === "dispatch_nudge" ||
+          opts.source_event === "boot_prompt") &&
         hasPendingSubmitEvidence &&
         screenCli === "codex";
       const cursorFollowupRetryEligiblePendingInput =
@@ -5216,7 +5391,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           retry_count: retryCount,
           delivery:
             opts.source_event === "send_to" ||
-            opts.source_event === "dispatch_nudge"
+            opts.source_event === "dispatch_nudge" ||
+            opts.require_attributable_submit_evidence === true
               ? "pending_verify"
               : "submitted",
         };
@@ -5252,7 +5428,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           })
         : null;
     const allowPendingVerify =
-      opts.source_event === "send_to" || opts.source_event === "dispatch_nudge";
+      opts.source_event === "send_to" ||
+      opts.source_event === "dispatch_nudge" ||
+      opts.require_attributable_submit_evidence === true;
     if (allowPendingVerify && submitVerified === false) {
       return {
         submit_verified: null,
@@ -5341,6 +5519,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     delivery_id?: string;
     verify_submit?: boolean;
     allow_recovery_enter_retry?: boolean;
+    require_observed_payload_before_enter?: boolean;
     submit_verify_timeout_ms?: number;
     stableSurfaceIdentity?: string | null;
     beforeMutation?: () => Promise<void>;
@@ -5472,68 +5651,99 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     if (opts.press_enter) {
       let cursorResponseBaseline: readonly string[] | null = null;
-      if (
-        opts.verify_submit &&
-        deliverySafetySnapshot &&
-        inferComposerCli(
-          deliverySafetySnapshot.text,
-          deliverySafetySnapshot.parsed,
-        ) === "cursor"
-      ) {
-        await opts.beforeMutation?.();
-        const preReturnSnapshot = await readParsedSurface(
-          opts.surface,
-          opts.workspace,
-          { throwOnSurfaceGone: true },
-        );
-        cursorResponseBaseline = preReturnSnapshot
-          ? cursorSubmittedResponseEvidenceSignatures(
-              preReturnSnapshot.text,
-              submittedText,
-            )
+      const preReturnBootEvidence =
+        opts.require_observed_payload_before_enter === true &&
+        (opts.verify_submit ?? false)
+          ? await waitForCompletePayloadInComposer({
+              surface: opts.surface,
+              workspace: opts.workspace,
+              text: submittedText,
+              timeout_ms:
+                Math.min(
+                  opts.submit_verify_timeout_ms ??
+                    SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
+                  BOOT_PAYLOAD_OBSERVE_TIMEOUT_MS,
+                ),
+              beforeRead: opts.beforeMutation,
+            })
           : null;
-      }
-      await delay(computeEnterDelayMs(bytes, opts.chunks.length));
-      await sendKeyWithRetry(
-        opts.surface,
-        "return",
-        opts.workspace,
-        opts.beforeMutation,
-      );
-      appendDeliveryEvent({
-        event_type: "press_enter",
-        source_agent: opts.source_agent ?? null,
-        target_surface: opts.surface,
-        bytes,
-        press_enter: true,
-        submit_verified: null,
-        retry_count,
-      });
-
-      const verification = await verifySubmitAfterEnter({
-        surface: opts.surface,
-        workspace: opts.workspace,
-        text: submittedText,
-        bytes,
-        source_event: opts.source_event ?? "send_command",
-        source_agent: opts.source_agent,
-        verify_submit: opts.verify_submit ?? false,
-        allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
-        timeout_ms: opts.submit_verify_timeout_ms,
-        cursor_response_baseline: cursorResponseBaseline,
-        require_working_status: opts.source_event === "boot_prompt",
-        beforeMutation: opts.beforeMutation,
-      });
-      submit_verified = verification.submit_verified;
-      submit_verification_reason = verification.submit_verification_reason;
-      retry_count = verification.retry_count;
-      deliveryOutcome = verification.delivery;
       if (
-        deliveryOutcome === "pending_verify" ||
-        deliveryOutcome === "queued_followup"
+        opts.require_observed_payload_before_enter === true &&
+        (opts.verify_submit ?? false) &&
+        preReturnBootEvidence === null
       ) {
         submit_verified = null;
         submit_verification_reason = null;
+        deliveryOutcome = "pending_verify";
+      } else {
+        if (
+          opts.verify_submit &&
+          deliverySafetySnapshot &&
+          inferComposerCli(
+            deliverySafetySnapshot.text,
+            deliverySafetySnapshot.parsed,
+          ) === "cursor"
+        ) {
+          await opts.beforeMutation?.();
+          const preReturnSnapshot = await readParsedSurface(
+            opts.surface,
+            opts.workspace,
+            { throwOnSurfaceGone: true },
+          );
+          cursorResponseBaseline = preReturnSnapshot
+            ? cursorSubmittedResponseEvidenceSignatures(
+                preReturnSnapshot.text,
+                submittedText,
+              )
+            : null;
+        }
+        await delay(computeEnterDelayMs(bytes, opts.chunks.length));
+        await sendKeyWithRetry(
+          opts.surface,
+          "return",
+          opts.workspace,
+          opts.beforeMutation,
+        );
+        appendDeliveryEvent({
+          event_type: "press_enter",
+          source_agent: opts.source_agent ?? null,
+          target_surface: opts.surface,
+          bytes,
+          press_enter: true,
+          submit_verified: null,
+          retry_count,
+        });
+
+        const verification = await verifySubmitAfterEnter({
+          surface: opts.surface,
+          workspace: opts.workspace,
+          text: submittedText,
+          bytes,
+          source_event: opts.source_event ?? "send_command",
+          source_agent: opts.source_agent,
+          verify_submit: opts.verify_submit ?? false,
+          allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
+          timeout_ms: opts.submit_verify_timeout_ms,
+          cursor_response_baseline: cursorResponseBaseline,
+          pre_type_screen: deliverySafetySnapshot?.text,
+          pre_return_screen: preReturnBootEvidence?.screenText,
+          pre_return_metrics: preReturnBootEvidence?.metrics,
+          require_attributable_submit_evidence:
+            opts.require_observed_payload_before_enter === true,
+          require_working_status: opts.source_event === "boot_prompt",
+          beforeMutation: opts.beforeMutation,
+        });
+        submit_verified = verification.submit_verified;
+        submit_verification_reason = verification.submit_verification_reason;
+        retry_count = verification.retry_count;
+        deliveryOutcome = verification.delivery;
+        if (
+          deliveryOutcome === "pending_verify" ||
+          deliveryOutcome === "queued_followup"
+        ) {
+          submit_verified = null;
+          submit_verification_reason = null;
+        }
       }
     }
 
@@ -5619,6 +5829,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   }): Promise<{
     metrics: RawSubmitEvidenceMetrics | null;
     route: { surface: string; workspace?: string };
+    cli: CliType;
   }> => {
     let deadline = Date.now() + opts.timeout_ms;
     let lastText = "";
@@ -5784,10 +5995,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? (consecutiveMatches.get(candidate) ?? 0) + 1
             : 0;
           consecutiveMatches.set(candidate, count);
-          if (count >= match.consecutive) {
+          if (
+            count >= requiredBootReadyObservations(candidate, screen.text)
+          ) {
             return {
-              metrics: parseRawSubmitEvidenceMetrics(screen.text),
+              metrics: parseSubmitEvidenceMetrics(screen.text, parsed),
               route: target,
+              cli: candidate,
             };
           }
         }
@@ -5838,7 +6052,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       });
       if (snapshot) {
         lastText = snapshot.text;
-        const metrics = parseRawSubmitEvidenceMetrics(snapshot.text);
+        const metrics = parseSubmitEvidenceMetrics(
+          snapshot.text,
+          snapshot.parsed,
+        );
         // AIDEV-NOTE (T2 #427): `0 tokens` is a definitive negative -- an agent
         // handed a prompt that has consumed nothing did not receive it. A slow
         // boot (MCP servers still connecting, banner mid-render) can present a
@@ -6555,6 +6772,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               sentChunks = count;
             },
             verify_submit: true,
+            // Submission evidence is a boot-delivery invariant. CLI-specific
+            // readiness patterns decide when typing may begin; no CLI may turn
+            // status alone into proof that cmuxlayer's payload was submitted.
+            require_observed_payload_before_enter: true,
             submit_verify_timeout_ms: opts.timeout_ms
               ? Math.min(SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS, opts.timeout_ms)
               : undefined,

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -9,6 +9,7 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ExecFn } from "../src/cmux-client.js";
+import { CLI_READY_PATTERNS } from "../src/pattern-registry.js";
 import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
 
 let testDir = "";
@@ -533,6 +534,7 @@ describe("T2 delivery truth — CLI-fallback hang guard (#450)", () => {
 
 function makeBootSplitExec(postReturnScreen: string): ExecFn {
   let promptSent = false;
+  let returnPressed = false;
   return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
     if (args.includes("new-split")) {
       return {
@@ -588,12 +590,18 @@ function makeBootSplitExec(postReturnScreen: string): ExecFn {
       promptSent = true;
       return { stdout: "{}", stderr: "" };
     }
+    if (args.includes("send-key") && args.includes("return")) {
+      returnPressed = true;
+      return { stdout: "{}", stderr: "" };
+    }
     if (args.includes("read-screen")) {
       return {
         stdout: JSON.stringify({
           surface: "surface:2",
           text: promptSent
-            ? postReturnScreen
+            ? returnPressed
+              ? postReturnScreen
+              : "Claude Code\n> Read and follow the brief"
             : "previous shell output: bun install\nClaude Code\n> ",
           lines: 80,
           scrollback_used: false,
@@ -650,13 +658,15 @@ describe("T2 delivery truth — boot consumption evidence (#427)", () => {
     );
     const parsed = parseToolResult(result);
 
-    // The spawn reports the truth instead of a fully-verified receipt for a
-    // prompt the agent never consumed.
-    expect(parsed.ok).toBe(false);
-    expect(parsed.submit_verified).not.toBe(true);
-    expect(parsed.delivered).not.toBe(true);
-    expect(parsed.boot_prompt_delivered).not.toBe(true);
-    expect(parsed.error).toMatch(/boot prompt submit evidence/i);
+    // The spawn reports the truth as a nonterminal receipt for a prompt the
+    // agent never consumed; callers may verify later without respawning.
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+    });
   }, 20_000);
 
   it("still verifies a boot prompt once the CLI has consumed tokens", async () => {
@@ -665,7 +675,7 @@ describe("T2 delivery truth — boot consumption evidence (#427)", () => {
       [
         "Claude Code",
         "> ",
-        "  1.2k tokens",
+        "  1,200 tokens",
         "  Opus 5 | $0.03 | 1m",
         "Working (1s - esc to interrupt)",
       ].join("\n"),
@@ -687,5 +697,382 @@ describe("T2 delivery truth — boot consumption evidence (#427)", () => {
 
     expect(parsed.boot_prompt_receipt.submit_verified).toBe(true);
     expect(parsed.boot_prompt_receipt.delivered).toBe(true);
+  }, 20_000);
+});
+
+describe("boot-submit readiness and attributable evidence", () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "cmuxlayer-boot-readiness-"));
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  const codexReady = [
+    ">_ OpenAI Codex",
+    "› Ask Codex to do anything",
+    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+  ].join("\n");
+
+  const writeBootPrompt = () => {
+    const promptPath = join(testDir, "boot.md");
+    writeFileSync(promptPath, "Read and follow the brief", "utf8");
+    return promptPath;
+  };
+
+  function makeCodexBootExec(opts: {
+    payloadAppears: boolean;
+    submitAfterReturn?: number | null;
+    staleReadyAfterReturn?: boolean;
+    cli?: "codex" | "claude";
+  }): { exec: ExecFn; returnPresses: () => number } {
+    let promptSent = false;
+    let returnPresses = 0;
+    const exec: ExecFn = vi.fn().mockImplementation(
+      async (_cmd, args: string[]) => {
+        if (args.includes("new-split")) {
+          const cli = opts.cli ?? "codex";
+          return {
+            stdout: JSON.stringify({
+              workspace: "workspace:1",
+              surface: "surface:2",
+              pane: "pane:1",
+              title: cli === "claude" ? "cmuxlayerClaude" : "cmuxlayerCodex",
+              type: "terminal",
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-panes")) {
+          return {
+            stdout: JSON.stringify({
+              workspace_ref: "workspace:1",
+              window_ref: "window:1",
+              panes: [
+                {
+                  ref: "pane:1",
+                  index: 0,
+                  focused: true,
+                  surface_count: 1,
+                  surface_refs: ["surface:2"],
+                  selected_surface_ref: "surface:2",
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-pane-surfaces")) {
+          return {
+            stdout: JSON.stringify({
+              workspace_ref: "workspace:1",
+              window_ref: "window:1",
+              pane_ref: "pane:1",
+              surfaces: [
+                {
+                  ref: "surface:2",
+                  title: "cmuxlayerCodex",
+                  type: "terminal",
+                  index: 0,
+                  selected: true,
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("send") && !args.includes("send-key")) {
+          promptSent = true;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (args.includes("send-key") && args.includes("return")) {
+          returnPresses += 1;
+          return { stdout: "{}", stderr: "" };
+        }
+        if (args.includes("read-screen")) {
+          const cli = opts.cli ?? "codex";
+          const readyScreen =
+            cli === "claude"
+              ? ["Claude Code", "What can I help you with?", "❯"].join("\n")
+              : codexReady;
+          const submitted =
+            opts.submitAfterReturn !== null &&
+            opts.submitAfterReturn !== undefined &&
+            returnPresses >= opts.submitAfterReturn;
+          const text = !promptSent
+            ? readyScreen
+            : opts.staleReadyAfterReturn && returnPresses > 0
+              ? readyScreen
+            : submitted
+              ? cli === "claude"
+                ? [
+                    "Claude Code",
+                    "Read and follow the brief",
+                    "Working",
+                    "❯",
+                  ].join("\n")
+                : [
+                    ">_ OpenAI Codex",
+                    "• Read and follow the brief",
+                    "Working (1s • esc to interrupt)",
+                    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+                  ].join("\n")
+              : opts.payloadAppears
+                ? cli === "claude"
+                  ? ["Claude Code", "❯ Read and follow the brief"].join("\n")
+                  : [
+                      ">_ OpenAI Codex",
+                      "» Read and follow the brief",
+                      "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+                    ].join("\n")
+                : cli === "claude"
+                  ? ["Claude Code", "Working", "❯"].join("\n")
+                  : [
+                      ">_ OpenAI Codex",
+                      "› Ask Codex to do anything",
+                      "Working (1s • esc to interrupt)",
+                      "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+                    ].join("\n");
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:2",
+              text,
+              lines: 80,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return { stdout: "{}", stderr: "" };
+      },
+    );
+    return { exec, returnPresses: () => returnPresses };
+  }
+
+  it("correlates the complete multi-paragraph Codex composer including blank lines and the » glyph", async () => {
+    const { __submitEvidenceTestHooks } = await loadServerModule();
+    const submitted = [
+      "Read and follow /tmp/brief.md",
+      "",
+      "cmuxlayer contract for agent-1: Read and follow /tmp/contract.md",
+    ].join("\n");
+    const screen = [
+      ">_ OpenAI Codex",
+      "» Read and follow /tmp/brief.md",
+      "",
+      "  cmuxlayer contract for agent-1: Read and follow /tmp/contract.md",
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+    ].join("\n");
+
+    expect(
+      __submitEvidenceTestHooks.extractComposerInputRegion(screen, submitted),
+    ).toContain("cmuxlayer contract for agent-1");
+    expect(
+      __submitEvidenceTestHooks.screenShowsCompletePendingInput(
+        screen,
+        submitted,
+      ),
+    ).toBe(true);
+    expect(
+      __submitEvidenceTestHooks.screenShowsCompletePendingInput(
+        screen.replace("» Read and follow /tmp/brief.md", "» unrelated tail"),
+        submitted,
+      ),
+    ).toBe(false);
+  });
+
+  it("requires multiple boot observations for a modern Codex ready composer without changing the global registry", async () => {
+    const { __submitEvidenceTestHooks } = await loadServerModule();
+    expect(CLI_READY_PATTERNS.codex.consecutive).toBe(1);
+    expect(
+      (__submitEvidenceTestHooks as any).requiredBootReadyObservations(
+        "codex",
+        codexReady,
+      ),
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not treat the combined Codex queue/context footer as composer content", async () => {
+    const { __submitEvidenceTestHooks } = await loadServerModule();
+    const screen = [
+      ">_ OpenAI Codex",
+      "› Ask Codex to do anything",
+      "",
+      "  tab to queue message                                      100% context left",
+      "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+    ].join("\n");
+
+    expect(
+      __submitEvidenceTestHooks.extractComposerInputRegion(screen),
+    ).toBe("");
+  });
+
+  it("does not press Return or certify status plus token_count:null before observing the payload", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: false,
+      submitAfterReturn: null,
+    });
+    const server = createServer({
+      exec: harness.exec,
+      skipAgentLifecycle: true,
+    });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 500,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      retry_count: 0,
+    });
+    expect(harness.returnPresses()).toBe(0);
+  }, 20_000);
+
+  it("requires attributable pre-Return payload evidence for non-Codex boot prompts too", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      cli: "claude",
+      payloadAppears: false,
+      submitAfterReturn: null,
+    });
+    const server = createServer({
+      exec: harness.exec,
+      skipAgentLifecycle: true,
+    });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        cli: "claude",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 500,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      retry_count: 0,
+    });
+    expect(harness.returnPresses()).toBe(0);
+  }, 20_000);
+
+  it("does not certify a stale pre-type ready frame after Return", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: null,
+      staleReadyAfterReturn: true,
+    });
+    const server = createServer({
+      exec: harness.exec,
+      skipAgentLifecycle: true,
+    });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 750,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      retry_count: 0,
+    });
+    expect(harness.returnPresses()).toBe(1);
+  }, 20_000);
+
+  it("uses one bounded recovery Return after the observed payload survives the first Return", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 2,
+    });
+    const server = createServer({
+      exec: harness.exec,
+      skipAgentLifecycle: true,
+    });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 1_500,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: true,
+      delivered: true,
+      delivery_state: "submitted",
+      submit_verified: true,
+      retry_count: 1,
+    });
+    expect(harness.returnPresses()).toBe(2);
+  }, 20_000);
+
+  it("returns nonterminal pending_verify when one recovery Return still leaves the observed payload pending", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: null,
+    });
+    const server = createServer({
+      exec: harness.exec,
+      skipAgentLifecycle: true,
+    });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 1_500,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      retry_count: 1,
+    });
+    expect(harness.returnPresses()).toBe(2);
   }, 20_000);
 });

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -63,6 +63,8 @@ function makeExec(
 ): ExecFn {
   let promptPending = false;
   let pastePending = false;
+  let pendingText = "";
+  let pasteText = "";
   let currentScreenText = screenText;
   const surfaces: TestSurface[] = [
     {
@@ -154,18 +156,25 @@ function makeExec(
     }
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
-        setScreenText("Claude Code\n✻ Working\n");
+        setScreenText(`Claude Code\n• ${pendingText}\n✻ Working\n❯`);
         promptPending = false;
+        pendingText = "";
       }
       return { stdout: "{}", stderr: "" };
     }
     if (args.includes("set-buffer")) {
-      pastePending = String(args.at(-1) ?? "").trim().length > 0;
+      pasteText = String(args.at(-1) ?? "");
+      pastePending = pasteText.trim().length > 0;
       return { stdout: "{}", stderr: "" };
     }
     if (args.includes("paste-buffer")) {
-      if (pastePending) promptPending = true;
+      if (pastePending) {
+        promptPending = true;
+        pendingText = pasteText;
+        setScreenText(`Claude Code\n❯ ${pendingText}`);
+      }
       pastePending = false;
+      pasteText = "";
       return { stdout: "{}", stderr: "" };
     }
     if (args.includes("send")) {
@@ -176,6 +185,8 @@ function makeExec(
           !/[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b/.test(text))
       ) {
         promptPending = true;
+        pendingText = text;
+        setScreenText(`Claude Code\n❯ ${pendingText}`);
       }
     }
     return {

--- a/tests/pattern-registry.test.ts
+++ b/tests/pattern-registry.test.ts
@@ -61,6 +61,7 @@ describe("CLI_INPUT_PROMPT_PREFIXES", () => {
   it("recognizes typed composer lines for each supported CLI", () => {
     expect(lineStartsWithCliInputPrompt("claude", "❯ Do the task")).toBe(true);
     expect(lineStartsWithCliInputPrompt("codex", "› Do the task")).toBe(true);
+    expect(lineStartsWithCliInputPrompt("codex", "» Do the task")).toBe(true);
     expect(lineStartsWithCliInputPrompt("cursor", "cursor> Do the task")).toBe(
       true,
     );
@@ -258,6 +259,47 @@ gpt-5.5 xhigh · ~/Gits/brainlayer
 `,
     );
     expect(result.matched).toBe(true);
+  });
+
+  it.each([
+    [
+      "MCP startup",
+      [
+        "Starting MCP servers (6/9): codex_apps, exa, openaiDeveloperDocs",
+        "",
+        "› Ask Codex to do anything",
+        "",
+        "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+      ].join("\n"),
+    ],
+    [
+      "model loading",
+      [
+        "╭──────────────────────────╮",
+        "│ OpenAI Codex             │",
+        "│ model: loading           │",
+        "╰──────────────────────────╯",
+        "",
+        "› Ask Codex to do anything",
+        "",
+        "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+      ].join("\n"),
+    ],
+  ])("does not match Codex %s frames as ready", (_label, screen) => {
+    expect(matchReadyPattern("codex", screen).matched).toBe(false);
+  });
+
+  it("matches the current Codex » ready composer", () => {
+    expect(
+      matchReadyPattern(
+        "codex",
+        [
+          ">_ OpenAI Codex",
+          "» Ask Codex to do anything",
+          "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+        ].join("\n"),
+      ).matched,
+    ).toBe(true);
   });
 
   it("does not treat bare active Codex status lines as ready", () => {

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -71,14 +71,16 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
   let readyText =
     typeof initialReadyText === "function" ? initialReadyText() : initialReadyText;
   let promptPending = false;
+  let pendingText = "";
   let submissionObservationPending = false;
 
   return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
         readyText =
-          "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+          `${pendingText}\ngpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)`;
         promptPending = false;
+        pendingText = "";
         submissionObservationPending = true;
       }
       return { stdout: "{}", stderr: "" };
@@ -91,12 +93,32 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
         (text.includes("cmuxlayer contract for") || !/Codex\b/.test(text))
       ) {
         promptPending = true;
+        pendingText = text;
+        if (typeof initialReadyText !== "function") {
+          readyText = [
+            ">_ OpenAI Codex",
+            `› ${text}`,
+            "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+          ].join("\n");
+        }
       }
+      return { stdout: "{}", stderr: "" };
+    }
+
+    if (args.includes("set-buffer")) {
+      pendingText = String(args.at(-1) ?? "");
       return { stdout: "{}", stderr: "" };
     }
 
     if (args.includes("paste-buffer")) {
       promptPending = true;
+      if (typeof initialReadyText !== "function") {
+        readyText = [
+          ">_ OpenAI Codex",
+          `› ${pendingText}`,
+          "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+        ].join("\n");
+      }
       return { stdout: "{}", stderr: "" };
     }
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -127,6 +127,7 @@ function makeLifecycleExec(opts?: {
   let readyText = "What can I help you with?\n>";
   let surfaceLive = true;
   let promptPending = false;
+  let pendingText = "";
   let activeCli: "claude" | "codex" | "cursor" = "claude";
   let createdSurfaceCount = 0;
   let currentSurface = "surface:new";
@@ -147,9 +148,9 @@ function makeLifecycleExec(opts?: {
       return "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)";
     }
     if (activeCli === "cursor") {
-      return "cursor> \nWorking (1s • esc to interrupt)";
+      return "Cursor Agent\nWorking (1s • esc to interrupt)\ncursor> ";
     }
-    return "Claude Code\n✻ Working\n";
+    return "Claude Code\n✻ Working\n❯";
   };
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("new-split") || args.includes("new-surface")) {
@@ -168,8 +169,14 @@ function makeLifecycleExec(opts?: {
     }
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
-        readyText = workingText();
+        readyText =
+          activeCli === "codex"
+            ? `${pendingText}\n${workingText()}`
+            : activeCli === "cursor"
+              ? `Cursor Agent\n${pendingText}\nWorking (1s • esc to interrupt)\ncursor> `
+            : workingText();
         promptPending = false;
+        pendingText = "";
       }
       return { stdout: "{}", stderr: "" };
     }
@@ -194,6 +201,18 @@ function makeLifecycleExec(opts?: {
         )
       ) {
         promptPending = true;
+        pendingText = text;
+        if (activeCli === "codex") {
+          readyText = [
+            ">_ OpenAI Codex",
+            `› ${text}`,
+            "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+          ].join("\n");
+        } else if (activeCli === "cursor") {
+          readyText = `Cursor Agent\ncursor> ${text}\nAuto`;
+        } else {
+          readyText = `Claude Code\n❯ ${text}`;
+        }
       }
     }
 
@@ -2539,6 +2558,9 @@ describe("agent lifecycle tool handlers", () => {
 
   it("spawn_agent uses the repo workspace before the selected workspace when caller env is absent", async () => {
     const calls: string[] = [];
+    let launchSent = false;
+    let pendingBootText = "";
+    let bootSubmitted = false;
     const mockClient = {
       createWorkspace: vi.fn(),
       selectWorkspace: vi.fn().mockImplementation(async (workspace: string) => {
@@ -2583,14 +2605,23 @@ describe("agent lifecycle tool handlers", () => {
       }),
       newSurface: vi.fn(),
       focusSurface: vi.fn().mockResolvedValue(undefined),
-      send: vi.fn().mockResolvedValue(undefined),
-      sendKey: vi.fn().mockResolvedValue(undefined),
-      readScreen: vi.fn().mockResolvedValue({
-        surface: "surface:inherit",
-        text: "OpenAI Codex\ncodex> ",
-        lines: 1,
-        scrollback_used: false,
+      send: vi.fn().mockImplementation(async (_surface, text: string) => {
+        if (!launchSent) launchSent = true;
+        else pendingBootText += text;
       }),
+      sendKey: vi.fn().mockImplementation(async (_surface, key: string) => {
+        if (key === "return" && pendingBootText) bootSubmitted = true;
+      }),
+      readScreen: vi.fn().mockImplementation(async () => ({
+        surface: "surface:inherit",
+        text: !pendingBootText
+          ? "OpenAI Codex\ncodex> "
+          : bootSubmitted
+            ? `${pendingBootText}\nOpenAI Codex\nWorking (1s)`
+            : `OpenAI Codex\n› ${pendingBootText}\ngpt-5.5 high · ~/repo`,
+        lines: 20,
+        scrollback_used: false,
+      })),
       log: vi.fn().mockResolvedValue(undefined),
       setStatus: vi.fn().mockResolvedValue(undefined),
       clearStatus: vi.fn().mockResolvedValue(undefined),
@@ -2645,6 +2676,9 @@ describe("agent lifecycle tool handlers", () => {
 
     try {
       const calls: string[] = [];
+      let launchSent = false;
+      let pendingBootText = "";
+      let bootSubmitted = false;
       const mockClient = {
         createWorkspace: vi.fn(),
         selectWorkspace: vi
@@ -2693,14 +2727,23 @@ describe("agent lifecycle tool handlers", () => {
         }),
         newSurface: vi.fn(),
         focusSurface: vi.fn().mockResolvedValue(undefined),
-        send: vi.fn().mockResolvedValue(undefined),
-        sendKey: vi.fn().mockResolvedValue(undefined),
-        readScreen: vi.fn().mockResolvedValue({
-          surface: "surface:caller",
-          text: "OpenAI Codex\ncodex> ",
-          lines: 1,
-          scrollback_used: false,
+        send: vi.fn().mockImplementation(async (_surface, text: string) => {
+          if (!launchSent) launchSent = true;
+          else pendingBootText += text;
         }),
+        sendKey: vi.fn().mockImplementation(async (_surface, key: string) => {
+          if (key === "return" && pendingBootText) bootSubmitted = true;
+        }),
+        readScreen: vi.fn().mockImplementation(async () => ({
+          surface: "surface:caller",
+          text: !pendingBootText
+            ? "OpenAI Codex\ncodex> "
+            : bootSubmitted
+              ? `${pendingBootText}\nOpenAI Codex\nWorking (1s)`
+              : `OpenAI Codex\n› ${pendingBootText}\ngpt-5.5 high · ~/repo`,
+          lines: 20,
+          scrollback_used: false,
+        })),
         log: vi.fn().mockResolvedValue(undefined),
         setStatus: vi.fn().mockResolvedValue(undefined),
         clearStatus: vi.fn().mockResolvedValue(undefined),
@@ -3656,6 +3699,7 @@ describe("agent lifecycle tool handlers", () => {
     const buffers = new Map<string, string>();
     let promptPasted = false;
     let promptSubmitted = false;
+    let pastedPrompt = "";
     mockExec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
       if (args.includes("set-buffer")) {
         const chunk = String(args.at(-1) ?? "");
@@ -3669,6 +3713,9 @@ describe("agent lifecycle tool handlers", () => {
       }
       if (args.includes("paste-buffer")) {
         promptPasted = true;
+        const nameIndex = args.indexOf("--name");
+        const name = nameIndex >= 0 ? args[nameIndex + 1] : "default";
+        pastedPrompt = buffers.get(name) ?? "";
         return { stdout: "{}", stderr: "" };
       }
       if (
@@ -3679,11 +3726,17 @@ describe("agent lifecycle tool handlers", () => {
         promptSubmitted = true;
         return { stdout: "{}", stderr: "" };
       }
-      if (args.includes("read-screen") && promptSubmitted) {
+      if (args.includes("read-screen") && promptPasted) {
         return {
           stdout: JSON.stringify({
             surface: "surface:new",
-            text: "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)",
+            text: promptSubmitted
+              ? `${pastedPrompt}\ngpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)`
+              : [
+                  ">_ OpenAI Codex",
+                  `› ${pastedPrompt}`,
+                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
+                ].join("\n"),
             lines: 20,
             scrollback_used: false,
           }),
@@ -6641,7 +6694,7 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
-  it("new_worktree_split reports the created identity when boot prompt verification fails", async () => {
+  it("new_worktree_split reports pending verification when boot prompt evidence is unreadable", async () => {
     vi.useFakeTimers();
     try {
       const gitsDir = join(TEST_DIR, "Gits");
@@ -6697,14 +6750,19 @@ describe("agent lifecycle tool handlers", () => {
       const result = await resultPromise;
       const parsed = parseToolResult(result);
 
-      expect(parsed.ok).toBe(false);
+      expect(parsed.ok).toBe(true);
       expect(parsed.agent_id).toEqual(expect.any(String));
       expect(parsed.surface_id).toBe("surface:new");
       expect(parsed.workspace_id).toBe("workspace:1");
-      expect(parsed.submit_verification_reason).toBe(
-        "surface_read_unavailable",
-      );
-      expect(parsed.retry_safe).toBe(false);
+      expect(parsed.boot_prompt_receipt).toMatchObject({
+        delivered: false,
+        terminal: false,
+        typed: true,
+        submit_attempted: true,
+        submit_verified: null,
+        delivery_state: "pending_verify",
+        retry_count: 0,
+      });
     } finally {
       vi.useRealTimers();
     }
@@ -9687,6 +9745,9 @@ I cannot commit, push, or open a PR without explicit permission, so I am waiting
 codex>
 `;
     let blockerSurfaceLive = false;
+    let launchSent = false;
+    let pendingBootText = "";
+    let bootSubmitted = false;
     const mockClient = {
       createWorkspace: vi.fn(),
       selectWorkspace: vi.fn().mockResolvedValue(undefined),
@@ -9744,14 +9805,24 @@ codex>
       }),
       newSurface: vi.fn(),
       focusSurface: vi.fn().mockResolvedValue(undefined),
-      send: vi.fn().mockResolvedValue(undefined),
-      sendKey: vi.fn().mockResolvedValue(undefined),
-      readScreen: vi.fn().mockResolvedValue({
+      send: vi.fn().mockImplementation(async (_surface, text: string) => {
+        if (!launchSent) launchSent = true;
+        else pendingBootText += text;
+      }),
+      sendKey: vi.fn().mockImplementation(async (_surface, key: string) => {
+        if (key === "return" && pendingBootText) bootSubmitted = true;
+      }),
+      readScreen: vi.fn().mockImplementation(async () => ({
         surface: "surface:blocker",
-        text: blockerScreen,
+        text:
+          pendingBootText && !bootSubmitted
+            ? `OpenAI Codex\n› ${pendingBootText}\ngpt-5.5 high · ~/repo`
+            : bootSubmitted
+              ? `OpenAI Codex\n• ${pendingBootText}\nWorking\n${blockerScreen}`
+            : blockerScreen,
         lines: 20,
         scrollback_used: false,
-      }),
+      })),
       log: vi.fn().mockResolvedValue(undefined),
       setStatus: vi.fn().mockResolvedValue(undefined),
       clearStatus: vi.fn().mockResolvedValue(undefined),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -145,6 +145,21 @@ function createServerWithoutCallerContext(
   return server;
 }
 
+const codexComposerFrame = (text: string): string =>
+  [
+    "OpenAI Codex",
+    `» ${text}`,
+    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+  ].join("\n");
+
+const codexSubmittedFrame = (text: string): string =>
+  [
+    "OpenAI Codex",
+    `• ${text}`,
+    "Working (1s • esc to interrupt)",
+    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+  ].join("\n");
+
 afterEach(async () => {
   for (const server of [...openServers]) {
     await server.close();
@@ -1316,8 +1331,8 @@ describe("tool handler integration", () => {
   it("spawn_in_workspace tool handler creates, selects, then spawns agents", async () => {
     const calls: string[] = [];
     let surfaceIndex = 0;
-    const pendingBootContracts = new Set<string>();
-    const submittedBootContracts = new Set<string>();
+    const pendingBootContracts = new Map<string, string>();
+    const submittedBootContracts = new Map<string, string>();
     const launchedSurfaces = new Set<string>();
     const mockClient = {
       createWorkspace: vi.fn().mockImplementation(async (title: string) => {
@@ -1356,7 +1371,7 @@ describe("tool handler integration", () => {
       focusSurface: vi.fn().mockResolvedValue(undefined),
       send: vi.fn().mockImplementation(async (surface: string, text: string) => {
         if (text.includes("cmuxlayer contract for")) {
-          pendingBootContracts.add(surface);
+          pendingBootContracts.set(surface, text);
         } else {
           launchedSurfaces.add(surface);
         }
@@ -1364,27 +1379,36 @@ describe("tool handler integration", () => {
       pasteText: vi.fn().mockImplementation(
         async (surface: string, text: string) => {
           if (text.includes("cmuxlayer contract for")) {
-            pendingBootContracts.add(surface);
+            pendingBootContracts.set(surface, text);
           }
         },
       ),
       sendKey: vi.fn().mockImplementation(async (surface: string, key: string) => {
-        if (key === "return" && pendingBootContracts.delete(surface)) {
-          submittedBootContracts.add(surface);
+        if (key === "return" && pendingBootContracts.has(surface)) {
+          const pending = pendingBootContracts.get(surface) ?? "";
+          pendingBootContracts.delete(surface);
+          submittedBootContracts.set(surface, pending);
         }
       }),
-      readScreen: vi.fn().mockImplementation(async (surface: string) => ({
-        surface,
-        text: submittedBootContracts.has(surface)
-          ? "Working (1s - esc to interrupt)"
-          : !launchedSurfaces.has(surface)
-            ? "$ "
-            : surface === "surface:2"
-              ? "OpenAI Codex\nmodel: gpt-5.4\n\n›"
-              : "Claude Code\n>",
-        lines: 1,
-        scrollback_used: false,
-      })),
+      readScreen: vi.fn().mockImplementation(async (surface: string) => {
+        const pending = pendingBootContracts.get(surface);
+        return {
+          surface,
+          text: submittedBootContracts.has(surface)
+            ? `• ${submittedBootContracts.get(surface)}\nWorking (1s - esc to interrupt)`
+            : pending
+              ? surface === "surface:2"
+                ? `OpenAI Codex\n» ${pending}\ngpt-5.4 high · ~/Gits/cmuxlayer`
+                : `Claude Code\n❯ ${pending}`
+              : !launchedSurfaces.has(surface)
+                ? "$ "
+                : surface === "surface:2"
+                  ? "OpenAI Codex\nmodel: gpt-5.4\n\n›"
+                  : "Claude Code\n>",
+          lines: 80,
+          scrollback_used: false,
+        };
+      }),
       log: vi.fn().mockResolvedValue(undefined),
       setStatus: vi.fn().mockResolvedValue(undefined),
       clearStatus: vi.fn().mockResolvedValue(undefined),
@@ -3614,13 +3638,16 @@ describe("tool handler integration", () => {
     const pointer = `Read and follow ${promptPath}`;
     writeFileSync(promptPath, bootPrompt, "utf8");
     let promptSent = false;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
             text: promptSent
-              ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+              ? promptSubmitted
+                ? `• ${pointer}\nWorking (1s • esc to interrupt)\ngpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer`
+                : `OpenAI Codex\n» ${pointer}\ngpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer`
               : "codex> ",
             lines: 20,
             scrollback_used: false,
@@ -3630,6 +3657,13 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send") && args.at(-1) === pointer) {
         promptSent = true;
+      }
+      if (
+        args.includes("send-key") &&
+        args.at(-1) === "return" &&
+        promptSent
+      ) {
+        promptSubmitted = true;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -3739,12 +3773,17 @@ describe("tool handler integration", () => {
     writeFileSync(promptPath, "boot prompt", "utf8");
     let promptSent = false;
     let returnPresses = 0;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
-            text: "Claude Code\nWhat can I help you with?\n>",
+            text: !promptSent
+              ? "Claude Code\nWhat can I help you with?\n>"
+              : !promptSubmitted
+                ? "Claude Code\n❯ boot prompt"
+                : "Claude Code\n• boot prompt\nWhat can I help you with?\n❯",
             lines: 20,
             scrollback_used: false,
           }),
@@ -3753,6 +3792,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key") && args.includes("return")) {
         returnPresses += 1;
+        if (promptSent) promptSubmitted = true;
       }
       if (
         args.includes("send") &&
@@ -3830,9 +3870,14 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+    });
     expect(promptSent).toBe(true);
   }, 10_000);
 
@@ -3841,13 +3886,16 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
     let promptSent = false;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
             text: promptSent
-              ? "Claude Code\n❯ boot prompt\n\nWhat can I help you with?\n❯"
+              ? promptSubmitted
+                ? "Claude Code\n❯ boot prompt\n\nWhat can I help you with?\n❯"
+                : "Claude Code\n❯ boot prompt"
               : "Claude Code\nWhat can I help you with?\n>",
             lines: 20,
             scrollback_used: false,
@@ -3860,6 +3908,9 @@ describe("tool handler integration", () => {
         String(args.at(-1) ?? "") === "boot prompt"
       ) {
         promptSent = true;
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (promptSent) promptSubmitted = true;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -3904,12 +3955,7 @@ describe("tool handler integration", () => {
                   "› still typed here",
                   "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
                 ].join("\n")
-              : [
-                  "OpenAI Codex",
-                  "Model: gpt-5.5 xhigh",
-                  "›",
-                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
-                ].join("\n"),
+              : "codex> ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -3939,9 +3985,13 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      terminal: false,
+    });
     expect(promptSent).toBe(true);
   }, 10_000);
 
@@ -3950,19 +4000,22 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
     let promptSent = false;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
-            text: promptSent
+            text: promptSent && promptSubmitted
               ? [
                   "Claude Code",
                   "What can I help you with?",
                   "❯",
                   "  ⎇ cmuxlayer/fix-submit | 🔧 13",
                 ].join("\n")
-              : "Claude Code\nWhat can I help you with?\n❯",
+              : promptSent
+                ? "Claude Code\n❯ boot prompt"
+                : "Claude Code\nWhat can I help you with?\n❯",
             lines: 20,
             scrollback_used: false,
           }),
@@ -3974,6 +4027,9 @@ describe("tool handler integration", () => {
         String(args.at(-1) ?? "") === "boot prompt"
       ) {
         promptSent = true;
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (promptSent) promptSubmitted = true;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -4006,14 +4062,17 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, "boot prompt", "utf8");
     let promptSent = false;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:1",
-            text: promptSent
+            text: promptSent && promptSubmitted
               ? REAL_CLAUDE_SUBMIT_EVIDENCE_SCREEN
-              : REAL_CLAUDE_READY_BASELINE_SCREEN,
+              : promptSent
+                ? "Claude Code\n❯ boot prompt"
+                : REAL_CLAUDE_READY_BASELINE_SCREEN,
             lines: 30,
             scrollback_used: false,
           }),
@@ -4025,6 +4084,9 @@ describe("tool handler integration", () => {
         String(args.at(-1) ?? "") === "boot prompt"
       ) {
         promptSent = true;
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (promptSent) promptSubmitted = true;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -4094,9 +4156,14 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+    });
     expect(promptSent).toBe(true);
   }, 10_000);
 
@@ -4143,9 +4210,14 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      terminal: false,
+      delivered: false,
+      delivery_state: "pending_verify",
+      submit_verified: null,
+    });
     expect(promptSent).toBe(true);
   }, 10_000);
 
@@ -4166,12 +4238,7 @@ describe("tool handler integration", () => {
                   "› Use 500 tokens and budget $5.00",
                   "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
                 ].join("\n")
-              : [
-                  "OpenAI Codex",
-                  "Model: gpt-5.5 xhigh",
-                  "›",
-                  "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer",
-                ].join("\n"),
+              : "codex> ",
             lines: 20,
             scrollback_used: false,
           }),
@@ -4201,9 +4268,13 @@ describe("tool handler integration", () => {
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "pending_verify",
+      submit_verified: null,
+      terminal: false,
+    });
     expect(promptSent).toBe(true);
   }, 10_000);
 
@@ -4302,6 +4373,7 @@ describe("tool handler integration", () => {
     let reads = 0;
     let readsWhenBootPromptSent: number | null = null;
     let promptSent = false;
+    let promptSubmitted = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("read-screen")) {
         reads += 1;
@@ -4309,7 +4381,9 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:1",
             text: promptSent
-              ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+              ? promptSubmitted
+                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                : "Gemini CLI\n> boot prompt"
               : reads === 1
                 ? "Gemini CLI\nbooting\n>"
                 : "Gemini CLI\nready\n>",
@@ -4325,6 +4399,9 @@ describe("tool handler integration", () => {
       ) {
         readsWhenBootPromptSent = reads;
         promptSent = true;
+      }
+      if (args.includes("send-key") && args.includes("return")) {
+        if (promptSent) promptSubmitted = true;
       }
       return { stdout: "{}", stderr: "" };
     });
@@ -4344,9 +4421,9 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     // Two readiness matches, launch-command preflight, boot-prompt preflight,
-    // then post-submit verification.
+    // complete composer observation, then post-submit verification.
     expect(readsWhenBootPromptSent).toBe(4);
-    expect(reads).toBe(5);
+    expect(reads).toBe(7);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["send", "--surface", "surface:1", "boot prompt"]),
@@ -8435,6 +8512,8 @@ describe("tool handler integration", () => {
 
       let launcherSends = 0;
       let promptSent = false;
+      let pendingBootText = "";
+      let bootPromptSubmitted = false;
       let returnPresses = 0;
       let readsAfterFirstLaunch = 0;
       let surfaceCreated = false;
@@ -8484,6 +8563,7 @@ describe("tool handler integration", () => {
         }
         if (args.includes("send-key") && args.includes("return")) {
           returnPresses += 1;
+          if (promptSent) bootPromptSubmitted = true;
           return { stdout: "{}", stderr: "" };
         }
         if (args.includes("send")) {
@@ -8499,13 +8579,17 @@ describe("tool handler integration", () => {
             launcherSends += 1;
           } else if (text.includes(prompt)) {
             promptSent = true;
+            pendingBootText = text;
           }
           return { stdout: "{}", stderr: "" };
         }
         if (args.includes("set-buffer")) {
           const text = String(args.at(-1) ?? "");
           sentTexts.push(text);
-          if (text.includes(prompt)) promptSent = true;
+          if (text.includes(prompt)) {
+            promptSent = true;
+            pendingBootText = text;
+          }
           return { stdout: "{}", stderr: "" };
         }
         if (args.includes("read-screen")) {
@@ -8529,7 +8613,9 @@ describe("tool handler integration", () => {
           } else if (launcherSends >= 2 && !promptSent) {
             text = fixture.screens.ready;
           } else if (promptSent) {
-            text = fixture.screens.working;
+            text = bootPromptSubmitted
+              ? codexSubmittedFrame(pendingBootText)
+              : codexComposerFrame(pendingBootText);
           }
           return {
             stdout: JSON.stringify({
@@ -8629,6 +8715,7 @@ describe("tool handler integration", () => {
     let promptSent = false;
     let readsAfterLaunch = 0;
     let launcherReturnPresses = 0;
+    let bootPromptSubmitted = false;
     let composer = "";
     const submittedCommands: string[] = [];
 
@@ -8640,6 +8727,7 @@ describe("tool handler integration", () => {
           composer += text;
         } else if (text === "boot after stranded launcher") {
           promptSent = true;
+          composer = text;
         }
         return { stdout: "{}", stderr: "" };
       }
@@ -8664,14 +8752,18 @@ describe("tool handler integration", () => {
               throw new Error("socket closed before receiving response");
             }
           }
+        } else if (key === "return" && promptSent) {
+          bootPromptSubmitted = true;
+          composer = "";
         }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("read-screen")) {
         let text = "$ ";
         if (promptSent) {
-          text =
-            "gpt-5.6-sol high · ~/Gits/cmuxlayer.wt/spawn-reliability-3head\nWorking (1s • esc to interrupt)";
+          text = bootPromptSubmitted
+            ? codexSubmittedFrame("boot after stranded launcher")
+            : codexComposerFrame(composer);
         } else if (launcherSends > 0) {
           readsAfterLaunch += 1;
           if (submittedCommands.length > 0) {
@@ -8806,12 +8898,14 @@ describe("tool handler integration", () => {
       if (args.includes("read-screen")) {
         const submitted = submittedCommands.at(-1);
         const text =
-          submitted === fixture.corrupted_command
+          composer.includes("cmuxlayer contract for")
+            ? codexComposerFrame(composer)
+            : submitted === fixture.corrupted_command
             ? fixture.screen
             : submitted === fixture.launcher_command
               ? "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›"
               : submitted?.includes("cmuxlayer contract for")
-                ? "OpenAI Codex\nWorking (1s - esc to interrupt)"
+                ? codexSubmittedFrame(submitted)
               : composer
                 ? `etanheyman ~/Gits/brainlayer [main] $ ${composer}`
                 : "etanheyman ~/Gits/brainlayer [main] $";
@@ -8976,8 +9070,10 @@ describe("tool handler integration", () => {
       }
       if (args.includes("read-screen")) {
         let text = fixture.replay.stale_probe_screen;
-        if (submittedCommands.at(-1)?.includes("cmuxlayer contract for")) {
-          text = "OpenAI Codex\nWorking (1s - esc to interrupt)";
+        if (composer.includes("cmuxlayer contract for")) {
+          text = codexComposerFrame(composer);
+        } else if (submittedCommands.at(-1)?.includes("cmuxlayer contract for")) {
+          text = codexSubmittedFrame(submittedCommands.at(-1) ?? "");
         } else if (submittedCommands.length > 0) {
           text = "OpenAI Codex\nmodel: gpt-5.6-sol xhigh\n\n›";
         } else if (launcherWriteBecameAmbiguous) {
@@ -9083,6 +9179,8 @@ describe("tool handler integration", () => {
     let launcherSends = 0;
     let updateAccepted = false;
     let promptSent = false;
+    let pendingBootText = "";
+    let bootPromptSubmitted = false;
     let readsAfterFirstLaunch = 0;
     let updateReads = 0;
     let updateMenuSeen = false;
@@ -9136,6 +9234,9 @@ describe("tool handler integration", () => {
       if (args.includes("send-key")) {
         const key = String(args.at(-1) ?? "");
         sentKeys.push(key);
+        if (key === "return" && promptSent) {
+          bootPromptSubmitted = true;
+        }
         if (updateMenuSeen && !updateAccepted) {
           updateMenuKeys.push(key);
           if (
@@ -9157,13 +9258,17 @@ describe("tool handler integration", () => {
           launcherSends += 1;
         } else if (text.includes(prompt)) {
           promptSent = true;
+          pendingBootText = text;
         }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("set-buffer")) {
         const text = String(args.at(-1) ?? "");
         sentTexts.push(text);
-        if (text.includes(prompt)) promptSent = true;
+        if (text.includes(prompt)) {
+          promptSent = true;
+          pendingBootText = text;
+        }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("read-screen")) {
@@ -9185,7 +9290,9 @@ describe("tool handler integration", () => {
         } else if (launcherSends >= 2 && !promptSent) {
           text = fixture.screens.ready;
         } else if (promptSent) {
-          text = fixture.screens.working;
+          text = bootPromptSubmitted
+            ? codexSubmittedFrame(pendingBootText)
+            : codexComposerFrame(pendingBootText);
         }
         return {
           stdout: JSON.stringify({
@@ -9281,6 +9388,8 @@ describe("tool handler integration", () => {
     let updateMenuAccepted = false;
     let updateMenuSeen = false;
     let promptSent = false;
+    let pendingBootText = "";
+    let bootPromptSubmitted = false;
     let postDismissMenuReads = 0;
     let surfaceCreated = false;
     const sentTexts: string[] = [];
@@ -9331,6 +9440,9 @@ describe("tool handler integration", () => {
       if (args.includes("send-key")) {
         const key = String(args.at(-1) ?? "");
         sentKeys.push(key);
+        if (key === "return" && promptSent) {
+          bootPromptSubmitted = true;
+        }
         if (key === "return" && updateMenuSeen) {
           updateMenuAccepted = true;
         }
@@ -9346,13 +9458,17 @@ describe("tool handler integration", () => {
           launcherSent = true;
         } else if (text.includes(prompt)) {
           promptSent = true;
+          pendingBootText = text;
         }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("set-buffer")) {
         const text = String(args.at(-1) ?? "");
         sentTexts.push(text);
-        if (text.includes(prompt)) promptSent = true;
+        if (text.includes(prompt)) {
+          promptSent = true;
+          pendingBootText = text;
+        }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("read-screen")) {
@@ -9364,8 +9480,9 @@ describe("tool handler integration", () => {
           postDismissMenuReads += 1;
           text = postDismissMenuReads === 1 ? updateMenu : "codex> ";
         } else if (promptSent) {
-          text =
-            "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
+          text = bootPromptSubmitted
+            ? codexSubmittedFrame(pendingBootText)
+            : codexComposerFrame(pendingBootText);
         }
         return {
           stdout: JSON.stringify({
@@ -9662,6 +9779,7 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, prompt, "utf8");
     let promptSent = false;
+    let promptSubmitted = false;
     let returnPresses = 0;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
@@ -9721,6 +9839,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key") && args.includes("return")) {
         returnPresses += 1;
+        if (promptSent) promptSubmitted = true;
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("read-screen")) {
@@ -9728,7 +9847,9 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:2",
             text: promptSent
-              ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+              ? promptSubmitted
+                ? codexSubmittedFrame(prompt)
+                : codexComposerFrame(prompt)
               : "previous shell output: bun install\ncodex> ",
             lines: 80,
             scrollback_used: false,
@@ -9778,6 +9899,7 @@ describe("tool handler integration", () => {
     let returnPresses = 0;
     let reads = 0;
     let lineCleared = false;
+    let promptSubmitted = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-workspaces")) {
@@ -9840,7 +9962,10 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key")) {
         if (args.includes("ctrl-c")) lineCleared = true;
-        if (args.includes("return")) returnPresses += 1;
+        if (args.includes("return")) {
+          returnPresses += 1;
+          if (promptSent) promptSubmitted = true;
+        }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -9862,7 +9987,9 @@ describe("tool handler integration", () => {
             : launcherSends === 0 && reads === 2
               ? "Please restart Codex\netan@mac % "
               : promptSent
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                ? promptSubmitted
+                  ? codexSubmittedFrame(prompt)
+                  : codexComposerFrame(prompt)
                 : "codex> ";
         return {
           stdout: JSON.stringify({
@@ -9913,6 +10040,7 @@ describe("tool handler integration", () => {
     let returnPresses = 0;
     let reads = 0;
     let lineCleared = false;
+    let promptSubmitted = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-workspaces")) {
@@ -9975,7 +10103,10 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key")) {
         if (args.includes("ctrl-c")) lineCleared = true;
-        if (args.includes("return")) returnPresses += 1;
+        if (args.includes("return")) {
+          returnPresses += 1;
+          if (promptSent) promptSubmitted = true;
+        }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -9997,7 +10128,9 @@ describe("tool handler integration", () => {
             : launcherSends === 0 && reads === 2
               ? "Please restart Gemini\netan@mac % "
               : promptSent
-                ? "Gemini CLI\n✦ Working..."
+                ? promptSubmitted
+                  ? `Gemini CLI\n• ${prompt}\n✦ Working...`
+                  : `Gemini CLI\n❯ ${prompt}`
                 : "Gemini CLI\n>\n";
         return {
           stdout: JSON.stringify({
@@ -10052,6 +10185,7 @@ describe("tool handler integration", () => {
     let returnPresses = 0;
     let reads = 0;
     let lineCleared = false;
+    let promptSubmitted = false;
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       const placementResult = defaultPanePlacementResult(args);
@@ -10070,7 +10204,10 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send-key")) {
         if (args.includes("ctrl-c")) lineCleared = true;
-        if (args.includes("return")) returnPresses += 1;
+        if (args.includes("return")) {
+          returnPresses += 1;
+          if (promptSent) promptSubmitted = true;
+        }
         return { stdout: "{}", stderr: "" };
       }
       if (args.includes("send")) {
@@ -10092,7 +10229,9 @@ describe("tool handler integration", () => {
             : launcherSends === 0 && reads === 2
               ? "Please restart Codex\netan@mac % "
               : promptSent
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                ? promptSubmitted
+                  ? codexSubmittedFrame(prompt)
+                  : codexComposerFrame(prompt)
                 : "codex> ";
         return {
           stdout: JSON.stringify({
@@ -10164,9 +10303,11 @@ describe("tool handler integration", () => {
       }
       if (args.includes("read-screen")) {
         const text =
-          promptSent && returnPresses >= 2
-            ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
-            : "codex> ";
+          !promptSent
+            ? "codex> "
+            : returnPresses >= 1
+              ? codexSubmittedFrame(prompt)
+              : codexComposerFrame(prompt);
         return {
           stdout: JSON.stringify({
             surface: "surface:2",
@@ -10238,7 +10379,7 @@ describe("tool handler integration", () => {
         return {
           stdout: JSON.stringify({
             surface: "surface:2",
-            text: "codex> ",
+            text: promptSent ? codexComposerFrame(prompt) : "codex> ",
             lines: 30,
             scrollback_used: false,
           }),
@@ -10312,9 +10453,9 @@ describe("tool handler integration", () => {
             surface: "surface:2",
             text:
               promptSent && returnPresses >= 1
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
+                ? codexSubmittedFrame(prompt)
                 : promptSent
-                  ? `codex> ${prompt}`
+                  ? codexComposerFrame(prompt)
                   : "codex> ",
             lines: 30,
             scrollback_used: false,
@@ -10345,7 +10486,7 @@ describe("tool handler integration", () => {
     expect(transientFailureThrown).toBe(true);
   }, 10_000);
 
-  it("new_split fails when the boot prompt clears without agent identity", async () => {
+  it("new_split leaves boot submission pending when the prompt clears without attributable evidence", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-idle-after-clear.md");
     const prompt = "short boot prompt";
@@ -10384,7 +10525,7 @@ describe("tool handler integration", () => {
                 ? "codex> "
                 : returnPresses >= 1
                   ? "> "
-                  : `> ${prompt}`,
+                  : codexComposerFrame(prompt),
             lines: 80,
             scrollback_used: false,
           }),
@@ -10408,15 +10549,18 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Timed out");
-    expect(parsed.submit_verified).toBe(false);
-    expect(parsed.submit_verification_reason).toBe(
-      "working_status_not_observed",
-    );
-    expect(parsed.retry_safe).toBe(false);
-    expect(parsed.boot_prompt_delivered).not.toBe(true);
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(false);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivered: false,
+      terminal: false,
+      typed: true,
+      submit_attempted: true,
+      submit_verified: null,
+      delivery_state: "pending_verify",
+      retry_count: 0,
+    });
     expect(returnPresses).toBe(1);
   }, 10_000);
 
@@ -10453,9 +10597,7 @@ describe("tool handler integration", () => {
           stdout: JSON.stringify({
             surface: "surface:2",
             text:
-              promptSent && returnPresses > 0
-                ? `codex> ${prompt}`
-                : "codex> ",
+              promptSent ? codexComposerFrame(prompt) : "codex> ",
             lines: 30,
             scrollback_used: false,
           }),
@@ -10482,25 +10624,19 @@ describe("tool handler integration", () => {
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
-    expect(result.isError).toBe(true);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Boot prompt delivery failed");
-    expect(parsed.error).toContain("Enter submit could not be verified");
-    expect(parsed.submit_verified).toBe(false);
-    expect(parsed.submit_verification_reason).toBe("input_still_pending");
-    expect(parsed.retry_safe).toBe(false);
-    expect(parsed.boot_prompt_delivered).not.toBe(true);
-    expect(parsed).toMatchObject({
+    expect(result.isError).not.toBe(true);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(false);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
       delivered: false,
       terminal: false,
       typed: true,
       submit_attempted: true,
-      submit_verified: false,
-      retry_count: 0,
+      submit_verified: null,
+      delivery_state: "pending_verify",
+      retry_count: 1,
     });
-    expect(parsed).not.toHaveProperty("delivery");
-    expect(parsed).not.toHaveProperty("delivery_state");
-    expect(returnPresses).toBe(1);
+    expect(returnPresses).toBe(2);
   }, 10_000);
 
   it("new_split reports a short boot prompt delivered after submit verification succeeds", async () => {
@@ -10510,6 +10646,7 @@ describe("tool handler integration", () => {
     mkdirSync(CHANNEL_TEST_DIR, { recursive: true });
     writeFileSync(promptPath, prompt, "utf8");
     let returnPresses = 0;
+    let promptSent = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("new-split")) {
         return {
@@ -10527,14 +10664,20 @@ describe("tool handler integration", () => {
         returnPresses += 1;
         return { stdout: "{}", stderr: "" };
       }
+      if (args.includes("send") || args.includes("set-buffer")) {
+        promptSent = true;
+        return { stdout: "{}", stderr: "" };
+      }
       if (args.includes("read-screen")) {
         return {
           stdout: JSON.stringify({
             surface: "surface:2",
             text:
-              returnPresses > 0
-                ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
-                : "codex> ",
+              !promptSent
+                ? "codex> "
+                : returnPresses > 0
+                  ? codexSubmittedFrame(prompt)
+                  : codexComposerFrame(prompt),
             lines: 30,
             scrollback_used: false,
           }),
@@ -10562,7 +10705,7 @@ describe("tool handler integration", () => {
     expect(returnPresses).toBe(1);
   }, 10_000);
 
-  it("new_split keeps verifying long boot prompts without retrying Return", async () => {
+  it("new_split leaves a long boot prompt pending when only generic Working appears", async () => {
     vi.useRealTimers();
     const promptPath = join(CHANNEL_TEST_DIR, "split-long-retry.md");
     const prompt = "long boot prompt ".repeat(40);
@@ -10605,7 +10748,7 @@ describe("tool handler integration", () => {
                 ? "codex> "
                 : returnPresses >= 1
                   ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
-                  : `codex> ${typedText.slice(-100)}`,
+                  : codexComposerFrame(typedText),
             lines: 30,
             scrollback_used: false,
           }),
@@ -10629,7 +10772,16 @@ describe("tool handler integration", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.boot_prompt_delivered).toBe(true);
+    expect(parsed.boot_prompt_delivered).toBe(false);
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivered: false,
+      terminal: false,
+      typed: true,
+      submit_attempted: true,
+      submit_verified: null,
+      delivery_state: "pending_verify",
+      retry_count: 0,
+    });
     expect(sendCalls).toHaveLength(1);
     expect(sendCalls.join("")).toBe(prompt);
     expect(returnPresses).toBe(1);


### PR DESCRIPTION
Recon measured 15/15 boot receipts claiming submit_verified:true while only
2/15 actually submitted. Root cause was a readiness race, not payload shape --
which is why #427/#483 and #500/#503 both missed it: they targeted payload and
placeholder handling, and boot has its own source event and readiness path.

- Readiness rejects unstable launch frames (`Starting MCP servers`,
  `model: loading`), accepts the live `»` composer glyph, and requires two
  stable observations for modern Codex ready frames.
- The complete boot payload must be observed in the composer BEFORE Return,
  bounded independently at 250ms so a surface that never paints cannot hold a
  spawn for the whole verification window.
- Post-Return evidence must be attributable, for EVERY boot CLI: token/cost
  increase, a complete transcript echo, or a composer-region transition that
  cannot be a replayed pre-type ready frame. Status plus token_count:null is
  no longer sufficient.
- Internal blank lines are preserved when extracting composer content, so the
  two-paragraph pointer correlates instead of matching an 80-char tail.
- One bounded recovery Return, only after the payload was observed. Absent
  evidence returns nonterminal pending_verify, never terminal submitted (#483).
- Lifecycle mocks now render the real sequence (typed composer, Return,
  attributable response) instead of jumping straight to `Working`. That
  unrealistic fake is what let this survive two prior fixes; no assertion was
  weakened -- `git diff tests/inbox-nudge.test.ts | grep -c 'expect('` is 0.

DISCLOSURES
- `pending_verify` on the un-observed pre-Return path means NOT SENT: the
  Return is deliberately not pressed. Elsewhere in this codebase that state
  means sent-but-unverified.
- Brief item 5 (real Codex lifecycle, N>=3, slowed startup) is NOT satisfied.
  The worker sandbox could not reach the cmux socket
  (`cmux-501.sock (Operation not permitted, errno 1)`, #501), and two lead-seat
  runs failed with `cmuxlayer daemon temporarily offline` -- the lane build's
  harness client could not stay connected. The race is covered by unit and
  fixture tests only. Do not merge until a live N>=3 run is green.

Suite 140 files / 3217 passed / 1 skipped; typecheck exit 0. Independently
reviewed twice (ITERATE, ITERATE, ACCEPT) with each blocker re-verified.


Fixes #427

— cmuxlayerClaude-0719212e (lead) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"cmuxlayerClaude-0719212e","role":"lead","harness":"claude-code","model":"claude-opus-5","model_source":"session-jsonl","session":"ae9b1914","ts":"2026-08-20T13:00:23Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core boot/spawn submit verification and public receipt semantics (`ok` with `pending_verify` vs errors); mistakes could block spawns or mislead orchestrators, but scope is terminal-screen heuristics rather than auth or data stores.
> 
> **Overview**
> Fixes false **submit_verified** on boot when Codex (and other CLIs) looked ready or “Working” before the brief was actually typed, submitted, or consumed.
> 
> **Readiness** now rejects unstable Codex launch frames (`Starting MCP servers`, `model: loading`), recognizes the `»` composer glyph, and can require **two** stable ready observations for modern Codex composers without `codex>`.
> 
> **Pre-Return gate:** boot delivery sets `require_observed_payload_before_enter` so the **full** payload must appear in the composer (including internal blank lines) within a **250ms** bounded wait; if not, **Return is not pressed** and the receipt is nonterminal `pending_verify` (`ok: true`) instead of a hard failure or false verified submit.
> 
> **Post-Return verification** demands **attributable** evidence (token/cost delta, full transcript echo, or monotonic composer change—not replayed pre-type UI); generic status plus `token_count: null` no longer counts. One bounded recovery **Return** applies after the payload was observed; otherwise callers get `pending_verify`, not terminal `submitted`.
> 
> Tests and lifecycle mocks were updated to simulate typed composer → Return → response instead of jumping straight to `Working`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7136fc60b1e7b113daa7131b46e880745db04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject Codex ready state during unstable launch and require attributable evidence before certifying submits
> - Introduces `CODEX_UNSTABLE_LAUNCH_RE` in [pattern-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/511/files#diff-1f1872f4b73cb466921af9511f51f36eab87d558851ccc6f9e68a0a552286b4a); `matchReadyPattern` now returns `matched=false` for Codex screens showing MCP startup or model loading markers.
> - Broadens `CODEX_READY_RE` and `CLI_INPUT_PROMPT_PREFIXES` to accept `»` as a valid Codex prompt marker alongside `›`.
> - Adds `requiredBootReadyObservations` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/511/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595); Codex screens without a visible `codex>` prompt now require at least 2 consecutive ready confirmations.
> - Reworks submit verification in `verifySubmitAfterEnter` and `createServer` to require attributable evidence (complete composer content match, token/cost deltas, or transcript echo) before certifying delivery. If the full payload is not observed in the composer within `BOOT_PAYLOAD_OBSERVE_TIMEOUT_MS` (250ms), Enter is not pressed and the outcome becomes `pending_verify` with `submit_verified=null`.
> - Behavioral Change: many boot scenarios that previously returned hard failures now return `ok=true` with a non-terminal `boot_prompt_receipt` in `delivery_state='pending_verify'`. Callers that treated these as fatal errors must handle the pending receipt instead.
> - Risk: `isComposerFooterOrChromeLine` and `extractComposerInputRegion` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/511/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now use broader heuristics for chrome detection and blank-line handling; multi-line prompts with footer-like content may be misclassified.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4d7136f. 2 files reviewed, 4 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Codex readiness detection, including support for the `»` prompt marker.
  * Boot prompt delivery now verifies submissions using screen and activity evidence.
  * Added clearer pending-verification states when submission cannot be confirmed.

* **Bug Fixes**
  * Prevented startup and model-loading screens from being treated as ready.
  * Improved handling of multiline prompts, blank lines, stale screens, and delayed responses.
  * Increased reliability of prompt delivery across supported agent surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->