### PR TITLE
Expose submit verification evidence in receipts

### DIFF
--- a/docs/plans/2026-08-21-lane-427-submit-evidence.md
+++ b/docs/plans/2026-08-21-lane-427-submit-evidence.md
@@ -1,0 +1,62 @@
+# Lane 427 Submit Evidence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make every verified delivery receipt identify the evidence branch that certified submission, then use live evidence to repair only the branch responsible for issue #427's remaining false green.
+
+**Architecture:** Extend the existing delivery receipt and verifier result with one nullable `submit_evidence` discriminator. Preserve the verifier's current evidence ordering, expose the discriminator through boot/spawn responses, run the instrumented implementation against real Codex lifecycle probes, and add a branch-specific regression before changing verifier behavior.
+
+**Tech Stack:** TypeScript, Zod, Bun, Vitest, cmuxlayer MCP/CLI live probes.
+
+---
+
+### Task 1: Add the diagnostic discriminator
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/delivery-truth-t2.test.ts`
+- Test: `tests/enter-reliability.test.ts`
+- Test: `tests/spawn-response.test.ts`
+
+1. Add failing receipt assertions for `token_delta`, `transcript_echo`, `cleared_composer`, `status_only`, and `null` where submission is not verified.
+2. Run only the touched tests with `bun run vitest run ...` and confirm the assertions fail because `submit_evidence` is absent.
+3. Add a `SubmitEvidence` union and propagate it from `verifySubmitAfterEnter` through `buildPublicDeliveryReceipt` and the public output schema.
+4. Keep evidence precedence explicit: token/cost delta, transcript echo/fresh Cursor response, cleared composer, then legacy status-only evidence.
+5. Re-run focused tests and compile touched tests directly.
+6. Commit the diagnostic separately.
+
+### Task 2: Identify the live false-green branch
+
+**Files:**
+- Record: `/Users/etanheyman/.cmux/agents/cmuxlayerCodex-7d26448d/report.md`
+
+1. Build and launch the instrumented branch through the repository's supported local/live path.
+2. Spawn Codex with `boot_prompt_path` at least three times.
+3. Immediately record receipt fields plus raw screen `status`, `control_state`, payload-in-composer, and agent-output presence.
+4. Classify accepted-prompt echo only when the screen is `working`/`busy`; classify false green only when all four brief conditions hold.
+5. If a false green appears, name its exact `submit_evidence`; if none appears, report the complete N>=3 table and do not invent a branch.
+
+### Task 3: Fix only the proven branch
+
+**Files:**
+- Modify: `src/server.ts` only if Task 2 identifies a verifier branch defect
+- Test: the narrow existing verifier test file that models the observed frame sequence
+
+1. Encode the exact live frame sequence as a failing regression and run it red.
+2. State one root-cause hypothesis tied to the recorded `submit_evidence` value.
+3. Make the smallest verifier change that invalidates that evidence on the false-green sequence.
+4. Run the regression green, then all focused delivery/boot tests.
+5. If the Return genuinely landed and Codex dropped it, do not patch the verifier; document that result instead.
+
+### Task 4: Verify and hand off
+
+**Files:**
+- Write: `/Users/etanheyman/.cmux/agents/cmuxlayerCodex-7d26448d/report.md`
+- Append: `/Users/etanheyman/Gits/orchestrator/collab/LEADS.md`
+
+1. Run `bun run test` and `bun run typecheck`.
+2. Compile each touched test file directly because repository typecheck excludes tests.
+3. Run final live Codex N>=3 and preserve raw per-probe values verbatim.
+4. Run review, commit the branch-specific fix if one was warranted, push, and open a ready-for-review PR without merging.
+5. Write the engine report with red/green commands and outputs, PR/SHA evidence, and the exact done marker.
+6. Append one concise handoff line to `LEADS.md`, then acknowledge any handled mailbox messages with their canonical IDs.

--- a/src/server.ts
+++ b/src/server.ts
@@ -616,6 +616,15 @@ const DeliveryOutputShape = {
   typed: z.boolean().optional(),
   submit_attempted: z.boolean().optional(),
   submit_verified: z.boolean().nullable().optional(),
+  submit_evidence: z
+    .enum([
+      "token_delta",
+      "transcript_echo",
+      "cleared_composer",
+      "status_only",
+    ])
+    .nullable()
+    .optional(),
   delivery_id: z.string().optional(),
   duplicate_of: z.string().optional(),
   needs_attention: z.boolean().optional(),
@@ -914,10 +923,17 @@ export const DELIVERY_RECEIPT_VOCABULARY = [
   "typed",
   "submit_attempted",
   "submit_verified",
+  "submit_evidence",
   "retry_count",
   "needs_attention",
   "attention_reason",
 ] as const;
+
+export type SubmitEvidence =
+  | "token_delta"
+  | "transcript_echo"
+  | "cleared_composer"
+  | "status_only";
 
 type PublicDeliveryState =
   | "submitted"
@@ -933,6 +949,7 @@ export interface PublicDeliveryReceipt {
   typed: boolean;
   submit_attempted: boolean;
   submit_verified: boolean | null;
+  submit_evidence?: SubmitEvidence | null;
   retry_count: number;
   delivery?: PublicDeliveryState;
   delivery_state?: PublicDeliveryState;
@@ -954,6 +971,7 @@ export function buildPublicDeliveryReceipt(input: {
   typed: boolean;
   submit_attempted: boolean;
   submit_verified: boolean | null;
+  submit_evidence?: SubmitEvidence | null;
   retry_count: number;
   needs_attention?: boolean;
   attention_reason?: string | null;
@@ -980,6 +998,9 @@ export function buildPublicDeliveryReceipt(input: {
     typed: input.typed,
     submit_attempted: input.submit_attempted,
     submit_verified: input.submit_verified,
+    ...(input.submit_verified !== null
+      ? { submit_evidence: input.submit_evidence ?? null }
+      : {}),
     retry_count: input.retry_count,
     ...(evidencedState
       ? { delivery: evidencedState, delivery_state: evidencedState }
@@ -5116,6 +5137,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     beforeMutation?: () => Promise<void>;
   }): Promise<{
     submit_verified: boolean | null;
+    submit_evidence: SubmitEvidence | null;
     submit_verification_reason: SubmitVerificationFailureReason | null;
     retry_count: number;
     delivery: "submitted" | "queued" | "queued_followup" | "pending_verify";
@@ -5125,6 +5147,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // command was at or below SEND_INPUT_CHUNK_THRESHOLD; it is not a failure.
       return {
         submit_verified: null,
+        submit_evidence: null,
         submit_verification_reason: null,
         retry_count: 0,
         delivery: "submitted",
@@ -5184,6 +5207,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         ) {
           return {
             submit_verified: false,
+            submit_evidence: null,
             submit_verification_reason: "input_still_pending",
             retry_count: retryCount,
             delivery: "submitted",
@@ -5191,6 +5215,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
         return {
           submit_verified: null,
+          submit_evidence: null,
           submit_verification_reason: null,
           retry_count: retryCount,
           delivery: "queued",
@@ -5203,6 +5228,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ) {
         return {
           submit_verified: null,
+          submit_evidence: null,
           submit_verification_reason: null,
           retry_count: retryCount,
           delivery: "queued_followup",
@@ -5274,8 +5300,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           bootHasTranscriptEcho ||
           cursorShowsSubmittedResponse)
       ) {
+        const submitEvidence: SubmitEvidence = bootHasTokenOrCostDelta
+          ? "token_delta"
+          : bootHasTranscriptEcho || cursorShowsSubmittedResponse
+            ? "transcript_echo"
+            : "status_only";
         return {
           submit_verified: true,
+          submit_evidence: submitEvidence,
           submit_verification_reason: null,
           retry_count: retryCount,
           delivery: "submitted",
@@ -5298,6 +5330,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           sawAllowedClearedComposerEvidence = true;
           return {
             submit_verified: true,
+            submit_evidence: "cleared_composer",
             submit_verification_reason: null,
             retry_count: retryCount,
             delivery: "submitted",
@@ -5387,6 +5420,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ) {
         return {
           submit_verified: false,
+          submit_evidence: null,
           submit_verification_reason: "input_still_pending",
           retry_count: retryCount,
           delivery:
@@ -5403,6 +5437,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (sawClearedComposerEvidence && sawAllowedClearedComposerEvidence) {
       return {
         submit_verified: true,
+        submit_evidence: "cleared_composer",
         submit_verification_reason: null,
         retry_count: retryCount,
         delivery: "submitted",
@@ -5434,6 +5469,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (allowPendingVerify && submitVerified === false) {
       return {
         submit_verified: null,
+        submit_evidence: null,
         submit_verification_reason: null,
         retry_count: retryCount,
         delivery: "pending_verify",
@@ -5441,6 +5477,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
     return {
       submit_verified: submitVerified,
+      submit_evidence: null,
       submit_verification_reason: failureReason,
       retry_count: retryCount,
       delivery: "submitted",
@@ -5642,6 +5679,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
     const submittedText = opts.chunks.join("");
     let submit_verified: boolean | null = null;
+    let submit_evidence: SubmitEvidence | null = null;
     let submit_verification_reason: SubmitVerificationFailureReason | null =
       null;
     let retry_count = 0;
@@ -5734,6 +5772,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           beforeMutation: opts.beforeMutation,
         });
         submit_verified = verification.submit_verified;
+        submit_evidence = verification.submit_evidence;
         submit_verification_reason = verification.submit_verification_reason;
         retry_count = verification.retry_count;
         deliveryOutcome = verification.delivery;
@@ -5742,6 +5781,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           deliveryOutcome === "queued_followup"
         ) {
           submit_verified = null;
+          submit_evidence = null;
           submit_verification_reason = null;
         }
       }
@@ -5797,6 +5837,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       typed: bytes > 0,
       submit_attempted: Boolean(opts.press_enter),
       submit_verified,
+      submit_evidence,
       retry_count,
     });
 
@@ -6039,7 +6080,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     timeout_ms: number;
     baseline_metrics?: RawSubmitEvidenceMetrics | null;
     beforeRead?: () => Promise<void>;
-  }): Promise<void> => {
+  }): Promise<SubmitEvidence> => {
     const start = Date.now();
     let lastText = "";
     let lastClearedComposerInput: string | null = null;
@@ -6065,8 +6106,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         // A NULL count stays inconclusive on purpose: several CLIs never
         // report one, and reading unknown as zero would break every boot.
         const consumptionRefuted = metrics.tokenCount === 0;
-        if (!consumptionRefuted && isSubmitVerifiedStatus(snapshot.parsed.status)) {
-          return;
+        if (
+          !consumptionRefuted &&
+          isSubmitVerifiedStatus(snapshot.parsed.status)
+        ) {
+          return "status_only";
         }
 
         const composerInput = extractComposerInputRegion(snapshot.text);
@@ -6079,7 +6123,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !hasPendingInput &&
           hasRawSubmitEvidenceIncrease(metrics, opts.baseline_metrics)
         ) {
-          return;
+          return "token_delta";
         }
 
         const composerCleared =
@@ -6099,7 +6143,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           if (stableClearedComposerPolls >= 2) {
-            return;
+            return "cleared_composer";
           }
         } else {
           lastClearedComposerInput = null;
@@ -6807,8 +6851,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           !snapshot ||
           !screenShowsPendingInput(snapshot.text, sanitizedText)
         ) {
+          let submitEvidence: SubmitEvidence;
           try {
-            await waitForBootPromptSubmitEvidence({
+            submitEvidence = await waitForBootPromptSubmitEvidence({
               surface: deliveryRoute.surface,
               workspace: deliveryRoute.workspace,
               text: sanitizedText,
@@ -6839,6 +6884,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               typed: true,
               submit_attempted: true,
               submit_verified: true,
+              submit_evidence: submitEvidence,
               retry_count: error.retry_count,
             }),
             bytes: Buffer.byteLength(sanitizedText, "utf8"),
@@ -15395,6 +15441,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     typed: delivery.typed,
                     submit_attempted: delivery.submit_attempted,
                     submit_verified: delivery.submit_verified,
+                    submit_evidence: delivery.submit_evidence,
                     retry_count: delivery.retry_count,
                   }),
                   accepted: true,
@@ -15713,6 +15760,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             typed: delivery.typed,
             submit_attempted: delivery.submit_attempted,
             submit_verified: delivery.submit_verified,
+            submit_evidence: delivery.submit_evidence,
             retry_count: delivery.retry_count,
           });
           failedReceiptPayload = { ...publicReceipt };

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -458,15 +458,16 @@ describe("T2 delivery truth — unmissable non-delivery (#445)", () => {
   it("leaves a verified submitted receipt unwarned and keeps an explicit WARNING", async () => {
     const { buildPublicDeliveryReceipt, pausedTargetWarning } =
       await loadServerModule();
-    expect(
-      buildPublicDeliveryReceipt({
-        delivery_state: "submitted",
-        typed: true,
-        submit_attempted: true,
-        submit_verified: true,
-        retry_count: 0,
-      }).WARNING,
-    ).toBeUndefined();
+    const submitted = buildPublicDeliveryReceipt({
+      delivery_state: "submitted",
+      typed: true,
+      submit_attempted: true,
+      submit_verified: true,
+      submit_evidence: "status_only",
+      retry_count: 0,
+    });
+    expect(submitted.WARNING).toBeUndefined();
+    expect(submitted.submit_evidence).toBe("status_only");
     expect(
       buildPublicDeliveryReceipt({
         delivery_state: "queued",
@@ -696,6 +697,7 @@ describe("T2 delivery truth — boot consumption evidence (#427)", () => {
     const parsed = parseToolResult(result);
 
     expect(parsed.boot_prompt_receipt.submit_verified).toBe(true);
+    expect(parsed.boot_prompt_receipt.submit_evidence).toBe("token_delta");
     expect(parsed.boot_prompt_receipt.delivered).toBe(true);
   }, 20_000);
 });
@@ -1038,6 +1040,7 @@ describe("boot-submit readiness and attributable evidence", () => {
       delivered: true,
       delivery_state: "submitted",
       submit_verified: true,
+      submit_evidence: "transcript_echo",
       retry_count: 1,
     });
     expect(harness.returnPresses()).toBe(2);

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -654,6 +654,7 @@ describe("enter reliability", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.delivery).toBe("submitted");
     expect(parsed.submit_verified).toBe(true);
+    expect(parsed.submit_evidence).toBe("cleared_composer");
     expect(parsed.retry_count).toBe(1);
     expect(client.sendCalls.join("")).toHaveLength(2000);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
@@ -691,6 +692,7 @@ describe("enter reliability", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBe(true);
+    expect(parsed.submit_evidence).toBe("cleared_composer");
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -8275,7 +8275,7 @@ describe("agent lifecycle tool handlers", () => {
     const result = await registeredTestTool(server, "send_to").handler(
       {
         text: "Review the P6 receipt set",
-        press_enter: false,
+        press_enter: true,
         targeting: {
           role: "reviewer",
           workspace: "workspace:one",
@@ -8299,7 +8299,7 @@ describe("agent lifecycle tool handlers", () => {
       },
       target_count: 3,
       resolved_target_count: 1,
-      delivered_count: 0,
+      delivered_count: 1,
       failed_count: 0,
       skipped_count: 2,
       receipts: expect.arrayContaining([
@@ -8307,9 +8307,11 @@ describe("agent lifecycle tool handlers", () => {
           requested_agent_id: "reviewer-a",
           agent_id: "reviewer-a",
           resolution: "resolved",
-          delivered: false,
+          delivered: true,
           typed: true,
-          terminal: false,
+          terminal: true,
+          submit_verified: true,
+          submit_evidence: "status_only",
         }),
         expect.objectContaining({
           requested_agent_id: "reviewer-excluded",


### PR DESCRIPTION
## Summary

- add `submit_evidence` to public delivery receipts with `token_delta`, `transcript_echo`, `cleared_composer`, `status_only`, or `null`
- preserve the evidence identity through boot recovery and singular/batch `send_to` receipt construction
- add branch-specific receipt assertions without changing verifier acceptance predicates

## Live diagnostic

An isolated branch-daemon N=3 Codex `boot_prompt_path` run produced `submit_evidence:"transcript_echo"` on all three probes. Every immediate and settled screen was `working` / `busy`, with the payload absent from the active composer and no false-green conjunction. The reported 1/3 failure was not reproduced, so this PR deliberately does not change a verifier acceptance branch.

## Verification

- `bun run test`: 140 files passed; 3217 passed, 1 skipped
- `bun run typecheck`: passed
- direct touched-test syntax compile with `tsc --noEmit --noCheck`: passed
- `bun run build`: passed
- Claude pair review: ACCEPT

Relates to #427. Do not merge until the live false-green case is reproduced and its recorded branch identifies the correct narrow fix.

— cmuxlayerCodex-7d26448d (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-7d26448d","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02467","ts":"2026-08-21T13:23:27Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public delivery-receipt contract and submit-verification plumbing, but does not change which frames count as verified. Residual #427 false-green risk remains until a live branch is reproduced.
> 
> **Overview**
> Adds a nullable `submit_evidence` discriminator on public delivery receipts so callers can see *which* verifier branch certified a submit (`token_delta`, `transcript_echo`, `cleared_composer`, `status_only`).
> 
> The field is threaded from `verifySubmitAfterEnter` and boot-prompt recovery through `buildPublicDeliveryReceipt` and singular/batch `send_to` outputs. Evidence is omitted when `submit_verified` is `null`. **Verifier acceptance predicates are unchanged**; live Codex probes did not reproduce a false-green, so no branch is patched.
> 
> Tests assert the discriminator on representative boot, enter-retry, and targeted-send paths. Relates to #427 as a diagnostic, not a fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114d87c3fe25e3dadacc80965d306c47a5317f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `submit_evidence` discriminator to delivery receipts
> - Introduces an optional nullable `submit_evidence` field on `PublicDeliveryReceipt` and the `DeliveryOutputShape` schema, typed as a union of `'token_delta' | 'transcript_echo' | 'cleared_composer' | 'status_only'`
> - Extends `buildPublicDeliveryReceipt`, `verifySubmitAfterEnter`, `waitForBootPromptSubmitEvidence`, and the send-input/collectDeliveryEvidence/boot-prompt flows to classify and propagate the evidence kind through to returned receipts
> - Evidence is set to `null` for non-attempted, inconclusive, queued, or pending-verify states; otherwise it reflects the strongest observed signal (token delta, transcript echo, cleared composer, or verified status only)
> - Updates tests in `tests/delivery-truth-t2.test.ts`, `tests/enter-reliability.test.ts`, and `tests/server-agent-tools.test.ts` to assert specific `submit_evidence` values
> - Behavioral Change: `DELIVERY_RECEIPT_VOCABULARY` now includes `'submit_evidence'`; any consumer enumerating that array sees the new entry. `waitForBootPromptSubmitEvidence` return type changes from `Promise<void>` to `Promise<SubmitEvidence>`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 114d87c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivery receipts now show how message submission was verified, including token growth, transcript confirmation, composer clearance, or status confirmation.
  * Submission evidence is reported consistently across direct delivery, recovery flows, lifecycle receipts, and targeted messaging.

* **Tests**
  * Expanded coverage verifies evidence reporting for successful submissions, retries, recovery, and targeted delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->