### PR TITLE
feat: ship session self-registration hooks

### DIFF
--- a/assets/hooks/cmux-self-register.py
+++ b/assets/hooks/cmux-self-register.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""SessionStart hook: boot-time SELF-REGISTRATION of the CLI session id.
+
+orc-driver P0 (2026-07-18): cmuxlayer's session-id capture only fires on
+spawn_agent, but the fleet spawns RAW — so 25/25 agents show session_id:null
+and cmuxlayer falls back to scan-side cwd+recency inference (the #333 resync
+wedge). This flips capture to the correct side: each session, at boot, appends
+its own record to a registry file cmuxlayer reads (read-side contract v1,
+cmuxLead-v2). Kills scanning, kills inference, worktree-precise, raw-spawn-safe.
+
+Fail-OPEN always: a registration failure must never block session start.
+Writes ONE JSONL line matching the agreed schema:
+  {session_id, cwd, pid, cli, launcher, session_path, ts}
+"""
+import json
+import os
+import sys
+import time
+
+# Interface agreed with cmuxlayer read side (cmuxLead-v2 contract v2).
+REGISTRY = os.environ.get("CMUXLAYER_SESSION_REGISTRY") or os.path.expanduser(
+    "~/.cmuxlayer/session-registry.jsonl"
+)
+
+
+def main():
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        payload = {}
+
+    session_id = payload.get("session_id") or ""
+    if not session_id:
+        return  # never fabricate an id
+
+    entry = {
+        "session_id": session_id,
+        # PRIMARY join key (contract v2): cmux injects CMUX_SURFACE_ID into every
+        # pane; cmuxlayer already keys on agent.surface_uuid. pid/cwd proved
+        # unreliable in prod (AgentRecord.pid != CLI pid; launch_cwd = shell-home
+        # or null), so surface_uuid is the information-theoretic join.
+        "surface_uuid": os.environ.get("CMUX_SURFACE_ID") or "",
+        "cwd": payload.get("cwd") or os.getcwd(),  # optional secondary validator
+        "pid": os.getppid(),  # telemetry only (Claude proc; no longer a join key)
+        "cli": "claude",  # SessionStart fires for Claude only
+        "launcher": os.environ.get("CMUX_LAUNCHER")
+        or os.environ.get("REPOGOLEM_LAUNCHER")
+        or "",
+        # Claude's transcript_path is the analogue of Codex's rollout path.
+        "session_path": payload.get("transcript_path") or "",
+        "ts": int(time.time() * 1000),  # epoch MS per contract
+    }
+    try:
+        os.makedirs(os.path.dirname(REGISTRY), exist_ok=True)
+        with open(REGISTRY, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception:
+        pass  # fail-open
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        sys.exit(0)

--- a/assets/hooks/cmux-self-register.py
+++ b/assets/hooks/cmux-self-register.py
@@ -18,8 +18,9 @@ import sys
 import time
 
 # Interface agreed with cmuxlayer read side (cmuxLead-v2 contract v2).
-REGISTRY = os.environ.get("CMUXLAYER_SESSION_REGISTRY") or os.path.expanduser(
-    "~/.cmuxlayer/session-registry.jsonl"
+REGISTRY = (
+    os.environ.get("CMUXLAYER_SESSION_REGISTRY", "").strip()
+    or os.path.expanduser("~/.cmuxlayer/session-registry.jsonl")
 )
 
 
@@ -52,7 +53,9 @@ def main():
         "ts": int(time.time() * 1000),  # epoch MS per contract
     }
     try:
-        os.makedirs(os.path.dirname(REGISTRY), exist_ok=True)
+        registry_dir = os.path.dirname(REGISTRY)
+        if registry_dir:
+            os.makedirs(registry_dir, exist_ok=True)
         with open(REGISTRY, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
     except Exception:

--- a/assets/hooks/cmux-self-register.py
+++ b/assets/hooks/cmux-self-register.py
@@ -30,8 +30,9 @@ def main():
         payload = {}
 
     session_id = payload.get("session_id") or ""
-    if not session_id:
-        return  # never fabricate an id
+    surface_uuid = os.environ.get("CMUX_SURFACE_ID") or ""
+    if not session_id or not surface_uuid:
+        return  # never fabricate either identity field
 
     entry = {
         "session_id": session_id,
@@ -39,7 +40,7 @@ def main():
         # pane; cmuxlayer already keys on agent.surface_uuid. pid/cwd proved
         # unreliable in prod (AgentRecord.pid != CLI pid; launch_cwd = shell-home
         # or null), so surface_uuid is the information-theoretic join.
-        "surface_uuid": os.environ.get("CMUX_SURFACE_ID") or "",
+        "surface_uuid": surface_uuid,
         "cwd": payload.get("cwd") or os.getcwd(),  # optional secondary validator
         "pid": os.getppid(),  # telemetry only (Claude proc; no longer a join key)
         "cli": "claude",  # SessionStart fires for Claude only

--- a/assets/hooks/codex-cmux-self-register.py
+++ b/assets/hooks/codex-cmux-self-register.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Codex SessionStart hook: append this CLI session to cmuxlayer's registry.
+
+The hook is deliberately silent and fail-open. It never guesses a session or
+surface identity: without either required join field, it writes no row.
+"""
+
+import json
+import os
+import sys
+import time
+
+REGISTRY = os.environ.get("CMUXLAYER_SESSION_REGISTRY") or os.path.expanduser(
+    "~/.cmuxlayer/session-registry.jsonl"
+)
+
+
+def main():
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        payload = {}
+
+    session_id = payload.get("session_id") or ""
+    surface_uuid = os.environ.get("CMUX_SURFACE_ID") or ""
+    if not session_id or not surface_uuid:
+        return
+
+    entry = {
+        "session_id": session_id,
+        # Authoritative identity join: which registered pane is this?
+        "surface_uuid": surface_uuid,
+        "cwd": payload.get("cwd") or os.getcwd(),
+        # Codex launches the command hook as its child. The parent is the live
+        # CLI process; this pid plus ts is liveness evidence, never a join key.
+        "pid": os.getppid(),
+        "cli": "codex",
+        "launcher": os.environ.get("CMUX_LAUNCHER")
+        or os.environ.get("REPOGOLEM_LAUNCHER")
+        or "",
+        "session_path": payload.get("transcript_path") or "",
+        "ts": int(time.time() * 1000),
+    }
+    try:
+        os.makedirs(os.path.dirname(REGISTRY), exist_ok=True)
+        with open(REGISTRY, "a", encoding="utf-8") as registry:
+            registry.write(json.dumps(entry) + "\n")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        sys.exit(0)

--- a/assets/hooks/codex-cmux-self-register.py
+++ b/assets/hooks/codex-cmux-self-register.py
@@ -10,8 +10,9 @@ import os
 import sys
 import time
 
-REGISTRY = os.environ.get("CMUXLAYER_SESSION_REGISTRY") or os.path.expanduser(
-    "~/.cmuxlayer/session-registry.jsonl"
+REGISTRY = (
+    os.environ.get("CMUXLAYER_SESSION_REGISTRY", "").strip()
+    or os.path.expanduser("~/.cmuxlayer/session-registry.jsonl")
 )
 
 
@@ -42,7 +43,9 @@ def main():
         "ts": int(time.time() * 1000),
     }
     try:
-        os.makedirs(os.path.dirname(REGISTRY), exist_ok=True)
+        registry_dir = os.path.dirname(REGISTRY)
+        if registry_dir:
+            os.makedirs(registry_dir, exist_ok=True)
         with open(REGISTRY, "a", encoding="utf-8") as registry:
             registry.write(json.dumps(entry) + "\n")
     except Exception:

