### PR TITLE
fix(lifecycle): preserve live agent identity through topology gaps

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8348,6 +8348,61 @@ export class AgentEngine {
     return this.resolveAgentRoute(agent.agent_id);
   }
 
+  /**
+   * Stop/close must remain usable in socketless CLI mode. When observer
+   * identity is unavailable, require a complete fresh topology to prove the
+   * record's exact stable UUID instead of trusting its mutable surface ref.
+   * This fallback is deliberately scoped to teardown; other terminal I/O
+   * keeps the observer-ownership gate.
+   */
+  private async resolveAgentStopIoRoute(agentId: string): Promise<AgentRoute> {
+    if (
+      !this.registry.isObserverOwnershipEnforced() ||
+      this.registry.getObserverEpoch()
+    ) {
+      return this.resolveAgentIoRoute(agentId);
+    }
+
+    let agent = this.registry.get(agentId);
+    if (!agent) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    if (!agent.surface_uuid) {
+      return this.resolveAgentIoRoute(agentId);
+    }
+
+    const topology = await collectSurfaceTopology(this.client);
+    const binding = resolveAgentSurfaceBinding(agent, topology);
+    if (
+      topology?.complete !== true ||
+      !binding ||
+      binding.provenance !== "uuid" ||
+      topology.surfaceIdByRef.get(binding.surfaceRef)?.trim().toLowerCase() !==
+        agent.surface_uuid.trim().toLowerCase()
+    ) {
+      throw new Error(
+        `Observer identity is unavailable and fresh complete topology did not ` +
+          `prove stable surface UUID ${agent.surface_uuid} for agent ` +
+          `"${agent.agent_id}"; refusing teardown through mutable ref ` +
+          `${agent.surface_id}.`,
+      );
+    }
+
+    const workspaceId = binding.workspaceId ?? agent.workspace_id ?? null;
+    const patch: Partial<AgentRecord> = {};
+    if (agent.surface_id !== binding.surfaceRef) {
+      patch.surface_id = binding.surfaceRef;
+    }
+    if ((agent.workspace_id ?? null) !== workspaceId) {
+      patch.workspace_id = workspaceId;
+    }
+    if (Object.keys(patch).length > 0) {
+      agent = this.stateMgr.updateRecord(agent.agent_id, patch);
+      this.registry.set(agent.agent_id, agent);
+    }
+    return this.resolveAgentRoute(agent.agent_id);
+  }
+
   private async resolvePaneForSurface(
     surfaceId: string,
     workspaceId?: string | null,
@@ -8521,6 +8576,21 @@ export class AgentEngine {
     return route;
   }
 
+  private async resolveUnchangedAgentStopIoRoute(
+    agentId: string,
+    expectedRoute: AgentRoute,
+    operation: string,
+  ): Promise<AgentRoute> {
+    const route = await this.resolveAgentStopIoRoute(agentId);
+    if (!this.sameSurfaceRoute(expectedRoute, route)) {
+      throw new Error(
+        `Agent "${agentId}" surface route changed during ${operation}; ` +
+          `refusing stale terminal evidence or mutation.`,
+      );
+    }
+    return route;
+  }
+
   private processLiveness(pid: number | null | undefined): ProcessLiveness {
     return processLiveness(pid);
   }
@@ -8595,12 +8665,18 @@ export class AgentEngine {
     }
 
     try {
-      if (!this.registry.canControlSurface(agent)) return false;
-      const topology = await this.collectObservedSurfaceTopology();
+      const observerOwnsRecord = this.registry.canControlSurface(agent);
+      if (!observerOwnsRecord && this.registry.getObserverEpoch()) {
+        // A known but different observer cannot prove this record absent.
+        return false;
+      }
+      const topology = observerOwnsRecord
+        ? await this.collectObservedSurfaceTopology()
+        : await collectSurfaceTopology(this.client);
       if (
         topology?.complete !== true ||
         topology.workspaceBySurface.size === 0 ||
-        !this.registry.canControlSurface(agent)
+        (observerOwnsRecord && !this.registry.canControlSurface(agent))
       ) {
         return false;
       }
@@ -8728,7 +8804,7 @@ export class AgentEngine {
       return; // Already stopped
     }
 
-    let route = await this.resolveAgentIoRoute(canonicalAgentId);
+    let route = await this.resolveAgentStopIoRoute(canonicalAgentId);
     agent = this.registry.get(canonicalAgentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
@@ -8738,13 +8814,13 @@ export class AgentEngine {
       route.surface_id,
       route.workspace_id,
     );
-    let finalRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+    let finalRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
     if (!this.sameSurfaceRoute(route, finalRoute)) {
       stopClosePolicy = await this.resolveStopSurfaceClosePolicy(
         finalRoute.surface_id,
         finalRoute.workspace_id,
       );
-      const confirmedRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+      const confirmedRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(finalRoute, confirmedRoute)) {
         throw new Error(
           `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +
@@ -8759,7 +8835,7 @@ export class AgentEngine {
       throw new Error(`Agent not found: ${agentId}`);
     }
     await opts?.beforeSurfaceMutation?.(route);
-    const mutationRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+    const mutationRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
     if (!this.sameSurfaceRoute(route, mutationRoute)) {
       throw new Error(
         `Agent "${canonicalAgentId}" surface route changed during the ` +
@@ -8772,7 +8848,7 @@ export class AgentEngine {
         route.surface_id,
         route.workspace_id,
       );
-      const closeRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+      const closeRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(route, closeRoute)) {
         throw new Error(
           `Agent "${canonicalAgentId}" surface route changed while refreshing ` +
@@ -8819,7 +8895,7 @@ export class AgentEngine {
     } else {
       // Graceful: send Ctrl+C
       const assertSignalRouteCurrent = async (): Promise<void> => {
-        await this.resolveUnchangedAgentIoRoute(
+        await this.resolveUnchangedAgentStopIoRoute(
           canonicalAgentId,
           route,
           "Ctrl+C",
@@ -8842,7 +8918,7 @@ export class AgentEngine {
     // after the signal so a recycled ref is never closed by mistake.
     let closeRoute: AgentRoute | null = null;
     try {
-      closeRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+      closeRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
     } catch (error) {
       if (!(await this.isAgentSurfaceGone(agent))) {
         throw error;
@@ -8856,14 +8932,14 @@ export class AgentEngine {
         closeRoute.workspace_id,
       );
       let confirmedCloseRoute =
-        await this.resolveAgentIoRoute(canonicalAgentId);
+        await this.resolveAgentStopIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(closeRoute, confirmedCloseRoute)) {
         closeRoute = confirmedCloseRoute;
         stopClosePolicy = await this.resolveStopSurfaceClosePolicy(
           closeRoute.surface_id,
           closeRoute.workspace_id,
         );
-        confirmedCloseRoute = await this.resolveAgentIoRoute(canonicalAgentId);
+        confirmedCloseRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
         if (!this.sameSurfaceRoute(closeRoute, confirmedCloseRoute)) {
           throw new Error(
             `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +
@@ -8878,7 +8954,7 @@ export class AgentEngine {
       }
 
       const assertCloseRouteCurrent = async (): Promise<void> => {
-        await this.resolveUnchangedAgentIoRoute(
+        await this.resolveUnchangedAgentStopIoRoute(
           canonicalAgentId,
           route,
           "surface close",

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -245,8 +245,8 @@ import {
   type FleetSidebarPublisherLike,
 } from "./fleet-sidebar.js";
 import {
+  agentProcessMayBeAlive,
   processLiveness,
-  processMayBeAlive,
   type ProcessLiveness,
 } from "./process-liveness.js";
 
@@ -487,6 +487,8 @@ type CreatedAgentSurface = AgentSurfacePlacement & {
 export interface CapturedSessionIdentity {
   session_id: string;
   path?: string | null;
+  pid?: number | null;
+  pid_registered_at?: string | null;
 }
 
 export type SessionIdentityResolver = (
@@ -3154,7 +3156,16 @@ export class AgentEngine {
     if (typeof identity === "string") {
       return { session_id: identity, path: null };
     }
-    return { session_id: identity.session_id, path: identity.path ?? null };
+    return {
+      session_id: identity.session_id,
+      path: identity.path ?? null,
+      ...(identity.pid && identity.pid > 0 && identity.pid_registered_at
+        ? {
+            pid: identity.pid,
+            pid_registered_at: identity.pid_registered_at,
+          }
+        : {}),
+    };
   }
 
   private rekeyAgentMapEntry<T>(
@@ -3254,6 +3265,14 @@ export class AgentEngine {
     let updated = this.stateMgr.updateRecord(agent.agent_id, {
       cli_session_id: identity.session_id,
       cli_session_path: identity.path,
+      ...(agent.surface_provenance === "cmuxlayer_spawn" &&
+      identity.pid &&
+      identity.pid_registered_at
+        ? {
+            pid: identity.pid,
+            pid_registered_at: identity.pid_registered_at,
+          }
+        : {}),
       transcript_session_capture_deferred: false,
       transcript_session_capture_attempts: 0,
     });
@@ -3412,6 +3431,29 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
+      if (
+        !agent.pid &&
+        this.selfRegistrationSessionResolver &&
+        TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state) &&
+        JSONL_HARNESSES.has(agent.cli) &&
+        agent.surface_uuid?.trim()
+      ) {
+        try {
+          const registered = this.selfRegistrationSessionResolver(agent);
+          if (registered) {
+            const identity = this.normalizeCapturedSessionIdentity(registered);
+            if (
+              identity.session_id === agent.cli_session_id &&
+              identity.pid &&
+              identity.pid_registered_at
+            ) {
+              agent = this.finalizeCapturedSession(agent, identity);
+            }
+          }
+        } catch {
+          // Session identity is already durable; retry process evidence later.
+        }
+      }
       if (
         agent.transcript_session_capture_deferred === true ||
         (agent.transcript_session_capture_attempts ?? 0) > 0
@@ -7657,22 +7699,22 @@ export class AgentEngine {
    */
   async resumeAgent(
     agentId: string,
-    opts?: { workspace?: string },
+    opts?: { workspace?: string; force?: boolean },
   ): Promise<SpawnAgentResult> {
     const agent =
       this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
-    if (processMayBeAlive(agent.pid)) {
-      throw new Error(
-        `Agent "${agent.agent_id}" cannot resume while recorded pid ` +
-          `${agent.pid} is still alive or cannot be proven gone`,
-      );
-    }
     if (!TERMINAL_STATES.has(agent.state)) {
       throw new Error(
         `Agent "${agent.agent_id}" is ${agent.state}; explicit resume requires a terminal agent`,
+      );
+    }
+    if (!opts?.force && agentProcessMayBeAlive(agent)) {
+      throw new Error(
+        `Agent "${agent.agent_id}" cannot resume while recorded pid ` +
+          `${agent.pid} is still alive or cannot be proven gone`,
       );
     }
     if (!agent.cli_session_id) {
@@ -8300,7 +8342,7 @@ export class AgentEngine {
     const topology = await this.collectObservedSurfaceTopology();
     const binding = resolveAgentSurfaceBinding(agent, topology);
     if (!binding || binding.provenance !== "uuid") {
-      if (processMayBeAlive(agent.pid)) {
+      if (agentProcessMayBeAlive(agent)) {
         throw new Error(
           `Agent "${agent.agent_id}" still has live recorded pid ${agent.pid}; ` +
             `the current topology did not prove its surface route, so its ` +
@@ -8369,6 +8411,13 @@ export class AgentEngine {
     }
     if (!agent.surface_uuid) {
       return this.resolveAgentIoRoute(agentId);
+    }
+    if (agent.surface_observer_id) {
+      throw new Error(
+        `Observer identity is unavailable and agent "${agent.agent_id}" is ` +
+          `owned by ${agent.surface_observer_id}; refusing socketless teardown ` +
+          `without matching observer ownership.`,
+      );
     }
 
     const topology = await collectSurfaceTopology(this.client);
@@ -8668,6 +8717,9 @@ export class AgentEngine {
       const observerOwnsRecord = this.registry.canControlSurface(agent);
       if (!observerOwnsRecord && this.registry.getObserverEpoch()) {
         // A known but different observer cannot prove this record absent.
+        return false;
+      }
+      if (!observerOwnsRecord && agent.surface_observer_id) {
         return false;
       }
       const topology = observerOwnsRecord

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -245,6 +245,7 @@ import {
   type FleetSidebarPublisherLike,
 } from "./fleet-sidebar.js";
 import {
+  agentProcessLiveness,
   agentProcessMayBeAlive,
   processLiveness,
   type ProcessLiveness,
@@ -3441,15 +3442,9 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
-      if (
-        !agent.pid &&
-        this.selfRegistrationSessionResolver &&
-        TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state) &&
-        JSONL_HARNESSES.has(agent.cli) &&
-        agent.surface_uuid?.trim()
-      ) {
+      if (!agent.pid && this.canUseSelfRegistrationSessionResolver(agent)) {
         try {
-          const registered = this.selfRegistrationSessionResolver(agent);
+          const registered = this.selfRegistrationSessionResolver?.(agent);
           if (registered) {
             const identity = this.normalizeCapturedSessionIdentity(registered);
             if (
@@ -7721,7 +7716,11 @@ export class AgentEngine {
         `Agent "${agent.agent_id}" is ${agent.state}; explicit resume requires a terminal agent`,
       );
     }
-    if (!opts?.force && agentProcessMayBeAlive(agent)) {
+    const recordedProcessLiveness = agentProcessLiveness(agent);
+    if (
+      recordedProcessLiveness === "alive" ||
+      (recordedProcessLiveness === "unknown" && !opts?.force)
+    ) {
       throw new Error(
         `Agent "${agent.agent_id}" cannot resume while recorded pid ` +
           `${agent.pid} is still alive or cannot be proven gone`,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -244,8 +244,11 @@ import {
   type FleetSidebarCandidate,
   type FleetSidebarPublisherLike,
 } from "./fleet-sidebar.js";
-
-type ProcessLiveness = "alive" | "gone" | "unknown";
+import {
+  processLiveness,
+  processMayBeAlive,
+  type ProcessLiveness,
+} from "./process-liveness.js";
 
 export type AgentDeliveryState =
   | "submitted"
@@ -7661,6 +7664,12 @@ export class AgentEngine {
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
+    if (processMayBeAlive(agent.pid)) {
+      throw new Error(
+        `Agent "${agent.agent_id}" cannot resume while recorded pid ` +
+          `${agent.pid} is still alive or cannot be proven gone`,
+      );
+    }
     if (!TERMINAL_STATES.has(agent.state)) {
       throw new Error(
         `Agent "${agent.agent_id}" is ${agent.state}; explicit resume requires a terminal agent`,
@@ -8291,6 +8300,13 @@ export class AgentEngine {
     const topology = await this.collectObservedSurfaceTopology();
     const binding = resolveAgentSurfaceBinding(agent, topology);
     if (!binding || binding.provenance !== "uuid") {
+      if (processMayBeAlive(agent.pid)) {
+        throw new Error(
+          `Agent "${agent.agent_id}" still has live recorded pid ${agent.pid}; ` +
+            `the current topology did not prove its surface route, so its ` +
+            `engine-issued identity is retained and terminal I/O is deferred.`,
+        );
+      }
       throw new Error(
         `Stable surface UUID ${agent.surface_uuid} for agent ` +
           `"${agent.agent_id}" is not live or uniquely resolvable in a ` +
@@ -8506,21 +8522,7 @@ export class AgentEngine {
   }
 
   private processLiveness(pid: number | null | undefined): ProcessLiveness {
-    if (!pid) return "gone";
-    try {
-      process.kill(pid, 0);
-      return "alive";
-    } catch (error) {
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "code" in error &&
-        (error as { code?: unknown }).code === "ESRCH"
-      ) {
-        return "gone";
-      }
-      return "unknown";
-    }
+    return processLiveness(pid);
   }
 
   private isProcessMissingError(error: unknown): boolean {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3262,17 +3262,21 @@ export class AgentEngine {
     capturedIdentity: CapturedSessionIdentity | string,
   ): AgentRecord {
     const identity = this.normalizeCapturedSessionIdentity(capturedIdentity);
+    const hasCapturedProcessEvidence = Boolean(
+      agent.surface_provenance === "cmuxlayer_spawn" &&
+        identity.pid &&
+        identity.pid_registered_at,
+    );
+    const capturedProcessEvidence = hasCapturedProcessEvidence
+      ? {
+          pid: identity.pid!,
+          pid_registered_at: identity.pid_registered_at!,
+        }
+      : {};
     let updated = this.stateMgr.updateRecord(agent.agent_id, {
       cli_session_id: identity.session_id,
-      cli_session_path: identity.path,
-      ...(agent.surface_provenance === "cmuxlayer_spawn" &&
-      identity.pid &&
-      identity.pid_registered_at
-        ? {
-            pid: identity.pid,
-            pid_registered_at: identity.pid_registered_at,
-          }
-        : {}),
+      cli_session_path: identity.path ?? agent.cli_session_path ?? null,
+      ...capturedProcessEvidence,
       transcript_session_capture_deferred: false,
       transcript_session_capture_attempts: 0,
     });
@@ -3317,15 +3321,21 @@ export class AgentEngine {
       }
       const sessionPath =
         identity.path ?? existingFinal.cli_session_path ?? null;
+      const processEvidenceMatches =
+        !hasCapturedProcessEvidence ||
+        (existingFinal.pid === identity.pid &&
+          existingFinal.pid_registered_at === identity.pid_registered_at);
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
         existingFinal.cli_session_path === sessionPath &&
+        processEvidenceMatches &&
         existingFinal.transcript_session_capture_deferred !== true &&
         (existingFinal.transcript_session_capture_attempts ?? 0) === 0
           ? existingFinal
           : this.stateMgr.updateRecord(finalAgentId, {
               cli_session_id: identity.session_id,
               cli_session_path: sessionPath,
+              ...capturedProcessEvidence,
               transcript_session_capture_deferred: false,
               transcript_session_capture_attempts: 0,
             });
@@ -8417,6 +8427,20 @@ export class AgentEngine {
         `Observer identity is unavailable and agent "${agent.agent_id}" is ` +
           `owned by ${agent.surface_observer_id}; refusing socketless teardown ` +
           `without matching observer ownership.`,
+      );
+    }
+    const normalizedSurfaceUuid = agent.surface_uuid.trim().toLowerCase();
+    const routedAgentId = agent.agent_id;
+    const competingRecord = this.registry.list().find(
+      (candidate) =>
+        candidate.agent_id !== routedAgentId &&
+        candidate.surface_uuid?.trim().toLowerCase() === normalizedSurfaceUuid,
+    );
+    if (competingRecord) {
+      throw new Error(
+        `Agent "${agent.agent_id}" cannot use socketless teardown because ` +
+          `stable surface UUID ${agent.surface_uuid} is also claimed by ` +
+          `agent "${competingRecord.agent_id}".`,
       );
     }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -2061,10 +2061,29 @@ export class AgentRegistry {
     const liveSurfaceRefs = new Set(
       discovered.map((entry) => entry.surface_id),
     );
-    const candidates = discovered.map((entry) =>
-      entry.read_error
-        ? null
-        : this.repairCandidateForDiscovery(entry, opts?.seatRegistry),
+
+    for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
+      evicted.add(removed);
+    }
+
+    const repairEligible = discovered.map((entry) => {
+      if (entry.read_error) return false;
+      if (!opts?.orphansOnly) return true;
+      const surfaceRecords = [...this.agents.values()].filter(
+        (record) => record.surface_id === entry.surface_id,
+      );
+      return (
+        surfaceRecords.length === 0 ||
+        surfaceRecords.some(
+          (record) =>
+            isAutoAgentId(record.agent_id) || isPendingAgentId(record.agent_id),
+        )
+      );
+    });
+    const candidates = discovered.map((entry, index) =>
+      repairEligible[index]
+        ? this.repairCandidateForDiscovery(entry, opts?.seatRegistry)
+        : null,
     );
     const candidateCounts = new Map<string, number>();
     for (const candidate of candidates) {
@@ -2080,25 +2099,8 @@ export class AgentRegistry {
       }
     }
 
-    for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
-      evicted.add(removed);
-    }
-
     for (const [entryIndex, entry] of discovered.entries()) {
-      if (entry.read_error) continue;
-      if (opts?.orphansOnly) {
-        const surfaceRecords = [...this.agents.values()].filter(
-          (record) => record.surface_id === entry.surface_id,
-        );
-        const needsRepair =
-          surfaceRecords.length === 0 ||
-          surfaceRecords.some(
-            (record) =>
-              isAutoAgentId(record.agent_id) ||
-              isPendingAgentId(record.agent_id),
-          );
-        if (!needsRepair) continue;
-      }
+      if (!repairEligible[entryIndex]) continue;
       const candidate = candidates[entryIndex];
       if (!candidate) continue;
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -2061,12 +2061,30 @@ export class AgentRegistry {
     const liveSurfaceRefs = new Set(
       discovered.map((entry) => entry.surface_id),
     );
+    const candidates = discovered.map((entry) =>
+      entry.read_error
+        ? null
+        : this.repairCandidateForDiscovery(entry, opts?.seatRegistry),
+    );
+    const candidateCounts = new Map<string, number>();
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      candidateCounts.set(
+        candidate.agentId,
+        (candidateCounts.get(candidate.agentId) ?? 0) + 1,
+      );
+    }
+    for (const [agentId, count] of candidateCounts) {
+      if (count > 1) {
+        this.aliases.delete(agentId);
+      }
+    }
 
     for (const removed of this.evictPendingGhostRegistrations(liveSurfaceRefs)) {
       evicted.add(removed);
     }
 
-    for (const entry of discovered) {
+    for (const [entryIndex, entry] of discovered.entries()) {
       if (entry.read_error) continue;
       if (opts?.orphansOnly) {
         const surfaceRecords = [...this.agents.values()].filter(
@@ -2081,10 +2099,7 @@ export class AgentRegistry {
           );
         if (!needsRepair) continue;
       }
-      const candidate = this.repairCandidateForDiscovery(
-        entry,
-        opts?.seatRegistry,
-      );
+      const candidate = candidates[entryIndex];
       if (!candidate) continue;
 
       try {
@@ -2093,6 +2108,7 @@ export class AgentRegistry {
           candidate,
           evicted,
           liveSurfaceRefs,
+          candidateCounts.get(candidate.agentId) === 1,
         );
         if (repair) {
           repaired.push(repair);
@@ -2175,6 +2191,7 @@ export class AgentRegistry {
     candidate: RegistryRepairCandidate,
     evicted: Set<string>,
     liveSurfaceRefs: ReadonlySet<string>,
+    candidateAliasIsUnique: boolean,
   ): RegistryRepairEntry | null {
     const recordsForSurface = [...this.agents.values()].filter(
       (agent) => agent.surface_id === discovered.surface_id,
@@ -2206,6 +2223,7 @@ export class AgentRegistry {
     if (managedRecord) {
       const existingAliasTarget = this.get(candidate.agentId);
       const shouldPublishCandidateAlias =
+        candidateAliasIsUnique &&
         candidate.agentId !== managedRecord.agent_id &&
         (!existingAliasTarget ||
           existingAliasTarget.agent_id === managedRecord.agent_id);

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -2229,7 +2229,7 @@ export class AgentRegistry {
         discovered,
         candidate,
       );
-      if (shouldPublishCandidateAlias) {
+      if (updated && shouldPublishCandidateAlias) {
         this.aliases.set(candidate.agentId, managedRecord.agent_id);
       }
       return updated
@@ -2320,7 +2320,7 @@ export class AgentRegistry {
       patch.surface_observer_id = observerId;
     }
     if (Object.keys(patch).length === 0) {
-      return null;
+      return record;
     }
 
     let updated: AgentRecord;

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -36,7 +36,7 @@ import { validateSurfaceIdentityBijection } from "./surface-topology.js";
 import { deriveCmuxObserverOwnerId } from "./cmux-observer-identity.js";
 import { inferRepoFromDirectory } from "./repo-workspace.js";
 import { resumeArtifactStatus } from "./resume-verification.js";
-import { processMayBeAlive } from "./process-liveness.js";
+import { agentProcessMayBeAlive } from "./process-liveness.js";
 
 export type SurfaceProvider = () => Promise<CmuxSurface[]>;
 
@@ -847,7 +847,7 @@ export class AgentRegistry {
       // after one missing-surface observation, then discovery re-minted the
       // pane under its bare seat name. Retain the canonical row and all of its
       // parent/provenance metadata until the recorded pid is proven gone.
-      if (processMayBeAlive(agent.pid)) {
+      if (agentProcessMayBeAlive(agent)) {
         this.surfacelessObservations.delete(agent.agent_id);
         continue;
       }
@@ -1752,7 +1752,7 @@ export class AgentRegistry {
         this.unclaimedAbsenceObservations.delete(agent.agent_id);
         continue;
       }
-      if (processMayBeAlive(agent.pid)) {
+      if (agentProcessMayBeAlive(agent)) {
         this.surfacelessObservations.delete(agent.agent_id);
         this.unclaimedAbsenceObservations.delete(agent.agent_id);
         continue;
@@ -2552,7 +2552,7 @@ export class AgentRegistry {
       if (shouldRetainForExplicitResume(agent)) {
         continue;
       }
-      if (processMayBeAlive(agent.pid)) {
+      if (agentProcessMayBeAlive(agent)) {
         continue;
       }
       if (!this.canPurgeAtStartup(agent)) {
@@ -2613,7 +2613,7 @@ export class AgentRegistry {
       if (shouldRetainForExplicitResume(agent)) {
         continue;
       }
-      if (processMayBeAlive(agent.pid)) {
+      if (agentProcessMayBeAlive(agent)) {
         this.surfacelessObservations.delete(agent.agent_id);
         continue;
       }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -36,6 +36,7 @@ import { validateSurfaceIdentityBijection } from "./surface-topology.js";
 import { deriveCmuxObserverOwnerId } from "./cmux-observer-identity.js";
 import { inferRepoFromDirectory } from "./repo-workspace.js";
 import { resumeArtifactStatus } from "./resume-verification.js";
+import { processMayBeAlive } from "./process-liveness.js";
 
 export type SurfaceProvider = () => Promise<CmuxSurface[]>;
 
@@ -840,6 +841,16 @@ export class AgentRegistry {
       }
 
       if (TERMINAL_STATES.has(agent.state)) continue;
+
+      // A topology miss cannot overrule a process that still exists. The live
+      // incident that motivated this guard removed an engine-issued id 10 ms
+      // after one missing-surface observation, then discovery re-minted the
+      // pane under its bare seat name. Retain the canonical row and all of its
+      // parent/provenance metadata until the recorded pid is proven gone.
+      if (processMayBeAlive(agent.pid)) {
+        this.surfacelessObservations.delete(agent.agent_id);
+        continue;
+      }
 
       if (
         this.isSurfacelessConfirmed(
@@ -1741,6 +1752,11 @@ export class AgentRegistry {
         this.unclaimedAbsenceObservations.delete(agent.agent_id);
         continue;
       }
+      if (processMayBeAlive(agent.pid)) {
+        this.surfacelessObservations.delete(agent.agent_id);
+        this.unclaimedAbsenceObservations.delete(agent.agent_id);
+        continue;
+      }
       if (this.matchingLiveSurface(agent, surfaces)) {
         this.surfacelessObservations.delete(agent.agent_id);
         this.unclaimedAbsenceObservations.delete(agent.agent_id);
@@ -2188,6 +2204,11 @@ export class AgentRegistry {
     );
 
     if (managedRecord) {
+      const existingAliasTarget = this.get(candidate.agentId);
+      const shouldPublishCandidateAlias =
+        candidate.agentId !== managedRecord.agent_id &&
+        (!existingAliasTarget ||
+          existingAliasTarget.agent_id === managedRecord.agent_id);
       for (const duplicate of recordsForSurface) {
         if (
           !isAutoAgentId(duplicate.agent_id) ||
@@ -2208,6 +2229,9 @@ export class AgentRegistry {
         discovered,
         candidate,
       );
+      if (shouldPublishCandidateAlias) {
+        this.aliases.set(candidate.agentId, managedRecord.agent_id);
+      }
       return updated
         ? this.repairEntry(updated, discovered, candidate, "updated")
         : null;
@@ -2528,6 +2552,9 @@ export class AgentRegistry {
       if (shouldRetainForExplicitResume(agent)) {
         continue;
       }
+      if (processMayBeAlive(agent.pid)) {
+        continue;
+      }
       if (!this.canPurgeAtStartup(agent)) {
         continue;
       }
@@ -2584,6 +2611,10 @@ export class AgentRegistry {
         continue;
       }
       if (shouldRetainForExplicitResume(agent)) {
+        continue;
+      }
+      if (processMayBeAlive(agent.pid)) {
+        this.surfacelessObservations.delete(agent.agent_id);
         continue;
       }
       const role = inferRecordRoleOrNull(agent);

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -87,6 +87,8 @@ export interface AgentRecord {
    */
   boot_prompt_text?: string | null;
   pid: number | null;
+  /** Hook registration time that binds `pid` to this launch generation. */
+  pid_registered_at?: string | null;
   version: number;
   created_at: string;
   updated_at: string;

--- a/src/live-agent-state.ts
+++ b/src/live-agent-state.ts
@@ -164,5 +164,5 @@ export function isLiveInteractive(live: LiveAgentState): boolean {
  */
 export function isLiveDeliverable(live: LiveAgentState): boolean {
   if (INTERACTIVE_AGENT_STATES.has(live.registry_state)) return true;
-  return live.screen_state === "ready";
+  return live.registry_state !== "booting" && live.screen_state === "ready";
 }

--- a/src/live-agent-state.ts
+++ b/src/live-agent-state.ts
@@ -157,19 +157,12 @@ export function isLiveInteractive(live: LiveAgentState): boolean {
  * says `done`. Gating this on the record is what returned `delivery:"failed"`,
  * `terminal:true` to an agent sitting at a live prompt (ledger row 4).
  *
- * Deliberately only ever WIDENS what the record allowed. A false refusal to a
- * live agent is the harm this lane exists to kill; the other direction already
- * has `allow_busy` and the bare-shell refusal ahead of it.
+ * A target-scoped live ready prompt is authoritative for this question even
+ * when the registry still says `working`: the prompt proves the composer can
+ * accept input, while the record only describes an earlier turn. The
+ * bare-shell and picker/overlay guards run before this decision.
  */
 export function isLiveDeliverable(live: LiveAgentState): boolean {
   if (INTERACTIVE_AGENT_STATES.has(live.registry_state)) return true;
-  // A live agent prompt overrides a TERMINAL record — that, and only that, is
-  // the #408 poisoning case. Every other record state keeps its gate: a
-  // `booting` pane may still be receiving its launcher line, and a `working`
-  // one is mid-turn, where a momentarily-ready parse must not be read as
-  // permission to type (that is what `allow_busy` is for).
-  return (
-    live.screen_state === "ready" &&
-    TERMINAL_AGENT_STATES.has(live.registry_state)
-  );
+  return live.screen_state === "ready";
 }

--- a/src/process-liveness.ts
+++ b/src/process-liveness.ts
@@ -3,6 +3,8 @@ import type { AgentRecord } from "./agent-types.js";
 
 export type ProcessLiveness = "alive" | "gone" | "unknown";
 
+const PROCESS_START_PROBE_TIMEOUT_MS = 250;
+
 const PROCESS_START_SKEW_MS = 5_000;
 
 type AgentProcessRecord = Pick<
@@ -47,6 +49,7 @@ export function processStartedAtMs(pid: number): number | null {
     const output = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: PROCESS_START_PROBE_TIMEOUT_MS,
     }).trim();
     if (!output) return null;
     const parsed = Date.parse(output);

--- a/src/process-liveness.ts
+++ b/src/process-liveness.ts
@@ -1,4 +1,14 @@
+import { execFileSync } from "node:child_process";
+import type { AgentRecord } from "./agent-types.js";
+
 export type ProcessLiveness = "alive" | "gone" | "unknown";
+
+const PROCESS_START_SKEW_MS = 5_000;
+
+type AgentProcessRecord = Pick<
+  AgentRecord,
+  "pid" | "created_at" | "pid_registered_at"
+>;
 
 /**
  * Probe a recorded process without signalling it. Only ESRCH proves absence;
@@ -29,4 +39,64 @@ export function processMayBeAlive(
   pid: number | null | undefined,
 ): boolean {
   return Boolean(pid) && processLiveness(pid) !== "gone";
+}
+
+/** Read the fixed process start timestamp used to distinguish PID reuse. */
+export function processStartedAtMs(pid: number): number | null {
+  try {
+    const output = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!output) return null;
+    const parsed = Date.parse(output);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Qualify a live numeric PID against the launch-to-registration window that
+ * production persisted. A process outside that window is a recycled PID, so
+ * the recorded agent process is gone even though the number is live again.
+ */
+export function qualifyAgentProcessLiveness(
+  agent: AgentProcessRecord,
+  observed: ProcessLiveness,
+  startedAtMs: number | null,
+): ProcessLiveness {
+  if (observed !== "alive") return observed;
+  const createdAtMs = Date.parse(agent.created_at);
+  const registeredAtMs = Date.parse(agent.pid_registered_at ?? "");
+  if (
+    !Number.isFinite(createdAtMs) ||
+    !Number.isFinite(registeredAtMs) ||
+    startedAtMs === null
+  ) {
+    return "unknown";
+  }
+  if (
+    startedAtMs < createdAtMs - PROCESS_START_SKEW_MS ||
+    startedAtMs > registeredAtMs
+  ) {
+    return "gone";
+  }
+  return "alive";
+}
+
+export function agentProcessLiveness(
+  agent: AgentProcessRecord,
+): ProcessLiveness {
+  const observed = processLiveness(agent.pid);
+  if (observed !== "alive" || !agent.pid) return observed;
+  return qualifyAgentProcessLiveness(
+    agent,
+    observed,
+    processStartedAtMs(agent.pid),
+  );
+}
+
+export function agentProcessMayBeAlive(agent: AgentProcessRecord): boolean {
+  return Boolean(agent.pid) && agentProcessLiveness(agent) !== "gone";
 }

--- a/src/process-liveness.ts
+++ b/src/process-liveness.ts
@@ -82,6 +82,15 @@ export function qualifyAgentProcessLiveness(
   ) {
     return "gone";
   }
+  if (
+    Math.floor(startedAtMs / 1_000) === Math.floor(registeredAtMs / 1_000)
+  ) {
+    // macOS `ps lstart` has only whole-second precision. A process launched
+    // after registration within this same displayed second is indistinguishable
+    // from the original process, so retain/refuse fail-closed rather than call
+    // either identity proven.
+    return "unknown";
+  }
   return "alive";
 }
 

--- a/src/process-liveness.ts
+++ b/src/process-liveness.ts
@@ -1,0 +1,32 @@
+export type ProcessLiveness = "alive" | "gone" | "unknown";
+
+/**
+ * Probe a recorded process without signalling it. Only ESRCH proves absence;
+ * permission and platform errors are inconclusive and must fail closed for
+ * resume/teardown decisions.
+ */
+export function processLiveness(
+  pid: number | null | undefined,
+): ProcessLiveness {
+  if (!pid) return "gone";
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ESRCH"
+    ) {
+      return "gone";
+    }
+    return "unknown";
+  }
+}
+
+export function processMayBeAlive(
+  pid: number | null | undefined,
+): boolean {
+  return Boolean(pid) && processLiveness(pid) !== "gone";
+}

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -228,9 +228,9 @@ function parseSelfRegistrationBufferLines(
 /**
  * Choose the winning entry among records for one stable surface UUID.
  *
- * AgentRecord.pid is not a CLI process pid: production record creation,
- * recovery, repair, and auto-discovery paths all leave it null. It therefore
- * cannot soundly participate in identity selection. When launch_cwd is known
+ * AgentRecord.pid is deliberately irrelevant to session identity selection:
+ * records begin with it null and later capture it as qualified process
+ * evidence. When launch_cwd is known
  * and at least one candidate matches it exactly, that subset is preferred as
  * an optional validator. The winner is then the newest `ts` (epoch ms); on an
  * exact tie the later (last-appended) record wins.
@@ -453,9 +453,8 @@ function makeIncrementalEntryIndexReader(
  * against the reader clock so a row from before a backward clock correction
  * cannot dominate. A row with explicit `cli` metadata must match the agent;
  * missing CLI remains compatible with older writers. AgentRecord pid is
- * deliberately ignored because production does not populate it with the CLI
- * process pid. Returns
- * `{ session_id, path }` or `null`. NO filesystem scan of session dirs; a
+ * deliberately ignored for candidate selection. Returns captured session and
+ * hook process evidence, or `null`. NO filesystem scan of session dirs; a
  * missing/unreadable/empty registry, an agent without a stable surface UUID, or
  * no UUID match all return `null` (the caller then falls back to the scan).
  */
@@ -515,6 +514,12 @@ export function makeSelfRegistrationSessionResolver(
     return {
       session_id: chosen.session_id,
       path: chosen.session_path ?? null,
+      ...(chosen.pid && chosen.pid > 0 && chosen.ts !== null
+        ? {
+            pid: chosen.pid,
+            pid_registered_at: new Date(chosen.ts).toISOString(),
+          }
+        : {}),
     };
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7353,6 +7353,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const findSurfaceByRef = async (
     surfaceRef: string,
     workspace?: string,
+    opts?: { throwOnError?: boolean },
   ): Promise<CmuxSurface | null> => {
     try {
       const workspaceRefs = workspace
@@ -7374,7 +7375,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         }
       }
-    } catch {
+    } catch (error) {
+      if (opts?.throwOnError) throw error;
       return null;
     }
 
@@ -10194,9 +10196,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // through a now-stale UUID/ref and turn an observed success into a
           // stale-route failure. Terminal agents take the path below because
           // stop_agent is then a no-op and their pane still needs closing.
-          if (
-            (await findSurfaceByRef(boundSurface, boundWorkspace)) === null
-          ) {
+          let boundSurfaceAfterStop: CmuxSurface | null;
+          try {
+            boundSurfaceAfterStop = await findSurfaceByRef(
+              boundSurface,
+              boundWorkspace,
+              { throwOnError: true },
+            );
+          } catch (error) {
+            const reason =
+              error instanceof Error ? error.message : String(error);
+            return err(
+              new Error(
+                `close_surface scope=agent: agent ${args.agent_id} was stopped ` +
+                  `but surface ${boundSurface} closure could not be verified — ${reason}`,
+              ),
+              {
+                ...stopContent,
+                scope: "agent",
+                agent_stopped: true,
+                surface: boundSurface,
+                surface_closed: false,
+                surface_close_error: reason,
+              },
+            );
+          }
+          if (boundSurfaceAfterStop === null) {
             const data = {
               ...stopContent,
               scope: "agent",

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
 import { StateManager } from "./state-manager.js";
 import { shellQuote } from "./agent-command.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
+import { processMayBeAlive } from "./process-liveness.js";
 import {
   currentTransportRetryCount,
   withTransportRetryTracking,
@@ -10131,6 +10132,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const boundAgent = context.lifecycleRegistry?.get(args.agent_id) ?? null;
           const boundSurface = boundAgent?.surface_id?.trim() || null;
           const boundWorkspace = boundAgent?.workspace_id ?? undefined;
+          if (!args.force && processMayBeAlive(boundAgent?.pid)) {
+            return okFormatted(
+              `close_surface scope=agent refused — agent ${args.agent_id} still has live recorded pid ${boundAgent?.pid}`,
+              {
+                scope: "agent",
+                agent_id: args.agent_id,
+                pid: boundAgent?.pid,
+                agent_stopped: false,
+                surface: boundSurface,
+                surface_closed: false,
+                surface_close_skipped: "live_process",
+                WARNING:
+                  `Live process ${boundAgent?.pid} was not stopped and its surface was not closed; pass force:true for deliberate teardown.`,
+              },
+            );
+          }
           const result = await handler(
             { agent_id: args.agent_id, force: args.force },
             {},
@@ -10172,6 +10189,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               data,
             );
           }
+          // stop_agent owns teardown for a nonterminal agent and may already
+          // have closed the exact bound surface. Do not run a second raw close
+          // through a now-stale UUID/ref and turn an observed success into a
+          // stale-route failure. Terminal agents take the path below because
+          // stop_agent is then a no-op and their pane still needs closing.
+          if (
+            (await findSurfaceByRef(boundSurface, boundWorkspace)) === null
+          ) {
+            const data = {
+              ...stopContent,
+              scope: "agent",
+              agent_stopped: true,
+              surface: boundSurface,
+              surface_closed: true,
+            };
+            return okFormatted(
+              `close_surface scope=agent — agent ${args.agent_id} stopped and surface ${boundSurface} closed`,
+              data,
+            );
+          }
           const closeHandler = toolHandlersByName.get("close_surface");
           if (!closeHandler) {
             throw new Error("Internal surface close adapter unavailable");
@@ -10181,14 +10218,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               scope: "surface",
               surface: boundSurface,
               workspace: boundWorkspace,
-              // AIDEV-NOTE (#485 review): pass the caller's own force through
-              // rather than forcing unconditionally. stop_agent has no liveness
-              // refusal of its own, so forcing here would let an unforced
-              // close_surface(scope:"agent") tear down a still-live agent's
-              // pane through a guard that could never fire for this scope --
-              // a silent escalation of destructiveness. If the guard refuses,
-              // the receipt says the agent stopped and the pane did not close.
-              force: args.force ?? false,
+              // The outer agent-scope path now refuses an unforced close when
+              // its recorded process is live. After stop_agent succeeds, the
+              // remaining surface may still have a transient auto-discovery
+              // row; force the surface half so that duplicate cannot veto the
+              // teardown that this same agent-scope call already authorized.
+              force: true,
             },
             {},
           );
@@ -15365,29 +15400,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 });
                 continue;
               }
-              if (!args.allow_busy && agent.state === "working") {
-                const queued = engine.queueDelivery({
-                  delivery_id: deliveryId,
-                  agent_id: agent.agent_id,
-                  text: args.text,
-                  press_enter: args.press_enter,
-                  source_event: "send_to",
-                });
-                mutableReceipts.push({
-                  ...resolutionMetadata,
-                  agent_id: agent.agent_id,
-                  ...buildPublicDeliveryReceipt({
-                    delivery_state: "queued",
-                    delivery_id: queued.delivery_id,
-                    typed: false,
-                    submit_attempted: false,
-                    submit_verified: queued.submit_verified,
-                    retry_count: queued.retry_count,
-                  }),
-                  accepted: true,
-                });
-                continue;
-              }
               try {
                 const delivery = await deliverAgentInput({
                   agent_id: agent.agent_id,
@@ -15447,6 +15459,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   accepted: true,
                 });
               } catch (error) {
+                if (error instanceof RetryableDeliveryError) {
+                  const queued = engine.queueDelivery({
+                    delivery_id: deliveryId,
+                    agent_id: agent.agent_id,
+                    text: args.text,
+                    press_enter: args.press_enter,
+                    source_event: "send_to",
+                  });
+                  mutableReceipts.push({
+                    ...resolutionMetadata,
+                    agent_id: agent.agent_id,
+                    ...buildPublicDeliveryReceipt({
+                      delivery_state: "queued",
+                      delivery_id: queued.delivery_id,
+                      typed: false,
+                      submit_attempted: false,
+                      submit_verified: queued.submit_verified,
+                      retry_count: queued.retry_count,
+                      WARNING: `Delivery is queued for retry, not delivered yet: ${error.message}`,
+                    }),
+                    accepted: true,
+                  });
+                  continue;
+                }
                 const failed = engine.resolveDelivery(
                   {
                     delivery_id: deliveryId,
@@ -15604,31 +15640,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             };
             return okFormatted(
               `WARNING — send_to queued; paused target ${agentId} cannot act`,
-              data,
-            );
-          }
-          if (!args.allow_busy && targetAgent?.state === "working") {
-            const receipt = engine.queueDelivery({
-              delivery_id: deliveryId,
-              agent_id: agentId,
-              text: args.text,
-              press_enter: args.press_enter,
-              source_event: "send_to",
-            });
-            const data = {
-              accepted: true,
-              agent_id: agentId,
-              ...buildPublicDeliveryReceipt({
-                delivery_state: "queued",
-                delivery_id: receipt.delivery_id,
-                typed: false,
-                submit_attempted: false,
-                submit_verified: receipt.submit_verified,
-                retry_count: receipt.retry_count,
-              }),
-            };
-            return okFormatted(
-              `send_to accepted — delivery ${receipt.delivery_id} queued`,
               data,
             );
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import {
 import { StateManager } from "./state-manager.js";
 import { shellQuote } from "./agent-command.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
-import { processMayBeAlive } from "./process-liveness.js";
+import { agentProcessMayBeAlive } from "./process-liveness.js";
 import {
   currentTransportRetryCount,
   withTransportRetryTracking,
@@ -10132,7 +10132,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const boundAgent = context.lifecycleRegistry?.get(args.agent_id) ?? null;
           const boundSurface = boundAgent?.surface_id?.trim() || null;
           const boundWorkspace = boundAgent?.workspace_id ?? undefined;
-          if (!args.force && processMayBeAlive(boundAgent?.pid)) {
+          if (!args.force && boundAgent && agentProcessMayBeAlive(boundAgent)) {
             return okFormatted(
               `close_surface scope=agent refused — agent ${args.agent_id} still has live recorded pid ${boundAgent?.pid}`,
               {
@@ -10218,12 +10218,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               scope: "surface",
               surface: boundSurface,
               workspace: boundWorkspace,
-              // The outer agent-scope path now refuses an unforced close when
-              // its recorded process is live. After stop_agent succeeds, the
-              // remaining surface may still have a transient auto-discovery
-              // row; force the surface half so that duplicate cannot veto the
-              // teardown that this same agent-scope call already authorized.
-              force: true,
+              // Preserve the surface path's cross-record guard. The outer
+              // process check protects this record; it does not authorize
+              // tearing down a surface another nonterminal record owns.
+              force: args.force ?? false,
             },
             {},
           );
@@ -12123,6 +12121,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe(
             "THE way to revive an agent: resume this captured session on a fresh surface, keeping its public agent ID and re-issuing its coordination contract. cmuxlayer never revives a pane by itself (#492) -- a pane you close stays closed -- so a lead that wants an agent back asks here, by id. Refused with a reason when the session transcript is not on disk, rather than opening an empty pane. Mutually exclusive with new-spawn fields.",
           ),
+        force: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "With resume_agent_id only: override inconclusive recorded-process liveness after the caller deliberately verifies the old agent is gone. Does not bypass session or terminal-state requirements.",
+          ),
         repo: z
           .string()
           .optional()
@@ -12333,6 +12338,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
             const result = await engine.resumeAgent(args.resume_agent_id, {
               workspace,
+              force: args.force,
             });
             creation.record({
               agent_id: result.agent_id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -10135,9 +10135,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const boundSurface = boundAgent?.surface_id?.trim() || null;
           const boundWorkspace = boundAgent?.workspace_id ?? undefined;
           if (!args.force && boundAgent && agentProcessMayBeAlive(boundAgent)) {
-            return okFormatted(
-              `close_surface scope=agent refused — agent ${args.agent_id} still has live recorded pid ${boundAgent?.pid}`,
+            return err(
+              new Error(
+                `close_surface scope=agent refused — agent ${args.agent_id} still has live recorded pid ${boundAgent?.pid}`,
+              ),
               {
+                refused: true,
                 scope: "agent",
                 agent_id: args.agent_id,
                 pid: boundAgent?.pid,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 const spawnMock = vi.hoisted(() => vi.fn());
 const execFileMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
   execFile: execFileMock,
+  execFileSync: execFileSyncMock,
 }));
 
 import {
@@ -47,6 +49,7 @@ import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
 import { dispatch, readInbox, writeHeartbeat } from "../src/inbox.js";
 import { readWatchRegistry } from "../src/watch-spec.js";
 import { useHarnessHome } from "./helpers/harness-home.js";
+import { persistProductionProcessRecord } from "./helpers/production-process-record.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
 // #482/#492: `resumable` reads the transcript store, so these tests own a
@@ -3700,8 +3703,10 @@ describe("AgentEngine", () => {
     it("P0 D2 refuses explicit resume when the recorded pid is still alive", async () => {
       const agentId = "agent-live-pid-must-not-resume";
       const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
-      stateMgr.writeState(
-        makeRecord({
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry: engine.getRegistry(),
+        record: makeRecord({
           agent_id: agentId,
           state: "done",
           surface_id: "surface:live-process",
@@ -3710,11 +3715,10 @@ describe("AgentEngine", () => {
           cli: "codex",
           cli_session_id: sessionId,
           launcher_name: "brainlayerCodex",
-          pid: process.pid,
+          pid: null,
         }),
-      );
+      });
       harnessHome.give("codex", sessionId);
-      await engine.getRegistry().reconstitute();
 
       // D1 -> D4 -> D2 is one chain: an unsafe close leaves a live process in
       // terminal registry state, and terminal registry state is currently the
@@ -3728,6 +3732,63 @@ describe("AgentEngine", () => {
       );
       expect(mockClient.newSplit).not.toHaveBeenCalled();
       expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
+    it("allows an explicit forced resume when pid liveness is unprobeable", async () => {
+      const agentId = "agent-unknown-pid-force-resume";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "done",
+          surface_id: "surface:old-unknown-process",
+          workspace_id: "ws:1",
+          repo: "brainlayer",
+          cli: "codex",
+          cli_session_id: sessionId,
+          launcher_name: "brainlayerCodex",
+          pid: 34567,
+        }),
+      );
+      harnessHome.give("codex", sessionId);
+      await engine.getRegistry().reconstitute();
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          if (pid === 34567 && signal === 0) {
+            throw Object.assign(new Error("operation not permitted"), {
+              code: "EPERM",
+            });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        const resumed = await engine.resumeAgent(agentId, { force: true });
+
+        expect(resumed.agent_id).toBe(agentId);
+        expect(resumed.surface_id).toBe("surface:new");
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
+    it("reports non-terminal state before consulting pid liveness on resume", async () => {
+      const agentId = "agent-working-pid-resume";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "working",
+          surface_id: "surface:working",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          pid: process.pid,
+        }),
+      );
+      await engine.getRegistry().reconstitute();
+
+      await expect(engine.resumeAgent(agentId)).rejects.toThrow(
+        /is working.*requires a terminal agent/i,
+      );
     });
 
     it("explicitly resumes a launcher-less agent through the raw CLI", async () => {
@@ -10797,7 +10858,7 @@ Session ID: ${sessionId}`,
         {
           agent_id: "live-pid-stale-surface-root",
           state: "error",
-          pid: process.pid,
+          pid: null,
           surface_id: "surface:recently-observed",
           surface_uuid: stableUuid,
           error: `Surface surface:recently-observed disappeared`,
@@ -10810,11 +10871,16 @@ Session ID: ${sessionId}`,
           },
         ],
       );
+      const productionRecord = await persistProductionProcessRecord({
+        stateMgr,
+        registry: engine.getRegistry(),
+        record,
+      });
 
       expect(() => process.kill(process.pid, 0)).not.toThrow();
       let routeError: unknown = null;
       try {
-        await engine.resolveAgentIoRoute(record.agent_id);
+        await engine.resolveAgentIoRoute(productionRecord.agent_id);
       } catch (error) {
         routeError = error;
       }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3706,19 +3706,21 @@ describe("AgentEngine", () => {
       await persistProductionProcessRecord({
         stateMgr,
         registry: engine.getRegistry(),
+        registeredAtMs: Date.parse("2026-08-23T11:00:05.000Z"),
         record: makeRecord({
           agent_id: agentId,
           state: "done",
           surface_id: "surface:live-process",
           workspace_id: "ws:1",
           repo: "brainlayer",
-          cli: "codex",
+          cli: "claude",
           cli_session_id: sessionId,
-          launcher_name: "brainlayerCodex",
+          launcher_name: "brainlayerClaude",
           pid: null,
         }),
       });
-      harnessHome.give("codex", sessionId);
+      harnessHome.give("claude", sessionId);
+      execFileSyncMock.mockReturnValueOnce("Sun Aug 23 11:00:02 2026\n");
 
       // D1 -> D4 -> D2 is one chain: an unsafe close leaves a live process in
       // terminal registry state, and terminal registry state is currently the
@@ -3730,6 +3732,35 @@ describe("AgentEngine", () => {
           "i",
         ),
       );
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
+    it("refuses a forced resume when the recorded pid is definitely alive", async () => {
+      const agentId = "agent-live-pid-force-must-not-resume";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry: engine.getRegistry(),
+        registeredAtMs: Date.parse("2026-08-23T11:00:05.000Z"),
+        record: makeRecord({
+          agent_id: agentId,
+          state: "done",
+          surface_id: "surface:live-force-process",
+          workspace_id: "ws:1",
+          repo: "brainlayer",
+          cli: "claude",
+          cli_session_id: sessionId,
+          launcher_name: "brainlayerClaude",
+          pid: null,
+        }),
+      });
+      harnessHome.give("claude", sessionId);
+      execFileSyncMock.mockReturnValueOnce("Sun Aug 23 11:00:02 2026\n");
+
+      await expect(
+        engine.resumeAgent(agentId, { force: true }),
+      ).rejects.toThrow(/still alive/i);
       expect(mockClient.newSplit).not.toHaveBeenCalled();
       expect(mockClient.newSurface).not.toHaveBeenCalled();
     });
@@ -4175,6 +4206,52 @@ describe("AgentEngine", () => {
         cli_session_path: rolloutPath,
       });
       expect(engine.getAgentState("cmuxlayerCodex-aaaaaaaa")).toBeNull();
+    });
+
+    it("does not backfill Codex pid evidence from self-registration", async () => {
+      const agentId = "cmuxlayerCodex-existing-session";
+      const sessionId = "019fec96-588d-7000-8000-000000000000";
+      const selfRegistrationResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: null,
+        pid: process.pid,
+        pid_registered_at: "2026-08-23T11:00:05.000Z",
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: selfRegistrationResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          repo: "cmuxlayer",
+          cli: "codex",
+          state: "working",
+          surface_id: "surface:codex-existing-session",
+          surface_uuid: "11111111-2222-4333-8444-555555555555",
+          cli_session_id: sessionId,
+          cli_session_path: "/durable/codex/rollout.jsonl",
+          pid: null,
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:codex-existing-session"),
+          id: "11111111-2222-4333-8444-555555555555",
+        },
+      ];
+      await registry.reconstitute();
+
+      await engine.captureBootSessionId(agentId);
+
+      expect(selfRegistrationResolver).not.toHaveBeenCalled();
+      expect(engine.getAgentState(agentId)).toMatchObject({
+        pid: null,
+        cli_session_path: "/durable/codex/rollout.jsonl",
+      });
     });
 
     it("does not advertise an unrunnable legacy session route", async () => {
@@ -10977,6 +11054,7 @@ Session ID: ${sessionId}`,
       const record = installLegacyAgent(
         {
           agent_id: "live-pid-stale-surface-root",
+          cli: "claude",
           state: "error",
           pid: null,
           surface_id: "surface:recently-observed",
@@ -10997,6 +11075,10 @@ Session ID: ${sessionId}`,
         record,
       });
 
+      expect(productionRecord).toMatchObject({
+        cli: "claude",
+        pid: process.pid,
+      });
       expect(() => process.kill(process.pid, 0)).not.toThrow();
       let routeError: unknown = null;
       try {
@@ -11006,6 +11088,9 @@ Session ID: ${sessionId}`,
       }
 
       expect(routeError).toBeInstanceOf(Error);
+      expect((routeError as Error).message).toMatch(
+        new RegExp(`live recorded pid ${process.pid}`, "i"),
+      );
       expect((routeError as Error).message).not.toMatch(
         /stable surface UUID.*(?:not live|no longer live)/i,
       );

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4347,6 +4347,126 @@ Session ID: ${sessionId}`,
       expect(existsSync(stableMarker)).toBe(true);
     });
 
+    it("preserves a durable transcript path while backfilling pid-only registration evidence", async () => {
+      const agentId = "cmuxlayerClaude-durable-path";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      const sessionPath = "/durable/claude/session.jsonl";
+      const surfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: () => ({
+          session_id: sessionId,
+          path: null,
+          pid: process.pid,
+          pid_registered_at: "2026-08-23T11:00:05.000Z",
+        }),
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          repo: "cmuxlayer",
+          cli: "claude",
+          state: "working",
+          surface_id: "surface:durable-path",
+          surface_uuid: surfaceUuid,
+          surface_provenance: "cmuxlayer_spawn",
+          cli_session_id: sessionId,
+          cli_session_path: sessionPath,
+          pid: null,
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:durable-path"),
+          id: surfaceUuid,
+          workspace_ref: "ws:durable-path",
+        },
+      ];
+      await registry.reconstitute();
+
+      await engine.captureBootSessionId(agentId);
+
+      expect(engine.getAgentState(agentId)).toMatchObject({
+        cli_session_id: sessionId,
+        cli_session_path: sessionPath,
+        pid: process.pid,
+        pid_registered_at: "2026-08-23T11:00:05.000Z",
+      });
+    });
+
+    it("keeps captured pid evidence when a pending row converges on an existing final session", async () => {
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      const finalAgentId = "cmuxlayerClaude-019d9aa5";
+      const pendingAgentId = "cmuxlayerClaude-pending-pid-merge";
+      const surfaceUuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: () => ({
+          session_id: sessionId,
+          path: null,
+          pid: process.pid,
+          pid_registered_at: "2026-08-23T11:00:05.000Z",
+        }),
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: finalAgentId,
+          repo: "cmuxlayer",
+          cli: "claude",
+          state: "working",
+          surface_id: "surface:existing-final",
+          surface_uuid: surfaceUuid,
+          surface_provenance: "cmuxlayer_spawn",
+          cli_session_id: sessionId,
+          cli_session_path: "/durable/claude/existing.jsonl",
+          pid: null,
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: pendingAgentId,
+          repo: "cmuxlayer",
+          cli: "claude",
+          state: "booting",
+          surface_id: "surface:existing-final",
+          surface_uuid: surfaceUuid,
+          surface_provenance: "cmuxlayer_spawn",
+          cli_session_id: null,
+          cli_session_path: null,
+          pid: null,
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:existing-final"),
+          id: surfaceUuid,
+          workspace_ref: "ws:existing-final",
+        },
+      ];
+      await registry.reconstitute();
+
+      await engine.captureBootSessionId(pendingAgentId);
+
+      expect(engine.getAgentState(finalAgentId)).toMatchObject({
+        cli_session_id: sessionId,
+        cli_session_path: "/durable/claude/existing.jsonl",
+        pid: process.pid,
+        pid_registered_at: "2026-08-23T11:00:05.000Z",
+      });
+      expect(engine.getAgentState(pendingAgentId)).toMatchObject({
+        agent_id: finalAgentId,
+        pid: process.pid,
+        pid_registered_at: "2026-08-23T11:00:05.000Z",
+      });
+      expect(stateMgr.readState(pendingAgentId)).toBeNull();
+    });
+
     it("periodically reaps only old pending markers absent from registry and state", async () => {
       vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"));
       const nowSeconds = Math.floor(Date.now() / 1_000);
@@ -11095,6 +11215,57 @@ Session ID: ${sessionId}`,
         "c-c",
         expect.anything(),
       );
+    });
+
+    it("refuses socketless teardown when another record claims the same stable UUID", async () => {
+      engine.dispose();
+      const surfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+      const registry = new AgentRegistry(
+        stateMgr,
+        async () => liveSurfaces,
+        {
+          observerIdProvider: () => null,
+          observerEpochProvider: () => null,
+        },
+      );
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        stopPostConditionTimeoutMs: 20,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-stop-stale-duplicate",
+          state: "working",
+          surface_id: "surface:stale-ref",
+          surface_uuid: surfaceUuid,
+          workspace_id: "ws:1",
+        }),
+      );
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-stop-canonical-owner",
+          state: "ready",
+          surface_id: "surface:canonical",
+          surface_uuid: surfaceUuid,
+          workspace_id: "ws:1",
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:canonical"),
+          id: surfaceUuid,
+          workspace_ref: "ws:1",
+        },
+      ];
+      await registry.reconstitute();
+
+      await expect(
+        engine.stopAgent("agent-stop-stale-duplicate"),
+      ).rejects.toThrow(/same stable surface UUID|claimed by.*canonical-owner/i);
+
+      expect(mockClient.sendKey).not.toHaveBeenCalled();
+      expect(mockClient.closeSurface).not.toHaveBeenCalled();
     });
 
     it("guards a freshly re-resolved moved UUID immediately before stop I/O", async () => {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3697,6 +3697,39 @@ describe("AgentEngine", () => {
       expect(engine.getAgentState("agent-stable-resume")?.state).toBe("booting");
     });
 
+    it("P0 D2 refuses explicit resume when the recorded pid is still alive", async () => {
+      const agentId = "agent-live-pid-must-not-resume";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "done",
+          surface_id: "surface:live-process",
+          workspace_id: "ws:1",
+          repo: "brainlayer",
+          cli: "codex",
+          cli_session_id: sessionId,
+          launcher_name: "brainlayerCodex",
+          pid: process.pid,
+        }),
+      );
+      harnessHome.give("codex", sessionId);
+      await engine.getRegistry().reconstitute();
+
+      // D1 -> D4 -> D2 is one chain: an unsafe close leaves a live process in
+      // terminal registry state, and terminal registry state is currently the
+      // only resume guard. Process liveness must close that duplication path.
+      expect(() => process.kill(process.pid, 0)).not.toThrow();
+      await expect(engine.resumeAgent(agentId)).rejects.toThrow(
+        new RegExp(
+          `(?:alive|live).*${process.pid}|${process.pid}.*(?:alive|live)`,
+          "i",
+        ),
+      );
+      expect(mockClient.newSplit).not.toHaveBeenCalled();
+      expect(mockClient.newSurface).not.toHaveBeenCalled();
+    });
+
     it("explicitly resumes a launcher-less agent through the raw CLI", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -10757,6 +10790,40 @@ Session ID: ${sessionId}`,
       registry.set(record.agent_id, record);
       return record;
     }
+
+    it("P0 D1 never declares a stable surface UUID dead while the agent pid is alive", async () => {
+      const stableUuid = "11111111-2222-4333-8444-555555555555";
+      const record = installLegacyAgent(
+        {
+          agent_id: "live-pid-stale-surface-root",
+          state: "error",
+          pid: process.pid,
+          surface_id: "surface:recently-observed",
+          surface_uuid: stableUuid,
+          error: `Surface surface:recently-observed disappeared`,
+        },
+        [
+          {
+            ...makeSurface("surface:witness"),
+            id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            workspace_ref: "workspace:witness",
+          },
+        ],
+      );
+
+      expect(() => process.kill(process.pid, 0)).not.toThrow();
+      let routeError: unknown = null;
+      try {
+        await engine.resolveAgentIoRoute(record.agent_id);
+      } catch (error) {
+        routeError = error;
+      }
+
+      expect(routeError).toBeInstanceOf(Error);
+      expect((routeError as Error).message).not.toMatch(
+        /stable surface UUID.*(?:not live|no longer live)/i,
+      );
+    });
 
     it("refuses an owned UUID-less route when fresh all-ref topology lacks its ref", async () => {
       const record = installLegacyAgent({}, [makeSurface("surface:witness")]);

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1758,6 +1758,123 @@ describe("AgentRegistry", () => {
   });
 
   describe("repairFromDiscovery", () => {
+    it("keeps the engine-issued id addressable across a transient missing-surface scan", async () => {
+      const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
+      const engineId = "cmuxlayerCodex-bff10108";
+      const parentId = "cmuxlayerClaude-b0a43f90";
+      let surfaces = [
+        {
+          ...makeSurface("surface:871"),
+          id: surfaceUuid,
+        },
+      ];
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: engineId,
+          surface_id: "surface:871",
+          surface_uuid: surfaceUuid,
+          state: "ready",
+          repo: "cmuxlayer",
+          cli: "codex",
+          launcher_name: "cmuxlayerCodex",
+          pid: process.pid,
+          parent_agent_id: parentId,
+          surface_provenance: "cmuxlayer_spawn",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => surfaces);
+      await registry.reconstitute();
+
+      surfaces = [
+        {
+          ...makeSurface("surface:witness"),
+          id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        },
+      ];
+      await registry.reconcile({ confirmationMs: 0 });
+      await registry.purgeTerminal({ confirmationMs: 0 });
+
+      surfaces = [
+        {
+          ...makeSurface("surface:871"),
+          id: surfaceUuid,
+        },
+      ];
+      registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:871",
+            surface_uuid: surfaceUuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        {
+          seatRegistry: {
+            ...REPAIR_SEATS,
+            cmuxlayerCodex: {
+              repo: "cmuxlayer",
+              launchers: { codex: "cmuxlayerCodex" },
+              lane: "cmuxlayer-worker",
+              role: "worker",
+            },
+          },
+        },
+      );
+
+      expect(registry.get(engineId)).toMatchObject({
+        agent_id: engineId,
+        parent_agent_id: parentId,
+        surface_provenance: "cmuxlayer_spawn",
+      });
+      expect(registry.get("cmuxlayerCodex")).toBe(registry.get(engineId));
+      expect(stateMgr.readState("cmuxlayerCodex")).toBeNull();
+    });
+
+    it("does not publish a bare-seat alias when managed repair fails", async () => {
+      const engineId = "cmuxlayerCodex-bff10108";
+      const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: engineId,
+          surface_id: "surface:871",
+          surface_uuid: surfaceUuid,
+          repo: "cmuxlayer",
+          cli: "codex",
+          launcher_name: "cmuxlayerCodex",
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => []);
+      await registry.reconstitute();
+      stateMgr.removeState(engineId);
+
+      const result = registry.repairFromDiscovery(
+          [
+            makeDiscovered({
+              surface_id: "surface:871",
+              surface_uuid: surfaceUuid,
+              surface_title: "cmuxlayerCodex",
+              cli: "codex",
+            }),
+          ],
+          {
+            seatRegistry: {
+              ...REPAIR_SEATS,
+              cmuxlayerCodex: {
+                repo: "cmuxlayer",
+                launchers: { codex: "cmuxlayerCodex" },
+                lane: "cmuxlayer-worker",
+                role: "worker",
+              },
+            },
+          },
+        );
+      expect(result.skipped).toMatchObject([
+        { agent_id: engineId, reason: `Agent not found: ${engineId}` },
+      ]);
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
     it.each([
       ["gemini", "golemsGemini"],
       ["kiro", "golemsKiro"],
@@ -3107,6 +3224,26 @@ describe("AgentRegistry", () => {
       expect(stateMgr.readState("local-terminal")).toBeNull();
       expect(stateMgr.readState("foreign-terminal")).not.toBeNull();
     });
+
+    it("startup purge retains a terminal row whose process may still be alive", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "live-pid-terminal",
+          state: "error",
+          surface_id: "surface:missing",
+          pid: process.pid,
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:witness"),
+      ]);
+      await registry.reconstitute();
+
+      expect(registry.purgeAllTerminal()).toEqual([]);
+      expect(registry.get("live-pid-terminal")).toMatchObject({
+        pid: process.pid,
+      });
+    });
   });
 
   describe("purgeTerminal", () => {
@@ -3243,6 +3380,28 @@ describe("AgentRegistry", () => {
   });
 
   describe("evictSurfaceless confirmation", () => {
+    it("retains a surfaceless row whose process may still be alive", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "live-pid-surfaceless",
+          state: "working",
+          surface_id: "surface:missing",
+          pid: process.pid,
+        }),
+      );
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:witness"),
+      ]);
+      await registry.reconstitute();
+
+      await expect(
+        registry.evictSurfaceless({ confirmationMs: 0 }),
+      ).resolves.toEqual([]);
+      expect(registry.get("live-pid-surfaceless")).toMatchObject({
+        pid: process.pid,
+      });
+    });
+
     it("retains deferred transcript captures through normal absence cleanup", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1759,6 +1759,50 @@ describe("AgentRegistry", () => {
   });
 
   describe("repairFromDiscovery", () => {
+    it("skips healthy surfaces before candidate inference in orphans-only repair", () => {
+      const healthy = makeRecord({
+        agent_id: "healthy-managed-agent",
+        surface_id: "surface:healthy",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+      });
+      stateMgr.writeState(healthy);
+      const registry = new AgentRegistry(stateMgr, async () => [], {
+        explicitRoleProvider: (entry) => {
+          if (entry.surface_id === healthy.surface_id) {
+            throw new Error("healthy surface role inference must be skipped");
+          }
+          return "worker";
+        },
+      });
+      registry.set(healthy.agent_id, healthy);
+
+      expect(() =>
+        registry.repairFromDiscovery(
+          [
+            makeDiscovered({
+              surface_id: healthy.surface_id,
+              surface_uuid: healthy.surface_uuid,
+              surface_title: "publish 24h dashboard",
+              cli: "codex",
+            }),
+            makeDiscovered({
+              surface_id: "surface:orphan",
+              surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+              surface_title: "golemsCodex",
+              cli: "codex",
+            }),
+          ],
+          { seatRegistry: REPAIR_SEATS, orphansOnly: true },
+        ),
+      ).not.toThrow();
+      expect(registry.get(healthy.agent_id)).toMatchObject({
+        agent_id: healthy.agent_id,
+      });
+      expect(registry.get("golemsCodex")).toMatchObject({
+        surface_id: "surface:orphan",
+      });
+    });
+
     it("withholds a launcher alias shared by multiple live managed workers", () => {
       const first = makeRecord({
         agent_id: "cmuxlayerCodex-worker-one",

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1877,6 +1877,55 @@ describe("AgentRegistry", () => {
       expect(registry.get("cmuxlayerCodex")).toBeNull();
     });
 
+    it("does not publish a seat alias when observer ownership disappears during repair", () => {
+      const engineId = "cmuxlayerCodex-bff10108";
+      const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
+      const record = makeRecord({
+        agent_id: engineId,
+        surface_id: "surface:871",
+        surface_uuid: surfaceUuid,
+        surface_observer_id: "cmux:observer-a",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      stateMgr.writeState(record);
+      let observerReads = 0;
+      const registry = new AgentRegistry(stateMgr, async () => [], {
+        observerIdProvider: () => {
+          observerReads += 1;
+          return observerReads === 1 ? "cmux:observer-a" : null;
+        },
+      });
+      registry.set(engineId, record);
+
+      const result = registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:871",
+            surface_uuid: surfaceUuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        {
+          seatRegistry: {
+            ...REPAIR_SEATS,
+            cmuxlayerCodex: {
+              repo: "cmuxlayer",
+              launchers: { codex: "cmuxlayerCodex" },
+              lane: "cmuxlayer-worker",
+              role: "worker",
+            },
+          },
+        },
+      );
+
+      expect(result.repaired).toEqual([]);
+      expect(registry.get(engineId)).toBe(record);
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
     it("keeps two live same-repo workers addressable only by their engine-issued ids", async () => {
       const firstId = "cmuxlayerCodex-aaaaaaaa";
       const secondId = "cmuxlayerCodex-bbbbbbbb";

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -12,6 +12,7 @@ import type { AgentRecord, AgentState } from "../src/agent-types.js";
 import type { DiscoveredAgent } from "../src/agent-discovery.js";
 import type { SeatRegistry } from "../src/seat-identity.js";
 import type { CmuxSurface } from "../src/types.js";
+import { persistProductionProcessRecord } from "./helpers/production-process-record.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-registry");
 const DEAD_CODEX_SHELL_SCREEN = (
@@ -1768,8 +1769,11 @@ describe("AgentRegistry", () => {
           id: surfaceUuid,
         },
       ];
-      stateMgr.writeState(
-        makeRecord({
+      const registry = new AgentRegistry(stateMgr, async () => surfaces);
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry,
+        record: makeRecord({
           agent_id: engineId,
           surface_id: "surface:871",
           surface_uuid: surfaceUuid,
@@ -1777,13 +1781,11 @@ describe("AgentRegistry", () => {
           repo: "cmuxlayer",
           cli: "codex",
           launcher_name: "cmuxlayerCodex",
-          pid: process.pid,
+          pid: null,
           parent_agent_id: parentId,
           surface_provenance: "cmuxlayer_spawn",
         }),
-      );
-      const registry = new AgentRegistry(stateMgr, async () => surfaces);
-      await registry.reconstitute();
+      });
 
       surfaces = [
         {
@@ -1831,7 +1833,7 @@ describe("AgentRegistry", () => {
       expect(stateMgr.readState("cmuxlayerCodex")).toBeNull();
     });
 
-    it("does not publish a bare-seat alias when managed repair fails", async () => {
+    it("removes a failed managed repair without leaving a resolvable alias", async () => {
       const engineId = "cmuxlayerCodex-bff10108";
       const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
       stateMgr.writeState(
@@ -1873,6 +1875,62 @@ describe("AgentRegistry", () => {
         { agent_id: engineId, reason: `Agent not found: ${engineId}` },
       ]);
       expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
+    it("keeps two live same-repo workers addressable only by their engine-issued ids", async () => {
+      const firstId = "cmuxlayerCodex-aaaaaaaa";
+      const secondId = "cmuxlayerCodex-bbbbbbbb";
+      const firstUuid = "11111111-2222-4333-8444-555555555555";
+      const secondUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+      for (const [agentId, surfaceId, surfaceUuid] of [
+        [firstId, "surface:871", firstUuid],
+        [secondId, "surface:872", secondUuid],
+      ] as const) {
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: agentId,
+            surface_id: surfaceId,
+            surface_uuid: surfaceUuid,
+            repo: "cmuxlayer",
+            cli: "codex",
+            launcher_name: "cmuxlayerCodex",
+          }),
+        );
+      }
+      const registry = new AgentRegistry(stateMgr, async () => []);
+      await registry.reconstitute();
+      const seatRegistry = {
+        ...REPAIR_SEATS,
+        cmuxlayerCodex: {
+          repo: "cmuxlayer",
+          launchers: { codex: "cmuxlayerCodex" },
+          lane: "cmuxlayer-worker",
+          role: "worker" as const,
+        },
+      };
+
+      registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: "surface:871",
+            surface_uuid: firstUuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+          makeDiscovered({
+            surface_id: "surface:872",
+            surface_uuid: secondUuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        { seatRegistry },
+      );
+
+      expect(registry.get(firstId)?.agent_id).toBe(firstId);
+      expect(registry.get(secondId)?.agent_id).toBe(secondId);
+      expect(registry.get("cmuxlayerCodex")?.agent_id).toBe(firstId);
+      expect(registry.get("cmuxlayerCodex")?.agent_id).not.toBe(secondId);
     });
 
     it.each([
@@ -3226,18 +3284,19 @@ describe("AgentRegistry", () => {
     });
 
     it("startup purge retains a terminal row whose process may still be alive", async () => {
-      stateMgr.writeState(
-        makeRecord({
-          agent_id: "live-pid-terminal",
-          state: "error",
-          surface_id: "surface:missing",
-          pid: process.pid,
-        }),
-      );
       const registry = new AgentRegistry(stateMgr, async () => [
         makeSurface("surface:witness"),
       ]);
-      await registry.reconstitute();
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry,
+        record: makeRecord({
+          agent_id: "live-pid-terminal",
+          state: "error",
+          surface_id: "surface:missing",
+          pid: null,
+        }),
+      });
 
       expect(registry.purgeAllTerminal()).toEqual([]);
       expect(registry.get("live-pid-terminal")).toMatchObject({
@@ -3247,6 +3306,25 @@ describe("AgentRegistry", () => {
   });
 
   describe("purgeTerminal", () => {
+    it("retains a terminal worker whose production-captured process is live", async () => {
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:witness"),
+      ]);
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry,
+        record: makeRecord({
+          agent_id: "live-process-periodic-terminal",
+          state: "done",
+          role: "worker",
+          surface_id: "surface:missing-periodic",
+          pid: null,
+        }),
+      });
+
+      await expect(registry.purgeTerminal({ confirmationMs: 0 })).resolves.toBe(0);
+      expect(registry.get("live-process-periodic-terminal")).not.toBeNull();
+    });
     it("does not purge terminal workers when surface enumeration is empty", async () => {
       stateMgr.writeState(
         makeRecord({
@@ -3381,18 +3459,19 @@ describe("AgentRegistry", () => {
 
   describe("evictSurfaceless confirmation", () => {
     it("retains a surfaceless row whose process may still be alive", async () => {
-      stateMgr.writeState(
-        makeRecord({
-          agent_id: "live-pid-surfaceless",
-          state: "working",
-          surface_id: "surface:missing",
-          pid: process.pid,
-        }),
-      );
       const registry = new AgentRegistry(stateMgr, async () => [
         makeSurface("surface:witness"),
       ]);
-      await registry.reconstitute();
+      await persistProductionProcessRecord({
+        stateMgr,
+        registry,
+        record: makeRecord({
+          agent_id: "live-pid-surfaceless",
+          state: "working",
+          surface_id: "surface:missing",
+          pid: null,
+        }),
+      });
 
       await expect(
         registry.evictSurfaceless({ confirmationMs: 0 }),

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1759,9 +1759,69 @@ describe("AgentRegistry", () => {
   });
 
   describe("repairFromDiscovery", () => {
+    it("withholds a launcher alias shared by multiple live managed workers", () => {
+      const first = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-one",
+        surface_id: "surface:worker-one",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      const second = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-two",
+        surface_id: "surface:worker-two",
+        surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      stateMgr.writeState(first);
+      stateMgr.writeState(second);
+      const registry = new AgentRegistry(stateMgr, async () => []);
+      registry.set(first.agent_id, first);
+      registry.set(second.agent_id, second);
+
+      registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: first.surface_id,
+            surface_uuid: first.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+          makeDiscovered({
+            surface_id: second.surface_id,
+            surface_uuid: second.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        {
+          seatRegistry: {
+            ...REPAIR_SEATS,
+            cmuxlayerCodex: {
+              repo: "cmuxlayer",
+              launchers: { codex: "cmuxlayerCodex" },
+              lane: "cmuxlayer-worker",
+              role: "worker",
+            },
+          },
+        },
+      );
+
+      expect(registry.get(first.agent_id)).toMatchObject({
+        agent_id: first.agent_id,
+      });
+      expect(registry.get(second.agent_id)).toMatchObject({
+        agent_id: second.agent_id,
+      });
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
     it("keeps the engine-issued id addressable across a transient missing-surface scan", async () => {
       const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
-      const engineId = "cmuxlayerCodex-bff10108";
+      const engineId = "cmuxlayerClaude-bff10108";
       const parentId = "cmuxlayerClaude-b0a43f90";
       let surfaces = [
         {
@@ -1779,8 +1839,8 @@ describe("AgentRegistry", () => {
           surface_uuid: surfaceUuid,
           state: "ready",
           repo: "cmuxlayer",
-          cli: "codex",
-          launcher_name: "cmuxlayerCodex",
+          cli: "claude",
+          launcher_name: "cmuxlayerClaude",
           pid: null,
           parent_agent_id: parentId,
           surface_provenance: "cmuxlayer_spawn",
@@ -1807,16 +1867,16 @@ describe("AgentRegistry", () => {
           makeDiscovered({
             surface_id: "surface:871",
             surface_uuid: surfaceUuid,
-            surface_title: "cmuxlayerCodex",
-            cli: "codex",
+            surface_title: "cmuxlayerClaude",
+            cli: "claude",
           }),
         ],
         {
           seatRegistry: {
             ...REPAIR_SEATS,
-            cmuxlayerCodex: {
+            cmuxlayerClaude: {
               repo: "cmuxlayer",
-              launchers: { codex: "cmuxlayerCodex" },
+              launchers: { claude: "cmuxlayerClaude" },
               lane: "cmuxlayer-worker",
               role: "worker",
             },
@@ -1829,8 +1889,8 @@ describe("AgentRegistry", () => {
         parent_agent_id: parentId,
         surface_provenance: "cmuxlayer_spawn",
       });
-      expect(registry.get("cmuxlayerCodex")).toBe(registry.get(engineId));
-      expect(stateMgr.readState("cmuxlayerCodex")).toBeNull();
+      expect(registry.get("cmuxlayerClaude")).toBe(registry.get(engineId));
+      expect(stateMgr.readState("cmuxlayerClaude")).toBeNull();
     });
 
     it("removes a failed managed repair without leaving a resolvable alias", async () => {
@@ -1978,8 +2038,7 @@ describe("AgentRegistry", () => {
 
       expect(registry.get(firstId)?.agent_id).toBe(firstId);
       expect(registry.get(secondId)?.agent_id).toBe(secondId);
-      expect(registry.get("cmuxlayerCodex")?.agent_id).toBe(firstId);
-      expect(registry.get("cmuxlayerCodex")?.agent_id).not.toBe(secondId);
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
     });
 
     it.each([
@@ -3341,6 +3400,7 @@ describe("AgentRegistry", () => {
         registry,
         record: makeRecord({
           agent_id: "live-pid-terminal",
+          cli: "claude",
           state: "error",
           surface_id: "surface:missing",
           pid: null,
@@ -3364,6 +3424,7 @@ describe("AgentRegistry", () => {
         registry,
         record: makeRecord({
           agent_id: "live-process-periodic-terminal",
+          cli: "claude",
           state: "done",
           role: "worker",
           surface_id: "surface:missing-periodic",
@@ -3516,6 +3577,7 @@ describe("AgentRegistry", () => {
         registry,
         record: makeRecord({
           agent_id: "live-pid-surfaceless",
+          cli: "claude",
           state: "working",
           surface_id: "surface:missing",
           pid: null,

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -261,6 +261,33 @@ describe("F1 — live state, not the stale registry record", () => {
     // separate state-machine decision, not part of this gate fix.
   });
 
+  it("P1 D8 submits to a screen-idle agent even when its registry record says working", async () => {
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-bff10108",
+        surface_id: client.idleSurface,
+        state: "working",
+      }),
+    );
+
+    const result = await callTool(server, "send_to", {
+      mode: "agent",
+      agent_id: "cmuxlayerCodex-bff10108",
+      text: "Phase 1 now",
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.accepted ?? parsed.ok, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.delivered, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.submit_verified, JSON.stringify(parsed)).toBe(true);
+    expect(parsed.delivery_state ?? parsed.delivery).not.toBe("queued");
+    expect(client.sendCalls).toContain(
+      `${client.idleSurface}:Phase 1 now`,
+    );
+  });
+
   it("send_to still refuses when the live screen agrees the surface is dead", async () => {
     client.screens["surface:idle"] = "$ ";
     registerAgent(

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -356,6 +356,45 @@ describe("F1 — live state, not the stale registry record", () => {
     ]);
   });
 
+  it("P0 D3 keeps a lead's mine=true children visible in list_surfaces", async () => {
+    const lead = registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerClaude-p0-lead",
+        surface_id: client.idleSurface,
+        state: "ready",
+      }),
+    );
+    registerAgent(
+      server,
+      makeAgent({
+        agent_id: "cmuxlayerCodex-p0-child",
+        surface_id: client.workingSurface,
+        state: "working",
+        parent_agent_id: lead.agent_id,
+      }),
+    );
+
+    const mine = await runWithCallerContext(
+      { workspaceId: client.workspace, surfaceId: lead.surface_id },
+      async () =>
+        parseResult(await callTool(server, "list_agents", { mine: true })),
+    );
+    const listed = parseResult(
+      await callTool(server, "list_surfaces", { workspace: client.workspace }),
+    );
+    const surfaceRefs = new Set(
+      (listed.surfaces ?? []).map((surface: { ref?: string }) => surface.ref),
+    );
+
+    expect(mine.agents.map((agent: any) => agent.agent_id)).toEqual([
+      "cmuxlayerCodex-p0-child",
+    ]);
+    for (const child of mine.agents) {
+      expect(surfaceRefs).toContain(child.surface_id);
+    }
+  });
+
   it("#468: a terminal record from a prior observer cannot claim a recycled ref", async () => {
     // `surface_id` is a RECYCLABLE ref. A dead worker's record whose ref was
     // reused by a new pane used to win the last resolution tier and become the

--- a/tests/helpers/production-process-record.ts
+++ b/tests/helpers/production-process-record.ts
@@ -68,21 +68,18 @@ export async function persistProductionProcessRecord(input: {
     captured = input.stateMgr.transition(captured!.agent_id, state);
     input.registry.set(captured!.agent_id, captured!);
   };
-  if (targetState === "ready") advance("ready");
-  if (targetState === "working") {
-    advance("ready");
-    advance("working");
+  const paths: Partial<Record<AgentState, AgentState[]>> = {
+    booting: [],
+    ready: ["ready"],
+    working: ["ready", "working"],
+    idle: ["ready", "working", "idle"],
+    done: ["ready", "working", "done"],
+    error: ["error"],
+  };
+  const path = paths[targetState];
+  if (!path) {
+    throw new Error(`unsupported production record state: ${targetState}`);
   }
-  if (targetState === "idle") {
-    advance("ready");
-    advance("working");
-    advance("idle");
-  }
-  if (targetState === "done") {
-    advance("ready");
-    advance("working");
-    advance("done");
-  }
-  if (targetState === "error") advance("error");
+  for (const state of path) advance(state);
   return captured;
 }

--- a/tests/helpers/production-process-record.ts
+++ b/tests/helpers/production-process-record.ts
@@ -1,0 +1,88 @@
+import { AgentEngine } from "../../src/agent-engine.js";
+import type { AgentRecord, AgentState } from "../../src/agent-types.js";
+import type { CmuxClient } from "../../src/cmux-client.js";
+import { AgentRegistry } from "../../src/agent-registry.js";
+import { makeSelfRegistrationSessionResolver } from "../../src/self-registration.js";
+import { StateManager } from "../../src/state-manager.js";
+
+const PRODUCTION_SESSION_ID = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+
+/**
+ * Build the record shape production emits: persist pid:null, then consume the
+ * hook JSONL through AgentEngine.captureBootSessionId before state advances.
+ */
+export async function persistProductionProcessRecord(input: {
+  stateMgr: StateManager;
+  registry: AgentRegistry;
+  record: AgentRecord;
+  pid?: number;
+  registeredAtMs?: number;
+}): Promise<AgentRecord> {
+  const pid = input.pid ?? process.pid;
+  const registeredAtMs = input.registeredAtMs ?? Date.now();
+  const targetState = input.record.state;
+  const booting: AgentRecord = {
+    ...input.record,
+    state: "booting",
+    pid: null,
+    pid_registered_at: null,
+    surface_provenance: "cmuxlayer_spawn",
+    cli_session_id: input.record.cli_session_id ?? PRODUCTION_SESSION_ID,
+    surface_uuid:
+      input.record.surface_uuid ??
+      "11111111-2222-4333-8444-555555555555",
+  };
+  input.stateMgr.writeState(booting);
+  input.registry.set(booting.agent_id, booting);
+
+  const resolver = makeSelfRegistrationSessionResolver({
+    registryPath: "/test/session-registry.jsonl",
+    readFile: () =>
+      `${JSON.stringify({
+        session_id: booting.cli_session_id,
+        surface_uuid: booting.surface_uuid,
+        cwd: booting.launch_cwd ?? null,
+        pid,
+        cli: booting.cli,
+        ts: registeredAtMs,
+      })}\n`,
+    now: () => registeredAtMs,
+  });
+  const engine = new AgentEngine(
+    input.stateMgr,
+    input.registry,
+    {
+      readScreen: async () => ({ text: "", lines: 0, scrollback_used: false }),
+    } as CmuxClient,
+    {
+      spawnPreflight: async () => {},
+      selfRegistrationSessionResolver: resolver,
+      sessionIdentityResolver: () => null,
+    },
+  );
+  let captured = await engine.captureBootSessionId(booting.agent_id);
+  engine.dispose();
+  if (!captured) throw new Error("production process capture returned null");
+
+  const advance = (state: AgentState): void => {
+    captured = input.stateMgr.transition(captured!.agent_id, state);
+    input.registry.set(captured!.agent_id, captured!);
+  };
+  if (targetState === "ready") advance("ready");
+  if (targetState === "working") {
+    advance("ready");
+    advance("working");
+  }
+  if (targetState === "idle") {
+    advance("ready");
+    advance("working");
+    advance("idle");
+  }
+  if (targetState === "done") {
+    advance("ready");
+    advance("working");
+    advance("done");
+  }
+  if (targetState === "error") advance("error");
+  return captured;
+}

--- a/tests/live-agent-state.test.ts
+++ b/tests/live-agent-state.test.ts
@@ -112,6 +112,18 @@ describe("resolveLiveAgentState — live truth, registry as fallback provenance"
     expect(isLiveDeliverable(resolved)).toBe(true);
   });
 
+  it("does not deliver into a ready composer while boot-prompt delivery still owns the pane", () => {
+    const resolved = resolveLiveAgentState(record({ state: "booting" }), {
+      status: "idle",
+      agent_type: "claude",
+      control_state: "ready",
+    });
+
+    expect(resolved.registry_state).toBe("booting");
+    expect(resolved.screen_state).toBe("ready");
+    expect(isLiveDeliverable(resolved)).toBe(false);
+  });
+
   it("lets a ready prompt clear a stale error record", () => {
     const resolved = resolveLiveAgentState(record({ state: "error" }), {
       status: "idle",

--- a/tests/process-liveness.test.ts
+++ b/tests/process-liveness.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+}));
 import type { AgentRecord } from "../src/agent-types.js";
-import { qualifyAgentProcessLiveness } from "../src/process-liveness.js";
+import {
+  processStartedAtMs,
+  qualifyAgentProcessLiveness,
+} from "../src/process-liveness.js";
 
 function processRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
   return {
@@ -28,6 +36,18 @@ function processRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
 }
 
 describe("qualified agent process liveness", () => {
+  it("bounds the synchronous ps identity probe", () => {
+    execFileSyncMock.mockReturnValueOnce("Sat Aug 23 11:00:02 2026\n");
+
+    processStartedAtMs(43210);
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "ps",
+      ["-o", "lstart=", "-p", "43210"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
   it("accepts a process started inside the production creation-registration window", () => {
     expect(
       qualifyAgentProcessLiveness(

--- a/tests/process-liveness.test.ts
+++ b/tests/process-liveness.test.ts
@@ -48,6 +48,18 @@ describe("qualified agent process liveness", () => {
     ).toBe("gone");
   });
 
+  it("fails closed when second-granular ps time cannot distinguish same-second pid reuse", () => {
+    expect(
+      qualifyAgentProcessLiveness(
+        processRecord({
+          pid_registered_at: "2026-08-23T11:00:05.900Z",
+        }),
+        "alive",
+        Date.parse("2026-08-23T11:00:05.000Z"),
+      ),
+    ).toBe("unknown");
+  });
+
   it("fails closed when a live pid lacks production registration provenance", () => {
     expect(
       qualifyAgentProcessLiveness(

--- a/tests/process-liveness.test.ts
+++ b/tests/process-liveness.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRecord } from "../src/agent-types.js";
+import { qualifyAgentProcessLiveness } from "../src/process-liveness.js";
+
+function processRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    agent_id: "cmuxlayerCodex-process",
+    surface_id: "surface:1",
+    state: "working",
+    repo: "cmuxlayer",
+    model: "gpt-5.6",
+    cli: "codex",
+    cli_session_id: "sid-process",
+    task_summary: "process qualification",
+    pid: 43210,
+    pid_registered_at: "2026-08-23T11:00:05.000Z",
+    version: 1,
+    created_at: "2026-08-23T11:00:00.000Z",
+    updated_at: "2026-08-23T11:00:05.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    ...overrides,
+  } as AgentRecord;
+}
+
+describe("qualified agent process liveness", () => {
+  it("accepts a process started inside the production creation-registration window", () => {
+    expect(
+      qualifyAgentProcessLiveness(
+        processRecord(),
+        "alive",
+        Date.parse("2026-08-23T11:00:02.000Z"),
+      ),
+    ).toBe("alive");
+  });
+
+  it("treats a recycled pid started after self-registration as the old agent process gone", () => {
+    expect(
+      qualifyAgentProcessLiveness(
+        processRecord(),
+        "alive",
+        Date.parse("2026-08-23T11:01:00.000Z"),
+      ),
+    ).toBe("gone");
+  });
+
+  it("fails closed when a live pid lacks production registration provenance", () => {
+    expect(
+      qualifyAgentProcessLiveness(
+        processRecord({ pid_registered_at: null }),
+        "alive",
+        Date.parse("2026-08-23T11:00:02.000Z"),
+      ),
+    ).toBe("unknown");
+  });
+});

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -1317,13 +1317,12 @@ describe("AgentEngine self-registration wiring", () => {
     engine.dispose();
   });
 
-  it("persists production self-registration process evidence for an existing Codex session", async () => {
-    const registeredAt = "2026-08-23T11:00:05.000Z";
+  it("does not use Claude-only self-registration process evidence for an existing Codex session", async () => {
     const selfRegistrationSessionResolver = vi.fn(() => ({
       session_id: "sid-codex-existing",
       path: "/rollout/codex.jsonl",
       pid: 43210,
-      pid_registered_at: registeredAt,
+      pid_registered_at: "2026-08-23T11:00:05.000Z",
     }));
     const { engine, stateMgr, registry } = makeEngineHarness(
       selfRegistrationSessionResolver,
@@ -1343,10 +1342,9 @@ describe("AgentEngine self-registration wiring", () => {
 
     expect(captured).toMatchObject({
       cli_session_id: "sid-codex-existing",
-      pid: 43210,
-      pid_registered_at: registeredAt,
+      pid: null,
     });
-    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
+    expect(selfRegistrationSessionResolver).not.toHaveBeenCalled();
     engine.dispose();
   });
 });

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -196,6 +196,35 @@ describe("parseSelfRegistrationLines", () => {
     });
   });
 
+  it("returns the hook pid with its registration timestamp", () => {
+    const registeredAt = Date.parse("2026-08-23T11:00:05.000Z");
+    const resolve = makeSelfRegistrationSessionResolver({
+      registryPath: "/fake/registry.jsonl",
+      readFile: () =>
+        jsonl({
+          session_id: "sid-with-process",
+          cwd: "/w",
+          pid: 43210,
+          ts: registeredAt,
+        }),
+      now: () => registeredAt,
+    });
+
+    expect(
+      resolve(
+        agent({
+          launch_cwd: "/w",
+          created_at: "2026-08-23T11:00:00.000Z",
+        }),
+      ),
+    ).toEqual({
+      session_id: "sid-with-process",
+      path: null,
+      pid: 43210,
+      pid_registered_at: "2026-08-23T11:00:05.000Z",
+    });
+  });
+
   it("does not use fractional pid or timestamp values as integer identity metadata", () => {
     const entries = parseSelfRegistrationLines(
       jsonl({
@@ -709,6 +738,8 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ launch_cwd: "/Users/e/Gits/cmuxlayer" }))).toEqual({
       session_id: "sid-exact",
       path: "/rollout/exact.jsonl",
+      pid: 111,
+      pid_registered_at: "1970-01-01T00:00:05.000Z",
     });
   });
 
@@ -719,6 +750,8 @@ describe("makeSelfRegistrationSessionResolver", () => {
     expect(resolve(agent({ launch_cwd: "/w" }))).toEqual({
       session_id: "sid-1",
       path: null,
+      pid: 1,
+      pid_registered_at: "1970-01-01T00:00:00.001Z",
     });
   });
 
@@ -1281,6 +1314,39 @@ describe("AgentEngine self-registration wiring", () => {
     expect(captured.cli_session_id).toBe("sid-first-connect");
     expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
     expect(scanSpy).not.toHaveBeenCalled();
+    engine.dispose();
+  });
+
+  it("persists production self-registration process evidence for an existing Codex session", async () => {
+    const registeredAt = "2026-08-23T11:00:05.000Z";
+    const selfRegistrationSessionResolver = vi.fn(() => ({
+      session_id: "sid-codex-existing",
+      path: "/rollout/codex.jsonl",
+      pid: 43210,
+      pid_registered_at: registeredAt,
+    }));
+    const { engine, stateMgr, registry } = makeEngineHarness(
+      selfRegistrationSessionResolver,
+    );
+    const codexAgent = agent({
+      agent_id: "cmuxlayerCodex-existing",
+      cli: "codex",
+      state: "booting",
+      cli_session_id: "sid-codex-existing",
+      pid: null,
+      surface_provenance: "cmuxlayer_spawn",
+    });
+    stateMgr.writeState(codexAgent);
+    registry.set(codexAgent.agent_id, codexAgent);
+
+    const captured = await engine.captureBootSessionId(codexAgent.agent_id);
+
+    expect(captured).toMatchObject({
+      cli_session_id: "sid-codex-existing",
+      pid: 43210,
+      pid_registered_at: registeredAt,
+    });
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
     engine.dispose();
   });
 });

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -569,7 +569,7 @@ describe("send_to v2 background verify", () => {
     expect(client.sendCalls.length).toBe(typedAfterFirst);
   });
 
-  it("suppresses an identical send while the engine queue still holds the first delivery", async () => {
+  it("suppresses an identical send while screen-ready delivery verification is pending", async () => {
     const client = new FakeAgentSurfaceClient();
     server = createVerifyServer(client);
     registerAgent(server, { state: "working" });
@@ -581,7 +581,7 @@ describe("send_to v2 background verify", () => {
         press_enter: true,
       }),
     );
-    expect(first.delivery_state).toBe("queued");
+    expect(first.delivery_state).toBe("pending_verify");
 
     const second = parseResult(
       await callTool(server, "send_to", {
@@ -593,7 +593,7 @@ describe("send_to v2 background verify", () => {
 
     expect(second.delivery_id).toBe(first.delivery_id);
     expect(second.duplicate_of).toBe(first.delivery_id);
-    expect(client.sendCalls).toEqual([]);
+    expect(client.sendCalls).toEqual(["queued once"]);
   });
 
   it("confirms failure after the verify deadline and writes a local evidence ticket", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -212,6 +212,10 @@ function makeServer(exec: ExecFn) {
     disableSpawnPreflight: true,
     controlHealthIntervalMs: 0,
     sessionIdentityResolver: () => null,
+    // Model CI/fresh-clone CLI mode explicitly. Ambient access to a developer's
+    // real cmux socket must not decide whether teardown receipts are truthful.
+    surfaceObserverOwnerIdProvider: () => null,
+    surfaceObserverEpochProvider: () => null,
   }) as unknown;
 }
 

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -37,6 +37,9 @@ function payload(result: ToolCallResult): Record<string, unknown> {
 }
 
 const SURFACE = "surface:89";
+const SURFACE_UUID = "80A5FA59-16D7-41A0-93D4-596423BFB3E3";
+const WITNESS_SURFACE = "surface:witness";
+const WITNESS_UUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE";
 
 const IDLE_CLAUDE_SCREEN = "Claude Code\nWhat can I help you with?\n> ";
 const POPULATED_CLAUDE_SCREEN =
@@ -75,6 +78,8 @@ function makeExec(opts?: {
   closeSurfaceFails?: boolean;
   /** Model a cmux that accepts close-surface but keeps listing the pane. */
   closeLeavesSurfaceListed?: boolean;
+  /** Keep a second surface so absence of the target is authoritative. */
+  witnessSurface?: boolean;
 }): ExecFn & { calls: string[][] } {
   const calls: string[][] = [];
   let surfaceLive = true;
@@ -97,6 +102,14 @@ function makeExec(opts?: {
       };
     }
     if (args.includes("list-panes")) {
+      const surfaceRefs = [
+        ...(surfaceLive ? [SURFACE] : []),
+        ...(opts?.witnessSurface ? [WITNESS_SURFACE] : []),
+      ];
+      const surfaceIds = [
+        ...(surfaceLive ? [SURFACE_UUID] : []),
+        ...(opts?.witnessSurface ? [WITNESS_UUID] : []),
+      ];
       return {
         stdout: JSON.stringify({
           workspace_ref: "workspace:1",
@@ -106,8 +119,9 @@ function makeExec(opts?: {
               ref: "pane:1",
               workspace: "workspace:1",
               focused: true,
-              surface_count: surfaceLive ? 1 : 0,
-              surface_refs: surfaceLive ? [SURFACE] : [],
+              surface_count: surfaceRefs.length,
+              surface_refs: surfaceRefs,
+              ...(opts?.witnessSurface ? { surface_ids: surfaceIds } : {}),
             },
           ],
         }),
@@ -119,18 +133,34 @@ function makeExec(opts?: {
         stdout: JSON.stringify({
           pane_ref: "pane:1",
           workspace_ref: "workspace:1",
-          surfaces: surfaceLive
-            ? [
-                {
-                  ref: SURFACE,
-                  pane: "pane:1",
-                  workspace: "workspace:1",
-                  title: "golemsClaude",
-                  type: "terminal",
-                  selected: true,
-                },
-              ]
-            : [],
+          surfaces: [
+            ...(surfaceLive
+              ? [
+                  {
+                    ...(opts?.witnessSurface ? { id: SURFACE_UUID } : {}),
+                    ref: SURFACE,
+                    pane: "pane:1",
+                    workspace: "workspace:1",
+                    title: "golemsClaude",
+                    type: "terminal",
+                    selected: true,
+                  },
+                ]
+              : []),
+            ...(opts?.witnessSurface
+              ? [
+                  {
+                    id: WITNESS_UUID,
+                    ref: WITNESS_SURFACE,
+                    pane: "pane:1",
+                    workspace: "workspace:1",
+                    title: "witness shell",
+                    type: "terminal",
+                    selected: !surfaceLive,
+                  },
+                ]
+              : []),
+          ],
         }),
         stderr: "",
       };
@@ -515,6 +545,79 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     const data = payload(result);
     expect(data.surface_closed).toBe(false);
     expect(await listSurfaceRefs(server)).toContain(SURFACE);
+  });
+
+  it("P0 D4a an unforced agent close leaves both the live agent and its pane alone", async () => {
+    // Reviewer catch: stop_agent has no liveness refusal of its own, so forcing
+    // the inner close unconditionally would let an UNFORCED close_surface tear
+    // down a still-live agent's pane through a guard that could never fire for
+    // this scope. The caller's own force is passed through instead.
+    const exec = makeExec({
+      screen: () => WORKING_CLAUDE_SCREEN,
+      witnessSurface: true,
+    });
+    const server = makeServer(exec);
+    const record = seedAgent(server, {
+      state: "done",
+      pid: process.pid,
+      surface_uuid: SURFACE_UUID,
+    });
+
+    expect(() => process.kill(process.pid, 0)).not.toThrow();
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+
+    const data = payload(result);
+    expect(data.agent_stopped).toBe(false);
+    expect(data.surface_closed).toBe(false);
+    expect(await listSurfaceRefs(server)).toContain(SURFACE);
+    expect(() => process.kill(process.pid, 0)).not.toThrow();
+  });
+
+  it("P0 D4b does not call a just-observed stable UUID stale after stopping the agent", async () => {
+    const exec = makeExec({
+      screen: () => WORKING_CLAUDE_SCREEN,
+      witnessSurface: true,
+    });
+    const server = makeServer(exec);
+    const record = seedAgent(server, {
+      state: "working",
+      surface_uuid: SURFACE_UUID,
+    });
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+    const data = payload(result);
+
+    expect(String(data.error ?? data.surface_close_error ?? "")).not.toMatch(
+      /stable surface UUID.*(?:not live|no longer live)/i,
+    );
+  });
+
+  it("P0 D4c reports the surface closed when an immediate listing proves it is gone", async () => {
+    const exec = makeExec({
+      screen: () => WORKING_CLAUDE_SCREEN,
+      witnessSurface: true,
+    });
+    const server = makeServer(exec);
+    const record = seedAgent(server, {
+      state: "working",
+      surface_uuid: SURFACE_UUID,
+    });
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+    const data = payload(result);
+
+    expect(await listSurfaceRefs(server)).not.toContain(SURFACE);
+    expect(data.surface_closed).toBe(true);
   });
 
   it("cross-checks scope=workspace: the delegate really deletes, and says so", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -212,6 +212,15 @@ function makeServer(exec: ExecFn) {
     disableSpawnPreflight: true,
     controlHealthIntervalMs: 0,
     sessionIdentityResolver: () => null,
+    selfRegistrationSessionResolver: (agent) =>
+      agent.cli_session_id
+        ? {
+            session_id: agent.cli_session_id,
+            path: agent.cli_session_path ?? null,
+            pid: process.pid,
+            pid_registered_at: new Date().toISOString(),
+          }
+        : null,
     // Model CI/fresh-clone CLI mode explicitly. Ambient access to a developer's
     // real cmux socket must not decide whether teardown receipts are truthful.
     surfaceObserverOwnerIdProvider: () => null,
@@ -402,6 +411,32 @@ function seedAgent(server: unknown, overrides: Partial<AgentRecord> = {}) {
   return record;
 }
 
+async function seedProductionLiveProcess(
+  server: unknown,
+  overrides: Partial<AgentRecord> = {},
+): Promise<AgentRecord> {
+  const seeded = seedAgent(server, {
+    state: "working",
+    cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+    surface_uuid: SURFACE_UUID,
+    surface_provenance: "cmuxlayer_spawn",
+    pid: null,
+    ...overrides,
+  });
+  const engine = getEngine(server) as unknown as {
+    captureBootSessionId(id: string): Promise<AgentRecord | null>;
+    stateMgr: {
+      transition(id: string, state: string): AgentRecord;
+    };
+    getRegistry(): { set(id: string, record: AgentRecord): unknown };
+  };
+  const captured = await engine.captureBootSessionId(seeded.agent_id);
+  if (!captured?.pid) throw new Error("production PID capture failed");
+  const done = engine.stateMgr.transition(seeded.agent_id, "done");
+  engine.getRegistry().set(done.agent_id, done);
+  return done;
+}
+
 async function listSurfaceRefs(server: unknown): Promise<string[]> {
   const result = (await getTool(server, "list_surfaces").handler(
     {},
@@ -552,20 +587,14 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
   });
 
   it("P0 D4a an unforced agent close leaves both the live agent and its pane alone", async () => {
-    // Reviewer catch: stop_agent has no liveness refusal of its own, so forcing
-    // the inner close unconditionally would let an UNFORCED close_surface tear
-    // down a still-live agent's pane through a guard that could never fire for
-    // this scope. The caller's own force is passed through instead.
+    // The agent-scope liveness check and the surface-scope cross-record check
+    // remain independent; neither escalates an unforced request.
     const exec = makeExec({
       screen: () => WORKING_CLAUDE_SCREEN,
       witnessSurface: true,
     });
     const server = makeServer(exec);
-    const record = seedAgent(server, {
-      state: "done",
-      pid: process.pid,
-      surface_uuid: SURFACE_UUID,
-    });
+    const record = await seedProductionLiveProcess(server);
 
     expect(() => process.kill(process.pid, 0)).not.toThrow();
 
@@ -579,6 +608,32 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     expect(data.surface_closed).toBe(false);
     expect(await listSurfaceRefs(server)).toContain(SURFACE);
     expect(() => process.kill(process.pid, 0)).not.toThrow();
+  });
+
+  it("does not let agent scope bypass a different live record backing the surface", async () => {
+    const exec = makeExec({ screen: () => WORKING_CLAUDE_SCREEN });
+    const server = makeServer(exec);
+    const target = seedAgent(server, {
+      agent_id: "golemsClaude-terminal-target",
+      state: "done",
+      surface_uuid: null,
+    });
+    seedAgent(server, {
+      agent_id: "golemsClaude-live-backing-record",
+      state: "working",
+      surface_uuid: null,
+    });
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: target.agent_id },
+      {},
+    )) as ToolCallResult;
+
+    expect(result.isError).toBe(true);
+    expect(String(payload(result).error)).toContain(
+      "golemsClaude-live-backing-record",
+    );
+    expect(await listSurfaceRefs(server)).toContain(SURFACE);
   });
 
   it("P0 D4b does not call a just-observed stable UUID stale after stopping the agent", async () => {
@@ -622,6 +677,29 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
 
     expect(await listSurfaceRefs(server)).not.toContain(SURFACE);
     expect(data.surface_closed).toBe(true);
+  });
+
+  it("refuses socketless teardown of a surface owned by a different observer", async () => {
+    const exec = makeExec({
+      screen: () => WORKING_CLAUDE_SCREEN,
+      witnessSurface: true,
+    });
+    const server = makeServer(exec);
+    const record = seedAgent(server, {
+      state: "working",
+      surface_uuid: SURFACE_UUID,
+      surface_observer_id: "cmux:/tmp/observer-b.sock",
+    });
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+
+    expect(result.isError).toBe(true);
+    expect(String(payload(result).error)).toMatch(/observer|ownership/i);
+    expect(await listSurfaceRefs(server)).toContain(SURFACE);
+    expect(exec.calls.some((args) => args.includes("close-surface"))).toBe(false);
   });
 
   it("cross-checks scope=workspace: the delegate really deletes, and says so", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -80,6 +80,8 @@ function makeExec(opts?: {
   closeLeavesSurfaceListed?: boolean;
   /** Keep a second surface so absence of the target is authoritative. */
   witnessSurface?: boolean;
+  /** Model transient topology failure while verifying agent-scope closure. */
+  surfaceEnumerationFails?: boolean;
 }): ExecFn & { calls: string[][] } {
   const calls: string[][] = [];
   let surfaceLive = true;
@@ -102,6 +104,9 @@ function makeExec(opts?: {
       };
     }
     if (args.includes("list-panes")) {
+      if (opts?.surfaceEnumerationFails) {
+        throw new Error("cmux list-panes: transient enumeration failure");
+      }
       const surfaceRefs = [
         ...(surfaceLive ? [SURFACE] : []),
         ...(opts?.witnessSurface ? [WITNESS_SURFACE] : []),
@@ -546,6 +551,27 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     expect(data.surface_closed).toBe(false);
     expect(String(data.error)).toMatch(/surface/i);
     expect(await listSurfaceRefs(server)).toContain(SURFACE);
+  });
+
+  it("does not report a surface closed when topology enumeration failed", async () => {
+    const exec = makeExec({
+      screen: () => IDLE_CLAUDE_SCREEN,
+      surfaceEnumerationFails: true,
+    });
+    const server = makeServer(exec);
+    const record = seedAgent(server);
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+
+    const data = payload(result);
+    expect(result.isError).toBe(true);
+    expect(data.agent_stopped).toBe(true);
+    expect(data.surface_closed).toBe(false);
+    expect(String(data.error)).toMatch(/enumerat|verify.*surface/i);
+    expect(exec.calls.some((args) => args.includes("close-surface"))).toBe(false);
   });
 
   it("states plainly that there was no surface to close rather than implying one closed", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -630,6 +630,8 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     )) as ToolCallResult;
 
     const data = payload(result);
+    expect(result.isError).toBe(true);
+    expect(data.ok).toBe(false);
     expect(data.agent_stopped).toBe(false);
     expect(data.surface_closed).toBe(false);
     expect(await listSurfaceRefs(server)).toContain(SURFACE);

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -112,10 +112,6 @@ function parseResult(result: {
 }
 
 describe("thin-core tool palette", () => {
-  it("P0 D7 exposes an agent-initiated blocker escalation to its parent", () => {
-    expect(PUBLIC_TOOL_NAMES).toContain("report_to_parent");
-  });
-
   it("publishes only the ratified Phase 5 surface", () => {
     const server = createServer({
       exec: makeExec(),

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -112,6 +112,10 @@ function parseResult(result: {
 }
 
 describe("thin-core tool palette", () => {
+  it("P0 D7 exposes an agent-initiated blocker escalation to its parent", () => {
+    expect(PUBLIC_TOOL_NAMES).toContain("report_to_parent");
+  });
+
   it("publishes only the ratified Phase 5 surface", () => {
     const server = createServer({
       exec: makeExec(),


### PR DESCRIPTION
## Summary

- Preserve live managed-agent identity through transient topology gaps instead of purging, duplicating, or misrouting the original record.
- Capture self-registration PID evidence on production spawn/rebind paths, qualify it against process start time, and use it for resume, purge, routing, and teardown decisions.
- Keep observer ownership and cross-record teardown guards intact in socketless operation, add a deliberate forced-resume escape hatch, and prevent booting panes from becoming deliverable early.
- Add production-shaped regressions that begin with `pid: null` and acquire PID evidence through the real self-registration resolver.

## Coverage boundary

PID capture currently covers **Claude only in practice**. The resolver supports Codex rows, but cmuxlayer ships no Codex self-registration hook and none exists in the installed configuration, so Codex agents do not yet emit the PID evidence consumed by these guards. D7 / `report_to_parent` remains deliberately held back and is not included in this PR.

## Tracked follow-ups

- [#520 — add self-registration hooks for Codex and Cursor](https://github.com/EtanHey/cmuxlayer/issues/520)
- [#521 — persist observer ownership for socketless and legacy records](https://github.com/EtanHey/cmuxlayer/issues/521)
- [#522 — avoid synchronous process-start probes in reconcile loops](https://github.com/EtanHey/cmuxlayer/issues/522)

## Verification

- `bun run typecheck`
- `bunx vitest run` — 141 files passed; 3,246 passed, 1 skipped
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run` — identical result
- Normal pre-push hook — 3,246 passed, 1 skipped
- Independent pair review on production Claude registry data: HAPPY at `e0b3cfe`

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02e1d","ts":"2026-08-23T12:14:55Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches agent identity, resume, purge, routing, and teardown. Incorrect liveness or UUID proofs can leave live processes running, block legitimate stop/resume, or close the wrong pane.
> 
> **Overview**
> Keeps a live managed agent’s engine-issued identity through topology gaps instead of evicting it and reminting a seat-named duplicate.
> 
> Self-registration now persists `pid` + `pid_registered_at`. New `process-liveness` helpers probe the PID and qualify start time against the spawn/registration window so recycled PIDs fail closed. Resume, purge, surfaceless eviction, and I/O routing refuse action while that process may still be alive. Resume can take `force` only when liveness is unknown, never when the PID is proven alive.
> 
> Stop/close in socketless CLI mode must prove the record’s stable UUID on a complete topology (and refuse competing UUID claims). `close_surface` (agent scope) refuses unforced teardown of a live PID and treats a missing surface after stop as already closed rather than issuing a second stale close.
> 
> `send_to` no longer pre-queues just because the registry says `working`; a ready screen can deliver unless the agent is still `booting`. PID capture remains Claude-only in practice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965741960d823a0ff0b5424dfa2d81f510bf6049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve live agent identity through topology gaps via PID liveness checks
> - Adds `process-liveness.ts` with `agentProcessLiveness` and `agentProcessMayBeAlive` that probe PID existence via `process.kill` and qualify against the agent's creation-to-registration time window using `ps` start time
> - `AgentEngine.resumeAgent` now refuses resume when the recorded PID may be alive unless `force` is set; `stopAgent` and `close_surface` use stricter stop-specific route validation that requires fresh complete topology proof in socketless mode
> - `AgentRegistry` startup purge, surfaceless detection, and absence reconciliation now skip agents whose recorded process may be alive, preventing false teardowns during transient topology gaps
> - `makeSelfRegistrationSessionResolver` and `CapturedSessionIdentity` now carry `pid` and `pid_registered_at` so captured process evidence persists alongside session identity
> - `send_to` no longer pre-queues based on busy state; it attempts delivery and only queues on `RetryableDeliveryError`. `isLiveDeliverable` now allows delivery to ready prompts when registry state is `working`; only `booting` blocks
> - Risk: `resumeAgent` without `force` will now reject when PID liveness is `unknown` (e.g., `process.kill` returns `EPERM` or `pid_registered_at` is absent) — callers that previously resumed blindly must pass `force: true`. `close_surface` with `scope=agent` refuses non-forced teardown when `agentProcessMayBeAlive` returns true in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/523/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595). Registry repair in [agent-registry.ts](https://github.com/EtanHey/cmuxlayer/pull/523/files#diff-0d60b018bf3077cf672b99b42a9e57bddafe6ceb878621ab79b5ce52ab374aa6) now withholds shared launcher aliases when multiple live workers claim them, so alias-based addressing may change for same-repo multi-agent setups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9657419.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that prevent resuming or closing agents while their recorded processes may still be running.
  * Added an optional force option for resume operations when process status cannot be confirmed.
  * Improved recovery and stop handling when observer information is unavailable.
  * Preserved agent records more reliably during reconciliation and cleanup.

* **Bug Fixes**
  * Improved delivery verification for screen-ready agents.
  * Prevented duplicate surface closure and corrected live-state handling.
  * Improved stable surface identification after topology changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->