### PR TITLE
feat: add hierarchy-bound parent reporting

### DIFF
--- a/docs/plans/2026-08-23-report-to-parent-design.md
+++ b/docs/plans/2026-08-23-report-to-parent-design.md
@@ -1,0 +1,49 @@
+# Report to Parent and Spawn Report Watch Design
+
+## Status
+
+Approved by Etan on 2026-08-23.
+
+## Scope
+
+Phase 3 contains exactly three coupled changes:
+
+1. Add the tenth public tool, `report_to_parent`, for an agent-chosen blocker escalation.
+2. At child spawn, automatically arm a persistent watch owned by the parent on the child’s engine-issued `report_path` and `done_marker`.
+3. Keep long `wait_for` MCP calls alive by emitting progress more frequently than the harness’s 120-second no-progress cutoff.
+
+No sender-side delivery receipts, degraded spawn-receipt events, or other backlog defects are in scope.
+
+## Public tool contract
+
+`report_to_parent` accepts one `blocker` string capped at 500 characters. The caller cannot pass a target or parent identifier. cmuxlayer resolves the managed caller from the current surface and reads `parent_agent_id` from the registry.
+
+The tool appends a durable inbox envelope to the direct parent, then wakes that parent through the same guarded, evidence-backed terminal delivery path used by `send_to` and inbox nudges. Its lean result names the child, intended parent, actual notified agent, and whether delivery was direct or fallback.
+
+This is a separate public tool because its authority and meaning differ from `send_to`: the hierarchy determines the address, and successful return means a blocker was escalated rather than arbitrary text was sent.
+
+## Delivery failure
+
+The direct parent remains the durable recipient. If its surface is dead, wedged, or unreachable, cmuxlayer walks the registry ancestry and attempts to wake the nearest reachable ancestor with the blocker plus the direct-parent delivery failure. If no ancestor accepts verified delivery, the tool returns an error. The child therefore never receives a success response merely because a mailbox append succeeded.
+
+This reuses the delivery mechanics of `agent_halt_escalation` without duplicating its detection policy. `agent_halt_escalation` is engine-selected recovery for an observed halt; `report_to_parent` is agent-selected escalation of a known blocker.
+
+## Spawn-side report watch
+
+After issuing and persisting the child coordination contract, spawn ensures the report file exists and arms a WatchSpec with:
+
+- `owner`: the registry-derived parent agent ID
+- `target`: the child’s engine-issued absolute report path
+- `marker`: the child’s engine-issued done marker
+- `watermark`: the marker count at arm time
+- a far-future deadline, because completion—not a short timer—owns the lifecycle
+
+The WatchSpec registry is file-backed, so parent session restarts do not lose the watch. A fired watch is delivered to the owner’s current registered surface through the guarded relay. Failed delivery remains `notification_pending` and is retried by later sweeps. Counting only markers beyond the arm-time watermark prevents stale append-per-run markers from firing.
+
+## Long wait progress
+
+`wait_for` uses the MCP request’s progress token, when supplied, to emit progress notifications at intervals below 60 seconds until the wait resolves. The existing timeout remains meaningful; the harness sees observable progress rather than aborting a valid long wait at roughly 120 seconds.
+
+## Verification
+
+Tests cover the public palette, registry-derived authority, no-parent refusal, direct delivery, unreachable/dead parent fallback, simultaneous child reports, automatic spawn watch arming, stale-marker watermarking, persisted-watch delivery after parent restart, and progress notification cadence. Final gates are typecheck, the full suite with socket variables present, the full suite with both socket variables unset, and a fresh-pane real-client check because spawn/registry behavior changes.

--- a/docs/plans/2026-08-23-report-to-parent.md
+++ b/docs/plans/2026-08-23-report-to-parent.md
@@ -1,0 +1,72 @@
+# Report to Parent Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add hierarchy-bound blocker escalation, automatic persistent parent watches for child reports, and progress-bearing long waits.
+
+**Architecture:** Reuse inbox durability and the guarded lifecycle relay for blocker delivery. Reuse the persistent WatchSpec registry for report completion, but route agent-owned watch notifications into the owner’s current surface and arm the watch automatically from the spawn contract. Emit MCP progress notifications from the `wait_for` handler while its engine promise remains pending.
+
+**Tech Stack:** TypeScript, Bun, Vitest, MCP SDK, cmux lifecycle registry and delivery engine.
+
+---
+
+### Task 1: Restore the held-back public contract
+
+**Files:**
+- Modify: `tests/thin-core-tools.test.ts`
+
+1. Apply `docs.local/golden-path/d7-test-holdback.patch` from the repository root.
+2. Run the focused P0 D7 test and verify it fails because `report_to_parent` is absent.
+3. Add no production code before that failure is observed.
+
+### Task 2: Specify blocker escalation behavior
+
+**Files:**
+- Modify: `tests/server-agent-tools.test.ts`
+- Modify: `src/server.ts`
+- Modify: `src/palette.ts`
+
+1. Add failing tests for registry-derived parent routing, root-agent refusal, parent delivery failure with ancestor fallback, dead parent handling, and concurrent children.
+2. Run each focused test and verify the expected behavioral failure.
+3. Register `report_to_parent` as the tenth public/default-palette tool with a 500-character `blocker` argument and lean output schema.
+4. Implement durable direct-parent dispatch followed by guarded active delivery.
+5. Walk only the persisted ancestor chain after direct-parent wake failure; return an error if no wake is evidence-backed.
+6. Run the focused tests to green.
+
+### Task 3: Auto-arm parent report watches at spawn
+
+**Files:**
+- Modify: `tests/server-agent-tools.test.ts`
+- Modify: `tests/watch-spec-production.test.ts`
+- Modify: `src/server.ts`
+- Modify: `src/watch-spec.ts` only if a narrow reusable helper is required
+
+1. Add failing tests proving spawn arms a parent-owned file watch without parent action, captures the current marker count, and survives a recreated server/parent session through the persistent registry.
+2. Add a failing test proving a fired agent-owned watch wakes the owner through the guarded relay and stays pending when delivery fails.
+3. Ensure the engine-issued report file exists without truncating prior content, then arm the watch after the spawn contract is persisted.
+4. Route agent-owned WatchSpec notifications to the owner’s current surface; retain the configured external notifier for non-agent owners.
+5. Run the focused tests to green.
+
+### Task 4: Emit long-wait MCP progress
+
+**Files:**
+- Modify: `tests/watch-spec-mcp.test.ts`
+- Modify: `tests/server-agent-tools.test.ts`
+- Modify: `src/server.ts`
+
+1. Add a fake-timer failing test that provides an MCP progress token and holds `wait_for` open beyond one progress interval.
+2. Verify a progress notification is emitted before 60 seconds and the timer is cleared after completion.
+3. Implement a scoped progress heartbeat around every blocking `wait_for` mode using the request handler’s progress notification channel.
+4. Run the focused tests to green.
+
+### Task 5: Verify and report
+
+**Files:**
+- Modify: `/Users/etanheyman/.cmux/agents/cmuxlayerCodex-3d89bb53/report.md`
+
+1. Run `bun run typecheck`.
+2. Run `bunx vitest run` and record exact totals.
+3. Run `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run` and confirm the totals agree exactly.
+4. Run the fresh-pane real-client spawn/report watch check and record whether it was actually run and what it observed.
+5. Inspect the final diff and report only verified claims.
+6. Write the contract report; its final line must be exactly `DONE_CMUXLAYERCODEX_3D89BB53`.

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -272,6 +272,7 @@ export type DeliveryEventType =
   | "supersede_agent_goal"
   | "interact"
   | "press_enter"