--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -25,6 +25,21 @@ or `npm install -g cmuxlayer`. Both provide the `cmuxlayer` command.
 cmuxlayer init
 ```
 
+Then install the lifecycle hooks that let Claude and Codex sessions register
+their stable cmux surface identity and live process evidence:
+
+```bash
+cmuxlayer install-session-hooks
+```
+
+The installer adds one `SessionStart` command without replacing other hooks,
+backs up each existing JSON config before changing it, and is safe to run again.
+Codex may ask you to review the new user hook with `/hooks`; unattended
+cmuxlayer launches use Codex's hook-trust bypass after the packaged script has
+already been vetted. Cursor hook wiring is not installed because its lifecycle
+payload is not contract-compatible with the Claude/Codex scripts. Gemini and
+Kiro are outside cmuxlayer's JSONL session-harness set.
+
 The wizard asks three things.
 
 **Which repositories?** Give the absolute path to each checkout you want to be

--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -34,11 +34,14 @@ cmuxlayer install-session-hooks
 
 The installer adds one `SessionStart` command without replacing other hooks,
 backs up each existing JSON config before changing it, and is safe to run again.
-Codex may ask you to review the new user hook with `/hooks`; unattended
-cmuxlayer launches use Codex's hook-trust bypass after the packaged script has
-already been vetted. Cursor hook wiring is not installed because its lifecycle
-payload is not contract-compatible with the Claude/Codex scripts. Gemini and
-Kiro are outside cmuxlayer's JSONL session-harness set.
+Codex hooks are enabled by default. Unattended cmuxlayer launches pass
+`--dangerously-bypass-hook-trust` after the packaged script has been vetted;
+prompting-mode or manually launched Codex sessions require a one-time `/hooks`
+review whenever the exact hook definition changes. If `[features] hooks = false`
+is set in `~/.codex/config.toml`, enable it before relying on registration.
+Cursor hook wiring is not installed because its lifecycle payload is not
+contract-compatible with the Claude/Codex scripts. Gemini and Kiro are outside
+cmuxlayer's JSONL session-harness set.
 
 The wizard asks three things.
 

--- a/docs/registry-optional-spawn.md
+++ b/docs/registry-optional-spawn.md
@@ -31,7 +31,7 @@ Raw flags, verified against each CLI's `--help`:
 | cli | binary | skip flag | model flag | resume |
 |---|---|---|---|---|
 | claude | `claude` | `--dangerously-skip-permissions` | `--model` | `--resume <uuid>` |
-| codex | `codex` | `--dangerously-bypass-approvals-and-sandbox` | `-m` | `resume <uuid>` (global flags precede the subcommand) |
+| codex | `codex` | `--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust` | `-m` | `resume <uuid>` (global flags precede the subcommand) |
 | cursor | `cursor agent` | `--force` | `--model` | `--resume <uuid>` |
 | gemini | `gemini` | `-y` | `--model` | **none** — see below |
 
@@ -117,7 +117,7 @@ background pane that stops on its first tool call reads as a hung pane. An
 install that would rather be asked sets
 `CMUXLAYER_SPAWN_PERMISSION_MODE=default` (what `cmuxlayer init --permissions
 ask` writes), and then **neither** lane carries a bypass: the raw lane drops
-`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox`
+`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust`
 / `--force` / `-y`, and the launcher lane drops `-s`. Launch and resume move
 together, so a resumed agent comes back in the mode it was spawned in.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "files": [
     "dist",
     "assets/sidebars/fleet.swift",
+    "assets/hooks",
     "scripts/install-fleet-sidebar.mjs",
     "scripts/install-fleet-sidebar-dev.mjs",
     "LICENSE",

--- a/src/agent-command.ts
+++ b/src/agent-command.ts
@@ -70,7 +70,8 @@ export function rawResumeNeedsCwd(cli: CliType): boolean {
 /**
  * Raw skip-approval flags, the CLI-level equivalent of the repoGolem launcher
  * `-s`. Verified against each installed CLI's `--help`:
- *   claude --dangerously-skip-permissions   codex --dangerously-bypass-approvals-and-sandbox
+ *   claude --dangerously-skip-permissions
+ *   codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust
  *   cursor agent --force                    gemini -y
  *
  * AIDEV-NOTE: these belong on the RESUME command too, not just spawn. A
@@ -79,7 +80,8 @@ export function rawResumeNeedsCwd(cli: CliType): boolean {
  */
 export const RAW_SKIP_APPROVALS: Partial<Record<CliType, string>> = {
   claude: "--dangerously-skip-permissions",
-  codex: "--dangerously-bypass-approvals-and-sandbox",
+  codex:
+    "--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
   cursor: "--force",
   gemini: "-y",
 };
@@ -163,7 +165,9 @@ export function buildResumeCommand(
       return `${launcher}${skipArg} --resume ${sessionId}`;
     case "codex":
       return `${launcher}${
-        bypass ? " --dangerously-bypass-approvals-and-sandbox" : ""
+        bypass
+          ? " --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust"
+          : ""
       } resume ${sessionId}`;
     case "gemini":
       return `${launcher}${skipArg} --resume ${sessionId}`;
@@ -223,4 +227,3 @@ export function buildRawResumeCommand(
       throw new Error("unreachable: gemini raw resume is refused above");
   }
 }
-

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -2926,8 +2926,19 @@ export class AgentEngine {
   }
 
   private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
-    return Boolean(
+    return (
       agent.cli !== "codex" &&
+      this.canUseSelfRegistrationProcessEvidence(agent)
+    );
+  }
+
+  /**
+   * A Codex rollout remains authoritative for session identity. Once that
+   * identity is durable, an exact-session self-registration match may supply
+   * only the process evidence used by lifecycle guards.
+   */
+  private canUseSelfRegistrationProcessEvidence(agent: AgentRecord): boolean {
+    return Boolean(
       this.selfRegistrationSessionResolver &&
       TRANSCRIPT_SESSION_CAPTURE_STATES.has(agent.state) &&
       JSONL_HARNESSES.has(agent.cli) &&
@@ -3443,7 +3454,7 @@ export class AgentEngine {
   ): Promise<AgentRecord> {
     if (agent.cli_session_id) {
       const canResolveSelfRegistration =
-        this.canUseSelfRegistrationSessionResolver(agent);
+        this.canUseSelfRegistrationProcessEvidence(agent);
       const recordedProcessGone =
         canResolveSelfRegistration &&
         Boolean(agent.pid) &&

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3473,10 +3473,13 @@ export class AgentEngine {
             const replacementRegisteredAtMs = Date.parse(
               identity.pid_registered_at ?? "",
             );
+            const replacementHasFiniteTimestamp = Number.isFinite(
+              replacementRegisteredAtMs,
+            );
             const replacementIsNewer =
-              !agent.pid ||
-              (Number.isFinite(previousRegisteredAtMs) &&
-                Number.isFinite(replacementRegisteredAtMs) &&
+              replacementHasFiniteTimestamp &&
+              (!agent.pid ||
+                !Number.isFinite(previousRegisteredAtMs) ||
                 replacementRegisteredAtMs > previousRegisteredAtMs);
             if (
               identity.session_id === agent.cli_session_id &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { isMainModule } from "./is-main.js";
 import { writeInboxCursor } from "./inbox.js";
 import { runInitCli } from "./init-cli.js";
 import { loadCmuxlayerConfigFile } from "./config-file.js";
+import { installSessionHooks } from "./self-registration-hooks-installer.js";
 
 const HELP_TEXT = `cmuxlayer — Terminal multiplexer MCP server for AI agent workspace orchestration.
 
@@ -34,6 +35,9 @@ Usage:
                        standard §0/§1/§3/§6) and exit. Read-only; no mutation.
                        Add --json for machine-readable output. Exits 0 when
                        healthy.
+  cmuxlayer install-session-hooks
+                       Install the Claude and Codex SessionStart registry hooks.
+                       Existing hook configuration is merged and backed up.
   cmuxlayer fleet-sidebar <collapse|expand|toggle> <lane>
                        Persist an independent Fleet lane state. Supported lanes:
                        orc, golems, voicelayer, skillCreator, cmuxlayer, other.
@@ -92,6 +96,13 @@ async function main() {
       (json ? renderDoctorJson(report) : renderDoctorText(report)) + "\n",
     );
     process.exitCode = report.healthy ? 0 : 1;
