### PR TITLE
fix(wait): match agents already at rest

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7846,12 +7846,19 @@ export class AgentEngine {
       initialState,
     );
     if (initialEvidence) {
+      const stateEstablishedByScreen =
+        initialLive?.source === "screen" && initialState !== initial.state;
       return {
         matched: true,
         state: initialState,
         elapsed: Date.now() - start,
-        source: initialEvidence === "state" ? "immediate" : initialEvidence,
-        agent: toPublicAgent(initial),
+        source:
+          initialEvidence === "state"
+            ? stateEstablishedByScreen
+              ? "screen"
+              : "immediate"
+            : initialEvidence,
+        agent: toPublicAgent({ ...initial, state: initialState }),
       };
     }
 
@@ -7895,9 +7902,31 @@ export class AgentEngine {
         const elapsed = Date.now() - start;
         if (elapsed >= timeoutMs) {
           clearInterval(checkInterval);
-          await this.registry.reconcile({
-            confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
-          });
+          try {
+            await this.registry.reconcile({
+              confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
+            });
+          } catch (error) {
+            const current = this.registry.get(agentId);
+            const failureState = current
+              ? this.terminationStateOf(current, this.liveStateOf(current))
+              : "error";
+            const detail =
+              error instanceof Error ? error.message : String(error);
+            finish({
+              matched: false,
+              state: failureState,
+              elapsed,
+              source: "timeout",
+              agent: current
+                ? toPublicAgent({ ...current, state: failureState })
+                : null,
+              error:
+                `Timed out after ${timeoutMs}ms waiting for state "${targetState}"; ` +
+                `final reconciliation failed: ${detail}`,
+            });
+            return;
+          }
           let current = this.registry.get(agentId);
           // The timeout answer is the one a lead acts on, and it lands after
           // the memo from the last cadence refresh has expired -- so buy one

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -44,6 +44,7 @@ import {
 } from "./agent-registry.js";
 import type { AgentDiscovery } from "./agent-discovery.js";
 import {
+  INTERACTIVE_AGENT_STATES,
   isLiveActive,
   resolveLiveAgentState,
   type LiveAgentState,
@@ -2443,7 +2444,10 @@ export class AgentEngine {
     targetState: AgentState,
     effectiveState: AgentState = agent.state,
   ): Promise<TargetStateEvidenceSource | null> {
-    if (effectiveState !== targetState) return null;
+    const restingStateMatch =
+      INTERACTIVE_AGENT_STATES.has(targetState) &&
+      INTERACTIVE_AGENT_STATES.has(effectiveState);
+    if (effectiveState !== targetState && !restingStateMatch) return null;
     if (!this.requiresOutputDoneEvidence(targetState)) return "state";
     if (await this.hasGroundTruthDone(agent)) return "transcript";
     return this.hasRecordedOutputDoneEvidence(agent) ||
@@ -7892,7 +7896,10 @@ export class AgentEngine {
         const elapsed = Date.now() - start;
         if (elapsed >= timeoutMs) {
           clearInterval(checkInterval);
-          const current = this.registry.get(agentId);
+          await this.registry.reconcile({
+            confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
+          });
+          let current = this.registry.get(agentId);
           // The timeout answer is the one a lead acts on, and it lands after
           // the memo from the last cadence refresh has expired -- so buy one
           // final observation rather than reporting the record by default.
@@ -7901,12 +7908,47 @@ export class AgentEngine {
           const timeoutLive = current
             ? await this.refreshLiveState(current)
             : null;
+          let timeoutState =
+            current && timeoutLive
+              ? this.terminationStateOf(current, timeoutLive)
+              : "error";
+          let refreshedSource: RefreshedTargetStateEvidenceSource | undefined;
+          if (current && targetState === "idle") {
+            const refreshed = await this.refreshTargetStateEvidence(
+              current,
+              targetState,
+              waitForReadyPatternMatches,
+              timeoutState,
+            );
+            current = refreshed.agent;
+            refreshedSource = refreshed.source;
+            timeoutState =
+              refreshed.source === "screen"
+                ? current.state
+                : this.terminationStateOf(current, this.liveStateOf(current));
+          }
+          const timeoutEvidence = current && targetState === "idle"
+            ? await this.getTargetStateEvidenceSource(
+                current,
+                targetState,
+                timeoutState,
+              )
+            : null;
+          if (current && timeoutEvidence) {
+            finish({
+              matched: true,
+              state: timeoutState,
+              elapsed,
+              source:
+                refreshedSource ??
+                (timeoutEvidence === "state" ? "sweep" : timeoutEvidence),
+              agent: toPublicAgent({ ...current, state: timeoutState }),
+            });
+            return;
+          }
           finish({
             matched: false,
-            state:
-              current && timeoutLive
-                ? this.terminationStateOf(current, timeoutLive)
-                : "error",
+            state: timeoutState,
             elapsed,
             source: "timeout",
             agent: current ? toPublicAgent(current) : null,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -735,7 +735,6 @@ export interface RolePlacementReconcileSummary {
 
 export type AgentLifecycleEvent = "spawned" | "done" | "errored" | "health";
 
-const INTERACTIVE_STATES = new Set<AgentState>(["ready", "idle"]);
 const TERMINAL_STATES = new Set<AgentState>(["done", "error"]);
 const WAIT_FOR_SWEEP_INTERVAL_MS = 1000;
 /** One retry: a watch observation must not read a transient failure as absence. */
@@ -7951,7 +7950,9 @@ export class AgentEngine {
             state: timeoutState,
             elapsed,
             source: "timeout",
-            agent: current ? toPublicAgent(current) : null,
+            agent: current
+              ? toPublicAgent({ ...current, state: timeoutState })
+              : null,
             error: `Timed out after ${timeoutMs}ms waiting for state "${targetState}"`,
           });
           return;
@@ -8918,10 +8919,10 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    if (!INTERACTIVE_STATES.has(agent.state)) {
+    if (!INTERACTIVE_AGENT_STATES.has(agent.state)) {
       throw new Error(
         `Agent "${agentId}" is not in an interactive state (current: ${agent.state}). ` +
-          `Must be in: ${[...INTERACTIVE_STATES].join(", ")}`,
+          `Must be in: ${[...INTERACTIVE_AGENT_STATES].join(", ")}`,
       );
     }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7941,7 +7941,15 @@ export class AgentEngine {
               ? this.terminationStateOf(current, timeoutLive)
               : "error";
           let refreshedSource: RefreshedTargetStateEvidenceSource | undefined;
-          if (current && targetState === "idle") {
+          const finalReadyNeedsAnotherConsecutiveObservation =
+            current !== null &&
+            targetState === "ready" &&
+            matchReadyPattern(current.cli, "").consecutive > 1;
+          if (
+            current &&
+            INTERACTIVE_AGENT_STATES.has(targetState) &&
+            !finalReadyNeedsAnotherConsecutiveObservation
+          ) {
             const refreshed = await this.refreshTargetStateEvidence(
               current,
               targetState,
@@ -7955,7 +7963,24 @@ export class AgentEngine {
                 ? current.state
                 : this.terminationStateOf(current, this.liveStateOf(current));
           }
-          const timeoutEvidence = current && targetState === "idle"
+          const timeoutStateEstablishedByScreen =
+            current !== null &&
+            timeoutLive?.source === "screen" &&
+            timeoutState !== current.state;
+          const singleObservationReadyIsSafe =
+            current !== null &&
+            targetState === "ready" &&
+            timeoutStateEstablishedByScreen &&
+            matchReadyPattern(current.cli, "").consecutive === 1;
+          const timeoutInteractiveEvidenceIsGated =
+            targetState === "idle" ||
+            refreshedSource !== undefined ||
+            (current !== null && INTERACTIVE_AGENT_STATES.has(current.state)) ||
+            singleObservationReadyIsSafe;
+          const timeoutEvidence =
+            current &&
+            INTERACTIVE_AGENT_STATES.has(targetState) &&
+            timeoutInteractiveEvidenceIsGated
             ? await this.getTargetStateEvidenceSource(
                 current,
                 targetState,
@@ -7969,7 +7994,11 @@ export class AgentEngine {
               elapsed,
               source:
                 refreshedSource ??
-                (timeoutEvidence === "state" ? "sweep" : timeoutEvidence),
+                (timeoutEvidence === "state"
+                  ? timeoutStateEstablishedByScreen
+                    ? "screen"
+                    : "sweep"
+                  : timeoutEvidence),
               agent: toPublicAgent({ ...current, state: timeoutState }),
             });
             return;
@@ -8038,6 +8067,8 @@ export class AgentEngine {
           liveState,
         );
         if (evidenceSource) {
+          const stateEstablishedByScreen =
+            live?.source === "screen" && liveState !== current.state;
           clearInterval(checkInterval);
           finish({
             matched: true,
@@ -8045,8 +8076,12 @@ export class AgentEngine {
             elapsed,
             source:
               refreshed.source ??
-              (evidenceSource === "state" ? "sweep" : evidenceSource),
-            agent: toPublicAgent(current),
+              (evidenceSource === "state"
+                ? stateEstablishedByScreen
+                  ? "screen"
+                  : "sweep"
+                : evidenceSource),
+            agent: toPublicAgent({ ...current, state: liveState }),
           });
           return;
         }

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -270,6 +270,50 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     expect(result.elapsed).toBeLessThan(1_000);
   });
 
+  it("attributes a cross-resting match to the screen and aligns the embedded state", async () => {
+    stateMgr.writeState(makeRecord({ state: "working", cli: "codex" }));
+    await engine.getRegistry().reconstitute();
+    engine.setLiveStateResolver(restingCodexProbe);
+
+    const result = await engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      20_000,
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("ready");
+    expect(result.source).toBe("screen");
+    expect(result.agent?.state).toBe("ready");
+  });
+
+  it("resolves a bounded failure when final timeout reconciliation throws", async () => {
+    vi.useFakeTimers();
+    stateMgr.writeState(makeRecord({ state: "working" }));
+    await engine.getRegistry().reconstitute();
+    engine.setLiveStateResolver(workingScreenProbe);
+    vi.spyOn(engine.getRegistry(), "reconcile").mockRejectedValueOnce(
+      new Error("state disk unavailable"),
+    );
+
+    const pending = engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      500,
+    );
+    const hung = new Promise<"hung">((resolve) => {
+      setTimeout(() => resolve("hung"), 2_500);
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await Promise.race([pending, hung]);
+
+    expect(result).not.toBe("hung");
+    if (result === "hung") return;
+    expect(result.matched).toBe(false);
+    expect(result.source).toBe("timeout");
+    expect(result.error).toContain("state disk unavailable");
+  });
+
   it("matches final resting evidence instead of timing out beside an idle observation", async () => {
     vi.useFakeTimers();
     engine.dispose();

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -518,6 +518,7 @@ describe("F1b round 2 — the wait buys its own evidence instead of hoping the c
     expect(result.source).toBe("timeout");
     expect(result.elapsed).toBeGreaterThanOrEqual(1_500);
     expect(result.state).toBe("working");
+    expect(result.agent?.state).toBe("working");
     expect(result.error).not.toBe("Agent has already completed");
   });
 

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -314,6 +314,79 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     expect(result.error).toContain("state disk unavailable");
   });
 
+  it("matches a ready target from gated final screen evidence", async () => {
+    vi.useFakeTimers();
+    engine.dispose();
+    buildEngine(
+      makeMockClient({
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:worker",
+          text: RESTING_CODEX_SCREEN,
+          lines: 30,
+          scrollback_used: false,
+        }),
+      } as Partial<CmuxClient>),
+    );
+    stateMgr.writeState(makeRecord({ state: "booting", cli: "codex" }));
+    await engine.getRegistry().reconstitute();
+    const freshProbe = vi
+      .fn()
+      .mockImplementationOnce(async (agent: AgentRecord) =>
+        workingScreenProbe(agent),
+      )
+      .mockImplementation(async (agent: AgentRecord) =>
+        restingCodexProbe(agent),
+      );
+    engine.setFreshLiveStateProbe(freshProbe);
+
+    const pending = engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "ready",
+      500,
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    const result = await pending;
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("ready");
+    expect(result.source).toBe("screen");
+    expect(result.agent?.state).toBe("ready");
+  });
+
+  it("preserves screen provenance and state on a polling cross-rest match", async () => {
+    vi.useFakeTimers();
+    engine.dispose();
+    buildEngine(
+      makeMockClient({
+        readScreen: vi.fn().mockRejectedValue(new Error("screen write race")),
+      } as Partial<CmuxClient>),
+    );
+    stateMgr.writeState(makeRecord({ state: "working", cli: "codex" }));
+    await engine.getRegistry().reconstitute();
+    const freshProbe = vi
+      .fn()
+      .mockImplementationOnce(async (agent: AgentRecord) =>
+        workingScreenProbe(agent),
+      )
+      .mockImplementation(async (agent: AgentRecord) =>
+        restingCodexProbe(agent),
+      );
+    engine.setFreshLiveStateProbe(freshProbe);
+
+    const pending = engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      5_000,
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await pending;
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("ready");
+    expect(result.source).toBe("screen");
+    expect(result.agent?.state).toBe("ready");
+  });
+
   it("matches final resting evidence instead of timing out beside an idle observation", async () => {
     vi.useFakeTimers();
     engine.dispose();

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -32,7 +32,18 @@ const WORKING_SCREEN = [
   "╰──────────────────────────────────────────────╯",
 ].join("\n");
 
-function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
+const RESTING_CODEX_SCREEN = [
+  ">_ OpenAI Codex",
+  "› Ask Codex to do anything",
+  "",
+  "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+].join("\n");
+
+type TestEngineClient = CmuxClient & {
+  notifyLifecycleEvent: ReturnType<typeof vi.fn>;
+};
+
+function makeMockClient(overrides?: Partial<CmuxClient>): TestEngineClient {
   return {
     newSplit: vi.fn(),
     newSurface: vi.fn(),
@@ -96,8 +107,9 @@ function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
     identify: vi.fn().mockResolvedValue({}),
     browser: vi.fn().mockResolvedValue({}),
     log: vi.fn(),
+    notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
     ...overrides,
-  } as unknown as CmuxClient;
+  } as unknown as TestEngineClient;
 }
 
 function makeSurface(ref: string): CmuxSurface {
@@ -125,9 +137,6 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
     deletion_intent: false,
     quality: "unknown",
     max_cost_per_agent: null,
-    crash_recover: false,
-    respawn_attempts: 0,
-    user_killed: false,
     ...overrides,
   };
 }
@@ -140,12 +149,20 @@ const workingScreenProbe = (agent: AgentRecord) =>
     control_state: "busy",
   });
 
+/** A Codex pane at rest: the screen says idle while live state normalises ready. */
+const restingCodexProbe = (agent: AgentRecord) =>
+  resolveLiveAgentState(agent, {
+    status: "idle",
+    agent_type: "codex",
+    control_state: "ready",
+  });
+
 describe("F1b #473 — wait_for terminates on live state, never on a contradicted record", () => {
   let stateMgr: StateManager;
   let engine: AgentEngine;
   let liveSurfaces: CmuxSurface[];
 
-  const buildEngine = (client?: CmuxClient): void => {
+  const buildEngine = (client?: TestEngineClient): void => {
     stateMgr = new StateManager(TEST_DIR);
     liveSurfaces = [makeSurface("surface:worker")];
     const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
@@ -235,6 +252,68 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     expect(result.matched).toBe(false);
     expect(result.state).toBe("working");
   });
+
+  it("matches target idle immediately when a Codex agent is already resting at ready", async () => {
+    stateMgr.writeState(makeRecord({ state: "ready", cli: "codex" }));
+    await engine.getRegistry().reconstitute();
+    engine.setLiveStateResolver(restingCodexProbe);
+
+    const result = await engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      20_000,
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("ready");
+    expect(result.source).toBe("immediate");
+    expect(result.elapsed).toBeLessThan(1_000);
+  });
+
+  it("matches final resting evidence instead of timing out beside an idle observation", async () => {
+    vi.useFakeTimers();
+    engine.dispose();
+    buildEngine(
+      makeMockClient({
+        readScreen: vi.fn().mockResolvedValue({
+          surface: "surface:worker",
+          text: RESTING_CODEX_SCREEN,
+          lines: 30,
+          scrollback_used: false,
+        }),
+      } as Partial<CmuxClient>),
+    );
+    liveSurfaces = [{ ...makeSurface("surface:worker"), id: "uuid-worker" }];
+    stateMgr.writeState(
+      makeRecord({
+        state: "working",
+        cli: "codex",
+        surface_uuid: "uuid-worker",
+      }),
+    );
+    await engine.getRegistry().reconstitute();
+    engine.setLiveStateResolver(workingScreenProbe);
+    // The live resolver remains stale-working even after the final direct
+    // screen read sees rest. The screen-backed transition must win.
+    const freshProbe = vi.fn(async (agent: AgentRecord) =>
+      workingScreenProbe(agent),
+    );
+    engine.setFreshLiveStateProbe(freshProbe);
+
+    const pending = engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      500,
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    const result = await pending;
+
+    expect(result.matched).toBe(true);
+    expect(result.state).toBe("idle");
+    expect(result.source).toBe("screen");
+    expect(result.agent?.state).toBe("idle");
+    expect(result.error).toBeUndefined();
+  });
 });
 
 describe("F1b #472 — a watch arms on any observable agent", () => {
@@ -242,7 +321,7 @@ describe("F1b #472 — a watch arms on any observable agent", () => {
   let engine: AgentEngine;
   let liveSurfaces: CmuxSurface[];
 
-  const buildEngine = (client?: CmuxClient): void => {
+  const buildEngine = (client?: TestEngineClient): void => {
     stateMgr = new StateManager(TEST_DIR);
     liveSurfaces = [makeSurface("surface:worker")];
     const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
@@ -349,7 +428,13 @@ describe("F1b #472 — a watch arms on any observable agent", () => {
       name: "WatchArmError",
       code: "watch_target_missing",
     });
-    const error = await engine.armWatch(spec("idle")).catch((e) => e as WatchArmError);
+    let error: WatchArmError | null = null;
+    try {
+      await engine.armWatch(spec("idle"));
+    } catch (caught) {
+      error = caught as WatchArmError;
+    }
+    if (!error) throw new Error("Expected watch arm to fail");
     expect(error.message).not.toContain("does not exist");
     expect(error.message).toContain("voicelayerClaude-2ac0d960");
     expect(error.message).toMatch(/no registry or state record/i);
@@ -394,7 +479,7 @@ describe("F1b round 2 — the wait buys its own evidence instead of hoping the c
   let engine: AgentEngine;
   let liveSurfaces: CmuxSurface[];
 
-  const buildEngine = (client?: CmuxClient): void => {
+  const buildEngine = (client?: TestEngineClient): void => {
     stateMgr = new StateManager(TEST_DIR);
     liveSurfaces = [makeSurface("surface:worker")];
     const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);


### PR DESCRIPTION
## Summary

- Treat `ready` and `idle` as equivalent resting states when evaluating `wait_for` targets. This is intentionally bidirectional: Codex can expose an idle screen while the registry normalizes that state to ready, and compatibility avoids rejecting existing callers that use either value.
- On an `idle` timeout boundary, reconcile the registry and recheck final screen/live evidence before returning a timeout, while keeping the returned source and embedded agent state consistent with the evidence.
- Preserve the existing done-poison fail-safe and Kiro consecutive-ready behavior.

Closes #513.

## Verification

- RED: focused tests failed for an already-resting Codex agent and for final resting evidence observed at the timeout boundary.
- GREEN: `tests/f1b-wait-for-watch-live-state.test.ts` — 29/29 passed.
- `bun run test` — 140 files passed; 3223 passed, 1 skipped.
- `bun run typecheck` — passed.
- Direct strict compile of the touched test file — passed.
- Live throwaway proof: after independently observing the agent screen at `idle` with registry state `ready`, `wait_for(state: "idle", timeout_ms: 20000)` matched immediately in 38 ms engine time / 80.9 ms wall time.

## Review notes

- Claude's initial pair review returned approve-with-fixes. Its source-label, timeout-reconciliation, embedded-state, and shared-state-set findings were addressed. A final Claude rerun was blocked by the account's visible spend-limit picker; no billing action or key submission was attempted.
- Local and remote CodeRabbit findings for stale live-state overwrite, timeout result consistency, and the duplicate interactive-state set were reproduced and fixed. The latest incremental pass was rate-limited.
- Codex review ran three rounds. Its screen provenance, bounded reconciliation failure, ready-at-deadline, and polling cross-rest findings were reproduced and fixed with regression tests; every review thread is resolved. The final logic preserves Kiro/Gemini consecutive-ready safety.

— cmuxlayerCodex-4674d93a (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-4674d93a","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0249f","ts":"2026-08-21T14:27:01Z"} -->