+  | "report_to_parent"
   | "dispatch_nudge";
 
 export interface DeliveryTelemetryEvent {

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -3,6 +3,7 @@ export const CMUXLAYER_DEFAULT_PALETTE_ENV =
 
 export const REGISTERED_TOOL_NAMES = [
   "spawn_agent",
+  "report_to_parent",
   "send_to",
   "read_screen",
   "list_agents",

--- a/src/server.ts
+++ b/src/server.ts
@@ -5218,7 +5218,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       if (hasQueuedAgentInput) {
         if (
           opts.source_event !== "send_to" &&
-          opts.source_event !== "dispatch_nudge"
+          opts.source_event !== "dispatch_nudge" &&
+          opts.source_event !== "report_to_parent"
         ) {
           return {
             submit_verified: false,
@@ -5238,7 +5239,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       if (
         (opts.source_event === "send_to" ||
-          opts.source_event === "dispatch_nudge") &&
+          opts.source_event === "dispatch_nudge" ||
+          opts.source_event === "report_to_parent") &&
         screenShowsQueuedCursorFollowup(snapshot.text, opts.text)
       ) {
         return {
@@ -5367,13 +5369,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         opts.allow_recovery_enter_retry !== false &&
         (opts.source_event === "send_to" ||
           opts.source_event === "dispatch_nudge" ||
+          opts.source_event === "report_to_parent" ||
           opts.source_event === "boot_prompt") &&
         hasPendingSubmitEvidence &&
         screenCli === "codex";
       const cursorFollowupRetryEligiblePendingInput =
         opts.allow_recovery_enter_retry !== false &&
         (opts.source_event === "send_to" ||
-          opts.source_event === "dispatch_nudge") &&
+          opts.source_event === "dispatch_nudge" ||
+          opts.source_event === "report_to_parent") &&
         hasPendingSubmitEvidence &&
         screenCli === "cursor" &&
         screenShowsCursorFollowupNeedsEnter(snapshot.text);
@@ -5441,6 +5445,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery:
             opts.source_event === "send_to" ||
             opts.source_event === "dispatch_nudge" ||
+            opts.source_event === "report_to_parent" ||
             opts.require_attributable_submit_evidence === true
               ? "pending_verify"
               : "submitted",
@@ -5480,6 +5485,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const allowPendingVerify =
       opts.source_event === "send_to" ||
       opts.source_event === "dispatch_nudge" ||
+      opts.source_event === "report_to_parent" ||
       opts.require_attributable_submit_evidence === true;
     if (allowPendingVerify && submitVerified === false) {
       return {
@@ -5653,7 +5659,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       opts.source_event === "send_to" ||
       opts.source_event === "send_to_agent" ||
       opts.source_event === "send_input" ||
-      opts.source_event === "dispatch_nudge";
+      opts.source_event === "dispatch_nudge" ||
+      opts.source_event === "report_to_parent";
     const draftGuardText = opts.chunks.join("");
     const deliverySafetySnapshot = await assertDeliveryTargetIsSafe({
       surface: opts.surface,
@@ -12051,7 +12058,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             // retain their stricter no-retry evidence semantics.
             allow_recovery_enter_retry:
               args.source_event === "send_to" ||
-              args.source_event === "dispatch_nudge",
+              args.source_event === "dispatch_nudge" ||
+              args.source_event === "report_to_parent",
             submit_verify_timeout_ms: args.allow_busy
               ? BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS
               : undefined,
@@ -12097,7 +12105,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const deliverReportInboxPointer = async (
       recipient: AgentRecord,
       message: ReturnType<typeof dispatch>,
-    ): Promise<{ delivery: "submitted" | "queued"; delivery_id?: string }> => {
+    ): Promise<{
+      delivery: "submitted" | "queued" | "queued_followup" | "pending_verify";
+      delivery_id?: string;
+    }> => {
       const pointer = formatInboxPing(
         message,
         inboxPath(recipient.agent_id, inboxOpts),
@@ -12118,14 +12129,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           agent_id: recipient.agent_id,
           text: pointer,
           press_enter: true,
-          allow_busy: true,
+          allow_busy: false,
           source_event: "report_to_parent",
           delivery_id: deliveryId,
         });
       } catch (error) {
         if (
-          error instanceof Error &&
-          /\bis busy\b/.test(error.message)
+          error instanceof RetryableDeliveryError ||
+          (error instanceof Error && /\bis busy\b/.test(error.message))
         ) {
           const queued = engine.queueDelivery({
             agent_id: recipient.agent_id,
@@ -12139,14 +12150,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       }
       if (
         delivered.delivery !== "submitted" &&
-        delivered.delivery !== "queued"
+        delivered.delivery !== "queued" &&
+        delivered.delivery !== "queued_followup" &&
+        delivered.delivery !== "pending_verify"
       ) {
         throw new Error(
           "parent blocker wake produced no evidence-backed delivery state",
         );
       }
-      if (delivered.delivery === "queued") {
+      if (
+        delivered.delivery === "queued" ||
+        delivered.delivery === "queued_followup"
+      ) {
         engine.acceptComposerQueue({
+          delivery_id: deliveryId,
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          source_event: "report_to_parent",
+          retry_count: delivered.retry_count,
+          delivery_state: delivered.delivery,
+        });
+      } else if (delivered.delivery === "pending_verify") {
+        engine.acceptPendingVerify({
           delivery_id: deliveryId,
           agent_id: recipient.agent_id,
           text: pointer,

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,9 +6,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants, mkdtempSync, rmSync } from "node:fs";
-import { access, readFile } from "node:fs/promises";
+import { access, appendFile, mkdir, readFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { CmuxClient, type ExecFn } from "./cmux-client.js";
 import {
   CMUXLAYER_DEFAULT_PALETTE_ENV,
@@ -575,6 +575,7 @@ const SendToArgsSchema = z.object({
 
 export const PUBLIC_TOOL_NAMES = [
   "spawn_agent",
+  "report_to_parent",
   "send_to",
   "read_screen",
   "list_agents",
@@ -663,6 +664,19 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       coordination_footer_delivered: z.boolean().optional(),
       coordination_footer_note: z.string().optional(),
       boot_prompt_submit_verified: z.boolean().nullable().optional(),
+    })
+    .passthrough(),
+  report_to_parent: z
+    .object({
+      ...BaseOutputShape,
+      child_agent_id: z.string().optional(),
+      parent_agent_id: z.string().optional(),
+      notified_agent_id: z.string().optional(),
+      route: z.enum(["direct", "fallback"]).optional(),
+      durable: z.boolean().optional(),
+      delivery: z.enum(["submitted", "queued"]).optional(),
+      delivery_id: z.string().optional(),
+      error_code: z.string().optional(),
     })
     .passthrough(),
   send_to: z
@@ -11474,9 +11488,36 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           monitorRegistryPath: opts?.monitorRegistryPath,
           monitorRegistryNow: opts?.monitorRegistryNow,
           monitorRegistryNotify: opts?.monitorRegistryNotify,
-          watchRegistryPath: opts?.watchRegistryPath,
+          watchRegistryPath:
+            opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
           watchRegistryNow: opts?.watchRegistryNow,
-          watchNotify: opts?.watchNotify,
+          watchNotify: async (event) => {
+            const owner =
+              registry.get(event.owner) ?? stateMgr.readState(event.owner);
+            if (owner && lifecycleAgentInputDeliverer) {
+              try {
+                const delivery = await lifecycleAgentInputDeliverer({
+                  agent_id: owner.agent_id,
+                  text: `[report] done marker observed — read ${event.target}`,
+                  press_enter: true,
+                  allow_busy: true,
+                  source_event: "report_to_parent",
+                  delivery_id: randomUUID(),
+                });
+                return (
+                  delivery.delivery === "submitted" ||
+                  delivery.delivery === "queued"
+                );
+              } catch {
+                // Keep notification_pending=true. A later lifecycle sweep uses
+                // the parent's refreshed route after a session restart.
+                return false;
+              }
+            }
+            return opts?.watchNotify
+              ? (await opts.watchNotify(event)) !== false
+              : false;
+          },
           closeForensicsRunner: opts?.enableCloseForensics
             ? createDefaultCloseForensicsRunner({
                 stateMgr,
@@ -12025,6 +12066,208 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : {}),
       };
     });
+
+    const deliverReportInboxPointer = async (
+      recipient: AgentRecord,
+      message: ReturnType<typeof dispatch>,
+    ): Promise<{ delivery: "submitted" | "queued"; delivery_id?: string }> => {
+      const pointer = formatInboxPing(
+        message,
+        inboxPath(recipient.agent_id, inboxOpts),
+      );
+      if (recipient.state === "working") {
+        const queued = engine.queueDelivery({
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          source_event: "report_to_parent",
+        });
+        return { delivery: "queued", delivery_id: queued.delivery_id };
+      }
+      const deliveryId = randomUUID();
+      let delivered: Awaited<ReturnType<typeof deliverAgentInput>>;
+      try {
+        delivered = await deliverAgentInput({
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          allow_busy: true,
+          source_event: "report_to_parent",
+          delivery_id: deliveryId,
+        });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          /\bis busy\b/.test(error.message)
+        ) {
+          const queued = engine.queueDelivery({
+            agent_id: recipient.agent_id,
+            text: pointer,
+            press_enter: true,
+            source_event: "report_to_parent",
+          });
+          return { delivery: "queued", delivery_id: queued.delivery_id };
+        }
+        throw error;
+      }
+      if (
+        delivered.delivery !== "submitted" &&
+        delivered.delivery !== "queued"
+      ) {
+        throw new Error(
+          "parent blocker wake produced no evidence-backed delivery state",
+        );
+      }
+      if (delivered.delivery === "queued") {
+        engine.acceptComposerQueue({
+          delivery_id: deliveryId,
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          source_event: "report_to_parent",
+          retry_count: delivered.retry_count,
+        });
+      } else {
+        engine.resolveDelivery({
+          delivery_id: deliveryId,
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          source_event: "report_to_parent",
+          delivery_state: "submitted",
+          terminal: true,
+          retry_count: delivered.retry_count,
+          submit_verified: delivered.submit_verified,
+          error: null,
+        });
+      }
+      return { delivery: delivered.delivery, delivery_id: deliveryId };
+    };
+
+    server.tool(
+      "report_to_parent",
+      "Raise a short blocker to this managed agent's registry parent. cmuxlayer chooses the parent; callers cannot address arbitrary agents. The blocker is durably appended to the parent's inbox and its pointer is actively delivered. If that wake fails, cmuxlayer alerts the nearest reachable ancestor and returns fallback provenance. A root agent has no parent and receives an error.",
+      {
+        blocker: z
+          .string()
+          .trim()
+          .min(1)
+          .max(500)
+          .describe(
+            "Short blocker pointer, capped at 500 characters; put detailed evidence in a report file",
+          ),
+      },
+      ANNOTATIONS.mutating,
+      async (args) => {
+        await awaitLifecycleStart();
+        const child = resolveCurrentCallerAgent();
+        if (!child) {
+          return err("report_to_parent requires a managed calling agent", {
+            error_code: "report_caller_unmanaged",
+          });
+        }
+        if (!child.parent_agent_id) {
+          return err(`Agent ${child.agent_id} has no parent`, {
+            error_code: "report_parent_missing",
+            child_agent_id: child.agent_id,
+          });
+        }
+
+        const intendedParentId = child.parent_agent_id;
+        const directMessage = dispatch(
+          intendedParentId,
+          {
+            from: child.agent_id,
+            reply_to: child.agent_id,
+            via: child.surface_id,
+            observed_at: new Date().toISOString(),
+            to: intendedParentId,
+            tag: "parent_blocker",
+            task: args.blocker,
+          },
+          inboxOpts,
+        );
+        context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
+
+        const parent =
+          registry.get(intendedParentId) ?? stateMgr.readState(intendedParentId);
+        let directError = "parent is absent from the lifecycle registry";
+        if (parent) {
+          try {
+            const wake = await deliverReportInboxPointer(parent, directMessage);
+            return okFormatted(
+              `report_to_parent ${parent.agent_id}: ${wake.delivery}`,
+              {
+                child_agent_id: child.agent_id,
+                parent_agent_id: intendedParentId,
+                notified_agent_id: parent.agent_id,
+                route: "direct",
+                durable: true,
+                ...wake,
+              },
+            );
+          } catch (error) {
+            directError = error instanceof Error ? error.message : String(error);
+          }
+        }
+
+        const visited = new Set<string>([child.agent_id, intendedParentId]);
+        let ancestorId = parent?.parent_agent_id ?? null;
+        while (ancestorId && !visited.has(ancestorId)) {
+          visited.add(ancestorId);
+          const ancestor =
+            registry.get(ancestorId) ?? stateMgr.readState(ancestorId);
+          if (!ancestor) break;
+          const prefix =
+            `Delivery to parent ${intendedParentId} failed (${directError}). ` +
+            `Child ${child.agent_id} reports: `;
+          const fallbackTask = `${prefix}${args.blocker}`.slice(0, 500);
+          const fallbackMessage = dispatch(
+            ancestor.agent_id,
+            {
+              from: child.agent_id,
+              reply_to: child.agent_id,
+              via: child.surface_id,
+              observed_at: new Date().toISOString(),
+              to: ancestor.agent_id,
+              tag: "parent_delivery_failed",
+              task: fallbackTask,
+            },
+            inboxOpts,
+          );
+          try {
+            const wake = await deliverReportInboxPointer(
+              ancestor,
+              fallbackMessage,
+            );
+            return okFormatted(
+              `report_to_parent ${intendedParentId}: fallback ${ancestor.agent_id} ${wake.delivery}`,
+              {
+                child_agent_id: child.agent_id,
+                parent_agent_id: intendedParentId,
+                notified_agent_id: ancestor.agent_id,
+                route: "fallback",
+                durable: true,
+                ...wake,
+              },
+            );
+          } catch (error) {
+            directError = error instanceof Error ? error.message : String(error);
+            ancestorId = ancestor.parent_agent_id;
+          }
+        }
+
+        return err(
+          `Blocker was written to ${intendedParentId}'s inbox, but no parent or ancestor could be woken: ${directError}`,
+          {
+            error_code: "report_parent_unreachable",
+            child_agent_id: child.agent_id,
+            parent_agent_id: intendedParentId,
+            durable: true,
+          },
+        );
+      },
+    );
     engine.setDeliverySnapshotReader(async (receipt: AgentDeliveryReceipt) => {
       const agent = engine.getAgentState(receipt.agent_id);
       if (!agent) return null;
@@ -12884,6 +13127,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           } catch {
             // Receipt already carries the contract; a registry write failure
             // must not fail an otherwise-successful spawn.
+          }
+          if (result.parent_agent_id) {
+            await mkdir(dirname(coordination.report_path), { recursive: true });
+            await appendFile(coordination.report_path, "", "utf8");
+            await engine.armWatch({
+              owner: result.parent_agent_id,
+              target: coordination.report_path,
+              marker: coordination.done_marker,
+              deadline: Number.MAX_SAFE_INTEGER,
+            });
           }
           const spawnedBinding = engine.getAgentState(result.agent_id);
           appendStaleBuildWarning(result);
@@ -14024,7 +14277,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .describe("Timeout in milliseconds (default: 5 minutes)"),
       },
       ANNOTATIONS.mutating,
-      async (args) => {
+      async (args, extra) => {
+        const progressToken = extra._meta?.progressToken;
+        let progress = 0;
+        const progressTimer =
+          progressToken !== undefined
+            ? setInterval(() => {
+                progress += 1;
+                void extra
+                  .sendNotification({
+                    method: "notifications/progress",
+                    params: {
+                      progressToken,
+                      progress,
+                      message: "wait_for still waiting",
+                    },
+                  })
+                  .catch(() => {});
+              }, 45_000)
+            : null;
+        progressTimer?.unref?.();
         try {
           if (args.watch) {
             if (args.agent_id || args.ids || args.mine || args.delivery_id) {
@@ -14219,6 +14491,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
           }
           return err(e);
+        } finally {
+          if (progressTimer) clearInterval(progressTimer);
         }
       },
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -11492,27 +11492,54 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
+            let externalDelivered = true;
+            if (event.reason !== "predicate_matched" && opts?.watchNotify) {
+              try {
+                externalDelivered = (await opts.watchNotify(event)) !== false;
+              } catch {
+                externalDelivered = false;
+              }
+            }
             const owner =
               registry.get(event.owner) ?? stateMgr.readState(event.owner);
             if (owner && lifecycleAgentInputDeliverer) {
+              const text = (() => {
+                if (event.reason === "predicate_matched") {
+                  return event.target_kind === "file"
+                    ? `[report] done marker observed — read ${event.target}`
+                    : `[watch] agent predicate matched — inspect ${event.target}`;
+                }
+                if (event.reason === "target_missing") {
+                  return `[watch] target missing — expected file ${event.target}`;
+                }
+                if (event.reason === "deadline_elapsed") {
+                  return event.target_kind === "file"
+                    ? `[watch] deadline elapsed before marker — inspect ${event.target}`
+                    : `[watch] deadline elapsed before predicate — inspect agent ${event.target}`;
+                }
+                return `[watch] target agent ended before predicate — inspect ${event.target}`;
+              })();
               try {
                 const delivery = await lifecycleAgentInputDeliverer({
                   agent_id: owner.agent_id,
-                  text: `[report] done marker observed — read ${event.target}`,
+                  text,
                   press_enter: true,
                   allow_busy: true,
                   source_event: "report_to_parent",
                   delivery_id: randomUUID(),
                 });
-                return (
+                const ownerDelivered =
                   delivery.delivery === "submitted" ||
-                  delivery.delivery === "queued"
-                );
+                  delivery.delivery === "queued";
+                return ownerDelivered && externalDelivered;
               } catch {
                 // Keep notification_pending=true. A later lifecycle sweep uses
                 // the parent's refreshed route after a session restart.
                 return false;
               }
+            }
+            if (event.reason !== "predicate_matched") {
+              return opts?.watchNotify ? externalDelivered : false;
             }
             return opts?.watchNotify
               ? (await opts.watchNotify(event)) !== false
@@ -12144,6 +12171,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       return { delivery: delivered.delivery, delivery_id: deliveryId };
     };
 
+    const armParentReportWatch = async (
+      parentAgentId: string,
+      coordination: { report_path: string; done_marker: string },
+    ): Promise<string | null> => {
+      try {
+        await mkdir(dirname(coordination.report_path), { recursive: true });
+        await appendFile(coordination.report_path, "", "utf8");
+        await engine.armWatch({
+          owner: parentAgentId,
+          target: coordination.report_path,
+          marker: coordination.done_marker,
+          deadline: Number.MAX_SAFE_INTEGER,
+        });
+        return null;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return `Report watch was not armed for ${coordination.report_path}: ${detail}`;
+      }
+    };
+
     server.tool(
       "report_to_parent",
       "Raise a short blocker to this managed agent's registry parent. cmuxlayer chooses the parent; callers cannot address arbitrary agents. The blocker is durably appended to the parent's inbox and its pointer is actively delivered. If that wake fails, cmuxlayer alerts the nearest reachable ancestor and returns fallback provenance. A root agent has no parent and receives an error.",
@@ -12680,16 +12727,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               // Receipt already carries the contract; a registry write failure
               // must not fail an otherwise-successful resume.
             }
+            const reportWatchWarning = result.parent_agent_id
+              ? await armParentReportWatch(
+                  result.parent_agent_id,
+                  resumeCoordination,
+                )
+              : null;
+            const resumeWarnings = [
+              ...(result.warnings ?? []),
+              ...(reportWatchWarning ? [reportWatchWarning] : []),
+              ...(focusRestoreWarning ? [focusRestoreWarning] : []),
+            ];
             const resumed = {
               version: 1,
               type: "agent",
               resumed: true,
               ...result,
               role: inferRecordRoleOrNull(existing) ?? "worker",
-              ...(focusRestoreWarning
+              ...(resumeWarnings.length > 0
                 ? {
-                    warning: focusRestoreWarning,
-                    warnings: [focusRestoreWarning],
+                    warning: resumeWarnings.join(" | "),
+                    warnings: resumeWarnings,
                   }
                 : {}),
             };
@@ -13129,14 +13187,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             // must not fail an otherwise-successful spawn.
           }
           if (result.parent_agent_id) {
-            await mkdir(dirname(coordination.report_path), { recursive: true });
-            await appendFile(coordination.report_path, "", "utf8");
-            await engine.armWatch({
-              owner: result.parent_agent_id,
-              target: coordination.report_path,
-              marker: coordination.done_marker,
-              deadline: Number.MAX_SAFE_INTEGER,
-            });
+            const reportWatchWarning = await armParentReportWatch(
+              result.parent_agent_id,
+              coordination,
+            );
+            if (reportWatchWarning) {
+              result.warnings = [
+                ...(result.warnings ?? []),
+                reportWatchWarning,
+              ];
+            }
           }
           const spawnedBinding = engine.getAgentState(result.agent_id);
           appendStaleBuildWarning(result);

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -70,6 +70,7 @@ export interface WatchNotification {
   watch_id: string;
   owner: string;
   target: string;
+  target_kind: "file" | "agent";
   reason: WatchNotificationReason;
   observed_at_ms: number;
   watermark?: number;
@@ -539,6 +540,7 @@ function notificationFor(
     watch_id: record.watch_id,
     owner: record.owner,
     target: record.target,
+    target_kind: record.target_kind,
     reason,
     observed_at_ms: observedAt,
     ...(record.watermark !== undefined ? { watermark: record.watermark } : {}),

--- a/tests/default-palette.test.ts
+++ b/tests/default-palette.test.ts
@@ -13,6 +13,7 @@ const RATIFIED_TOOL_SURFACE = [
   "list_agents",
   "list_surfaces",
   "read_screen",
+  "report_to_parent",
   "send_to",
   "spawn_agent",
   "update_surface",

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -1251,6 +1251,59 @@ describe("report_to_parent hierarchy-bound escalation", () => {
     expect(sendCalls(exec).at(-1)?.join(" ")).toContain("surface:new");
   });
 
+  it("keeps a parent blocker durable without typing into a foreign draft", async () => {
+    await server.close();
+    exec = makeExec(
+      "Claude Code\n❯ do not submit this existing draft",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    server = createInboxServer(exec, inboxDir);
+    const parent = hierarchyRecord({
+      agentId: "lead-parent",
+      surfaceId: "surface:new",
+      surfaceUuid: parentUuid,
+      parentAgentId: null,
+    });
+    const child = hierarchyRecord({
+      agentId: "worker-child",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: parent.agent_id,
+    });
+    register(parent, child);
+    const before = sendCalls(exec).length;
+
+    const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
+      server._registeredTools.report_to_parent.handler(
+        { blocker: "Blocked while parent is composing" },
+        {} as any,
+      ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      route: "direct",
+      delivery: "queued",
+      durable: true,
+    });
+    expect(sendCalls(exec)).toHaveLength(before);
+    expect(readInbox(parent.agent_id, { baseDir: inboxDir })[0]?.task).toBe(
+      "Blocked while parent is composing",
+    );
+  });
+
   it("refuses a root caller with no registry parent", async () => {
     const root = hierarchyRecord({
       agentId: "orc-root",

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -43,6 +43,7 @@ import {
   withTestSurfaceObserver,
 } from "./helpers/test-surface-observer.js";
 import { runWithCallerContext } from "../src/caller-context.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-inbox-nudge");
 const PRIMARY_SURFACE_UUID = "11111111-1111-4111-8111-111111111111";
@@ -239,6 +240,48 @@ async function spawnTestAgent(server: any): Promise<string> {
   const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);
   expect(parsed.ok).toBe(true);
   return parsed.agent_id as string;
+}
+
+function hierarchyRecord(input: {
+  agentId: string;
+  surfaceId: string;
+  surfaceUuid: string;
+  parentAgentId: string | null;
+  state?: AgentRecord["state"];
+}): AgentRecord {
+  return {
+    agent_id: input.agentId,
+    surface_id: input.surfaceId,
+    surface_uuid: input.surfaceUuid,
+    workspace_id: "workspace:1",
+    state: input.state ?? "ready",
+    repo: "cmuxlayer",
+    model: "claude-sonnet-4-5",
+    cli: "claude",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "hierarchy fixture",
+    pid: null,
+    version: 1,
+    created_at: "2026-08-23T00:00:00.000Z",
+    updated_at: "2026-08-23T00:00:00.000Z",
+    error: null,
+    parent_agent_id: input.parentAgentId,
+    spawn_depth: input.parentAgentId ? 1 : 0,
+    role: input.parentAgentId ? "worker" : "orchestrator",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    boot_prompt_pending: false,
+    launch_cwd: null,
+    mcp_profile: null,
+    worktree_path: null,
+    worktree_branch: null,
+  };
 }
 
 describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
@@ -1111,5 +1154,271 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
       issue_codes: expect.arrayContaining(["inbox_channel_dir_deleted"]),
     });
     expect(parsed.health.issue_codes).not.toContain("inbox_monitor_not_alive");
+  });
+});
+
+describe("report_to_parent hierarchy-bound escalation", () => {
+  let inboxDir: string;
+  let exec: ExecFn;
+  let server: any;
+
+  const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const childTwoUuid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+  beforeEach(() => {
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    mkdirSync(STATE_DIR, { recursive: true });
+    inboxDir = mkdtempSync(join(tmpdir(), "cmux-report-parent-"));
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+        {
+          id: childTwoUuid,
+          ref: "surface:child-two",
+          title: "child-two-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    server = createInboxServer(exec, inboxDir);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    rmSync(STATE_DIR, { recursive: true, force: true });
+    rmSync(inboxDir, { recursive: true, force: true });
+  });
+
+  function register(...records: AgentRecord[]) {
+    const engine = server._registeredTools["interact"]._engine;
+    for (const record of records) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+  }
+
+  it("routes only to the caller's registry parent and actively wakes it", async () => {
+    const parent = hierarchyRecord({
+      agentId: "lead-parent",
+      surfaceId: "surface:new",
+      surfaceUuid: parentUuid,
+      parentAgentId: null,
+    });
+    const child = hierarchyRecord({
+      agentId: "worker-child",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: parent.agent_id,
+    });
+    register(parent, child);
+
+    const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
+      server._registeredTools.report_to_parent.handler(
+        { blocker: "Blocked on the signed release fixture" },
+        {} as any,
+      ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      child_agent_id: child.agent_id,
+      parent_agent_id: parent.agent_id,
+      notified_agent_id: parent.agent_id,
+      route: "direct",
+      durable: true,
+      delivery: "submitted",
+    });
+    expect(readInbox(parent.agent_id, { baseDir: inboxDir })).toHaveLength(1);
+    expect(readInbox(parent.agent_id, { baseDir: inboxDir })[0]).toMatchObject({
+      from: child.agent_id,
+      reply_to: child.agent_id,
+      to: parent.agent_id,
+      tag: "parent_blocker",
+      task: "Blocked on the signed release fixture",
+    });
+    expect(sendCalls(exec).at(-1)?.join(" ")).toContain("surface:new");
+  });
+
+  it("refuses a root caller with no registry parent", async () => {
+    const root = hierarchyRecord({
+      agentId: "orc-root",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: null,
+    });
+    register(root);
+
+    const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
+      server._registeredTools.report_to_parent.handler(
+        { blocker: "No parent exists" },
+        {} as any,
+      ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "report_parent_missing",
+      child_agent_id: root.agent_id,
+    });
+  });
+
+  it("escalates the wake failure to the nearest reachable grandparent", async () => {
+    await server.close();
+    const grandparentUuid = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "grandparent-pane",
+      undefined,
+      [
+        {
+          id: parentUuid,
+          ref: "surface:dead-parent",
+          title: "dead-parent-pane",
+          text: "$ ",
+        },
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      grandparentUuid,
+    );
+    server = createInboxServer(exec, inboxDir);
+    const grandparent = hierarchyRecord({
+      agentId: "orc-grandparent",
+      surfaceId: "surface:new",
+      surfaceUuid: grandparentUuid,
+      parentAgentId: null,
+    });
+    const parent = hierarchyRecord({
+      agentId: "dead-lead",
+      surfaceId: "surface:dead-parent",
+      surfaceUuid: parentUuid,
+      parentAgentId: grandparent.agent_id,
+      state: "error",
+    });
+    const child = hierarchyRecord({
+      agentId: "worker-child",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: parent.agent_id,
+    });
+    register(grandparent, parent, child);
+
+    const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
+      server._registeredTools.report_to_parent.handler(
+        { blocker: "Parent pane died during release validation" },
+        {} as any,
+      ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      parent_agent_id: parent.agent_id,
+      notified_agent_id: grandparent.agent_id,
+      route: "fallback",
+      durable: true,
+      delivery: "submitted",
+    });
+    expect(readInbox(parent.agent_id, { baseDir: inboxDir })[0]?.tag).toBe(
+      "parent_blocker",
+    );
+    expect(
+      readInbox(grandparent.agent_id, { baseDir: inboxDir })[0],
+    ).toMatchObject({
+      tag: "parent_delivery_failed",
+      task: expect.stringContaining("Parent pane died during release validation"),
+    });
+  });
+
+  it("returns a loud failure when the recorded parent is unreachable", async () => {
+    const child = hierarchyRecord({
+      agentId: "orphaned-worker",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: "missing-parent",
+    });
+    register(child);
+
+    const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
+      server._registeredTools.report_to_parent.handler(
+        { blocker: "Cannot reach the dependency owner" },
+        {} as any,
+      ),
+    );
+    const parsed =
+      result.structuredContent ?? JSON.parse(result.content[0].text);
+
+    expect(parsed).toMatchObject({
+      ok: false,
+      error_code: "report_parent_unreachable",
+      child_agent_id: child.agent_id,
+      parent_agent_id: "missing-parent",
+      durable: true,
+    });
+  });
+
+  it("keeps simultaneous child escalations as distinct durable messages", async () => {
+    const parent = hierarchyRecord({
+      agentId: "lead-parent",
+      surfaceId: "surface:new",
+      surfaceUuid: parentUuid,
+      parentAgentId: null,
+    });
+    const first = hierarchyRecord({
+      agentId: "worker-one",
+      surfaceId: "surface:child",
+      surfaceUuid: childUuid,
+      parentAgentId: parent.agent_id,
+    });
+    const second = hierarchyRecord({
+      agentId: "worker-two",
+      surfaceId: "surface:child-two",
+      surfaceUuid: childTwoUuid,
+      parentAgentId: parent.agent_id,
+    });
+    register(parent, first, second);
+
+    const [one, two] = await Promise.all([
+      runWithCallerContext({ surfaceId: childUuid }, () =>
+        server._registeredTools.report_to_parent.handler(
+          { blocker: "First blocker" },
+          {} as any,
+        ),
+      ),
+      runWithCallerContext({ surfaceId: childTwoUuid }, () =>
+        server._registeredTools.report_to_parent.handler(
+          { blocker: "Second blocker" },
+          {} as any,
+        ),
+      ),
+    ]);
+
+    expect(one.isError).not.toBe(true);
+    expect(two.isError, JSON.stringify(two.structuredContent)).not.toBe(true);
+    const messages = readInbox(parent.agent_id, { baseDir: inboxDir });
+    expect(messages.map((message) => message.task).sort()).toEqual([
+      "First blocker",
+      "Second blocker",
+    ]);
+    expect(new Set(messages.map((message) => message.id))).toHaveLength(2);
   });
 });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -198,6 +198,44 @@ function sentText(exec: ExecFn): string {
     .join("\n");
 }
 
+function parentRecord(
+  surfaceUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+): AgentRecord {
+  return {
+    agent_id: "lead-parent",
+    surface_id: "surface:new",
+    surface_uuid: surfaceUuid,
+    workspace_id: "workspace:1",
+    state: "ready",
+    repo: "cmuxlayer",
+    model: "claude-sonnet-4-5",
+    cli: "claude",
+    cli_session_id: null,
+    cli_session_path: null,
+    task_summary: "parent fixture",
+    pid: null,
+    version: 1,
+    created_at: "2026-08-23T00:00:00.000Z",
+    updated_at: "2026-08-23T00:00:00.000Z",
+    error: null,
+    parent_agent_id: null,
+    spawn_depth: 0,
+    role: "orchestrator",
+    auto_archive_on_done: false,
+    deletion_intent: false,
+    quality: "unknown",
+    max_cost_per_agent: null,
+    crash_recover: true,
+    respawn_attempts: 0,
+    user_killed: false,
+    boot_prompt_pending: false,
+    launch_cwd: null,
+    mcp_profile: null,
+    worktree_path: null,
+    worktree_branch: null,
+  };
+}
+
 describe("P11 spawn_agent issues the coordination contract", () => {
   let inboxDir: string;
   let exec: ExecFn;
@@ -307,39 +345,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       }),
     );
     let engine = server._registeredTools.interact._engine;
-    const parent = {
-      agent_id: "lead-parent",
-      surface_id: "surface:new",
-      surface_uuid: parentUuid,
-      workspace_id: "workspace:1",
-      state: "ready",
-      repo: "cmuxlayer",
-      model: "claude-sonnet-4-5",
-      cli: "claude",
-      cli_session_id: null,
-      cli_session_path: null,
-      task_summary: "parent fixture",
-      pid: null,
-      version: 1,
-      created_at: "2026-08-23T00:00:00.000Z",
-      updated_at: "2026-08-23T00:00:00.000Z",
-      error: null,
-      parent_agent_id: null,
-      spawn_depth: 0,
-      role: "orchestrator",
-      auto_archive_on_done: false,
-      deletion_intent: false,
-      quality: "unknown",
-      max_cost_per_agent: null,
-      crash_recover: true,
-      respawn_attempts: 0,
-      user_killed: false,
-      boot_prompt_pending: false,
-      launch_cwd: null,
-      mcp_profile: null,
-      worktree_path: null,
-      worktree_branch: null,
-    } satisfies AgentRecord;
+    const parent = parentRecord(parentUuid);
     engine.stateMgr.writeState(parent);
     engine.getRegistry().set(parent.agent_id, parent);
     const child = await spawn({ parent_agent_id: parent.agent_id });
@@ -395,6 +401,120 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         (watch) => watch.watch_id === rearmed.watch_id,
       )?.state,
     ).toBe("armed");
+  });
+
+  it("does not describe a missing report target as a done marker and preserves the reason-aware notifier", async () => {
+    await server.close();
+    const externalNotify = vi.fn().mockResolvedValue(true);
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchNotify: externalNotify,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord(parentUuid);
+    engine.stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+    const reportPath = join(inboxDir, "reaped-child", "report.md");
+    mkdirSync(join(inboxDir, "reaped-child"), { recursive: true });
+    writeFileSync(reportPath, "", "utf8");
+    await engine.armWatch({
+      owner: parent.agent_id,
+      target: reportPath,
+      marker: "DONE_REAPED_CHILD",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    rmSync(reportPath);
+    await engine.sweepWatchesBestEffort();
+
+    expect(sentText(exec)).not.toContain("done marker observed");
+    expect(sentText(exec)).toContain("target missing");
+    expect(externalNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: parent.agent_id,
+        target: reportPath,
+        target_kind: "file",
+        reason: "target_missing",
+      }),
+    );
+  });
+
+  it("keeps an already-created child spawn successful when its report watch cannot be armed", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const baseExec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:child",
+            surface_id: childUuid,
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord(parentUuid);
+    engine.stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+    const blockingFile = join(inboxDir, "not-a-directory");
+    writeFileSync(blockingFile, "blocks mkdir", "utf8");
+
+    const child = await spawn({
+      parent_agent_id: parent.agent_id,
+      report_path: join(blockingFile, "report.md"),
+    });
+
+    expect(child.ok, JSON.stringify(child)).toBe(true);
+    expect(child.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/report watch was not armed/i),
+      ]),
+    );
+    expect(engine.getAgentState(child.agent_id)).not.toBeNull();
   });
 
   // -------------------------------------------------------------------------

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -10,8 +10,10 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  appendFileSync,
   mkdirSync,
   mkdtempSync,
+  existsSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -31,6 +33,8 @@ import {
   issueCoordinationContract,
 } from "../src/coordination-paths.js";
 import { recommendedMonitorCommand } from "../src/inbox.js";
+import { readWatchRegistry } from "../src/watch-spec.js";
+import type { AgentRecord } from "../src/agent-types.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-p11-spawn");
 
@@ -49,6 +53,7 @@ function makeExec(
   primarySurfaceUuid?: string,
 ): ExecFn {
   let promptPending = false;
+  let promptSurface = "surface:new";
   let pastePending = false;
   let currentScreenText = screenText;
   const surfaces: TestSurface[] = [
@@ -60,9 +65,13 @@ function makeExec(
     },
     ...additionalSurfaces,
   ];
-  const setScreenText = (text: string) => {
-    currentScreenText = text;
-    if (mutableScreen) mutableScreen.text = text;
+  const setScreenText = (text: string, surfaceRef = "surface:new") => {
+    const surface = surfaces.find(({ ref }) => ref === surfaceRef);
+    if (surface) surface.text = text;
+    if (surfaceRef === "surface:new") {
+      currentScreenText = text;
+      if (mutableScreen) mutableScreen.text = text;
+    }
   };
   return vi.fn().mockImplementation(async (_cmd, args) => {
     if (args.includes("list-workspaces")) {
@@ -141,7 +150,7 @@ function makeExec(
     }
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
-        setScreenText("Claude Code\n✻ Working\n");
+        setScreenText("Claude Code\n✻ Working\n", promptSurface);
         promptPending = false;
       }
       return { stdout: "{}", stderr: "" };
@@ -163,6 +172,9 @@ function makeExec(
           !/[A-Za-z0-9_.-]+(?:Claude|Codex|Cursor|Gemini|Kiro)\b/.test(text))
       ) {
         promptPending = true;
+        promptSurface =
+          surfaces.find(({ ref }) => args.includes(ref))?.ref ?? "surface:new";
+        setScreenText(`Claude Code\n❯ ${text}`, promptSurface);
       }
     }
     return {
@@ -190,11 +202,13 @@ describe("P11 spawn_agent issues the coordination contract", () => {
   let inboxDir: string;
   let exec: ExecFn;
   let server: any;
+  let watchRegistryPath: string;
 
   beforeEach(() => {
     rmSync(STATE_DIR, { recursive: true, force: true });
     mkdirSync(STATE_DIR, { recursive: true });
     inboxDir = mkdtempSync(join(tmpdir(), "p11-inbox-"));
+    watchRegistryPath = join(inboxDir, "watch-specs.json");
     exec = makeExec();
     server = createServer(
       withTestSurfaceObserver({
@@ -202,6 +216,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         stateDir: STATE_DIR,
         disableSpawnPreflight: true,
         inboxBaseDir: inboxDir,
+        watchRegistryPath,
       }),
     );
   });
@@ -246,6 +261,140 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
     expect(detail.report_path).toBe(parsed.report_path);
     expect(detail.done_marker).toBe(parsed.done_marker);
+  });
+
+  it("automatically arms the parent's persistent watch on the child report", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const baseExec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:child",
+            surface_id: childUuid,
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    let engine = server._registeredTools.interact._engine;
+    const parent = {
+      agent_id: "lead-parent",
+      surface_id: "surface:new",
+      surface_uuid: parentUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "cmuxlayer",
+      model: "claude-sonnet-4-5",
+      cli: "claude",
+      cli_session_id: null,
+      cli_session_path: null,
+      task_summary: "parent fixture",
+      pid: null,
+      version: 1,
+      created_at: "2026-08-23T00:00:00.000Z",
+      updated_at: "2026-08-23T00:00:00.000Z",
+      error: null,
+      parent_agent_id: null,
+      spawn_depth: 0,
+      role: "orchestrator",
+      auto_archive_on_done: false,
+      deletion_intent: false,
+      quality: "unknown",
+      max_cost_per_agent: null,
+      crash_recover: true,
+      respawn_attempts: 0,
+      user_killed: false,
+      boot_prompt_pending: false,
+      launch_cwd: null,
+      mcp_profile: null,
+      worktree_path: null,
+      worktree_branch: null,
+    } satisfies AgentRecord;
+    engine.stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+    const child = await spawn({ parent_agent_id: parent.agent_id });
+
+    expect(child.ok, JSON.stringify(child)).toBe(true);
+    expect(child.parent_agent_id).toBe(parent.agent_id);
+    expect(existsSync(child.report_path)).toBe(true);
+    expect(readWatchRegistry({ registryPath: watchRegistryPath }).watches).toEqual([
+      expect.objectContaining({
+        owner: parent.agent_id,
+        target: child.report_path,
+        marker: child.done_marker,
+        watermark: 0,
+        state: "armed",
+      }),
+    ]);
+
+    await server.close();
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as any);
+    engine = server._registeredTools.interact._engine;
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    appendFileSync(child.report_path, `${child.done_marker}\n`, "utf8");
+    await engine.sweepWatchesBestEffort();
+    const afterCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
+    expect(
+      afterCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) =>
+            arg.includes("[report]") && arg.includes(child.report_path),
+        ),
+      ),
+    ).toBe(true);
+
+    const rearmed = await engine.armWatch({
+      owner: parent.agent_id,
+      target: child.report_path,
+      marker: child.done_marker,
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    expect(rearmed.watermark).toBe(1);
+    await engine.sweepWatchesBestEffort();
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
+        (watch) => watch.watch_id === rearmed.watch_id,
+      )?.state,
+    ).toBe("armed");
   });
 
   // -------------------------------------------------------------------------