+    return;
+  }
+  if (arg === "install-session-hooks") {
+    const result = await installSessionHooks();
+    for (const path of result.changed) process.stdout.write(`updated ${path}\n`);
+    for (const path of result.backups) process.stdout.write(`backup ${path}\n`);
+    if (result.changed.length === 0) process.stdout.write("already installed\n");
     return;
   }
   if (arg === "fleet-sidebar") {

--- a/src/self-registration-hooks-installer.ts
+++ b/src/self-registration-hooks-installer.ts
@@ -1,0 +1,204 @@
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type JsonObject = Record<string, unknown>;
+
+export interface InstallSessionHooksOptions {
+  homeDir?: string;
+  assetsDir?: string;
+}
+
+export interface InstallSessionHooksResult {
+  changed: string[];
+  backups: string[];
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function parseJsonObject(path: string, text: string): JsonObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`${path} must contain valid JSON; refusing to overwrite it`);
+  }
+  if (!isObject(parsed)) {
+    throw new Error(`${path} must contain a JSON object; refusing to overwrite it`);
+  }
+  return parsed;
+}
+
+async function readOptional(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function sessionStartGroups(config: JsonObject, path: string): JsonObject[] {
+  const hooks = config.hooks ?? (config.hooks = {});
+  if (!isObject(hooks)) {
+    throw new Error(`${path} hooks must be a JSON object; refusing to overwrite it`);
+  }
+  const groups = hooks.SessionStart ?? (hooks.SessionStart = []);
+  if (!Array.isArray(groups) || !groups.every(isObject)) {
+    throw new Error(
+      `${path} hooks.SessionStart must be an array; refusing to overwrite it`,
+    );
+  }
+  return groups;
+}
+
+function hasCommand(groups: JsonObject[], installedPath: string): boolean {
+  return groups.some((group) => {
+    const handlers = group.hooks;
+    return (
+      Array.isArray(handlers) &&
+      handlers.some(
+        (handler) =>
+          isObject(handler) &&
+          typeof handler.command === "string" &&
+          handler.command.includes(installedPath),
+      )
+    );
+  });
+}
+
+function mergeClaudeSettings(config: JsonObject, path: string, hookPath: string) {
+  const groups = sessionStartGroups(config, path);
+  if (!hasCommand(groups, hookPath)) {
+    groups.push({
+      matcher: ".*",
+      hooks: [
+        {
+          type: "command",
+          command: `python3 ${shellQuote(hookPath)}`,
+          timeout: 5000,
+          async: true,
+        },
+      ],
+    });
+  }
+}
+
+function mergeCodexHooks(config: JsonObject, path: string, hookPath: string) {
+  const groups = sessionStartGroups(config, path);
+  if (!hasCommand(groups, hookPath)) {
+    groups.push({
+      matcher: "startup|resume",
+      hooks: [
+        {
+          type: "command",
+          command: `python3 ${shellQuote(hookPath)}`,
+          timeout: 5,
+          async: true,
+        },
+      ],
+    });
+  }
+}
+
+async function nextBackupPath(path: string): Promise<string> {
+  for (let index = 0; ; index += 1) {
+    const candidate = index === 0 ? `${path}.bak` : `${path}.bak.${index}`;
+    try {
+      await access(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return candidate;
+      throw error;
+    }
+  }
+}
+
+async function writeChangedFile(
+  path: string,
+  content: string,
+  result: InstallSessionHooksResult,
+  mode?: number,
+): Promise<void> {
+  const existing = await readOptional(path);
+  if (existing === content) {
+    if (mode !== undefined) await chmod(path, mode);
+    return;
+  }
+  await mkdir(dirname(path), { recursive: true });
+  if (existing !== null) {
+    const backup = await nextBackupPath(path);
+    await copyFile(path, backup);
+    result.backups.push(backup);
+  }
+  const temporary = `${path}.tmp-${process.pid}`;
+  await writeFile(temporary, content, { encoding: "utf8", mode });
+  if (mode !== undefined) await chmod(temporary, mode);
+  await rename(temporary, path);
+  result.changed.push(path);
+}
+
+export function defaultSessionHookAssetsDir(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "assets", "hooks");
+}
+
+export async function installSessionHooks(
+  options: InstallSessionHooksOptions = {},
+): Promise<InstallSessionHooksResult> {
+  const homeDir = options.homeDir ?? homedir();
+  const assetsDir = options.assetsDir ?? defaultSessionHookAssetsDir();
+  const claudeSettingsPath = join(homeDir, ".claude", "settings.json");
+  const codexHooksPath = join(homeDir, ".codex", "hooks.json");
+  const claudeHookPath = join(homeDir, ".claude", "hooks", "cmux-self-register.py");
+  const codexHookPath = join(
+    homeDir,
+    ".codex",
+    "hooks",
+    "codex-cmux-self-register.py",
+  );
+
+  const [claudeText, codexText, claudeAsset, codexAsset] = await Promise.all([
+    readOptional(claudeSettingsPath),
+    readOptional(codexHooksPath),
+    readFile(join(assetsDir, "cmux-self-register.py"), "utf8"),
+    readFile(join(assetsDir, "codex-cmux-self-register.py"), "utf8"),
+  ]);
+
+  // Parse and validate every existing config before making the first mutation.
+  const claudeConfig = claudeText !== null
+    ? parseJsonObject(claudeSettingsPath, claudeText)
+    : {};
+  const codexConfig =
+    codexText !== null ? parseJsonObject(codexHooksPath, codexText) : {};
+  mergeClaudeSettings(claudeConfig, claudeSettingsPath, claudeHookPath);
+  mergeCodexHooks(codexConfig, codexHooksPath, codexHookPath);
+
+  const result: InstallSessionHooksResult = { changed: [], backups: [] };
+  await writeChangedFile(claudeHookPath, claudeAsset, result, 0o755);
+  await writeChangedFile(codexHookPath, codexAsset, result, 0o755);
+  await writeChangedFile(
+    claudeSettingsPath,
+    JSON.stringify(claudeConfig, null, 2) + "\n",
+    result,
+  );
+  await writeChangedFile(
+    codexHooksPath,
+    JSON.stringify(codexConfig, null, 2) + "\n",
+    result,
+  );
+  return result;
+}

--- a/src/self-registration-hooks-installer.ts
+++ b/src/self-registration-hooks-installer.ts
@@ -91,7 +91,7 @@ function mergeClaudeSettings(config: JsonObject, path: string, hookPath: string)
         {
           type: "command",
           command: `python3 ${shellQuote(hookPath)}`,
-          timeout: 5000,
+          timeout: 5,
           async: true,
         },
       ],

