### PR TITLE
fix(lifecycle): qualify process identity before teardown

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3442,15 +3442,36 @@ export class AgentEngine {
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
-      if (!agent.pid && this.canUseSelfRegistrationSessionResolver(agent)) {
+      const canResolveSelfRegistration =
+        this.canUseSelfRegistrationSessionResolver(agent);
+      const recordedProcessGone =
+        canResolveSelfRegistration &&
+        Boolean(agent.pid) &&
+        agentProcessLiveness(agent) === "gone";
+      if (
+        canResolveSelfRegistration &&
+        (!agent.pid || recordedProcessGone)
+      ) {
         try {
           const registered = this.selfRegistrationSessionResolver?.(agent);
           if (registered) {
             const identity = this.normalizeCapturedSessionIdentity(registered);
+            const previousRegisteredAtMs = Date.parse(
+              agent.pid_registered_at ?? "",
+            );
+            const replacementRegisteredAtMs = Date.parse(
+              identity.pid_registered_at ?? "",
+            );
+            const replacementIsNewer =
+              !agent.pid ||
+              (Number.isFinite(previousRegisteredAtMs) &&
+                Number.isFinite(replacementRegisteredAtMs) &&
+                replacementRegisteredAtMs > previousRegisteredAtMs);
             if (
               identity.session_id === agent.cli_session_id &&
               identity.pid &&
-              identity.pid_registered_at
+              identity.pid_registered_at &&
+              replacementIsNewer
             ) {
               agent = this.finalizeCapturedSession(agent, identity);
             }
@@ -8959,13 +8980,24 @@ export class AgentEngine {
 
     let forceSignalAccepted = force === true && !agent.pid;
     if (force && agent.pid) {
-      try {
-        process.kill(agent.pid, "SIGKILL");
+      const processIdentity = agentProcessLiveness(agent);
+      if (processIdentity === "gone") {
         forceSignalAccepted = true;
-      } catch (error) {
-        forceSignalAccepted = this.isProcessMissingError(error);
-        if (!forceSignalAccepted) rollbackUnacceptedStopIntent();
-        // Process may already be dead; other failures must preserve tracking.
+      } else if (processIdentity === "unknown") {
+        rollbackUnacceptedStopIntent();
+        throw new Error(
+          `Force stop refused for ${agent.agent_id}: recorded pid ${agent.pid} ` +
+            `identity is unknown; refusing SIGKILL.`,
+        );
+      } else {
+        try {
+          process.kill(agent.pid, "SIGKILL");
+          forceSignalAccepted = true;
+        } catch (error) {
+          forceSignalAccepted = this.isProcessMissingError(error);
+          if (!forceSignalAccepted) rollbackUnacceptedStopIntent();
+          // Process may already be dead; other failures must preserve tracking.
+        }
       }
     } else {
       // Graceful: send Ctrl+C

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8697,13 +8697,13 @@ export class AgentEngine {
     );
   }
 
-  private isProcessGone(pid: number | null | undefined): boolean {
-    const liveness = this.processLiveness(pid);
+  private isProcessGone(agent: AgentRecord): boolean {
+    const liveness = agentProcessLiveness(agent);
     return liveness === "gone" || liveness === "unknown";
   }
 
-  private isProcessConfirmedGone(pid: number | null | undefined): boolean {
-    return this.processLiveness(pid) === "gone";
+  private isProcessConfirmedGone(agent: AgentRecord): boolean {
+    return agentProcessLiveness(agent) === "gone";
   }
 
   /**
@@ -8803,8 +8803,8 @@ export class AgentEngine {
     treatUnknownProcessAsGone: boolean,
   ): Promise<StopPostConditionResult> {
     const processGone = treatUnknownProcessAsGone
-      ? this.isProcessGone(agent.pid)
-      : this.isProcessConfirmedGone(agent.pid);
+      ? this.isProcessGone(agent)
+      : this.isProcessConfirmedGone(agent);
     const [surfaceGone, paneGone] = await Promise.all([
       this.isAgentSurfaceGone(agent),
       this.isPaneGone(paneRef, agent.workspace_id),

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -2101,9 +2101,7 @@ export class AgentRegistry {
         : null,
     );
     const candidateAgentIds = discovered.map((entry) =>
-      entry.read_error
-        ? null
-        : repairCandidateAgentIdForSurface(entry, opts?.seatRegistry),
+      repairCandidateAgentIdForSurface(entry, opts?.seatRegistry),
     );
     const candidateCounts = new Map<string, number>();
     for (const agentId of candidateAgentIds) {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -375,6 +375,21 @@ function repairCandidateForSurface(
   };
 }
 
+function repairCandidateAgentIdForSurface(
+  discovered: DiscoveredAgent,
+  registry?: SeatRegistry | null,
+): string | null {
+  const launcher = inferRepairLauncher(discovered, registry);
+  if (!launcher) return null;
+  const seat = assertSeatIdentity({
+    repo: launcher.repo,
+    cli: launcher.cli,
+    launcherName: launcher.launcherName,
+    registry,
+  });
+  return seat.seat_id ?? launcher.launcherName;
+}
+
 function recordIdentityKeys(record: AgentRecord): string[] {
   return [
     record.seat_id ? `seat:${record.seat_id}` : null,
@@ -2085,12 +2100,17 @@ export class AgentRegistry {
         ? this.repairCandidateForDiscovery(entry, opts?.seatRegistry)
         : null,
     );
+    const candidateAgentIds = discovered.map((entry) =>
+      entry.read_error
+        ? null
+        : repairCandidateAgentIdForSurface(entry, opts?.seatRegistry),
+    );
     const candidateCounts = new Map<string, number>();
-    for (const candidate of candidates) {
-      if (!candidate) continue;
+    for (const agentId of candidateAgentIds) {
+      if (!agentId) continue;
       candidateCounts.set(
-        candidate.agentId,
-        (candidateCounts.get(candidate.agentId) ?? 0) + 1,
+        agentId,
+        (candidateCounts.get(agentId) ?? 0) + 1,
       );
     }
     for (const [agentId, count] of candidateCounts) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10134,7 +10134,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const boundAgent = context.lifecycleRegistry?.get(args.agent_id) ?? null;
           const boundSurface = boundAgent?.surface_id?.trim() || null;
           const boundWorkspace = boundAgent?.workspace_id ?? undefined;
-          if (!args.force && boundAgent && agentProcessMayBeAlive(boundAgent)) {
+          if (
+            !args.force &&
+            boundAgent &&
+            !TERMINAL_AGENT_STATES.has(boundAgent.state) &&
+            agentProcessMayBeAlive(boundAgent)
+          ) {
             return err(
               new Error(
                 `close_surface scope=agent refused — agent ${args.agent_id} still has live recorded pid ${boundAgent?.pid}`,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -12462,7 +12462,7 @@ Session ID: ${sessionId}`,
         );
         liveSurfaces = [makeSurface("surface:force-live")];
         await engine.getRegistry().reconstitute();
-        execFileSyncMock.mockReturnValue("Sun Aug 23 14:00:02 2026\n");
+        execFileSyncMock.mockReturnValue("2026-08-23T11:00:02.000Z\n");
 
         await expect(engine.stopAgent("agent-force-live", true)).rejects.toThrow(
           /post-condition/i,
@@ -12554,7 +12554,7 @@ Session ID: ${sessionId}`,
         );
         liveSurfaces = [makeSurface("surface:force-eperm")];
         await engine.getRegistry().reconstitute();
-        execFileSyncMock.mockReturnValue("Sun Aug 23 14:00:02 2026\n");
+        execFileSyncMock.mockReturnValue("2026-08-23T11:00:02.000Z\n");
 
         await expect(engine.stopAgent("agent-force-eperm", true)).rejects.toThrow(
           /process still alive/i,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4474,6 +4474,68 @@ Session ID: ${sessionId}`,
       });
     });
 
+    it("replaces stale pid evidence when the recorded process is proven gone", async () => {
+      const agentId = "cmuxlayerClaude-replaced-process";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      const oldPid = 31001;
+      const replacementPid = 31002;
+      const selfRegistrationResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: null,
+        pid: replacementPid,
+        pid_registered_at: "2026-08-23T11:05:00.000Z",
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: selfRegistrationResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          repo: "cmuxlayer",
+          cli: "claude",
+          state: "working",
+          surface_id: "surface:replaced-process",
+          surface_uuid: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
+          surface_provenance: "cmuxlayer_spawn",
+          cli_session_id: sessionId,
+          pid: oldPid,
+          pid_registered_at: "2026-08-23T11:00:05.000Z",
+          created_at: "2026-08-23T11:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:replaced-process"),
+          id: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
+        },
+      ];
+      await registry.reconstitute();
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          if (pid === oldPid && signal === 0) {
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        await engine.captureBootSessionId(agentId);
+
+        expect(selfRegistrationResolver).toHaveBeenCalledTimes(1);
+        expect(engine.getAgentState(agentId)).toMatchObject({
+          pid: replacementPid,
+          pid_registered_at: "2026-08-23T11:05:00.000Z",
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
     it("keeps captured pid evidence when a pending row converges on an existing final session", async () => {
       const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
       const finalAgentId = "cmuxlayerClaude-019d9aa5";
@@ -12277,6 +12339,57 @@ Session ID: ${sessionId}`,
       expect(engine.getAgentState("agent-force")).toBeNull();
     });
 
+    it("does not SIGKILL a recycled pid from production registration evidence", async () => {
+      const pid = 45678;
+      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+      let zeroProbeCount = 0;
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((targetPid: number, signal?: NodeJS.Signals | 0) => {
+          killCalls.push([targetPid, signal ?? 0]);
+          if (targetPid === pid && (signal ?? 0) === 0) {
+            zeroProbeCount += 1;
+            if (zeroProbeCount > 1) {
+              throw Object.assign(new Error("no such process"), {
+                code: "ESRCH",
+              });
+            }
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        await persistProductionProcessRecord({
+          stateMgr,
+          registry: engine.getRegistry(),
+          pid,
+          registeredAtMs: Date.parse("2026-08-23T11:00:05.000Z"),
+          record: makeRecord({
+            agent_id: "agent-force-recycled-pid",
+            state: "working",
+            surface_id: "surface:force-recycled-pid",
+            repo: "cmuxlayer",
+            cli: "claude",
+            created_at: "2026-08-23T11:00:00.000Z",
+          }),
+        });
+        liveSurfaces = [
+          {
+            ...makeSurface("surface:force-recycled-pid"),
+            id: "11111111-2222-4333-8444-555555555555",
+          },
+        ];
+        execFileSyncMock.mockReturnValue("Sun Aug 23 11:10:00 2026\n");
+
+        await engine.stopAgent("agent-force-recycled-pid", true);
+
+        expect(killCalls).toContainEqual([pid, 0]);
+        expect(killCalls).not.toContainEqual([pid, "SIGKILL"]);
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
     it("force-removes a terminal ghost without resolving surface I/O", async () => {
       engine.dispose();
       const scopedRegistry = new AgentRegistry(
@@ -12343,10 +12456,13 @@ Session ID: ${sessionId}`,
             state: "working",
             surface_id: "surface:force-live",
             pid: 12345,
+            created_at: "2026-08-23T11:00:00.000Z",
+            pid_registered_at: "2026-08-23T11:00:05.000Z",
           }),
         );
         liveSurfaces = [makeSurface("surface:force-live")];
         await engine.getRegistry().reconstitute();
+        execFileSyncMock.mockReturnValue("Sun Aug 23 14:00:02 2026\n");
 
         await expect(engine.stopAgent("agent-force-live", true)).rejects.toThrow(
           /post-condition/i,
@@ -12359,7 +12475,7 @@ Session ID: ${sessionId}`,
       }
     });
 
-    it("does not treat kill(0) permission errors as proof the process is still alive", async () => {
+    it("does not SIGKILL when process identity qualification is unknown", async () => {
       const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
       const killSpy = vi
         .spyOn(process, "kill")
@@ -12385,12 +12501,20 @@ Session ID: ${sessionId}`,
         liveSurfaces = [makeSurface("surface:force-unknown")];
         await engine.getRegistry().reconstitute();
 
-        await engine.stopAgent("agent-force-unknown", true);
+        await expect(
+          engine.stopAgent("agent-force-unknown", true),
+        ).rejects.toThrow(/unknown|qualif|identity|refus/i);
 
-        expect(killCalls).toContainEqual([23456, "SIGKILL"]);
         expect(killCalls).toContainEqual([23456, 0]);
-        expect(stateMgr.readState("agent-force-unknown")).toBeNull();
-        expect(engine.getAgentState("agent-force-unknown")).toBeNull();
+        expect(killCalls).not.toContainEqual([23456, "SIGKILL"]);
+        expect(stateMgr.readState("agent-force-unknown")).toMatchObject({
+          state: "working",
+          pid: 23456,
+        });
+        expect(engine.getAgentState("agent-force-unknown")).toMatchObject({
+          state: "working",
+          pid: 23456,
+        });
       } finally {
         killSpy.mockRestore();
       }
@@ -12409,9 +12533,12 @@ Session ID: ${sessionId}`,
         .spyOn(process, "kill")
         .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
           killCalls.push([pid, signal ?? 0]);
-          throw Object.assign(new Error("operation not permitted"), {
-            code: "EPERM",
-          });
+          if (signal === "SIGKILL") {
+            throw Object.assign(new Error("operation not permitted"), {
+              code: "EPERM",
+            });
+          }
+          return true;
         }) as typeof process.kill);
 
       try {
@@ -12421,10 +12548,13 @@ Session ID: ${sessionId}`,
             state: "working",
             surface_id: "surface:force-eperm",
             pid: 56789,
+            created_at: "2026-08-23T11:00:00.000Z",
+            pid_registered_at: "2026-08-23T11:00:05.000Z",
           }),
         );
         liveSurfaces = [makeSurface("surface:force-eperm")];
         await engine.getRegistry().reconstitute();
+        execFileSyncMock.mockReturnValue("Sun Aug 23 14:00:02 2026\n");
 
         await expect(engine.stopAgent("agent-force-eperm", true)).rejects.toThrow(
           /process still alive/i,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -206,6 +206,7 @@ describe("AgentEngine", () => {
     mkdirSync(TEST_DIR, { recursive: true });
     spawnMock.mockReset();
     spawnMock.mockImplementation(() => mockSpawnExit(1));
+    execFileSyncMock.mockReset();
     stateMgr = new StateManager(TEST_DIR);
     mockClient = makeMockClient();
     liveSurfaces = [];
@@ -12339,56 +12340,62 @@ Session ID: ${sessionId}`,
       expect(engine.getAgentState("agent-force")).toBeNull();
     });
 
-    it("does not SIGKILL a recycled pid from production registration evidence", async () => {
-      const pid = 45678;
-      const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
-      let zeroProbeCount = 0;
-      const killSpy = vi
-        .spyOn(process, "kill")
-        .mockImplementation(((targetPid: number, signal?: NodeJS.Signals | 0) => {
-          killCalls.push([targetPid, signal ?? 0]);
-          if (targetPid === pid && (signal ?? 0) === 0) {
-            zeroProbeCount += 1;
-            if (zeroProbeCount > 1) {
-              throw Object.assign(new Error("no such process"), {
-                code: "ESRCH",
-              });
-            }
+    it.each([false, true])(
+      "tears down a recycled pid that stays live without sending SIGKILL (force=%s)",
+      async (force) => {
+        const pid = 45678;
+        const killCalls: Array<[number, NodeJS.Signals | 0]> = [];
+        const killSpy = vi
+          .spyOn(process, "kill")
+          .mockImplementation(((
+            targetPid: number,
+            signal?: NodeJS.Signals | 0,
+          ) => {
+            killCalls.push([targetPid, signal ?? 0]);
+            return true;
+          }) as typeof process.kill);
+
+        try {
+          await persistProductionProcessRecord({
+            stateMgr,
+            registry: engine.getRegistry(),
+            pid,
+            registeredAtMs: Date.parse("2026-08-23T11:00:05.000Z"),
+            record: makeRecord({
+              agent_id: "agent-force-recycled-pid",
+              state: "working",
+              surface_id: "surface:force-recycled-pid",
+              repo: "cmuxlayer",
+              cli: "claude",
+              created_at: "2026-08-23T11:00:00.000Z",
+            }),
+          });
+          liveSurfaces = [
+            {
+              ...makeSurface("surface:force-recycled-pid"),
+              id: "11111111-2222-4333-8444-555555555555",
+            },
+          ];
+          execFileSyncMock.mockReturnValue("Sun Aug 23 11:10:00 2026\n");
+
+          await engine.stopAgent("agent-force-recycled-pid", force);
+
+          expect(killCalls).toContainEqual([pid, 0]);
+          expect(killCalls).not.toContainEqual([pid, "SIGKILL"]);
+          if (force) {
+            expect(stateMgr.readState("agent-force-recycled-pid")).toBeNull();
+            expect(engine.getAgentState("agent-force-recycled-pid")).toBeNull();
+          } else {
+            expect(stateMgr.readState("agent-force-recycled-pid")).toMatchObject({
+              state: "done",
+              user_killed: true,
+            });
           }
-          return true;
-        }) as typeof process.kill);
-
-      try {
-        await persistProductionProcessRecord({
-          stateMgr,
-          registry: engine.getRegistry(),
-          pid,
-          registeredAtMs: Date.parse("2026-08-23T11:00:05.000Z"),
-          record: makeRecord({
-            agent_id: "agent-force-recycled-pid",
-            state: "working",
-            surface_id: "surface:force-recycled-pid",
-            repo: "cmuxlayer",
-            cli: "claude",
-            created_at: "2026-08-23T11:00:00.000Z",
-          }),
-        });
-        liveSurfaces = [
-          {
-            ...makeSurface("surface:force-recycled-pid"),
-            id: "11111111-2222-4333-8444-555555555555",
-          },
-        ];
-        execFileSyncMock.mockReturnValue("Sun Aug 23 11:10:00 2026\n");
-
-        await engine.stopAgent("agent-force-recycled-pid", true);
-
-        expect(killCalls).toContainEqual([pid, 0]);
-        expect(killCalls).not.toContainEqual([pid, "SIGKILL"]);
-      } finally {
-        killSpy.mockRestore();
-      }
-    });
+        } finally {
+          killSpy.mockRestore();
+        }
+      },
+    );
 
     it("force-removes a terminal ghost without resolving surface I/O", async () => {
       engine.dispose();
@@ -12510,6 +12517,7 @@ Session ID: ${sessionId}`,
         expect(stateMgr.readState("agent-force-unknown")).toMatchObject({
           state: "working",
           pid: 23456,
+          user_killed: false,
         });
         expect(engine.getAgentState("agent-force-unknown")).toMatchObject({
           state: "working",

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1863,6 +1863,66 @@ describe("AgentRegistry", () => {
       expect(registry.get("cmuxlayerCodex")).toBeNull();
     });
 
+    it("counts healthy workers when withholding an orphans-only repair alias", () => {
+      const healthy = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-healthy",
+        surface_id: "surface:worker-healthy",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      const repairTarget = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-repair",
+        surface_id: "surface:worker-repair",
+        surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      const repairEligibilityDuplicate = makeRecord({
+        agent_id: "auto-cmuxlayer-worker-repair",
+        surface_id: repairTarget.surface_id,
+        surface_uuid: repairTarget.surface_uuid,
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      for (const record of [healthy, repairTarget, repairEligibilityDuplicate]) {
+        stateMgr.writeState(record);
+      }
+      const registry = new AgentRegistry(stateMgr, async () => []);
+      for (const record of [healthy, repairTarget, repairEligibilityDuplicate]) {
+        registry.set(record.agent_id, record);
+      }
+
+      registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: healthy.surface_id,
+            surface_uuid: healthy.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+          makeDiscovered({
+            surface_id: repairTarget.surface_id,
+            surface_uuid: repairTarget.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        { orphansOnly: true },
+      );
+
+      expect(registry.get(healthy.agent_id)).toMatchObject({
+        agent_id: healthy.agent_id,
+      });
+      expect(registry.get(repairTarget.agent_id)).toMatchObject({
+        agent_id: repairTarget.agent_id,
+      });
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
     it("keeps the engine-issued id addressable across a transient missing-surface scan", async () => {
       const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
       const engineId = "cmuxlayerClaude-bff10108";

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1923,6 +1923,67 @@ describe("AgentRegistry", () => {
       expect(registry.get("cmuxlayerCodex")).toBeNull();
     });
 
+    it("counts unread live workers when withholding an orphans-only repair alias", () => {
+      const unread = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-unread",
+        surface_id: "surface:worker-unread",
+        surface_uuid: "11111111-2222-4333-8444-555555555555",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      const repairTarget = makeRecord({
+        agent_id: "cmuxlayerCodex-worker-repair",
+        surface_id: "surface:worker-repair",
+        surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      const repairEligibilityDuplicate = makeRecord({
+        agent_id: "auto-cmuxlayer-worker-repair",
+        surface_id: repairTarget.surface_id,
+        surface_uuid: repairTarget.surface_uuid,
+        repo: "cmuxlayer",
+        cli: "codex",
+        launcher_name: "cmuxlayerCodex",
+      });
+      for (const record of [unread, repairTarget, repairEligibilityDuplicate]) {
+        stateMgr.writeState(record);
+      }
+      const registry = new AgentRegistry(stateMgr, async () => []);
+      for (const record of [unread, repairTarget, repairEligibilityDuplicate]) {
+        registry.set(record.agent_id, record);
+      }
+
+      registry.repairFromDiscovery(
+        [
+          makeDiscovered({
+            surface_id: unread.surface_id,
+            surface_uuid: unread.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+            read_error: true,
+          }),
+          makeDiscovered({
+            surface_id: repairTarget.surface_id,
+            surface_uuid: repairTarget.surface_uuid,
+            surface_title: "cmuxlayerCodex",
+            cli: "codex",
+          }),
+        ],
+        { orphansOnly: true },
+      );
+
+      expect(registry.get(unread.agent_id)).toMatchObject({
+        agent_id: unread.agent_id,
+      });
+      expect(registry.get(repairTarget.agent_id)).toMatchObject({
+        agent_id: repairTarget.agent_id,
+      });
+      expect(registry.get("cmuxlayerCodex")).toBeNull();
+    });
+
     it("keeps the engine-issued id addressable across a transient missing-surface scan", async () => {
       const surfaceUuid = "e9072772-a6ab-47ea-af04-b561d75ae6e2";
       const engineId = "cmuxlayerClaude-bff10108";

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -703,7 +703,7 @@ describe("Phase 10 painpoint e2e replay", () => {
     }
   });
 
-  it("candidate 19: public stop_agent force treats kill(0) EPERM as unknown/gone after SIGKILL", async () => {
+  it("candidate 19: public stop_agent force refuses unknown identity without SIGKILL", async () => {
     const dir = tempDir("candidate-19");
     new StateManager(dir).writeState(
       makeRecord({
@@ -734,18 +734,23 @@ describe("Phase 10 painpoint e2e replay", () => {
     try {
       const engine = getEngine(server);
       await engine.getRegistry().reconstitute();
-      const stopped = parseToolResult<{ state: AgentState }>(
-        await getTool(server, "stop_agent").handler(
-          { agent_id: "agent-force-unknown", force: true },
-          {},
-        ),
+      const result = await getTool(server, "stop_agent").handler(
+        { agent_id: "agent-force-unknown", force: true },
+        {},
       );
 
-      expect(stopped.state).toBe("done");
-      expect(killCalls).toContainEqual([23_456, "SIGKILL"]);
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        ok: false,
+        error: expect.stringMatching(/unknown.*refusing SIGKILL/i),
+      });
       expect(killCalls).toContainEqual([23_456, 0]);
-      expect(closeCalls).toEqual(["surface:force-unknown"]);
-      expect(new StateManager(dir).readState("agent-force-unknown")).toBeNull();
+      expect(killCalls).not.toContainEqual([23_456, "SIGKILL"]);
+      expect(closeCalls).toEqual([]);
+      expect(new StateManager(dir).readState("agent-force-unknown")).toMatchObject({
+        state: "working",
+        pid: 23_456,
+      });
     } finally {
       killSpy.mockRestore();
       await closeServer(server);

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -420,13 +420,14 @@ async function seedProductionLiveProcess(
   server: unknown,
   overrides: Partial<AgentRecord> = {},
 ): Promise<AgentRecord> {
+  const targetState = overrides.state ?? "working";
   const seeded = seedAgent(server, {
-    state: "working",
     cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     surface_uuid: SURFACE_UUID,
     surface_provenance: "cmuxlayer_spawn",
     pid: null,
     ...overrides,
+    state: "working",
   });
   const engine = getEngine(server) as unknown as {
     captureBootSessionId(id: string): Promise<AgentRecord | null>;
@@ -437,9 +438,10 @@ async function seedProductionLiveProcess(
   };
   const captured = await engine.captureBootSessionId(seeded.agent_id);
   if (!captured?.pid) throw new Error("production PID capture failed");
-  const done = engine.stateMgr.transition(seeded.agent_id, "done");
-  engine.getRegistry().set(done.agent_id, done);
-  return done;
+  if (captured.state === targetState) return captured;
+  const transitioned = engine.stateMgr.transition(seeded.agent_id, targetState);
+  engine.getRegistry().set(transitioned.agent_id, transitioned);
+  return transitioned;
 }
 
 async function listSurfaceRefs(server: unknown): Promise<string[]> {
@@ -635,6 +637,41 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     expect(data.agent_stopped).toBe(false);
     expect(data.surface_closed).toBe(false);
     expect(await listSurfaceRefs(server)).toContain(SURFACE);
+    expect(() => process.kill(process.pid, 0)).not.toThrow();
+  });
+
+  it("harvests a terminal agent pane without signalling its intentionally live process", async () => {
+    const exec = makeExec({
+      screen: () => IDLE_CLAUDE_SCREEN,
+      witnessSurface: true,
+    });
+    const server = makeServer(exec);
+    const productionRecord = await seedProductionLiveProcess(server, {
+      state: "done",
+    });
+    const engine = getEngine(server) as unknown as {
+      stateMgr: {
+        updateRecord(id: string, patch: Partial<AgentRecord>): AgentRecord;
+      };
+      getRegistry(): { set(id: string, record: AgentRecord): unknown };
+    };
+    const record = engine.stateMgr.updateRecord(productionRecord.agent_id, {
+      surface_uuid: null,
+    });
+    engine.getRegistry().set(record.agent_id, record);
+
+    expect(record).toMatchObject({ state: "done", pid: process.pid });
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id },
+      {},
+    )) as ToolCallResult;
+
+    expect(result.isError).toBeUndefined();
+    expect(payload(result)).toMatchObject({
+      agent_stopped: true,
+      surface_closed: true,
+    });
+    expect(await listSurfaceRefs(server)).not.toContain(SURFACE);
     expect(() => process.kill(process.pid, 0)).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

- qualify the recorded agent process immediately before forced teardown, signalling only a process still proven to be the same live identity
- include every live discovery in the orphan-repair uniqueness census while keeping the repair action set restricted to eligible records
- refresh stale Claude self-registration PIDs only from newer matching-session evidence after the recorded process is proven gone
- allow unforced pane harvest for terminal records while preserving the live-process close guard for nonterminal records
- qualify stop postconditions with the full agent process record, so a recycled PID cannot wedge force or graceful teardown
- count unread live surfaces when their retained topology and title evidence identifies a conflicting alias

## Safety polarity

- PID liveness `alive` permits the qualified `SIGKILL` path
- PID liveness `gone` completes teardown without signalling
- PID liveness `unknown` refuses teardown, sends no signal, and preserves tracking
- a recycled PID is never signalled
- terminal pane harvest does not weaken process teardown: closing the pane is allowed only because blocker 1 independently re-qualifies process identity immediately before any force signal

## Verification

- failing-first coverage added for all four P1 blockers
- `bunx vitest run`: 141 files passed, 3263 passed, 1 skipped, 0 failed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run`: identical result
- `bun run typecheck`: passed
- ordinary pre-push hook: 141 files passed, 3263 passed, 1 skipped
- local CodeRabbit review: 0 findings across all seven changed files
- independent round-2 findings addressed at `ba6f255`; re-review pending
- PID signal TOCTOU accepted as residual risk and tracked in #525 for a cross-platform identity-bound design

Fleet installation remains held. This PR must not merge without explicit user instruction.

— cmuxlayerCodex-bff10108 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-bff10108","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02e1d","ts":"2026-08-23T14:01:25Z"} -->