--- a/tests/public-output-schema-stdio.test.ts
+++ b/tests/public-output-schema-stdio.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
 
 const validArguments: Record<string, Record<string, unknown>> = {
   spawn_agent: { type: "terminal" },
+  report_to_parent: { blocker: "schema probe" },
   send_to: {
     mode: "surface",
     surface: "surface:test",
@@ -40,7 +41,7 @@ const validArguments: Record<string, Record<string, unknown>> = {
 };
 
 describe("public tool output schemas over stdio", () => {
-  it("accepts passthrough receipts from all nine tools after listTools caches Ajv validators", async () => {
+  it("accepts passthrough receipts from all ten tools after listTools caches Ajv validators", async () => {
     const testDir = mkdtempSync(join(tmpdir(), "cmuxlayer-output-schema-"));
     testDirs.push(testDir);
     const transport = new StdioClientTransport({
@@ -72,6 +73,16 @@ describe("public tool output schemas over stdio", () => {
       }
       const declaredFields: Record<string, string[]> = {
         spawn_agent: ["type", "cwd", "title", "cwd_receipt"],
+        report_to_parent: [
+          "child_agent_id",
+          "parent_agent_id",
+          "notified_agent_id",
+          "route",
+          "durable",
+          "delivery",
+          "delivery_id",
+          "error_code",
+        ],
         send_to: [
           "command",
           "title",

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -93,7 +93,7 @@ describe("B1: ToolAnnotations on all tools", () => {
 
   it("all registered test-mode tools have annotations", () => {
     const toolNames = Object.keys(tools);
-    expect(toolNames.length).toBe(44);
+    expect(toolNames.length).toBe(45);
     for (const name of toolNames) {
       expect(
         tools[name].annotations,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useHarnessHome } from "./helpers/harness-home.js";
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -50,6 +51,11 @@ import {
   runWithCallerContext,
 } from "../src/caller-context.js";
 import { MODEL_OVERRIDE_ENV } from "../src/model-policy.js";
+import {
+  armWatch,
+  readWatchRegistry,
+  sweepWatches,
+} from "../src/watch-spec.js";
 
 let TEST_DIR = join(tmpdir(), "cmux-agents-test-server-tools");
 const serverContexts: CmuxServerContext[] = [];
@@ -2391,8 +2397,20 @@ describe("agent lifecycle tool handlers", () => {
     // for was the one case where a lead could not even see where its worker
     // should report.
     const agentId = "cmuxlayerCodex-stable-resume-contract";
+    const parentId = "cmuxlayerClaude-resume-parent";
     const resumeInboxDir = mkdtempSync(join(tmpdir(), "p11b-resume-inbox-"));
+    const watchRegistryPath = join(resumeInboxDir, "watch-specs.json");
     const stateMgr = new StateManager(TEST_DIR);
+    stateMgr.writeState(
+      makeServerAgentRecord({
+        agent_id: parentId,
+        repo: "cmuxlayer",
+        cli: "claude",
+        role: "orchestrator",
+        state: "ready",
+        surface_id: "surface:parent",
+      }),
+    );
     stateMgr.writeState(
       makeServerAgentRecord({
         agent_id: agentId,
@@ -2401,8 +2419,34 @@ describe("agent lifecycle tool handlers", () => {
         state: "done",
         surface_id: "surface:old",
         cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        parent_agent_id: parentId,
+        spawn_depth: 1,
       }),
     );
+    const expected = issueCoordinationContract(agentId, {
+      baseDir: resumeInboxDir,
+    });
+    mkdirSync(join(resumeInboxDir, agentId), { recursive: true });
+    writeFileSync(expected.report_path, "", "utf8");
+    const oldWatch = await armWatch(
+      {
+        owner: parentId,
+        target: expected.report_path,
+        marker: expected.done_marker,
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: watchRegistryPath },
+    );
+    appendFileSync(expected.report_path, `${expected.done_marker}\n`, "utf8");
+    await sweepWatches({
+      registryPath: watchRegistryPath,
+      notify: async () => true,
+    });
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
+        (watch) => watch.watch_id === oldWatch.watch_id,
+      )?.state,
+    ).toBe("fired");
     const exec = makeLifecycleExec();
     const server = createTrackedServer({
       exec,
@@ -2410,6 +2454,7 @@ describe("agent lifecycle tool handlers", () => {
       disableSpawnPreflight: true,
       sessionIdentityResolver: () => null,
       inboxBaseDir: resumeInboxDir,
+      watchRegistryPath,
     });
     await serverContexts.at(-1)?.lifecycleStartPromise;
     const spawn = (server as any)._registeredTools["spawn_agent"];
@@ -2422,9 +2467,6 @@ describe("agent lifecycle tool handlers", () => {
 
       // Byte-identical to what the original spawn issued -- both strings derive
       // from agent_id alone, which is why refreshing is safe and idempotent.
-      const expected = issueCoordinationContract(agentId, {
-        baseDir: resumeInboxDir,
-      });
       expect(parsed.report_path).toBe(expected.report_path);
       expect(parsed.done_marker).toBe(expected.done_marker);
       expect(parsed.contract_path).toBe(
@@ -2448,6 +2490,23 @@ describe("agent lifecycle tool handlers", () => {
       ) as Record<string, unknown>;
       expect(detail.report_path).toBe(expected.report_path);
       expect(detail.done_marker).toBe(expected.done_marker);
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            watch_id: oldWatch.watch_id,
+            state: "fired",
+          }),
+          expect.objectContaining({
+            owner: parentId,
+            target: expected.report_path,
+            marker: expected.done_marker,
+            watermark: 1,
+            state: "armed",
+          }),
+        ]),
+      );
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2021,7 +2021,7 @@ describe("agent lifecycle tool registration", () => {
     const mockExec = makeLifecycleExec();
     const server = createLifecycleServer(mockExec);
     const registeredTools = (server as any)._registeredTools;
-    expect(Object.keys(registeredTools)).toHaveLength(44);
+    expect(Object.keys(registeredTools)).toHaveLength(45);
   });
 
   it("keeps resync_agents only as a removed compatibility stub", async () => {

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -5,6 +5,7 @@ import type { ExecFn } from "../src/cmux-client.js";
 
 const CORE_TOOL_NAMES = [
   "spawn_agent",
+  "report_to_parent",
   "send_to",
   "wait_for",
   "arm_watch",
@@ -112,6 +113,10 @@ function parseResult(result: {
 }
 
 describe("thin-core tool palette", () => {
+  it("P0 D7 exposes an agent-initiated blocker escalation to its parent", () => {
+    expect(PUBLIC_TOOL_NAMES).toContain("report_to_parent");
+  });
+
   it("publishes only the ratified Phase 5 surface", () => {
     const server = createServer({
       exec: makeExec(),

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -309,7 +309,7 @@ describe("V2 tool registration", () => {
     });
     const server = createV2Server(mockExec);
     const count = Object.keys((server as any)._registeredTools).length;
-    expect(count).toBe(44);
+    expect(count).toBe(45);
   });
 });
 

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -176,4 +176,57 @@ describe("WatchSpec MCP contract", () => {
     });
     expect(notify).toHaveBeenCalledOnce();
   });
+
+  it("D14 emits MCP progress before a long wait hits the harness silence cutoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const server = createWatchServer() as any;
+      const engine = server._registeredTools.interact._engine;
+      let resolveWait!: (value: unknown) => void;
+      vi.spyOn(engine, "waitForWatch").mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveWait = resolve;
+          }),
+      );
+      const sendNotification = vi.fn().mockResolvedValue(undefined);
+      const pending = server._registeredTools.wait_for.handler(
+        {
+          watch: {
+            owner: "lead-a",
+            target: join(TEST_DIR, "long-wait.md"),
+            marker: "DONE",
+            deadline: Date.now() + 300_000,
+          },
+          timeout_ms: 300_000,
+        },
+        {
+          _meta: { progressToken: "wait-progress-1" },
+          sendNotification,
+        } as any,
+      );
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      expect(sendNotification).toHaveBeenCalledWith({
+        method: "notifications/progress",
+        params: {
+          progressToken: "wait-progress-1",
+          progress: 1,
+          message: "wait_for still waiting",
+        },
+      });
+
+      resolveWait({
+        matched: true,
+        elapsed: 45_000,
+        watch: { watch_id: "watch-1", state: "fired" },
+      });
+      await pending;
+      const delivered = sendNotification.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(sendNotification).toHaveBeenCalledTimes(delivered);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- add a separate report_to_parent tool that resolves the destination from the durable parent registry relationship
- auto-arm parent-owned watches on a child report path for both fresh spawn and resume
- keep watch wakeups reason- and target-kind-aware so missing targets and deadlines are not reported as completion
- cover hierarchy containment, lifecycle arming, and notifier behavior with regression tests

## Verification

- bun run typecheck
- bunx vitest run: 142 files passed; 3290 passed, 1 skipped
- env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run: identical 142 files; 3290 passed, 1 skipped
- CMUX_CONTRACT_ALLOW_PROD=1 CMUX_CONTRACT_REQUIRE_LIVE=1 bun run test:contract: PASS real-cmux contract lane

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02f6a","ts":"2026-08-23T17:18:29Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public MCP palette and guarded agent-delivery/watch-notify paths, including a new default persistent watch registry under `stateDir`. Mis-routing or failed wakes would escalate blockers to the wrong ancestor or drop completion notices.
> 
> **Overview**
> Adds the tenth public tool, **`report_to_parent`**: a child can escalate a ≤500-char blocker to its registry parent (no caller-chosen target). The inbox write is durable; success requires an evidence-backed wake. If the parent cannot be woken, ancestry is walked and the nearest reachable ancestor is notified with `route: "fallback"`; otherwise the tool errors (`report_parent_missing` / `report_parent_unreachable`). Delivery reuses the `send_to` / nudge path, including draft-guard and busy-queue behavior.
> 
> **Spawn/resume** now auto-arms a parent-owned file watch on the child’s `report_path`/`done_marker` (far-future deadline, watermarked so stale markers do not fire). Watch arm failure is a warning, not a spawn failure. Agent-owned watch fires go through the guarded relay with reason-aware text (`done marker` vs `target missing` vs deadline); failed delivery stays `notification_pending`. Default `watchRegistryPath` is now `stateDir/watch-specs.json`. Notifications include `target_kind`.
> 
> **`wait_for`** emits MCP `notifications/progress` every 45s when a progress token is present, then clears the timer, so long waits survive the harness ~120s silence cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31acba433b14453755cea09299d7e74de5c40467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `report_to_parent` tool for hierarchy-bound blocker escalation
> - Introduces a new mutating tool `report_to_parent` that lets a managed child agent append a durable inbox envelope to its direct parent and attempt to wake the parent via guarded delivery. If the parent is unreachable, it walks persisted ancestry to notify the nearest reachable ancestor with a delivery-failure-prefixed blocker.
> - Automatically arms a parent-owned persistent file watch on the child's report marker at spawn and resume time, aggregating arming warnings without failing the spawn.
> - Augments the `wait_for` handler to emit `notifications/progress` every 45 seconds when a `_meta.progressToken` is present, keeping harness sessions alive during long waits.
> - Extends `DeliveryEventType` and delivery verification logic so `report_to_parent` participates in queue detection, pending-verify allowance, draft guards, and recovery retry on the same terms as `send_to` and `dispatch_nudge`.
> - Behavioral Change: `WatchNotification` now carries a `target_kind` field (`file` | `agent`); `watchNotify` routes agent-owned notifications through the guarded lifecycle input deliverer. Registered tool count increases from 44 to 45, and `default-palette`, `public-output-schema`, `security-hardening`, and related test counts are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31acba4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `report_to_parent` for sending blockers to a parent agent, with durable delivery and ancestor fallback.
  * Automatically enables parent-owned watches for child reports, including across resumed sessions.
  * Added periodic progress notifications for long-running `wait_for` requests.
  * Improved watch notifications with target details and delivery status.

* **Documentation**
  * Added design and implementation plans for parent reporting, watches, and progress updates.

* **Bug Fixes**
  * Preserved pending notifications when delivery fails and added warnings for watch setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->