--- a/src/self-registration-hooks-installer.ts
+++ b/src/self-registration-hooks-installer.ts
@@ -2,9 +2,12 @@ import {
   access,
   chmod,
   copyFile,
+  lstat,
   mkdir,
   readFile,
+  realpath,
   rename,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -67,7 +70,7 @@ function sessionStartGroups(config: JsonObject, path: string): JsonObject[] {
   return groups;
 }
 
-function hasCommand(groups: JsonObject[], installedPath: string): boolean {
+function hasCommand(groups: JsonObject[], expectedCommand: string): boolean {
   return groups.some((group) => {
     const handlers = group.hooks;
     return (
@@ -76,7 +79,7 @@ function hasCommand(groups: JsonObject[], installedPath: string): boolean {
         (handler) =>
           isObject(handler) &&
           typeof handler.command === "string" &&
-          handler.command.includes(installedPath),
+          handler.command === expectedCommand,
       )
     );
   });
@@ -84,13 +87,14 @@ function hasCommand(groups: JsonObject[], installedPath: string): boolean {
 
 function mergeClaudeSettings(config: JsonObject, path: string, hookPath: string) {
   const groups = sessionStartGroups(config, path);
-  if (!hasCommand(groups, hookPath)) {
+  const command = `exec python3 ${shellQuote(hookPath)}`;
+  if (!hasCommand(groups, command)) {
     groups.push({
       matcher: ".*",
       hooks: [
         {
           type: "command",
-          command: `python3 ${shellQuote(hookPath)}`,
+          command,
           timeout: 5,
           async: true,
         },
@@ -101,13 +105,14 @@ function mergeClaudeSettings(config: JsonObject, path: string, hookPath: string)
 
 function mergeCodexHooks(config: JsonObject, path: string, hookPath: string) {
   const groups = sessionStartGroups(config, path);
-  if (!hasCommand(groups, hookPath)) {
+  const command = `exec python3 ${shellQuote(hookPath)}`;
+  if (!hasCommand(groups, command)) {
     groups.push({
       matcher: "startup|resume",
       hooks: [
         {
           type: "command",
-          command: `python3 ${shellQuote(hookPath)}`,
+          command,
           timeout: 5,
           async: true,
         },
@@ -133,22 +138,34 @@ async function writeChangedFile(
   content: string,
   result: InstallSessionHooksResult,
   mode?: number,
+  defaultMode?: number,
 ): Promise<void> {
   const existing = await readOptional(path);
   if (existing === content) {
     if (mode !== undefined) await chmod(path, mode);
     return;
   }
-  await mkdir(dirname(path), { recursive: true });
+  let writePath = path;
+  let writeMode = mode;
   if (existing !== null) {
+    if ((await lstat(path)).isSymbolicLink()) {
+      writePath = await realpath(path);
+    }
+    if (writeMode === undefined) {
+      writeMode = (await stat(writePath)).mode & 0o7777;
+    }
     const backup = await nextBackupPath(path);
     await copyFile(path, backup);
     result.backups.push(backup);
+  } else if (writeMode === undefined) {
+    writeMode = defaultMode;
   }
-  const temporary = `${path}.tmp-${process.pid}`;
-  await writeFile(temporary, content, { encoding: "utf8", mode });
-  if (mode !== undefined) await chmod(temporary, mode);
-  await rename(temporary, path);
+  await mkdir(dirname(writePath), { recursive: true });
+  const temporary = `${writePath}.tmp-${process.pid}`;
+  await writeFile(temporary, content, { encoding: "utf8", mode: writeMode });
+  if (writeMode !== undefined) await chmod(temporary, writeMode);
+  await rename(temporary, writePath);
+  if (writeMode !== undefined) await chmod(writePath, writeMode);
   result.changed.push(path);
 }
 
@@ -194,11 +211,15 @@ export async function installSessionHooks(
     claudeSettingsPath,
     JSON.stringify(claudeConfig, null, 2) + "\n",
     result,
+    undefined,
+    0o600,
   );
   await writeChangedFile(
     codexHooksPath,
     JSON.stringify(codexConfig, null, 2) + "\n",
     result,
+    undefined,
+    0o600,
   );
   return result;
 }

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3695,7 +3695,7 @@ describe("AgentEngine", () => {
       expect(resumed.surface_id).toBe("surface:new");
       expect(mockClient.send).toHaveBeenCalledWith(
         "surface:new",
-        "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        "brainlayerCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
         { workspace: "ws:1" },
       );
       expect(engine.getAgentState("agent-stable-resume")?.state).toBe("booting");
@@ -5580,7 +5580,7 @@ Session ID: ${sessionId}`,
         session_id: sessionId,
         resumable: true,
         resume_command:
-          "cmuxlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019fec96-588d-7000-8000-000000000000",
+          "cmuxlayerCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019fec96-588d-7000-8000-000000000000",
       });
       vi.unstubAllEnvs();
     });
@@ -9845,7 +9845,7 @@ Session ID: ${sessionId}`,
           to: parent.agent_id,
           tag: "agent_halt_awaiting_input",
           task: expect.stringMatching(
-            /cmuxlayerCodex-awaiting.*surface:halt-awaiting.*awaiting_input.*1s.*send_key\(surface: "surface:halt-awaiting", key: "return"\).*codex --dangerously-bypass-approvals-and-sandbox resume 019fad12-1111-7222-8333-444455556666/s,
+            /cmuxlayerCodex-awaiting.*surface:halt-awaiting.*awaiting_input.*1s.*send_key\(surface: "surface:halt-awaiting", key: "return"\).*codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019fad12-1111-7222-8333-444455556666/s,
           ),
         }),
       ]);
@@ -13685,7 +13685,7 @@ describe("buildResumeCommand", () => {
 
   it("builds raw harness resume commands for engine-owned same-surface revival", () => {
     expect(buildRawResumeCommand("codex", "brainlayer", sessionId)).toBe(
-      `codex --dangerously-bypass-approvals-and-sandbox resume ${sessionId}`,
+      `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${sessionId}`,
     );
     expect(buildRawResumeCommand("claude", "brainlayer", sessionId)).toBe(
       `MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions --resume ${sessionId}`,
@@ -13715,7 +13715,7 @@ describe("buildResumeCommand", () => {
     expect(
       buildResumeCommand("codex", "brainlayer", sessionId, "brainlayerCodex"),
     ).toBe(
-      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
     expect(
       buildResumeCommand("cursor", "brainlayer", sessionId, "brainlayerCursor"),
@@ -13760,7 +13760,7 @@ describe("buildResumeCommand", () => {
         "brainlayerCodex [surface:606]",
       ),
     ).toBe(
-      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "brainlayerCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
   });
 
@@ -13768,7 +13768,7 @@ describe("buildResumeCommand", () => {
     expect(
       buildResumeCommand("codex", "matchmat", sessionId, "mm-worker"),
     ).toBe(
-      "mm-worker --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "mm-worker --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
   });
 

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4209,7 +4209,7 @@ describe("AgentEngine", () => {
       expect(engine.getAgentState("cmuxlayerCodex-aaaaaaaa")).toBeNull();
     });
 
-    it("does not backfill Codex pid evidence from self-registration", async () => {
+    it("backfills Codex pid evidence only after rollout identity is durable", async () => {
       const agentId = "cmuxlayerCodex-existing-session";
       const sessionId = "019fec96-588d-7000-8000-000000000000";
       const selfRegistrationResolver = vi.fn(() => ({
@@ -4233,6 +4233,7 @@ describe("AgentEngine", () => {
           state: "working",
           surface_id: "surface:codex-existing-session",
           surface_uuid: "11111111-2222-4333-8444-555555555555",
+          surface_provenance: "cmuxlayer_spawn",
           cli_session_id: sessionId,
           cli_session_path: "/durable/codex/rollout.jsonl",
           pid: null,
@@ -4248,9 +4249,10 @@ describe("AgentEngine", () => {
 
       await engine.captureBootSessionId(agentId);
 
-      expect(selfRegistrationResolver).not.toHaveBeenCalled();
+      expect(selfRegistrationResolver).toHaveBeenCalledTimes(1);
       expect(engine.getAgentState(agentId)).toMatchObject({
-        pid: null,
+        pid: process.pid,
+        pid_registered_at: "2026-08-23T11:00:05.000Z",
         cli_session_path: "/durable/codex/rollout.jsonl",
       });
     });

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4539,6 +4539,68 @@ Session ID: ${sessionId}`,
       }
     });
 
+    it("replaces gone legacy pid evidence when its registration time is missing", async () => {
+      const agentId = "cmuxlayerClaude-legacy-process-time";
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      const oldPid = 32001;
+      const replacementPid = 32002;
+      const selfRegistrationResolver = vi.fn(() => ({
+        session_id: sessionId,
+        path: null,
+        pid: replacementPid,
+        pid_registered_at: "2026-08-23T11:05:00.000Z",
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: selfRegistrationResolver,
+      });
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          repo: "cmuxlayer",
+          cli: "claude",
+          state: "working",
+          surface_id: "surface:legacy-process-time",
+          surface_uuid: "dddddddd-eeee-4fff-8aaa-bbbbbbbbbbbb",
+          surface_provenance: "cmuxlayer_spawn",
+          cli_session_id: sessionId,
+          pid: oldPid,
+          pid_registered_at: null,
+          created_at: "2026-08-23T11:00:00.000Z",
+        }),
+      );
+      liveSurfaces = [
+        {
+          ...makeSurface("surface:legacy-process-time"),
+          id: "dddddddd-eeee-4fff-8aaa-bbbbbbbbbbbb",
+        },
+      ];
+      await registry.reconstitute();
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+          if (pid === oldPid && signal === 0) {
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          return true;
+        }) as typeof process.kill);
+
+      try {
+        await engine.captureBootSessionId(agentId);
+
+        expect(selfRegistrationResolver).toHaveBeenCalledTimes(1);
+        expect(engine.getAgentState(agentId)).toMatchObject({
+          pid: replacementPid,
+          pid_registered_at: "2026-08-23T11:05:00.000Z",
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
     it("keeps captured pid evidence when a pending row converges on an existing final session", async () => {
       const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
       const finalAgentId = "cmuxlayerClaude-019d9aa5";

--- a/tests/agent-facade.test.ts
+++ b/tests/agent-facade.test.ts
@@ -174,7 +174,7 @@ describe("agent facade projections", () => {
     );
 
     expect(projected.resume_command).toBe(
-      "codex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
   });
 

--- a/tests/registry-optional-resume.test.ts
+++ b/tests/registry-optional-resume.test.ts
@@ -25,7 +25,7 @@ describe("raw resume commands carry a working directory", () => {
       buildRawResumeCommand("codex", "brainlayer", SESSION, {
         cwd: "/srv/repos/brainlayer",
       }),
-    ).toBe(`cd '/srv/repos/brainlayer' && codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`);
+    ).toBe(`cd '/srv/repos/brainlayer' && codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`);
     expect(
       buildRawResumeCommand("cursor", "brainlayer", SESSION, {
         cwd: "/srv/repos/brainlayer",
@@ -38,7 +38,7 @@ describe("raw resume commands carry a working directory", () => {
       buildRawResumeCommand("codex", "brainlayer", SESSION, {
         cwd: "/tmp/a b'c",
       }),
-    ).toBe(`cd '/tmp/a b'\\''c' && codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`);
+    ).toBe(`cd '/tmp/a b'\\''c' && codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`);
   });
 
   it("lets an explicit cwd override the kiro ~/Gits assumption", () => {
@@ -57,7 +57,7 @@ describe("raw resume commands carry a working directory", () => {
       `MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions --resume ${SESSION}`,
     );
     expect(buildRawResumeCommand("codex", "brainlayer", SESSION)).toBe(
-      `codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`,
+      `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`,
     );
   });
 });
@@ -71,7 +71,7 @@ describe("buildResumeCommand falls back to the raw CLI, never a guessed launcher
     ).toBe(`brainlayerClaude -s --resume ${SESSION}`);
     expect(
       buildResumeCommand("codex", "matchmat", SESSION, "mmCodex"),
-    ).toBe(`mmCodex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`);
+    ).toBe(`mmCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`);
   });
 
   it("emits raw CLI resume when no launcher was recorded (fresh install)", () => {
@@ -79,7 +79,7 @@ describe("buildResumeCommand falls back to the raw CLI, never a guessed launcher
       `MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions --resume ${SESSION}`,
     );
     expect(buildResumeCommand("codex", "brainlayer", SESSION)).toBe(
-      `codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`,
+      `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`,
     );
     expect(buildResumeCommand("cursor", "brainlayer", SESSION)).toBe(
       `cursor agent --force --resume ${SESSION}`,
@@ -100,7 +100,7 @@ describe("buildResumeCommand falls back to the raw CLI, never a guessed launcher
   it("falls back to raw when the recorded launcher name is unusable", () => {
     expect(
       buildResumeCommand("codex", "brainlayer", SESSION, "not a launcher!"),
-    ).toBe(`codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`);
+    ).toBe(`codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`);
   });
 
   it("never emits a nonexistent ${repo}${Suffix} binary", () => {
@@ -118,7 +118,7 @@ describe("buildResumeCommand falls back to the raw CLI, never a guessed launcher
       "--dangerously-skip-permissions",
     );
     expect(buildResumeCommand("codex", "brainlayer", SESSION)).toContain(
-      "--dangerously-bypass-approvals-and-sandbox",
+      "--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
     );
     expect(buildResumeCommand("cursor", "brainlayer", SESSION)).toContain(
       "--force",

--- a/tests/self-registration-hooks.test.ts
+++ b/tests/self-registration-hooks.test.ts
@@ -1,9 +1,13 @@
 import { execFile } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
+  lstatSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
+  symlinkSync,
   writeFileSync,
   mkdirSync,
 } from "node:fs";
@@ -28,12 +32,13 @@ async function runHook(
   hook: string,
   input: string,
   env: Record<string, string>,
+  cwd?: string,
 ) {
   return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
     const child = execFile(
       "python3",
       [hook],
-      { env: { ...process.env, ...env } },
+      { cwd, env: { ...process.env, ...env } },
       (error, stdout, stderr) => {
         if (error) reject(error);
         else resolve({ stdout, stderr });
@@ -45,6 +50,25 @@ async function runHook(
 
 function runCodexHook(input: string, env: Record<string, string>) {
   return runHook(codexHook, input, env);
+}
+
+async function runConfiguredHook(
+  command: string,
+  input: string,
+  env: Record<string, string>,
+) {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const child = execFile(
+      "sh",
+      ["-c", command],
+      { env: { ...process.env, ...env } },
+      (error, stdout, stderr) => {
+        if (error) reject(error);
+        else resolve({ stdout, stderr });
+      },
+    );
+    child.stdin!.end(input);
+  });
 }
 
 afterEach(() => {
@@ -154,6 +178,46 @@ describe("shipped self-registration hooks", () => {
     ).resolves.toEqual({ stdout: "", stderr: "" });
 
     expect(existsSync(registry)).toBe(false);
+  });
+
+  it.each([
+    ["Claude", claudeHook],
+    ["Codex", codexHook],
+  ])("trims the %s registry override before writing", async (_cli, hook) => {
+    const root = tempDir("cmux-hook-trimmed-registry-");
+    const registry = join(root, "registry.jsonl");
+
+    await runHook(
+      hook,
+      JSON.stringify({ session_id: "trimmed-session", cwd: root }),
+      {
+        CMUXLAYER_SESSION_REGISTRY: `  ${registry}  `,
+        CMUX_SURFACE_ID: "trimmed-surface",
+      },
+    );
+
+    expect(readFileSync(registry, "utf8")).toContain("trimmed-session");
+  });
+
+  it.each([
+    ["Claude", claudeHook],
+    ["Codex", codexHook],
+  ])("allows a relative %s registry override", async (_cli, hook) => {
+    const root = tempDir("cmux-hook-relative-registry-");
+
+    await runHook(
+      hook,
+      JSON.stringify({ session_id: "relative-session", cwd: root }),
+      {
+        CMUXLAYER_SESSION_REGISTRY: "registry.jsonl",
+        CMUX_SURFACE_ID: "relative-surface",
+      },
+      root,
+    );
+
+    expect(readFileSync(join(root, "registry.jsonl"), "utf8")).toContain(
+      "relative-session",
+    );
   });
 });
 
@@ -268,5 +332,120 @@ describe("installSessionHooks", () => {
     expect(readFileSync(codexHooks, "utf8")).toBe("{not valid json\n");
     expect(existsSync(join(homeDir, ".claude", "hooks"))).toBe(false);
     expect(existsSync(join(homeDir, ".codex", "hooks"))).toBe(false);
+  });
+
+  it("does not mistake a command containing the hook path for the installed hook", async () => {
+    const homeDir = tempDir("cmux-hook-exact-command-");
+    const claudeDir = join(homeDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const claudeSettings = join(claudeDir, "settings.json");
+    const installedHook = join(
+      claudeDir,
+      "hooks",
+      "cmux-self-register.py",
+    );
+    writeFileSync(
+      claudeSettings,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `exec python3 '${installedHook}.old'`,
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    await installSessionHooks({ homeDir, assetsDir: hookAssets });
+
+    const installed = JSON.parse(readFileSync(claudeSettings, "utf8"));
+    const commands = installed.hooks.SessionStart.flatMap((group: any) =>
+      group.hooks.map((handler: any) => handler.command),
+    );
+    expect(commands).toContain(`exec python3 '${installedHook}'`);
+    expect(commands).toContain(`exec python3 '${installedHook}.old'`);
+  });
+
+  it("preserves restrictive modes on existing config files", async () => {
+    const homeDir = tempDir("cmux-hook-config-mode-");
+    const claudeDir = join(homeDir, ".claude");
+    const codexDir = join(homeDir, ".codex");
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(codexDir, { recursive: true });
+    const claudeSettings = join(claudeDir, "settings.json");
+    const codexHooks = join(codexDir, "hooks.json");
+    writeFileSync(claudeSettings, "{}\n");
+    writeFileSync(codexHooks, "{}\n");
+    chmodSync(claudeSettings, 0o600);
+    chmodSync(codexHooks, 0o640);
+
+    await installSessionHooks({ homeDir, assetsDir: hookAssets });
+
+    expect(statSync(claudeSettings).mode & 0o777).toBe(0o600);
+    expect(statSync(codexHooks).mode & 0o777).toBe(0o640);
+  });
+
+  it("creates new config files with owner-only permissions", async () => {
+    const homeDir = tempDir("cmux-hook-new-config-mode-");
+
+    await installSessionHooks({ homeDir, assetsDir: hookAssets });
+
+    expect(
+      statSync(join(homeDir, ".claude", "settings.json")).mode & 0o777,
+    ).toBe(0o600);
+    expect(statSync(join(homeDir, ".codex", "hooks.json")).mode & 0o777).toBe(
+      0o600,
+    );
+  });
+
+  it("execs both configured hooks so they record the long-lived CLI pid", async () => {
+    const homeDir = tempDir("cmux-hook-cli-pid-");
+    await installSessionHooks({ homeDir, assetsDir: hookAssets });
+    const configurations = [
+      join(homeDir, ".claude", "settings.json"),
+      join(homeDir, ".codex", "hooks.json"),
+    ];
+
+    for (const [index, configPath] of configurations.entries()) {
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      const command = config.hooks.SessionStart[0].hooks[0].command;
+      expect(command).toMatch(/^exec python3 /);
+      const registry = join(homeDir, `registry-${index}.jsonl`);
+      await runConfiguredHook(
+        command,
+        JSON.stringify({ session_id: `session-${index}`, cwd: homeDir }),
+        {
+          CMUXLAYER_SESSION_REGISTRY: registry,
+          CMUX_SURFACE_ID: `surface-${index}`,
+        },
+      );
+      const row = JSON.parse(readFileSync(registry, "utf8"));
+      expect(row.pid).toBe(process.pid);
+    }
+  });
+
+  it("updates symlink targets without replacing managed config symlinks", async () => {
+    const homeDir = tempDir("cmux-hook-symlink-config-");
+    const claudeDir = join(homeDir, ".claude");
+    const dotfilesDir = join(homeDir, "dotfiles");
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(dotfilesDir, { recursive: true });
+    const target = join(dotfilesDir, "claude-settings.json");
+    const claudeSettings = join(claudeDir, "settings.json");
+    writeFileSync(target, "{}\n");
+    chmodSync(target, 0o600);
+    symlinkSync(target, claudeSettings);
+
+    await installSessionHooks({ homeDir, assetsDir: hookAssets });
+
+    expect(lstatSync(claudeSettings).isSymbolicLink()).toBe(true);
+    expect(readFileSync(target, "utf8")).toContain("cmux-self-register.py");
+    expect(statSync(target).mode & 0o777).toBe(0o600);
   });
 });

--- a/tests/self-registration-hooks.test.ts
+++ b/tests/self-registration-hooks.test.ts
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdtempSync,
@@ -25,11 +24,15 @@ function tempDir(prefix: string): string {
   return path;
 }
 
-async function runCodexHook(input: string, env: Record<string, string>) {
+async function runHook(
+  hook: string,
+  input: string,
+  env: Record<string, string>,
+) {
   return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
     const child = execFile(
       "python3",
-      [codexHook],
+      [hook],
       { env: { ...process.env, ...env } },
       (error, stdout, stderr) => {
         if (error) reject(error);
@@ -38,6 +41,10 @@ async function runCodexHook(input: string, env: Record<string, string>) {
     );
     child.stdin!.end(input);
   });
+}
+
+function runCodexHook(input: string, env: Record<string, string>) {
+  return runHook(codexHook, input, env);
 }
 
 afterEach(() => {
@@ -101,13 +108,16 @@ describe("Codex self-registration hook", () => {
       stderr: "",
     });
     await expect(
-      runCodexHook(JSON.stringify({ session_id: "session-without-surface" }), baseEnv),
+      runCodexHook(
+        JSON.stringify({ session_id: "session-without-surface" }),
+        baseEnv,
+      ),
     ).resolves.toEqual({ stdout: "", stderr: "" });
     await expect(
-      runCodexHook(
-        JSON.stringify({ cwd: root }),
-        { ...baseEnv, CMUX_SURFACE_ID: "surface-without-session" },
-      ),
+      runCodexHook(JSON.stringify({ cwd: root }), {
+        ...baseEnv,
+        CMUX_SURFACE_ID: "surface-without-session",
+      }),
     ).resolves.toEqual({ stdout: "", stderr: "" });
 
     expect(existsSync(registry)).toBe(false);
@@ -128,14 +138,22 @@ describe("Codex self-registration hook", () => {
 });
 
 describe("shipped self-registration hooks", () => {
-  it("vendors the existing Claude hook byte-for-byte", () => {
-    const digest = createHash("sha256")
-      .update(readFileSync(claudeHook))
-      .digest("hex");
+  it("writes no Claude row when the required surface identity is absent", async () => {
+    const root = tempDir("cmux-claude-hook-open-");
+    const registry = join(root, "registry.jsonl");
 
-    expect(digest).toBe(
-      "572018302b2c50801b9940a98958ac694b35d5264420c06b76df5396cf116792",
-    );
+    await expect(
+      runHook(
+        claudeHook,
+        JSON.stringify({ session_id: "session-without-surface", cwd: root }),
+        {
+          CMUXLAYER_SESSION_REGISTRY: registry,
+          CMUX_SURFACE_ID: "",
+        },
+      ),
+    ).resolves.toEqual({ stdout: "", stderr: "" });
+
+    expect(existsSync(registry)).toBe(false);
   });
 });
 
@@ -170,7 +188,10 @@ describe("installSessionHooks", () => {
       },
     };
     const originalToml = 'notify = ["existing", "turn-ended"]\n';
-    writeFileSync(claudeSettings, JSON.stringify(originalClaude, null, 2) + "\n");
+    writeFileSync(
+      claudeSettings,
+      JSON.stringify(originalClaude, null, 2) + "\n",
+    );
     writeFileSync(codexHooks, JSON.stringify(originalCodex, null, 2) + "\n");
     writeFileSync(codexConfig, originalToml);
 
@@ -192,6 +213,7 @@ describe("installSessionHooks", () => {
         expect.objectContaining({
           type: "command",
           command: expect.stringContaining("cmux-self-register.py"),
+          timeout: 5,
         }),
       ]),
     );
@@ -206,6 +228,7 @@ describe("installSessionHooks", () => {
           expect.objectContaining({
             type: "command",
             command: expect.stringContaining("codex-cmux-self-register.py"),
+            timeout: 5,
           }),
         ],
       }),
@@ -221,7 +244,10 @@ describe("installSessionHooks", () => {
       expect.arrayContaining([claudeSettings, codexHooks]),
     );
 
-    const second = await installSessionHooks({ homeDir, assetsDir: hookAssets });
+    const second = await installSessionHooks({
+      homeDir,
+      assetsDir: hookAssets,
+    });
     expect(second.changed).toEqual([]);
     expect(readFileSync(claudeSettings, "utf8")).toBe(firstClaudeText);
     expect(readFileSync(codexHooks, "utf8")).toBe(firstCodexText);

--- a/tests/self-registration-hooks.test.ts
+++ b/tests/self-registration-hooks.test.ts
@@ -1,0 +1,246 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installSessionHooks } from "../src/self-registration-hooks-installer.js";
+
+const repoRoot = join(__dirname, "..");
+const hookAssets = join(repoRoot, "assets", "hooks");
+const codexHook = join(hookAssets, "codex-cmux-self-register.py");
+const claudeHook = join(hookAssets, "cmux-self-register.py");
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const path = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(path);
+  return path;
+}
+
+async function runCodexHook(input: string, env: Record<string, string>) {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const child = execFile(
+      "python3",
+      [codexHook],
+      { env: { ...process.env, ...env } },
+      (error, stdout, stderr) => {
+        if (error) reject(error);
+        else resolve({ stdout, stderr });
+      },
+    );
+    child.stdin!.end(input);
+  });
+}
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe("Codex self-registration hook", () => {
+  it("writes the complete surface-bound registry contract with epoch milliseconds", async () => {
+    const root = tempDir("cmux-codex-hook-");
+    const registry = join(root, "registry.jsonl");
+    const cwd = join(root, "worktree");
+    mkdirSync(cwd);
+    const before = Date.now();
+
+    const result = await runCodexHook(
+      JSON.stringify({
+        hook_event_name: "SessionStart",
+        session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        transcript_path: "/tmp/rollout.jsonl",
+        cwd,
+        source: "startup",
+      }),
+      {
+        CMUXLAYER_SESSION_REGISTRY: registry,
+        CMUX_SURFACE_ID: "11111111-2222-4333-8444-555555555555",
+        CMUX_LAUNCHER: "cmuxlayerCodex",
+      },
+    );
+    const after = Date.now();
+
+    expect(result).toEqual({ stdout: "", stderr: "" });
+    const rows = readFileSync(registry, "utf8").trim().split("\n");
+    expect(rows).toHaveLength(1);
+    const row = JSON.parse(rows[0]!);
+    expect(row).toMatchObject({
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      surface_uuid: "11111111-2222-4333-8444-555555555555",
+      cwd,
+      pid: process.pid,
+      cli: "codex",
+      launcher: "cmuxlayerCodex",
+      session_path: "/tmp/rollout.jsonl",
+    });
+    expect(Number.isSafeInteger(row.ts)).toBe(true);
+    expect(row.ts).toBeGreaterThanOrEqual(before);
+    expect(row.ts).toBeLessThanOrEqual(after);
+  });
+
+  it("fails open and writes no unusable row when identity or surface is absent", async () => {
+    const root = tempDir("cmux-codex-hook-open-");
+    const registry = join(root, "registry.jsonl");
+    const baseEnv = {
+      CMUXLAYER_SESSION_REGISTRY: registry,
+      CMUX_SURFACE_ID: "",
+    };
+
+    await expect(runCodexHook("not json", baseEnv)).resolves.toEqual({
+      stdout: "",
+      stderr: "",
+    });
+    await expect(
+      runCodexHook(JSON.stringify({ session_id: "session-without-surface" }), baseEnv),
+    ).resolves.toEqual({ stdout: "", stderr: "" });
+    await expect(
+      runCodexHook(
+        JSON.stringify({ cwd: root }),
+        { ...baseEnv, CMUX_SURFACE_ID: "surface-without-session" },
+      ),
+    ).resolves.toEqual({ stdout: "", stderr: "" });
+
+    expect(existsSync(registry)).toBe(false);
+  });
+
+  it("exits zero when the registry cannot be written", async () => {
+    const root = tempDir("cmux-codex-hook-error-");
+    const result = await runCodexHook(
+      JSON.stringify({ session_id: "session", cwd: root }),
+      {
+        CMUXLAYER_SESSION_REGISTRY: root,
+        CMUX_SURFACE_ID: "surface",
+      },
+    );
+
+    expect(result).toEqual({ stdout: "", stderr: "" });
+  });
+});
+
+describe("shipped self-registration hooks", () => {
+  it("vendors the existing Claude hook byte-for-byte", () => {
+    const digest = createHash("sha256")
+      .update(readFileSync(claudeHook))
+      .digest("hex");
+
+    expect(digest).toBe(
+      "572018302b2c50801b9940a98958ac694b35d5264420c06b76df5396cf116792",
+    );
+  });
+});
+
+describe("installSessionHooks", () => {
+  it("backs up and merges both hook configs without clobbering existing settings", async () => {
+    const homeDir = tempDir("cmux-hook-home-");
+    const claudeDir = join(homeDir, ".claude");
+    const codexDir = join(homeDir, ".codex");
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(codexDir, { recursive: true });
+    const claudeSettings = join(claudeDir, "settings.json");
+    const codexHooks = join(codexDir, "hooks.json");
+    const codexConfig = join(codexDir, "config.toml");
+    const originalClaude = {
+      permissions: { allow: ["Read"] },
+      hooks: {
+        SessionStart: [
+          {
+            matcher: ".*",
+            hooks: [{ type: "command", command: "python3 existing.py" }],
+          },
+        ],
+        Stop: [{ hooks: [{ type: "command", command: "python3 stop.py" }] }],
+      },
+    };
+    const originalCodex = {
+      description: "keep me",
+      hooks: {
+        SessionEnd: [
+          { hooks: [{ type: "command", command: "python3 end.py" }] },
+        ],
+      },
+    };
+    const originalToml = 'notify = ["existing", "turn-ended"]\n';
+    writeFileSync(claudeSettings, JSON.stringify(originalClaude, null, 2) + "\n");
+    writeFileSync(codexHooks, JSON.stringify(originalCodex, null, 2) + "\n");
+    writeFileSync(codexConfig, originalToml);
+
+    const first = await installSessionHooks({ homeDir, assetsDir: hookAssets });
+    const firstClaudeText = readFileSync(claudeSettings, "utf8");
+    const firstCodexText = readFileSync(codexHooks, "utf8");
+    const installedClaude = JSON.parse(firstClaudeText);
+    const installedCodex = JSON.parse(firstCodexText);
+
+    expect(installedClaude.permissions).toEqual(originalClaude.permissions);
+    expect(installedClaude.hooks.Stop).toEqual(originalClaude.hooks.Stop);
+    expect(installedClaude.hooks.SessionStart[0]).toEqual(
+      originalClaude.hooks.SessionStart[0],
+    );
+    expect(
+      installedClaude.hooks.SessionStart.flatMap((group: any) => group.hooks),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "command",
+          command: expect.stringContaining("cmux-self-register.py"),
+        }),
+      ]),
+    );
+    expect(installedCodex.description).toBe("keep me");
+    expect(installedCodex.hooks.SessionEnd).toEqual(
+      originalCodex.hooks.SessionEnd,
+    );
+    expect(installedCodex.hooks.SessionStart).toEqual([
+      expect.objectContaining({
+        matcher: "startup|resume",
+        hooks: [
+          expect.objectContaining({
+            type: "command",
+            command: expect.stringContaining("codex-cmux-self-register.py"),
+          }),
+        ],
+      }),
+    ]);
+    expect(readFileSync(codexConfig, "utf8")).toBe(originalToml);
+    expect(readFileSync(`${claudeSettings}.bak`, "utf8")).toBe(
+      JSON.stringify(originalClaude, null, 2) + "\n",
+    );
+    expect(readFileSync(`${codexHooks}.bak`, "utf8")).toBe(
+      JSON.stringify(originalCodex, null, 2) + "\n",
+    );
+    expect(first.changed).toEqual(
+      expect.arrayContaining([claudeSettings, codexHooks]),
+    );
+
+    const second = await installSessionHooks({ homeDir, assetsDir: hookAssets });
+    expect(second.changed).toEqual([]);
+    expect(readFileSync(claudeSettings, "utf8")).toBe(firstClaudeText);
+    expect(readFileSync(codexHooks, "utf8")).toBe(firstCodexText);
+    expect(existsSync(`${claudeSettings}.bak.1`)).toBe(false);
+    expect(existsSync(`${codexHooks}.bak.1`)).toBe(false);
+  });
+
+  it("refuses invalid existing JSON before mutating anything", async () => {
+    const homeDir = tempDir("cmux-hook-invalid-");
+    const codexDir = join(homeDir, ".codex");
+    mkdirSync(codexDir, { recursive: true });
+    const codexHooks = join(codexDir, "hooks.json");
+    writeFileSync(codexHooks, "{not valid json\n");
+
+    await expect(
+      installSessionHooks({ homeDir, assetsDir: hookAssets }),
+    ).rejects.toThrow(/hooks\.json.*valid JSON/i);
+    expect(readFileSync(codexHooks, "utf8")).toBe("{not valid json\n");
+    expect(existsSync(join(homeDir, ".claude", "hooks"))).toBe(false);
+    expect(existsSync(join(homeDir, ".codex", "hooks"))).toBe(false);
+  });
+});

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -1317,7 +1317,7 @@ describe("AgentEngine self-registration wiring", () => {
     engine.dispose();
   });
 
-  it("does not use Claude-only self-registration process evidence for an existing Codex session", async () => {
+  it("backfills Codex process evidence when the hook matches the rollout session", async () => {
     const selfRegistrationSessionResolver = vi.fn(() => ({
       session_id: "sid-codex-existing",
       path: "/rollout/codex.jsonl",
@@ -1342,9 +1342,10 @@ describe("AgentEngine self-registration wiring", () => {
 
     expect(captured).toMatchObject({
       cli_session_id: "sid-codex-existing",
-      pid: null,
+      pid: 43210,
+      pid_registered_at: "2026-08-23T11:00:05.000Z",
     });
-    expect(selfRegistrationSessionResolver).not.toHaveBeenCalled();
+    expect(selfRegistrationSessionResolver).toHaveBeenCalledTimes(1);
     engine.dispose();
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7443,7 +7443,7 @@ describe("agent lifecycle tool handlers", () => {
     };
 
     expect(parsed.ok).toBe(true);
-    // Issue #392: `codex --dangerously-bypass-approvals-and-sandbox resume <uuid>` reads a global session store, so a
+    // Issue #392: `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume <uuid>` reads a global session store, so a
     // corrupt repo LABEL no longer blocks recovery -- the raw form is real and
     // runnable. Previously this row advertised nothing at all.
     expect(parsed.agents).toEqual([
@@ -7451,7 +7451,7 @@ describe("agent lifecycle tool handlers", () => {
       expect.objectContaining({
         agent_id: "corrupt-agent",
         resumable: expect.objectContaining({ value: true }),
-        resume_command: "codex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f4f",
+        resume_command: "codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f4f",
       }),
     ]);
     expect(parsed.skipped_agents).toBeUndefined();
@@ -9964,7 +9964,7 @@ codex>
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.resume_command).toBe(
-      "golemsCodex --dangerously-bypass-approvals-and-sandbox resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+      "golemsCodex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     );
   });
 

--- a/tests/spawn-permission-mode.test.ts
+++ b/tests/spawn-permission-mode.test.ts
@@ -49,10 +49,25 @@ describe("raw launch honours the permission mode", () => {
     ).toContain("--dangerously-skip-permissions");
   });
 
+  it("carries Codex hook-trust bypass alongside the unattended approval bypass", () => {
+    const command = buildLaunchCommand("codex", "alpha", undefined, undefined, {
+      cwd: "/code/alpha",
+      launchMode: "raw",
+    });
+
+    expect(command).toContain(
+      "--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
+    );
+    expect(command).toContain("--dangerously-bypass-hook-trust");
+  });
+
   it("drops the bypass for every raw CLI in default mode", () => {
     const cases: Array<[Parameters<typeof buildLaunchCommand>[0], string]> = [
       ["claude", "--dangerously-skip-permissions"],
-      ["codex", "--dangerously-bypass-approvals-and-sandbox"],
+      [
+        "codex",
+        "--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
+      ],
       ["cursor", "--force"],
       ["gemini", "-y"],
     ];
@@ -63,6 +78,9 @@ describe("raw launch honours the permission mode", () => {
         permissionMode: "default",
       });
       expect(command).not.toContain(flag);
+      if (cli === "codex") {
+        expect(command).not.toContain("--dangerously-bypass-hook-trust");
+      }
       expect(command).toContain("cd '/code/alpha'");
     }
   });

--- a/tests/spawn-resume-parity.test.ts
+++ b/tests/spawn-resume-parity.test.ts
@@ -106,7 +106,7 @@ const AGENT_ENV = "MCP_CONNECTION_NONBLOCKING=1 CLAUDE_CODE_NO_FLICKER=1";
  */
 const RAW_BYPASS: Record<string, string> = {
   claude: " --dangerously-skip-permissions",
-  codex: " --dangerously-bypass-approvals-and-sandbox",
+  codex: " --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
   cursor: " --force",
   gemini: " -y",
 };
@@ -121,7 +121,7 @@ const RESUME_BYPASS: Record<LauncherPath, Record<string, string>> = {
   // ...but the codex launcher's resume form spells it out in full.
   registry: {
     claude: " -s",
-    codex: " --dangerously-bypass-approvals-and-sandbox",
+    codex: " --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
     cursor: " -s",
     gemini: " -s",
   },
@@ -145,7 +145,7 @@ function expectedLaunch(cli: CliType, path: LauncherPath, root: string): string 
     case "claude":
       return `${cd}${AGENT_ENV} claude --dangerously-skip-permissions`;
     case "codex":
-      return `${cd}codex --dangerously-bypass-approvals-and-sandbox`;
+      return `${cd}codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust`;
     case "cursor":
       return `${cd}cursor agent --force`;
     case "gemini":
@@ -158,7 +158,7 @@ function expectedLaunch(cli: CliType, path: LauncherPath, root: string): string 
 function expectedResume(cli: CliType, path: LauncherPath, root: string): string {
   if (path === "registry") {
     return cli === "codex"
-      ? `${EXPECTED_LAUNCHER_NAME[cli]} --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`
+      ? `${EXPECTED_LAUNCHER_NAME[cli]} --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`
       : `${EXPECTED_LAUNCHER_NAME[cli]} -s --resume ${SESSION}`;
   }
   const cd = `cd '${root}' && `;
@@ -166,7 +166,7 @@ function expectedResume(cli: CliType, path: LauncherPath, root: string): string 
     case "claude":
       return `${cd}${AGENT_ENV} claude --dangerously-skip-permissions --resume ${SESSION}`;
     case "codex":
-      return `${cd}codex --dangerously-bypass-approvals-and-sandbox resume ${SESSION}`;
+      return `${cd}codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume ${SESSION}`;
     case "cursor":
       return `${cd}cursor agent --force --resume ${SESSION}`;
     default:


### PR DESCRIPTION
## Summary

- ship fail-open Claude and Codex `SessionStart` self-registration hooks plus an idempotent, backup-before-edit installer
- preserve Codex rollout session identity while using hook PID/timestamp only as surface-bound liveness evidence
- add Codex hook-trust bypass to unattended raw launch and resume commands; keep prompting mode explicit
- package the hook assets and document the Cursor/Gemini/Kiro scope boundary

Closes #520.

## Live acceptance proof

The accepted installed-build proof passed end to end:

- the first live Codex self-registration row landed in the registry
- the real resolver joined that row to the managed agent and recovered PID `20579`
- `agentProcessMayBeAlive` returned `true` while the Codex process was live
- after killing that exact process, liveness changed to `gone` and the guard returned `false`

## Fresh-install hook trust

A fresh Codex install still needs one of two trust paths:

1. cmuxlayer's unattended launch/resume command must include `--dangerously-bypass-hook-trust` (added by this PR), or
2. the user must run `/hooks` once and trust the installed hook for prompting/manual launches.

This is operationally required: an untrusted user hook does not merely skip registration in the observed fresh-install flow; it wedges the Codex spawn on an interactive trust prompt. The installer therefore cannot be treated as sufficient proof by itself.

## Verification

- pair-review round 2: accepted; all three findings fixed
- `bunx vitest run`: 142 files passed; 3270 tests passed, 1 skipped
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run`: identical 3270 passed, 1 skipped
- `bun run typecheck`: clean
- repository pre-push regression harness: exit 0
- isolated Codex 0.149.0 trust-bypass process probe: one correct registry row
- installed live resolver/guard/kill proof: passed as described above

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02f24","ts":"2026-08-23T15:57:34Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent lifecycle identity/liveness and Codex spawn/resume flags, including a new `--dangerously-bypass-hook-trust` on unattended Codex commands. Installer mutates user Claude/Codex hook configs with backups.
> 
> **Overview**
> Ships fail-open Claude and Codex `SessionStart` hooks that append a JSONL registry row (`session_id` + `CMUX_SURFACE_ID`, plus PID/timestamp) so cmuxlayer can join sessions without cwd/recency scanning. Adds `cmuxlayer install-session-hooks`, which merges those commands into existing Claude/Codex hook JSON, backs up files, and is idempotent.
> 
> Codex session identity still comes from the rollout. After that identity is durable, a matching hook row may only backfill process evidence for liveness guards, including replacing a gone PID when the old registration timestamp is missing.
> 
> Unattended Codex launch/resume now also pass `--dangerously-bypass-hook-trust` so the installed hook does not stall on a trust prompt; prompting mode still drops both bypass flags. Hook assets are packaged; Cursor/Gemini/Kiro remain out of this installer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428f1a57e1508d860c6ee040c6923c14e6b6d42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add session self-registration hooks for Claude and Codex with `install-session-hooks` CLI
> - Adds Python hook scripts ([cmux-self-register.py](https://github.com/EtanHey/cmuxlayer/pull/526/files#diff-9bd0b5f8180539d12f071f9ae486f9b5a3d1b91ebb5a8158b579f6f691d740ef) and [codex-cmux-self-register.py](https://github.com/EtanHey/cmuxlayer/pull/526/files#diff-2f88457ba5b5f5823793473b329c34bf0de54f29d71cd8ef5094c360d9866435)) that append session identity and process evidence (pid, cwd, launcher, timestamp) to a JSONL registry on session start
> - Adds [self-registration-hooks-installer.ts](https://github.com/EtanHey/cmuxlayer/pull/526/files#diff-1f9b977de42eaaa12046b129688e217723e558fce9a8933c98057982e3c3551c) and a `cmuxlayer install-session-hooks` CLI command that merges hook config into `~/.claude/settings.json` and `~/.codex/hooks.json`, creates backups, preserves file modes, and installs executable scripts to `~/.claude/hooks` and `~/.codex/hooks`
> - Splits `AgentEngine.canUseSelfRegistrationSessionResolver` into a resolver gate (Codex excluded) and a new `canUseSelfRegistrationProcessEvidence` helper (Codex included); `maybeCaptureBootSessionId` now backfills or replaces stale pid evidence when the old process is gone and the replacement has a finite `pid_registered_at`
> - Codex raw launch and resume commands now include `--dangerously-bypass-hook-trust` alongside `--dangerously-bypass-approvals-and-sandbox` in `RAW_SKIP_APPROVALS` and `buildResumeCommand`
> - Risk: Codex hooks require the `--dangerously-bypass-hook-trust` flag in all raw/resume launch paths; if a caller bypasses `AgentEngine` and omits this flag, Codex will not execute the self-registration hook
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 428f1a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to install Claude and Codex session hooks.
  * Session startup can now register sessions automatically for improved tracking.
  * Installations are repeatable, preserve existing settings, and create backups.

* **Improvements**
  * Codex launch and resume commands now include hook-trust bypass handling.
  * Added published hook assets and expanded installation documentation.

* **Bug Fixes**
  * Improved process identification when restoring Codex sessions.
  * Hook registration failures no longer prevent sessions from starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->